### PR TITLE
Use time_to_seconds instead of duration_to_seconds

### DIFF
--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -30,7 +30,7 @@ from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime_util import duration_to_seconds
+from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
     from typing import Any
@@ -484,7 +484,7 @@ def _parse_start_time_end_time(
     """Parse start_time and end_time and return them as int."""
 
     try:
-        maybe_start_time = duration_to_seconds(start_time, coerce_none_to_inf=False)
+        maybe_start_time = time_to_seconds(start_time, coerce_none_to_inf=False)
         if maybe_start_time is None:
             raise ValueError
         start_time = int(maybe_start_time)
@@ -495,9 +495,7 @@ def _parse_start_time_end_time(
         raise StreamlitAPIException(error_msg) from None
 
     try:
-        # TODO[kajarenc]: Replace `duration_to_seconds` with `time_to_seconds`
-        #  when PR #8343 is merged.
-        end_time = duration_to_seconds(end_time, coerce_none_to_inf=False)
+        end_time = time_to_seconds(end_time, coerce_none_to_inf=False)
         if end_time is not None:
             end_time = int(end_time)
     except StreamlitAPIException:

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -16,9 +16,7 @@
 
 from __future__ import annotations
 
-import math
-from datetime import timedelta
-from typing import Any, Literal, overload
+from typing import Any
 
 from streamlit import config
 from streamlit.errors import MarkdownFormattedException, StreamlitAPIException
@@ -73,45 +71,6 @@ def is_cacheable_msg(msg: ForwardMsg) -> bool:
         # Some message types never get cached
         return False
     return msg.ByteSize() >= int(config.get_option("global.minCachedMessageSize"))
-
-
-@overload
-def duration_to_seconds(
-    ttl: float | timedelta | str | None, *, coerce_none_to_inf: Literal[False]
-) -> float | None:
-    ...
-
-
-@overload
-def duration_to_seconds(ttl: float | timedelta | str | None) -> float:
-    ...
-
-
-def duration_to_seconds(
-    ttl: float | timedelta | str | None, *, coerce_none_to_inf: bool = True
-) -> float | None:
-    """
-    Convert a ttl value to a float representing "number of seconds".
-    """
-    if coerce_none_to_inf and ttl is None:
-        return math.inf
-    if isinstance(ttl, timedelta):
-        return ttl.total_seconds()
-    if isinstance(ttl, str):
-        import numpy as np
-        import pandas as pd
-
-        try:
-            out: float = pd.Timedelta(ttl).total_seconds()
-        except ValueError as ex:
-            raise BadDurationStringError(ttl) from ex
-
-        if np.isnan(out):
-            raise BadDurationStringError(ttl)
-
-        return out
-
-    return ttl
 
 
 def serialize_forward_msg(msg: ForwardMsg) -> bytes:


### PR DESCRIPTION
Use time_to_seconds instead of duration_to_seconds, remove `duration_to_seconds`since now it is unused.

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Tests for `_parse_start_time_end_time` already ensure this functionality
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
