### PR TITLE
Lower cypress workers to four

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
         # Be aware that specs should be sequential integers starting from 1 without gaps
         # based on logic in "Cypress Tests" step.
         # prettier-ignore
-        specs: [ 1, 2, 3, 4, 5, 6, ]
+        specs: [ 1, 2, 3, 4, ]
 
     steps:
       - name: Checkout Streamlit code
@@ -75,7 +75,7 @@ jobs:
         env:
           CURRENT_RUN: ${{matrix.specs}}
           CYPRESS_VERIFY_TIMEOUT: 90000
-          TOTAL_WORKERS: 6
+          TOTAL_WORKERS: 4
         run: |
           js_specs=(e2e/specs/*)
 


### PR DESCRIPTION
## Describe your changes

We have migrated a couple of additional tests which allows us to lower the total cypress worker count to four. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
