### PR TITLE
Adjust default date for st.date_input if today's date is out of bounds

### DIFF
--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -21,6 +21,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
+    List,
     Literal,
     Sequence,
     Tuple,
@@ -78,7 +79,6 @@ def _parse_date_value(
     if value == "today":
         parsed_dates = [datetime.now().date()]
     elif value == "default_value_today":
-        # Set value default.
         parsed_dates = [datetime.now().date()]
     elif isinstance(value, datetime):
         parsed_dates = [value.date()]
@@ -158,17 +158,27 @@ class _DateInputValues:
         max_value: SingleDateValue,
     ) -> _DateInputValues:
         parsed_value, is_range = _parse_date_value(value=value)
+        parsed_min = _parse_min_date(
+            min_value=min_value,
+            parsed_dates=parsed_value,
+        )
+        parsed_max = _parse_max_date(
+            max_value=max_value,
+            parsed_dates=parsed_value,
+        )
+
+        if value == "default_value_today":
+            v = cast(List[date], parsed_value)[0]
+            if v < parsed_min:
+                parsed_value = [parsed_min]
+            if v > parsed_max:
+                parsed_value = [parsed_max]
+
         return cls(
             value=parsed_value,
             is_range=is_range,
-            min=_parse_min_date(
-                min_value=min_value,
-                parsed_dates=parsed_value,
-            ),
-            max=_parse_max_date(
-                max_value=max_value,
-                parsed_dates=parsed_value,
-            ),
+            min=parsed_min,
+            max=parsed_max,
         )
 
     def __post_init__(self) -> None:

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -171,6 +171,20 @@ class DateInputTest(DeltaGeneratorTestCase):
     def test_value_in_range(self, value, min_date, max_date):
         st.date_input("the label", value=value, min_value=min_date, max_value=max_date)
 
+    def test_default_min_if_today_is_before_min(self):
+        min_date = date(9998, 2, 28)
+        st.date_input("the label", min_value=min_date, max_value=date(9999, 2, 28))
+
+        c = self.get_delta_from_queue().new_element.date_input
+        assert datetime.strptime(c.default[0], "%Y/%m/%d").date() == min_date
+
+    def test_default_max_if_today_is_after_min(self):
+        max_date = date(1001, 2, 28)
+        st.date_input("the label", min_value=date(1000, 2, 28), max_value=max_date)
+
+        c = self.get_delta_from_queue().new_element.date_input
+        assert datetime.strptime(c.default[0], "%Y/%m/%d").date() == max_date
+
     def test_range_session_state(self):
         """Test a range set by session state."""
         date_range_input = [date(2024, 1, 15), date(2024, 1, 15) + timedelta(2)]


### PR DESCRIPTION
The core issue with #6167 seems to not be the session state warning, but instead that we try
to set the default value of the `st.date_input` widget to today's date even if that date is not
within the specified min/max date interval.

This PR fixes this by setting the default to either the min or max date if today's date is out of
bounds.

Closes #6167