### PR TITLE
Change proto size field type to uint64 to allow large files (>4gb)

### DIFF
--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -79,7 +79,7 @@ message UploadedFileInfo {
   string name = 2;
 
   // The size of this file in bytes.
-  uint32 size = 3;
+  uint64 size = 3;
 
   // ID that can be used to retrieve a file.
   string file_id = 4;


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

The reported issue is caused by the field's type that cannot hold big enough integers.

Based on the [protobuf doc](https://protobuf.dev/programming-guides/proto3/), the types a compatible to each other, so we consider this to be a non-breaking change:
> int32, uint32, int64, uint64, and bool are all compatible – this means you can change a field from one of these types to another without breaking forwards- or backwards-compatibility. If a number is parsed from the wire which doesn’t fit in the corresponding type, you will get the same effect as if you had cast the number to that type in C++ (for example, if a 64-bit number is read as an int32, it will be truncated to 32 bits).

It seems like the field is still used by the `FileUploader`, which is why we change the type instead of removing / deprecating the field completely.


## GitHub Issue Link (if applicable)
Closes #5938

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
