### PR TITLE
Fix double script/callback run when replacing a file

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -301,6 +301,9 @@ describe("FileUploader widget tests", () => {
     expect(fileDropZoneInput.files?.[0]).toEqual(firstFile)
 
     expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(1)
+    // setFileUploaderStateValue should have been called once on init and once
+    // when the file was uploaded.
+    expect(props.widgetMgr.setFileUploaderStateValue).toHaveBeenCalledTimes(2)
 
     const secondFile = new File(["Another text in a file"], "filename2.txt", {
       type: "text/plain",
@@ -315,6 +318,9 @@ describe("FileUploader widget tests", () => {
     expect(currentFiles[0].textContent).toContain("filename2.txt")
     expect(fileDropZoneInput.files?.[0]).toEqual(secondFile)
     expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
+    // setFileUploaderStateValue should have been called once on init and
+    // once each for the first and second file uploads.
+    expect(props.widgetMgr.setFileUploaderStateValue).toHaveBeenCalledTimes(3)
   })
 
   it("uploads multiple files, even if some have errors", async () => {

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -79,6 +79,17 @@ class FileUploader extends React.PureComponent<Props, State> {
    */
   private localFileIdCounter = 1
 
+  /**
+   * A flag to handle the case where a file uploader that only accepts one file
+   * at a time has its file replaced, which we want to treat as a single change
+   * rather than the deletion of a file followed by the upload of another.
+   * Doing this ensures that the script (and thus callbacks, etc) is only run a
+   * single time when replacing a file.  Note that deleting a file and uploading
+   * a new one with two interactions (clicking the 'X', then dragging a file
+   * into the file uploader) will still cause the script to execute twice.
+   */
+  private forceUpdatingStatus = false
+
   public constructor(props: Props) {
     super(props)
     this.state = this.initialValue
@@ -137,7 +148,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
     // If any of our files is Uploading or Deleting, then we're currently
     // updating.
-    if (this.state.files.some(isFileUpdating)) {
+    if (this.state.files.some(isFileUpdating) || this.forceUpdatingStatus) {
       return "updating"
     }
 
@@ -255,7 +266,9 @@ class FileUploader extends React.PureComponent<Props, State> {
             f => f.status.type !== "error"
           )
           if (existingFile) {
+            this.forceUpdatingStatus = true
             this.deleteFile(existingFile.id)
+            this.forceUpdatingStatus = false
           }
         }
 


### PR DESCRIPTION
There's already a thorough description of the problem and its root cause in the associated issue, so
we don't duplicate it in this PR. The fix for this issue was to maintain a state variable keeping track
of whether we're in the process of replacing a file in the code path where the file uploader only allows
for a single file upload. The state is used to set the file uploader's status to "updating" while in
the process of replacing a file, which ensures that we don't double-trigger a script run. 

Closes #4877