### PR TITLE
Add element state support to widget manager

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -676,6 +676,47 @@ describe("Widget State Manager", () => {
       )
     })
   })
+
+  it("manages element state values", () => {
+    widgetMgr.setElementState("elementId", "elementStateValue")
+    expect(widgetMgr.getElementState("elementId")).toBe("elementStateValue")
+    widgetMgr.deleteElementState("elementId")
+    expect(widgetMgr.getElementState("elementId")).toBeUndefined()
+  })
+
+  it("cleans up widget & element states on removeInactive", () => {
+    const widgetId1 = "TEST_ID_1"
+    const widgetId2 = "TEST_ID_2"
+    const widgetId3 = "TEST_ID_3"
+    const widgetId4 = "TEST_ID_4"
+    const elementId1 = "TEST_ID_5"
+    const elementId2 = "TEST_ID_6"
+    widgetMgr.setStringValue({ id: widgetId1 }, "widgetState1", {
+      fromUi: false,
+    })
+    widgetMgr.setStringValue({ id: widgetId3 }, "widgetState2", {
+      fromUi: false,
+    })
+    widgetMgr.setStringValue({ id: widgetId2 }, "widgetState3", {
+      fromUi: false,
+    })
+    widgetMgr.setStringValue({ id: widgetId4 }, "widgetState4", {
+      fromUi: false,
+    })
+
+    widgetMgr.setElementState(elementId1, "elementState1")
+    widgetMgr.setElementState(elementId2, "elementState2")
+
+    const activeIds = new Set([widgetId3, widgetId4, elementId2])
+    widgetMgr.removeInactive(activeIds)
+
+    expect(widgetMgr.getStringValue({ id: widgetId1 })).toBeUndefined()
+    expect(widgetMgr.getStringValue({ id: widgetId2 })).toBeUndefined()
+    expect(widgetMgr.getStringValue({ id: widgetId3 })).toEqual("widgetState3")
+    expect(widgetMgr.getStringValue({ id: widgetId4 })).toEqual("widgetState4")
+    expect(widgetMgr.getElementState(elementId1)).toBeUndefined()
+    expect(widgetMgr.getElementState(elementId2)).toEqual("elementState2")
+  })
 })
 
 describe("WidgetStateDict", () => {

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -694,10 +694,10 @@ describe("Widget State Manager", () => {
     widgetMgr.setStringValue({ id: widgetId1 }, "widgetState1", {
       fromUi: false,
     })
-    widgetMgr.setStringValue({ id: widgetId3 }, "widgetState2", {
+    widgetMgr.setStringValue({ id: widgetId2 }, "widgetState2", {
       fromUi: false,
     })
-    widgetMgr.setStringValue({ id: widgetId2 }, "widgetState3", {
+    widgetMgr.setStringValue({ id: widgetId3 }, "widgetState3", {
       fromUi: false,
     })
     widgetMgr.setStringValue({ id: widgetId4 }, "widgetState4", {

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -175,6 +175,11 @@ export class WidgetStateManager {
   // Internal state for each form we're managing.
   private readonly forms = new Map<string, FormState>()
 
+  // A dictionary that maps elementId -> element state value.
+  // This is used to store frontend-only state for elements.
+  // This state is not never sent to the server.
+  private readonly elementStates = new Map<string, any>()
+
   // External data about all forms.
   private formsData: FormsData
 
@@ -586,6 +591,12 @@ export class WidgetStateManager {
   public removeInactive(activeIds: Set<string>): void {
     this.widgetStates.removeInactive(activeIds)
     this.forms.forEach(form => form.widgetStates.removeInactive(activeIds))
+
+    this.elementStates.forEach((value, key) => {
+      if (!activeIds.has(key)) {
+        this.deleteElementState(key)
+      }
+    })
   }
 
   /**
@@ -708,6 +719,35 @@ export class WidgetStateManager {
       this.formsData = newData
       this.props.formsDataChanged(this.formsData)
     }
+  }
+
+  /**
+   * Get the element state value for the given element ID, if it exists.
+   * This is a frontend-only state that is never sent to the server.
+   */
+  public getElementState(elementId: string): any {
+    return this.elementStates.get(elementId)
+  }
+
+  /**
+   * Sets the state of an element identified by its ID.
+   * This is a frontend-only state that is never sent to the server.
+   * It can be used to store element state to restore the state
+   * of an element in situations where an element is removed and re-added.
+   *
+   * @param {string} elementId - The unique identifier of the element.
+   * @param {any} value - The value to set for the element's state.
+   * @returns {void}
+   */
+  public setElementState(elementId: string, value: any): void {
+    this.elementStates.set(elementId, value)
+  }
+
+  /**
+   * Remove the element state associated with a given element ID.
+   */
+  public deleteElementState(elementId: string): void {
+    this.elementStates.delete(elementId)
   }
 }
 


### PR DESCRIPTION
## Describe your changes

This PR adds support for storing frontend element state. This allows elements to store some state and restore the state again in situations where the element component gets removed & re-added. One situation where this happens is if a new element is added above another element, which changes the delta path of all the following elements. We currently have this restoring logic for all widgets, but will also need it in some situations for non-widget elements. 

We also should eventually refactor the `WidgetStateManager` to a more generic `ElementStateManger`, which makes it more obvious that this can be used for frontend-only state as well as state that is synced between frontend and backend. I added a tech debt item for this [here](https://www.notion.so/snowflake-corp/Refactor-the-WidgetStateManager-to-make-it-more-generic-419887cdb68b472d8f0e7ffb6f6b0597). 


## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
