### PR TITLE
Readd mistakenly removed line and add explanatory comment

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -192,6 +192,11 @@ def fragment(
         def wrapped_fragment():
             import streamlit as st
 
+            # NOTE: We need to call get_script_run_ctx here again and can't just use the
+            # value of ctx from above captured by the closure because subsequent
+            # fragment runs will generally run in a new script run, thus we'll have a
+            # new ctx.
+            ctx = get_script_run_ctx(suppress_warning=True)
             assert ctx is not None
 
             if ctx.fragment_ids_this_run:


### PR DESCRIPTION
I accidentally introduced a bug in the `@st.experimental_fragment` feature right before merging the
feature branch because I thought that there was no need to re-fetch the script run context within a
fragment as it's already captured by the closure.

This is incorrect because we'll have a new context since the fragment run will happen in a new
script run, so this PR fixes the bug and adds an explanatory comment to prevent this from happening
again.

It'll be hard to add test coverage for this in a unit test, but I ran into this error while working on e2e
tests for the fragment decorator, so we'll add test coverage to prevent this from happening again
via a playwright test in a subsequent PR.