### PR TITLE
Fix escaping in docstrings

### DIFF
--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -532,8 +532,8 @@ def LinkColumn(
         * A string that is displayed in every cell, e.g. ``"Open link"``.
 
         * A regular expression (JS flavor, detected by usage of parentheses)
-          to extract a part of the URL via a capture group, e.g. ``"https://(.*?)\.example\.com"``
-          to extract the display text "foo" from the URL "\https://foo.example.com".
+          to extract a part of the URL via a capture group, e.g. ``"https://(.*?)\\.example\\.com"``
+          to extract the display text "foo" from the URL "https://foo.example.com".
 
         For more complex cases, you may use `Pandas Styler's format \
         <https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.format.html>`_

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -438,7 +438,7 @@ class ButtonMixin:
         disabled: bool = False,
         use_container_width: bool | None = None,
     ) -> DeltaGenerator:
-        """Display a link to another page in a multipage app or to an external page.
+        r"""Display a link to another page in a multipage app or to an external page.
 
         If another page in a multipage app is specified, clicking ``st.page_link``
         stops the current page execution and runs the specified page as if the


### PR DESCRIPTION
#8501 pointed out that `pytest` is complaining that we have invalid escape sequences in some docstrings.
This seems to have happened because we forgot to make one docstring a raw string (like the others in the
file) and because of some typos.

This ended up slipping by CI because they only appear as `DeprecationWarning`s, but more strict
`pytest` settings may cause them to appear as full errors.

Closes #8501