### PR TITLE
resolve path in get_module_paths

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -166,7 +166,7 @@ class LocalSourcesWatcher:
         for name, paths in module_paths.items():
             for path in paths:
                 if self._file_should_be_watched(path):
-                    self._register_watcher(str(Path(path).resolve()), name)
+                    self._register_watcher(path, name)
 
     def _exclude_blacklisted_paths(self, paths: set[str]) -> set[str]:
         return {p for p in paths if not self._folder_black_list.is_blacklisted(p)}
@@ -208,7 +208,7 @@ def get_module_paths(module: types.ModuleType) -> set[str]:
             _LOGGER.warning(f"Examining the path of {module.__name__} raised: {e}")
 
         all_paths.update(
-            [os.path.abspath(str(p)) for p in potential_paths if _is_valid_path(p)]
+            [str(Path(p).resolve()) for p in potential_paths if _is_valid_path(p)]
         )
     return all_paths
 


### PR DESCRIPTION
A continuation of https://github.com/streamlit/streamlit/pull/8372/files.

This is to avoid symlink like

```
/home/dev/.cache/bazel/_bazel_dev/b31cb3692daef370d4f0f88865fc052b/execroot/__main__/bazel-out/k8-fastbuild/bin/foo/bar.py
```

from being excluded by `_exclude_blacklisted_paths` in 

https://github.com/streamlit/streamlit/blob/f75ca3a19ad0ae975611e3671137a3661053098e/lib/streamlit/watcher/local_sources_watcher.py#L159

due to existence of `.cache` in the path since the `DEFAULT_FOLDER_BLACKLIST` has `"**/.*"` (https://github.com/streamlit/streamlit/blob/f75ca3a19ad0ae975611e3671137a3661053098e/lib/streamlit/folder_black_list.py#L22-L36).

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
