### PR TITLE
Add hint when add rows is used on vega lite chart

### DIFF
--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -197,6 +197,7 @@ export class ElementNode implements AppNode {
       datasets: modifiedDatasets,
       useContainerWidth: proto.useContainerWidth,
       vegaLiteTheme: proto.theme,
+      needsAddRows: proto.needsAddRows,
     }
 
     this.lazyVegaLiteChartElement = toReturn
@@ -319,6 +320,8 @@ export class ElementNode implements AppNode {
           ? draft.data.addRows(newDataSetQuiver)
           : newDataSetQuiver
       }
+
+      draft.needsAddRows = true
     })
   }
 }

--- a/lib/streamlit/elements/arrow_vega_lite.py
+++ b/lib/streamlit/elements/arrow_vega_lite.py
@@ -190,6 +190,8 @@ def marshall(
     if data is not None:
         arrow.marshall(proto.data, data)
 
+    proto.needs_add_rows = False
+
 
 # See https://vega.github.io/vega-lite/docs/encoding.html
 _CHANNELS = {

--- a/proto/streamlit/proto/ArrowVegaLiteChart.proto
+++ b/proto/streamlit/proto/ArrowVegaLiteChart.proto
@@ -40,5 +40,7 @@ message ArrowVegaLiteChart {
   // override the properties with a theme. Currently, only "streamlit" or None are accepted.
   string theme = 6;
 
+  bool needs_add_rows = 7;
+
   reserved 3;
 }


### PR DESCRIPTION
## Describe your changes

We have a lightweight check that's supposed to detect whether the data is a subset of the original data that checks the first and last value of the set, which creates some less than intended consequences (see issue). This change essentially handles the two use cases:

1. Disregard the check when a graph is changing.
2. Allow the use case for add rows to successfully add rows if necessary.

We fix this by adding an add_rows hint that we set only on the frontend. We use the hint to do the lightweight check and update the data.

**This needs more testing** but it looks like the unintended consequences include the fact that rerenders of the graph with superset data (not via `add_rows`) will rerender the whole graph (which feels fine).

## GitHub Issue Link (if applicable)
Closes #6689

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
