### PR TITLE
Fix issues with fragments writing to containers and the sidebar

### DIFF
--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -85,7 +85,7 @@ def spinner(text: str = "In progress...", *, _cache: bool = False) -> Iterator[N
                 display_message = False
         with legacy_caching.suppress_cached_st_function_warning():
             with caching.suppress_cached_st_function_warning():
-                if "chat_message" in set(message._active_dg._parent_block_types):
+                if "chat_message" in set(message._active_dg._ancestor_block_types):
                     # Temporary stale element fix:
                     # For chat messages, we are resetting the spinner placeholder to an
                     # empty container instead of an empty placeholder (st.empty) to have

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -316,10 +316,10 @@ class ChatMixin:
         # Use bottom position if chat input is within the main container
         # either directly or within a vertical container. If it has any
         # other container types as parents, we use inline position.
-        parent_block_types = set(self.dg._active_dg._parent_block_types)
+        ancestor_block_types = set(self.dg._active_dg._ancestor_block_types)
         if (
             self.dg._active_dg._root_container == RootContainer.MAIN
-            and not parent_block_types
+            and not ancestor_block_types
         ):
             position = "bottom"
         else:

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -382,6 +382,25 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
         delta = self.get_delta_from_queue()
         self.assertEqual(delta.fragment_id, "my_fragment_id")
 
+    def test_enqueue_explodes_if_fragment_writes_to_sidebar(self):
+        ctx = get_script_run_ctx()
+        ctx.current_fragment_id = "my_fragment_id"
+        ctx.fragment_ids_this_run = {"my_fragment_id"}
+
+        exc = "is not supported"
+        with pytest.raises(StreamlitAPIException, match=exc):
+            delta_generator.sidebar_dg._enqueue("text", TextProto())
+
+    def test_enqueue_can_write_to_container_in_sidebar(self):
+        ctx = get_script_run_ctx()
+        ctx.current_fragment_id = "my_fragment_id"
+        ctx.fragment_ids_this_run = {"my_fragment_id"}
+
+        delta_generator.sidebar_dg.container().write("Hello world")
+
+        deltas = self.get_all_deltas_from_queue()
+        assert [d.fragment_id for d in deltas] == ["my_fragment_id", "my_fragment_id"]
+
 
 class DeltaGeneratorContainerTest(DeltaGeneratorTestCase):
     """Test DeltaGenerator Container."""


### PR DESCRIPTION
This PR fixes two related bugs that currently exist in the `@st.experimental_fragment` feature:
* Brings back the "append" behavior when writing to an external container from a fragment.
  * This was broken due to the logic for whether to clear stale elements not taking elements
      written to different containers into account.
* Disallow direct writes to `st.sidebar.*` within a fragment.
   * Ideally we'd want to handle this in the same way as general containers, but unfortunately the sidebar
      (like the main container) is handled specially throughout the codebase, so we just throw an exception
      when a developer tries to do this for now.