### PR TITLE
Change the `fragmentId` to be a required property in `WidgetStateManager`

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1391,7 +1391,7 @@ describe("App", () => {
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const connectionManager = getMockConnectionManager()
 
-      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
       expect(connectionManager.sendMessage).toBeCalledTimes(1)
 
       expect(
@@ -1408,7 +1408,7 @@ describe("App", () => {
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const connectionManager = getMockConnectionManager()
 
-      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
       widgetStateManager.sendUpdateWidgetsMessage("myFragmentId")
       expect(connectionManager.sendMessage).toBeCalledTimes(2)
 
@@ -1428,7 +1428,7 @@ describe("App", () => {
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const connectionManager = getMockConnectionManager()
 
-      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
       expect(connectionManager.sendMessage).toBeCalledTimes(1)
 
       expect(
@@ -1445,7 +1445,7 @@ describe("App", () => {
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const connectionManager = getMockConnectionManager()
 
-      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
       expect(connectionManager.sendMessage).toBeCalledTimes(1)
 
       expect(
@@ -1467,7 +1467,7 @@ describe("App", () => {
       })
 
       window.history.pushState({}, "", "/foo/bar/baz")
-      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
 
       expect(
         // @ts-expect-error

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -568,7 +568,7 @@ export class App extends PureComponent<Props, State> {
 
     if (newState === ConnectionState.CONNECTED) {
       logMessage("Reconnected to server; requesting a script run")
-      this.widgetMgr.sendUpdateWidgetsMessage()
+      this.widgetMgr.sendUpdateWidgetsMessage(undefined)
       this.setState({ dialog: null })
     } else {
       setCookie("_streamlit_xsrf", "")
@@ -1340,7 +1340,7 @@ export class App extends PureComponent<Props, State> {
       this.saveSettings({ ...this.state.userSettings, runOnSave: true })
     }
 
-    this.widgetMgr.sendUpdateWidgetsMessage()
+    this.widgetMgr.sendUpdateWidgetsMessage(undefined)
   }
 
   sendLoadGitInfoBackMsg = (): void => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -568,6 +568,7 @@ export class App extends PureComponent<Props, State> {
 
     if (newState === ConnectionState.CONNECTED) {
       logMessage("Reconnected to server; requesting a script run")
+      // Trigger a full app rerun:
       this.widgetMgr.sendUpdateWidgetsMessage(undefined)
       this.setState({ dialog: null })
     } else {
@@ -1340,6 +1341,7 @@ export class App extends PureComponent<Props, State> {
       this.saveSettings({ ...this.state.userSettings, runOnSave: true })
     }
 
+    // Trigger a full app rerun:
     this.widgetMgr.sendUpdateWidgetsMessage(undefined)
   }
 

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -109,7 +109,12 @@ describe("Widget State Manager", () => {
     "sets string value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setStringValue(widget, "mockStringValue", { fromUi: true })
+      widgetMgr.setStringValue(
+        widget,
+        "mockStringValue",
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getStringValue(widget)).toBe("mockStringValue")
       assertCallbacks({ insideForm })
     }
@@ -119,7 +124,7 @@ describe("Widget State Manager", () => {
     "sets boolean value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setBoolValue(widget, true, { fromUi: true })
+      widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
       expect(widgetMgr.getBoolValue(widget)).toBe(true)
       assertCallbacks({ insideForm })
     }
@@ -129,7 +134,7 @@ describe("Widget State Manager", () => {
     "sets int value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setIntValue(widget, 100, { fromUi: true })
+      widgetMgr.setIntValue(widget, 100, { fromUi: true }, undefined)
       expect(widgetMgr.getIntValue(widget)).toBe(100)
       assertCallbacks({ insideForm })
     }
@@ -139,7 +144,7 @@ describe("Widget State Manager", () => {
     "sets float value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setDoubleValue(widget, 3.14, { fromUi: true })
+      widgetMgr.setDoubleValue(widget, 3.14, { fromUi: true }, undefined)
       expect(widgetMgr.getDoubleValue(widget)).toBe(3.14)
       assertCallbacks({ insideForm })
     }
@@ -151,7 +156,7 @@ describe("Widget State Manager", () => {
    */
   it("sets trigger value correctly", () => {
     const widget = getWidget({ insideForm: false })
-    widgetMgr.setTriggerValue(widget, { fromUi: true })
+    widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined)
     // @ts-expect-error
     expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
     assertCallbacks({ insideForm: false })
@@ -163,7 +168,12 @@ describe("Widget State Manager", () => {
    */
   it("sets string trigger value correctly", () => {
     const widget = getWidget({ insideForm: false })
-    widgetMgr.setStringTriggerValue(widget, "sample string", { fromUi: true })
+    widgetMgr.setStringTriggerValue(
+      widget,
+      "sample string",
+      { fromUi: true },
+      undefined
+    )
     // @ts-expect-error
     expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
     assertCallbacks({ insideForm: false })
@@ -173,9 +183,14 @@ describe("Widget State Manager", () => {
     "sets string array value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setStringArrayValue(widget, ["foo", "bar", "baz"], {
-        fromUi: true,
-      })
+      widgetMgr.setStringArrayValue(
+        widget,
+        ["foo", "bar", "baz"],
+        {
+          fromUi: true,
+        },
+        undefined
+      )
       expect(widgetMgr.getStringArrayValue(widget)).toEqual([
         "foo",
         "bar",
@@ -189,7 +204,12 @@ describe("Widget State Manager", () => {
     "sets int array value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setIntArrayValue(widget, [4, 5, 6], { fromUi: true })
+      widgetMgr.setIntArrayValue(
+        widget,
+        [4, 5, 6],
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getIntArrayValue(widget)).toEqual([4, 5, 6])
       assertCallbacks({ insideForm })
     }
@@ -199,9 +219,14 @@ describe("Widget State Manager", () => {
     "sets float array value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setDoubleArrayValue(widget, [1.1, 2.2, 3.3], {
-        fromUi: true,
-      })
+      widgetMgr.setDoubleArrayValue(
+        widget,
+        [1.1, 2.2, 3.3],
+        {
+          fromUi: true,
+        },
+        undefined
+      )
       expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([1.1, 2.2, 3.3])
       assertCallbacks({ insideForm })
     }
@@ -211,7 +236,12 @@ describe("Widget State Manager", () => {
     "sets ArrowTable value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setArrowValue(widget, MOCK_ARROW_TABLE, { fromUi: true })
+      widgetMgr.setArrowValue(
+        widget,
+        MOCK_ARROW_TABLE,
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getArrowValue(widget)).toEqual(MOCK_ARROW_TABLE)
       assertCallbacks({ insideForm })
     }
@@ -221,9 +251,14 @@ describe("Widget State Manager", () => {
     "sets JSON value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setJsonValue(widget, MOCK_JSON, {
-        fromUi: true,
-      })
+      widgetMgr.setJsonValue(
+        widget,
+        MOCK_JSON,
+        {
+          fromUi: true,
+        },
+        undefined
+      )
       expect(widgetMgr.getJsonValue(widget)).toBe(JSON.stringify(MOCK_JSON))
       assertCallbacks({ insideForm })
     }
@@ -233,7 +268,7 @@ describe("Widget State Manager", () => {
     "sets bytes value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setBytesValue(widget, MOCK_BYTES, { fromUi: true })
+      widgetMgr.setBytesValue(widget, MOCK_BYTES, { fromUi: true }, undefined)
       expect(widgetMgr.getBytesValue(widget)).toEqual(MOCK_BYTES)
       assertCallbacks({ insideForm })
     }
@@ -243,9 +278,14 @@ describe("Widget State Manager", () => {
     "sets FileUploaderState value correctly (insideForm=%p)",
     insideForm => {
       const widget = getWidget({ insideForm })
-      widgetMgr.setFileUploaderStateValue(widget, MOCK_FILE_UPLOADER_STATE, {
-        fromUi: true,
-      })
+      widgetMgr.setFileUploaderStateValue(
+        widget,
+        MOCK_FILE_UPLOADER_STATE,
+        {
+          fromUi: true,
+        },
+        undefined
+      )
       expect(widgetMgr.getFileUploaderStateValue(widget)).toEqual(
         MOCK_FILE_UPLOADER_STATE
       )
@@ -254,24 +294,39 @@ describe("Widget State Manager", () => {
   )
 
   it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
-    widgetMgr.setIntValue(MOCK_WIDGET, Number.MAX_SAFE_INTEGER, {
-      fromUi: true,
-    })
+    widgetMgr.setIntValue(
+      MOCK_WIDGET,
+      Number.MAX_SAFE_INTEGER,
+      {
+        fromUi: true,
+      },
+      undefined
+    )
 
     expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MAX_SAFE_INTEGER)
 
-    widgetMgr.setIntValue(MOCK_WIDGET, Number.MIN_SAFE_INTEGER, {
-      fromUi: true,
-    })
+    widgetMgr.setIntValue(
+      MOCK_WIDGET,
+      Number.MIN_SAFE_INTEGER,
+      {
+        fromUi: true,
+      },
+      undefined
+    )
 
     expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
   })
 
   it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
     const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
-    widgetMgr.setIntArrayValue(MOCK_WIDGET, values, {
-      fromUi: true,
-    })
+    widgetMgr.setIntArrayValue(
+      MOCK_WIDGET,
+      values,
+      {
+        fromUi: true,
+      },
+      undefined
+    )
 
     expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
   })
@@ -361,40 +416,60 @@ describe("Widget State Manager", () => {
 
   describe("Primitive types as JSON values", () => {
     it("sets string value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, "mockStringValue", { fromUi: true })
+      widgetMgr.setJsonValue(
+        MOCK_WIDGET,
+        "mockStringValue",
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify("mockStringValue")
       )
     })
 
     it("sets int value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, 45, { fromUi: true })
+      widgetMgr.setJsonValue(MOCK_WIDGET, 45, { fromUi: true }, undefined)
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(JSON.stringify(45))
     })
 
     it("sets float value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, 3.14, { fromUi: true })
+      widgetMgr.setJsonValue(MOCK_WIDGET, 3.14, { fromUi: true }, undefined)
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(JSON.stringify(3.14))
     })
 
     it("sets string array value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, ["foo", "bar", "baz"], {
-        fromUi: true,
-      })
+      widgetMgr.setJsonValue(
+        MOCK_WIDGET,
+        ["foo", "bar", "baz"],
+        {
+          fromUi: true,
+        },
+        undefined
+      )
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify(["foo", "bar", "baz"])
       )
     })
 
     it("sets int array value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, [5, 6, 7], { fromUi: true })
+      widgetMgr.setJsonValue(
+        MOCK_WIDGET,
+        [5, 6, 7],
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify([5, 6, 7])
       )
     })
 
     it("sets float array value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_WIDGET, [1.1, 2.2, 3.3], { fromUi: true })
+      widgetMgr.setJsonValue(
+        MOCK_WIDGET,
+        [1.1, 2.2, 3.3],
+        { fromUi: true },
+        undefined
+      )
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify([1.1, 2.2, 3.3])
       )
@@ -448,17 +523,27 @@ describe("Widget State Manager", () => {
       )
 
       // Populate a form
-      widgetMgr.setStringValue({ id: "widget1", formId }, "foo", {
-        fromUi: true,
-      })
-      widgetMgr.setStringValue({ id: "widget2", formId }, "bar", {
-        fromUi: true,
-      })
+      widgetMgr.setStringValue(
+        { id: "widget1", formId },
+        "foo",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
+      widgetMgr.setStringValue(
+        { id: "widget2", formId },
+        "bar",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
 
       // We have a single pending form.
       expect(formsData.formsWithPendingChanges).toEqual(new Set([formId]))
 
-      widgetMgr.submitForm(formId)
+      widgetMgr.submitForm(formId, undefined)
 
       // Our backMsg should be populated with our two widget values,
       // plus the submitButton's value.
@@ -485,11 +570,16 @@ describe("Widget State Manager", () => {
       )
 
       // Populate a form
-      widgetMgr.setStringValue({ id: "widget1", formId }, "foo", {
-        fromUi: true,
-      })
+      widgetMgr.setStringValue(
+        { id: "widget1", formId },
+        "foo",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
 
-      widgetMgr.submitForm(formId, undefined, "myFragmentId")
+      widgetMgr.submitForm(formId, "myFragmentId", undefined)
 
       // Our backMsg should be populated with our two widget values,
       // plus the submitButton's value.
@@ -508,9 +598,9 @@ describe("Widget State Manager", () => {
     })
 
     it("throws on invalid formId", () => {
-      expect(() => widgetMgr.submitForm(MOCK_WIDGET.formId)).toThrow(
-        `invalid formID ${MOCK_WIDGET.formId}`
-      )
+      expect(() =>
+        widgetMgr.submitForm(MOCK_WIDGET.formId, undefined)
+      ).toThrow(`invalid formID ${MOCK_WIDGET.formId}`)
     })
 
     it("submits the form for the first submitButton if an actualSubmitButton proto is passed", () => {
@@ -523,7 +613,7 @@ describe("Widget State Manager", () => {
         formId,
         new ButtonProto({ id: "secondSubmitButton" })
       )
-      widgetMgr.submitForm(formId)
+      widgetMgr.submitForm(formId, undefined)
 
       expect(sendBackMsg).toHaveBeenCalledWith(
         {
@@ -543,7 +633,7 @@ describe("Widget State Manager", () => {
         formId,
         new ButtonProto({ id: "secondSubmitButton" })
       )
-      widgetMgr.submitForm(formId)
+      widgetMgr.submitForm(formId, undefined)
 
       expect(sendBackMsg).not.toHaveBeenCalled()
     })
@@ -558,7 +648,7 @@ describe("Widget State Manager", () => {
         formId,
         new ButtonProto({ id: "secondSubmitButton", disabled: true })
       )
-      widgetMgr.submitForm(formId)
+      widgetMgr.submitForm(formId, undefined)
 
       expect(sendBackMsg).not.toHaveBeenCalled()
     })
@@ -576,14 +666,24 @@ describe("Widget State Manager", () => {
 
     beforeEach(() => {
       // Set widget value for the first form.
-      widgetMgr.setStringValue(FORM_1, "foo", {
-        fromUi: true,
-      })
+      widgetMgr.setStringValue(
+        FORM_1,
+        "foo",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
 
       // Set widget value for the second form.
-      widgetMgr.setStringValue(FORM_2, "bar", {
-        fromUi: true,
-      })
+      widgetMgr.setStringValue(
+        FORM_2,
+        "bar",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
     })
 
     it("checks that there are two pending forms", () => {
@@ -599,7 +699,7 @@ describe("Widget State Manager", () => {
       )
 
       // Submit the first form.
-      widgetMgr.submitForm(FORM_1.formId)
+      widgetMgr.submitForm(FORM_1.formId, undefined)
 
       // Our backMsg should be populated with the first form widget value,
       // plus the first submitButton's triggerValue.
@@ -615,7 +715,7 @@ describe("Widget State Manager", () => {
     })
 
     it("checks that only the second form is pending after the first is submitted", () => {
-      widgetMgr.submitForm(FORM_1.formId)
+      widgetMgr.submitForm(FORM_1.formId, undefined)
       expect(formsData.formsWithPendingChanges).toEqual(
         new Set([FORM_2.formId])
       )
@@ -623,9 +723,10 @@ describe("Widget State Manager", () => {
 
     it("calls sendBackMsg with data from both forms", () => {
       // Submit the first form and then the second form.
-      widgetMgr.submitForm(FORM_1.formId)
+      widgetMgr.submitForm(FORM_1.formId, undefined)
       widgetMgr.submitForm(
         FORM_2.formId,
+        undefined,
         new ButtonProto({ id: "submitButton2" })
       )
 
@@ -644,8 +745,8 @@ describe("Widget State Manager", () => {
     })
 
     it("checks that no more pending forms exist after both are submitted", () => {
-      widgetMgr.submitForm(FORM_1.formId)
-      widgetMgr.submitForm(FORM_2.formId)
+      widgetMgr.submitForm(FORM_1.formId, undefined)
+      widgetMgr.submitForm(FORM_2.formId, undefined)
       expect(formsData.formsWithPendingChanges).toEqual(new Set())
     })
 
@@ -662,6 +763,7 @@ describe("Widget State Manager", () => {
       // Submit the second form.
       widgetMgr.submitForm(
         FORM_2.formId,
+        undefined,
         new ButtonProto({ id: "submitButton2" })
       )
 
@@ -720,18 +822,38 @@ describe("Widget State Manager", () => {
     const widgetId4 = "TEST_ID_4"
     const elementId1 = "TEST_ID_5"
     const elementId2 = "TEST_ID_6"
-    widgetMgr.setStringValue({ id: widgetId1 }, "widgetState1", {
-      fromUi: false,
-    })
-    widgetMgr.setStringValue({ id: widgetId2 }, "widgetState2", {
-      fromUi: false,
-    })
-    widgetMgr.setStringValue({ id: widgetId3 }, "widgetState3", {
-      fromUi: false,
-    })
-    widgetMgr.setStringValue({ id: widgetId4 }, "widgetState4", {
-      fromUi: false,
-    })
+    widgetMgr.setStringValue(
+      { id: widgetId1 },
+      "widgetState1",
+      {
+        fromUi: false,
+      },
+      undefined
+    )
+    widgetMgr.setStringValue(
+      { id: widgetId2 },
+      "widgetState2",
+      {
+        fromUi: false,
+      },
+      undefined
+    )
+    widgetMgr.setStringValue(
+      { id: widgetId3 },
+      "widgetState3",
+      {
+        fromUi: false,
+      },
+      undefined
+    )
+    widgetMgr.setStringValue(
+      { id: widgetId4 },
+      "widgetState4",
+      {
+        fromUi: false,
+      },
+      undefined
+    )
 
     widgetMgr.setElementState(elementId1, "key1", "elementState1")
     widgetMgr.setElementState(elementId2, "key2", "elementState2")

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -154,7 +154,10 @@ class FormState {
 
 interface Props {
   /** Callback to deliver a message to the server */
-  sendRerunBackMsg: (widgetStates: WidgetStates, fragmentId?: string) => void
+  sendRerunBackMsg: (
+    widgetStates: WidgetStates,
+    fragmentId: string | undefined
+  ) => void
 
   /**
    * Callback invoked whenever our FormsData changed. (Because FormsData
@@ -213,8 +216,8 @@ export class WidgetStateManager {
    */
   public submitForm(
     formId: string,
-    actualSubmitButton?: WidgetInfo,
-    fragmentId?: string
+    fragmentId: string | undefined,
+    actualSubmitButton?: WidgetInfo
   ): void {
     if (!isValidFormId(formId)) {
       // This should never get thrown - only FormSubmitButton calls this
@@ -280,7 +283,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: string,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).stringTriggerValue =
       new StringTriggerValue({ data: value })
@@ -295,7 +298,7 @@ export class WidgetStateManager {
   public setTriggerValue(
     widget: WidgetInfo,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).triggerValue = true
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -315,7 +318,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: boolean,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).boolValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -334,7 +337,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: number | null,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).intValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -353,7 +356,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: number | null,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).doubleValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -372,7 +375,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: string | null,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).stringValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -382,7 +385,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: string[],
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).stringArrayValue = new StringArray({
       data: value,
@@ -422,7 +425,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: number[],
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
       data: value,
@@ -448,7 +451,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: number[],
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).intArrayValue = new SInt64Array({
       data: value,
@@ -469,7 +472,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: any,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).jsonValue = JSON.stringify(value)
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -479,7 +482,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: IArrowTable,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).arrowValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -502,7 +505,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: Uint8Array,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).bytesValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -521,7 +524,7 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     value: IFileUploaderState,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).fileUploaderStateValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
@@ -550,7 +553,7 @@ export class WidgetStateManager {
   private onWidgetValueChanged(
     formId: string | undefined,
     source: Source,
-    fragmentId?: string
+    fragmentId: string | undefined
   ): void {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
@@ -576,7 +579,7 @@ export class WidgetStateManager {
     })
   }
 
-  public sendUpdateWidgetsMessage(fragmentId?: string): void {
+  public sendUpdateWidgetsMessage(fragmentId: string | undefined): void {
     this.props.sendRerunBackMsg(
       this.widgetStates.createWidgetStatesMsg(),
       fragmentId

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -120,7 +120,8 @@ describe("sendEmptySelection", () => {
     widgetMgr.setStringValue(
       plotlyProto,
       '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     sendEmptySelection(
@@ -285,7 +286,8 @@ describe("handleSelection", () => {
     widgetMgr.setStringValue(
       proto,
       '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     handleSelection(event, widgetMgr, proto, mockFragmentId)

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -179,7 +179,7 @@ describe("Checkbox widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(screen.getByRole("checkbox")).not.toBeChecked()

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -145,7 +145,7 @@ describe("ColorPicker widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(colorBlock).toHaveStyle("background-color: #000000")

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -254,7 +254,7 @@ describe("DateInput widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(dateInput).toHaveValue(fullOriginalDate)

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -113,7 +113,8 @@ describe("FileUploader widget tests", () => {
           deleteUrl: "filename.txt",
         }),
       ]),
-      { fromUi: false }
+      { fromUi: false },
+      undefined
     )
 
     render(<FileUploader {...props} />)
@@ -667,7 +668,7 @@ describe("FileUploader widget tests", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
     rerender(<FileUploader {...props} />)
 
     // Our widget should be reset, and the widgetMgr should be updated

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -104,8 +104,8 @@ describe("FormSubmitButton", () => {
     fireEvent.click(formSubmitButton)
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
       props.element.formId,
-      props.element,
-      undefined
+      undefined,
+      props.element
     )
   })
 
@@ -119,8 +119,8 @@ describe("FormSubmitButton", () => {
     fireEvent.click(formSubmitButton)
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
       props.element.formId,
-      props.element,
-      "myFragmentId"
+      "myFragmentId",
+      props.element
     )
   })
 

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -71,7 +71,7 @@ export function FormSubmitButton(props: Props): ReactElement {
           fluidWidth={element.useContainerWidth ? fluidWidth : false}
           disabled={disabled || hasInProgressUpload}
           onClick={() => {
-            widgetMgr.submitForm(element.formId, element, fragmentId)
+            widgetMgr.submitForm(element.formId, fragmentId, element)
           }}
         >
           <StreamlitMarkdown

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -264,7 +264,7 @@ describe("Multiselect widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     const expandListButton = screen.getAllByTitle("open")[0]

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -181,7 +181,7 @@ describe("NumberInput widget", () => {
     })
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(numberInput).toHaveValue(props.element.default)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -306,7 +306,10 @@ export class NumberInput extends React.PureComponent<Props, State> {
         this.commitWidgetValue({ fromUi: true })
       }
       if (isInForm(this.props.element)) {
-        this.props.widgetMgr.submitForm(this.props.element.formId)
+        this.props.widgetMgr.submitForm(
+          this.props.element.formId,
+          this.props.fragmentId
+        )
       }
     }
   }

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -206,7 +206,7 @@ describe("Radio widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     // @ts-expect-error

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -123,7 +123,7 @@ describe("Selectbox widget", () => {
     )
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(screen.getByText("a")).toBeInTheDocument()

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -219,7 +219,7 @@ describe("Slider widget", () => {
       expect(slider).toHaveAttribute("aria-valuenow", "6")
 
       // "Submit" the form
-      props.widgetMgr.submitForm("form")
+      props.widgetMgr.submitForm("form", undefined)
 
       // Our widget should be reset, and the widgetMgr should be updated
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenLastCalledWith(

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -247,7 +247,7 @@ describe("TextArea widget", () => {
     expect(textArea).toHaveValue("TEST")
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(textArea).toHaveValue(props.element.default)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -176,7 +176,10 @@ class TextArea extends React.PureComponent<Props, State> {
       this.commitWidgetValue({ fromUi: true })
       const { formId } = this.props.element
       if (isInForm({ formId })) {
-        this.props.widgetMgr.submitForm(this.props.element.formId)
+        this.props.widgetMgr.submitForm(
+          this.props.element.formId,
+          this.props.fragmentId
+        )
       }
     }
   }

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -304,7 +304,7 @@ describe("TextInput widget", () => {
     fireEvent.change(textInput, { target: { value: "TEST" } })
 
     // "Submit" the form
-    props.widgetMgr.submitForm("form")
+    props.widgetMgr.submitForm("form", undefined)
 
     // Our widget should be reset, and the widgetMgr should be updated
     expect(textInput).toHaveValue(props.element.default)

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -184,7 +184,10 @@ class TextInput extends React.PureComponent<Props, State> {
         this.commitWidgetValue({ fromUi: true })
       }
       if (isInForm(this.props.element)) {
-        this.props.widgetMgr.submitForm(this.props.element.formId)
+        this.props.widgetMgr.submitForm(
+          this.props.element.formId,
+          this.props.fragmentId
+        )
       }
     }
   }

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -217,7 +217,7 @@ describe("TimeInput widget", () => {
 
     // "Submit" the form
     act(() => {
-      props.widgetMgr.submitForm("form")
+      props.widgetMgr.submitForm("form", undefined)
     })
 
     // Our widget should be reset, and the widgetMgr should be updated


### PR DESCRIPTION
## Describe your changes

The `fragmentId` is currently an optional property for all the set state methods in the `WidgetStateManager`. The reason here is that it sometimes has a value and sometimes is just `undefined`. But this makes it a bit too easy to forget to add it -> which can lead to features that are not compatible with fragments. 

This PR changes the property to required by changing from `fragmentId?: string` to `fragmentId: string | undefined`. This also uncovered a potentially existing issue with form submission & fragments, which will be fixed via this PR, e.g.:

https://github.com/streamlit/streamlit/pull/8533/files#diff-b6b2b8d7411dc40d04d4dc0442572c4835e84a79844cd2e299a469b7b2ec1a1cR309

## Testing Plan

- Update tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
