### PR TITLE
Move material icon styling to styled component

### DIFF
--- a/frontend/app/src/assets/css/icon-fonts.scss
+++ b/frontend/app/src/assets/css/icon-fonts.scss
@@ -23,20 +23,3 @@
   src: url("../fonts/MaterialSymbols/MaterialSymbols-Outlined.woff2")
     format("woff2");
 }
-
-.material-symbols-outlined {
-  font-family: "Material Symbols Outlined";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  font-feature-settings: "liga";
-  -webkit-font-feature-settings: "liga";
-  -webkit-font-smoothing: antialiased;
-}

--- a/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
@@ -24,10 +24,6 @@ import {
   StyledMaterialIconProps,
 } from "./styled-components"
 
-const ICON_PACK_MAPPING: Record<string, string> = {
-  material: "material-symbols-outlined",
-}
-
 interface MaterialIconProps {
   iconName: string
   pack: string
@@ -56,13 +52,7 @@ const MaterialFontIcon = ({
   ...props
 }: MaterialIconProps): ReactElement => {
   return (
-    // This is a recommended way to render material icons from the font
-    // Please see `Inserting the icon` section here:
-    // https://fonts.google.com/icons?selected=Material%20Symbols%20Outlined%3Asettings_applications%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4024
-    <StyledMaterialIcon
-      className={ICON_PACK_MAPPING[pack]}
-      {...getDefaultProps(props)}
-    >
+    <StyledMaterialIcon {...getDefaultProps(props)}>
       {snakeCase(iconName)}
     </StyledMaterialIcon>
   )

--- a/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
@@ -48,7 +48,6 @@ const getDefaultProps = ({
 
 const MaterialFontIcon = ({
   iconName,
-  pack,
   ...props
 }: MaterialIconProps): ReactElement => {
   return (

--- a/frontend/lib/src/components/shared/Icon/Material/styled-components.ts
+++ b/frontend/lib/src/components/shared/Icon/Material/styled-components.ts
@@ -50,6 +50,7 @@ export const StyledMaterialIcon = styled.span<StyledMaterialIconProps>(
       fontFeatureSettings: "liga",
       MozFontFeatureSettings: "liga",
       WebkitFontFeatureSettings: "liga",
+      WebkitFontSmoothing: "antialiased",
     }
   }
 )

--- a/frontend/lib/src/components/shared/Icon/Material/styled-components.ts
+++ b/frontend/lib/src/components/shared/Icon/Material/styled-components.ts
@@ -38,6 +38,18 @@ export const StyledMaterialIcon = styled.span<StyledMaterialIconProps>(
       margin: computeSpacingStyle(margin, theme),
       padding: computeSpacingStyle(padding, theme),
       userSelect: "none",
+      fontFamily: "Material Symbols Outlined",
+      fontWeight: "normal",
+      fontStyle: "normal",
+      lineHeight: 1,
+      letterSpacing: "normal",
+      textTransform: "none",
+      whiteSpace: "nowrap",
+      wordWrap: "normal",
+      direction: "ltr",
+      fontFeatureSettings: "liga",
+      MozFontFeatureSettings: "liga",
+      WebkitFontFeatureSettings: "liga",
     }
   }
 )


### PR DESCRIPTION
## Describe your changes

Move `.material-symbols-outlined` styling to corresponding styled component

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
