### PR TITLE
Gather metrics on `get_option`

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -210,9 +210,9 @@ status = _main.status
 toast = _event.toast
 
 # Config
-get_option = _config.get_option
 # We add the metrics tracking here, since importing
 # gather_metrics in config causes a circular dependency
+get_option = _gather_metrics("get_option", _config.get_option)
 set_option = _gather_metrics("set_option", _config.set_user_option)
 
 # Session State


### PR DESCRIPTION
## Describe your changes

Metrics are currently gathered on `st.set_option`. This PR also does so for `st.get_option`

## Testing Plan

- No testing required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
