### PR TITLE
Remove html comment from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-<!--
-⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
-https://github.com/streamlit/streamlit/wiki/Contributing
--->
-
 ## Describe your changes
 
 ## GitHub Issue Link (if applicable)


### PR DESCRIPTION
## Describe your changes

This PR removes the top HTML comment from the PR template. The contribution guidelines are already linked two times in the PR UI by Github; having this comment on top might not have a lot of additional benefits.

<img width="1020" alt="Screenshot 2024-04-19 at 11 34 45" src="https://github.com/streamlit/streamlit/assets/2852129/998195fe-608f-474a-aac7-f044825de1d0">

Problems with the HTML comment:
- since we had the PR description to the commit description when merging, the comment often gets added (when not manually removed), which looks weird.
- Its a bit annoying for core contributors to manually remove this header.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
