### PR TITLE
Remove widget id in block.tsx so there is no duplicate stale widgets

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -197,7 +197,7 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
                 node: node as ElementNode,
               }
 
-              return <ElementNodeRenderer {...childProps} />
+              return <ElementNodeRenderer key={index} {...childProps} />
             }
 
             // Recursive case: render a block, which can contain other blocks

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -200,7 +200,7 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
                 node: node as ElementNode,
               }
 
-              const key = getElementWidgetID(node.element) || index
+              const key = index
               return <ElementNodeRenderer key={key} {...childProps} />
             }
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -26,10 +26,7 @@ import { useTheme } from "@emotion/react"
 import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
 import { BlockNode, AppNode, ElementNode } from "@streamlit/lib/src/AppNode"
-import {
-  getElementWidgetID,
-  notNullOrUndefined,
-} from "@streamlit/lib/src/util/utils"
+import { notNullOrUndefined } from "@streamlit/lib/src/util/utils"
 import { Form } from "@streamlit/lib/src/components/widgets/Form"
 import Tabs, { TabProps } from "@streamlit/lib/src/components/elements/Tabs"
 import Popover from "@streamlit/lib/src/components/elements/Popover"

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -197,8 +197,7 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
                 node: node as ElementNode,
               }
 
-              const key = index
-              return <ElementNodeRenderer key={key} {...childProps} />
+              return <ElementNodeRenderer {...childProps} />
             }
 
             // Recursive case: render a block, which can contain other blocks

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -567,7 +567,13 @@ const RawElementNodeRenderer = (
     case "dateInput": {
       const dateInputProto = node.element.dateInput as DateInputProto
       widgetProps.disabled = widgetProps.disabled || dateInputProto.disabled
-      return <DateInput element={dateInputProto} {...widgetProps} />
+      return (
+        <DateInput
+          key={dateInputProto.id}
+          element={dateInputProto}
+          {...widgetProps}
+        />
+      )
     }
 
     case "fileUploader": {

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -519,7 +519,6 @@ const RawElementNodeRenderer = (
       return (
         <DownloadButton
           endpoints={props.endpoints}
-          key={downloadButtonProto.id}
           element={downloadButtonProto}
           {...widgetProps}
         />
@@ -531,7 +530,6 @@ const RawElementNodeRenderer = (
       widgetProps.disabled = widgetProps.disabled || cameraInputProto.disabled
       return (
         <CameraInput
-          key={cameraInputProto.id}
           element={cameraInputProto}
           uploadClient={props.uploadClient}
           {...widgetProps}
@@ -542,37 +540,19 @@ const RawElementNodeRenderer = (
     case "chatInput": {
       const chatInputProto = node.element.chatInput as ChatInputProto
       widgetProps.disabled = widgetProps.disabled || chatInputProto.disabled
-      return (
-        <ChatInput
-          key={chatInputProto.id}
-          element={chatInputProto}
-          {...widgetProps}
-        />
-      )
+      return <ChatInput element={chatInputProto} {...widgetProps} />
     }
 
     case "checkbox": {
       const checkboxProto = node.element.checkbox as CheckboxProto
       widgetProps.disabled = widgetProps.disabled || checkboxProto.disabled
-      return (
-        <Checkbox
-          key={checkboxProto.id}
-          element={checkboxProto}
-          {...widgetProps}
-        />
-      )
+      return <Checkbox element={checkboxProto} {...widgetProps} />
     }
 
     case "colorPicker": {
       const colorPickerProto = node.element.colorPicker as ColorPickerProto
       widgetProps.disabled = widgetProps.disabled || colorPickerProto.disabled
-      return (
-        <ColorPicker
-          key={colorPickerProto.id}
-          element={colorPickerProto}
-          {...widgetProps}
-        />
-      )
+      return <ColorPicker element={colorPickerProto} {...widgetProps} />
     }
 
     case "componentInstance":
@@ -587,13 +567,7 @@ const RawElementNodeRenderer = (
     case "dateInput": {
       const dateInputProto = node.element.dateInput as DateInputProto
       widgetProps.disabled = widgetProps.disabled || dateInputProto.disabled
-      return (
-        <DateInput
-          key={dateInputProto.id}
-          element={dateInputProto}
-          {...widgetProps}
-        />
-      )
+      return <DateInput element={dateInputProto} {...widgetProps} />
     }
 
     case "fileUploader": {
@@ -601,7 +575,6 @@ const RawElementNodeRenderer = (
       widgetProps.disabled = widgetProps.disabled || fileUploaderProto.disabled
       return (
         <FileUploader
-          key={fileUploaderProto.id}
           element={fileUploaderProto}
           uploadClient={props.uploadClient}
           {...widgetProps}
@@ -618,89 +591,49 @@ const RawElementNodeRenderer = (
     case "multiselect": {
       const multiSelectProto = node.element.multiselect as MultiSelectProto
       widgetProps.disabled = widgetProps.disabled || multiSelectProto.disabled
-      return (
-        <Multiselect
-          key={multiSelectProto.id}
-          element={multiSelectProto}
-          {...widgetProps}
-        />
-      )
+      return <Multiselect element={multiSelectProto} {...widgetProps} />
     }
 
     case "numberInput": {
       const numberInputProto = node.element.numberInput as NumberInputProto
       widgetProps.disabled = widgetProps.disabled || numberInputProto.disabled
-      return (
-        <NumberInput
-          key={numberInputProto.id}
-          element={numberInputProto}
-          {...widgetProps}
-        />
-      )
+      return <NumberInput element={numberInputProto} {...widgetProps} />
     }
 
     case "radio": {
       const radioProto = node.element.radio as RadioProto
       widgetProps.disabled = widgetProps.disabled || radioProto.disabled
-      return (
-        <Radio key={radioProto.id} element={radioProto} {...widgetProps} />
-      )
+      return <Radio element={radioProto} {...widgetProps} />
     }
 
     case "selectbox": {
       const selectboxProto = node.element.selectbox as SelectboxProto
       widgetProps.disabled = widgetProps.disabled || selectboxProto.disabled
-      return (
-        <Selectbox
-          key={selectboxProto.id}
-          element={selectboxProto}
-          {...widgetProps}
-        />
-      )
+      return <Selectbox element={selectboxProto} {...widgetProps} />
     }
 
     case "slider": {
       const sliderProto = node.element.slider as SliderProto
       widgetProps.disabled = widgetProps.disabled || sliderProto.disabled
-      return (
-        <Slider key={sliderProto.id} element={sliderProto} {...widgetProps} />
-      )
+      return <Slider element={sliderProto} {...widgetProps} />
     }
 
     case "textArea": {
       const textAreaProto = node.element.textArea as TextAreaProto
       widgetProps.disabled = widgetProps.disabled || textAreaProto.disabled
-      return (
-        <TextArea
-          key={textAreaProto.id}
-          element={textAreaProto}
-          {...widgetProps}
-        />
-      )
+      return <TextArea element={textAreaProto} {...widgetProps} />
     }
 
     case "textInput": {
       const textInputProto = node.element.textInput as TextInputProto
       widgetProps.disabled = widgetProps.disabled || textInputProto.disabled
-      return (
-        <TextInput
-          key={textInputProto.id}
-          element={textInputProto}
-          {...widgetProps}
-        />
-      )
+      return <TextInput element={textInputProto} {...widgetProps} />
     }
 
     case "timeInput": {
       const timeInputProto = node.element.timeInput as TimeInputProto
       widgetProps.disabled = widgetProps.disabled || timeInputProto.disabled
-      return (
-        <TimeInput
-          key={timeInputProto.id}
-          element={timeInputProto}
-          {...widgetProps}
-        />
-      )
+      return <TimeInput element={timeInputProto} {...widgetProps} />
     }
 
     default:

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -567,13 +567,7 @@ const RawElementNodeRenderer = (
     case "dateInput": {
       const dateInputProto = node.element.dateInput as DateInputProto
       widgetProps.disabled = widgetProps.disabled || dateInputProto.disabled
-      return (
-        <DateInput
-          key={dateInputProto.id}
-          element={dateInputProto}
-          {...widgetProps}
-        />
-      )
+      return <DateInput element={dateInputProto} {...widgetProps} />
     }
 
     case "fileUploader": {


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- fixes #8360 by removing the widget id for the react key
- this also seems to fix resetting plotly widgets for selections
  - This would could fix some Altair and Plotly widgets bugs because Altair and Plotly components remain but it will rerender and toss a duplicate widgetId console error and not rerender properly
- the delta message to the frontend will add an element with the same widget ID as another element in the same BlockNode, causing a React "Encountered two children with the same key" error in the frontend
- Using index is an antipattern and shouldn't be used if new elements are inserted at the top so it seems like that's why we originally used the widget id
  - source: https://robinpokorny.com/blog/index-as-a-key-is-an-anti-pattern/

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
