### PR TITLE
Use `cache_data` instead of `memo` decorator name

### DIFF
--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -120,10 +120,10 @@ cache keys act as one true cache key, just split up because the second part depe
 on the first.
 
 We need to treat widgets as implicit arguments of the cached function, because
-the behavior of the function, inluding what elements are created and what it
+the behavior of the function, including what elements are created and what it
 returns, can be and usually will be influenced by the values of those widgets.
 For example:
-> @st.memo
+> @st.cache_data
 > def example_fn(x):
 >     y = x + 1
 >     if st.checkbox("hi"):
@@ -379,7 +379,7 @@ class CachedMessageReplayContext(threading.local):
         dg: DeltaGenerator,
         st_func_name: str,
     ) -> None:
-        """If appropriate, warn about calling st.foo inside @memo.
+        """If appropriate, warn about calling st.foo inside @st.cache_data.
 
         DeltaGenerator's @_with_element and @_widget wrappers use this to warn
         the user when they're calling st.foo() from within a function that is


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Use `cache_data` instead of `memo` decorator name in cached_message_replay docstrings

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
