### PR TITLE
Clear stale elements when st.rerun() is used

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1093,35 +1093,34 @@ export class App extends PureComponent<Props, State> {
       status ===
         ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
     ) {
-      const successful =
-        status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
-        status ===
-          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
-
       window.setTimeout(() => {
         // Notify any subscribers of this event (and do it on the next cycle of
         // the event loop)
         this.state.scriptFinishedHandlers.map(handler => handler())
       }, 0)
 
-      if (successful) {
-        // Clear any stale elements left over from the previous run.
-        // (We don't do this if our script had a compilation error and didn't
-        // finish successfully.)
-        this.setState(
-          ({ scriptRunId, fragmentIdsThisRun }) => ({
-            // Apply any pending elements that haven't been applied.
-            elements: this.pendingElementsBuffer.clearStaleNodes(
-              scriptRunId,
-              fragmentIdsThisRun
-            ),
-          }),
-          () => {
-            // We now have no pending elements.
-            this.pendingElementsBuffer = this.state.elements
-          }
-        )
+      // Clear any stale elements left over from the previous run.
+      // (We don't do this if our script had a compilation error and didn't
+      // finish successfully.)
+      this.setState(
+        ({ scriptRunId, fragmentIdsThisRun }) => ({
+          // Apply any pending elements that haven't been applied.
+          elements: this.pendingElementsBuffer.clearStaleNodes(
+            scriptRunId,
+            fragmentIdsThisRun
+          ),
+        }),
+        () => {
+          // We now have no pending elements.
+          this.pendingElementsBuffer = this.state.elements
+        }
+      )
 
+      if (
+        status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
+        status ===
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+      ) {
         // Tell the WidgetManager which widgets still exist. It will remove
         // widget state for widgets that have been removed.
         const activeWidgetIds = new Set(

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -465,7 +465,7 @@ class AppSession:
             self._local_sources_watcher.update_watched_pages()
 
     def _clear_queue(self) -> None:
-        self._browser_queue.clear()
+        self._browser_queue.clear(retain_lifecycle_msgs=True)
 
     def _on_scriptrunner_event(
         self,

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -831,7 +831,9 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             side_effect=lambda msg: forward_msg_queue_events.append(msg)
         )
         mock_queue.clear = MagicMock(
-            side_effect=lambda: forward_msg_queue_events.append(CLEAR_QUEUE)
+            side_effect=lambda retain_lifecycle_msgs: forward_msg_queue_events.append(
+                CLEAR_QUEUE
+            )
         )
 
         session._browser_queue = mock_queue

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -60,30 +60,30 @@ ADD_ROWS_MSG.metadata.delta_path[:] = make_delta_path(RootContainer.MAIN, (), 0)
 class ForwardMsgQueueTest(unittest.TestCase):
     def test_simple_enqueue(self):
         """Enqueue a single ForwardMsg."""
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
-        rq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(NEW_SESSION_MSG)
 
-        self.assertFalse(rq.is_empty())
-        queue = rq.flush()
-        self.assertTrue(rq.is_empty())
+        self.assertFalse(fmq.is_empty())
+        queue = fmq.flush()
+        self.assertTrue(fmq.is_empty())
         self.assertEqual(1, len(queue))
         self.assertTrue(queue[0].new_session.config.allow_run_on_save)
 
     def test_enqueue_two(self):
         """Enqueue two ForwardMsgs."""
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
-        rq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(NEW_SESSION_MSG)
 
         TEXT_DELTA_MSG1.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 0
         )
-        rq.enqueue(TEXT_DELTA_MSG1)
+        fmq.enqueue(TEXT_DELTA_MSG1)
 
-        queue = rq.flush()
+        queue = fmq.flush()
         self.assertEqual(2, len(queue))
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
@@ -92,22 +92,22 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
     def test_enqueue_three(self):
         """Enqueue 3 ForwardMsgs."""
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
-        rq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(NEW_SESSION_MSG)
 
         TEXT_DELTA_MSG1.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 0
         )
-        rq.enqueue(TEXT_DELTA_MSG1)
+        fmq.enqueue(TEXT_DELTA_MSG1)
 
         TEXT_DELTA_MSG2.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 1
         )
-        rq.enqueue(TEXT_DELTA_MSG2)
+        fmq.enqueue(TEXT_DELTA_MSG2)
 
-        queue = rq.flush()
+        queue = fmq.flush()
         self.assertEqual(3, len(queue))
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
@@ -122,22 +122,22 @@ class ForwardMsgQueueTest(unittest.TestCase):
         """Enqueuing an element with the same delta_path as another element
         already in the queue should replace the original element.
         """
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
-        rq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(NEW_SESSION_MSG)
 
         TEXT_DELTA_MSG1.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 0
         )
