### PR TITLE
Change embedded app URL for dialog

### DIFF
--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -167,7 +167,7 @@ def dialog_decorator(
     >>>     f"You voted for {st.session_state.vote['item']} because {st.session_state.vote['reason']}"
 
     .. output::
-        https://doc-dialog.streamlit.app/
+        https://doc-modal-dialog.streamlit.app/
         height: 350px
 
     """


### PR DESCRIPTION
## Describe your changes
Change the URL of the docstring's embedded app for `st.experimental_dialog`

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
