### PR TITLE
Make check for component ready dynamic

### DIFF
--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -281,6 +281,7 @@ function ComponentInstance(props: Props): ReactElement {
     // Update the reference fields for the callback that we
     // passed to the componentRegistry
     onBackMsgRef.current = {
+      // isReady is a callback to ensure the caller receives the latest value
       isReady: () => isReadyRef.current,
       element,
       widgetMgr,

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -281,7 +281,7 @@ function ComponentInstance(props: Props): ReactElement {
     // Update the reference fields for the callback that we
     // passed to the componentRegistry
     onBackMsgRef.current = {
-      isReady: isReadyRef.current,
+      isReady: () => isReadyRef.current,
       element,
       widgetMgr,
       setComponentError,

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -62,7 +62,7 @@ describe("test componentUtils", () => {
       })
       ref = {
         current: {
-          isReady: true,
+          isReady: () => true,
           element,
           widgetMgr,
           setComponentError,
@@ -95,7 +95,7 @@ describe("test componentUtils", () => {
       })
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      ref.current!.isReady = false
+      ref.current!.isReady = () => false
       // when isReady = false, the callback should not be called
       iframeMessageHandler(ComponentMessageType.SET_FRAME_HEIGHT, {
         height: height,
@@ -113,7 +113,7 @@ describe("test componentUtils", () => {
       })
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      ref.current!.isReady = false
+      ref.current!.isReady = () => false
       // when isReady = false, the callback should not be called
       iframeMessageHandler(ComponentMessageType.SET_COMPONENT_VALUE, {
         value: jsonValue,

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -53,7 +53,7 @@ export type IframeMessage =
   | FrameHeightMessage
 
 export interface IframeMessageHandlerProps {
-  isReady: boolean
+  isReady: () => boolean
   element: ComponentInstanceProto
   widgetMgr: WidgetStateManager
   setComponentError: (error: Error) => void
@@ -99,7 +99,7 @@ export function createIframeMessageHandler(
     //  newest version whenever the callback is called without the need
     //  to register the callback to the outside
     const {
-      isReady,
+      isReady: readyCheck,
       element,
       widgetMgr,
       setComponentError,
@@ -107,6 +107,7 @@ export function createIframeMessageHandler(
       frameHeightCallback,
       fragmentId,
     } = callbacks.current
+    const isReady = readyCheck()
 
     switch (type) {
       case ComponentMessageType.COMPONENT_READY: {


### PR DESCRIPTION
## Describe your changes
From our issue, it seems that there's a race condition between our component being ready and our component sending us values. I believe this is a result of the fact that the event handler is not receiving the latest "ready state" by the time it receives the value. This change makes the ready state dynamic.

## GitHub Issue Link (if applicable)
Closes #8362

## Testing Plan

I think this would be difficult to test outside of manual testing. We could perhaps construct some large-scale unit test that simulates the race condition reliably, but I imagine the effort is not worth the benefit here (especially since this seems to impact Safari). We can supply a wheel file to developers to try out and confirm.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
