### PR TITLE
Fix broken python github actions

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -17,6 +17,7 @@ urllib3>=1.9
 hypothesis>=6.17.4
 parameterized
 # Pinned for now because AsyncTest doesn't work with pytest 8.2.0
+# https://github.com/pytest-dev/pytest/issues/12263
 pytest<8.2.0
 pytest-cov
 requests-mock

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -16,7 +16,8 @@ urllib3>=1.9
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized
-pytest
+# Pinned for now because AsyncTest doesn't work with pytest 8.2.0
+pytest<8.2.0
 pytest-cov
 requests-mock
 testfixtures


### PR DESCRIPTION
## Describe your changes
- Looks like pytest 8.2 breaks with tornado
- As a result, we should likely pin 8.1 pytest
- https://github.com/pytest-dev/pytest/issues/12263
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
