### PR TITLE
Don't forget to set fragmentIdsThisRun on full script runs too

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -925,6 +925,9 @@ export class App extends PureComponent<Props, State> {
           appPages: newSessionProto.appPages,
           currentPageScriptHash: newPageScriptHash,
           latestRunTime: performance.now(),
+          // If we're here, the fragmentIdsThisRun variable is always the
+          // empty array.
+          fragmentIdsThisRun,
         },
         () => {
           this.hostCommunicationMgr.sendMessageToHost({


### PR DESCRIPTION
I somehow managed to forget that we need to set the `fragmentIdsThisRun` state variable on
a full rerun too since otherwise running the full script after a fragment run will fail to reset the array.
User-visible issues due to this bug seem to be rare in practice but can be (probabilistically) observed 
when using `st.rerun` within a fragment.

The same script used to demonstrate the bug in #8332 can also be used to trigger this one:
```python
import streamlit as st

show_stuff = st.checkbox("Show stuff")
if show_stuff:
    st.write("hello")


@st.experimental_fragment
def fragment():
    if st.button("Rerun everything"):
        st.rerun()
        
fragment()
```

1. Click on the "Rerun everything" button
2. Rapidly select and unselect the checkbox.
3. Notice that (sometimes) a duplicate button will appear.