### PR TITLE
Remove snowflake extras python restriction

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -74,8 +74,8 @@ if not os.getenv("SNOWPARK_CONDA_BUILD"):
 
 EXTRA_REQUIRES = {
     "snowflake": [
-        "snowflake-snowpark-python>=0.9.0",
-        "snowflake-connector-python>=2.8.0",
+        "snowflake-snowpark-python>=0.9.0; python_version<'3.12'",
+        "snowflake-connector-python>=2.8.0; python_version<'3.12'",
     ]
 }
 

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -74,8 +74,8 @@ if not os.getenv("SNOWPARK_CONDA_BUILD"):
 
 EXTRA_REQUIRES = {
     "snowflake": [
-        "snowflake-snowpark-python>=0.9.0; python_version=='3.8'",
-        "snowflake-connector-python>=2.8.0; python_version=='3.8'",
+        "snowflake-snowpark-python>=0.9.0",
+        "snowflake-connector-python>=2.8.0",
     ]
 }
 


### PR DESCRIPTION
## Describe your changes

The snowflake extras are still set up to require Python 3.8. But Snowpark already supports Python 3.8-3.11 by now so we can remove this. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
