### PR TITLE
Fix Double Clicking Behavior to maintain correct Altair state

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -57,7 +57,7 @@ chart_interval = base.add_params(interval)
 
 st.subheader("Scatter chart with selection_interval")
 st.altair_chart(chart_interval, on_select="rerun", key="scatter_interval")
-if st.session_state.scatter_interval:
+if st.session_state.scatter_interval and len(st.session_state.scatter_interval) > 0:
     st.dataframe(st.session_state.scatter_interval)
 
 # BAR CHART

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -138,3 +138,26 @@ def test_shift_click_point_selection_scatter_chart_displays_dataframe(
 
     expect(themed_app.get_by_test_id("stDataFrame")).to_have_count(1)
     assert_snapshot(chart, name="st_altair_chart-scatter_double_selection_greyed")
+
+
+def test_double_click_interval_shows_no_dataframe(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    chart = app.get_by_test_id("stArrowVegaLiteChart").nth(1)
+    chart.scroll_into_view_if_needed()
+    expect(chart).to_be_visible()
+    chart.hover()
+    app.mouse.move(450, 450)
+    app.mouse.down()
+    app.mouse.move(550, 550)
+    app.mouse.up()
+    wait_for_app_run(app, wait_delay=3000)
+
+    expect(app.get_by_test_id("stDataFrame")).to_have_count(1)
+    chart.hover()
+    app.mouse.dblclick(500, 500)
+    wait_for_app_run(app, wait_delay=3000)
+    expect(app.get_by_test_id("stDataFrame")).to_have_count(0)
+    assert_snapshot(
+        chart, name="st_altair_chart-double_click_scatter_chart_no_interval"
+    )

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -158,6 +158,3 @@ def test_double_click_interval_shows_no_dataframe(
     app.mouse.dblclick(500, 500)
     wait_for_app_run(app, wait_delay=3000)
     expect(app.get_by_test_id("stDataFrame")).to_have_count(0)
-    assert_snapshot(
-        chart, name="st_altair_chart-double_click_scatter_chart_no_interval"
-    )

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -487,6 +487,19 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
         )
       })
 
+      const reset = () => {
+        this.setState({
+          selections: {},
+        })
+        this.props.widgetMgr?.setJsonValue(
+          this.props.element as WidgetInfo,
+          {},
+          {
+            fromUi: true,
+          }
+        )
+      }
+
       const resetGraph = debounce(150, (event: ScenegraphEvent) => {
         // no datum means click was not on a useful location https://stackoverflow.com/a/61782407
         try {
@@ -497,16 +510,7 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
             !event.item.datum &&
             Object.keys(this.state.selections).length > 0
           ) {
-            this.setState({
-              selections: {},
-            })
-            this.props.widgetMgr?.setJsonValue(
-              this.props.element as WidgetInfo,
-              {},
-              {
-                fromUi: true,
-              }
-            )
+            reset()
           }
         } catch (e) {
           logMessage(e)
@@ -516,16 +520,7 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       const doubleClickResetGraph = debounce(150, () => {
         try {
           if (Object.keys(this.state.selections).length > 0) {
-            this.setState({
-              selections: {},
-            })
-            this.props.widgetMgr?.setJsonValue(
-              this.props.element as WidgetInfo,
-              {},
-              {
-                fromUi: true,
-              }
-            )
+            reset()
           }
         } catch (e) {
           logMessage(e)

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -487,7 +487,7 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
         )
       })
 
-      const reset = () => {
+      const reset = (): void => {
         this.setState({
           selections: {},
         })

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -491,9 +491,10 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
         // no datum means click was not on a useful location https://stackoverflow.com/a/61782407
         try {
           console.log(event)
-          // @ts-expect-error
           if (
+            // @ts-expect-error
             !event.item ||
+            // @ts-expect-error
             (!event.item.datum &&
               Object.keys(this.state.selections).length > 0)
           ) {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -490,12 +490,12 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       const resetGraph = debounce(150, (event: ScenegraphEvent) => {
         // no datum means click was not on a useful location https://stackoverflow.com/a/61782407
         try {
+          // TODO(willhuang1997): Figure out how to resend empty dict when clicking out of interval
+          // Problem with doing so is that doing an interval itself is a click event and thus this function will run
           if (
             // @ts-expect-error
-            !event.item ||
-            // @ts-expect-error
-            (!event.item.datum &&
-              Object.keys(this.state.selections).length > 0)
+            !event.item.datum &&
+            Object.keys(this.state.selections).length > 0
           ) {
             this.setState({
               selections: {},
@@ -513,10 +513,9 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
         }
       })
 
-      const doubleClickResetGraph = debounce(150, (event: ScenegraphEvent) => {
+      const doubleClickResetGraph = debounce(150, () => {
         try {
-          // @ts-expect-error
-          if (!event.item && Object.keys(this.state.selections).length > 0) {
+          if (Object.keys(this.state.selections).length > 0) {
             this.setState({
               selections: {},
             })

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -532,7 +532,6 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       })
 
       view.addEventListener("dblclick", event => {
-        console.log(event)
         doubleClickResetGraph(event)
       })
     }

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -490,8 +490,33 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       const resetGraph = debounce(150, (event: ScenegraphEvent) => {
         // no datum means click was not on a useful location https://stackoverflow.com/a/61782407
         try {
+          console.log(event)
           // @ts-expect-error
-          if (!event.item.datum) {
+          if (
+            !event.item ||
+            (!event.item.datum &&
+              Object.keys(this.state.selections).length > 0)
+          ) {
+            this.setState({
+              selections: {},
+            })
+            this.props.widgetMgr?.setJsonValue(
+              this.props.element as WidgetInfo,
+              {},
+              {
+                fromUi: true,
+              }
+            )
+          }
+        } catch (e) {
+          logMessage(e)
+        }
+      })
+
+      const doubleClickResetGraph = debounce(150, (event: ScenegraphEvent) => {
+        try {
+          // @ts-expect-error
+          if (!event.item && Object.keys(this.state.selections).length > 0) {
             this.setState({
               selections: {},
             })
@@ -510,6 +535,11 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
 
       view.addEventListener("click", event => {
         resetGraph(event)
+      })
+
+      view.addEventListener("dblclick", event => {
+        console.log(event)
+        doubleClickResetGraph(event)
       })
     }
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -490,7 +490,6 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       const resetGraph = debounce(150, (event: ScenegraphEvent) => {
         // no datum means click was not on a useful location https://stackoverflow.com/a/61782407
         try {
-          console.log(event)
           if (
             // @ts-expect-error
             !event.item ||

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -14,9 +14,6 @@ setuptools>=65.5.1
 watchdog>=2.1.5
 urllib3>=1.9
 
-# needed for selection_interval / selection_point api
-altair>=5
-
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -14,6 +14,9 @@ setuptools>=65.5.1
 watchdog>=2.1.5
 urllib3>=1.9
 
+# needed for selection_interval / selection_point api
+altair>=5
+
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- add a double click method to reset
- do not rerun if there is no selection and there is no item
- Tried adding: rerun when clicking outside of interval but it looks like that breaks current functionality because doing an interval is a click and then that will return nothing.
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
