### PR TITLE
feat: support set mysql connection query from secrets.toml

### DIFF
--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -107,6 +107,7 @@ class SQLConnection(BaseConnection["Engine"]):
                 host=conn_params["host"],
                 port=int(conn_params["port"]) if "port" in conn_params else None,
                 database=conn_params.get("database"),
+                query=conn_params["query"] if "query" in conn_params else None,
             )
 
         create_engine_kwargs = ChainMap(

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -40,6 +40,7 @@ _ALL_CONNECTION_PARAMS = {
     "host",
     "port",
     "database",
+    "query",
 }
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -75,13 +75,18 @@ class SQLConnectionTest(unittest.TestCase):
     )
     @patch("sqlalchemy.create_engine")
     def test_kwargs_overwrite_secrets_values(self, patched_create_engine):
-        SQLConnection("my_sql_connection", port=2345, username="DnomaidEruza")
+        SQLConnection(
+            "my_sql_connection",
+            port=2345,
+            username="DnomaidEruza",
+            query={"charset": "utf8mb4"},
+        )
 
         patched_create_engine.assert_called_once()
         args, _ = patched_create_engine.call_args_list[0]
         assert (
             str(args[0])
-            == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres"
+            == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
         )
 
     def test_error_if_no_config(self):


### PR DESCRIPTION
## Describe your changes

Make it possible to set mysql connection query via `.streamlit/secrets.toml`. A a useful instance is: we can set mysql connection charset with this new feature, otherwise when we handle string contains particular characters like Chinese we will get `???`

As SQLAlchemy docs said, we can pass `query` param when create `sqlalchemy.engine.URL` object: https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create

![image](https://github.com/streamlit/streamlit/assets/16591903/a5815d70-4eb3-42b8-b40d-fbda134a4426)

### How to use it

I'd like to explain how to use the added **query** step by step:

1. Let's start with the [Connect Streamlit to MySQL](https://docs.streamlit.io/develop/tutorials/databases/mysql) doc

2. In **Add username and password to your local app secrets** section, there is a sample config file named `.streamlit/secrets.toml`:

```toml
# .streamlit/secrets.toml

[connections.mysql]
dialect = "mysql"
host = "localhost"
port = 3306
database = "xxx"
username = "xxx"
password = "xxx"
```

3. to set mysql connection query (such as charset), we can add a  `query` section

```toml
# .streamlit/secrets.toml

[connections.mysql]
dialect = "mysql"
host = "localhost"
port = 3306
database = "xxx"
username = "xxx"
password = "xxx"
query = { charset = "utf8mb4" }
```

btw, I have a question: how can I contribute to the [doc](https://docs.streamlit.io/develop/tutorials/databases/mysql#add-username-and-password-to-your-local-app-secrets) ?

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed

This change only add a param when create `sqlalchemy.engine.URL` object, and the param is already supported by SQLAlchemy for a long time.

- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
