### PR TITLE
Enable configuring the __webpack_public_path__

### DIFF
--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// NOTE: The following line needs to be the first import to ensure that we
+// correctly configure where chunked static assets are fetched from.
+import "./setWebpackPublicPath"
+
 import React from "react"
 import ReactDOM from "react-dom"
 

--- a/frontend/app/src/setWebpackPublicPath.ts
+++ b/frontend/app/src/setWebpackPublicPath.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// If __WEBPACK_PUBLIC_PATH_OVERRIDE is set, fetches of chunked static assets
+// will have their request base paths set to this value. For example, if
+// __WEBPACK_PUBLIC_PATH_OVERRIDE="https://example.com/", we'll attempt to
+// fetch someJavascriptCode.chunk.js from https://example.com/someJavascriptCode.chunk.js
+// Of course, we'll need to rework this if we ever decide to move away from
+// webpack.
+const webpackPublicPath: string | undefined = (window as any)
+  .__WEBPACK_PUBLIC_PATH_OVERRIDE
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+declare let __webpack_public_path__: string | undefined
+
+if (webpackPublicPath) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  __webpack_public_path__ = webpackPublicPath
+}
+
+export {}


### PR DESCRIPTION
In some deployment environments, we need to be able to configure where chunked static assets get
loaded from dynamially. In apps built by webpack, this can be done by setting `__webpack_public_path__`
early during app initialization. We let this be configured by a given deployment environment by
setting the webpack variable to whatever `window.__WEBPACK_PUBLIC_PATH_OVERRIDE` is set to
(if truthy).

Note that, due to how variables are scoped, the value of `__webpack_public_path__` can't be directly set
via script tags in our `index.html`, which is why we have to use the intermediary variable to set the one
used by webpack within code served in our JS bundle.