### PR TITLE
Fix unixodbc-dev dependency

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -39,7 +39,7 @@ runs:
         sudo apt update
         # protobuf, pyodbc, dot, & graphviz dependencies
         sudo apt install -y gnupg \
-            unixodbc-dev=2.3.9-5 \
+            unixodbc-dev=2.3.9-5ubuntu0.1 \
             graphviz \
             libgvc6 \
             protobuf-compiler

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -89,7 +89,7 @@ jobs:
           sudo apt update
           # protobuf, pyodbc, dot, & graphviz dependencies
           sudo apt install -y gnupg \
-              unixodbc-dev=2.3.9-5 \
+              unixodbc-dev=2.3.9-5ubuntu0.1 \
               graphviz \
               libgvc6 \
               protobuf-compiler


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

The [CI pipeline is broken](https://github.com/streamlit/streamlit/actions/runs/8541884100/job/23402271798?pr=8040) because it fails to install `unixodbc-dev`:
```
The following packages have unmet dependencies:
 unixodbc-dev : Depends: libodbc2 (= 2.3.9-5) but 2.3.9-5ubuntu0.1 is to be installed
                Depends: libodbccr2 (= 2.3.9-5) but 2.3.9-5ubuntu0.1 is to be installed
                Depends: libodbcinst2 (= 2.3.9-5) but 2.3.9-5ubuntu0.1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
