### PR TITLE
Switch back to using undeprecated pillow constant

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -296,9 +296,11 @@ def _ensure_image_size_and_format(
     if width > 0 and actual_width > width:
         # We need to resize the image.
         new_height = int(1.0 * actual_height * width / actual_width)
-        pil_image = pil_image.resize(
-            (width, new_height), resample=Image.Resampling.BILINEAR
-        )
+        # pillow reexports Image.Resampling.BILINEAR as Image.BILINEAR for backwards
+        # compatibility reasons, so we use the reexport to support older pillow
+        # versions. The types don't seem to reflect this, though, hence the type: ignore
+        # below.
+        pil_image = pil_image.resize((width, new_height), resample=Image.BILINEAR)  # type: ignore[attr-defined]
         return _PIL_to_bytes(pil_image, format=image_format, quality=90)
 
     if pil_image.format != image_format:


### PR DESCRIPTION
It turns out we're not actually supporting some of the versions of `pillow` that we say we do
because we use a constant that was first defined in version 9.1.0 in `st.image`. This const was
actually undeprecated before it was actually removed in [9.4.0](https://pillow.readthedocs.io/en/stable/releasenotes/9.4.0.html#restored-image-constants), so we can safely switch back to it
and un-break older `pillow` versions.

Closes #8486