-        rq.enqueue(TEXT_DELTA_MSG1)
+        fmq.enqueue(TEXT_DELTA_MSG1)
 
         TEXT_DELTA_MSG2.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 0
         )
-        rq.enqueue(TEXT_DELTA_MSG2)
+        fmq.enqueue(TEXT_DELTA_MSG2)
 
-        queue = rq.flush()
+        queue = fmq.flush()
         self.assertEqual(2, len(queue))
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
@@ -148,8 +148,8 @@ class ForwardMsgQueueTest(unittest.TestCase):
     def test_dont_replace_block(self, other_msg: ForwardMsg):
         """add_block deltas should never be replaced because they can
         have dependent deltas later in the queue."""
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
         ADD_BLOCK_MSG.metadata.delta_path[:] = make_delta_path(
             RootContainer.MAIN, (), 0
@@ -159,34 +159,34 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         # Delta messages should not replace `add_block` deltas with the
         # same delta_path.
-        rq.enqueue(ADD_BLOCK_MSG)
-        rq.enqueue(other_msg)
-        queue = rq.flush()
+        fmq.enqueue(ADD_BLOCK_MSG)
+        fmq.enqueue(other_msg)
+        queue = fmq.flush()
         self.assertEqual(2, len(queue))
         self.assertEqual(ADD_BLOCK_MSG, queue[0])
         self.assertEqual(other_msg, queue[1])
 
     def test_multiple_containers(self):
         """Deltas should only be coalesced if they're in the same container"""
-        rq = ForwardMsgQueue()
-        self.assertTrue(rq.is_empty())
+        fmq = ForwardMsgQueue()
+        self.assertTrue(fmq.is_empty())
 
-        rq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(NEW_SESSION_MSG)
 
         def enqueue_deltas(container: int, path: Tuple[int, ...]):
             # We deep-copy the protos because we mutate each one
             # multiple times.
             msg = copy.deepcopy(TEXT_DELTA_MSG1)
             msg.metadata.delta_path[:] = make_delta_path(container, path, 0)
-            rq.enqueue(msg)
+            fmq.enqueue(msg)
 
             msg = copy.deepcopy(DF_DELTA_MSG)
             msg.metadata.delta_path[:] = make_delta_path(container, path, 1)
-            rq.enqueue(msg)
+            fmq.enqueue(msg)
 
             msg = copy.deepcopy(ADD_ROWS_MSG)
             msg.metadata.delta_path[:] = make_delta_path(container, path, 1)
-            rq.enqueue(msg)
+            fmq.enqueue(msg)
 
         enqueue_deltas(RootContainer.MAIN, ())
         enqueue_deltas(RootContainer.SIDEBAR, (0, 0, 1))
@@ -198,8 +198,38 @@ class ForwardMsgQueueTest(unittest.TestCase):
             )
             self.assertEqual("text1", queue[idx].delta.new_element.text.body)
 
-        queue = rq.flush()
+        queue = fmq.flush()
         self.assertEqual(7, len(queue))
 
         assert_deltas(RootContainer.MAIN, (), 1)
         assert_deltas(RootContainer.SIDEBAR, (0, 0, 1), 4)
+
+    def test_clear_retain_lifecycle_msgs(self):
+        fmq = ForwardMsgQueue()
+
+        script_finished_msg = ForwardMsg()
+        script_finished_msg.script_finished = (
+            ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+        )
+
+        session_status_changed_msg = ForwardMsg()
+        session_status_changed_msg.session_status_changed.script_is_running = True
+
+        parent_msg = ForwardMsg()
+        parent_msg.parent_message.message = "hello"
+
+        fmq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(TEXT_DELTA_MSG1)
+        fmq.enqueue(script_finished_msg)
+        fmq.enqueue(session_status_changed_msg)
+        fmq.enqueue(parent_msg)
+
+        fmq.clear(retain_lifecycle_msgs=True)
+        assert fmq._queue == [
+            script_finished_msg,
+            session_status_changed_msg,
+            parent_msg,
+        ]
+
+        fmq.clear()
+        assert fmq._queue == []


### PR DESCRIPTION
#8360 was caused by the interaction of two bugs:
* We weren't clearing stale elements when a script is stopped early for rerun
* There's a race condition where important script lifecycle messages may be dropped when
   the script is rerun. We do want to drop most forward messages on a rerun as the rerun
   invalidates any delta/page_config/etc messages, but dropping lifecycle messages can
   cause the client to end up in a bad state.

In the somewhat rare case described in the issue where the rerun due to `st.rerun()` produces fewer
elements than the first script run, we can end up rendering two elements with the same react key, which
results in react being unable to remove duplicate elements as long as one element with that key exists.


Closes #8360