### PR TITLE
Update Auto Theme after print dialog if necessary

### DIFF
--- a/frontend/app/src/util/useThemeManager.ts
+++ b/frontend/app/src/util/useThemeManager.ts
@@ -96,7 +96,13 @@ export function useThemeManager(): [ThemeManager, object[]] {
   useEffect(() => {
     const mediaMatch = window.matchMedia("(prefers-color-scheme: dark)")
     mediaMatch.addEventListener("change", updateAutoTheme)
-    return () => mediaMatch.removeEventListener("change", updateAutoTheme)
+    // Browsers do not revert back to a dark theme after printing, so we
+    // should check and update the theme after printing if necessary.
+    window.addEventListener("afterprint", updateAutoTheme)
+    return () => {
+      mediaMatch.removeEventListener("change", updateAutoTheme)
+      window.removeEventListener("afterprint", updateAutoTheme)
+    }
   }, [theme, availableThemes, updateAutoTheme])
 
   return [


### PR DESCRIPTION
## Describe your changes
In some browsers (Chrome), the print action triggers the UI to move to light mode to printing (a good idea). It however does not allow the UI to trigger it back to dark mode after printing. This change will ensures a change back to dark mode happen after printing.

## GitHub Issue Link (if applicable)
Closes #7879 

## Testing Plan

- Unfortunately, it's hard to test via print dialog on unit and e2e tests See https://github.com/microsoft/playwright/issues/6543 It also seems to be tied to specific browsers, so I think there isn't much we can test here outside of manual testing.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
