### PR TITLE
Fix empty generator usage with `st.write_stream`

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -197,6 +197,10 @@ class WriteMixin:
                     ) from err
 
             if isinstance(chunk, str):
+                if not chunk:
+                    # Empty strings can be ignored
+                    continue
+
                 first_text = False
                 if not stream_container:
                     stream_container = self.dg.empty()
@@ -216,10 +220,14 @@ class WriteMixin:
 
         flush_stream_response()
 
-        # If the output only contains a single string, return it as a string
-        if len(written_content) == 1 and isinstance(written_content[0], str):
+        if not written_content:
+            # If nothing was streamed, return an empty string.
+            return ""
+        elif len(written_content) == 1 and isinstance(written_content[0], str):
+            # If the output only contains a single string, return it as a string
             return written_content[0]
-        # Otherwise return it as a list
+
+        # Otherwise return it as a list of write-compatible objects
         return written_content
 
     @gather_metrics("write")

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -494,8 +494,25 @@ class StreamlitStreamTest(unittest.TestCase):
         stream_return = st.write_stream(test_stream)
         self.assertEqual(stream_return, "Hello World")
 
-        stream_return = st.write_stream(test_stream())
-        self.assertEqual(stream_return, "Hello World")
+    def test_with_empty_chunks(self):
+        """Test st.write_stream with generator that returns empty chunks."""
+
+        def test_stream():
+            yield ""
+            yield ""
+
+        stream_return = st.write_stream(test_stream)
+        self.assertEqual(stream_return, "")
+
+    def test_with_empty_stream(self):
+        """Test st.write_stream with generator that returns empty chunks."""
+
+        def test_stream():
+            if False:
+                yield "Hello"
+
+        stream_return = st.write_stream(test_stream)
+        self.assertEqual(stream_return, "")
 
     def test_with_wrong_input(self):
         """Test st.write_stream with string or dataframe input generates exception."""


### PR DESCRIPTION
## Describe your changes

The output of `st.write_stream` is currently an empty list of either all chunks are empty strings or there isn't any `yield` event at all:

```python

def test_gen_1():
    yield ""
    yield ""
    yield ""

st.write(str(type(st.write_stream(test_gen_1))))

def test_gen_2():
    if False:
        yield "a"

st.write(str(type(st.write_stream(test_gen_2))))
```

However, in both of these situations, it should return an empty string instead. 

## Testing Plan

- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
