### PR TITLE
Fix usage of functional string

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -348,7 +348,7 @@ class DeltaGenerator(
                     message = (
                         f"Method `{name}()` does not exist for "
                         "`DeltaGenerator` objects. Did you mean "
-                        "`st.{name}()`?"
+                        f"`st.{name}()`?"
                     )
             else:
                 message = f"`{name}()` is not a valid Streamlit command."


### PR DESCRIPTION
## Describe your changes

Correctly use functional string for exception message. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
