### PR TITLE
Add BlueOak to acceptable licenses

### DIFF
--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -40,6 +40,7 @@ ACCEPTABLE_LICENSES = {
     "Apache-2.0",  # https://opensource.org/licenses/Apache-2.0
     "Apache-2.0 WITH LLVM-exception",  # https://spdx.org/licenses/LLVM-exception.html
     "0BSD",  # https://opensource.org/licenses/0BSD
+    "BlueOak-1.0.0", # https://blueoakcouncil.org/license/1.0.0
     "BSD-2-Clause",  # https://opensource.org/licenses/BSD-2-Clause
     "BSD-3-Clause",  # https://opensource.org/licenses/BSD-3-Clause
     "ISC",  # https://opensource.org/licenses/ISC

--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -40,7 +40,7 @@ ACCEPTABLE_LICENSES = {
     "Apache-2.0",  # https://opensource.org/licenses/Apache-2.0
     "Apache-2.0 WITH LLVM-exception",  # https://spdx.org/licenses/LLVM-exception.html
     "0BSD",  # https://opensource.org/licenses/0BSD
-    "BlueOak-1.0.0", # https://blueoakcouncil.org/license/1.0.0
+    "BlueOak-1.0.0",  # https://blueoakcouncil.org/license/1.0.0
     "BSD-2-Clause",  # https://opensource.org/licenses/BSD-2-Clause
     "BSD-3-Clause",  # https://opensource.org/licenses/BSD-3-Clause
     "ISC",  # https://opensource.org/licenses/ISC


### PR DESCRIPTION
## Describe your changes

Our licenses check is failing because one of the frontend dependencies changed the license to `BlueOak`.  We already checked this with legal a couple of weeks ago and its fine to add this to the acceptable licenses. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
