### PR TITLE
Handle setting session state keys to None for supported widgets

### DIFF
--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -36,6 +36,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.runtime.state.common import compute_widget_id
@@ -319,6 +320,10 @@ class NumberInputMixin:
                 f"\n`max_value` has {type(max_value).__name__} type."
                 f"\n`step` has {type(step).__name__} type."
             )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            value = None
 
         if value == "min":
             if min_value is not None:

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -33,6 +33,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.runtime.state.common import compute_widget_id, save_for_app_testing
@@ -288,6 +289,10 @@ class RadioMixin:
                 raise StreamlitAPIException(
                     f"Radio captions must be strings. Passed type: {type(caption).__name__}"
                 )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            index = None
 
         radio_proto = RadioProto()
         radio_proto.id = id

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -32,6 +32,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.runtime.state.common import compute_widget_id, save_for_app_testing
@@ -259,6 +260,10 @@ class SelectboxMixin:
             raise StreamlitAPIException(
                 "Selectbox index must be between 0 and length of options"
             )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            index = None
 
         selectbox_proto = SelectboxProto()
         selectbox_proto.id = id

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -33,6 +33,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.runtime.state.common import compute_widget_id
@@ -276,6 +277,10 @@ class TextWidgetsMixin:
             form_id=current_form_id(self.dg),
             page=ctx.page_script_hash if ctx else None,
         )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            value = None
 
         text_input_proto = TextInputProto()
         text_input_proto.id = id
@@ -535,6 +540,10 @@ class TextWidgetsMixin:
             form_id=current_form_id(self.dg),
             page=ctx.page_script_hash if ctx else None,
         )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            value = None
 
         text_area_proto = TextAreaProto()
         text_area_proto.id = id

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -447,6 +447,10 @@ class TimeWidgetsMixin:
         )
         del value
 
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            parsed_time = None
+
         time_input_proto = TimeInputProto()
         time_input_proto.id = id
         time_input_proto.label = label

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -293,3 +293,18 @@ def test_date_input_interaction():
     at = date_input.set_value(None).run()
     date_input = at.date_input[0]
     assert date_input.value is None
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "date_input" not in st.session_state:
+            st.session_state["date_input"] = None
+
+        st.date_input("date_input", key="date_input")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.date_input[0].value is None

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -397,3 +397,18 @@ def test_number_input_interaction():
     at = number_input.set_value(None).run()
     number_input = at.number_input[0]
     assert number_input.value is None
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "number_input" not in st.session_state:
+            st.session_state["number_input"] = None
+
+        st.number_input("number_input", key="number_input")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.number_input[0].value is None

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -307,3 +307,18 @@ def test_radio_enum_coercion():
     with patch_config_options({"runner.enumCoercion": "off"}):
         with pytest.raises(AssertionError):
             test_enum()  # expect a failure with the config value off.
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "radio" not in st.session_state:
+            st.session_state["radio"] = None
+
+        st.radio("radio", ["a", "b", "c"], key="radio")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.radio[0].value is None

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -259,3 +259,18 @@ def test_selectbox_enum_coercion():
     with patch_config_options({"runner.enumCoercion": "off"}):
         with pytest.raises(AssertionError):
             test_enum()  # expect a failure with the config value off.
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "selectbox" not in st.session_state:
+            st.session_state["selectbox"] = None
+
+        st.selectbox("selectbox", ["a", "b", "c"], key="selectbox")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.selectbox[0].value is None

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -201,3 +201,18 @@ def test_text_input_interaction():
     at = text_area.set_value(None).run()
     text_area = at.text_area[0]
     assert text_area.value is None
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "text_area" not in st.session_state:
+            st.session_state["text_area"] = None
+
+        st.text_area("text_area", key="text_area")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.text_area[0].value is None

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -208,3 +208,18 @@ def test_text_input_interaction():
     at = text_input.set_value(None).run()
     text_input = at.text_input[0]
     assert text_input.value is None
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "text_input" not in st.session_state:
+            st.session_state["text_input"] = None
+
+        st.text_input("text_input", key="text_input")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.text_input[0].value is None

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -133,3 +133,18 @@ def test_time_input_interaction():
     at = time_input.set_value(None).run()
     time_input = at.time_input[0]
     assert time_input.value is None
+
+
+def test_None_session_state_value_retained():
+    def script():
+        import streamlit as st
+
+        if "time_input" not in st.session_state:
+            st.session_state["time_input"] = None
+
+        st.time_input("time_input", key="time_input")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    at = at.button[0].click().run()
+    assert at.time_input[0].value is None


### PR DESCRIPTION
The root cause of the bug in #7649 is that, when the default value is set for a selectbox/radio/etc
and the widget has its value set to `None` via `session_state`, the serde instance ends up being
saved with the wrong value, which ends up resetting the widget to the default value in the next script
run.

We fix this by adding a check for `session_state` being set to `None` during widget initialization.

Closes #7649