### PR TITLE
resolve path when registering watcher for module paths

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -18,6 +18,7 @@ import collections
 import os
 import sys
 import types
+from pathlib import Path
 from typing import Callable, Final
 
 from streamlit import config, file_util
@@ -165,7 +166,7 @@ class LocalSourcesWatcher:
         for name, paths in module_paths.items():
             for path in paths:
                 if self._file_should_be_watched(path):
-                    self._register_watcher(path, name)
+                    self._register_watcher(str(Path(path).resolve()), name)
 
     def _exclude_blacklisted_paths(self, paths: set[str]) -> set[str]:
         return {p for p in paths if not self._folder_black_list.is_blacklisted(p)}


### PR DESCRIPTION
## Describe your changes

I am developing a streamlit app in Bazel, which creates many symlinks when building a project, e.g.

```
bazel-bin/projects/myapp/pages/0_Overview.py => foo/projects/myapp/pages/0_Overview.py
bazel-bin/projects/myapp/utils.py => => foo/projects/myapp/utils.py
```

I usually edit files in `foo/` during development, and I found that when updating module file (`utils.py`), the change is not detected by streamlit and the browser does not refresh, automatically. However, updating the page file (e.g. `0_Overview.py`) would lead to auto refresh. Then, after debugging, I think it's due to the inconsistency in resolutions of page and module paths.

Specifically, when streamlit is run and registering watchers, only the paths of page files get [resolved](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve) (make absolute path and resolve symlink), the relevant code snippets are

https://github.com/streamlit/streamlit/blob/4589b136c5a0880da4564fc98051922eb03a24d2/lib/streamlit/watcher/local_sources_watcher.py#L54-L58
https://github.com/streamlit/streamlit/blob/4589b136c5a0880da4564fc98051922eb03a24d2/lib/streamlit/source_util.py#L132
https://github.com/streamlit/streamlit/blob/4589b136c5a0880da4564fc98051922eb03a24d2/lib/streamlit/source_util.py#L147

However, the module paths don't get resolved

https://github.com/streamlit/streamlit/blob/4589b136c5a0880da4564fc98051922eb03a24d2/lib/streamlit/watcher/local_sources_watcher.py#L150

which explains the inconsistent auto refresh behavior and is what this PR updates. In essence, we only want to watch the change in the resolved paths, the content of the symlink path, which just holds a link to the source file, does not change.

## GitHub Issue Link (if applicable)

## Testing Plan

manually tested it's working.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
