### PR TITLE
Add ability to use timedelta and stings to `start_time` and `end_time`.

### DIFF
--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -484,7 +484,6 @@ def _timedelta_to_seconds(
         try:
             out: int = int(pd.Timedelta(media_time).total_seconds())
         except ValueError as ex:
-            # raise StreamlitAPIException(ttl) from ex
             raise StreamlitAPIException(
                 f"""Failed to convert '{media_time_param_name}' to a timedelta.
                 Please use a valid timedelta string. {media_time} string doesn't look

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -47,7 +47,7 @@ SubtitleData: TypeAlias = Union[
     str, Path, bytes, io.BytesIO, Dict[str, Union[str, Path, bytes, io.BytesIO]], None
 ]
 
-MediaTime: TypeAlias = Union[int, float, timedelta, str]
+MediaTime: TypeAlias = Union[int, timedelta, str]
 
 TIMEDELTA_PARSE_ERROR_MESSAGE: Final = (
     "Failed to convert '{param_name}' to a timedelta. "
@@ -64,10 +64,10 @@ class MediaMixin:
         self,
         data: MediaData,
         format: str = "audio/wav",
-        start_time: int = 0,
+        start_time: MediaTime = 0,
         *,
         sample_rate: int | None = None,
-        end_time: int | None = None,
+        end_time: MediaTime | None = None,
         loop: bool = False,
     ) -> DeltaGenerator:
         """Display an audio player.
@@ -157,10 +157,10 @@ class MediaMixin:
         self,
         data: MediaData,
         format: str = "video/mp4",
-        start_time: int = 0,
+        start_time: MediaTime = 0,
         *,  # keyword-only arguments:
         subtitles: SubtitleData = None,
-        end_time: int | None = None,
+        end_time: MediaTime | None = None,
         loop: bool = False,
     ) -> DeltaGenerator:
         """Display a video player.

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -30,6 +30,7 @@ from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime_util import ttl_to_seconds
 
 if TYPE_CHECKING:
     from typing import Any
@@ -481,8 +482,6 @@ def _parse_start_time_end_time(
     start_time: MediaTime, end_time: MediaTime | None
 ) -> tuple[int, int | None]:
     """Parse start_time and end_time and return them as int."""
-    # Importing ttl_to_seconds here to avoid circular import
-    from streamlit.runtime.caching.cache_utils import ttl_to_seconds
 
     try:
         maybe_start_time = ttl_to_seconds(start_time, coerce_none_to_inf=False)

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -486,17 +486,19 @@ def _timedelta_to_seconds(
         except ValueError as ex:
             raise StreamlitAPIException(
                 f"""Failed to convert '{media_time_param_name}' to a timedelta.
-                Please use a valid timedelta string. {media_time} string doesn't look
-                right. It should be formatted as `'1h34m'` or `14 seconds`, for example.
+                Please use a string in a format supported by  # noqa: W291
+                [Pandas's Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html),
+                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`.
                 Got: {media_time}
                 """
             ) from ex
 
         if np.isnan(out):
             raise StreamlitAPIException(
-                f"""Failed to convert '{media_time_param_name}' to a timedelta. Please
-                use a valid timedelta string.{media_time} string doesn't look right.
-                It should be formatted as `'1h34m'` or `14 seconds`, for example.
+                f"""Failed to convert '{media_time_param_name}' to a timedelta.
+                Please use a string in a format supported by
+                [Pandas's Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html),
+                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`.
                 Got: {media_time}
                 """
             )

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -495,6 +495,8 @@ def _parse_start_time_end_time(
         raise StreamlitAPIException(error_msg) from None
 
     try:
+        # TODO[kajarenc]: Replace `duration_to_seconds` with `time_to_seconds`
+        #  when PR #8343 is merged.
         end_time = duration_to_seconds(end_time, coerce_none_to_inf=False)
         if end_time is not None:
             end_time = int(end_time)

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -30,7 +30,7 @@ from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime_util import ttl_to_seconds
+from streamlit.runtime.runtime_util import duration_to_seconds
 
 if TYPE_CHECKING:
     from typing import Any
@@ -484,7 +484,7 @@ def _parse_start_time_end_time(
     """Parse start_time and end_time and return them as int."""
 
     try:
-        maybe_start_time = ttl_to_seconds(start_time, coerce_none_to_inf=False)
+        maybe_start_time = duration_to_seconds(start_time, coerce_none_to_inf=False)
         if maybe_start_time is None:
             raise ValueError
         start_time = int(maybe_start_time)
@@ -495,7 +495,7 @@ def _parse_start_time_end_time(
         raise StreamlitAPIException(error_msg) from None
 
     try:
-        end_time = ttl_to_seconds(end_time, coerce_none_to_inf=False)
+        end_time = duration_to_seconds(end_time, coerce_none_to_inf=False)
         if end_time is not None:
             end_time = int(end_time)
     except StreamlitAPIException:

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -47,7 +47,7 @@ SubtitleData: TypeAlias = Union[
     str, Path, bytes, io.BytesIO, Dict[str, Union[str, Path, bytes, io.BytesIO]], None
 ]
 
-MediaTime: TypeAlias = Union[int, timedelta, str]
+MediaTime: TypeAlias = Union[int, float, timedelta, str]
 
 TIMEDELTA_PARSE_ERROR_MESSAGE: Final = (
     "Failed to convert '{param_name}' to a timedelta. "

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -112,7 +112,7 @@ class MediaMixin:
            height: 865px
 
         """
-        start_time = _timedelta_to_seconds(start_time, "start_time")
+        start_time = int(_timedelta_to_seconds(start_time, "start_time"))
         end_time = _timedelta_to_seconds(end_time, "end_time")
 
         audio_proto = AudioProto()
@@ -251,7 +251,7 @@ class MediaMixin:
 
         """
 
-        start_time = _timedelta_to_seconds(start_time, "start_time")
+        start_time = int(_timedelta_to_seconds(start_time, "start_time"))
         end_time = _timedelta_to_seconds(end_time, "end_time")
 
         video_proto = VideoProto()

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -486,10 +486,9 @@ def _timedelta_to_seconds(
         except ValueError as ex:
             raise StreamlitAPIException(
                 f"""Failed to convert '{media_time_param_name}' to a timedelta.
-                Please use a string in a format supported by  # noqa: W291
+                Please use a string in a format supported by
                 [Pandas's Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html),
-                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`.
-                Got: {media_time}
+                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`. Got: {media_time}
                 """
             ) from ex
 
@@ -498,8 +497,7 @@ def _timedelta_to_seconds(
                 f"""Failed to convert '{media_time_param_name}' to a timedelta.
                 Please use a string in a format supported by
                 [Pandas's Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html),
-                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`.
-                Got: {media_time}
+                e.g. `"10s"`, `"15 seconds"`, or `"1h23s"`. Got: {media_time}
                 """
             )
 

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -29,7 +29,6 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime import caching
-from streamlit.runtime.caching.cache_utils import ttl_to_seconds
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
@@ -482,6 +481,9 @@ def _parse_start_time_end_time(
     start_time: MediaTime, end_time: MediaTime | None
 ) -> tuple[int, int | None]:
     """Parse start_time and end_time and return them as int."""
+    # Importing ttl_to_seconds here to avoid circular import
+    from streamlit.runtime.caching.cache_utils import ttl_to_seconds
+
     try:
         maybe_start_time = ttl_to_seconds(start_time, coerce_none_to_inf=False)
         if maybe_start_time is None:

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import re
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Final, Union, cast
 
@@ -44,6 +45,44 @@ MediaData: TypeAlias = Union[
 SubtitleData: TypeAlias = Union[
     str, Path, bytes, io.BytesIO, Dict[str, Union[str, Path, bytes, io.BytesIO]], None
 ]
+
+
+def timedelta_to_seconds(
+    media_time: timedelta | str | int | None,
+    media_time_param_name: str,
+) -> int | None:
+    """Convert a start_time / end_time value to an int representing "number of seconds"."""
+    if isinstance(media_time, timedelta):
+        return int(media_time.total_seconds())
+
+    if isinstance(media_time, str):
+        import numpy as np
+        import pandas as pd
+
+        try:
+            out: int = int(pd.Timedelta(media_time).total_seconds())
+        except ValueError as ex:
+            # raise StreamlitAPIException(ttl) from ex
+            raise StreamlitAPIException(
+                f"""Failed to convert '{media_time_param_name}' to a timedelta.
+                Please use a valid timedelta string.{media_time} string doesn't look
+                right. It should be formatted as `'1h34m'` or `14 seconds`, for example.
+                Got: {media_time}
+                """
+            ) from ex
+
+        if np.isnan(out):
+            raise StreamlitAPIException(
+                f"""Failed to convert '{media_time_param_name}' to a timedelta. Please
+                use a valid timedelta string.{media_time} string doesn't look right.
+                It should be formatted as `'1h34m'` or `14 seconds`, for example.
+                Got: {media_time}
+                """
+            )
+
+        return out
+
+    return media_time
 
 
 class MediaMixin:
@@ -111,6 +150,9 @@ class MediaMixin:
            height: 865px
 
         """
+        start_time = timedelta_to_seconds(start_time, "start_time")
+        end_time = timedelta_to_seconds(end_time, "end_time")
+
         audio_proto = AudioProto()
         coordinates = self.dg._get_delta_path_str()
 
@@ -246,6 +288,10 @@ class MediaMixin:
            for more information.
 
         """
+
+        start_time = timedelta_to_seconds(start_time, "start_time")
+        end_time = timedelta_to_seconds(end_time, "end_time")
+
         video_proto = VideoProto()
         coordinates = self.dg._get_delta_path_str()
         marshall_video(

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -35,7 +35,6 @@ from streamlit.runtime.caching.cache_utils import (
     Cache,
     CachedFuncInfo,
     make_cached_func_wrapper,
-    ttl_to_seconds,
 )
 from streamlit.runtime.caching.cached_message_replay import (
     CachedMessageReplayContext,
@@ -59,6 +58,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime_util import ttl_to_seconds
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -58,7 +58,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime_util import ttl_to_seconds
+from streamlit.runtime.runtime_util import duration_to_seconds
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 
@@ -154,7 +154,7 @@ class DataCaches(CacheStatsProvider):
         If it doesn't exist, create a new one with the given params.
         """
 
-        ttl_seconds = ttl_to_seconds(ttl, coerce_none_to_inf=False)
+        ttl_seconds = duration_to_seconds(ttl, coerce_none_to_inf=False)
 
         # Get the existing cache, if it exists, and validate that its params
         # haven't changed.
@@ -254,7 +254,7 @@ class DataCaches(CacheStatsProvider):
             CacheStorageContext.
         """
 
-        ttl_seconds = ttl_to_seconds(ttl, coerce_none_to_inf=False)
+        ttl_seconds = duration_to_seconds(ttl, coerce_none_to_inf=False)
 
         cache_context = self.create_cache_storage_context(
             function_key="DUMMY_KEY",

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -176,14 +176,3 @@ class UnevaluatedDataFrameError(StreamlitAPIException):
     """Used to display a message about uncollected dataframe being used"""
 
     pass
-
-
-class BadTTLStringError(StreamlitAPIException):
-    """Raised when a bad ttl= argument string is passed."""
-
-    def __init__(self, ttl: str):
-        MarkdownFormattedException.__init__(
-            self,
-            "TTL string doesn't look right. It should be formatted as"
-            f"`'1d2h34m'` or `2 days`, for example. Got: {ttl}",
-        )

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -45,7 +45,7 @@ from streamlit.runtime.caching.cached_message_replay import (
 )
 from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime_util import ttl_to_seconds
+from streamlit.runtime.runtime_util import duration_to_seconds
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 
@@ -89,7 +89,7 @@ class ResourceCaches(CacheStatsProvider):
         if max_entries is None:
             max_entries = math.inf
 
-        ttl_seconds = ttl_to_seconds(ttl)
+        ttl_seconds = duration_to_seconds(ttl)
 
         # Get the existing cache, if it exists, and validate that its params
         # haven't changed.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -35,7 +35,6 @@ from streamlit.runtime.caching.cache_utils import (
     Cache,
     CachedFuncInfo,
     make_cached_func_wrapper,
-    ttl_to_seconds,
 )
 from streamlit.runtime.caching.cached_message_replay import (
     CachedMessageReplayContext,
@@ -46,6 +45,7 @@ from streamlit.runtime.caching.cached_message_replay import (
 )
 from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime_util import ttl_to_seconds
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -66,18 +66,18 @@ def is_cacheable_msg(msg: ForwardMsg) -> bool:
 
 
 @overload
-def ttl_to_seconds(
+def duration_to_seconds(
     ttl: float | timedelta | str | None, *, coerce_none_to_inf: Literal[False]
 ) -> float | None:
     ...
 
 
 @overload
-def ttl_to_seconds(ttl: float | timedelta | str | None) -> float:
+def duration_to_seconds(ttl: float | timedelta | str | None) -> float:
     ...
 
 
-def ttl_to_seconds(
+def duration_to_seconds(
     ttl: float | timedelta | str | None, *, coerce_none_to_inf: bool = True
 ) -> float | None:
     """

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -16,11 +16,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+import math
+from datetime import timedelta
+from typing import Any, Literal, overload
 
 from streamlit import config
 from streamlit.errors import MarkdownFormattedException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.caching.cache_errors import BadTTLStringError
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
 
 
@@ -60,6 +63,45 @@ def is_cacheable_msg(msg: ForwardMsg) -> bool:
         # Some message types never get cached
         return False
     return msg.ByteSize() >= int(config.get_option("global.minCachedMessageSize"))
+
+
+@overload
+def ttl_to_seconds(
+    ttl: float | timedelta | str | None, *, coerce_none_to_inf: Literal[False]
+) -> float | None:
+    ...
+
+
+@overload
+def ttl_to_seconds(ttl: float | timedelta | str | None) -> float:
+    ...
+
+
+def ttl_to_seconds(
+    ttl: float | timedelta | str | None, *, coerce_none_to_inf: bool = True
+) -> float | None:
+    """
+    Convert a ttl value to a float representing "number of seconds".
+    """
+    if coerce_none_to_inf and ttl is None:
+        return math.inf
+    if isinstance(ttl, timedelta):
+        return ttl.total_seconds()
+    if isinstance(ttl, str):
+        import numpy as np
+        import pandas as pd
+
+        try:
+            out: float = pd.Timedelta(ttl).total_seconds()
+        except ValueError as ex:
+            raise BadTTLStringError(ttl) from ex
+
+        if np.isnan(out):
+            raise BadTTLStringError(ttl)
+
+        return out
+
+    return ttl
 
 
 def serialize_forward_msg(msg: ForwardMsg) -> bytes:

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -23,7 +23,10 @@ from parameterized import parameterized
 from scipy.io import wavfile
 
 import streamlit as st
-from streamlit.elements.media import _maybe_convert_to_wav_bytes, _timedelta_to_seconds
+from streamlit.elements.media import (
+    _maybe_convert_to_wav_bytes,
+    _parse_start_time_end_time,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.runtime.media_file_storage import MediaFileStorageError
@@ -278,34 +281,35 @@ class AudioTest(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            ("1s", 1),
-            ("1m", 60),
-            ("1m2s", 62),
-            ("1h2m3s", 3723),
-            ("10 seconds", 10),
-            ("3 minutes 10 seconds", 190),
+            ("1s", None, (1, None)),
+            ("1m", None, (60, None)),
+            ("1m2s", None, (62, None)),
+            (0, "1m", (0, 60)),
+            ("1h2m3s", None, (3723, None)),
+            ("10 seconds", "15 seconds", (10, 15)),
+            ("3 minutes 10 seconds", "3 minutes 20 seconds", (190, 200)),
         ]
     )
-    def test_time_delta_to_seconds_success(self, input_value, expected_value):
-        """Test that _timedelta_to_seconds works correctly."""
+    def test_parse_start_time_end_time_success(
+        self, input_start_time, input_end_time, expected_value
+    ):
+        """Test that _parse_start_time_end_time works correctly."""
         self.assertEqual(
-            _timedelta_to_seconds(input_value, media_time_param_name="start_time"),
+            _parse_start_time_end_time(input_start_time, input_end_time),
             expected_value,
         )
 
     @parameterized.expand(
         [
-            ("AAA", "start_time", "Failed to convert 'start_time' to a timedelta."),
-            ("BBB", "end_time", "Failed to convert 'end_time' to a timedelta."),
+            ("INVALID_VALUE", None, "Failed to convert 'start_time' to a timedelta"),
+            (5, "INVALID_VALUE", "Failed to convert 'end_time' to a timedelta"),
         ]
     )
-    def test_time_delta_to_seconds_success(
-        self, input_value, param_name, exception_text
-    ):
+    def test_time_delta_to_seconds_success(self, start_time, end_time, exception_text):
         """Test that _timedelta_to_seconds works with correct exception text."""
 
         with self.assertRaises(StreamlitAPIException) as e:
-            _timedelta_to_seconds(input_value, media_time_param_name=param_name)
+            _parse_start_time_end_time(start_time, end_time)
 
         self.assertIn(exception_text, str(e.exception))
-        self.assertIn(input_value, str(e.exception))
+        self.assertIn("INVALID_VALUE", str(e.exception))

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -286,6 +286,7 @@ class AudioTest(DeltaGeneratorTestCase):
             ("1m2s", None, (62, None)),
             (0, "1m", (0, 60)),
             ("1h2m3s", None, (3723, None)),
+            ("1m2s", "1m10s", (62, 70)),
             ("10 seconds", "15 seconds", (10, 15)),
             ("3 minutes 10 seconds", "3 minutes 20 seconds", (190, 200)),
         ]

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -305,8 +305,8 @@ class AudioTest(DeltaGeneratorTestCase):
             (5, "INVALID_VALUE", "Failed to convert 'end_time' to a timedelta"),
         ]
     )
-    def test_time_delta_to_seconds_success(self, start_time, end_time, exception_text):
-        """Test that _timedelta_to_seconds works with correct exception text."""
+    def test_parse_start_time_end_time_fail(self, start_time, end_time, exception_text):
+        """Test that _parse_start_time_end_time works with correct exception text."""
 
         with self.assertRaises(StreamlitAPIException) as e:
             _parse_start_time_end_time(start_time, end_time)

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -109,7 +109,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         self.assertEqual("st.audio", ds.name)
         self.assertEqual("method", ds.type)
 
-        signature = "(data: 'MediaData', format: 'str' = 'audio/wav', start_time: 'int' = 0, *, sample_rate: 'int | None' = None, end_time: 'int | None' = None, loop: 'bool' = False) -> 'DeltaGenerator'"
+        signature = "(data: 'MediaData', format: 'str' = 'audio/wav', start_time: 'MediaTime' = 0, *, sample_rate: 'int | None' = None, end_time: 'MediaTime | None' = None, loop: 'bool' = False) -> 'DeltaGenerator'"
 
         self.assertEqual(
             f"streamlit.delta_generator.MediaMixin.audio{signature}", ds.value

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -516,6 +516,7 @@ class AppSessionTest(unittest.TestCase):
         # Ensure that we don't count refs to session from an object that would have been
         # garbage collected along with it.
         gc.collect(2)
+
         self.assertEqual(len(gc.get_referrers(session)), 0)
 
     @patch("streamlit.runtime.app_session.AppSession._enqueue_forward_msg")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -15,6 +15,7 @@
 import asyncio
 import gc
 import threading
+import time
 import unittest
 from asyncio import AbstractEventLoop
 from typing import Any, Callable, List, Optional, cast
@@ -516,7 +517,8 @@ class AppSessionTest(unittest.TestCase):
         # Ensure that we don't count refs to session from an object that would have been
         # garbage collected along with it.
         gc.collect(2)
-
+        time.sleep(0.1)
+        gc.collect(2)
         self.assertEqual(len(gc.get_referrers(session)), 0)
 
     @patch("streamlit.runtime.app_session.AppSession._enqueue_forward_msg")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -15,7 +15,6 @@
 import asyncio
 import gc
 import threading
-import time
 import unittest
 from asyncio import AbstractEventLoop
 from typing import Any, Callable, List, Optional, cast
@@ -516,8 +515,6 @@ class AppSessionTest(unittest.TestCase):
         session.disconnect_file_watchers()
         # Ensure that we don't count refs to session from an object that would have been
         # garbage collected along with it.
-        gc.collect(2)
-        time.sleep(0.1)
         gc.collect(2)
         self.assertEqual(len(gc.get_referrers(session)), 0)
 

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -20,7 +20,7 @@ from typing import Any
 from parameterized import parameterized
 
 from streamlit.runtime.caching.cache_errors import BadTTLStringError
-from streamlit.runtime.runtime_util import ttl_to_seconds
+from streamlit.runtime.runtime_util import duration_to_seconds
 
 NORMAL_PARAMS = [
     ("float", 3.5, 3.5),
@@ -45,7 +45,7 @@ class CacheUtilsTest(unittest.TestCase):
     )
     def test_ttl_to_seconds_coerced(self, _, input_value: Any, expected_seconds: float):
         """Test the various types of input that ttl_to_seconds accepts."""
-        self.assertEqual(expected_seconds, ttl_to_seconds(input_value))
+        self.assertEqual(expected_seconds, duration_to_seconds(input_value))
 
     @parameterized.expand(
         [
@@ -58,13 +58,13 @@ class CacheUtilsTest(unittest.TestCase):
     ):
         """Test the various types of input that ttl_to_seconds accepts."""
         self.assertEqual(
-            expected_seconds, ttl_to_seconds(input_value, coerce_none_to_inf=False)
+            expected_seconds, duration_to_seconds(input_value, coerce_none_to_inf=False)
         )
 
     def test_ttl_str_exception(self):
         """Test that a badly-formatted TTL string raises an exception."""
         with self.assertRaises(BadTTLStringError):
-            ttl_to_seconds("")
+            duration_to_seconds("")
 
         with self.assertRaises(BadTTLStringError):
-            ttl_to_seconds("1 flecond")
+            duration_to_seconds("1 flecond")

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -20,7 +20,7 @@ from typing import Any
 from parameterized import parameterized
 
 from streamlit.runtime.caching.cache_errors import BadTTLStringError
-from streamlit.runtime.caching.cache_utils import ttl_to_seconds
+from streamlit.runtime.runtime_util import ttl_to_seconds
 
 NORMAL_PARAMS = [
     ("float", 3.5, 3.5),

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -19,8 +19,7 @@ from typing import Any
 
 from parameterized import parameterized
 
-from streamlit.runtime.caching.cache_errors import BadTTLStringError
-from streamlit.runtime.runtime_util import duration_to_seconds
+from streamlit.runtime.runtime_util import BadDurationStringError, duration_to_seconds
 
 NORMAL_PARAMS = [
     ("float", 3.5, 3.5),
@@ -63,8 +62,8 @@ class CacheUtilsTest(unittest.TestCase):
 
     def test_ttl_str_exception(self):
         """Test that a badly-formatted TTL string raises an exception."""
-        with self.assertRaises(BadTTLStringError):
+        with self.assertRaises(BadDurationStringError):
             duration_to_seconds("")
 
-        with self.assertRaises(BadTTLStringError):
+        with self.assertRaises(BadDurationStringError):
             duration_to_seconds("1 flecond")


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Add the ability to use time delta and stings to start_time and end_time. 

Also moved `ttl_to_seconds` function out of cache_utils to `runtime_utils` and renamed it to `duration_to_seconds`, since now it is also used outside of the cache module.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Added!
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
