### PR TITLE
Fix CI conda build

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -29,23 +29,22 @@ jobs:
           fetch-depth: 2
       - name: Set build config env vars
         uses: ./.github/actions/build_info
-      # We need to install Python 3.9 here because it's the latest version
-      # supported by the miniconda installer as of 2022/10/11.
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Install conda and conda-build
         env:
-          MINICONDA_RELEASE: "Miniconda3-py39_4.12.0-Linux-x86_64"
+          MINICONDA_RELEASE: "Miniconda3-py312_24.1.2-0-Linux-x86_64"
         run: |
           curl -sO "https://repo.anaconda.com/miniconda/${MINICONDA_RELEASE}.sh"
           bash "${MINICONDA_RELEASE}.sh" -b
-          conda install conda-build=3.28.4
+          conda install conda-build
       - name: Build Snowpark Conda Package - Fast
         timeout-minutes: 120
         run: |
           sudo apt install rsync
+          conda config --set conda_build.pkg_format 2
           SNOWPARK_CONDA_BUILD=1 BUILD_AS_FAST_AS_POSSIBLE=1 make conda-package

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@
 
 
 package:
-  name: {{ package_data.get('name')|lower }}
+  name: streamlit
   version: {{ package_data.get('version') }}
 
 source:
@@ -25,7 +25,7 @@ source:
 build:
   number: {{ environ.get('CONDA_BUILD_NUMBER', 0)|int }}
   noarch: python
-  script: python -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     {% for ep in package_data.get('entry_points').get('console_scripts') %}
       - {{ ep }}
@@ -53,6 +53,12 @@ requirements:
         - {{ req }}
       {% endif %}
     {% endfor %}
+        # We need to specify Python as a runtime requirement here, otherwise
+        # conda may try to use the system python installation rather than the
+        # python installation of the conda environment. The weird indentation
+        # is required to match the indentation of the requirements added via
+        # templating above.
+        - python {{ package_data.get('python_requires') }}
 
 test:
   imports:


### PR DESCRIPTION
There are a few `conda build` related problems that popped up around the same time that made this
CI stage particularly annoying to fix (especially given how opaque all of the conda errors are). They are:

* older versions of `conda build` stopped working for still-unknown reasons
* some versions of `conda` build seem to expect the name of a package to be defined directly in
   `meta.yaml` (rather than being templated it from a `setup.py` file or elsewhere), so we had to hard-code
   the package name `streamlit` into the recipe rather than pulling it from `setup.py`
* we were previously just using the system python installation to actually build the package, which wasn't
   an issue with older versions of `conda build` but seems to be an issue now
* it's also necessary to specify `python` as a run requirement, otherwise conda uses the system python
   installation while running tests, which causes the import test to fail since the installation of the newly built
   package happens within the conda env.