### PR TITLE
Fix 'Runtime not created' issue for custom components executed without Streamlit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ playwright:
 playwright-custom-components:
 	cd e2e_playwright; \
 	rm -rf ./test-results; \
-	pip_args="extra-streamlit-components streamlit-ace streamlit-antd-components streamlit-aggrid streamlit-autorefresh streamlit-chat streamlit-echarts streamlit-folium streamlit-lottie streamlit-option-menu streamlit-url-fragment"; \
+	pip_args="extra-streamlit-components streamlit-ace streamlit-antd-components streamlit-aggrid streamlit-autorefresh streamlit-chat streamlit-echarts streamlit-folium streamlit-lottie streamlit-navigation-bar==3.1.2 streamlit-option-menu streamlit-url-fragment";\
 	if command -v "uv" > /dev/null; then \
 		echo "Running command: uv pip install $${pip_args}"; \
 		uv pip install $${pip_args}; \

--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ playwright:
 playwright-custom-components:
 	cd e2e_playwright; \
 	rm -rf ./test-results; \
-	pip_args="extra-streamlit-components streamlit-ace streamlit-antd-components streamlit-aggrid streamlit-autorefresh streamlit-chat streamlit-echarts streamlit-folium streamlit-lottie streamlit-navigation-bar==3.1.2 streamlit-option-menu streamlit-url-fragment";\
+	pip_args="extra-streamlit-components streamlit-ace streamlit-antd-components streamlit-aggrid streamlit-autorefresh streamlit-chat streamlit-echarts streamlit-folium streamlit-lottie streamlit-navigation-bar==3.1.2 streamlit-option-menu streamlit-url-fragment"; \
 	if command -v "uv" > /dev/null; then \
 		echo "Running command: uv pip install $${pip_args}"; \
 		uv pip install $${pip_args}; \

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -204,7 +204,12 @@ def app_port(worker_id: str) -> int:
 @pytest.fixture(scope="module", autouse=True)
 def app_server(
     app_port: int, request: FixtureRequest
-) -> Generator[AsyncSubprocess, None, None]:
+) -> Generator[AsyncSubprocess | None, None, None]:
+    # modules / test marked with `no_app_server` run standalone without a Streamlit app
+    if "no_app_server" in request.keywords:
+        yield None
+        return
+
     """Fixture that starts and stops the Streamlit app server."""
     streamlit_proc = AsyncSubprocess(
         [

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -205,7 +205,7 @@ def app_port(worker_id: str) -> int:
 def app_server(
     app_port: int, request: FixtureRequest
 ) -> Generator[AsyncSubprocess | None, None, None]:
-    # modules / test marked with `no_app_server` run standalone without a Streamlit app
+    # modules / tests marked with `no_app_server` run standalone without a Streamlit app
     if "no_app_server" in request.keywords:
         yield None
         return

--- a/e2e_playwright/custom_components/components_without_runtime_test.py
+++ b/e2e_playwright/custom_components/components_without_runtime_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+In https://github.com/streamlit/streamlit/issues/8606 we learned that some custom components
+run without a started Streamlit process, e.g. for automated tests.
+The issue is fixed in https://github.com/streamlit/streamlit/pull/8610 and the tests
+are added to capture this kind of failure in the future.
+The module is marked with 'no_app_server' as we do not run an app here.
+"""
+
+import pytest
+
+# we do not need an app server here
+pytestmark = pytest.mark.no_app_server
+
+
+def test_folium_runs_standalone():
+    """Test that _RELEASE can be imported.
+
+    This use-case was reported as being broken in https://github.com/streamlit/streamlit/issues/8606
+    """
+    from streamlit_folium import _RELEASE
+
+    assert _RELEASE
+
+
+def test_navigation_bar_runs_standalone():
+    """Test that custom components can be run standlone without Streamlit throwing an error.
+
+    This use-case was reported as being broken in https://github.com/streamlit/streamlit/issues/8606
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["streamlit-navigation-bar"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout
+
+    # we install this specific version in the Makefile
+    assert result.stdout.strip() == "Streamlit Navigation Bar, version 3.1.2"

--- a/e2e_playwright/custom_components/popular_components_test.py
+++ b/e2e_playwright/custom_components/popular_components_test.py
@@ -94,8 +94,8 @@ def test_extra_streamlit_components(app: Page):
 def test_folium(app: Page):
     """Test that the folium component renders"""
     _select_component(app, "folium")
+    _expect_no_exception(app)
     _expect_iframe_attached(app)
-
 
 def test_lottie(app: Page):
     """Test that the lottie component renders"""

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     early: prioritize the execution of a fixture
+    no_app_server: does not run a Streamlit app
 filterwarnings =
     # PyTest filter syntax cheatsheet -> action:message:category:module:line
     ignore::UserWarning:altair.*:

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -47,7 +47,7 @@ def declare_component(
     name: str,
     path: str | None = None,
     url: str | None = None,
-) -> CustomComponent | None:
+) -> CustomComponent:
     """Create a custom component and register it if there is a ScriptRun context.
 
     The component is not registered when there is no ScriptRun context; this can happen when CustomComponents are executed as standalone commands, e.g. for testing.

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -21,6 +21,7 @@ from types import FrameType
 from streamlit.components.types.base_component_registry import BaseComponentRegistry
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.runtime import get_instance
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 
 def _get_module_name(caller_frame: FrameType) -> str:
@@ -46,7 +47,7 @@ def declare_component(
     name: str,
     path: str | None = None,
     url: str | None = None,
-) -> CustomComponent:
+) -> CustomComponent | None:
     """Create and register a custom component.
 
     Parameters
@@ -62,12 +63,17 @@ def declare_component(
 
     Returns
     -------
-    CustomComponent
+    CustomComponent or None
         A CustomComponent that can be called like a function.
         Calling the component will create a new instance of the component
         in the Streamlit app.
+        Returns None if no ScriptRunContext exists; this can happen when CustomComponents are executed as standalone commands, e.g. for testing.
 
     """
+
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return None
 
     # Get our stack frame.
     current_frame: FrameType | None = inspect.currentframe()

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -71,6 +71,7 @@ def declare_component(
 
     """
 
+    # the ctx can be None if a custom component script is run outside of Streamlit, e.g. via 'python ...'
     ctx = get_script_run_ctx()
     if ctx is None:
         return None


### PR DESCRIPTION
## Describe your changes

Closes #8606

The PR allows custom component modules to be executed standalone by not registering them with Streamlit at all, which makes sense since Streamlit is not started.

Also, adds tests to the `e2e_playwright/custom-components` suite to ensure this behavior for the future.

<details>
<summary>Playwright Test Output With the Fix</summary>

```bash
components_without_runtime_test.py ..

====================================================================== fixture duration top ======================================================================
total          name                                num avg            min           
0:00:00.000590                         grand total   7 0:00:00.000018 0:00:00.000014
===================================================================== test call duration top =====================================================================
total          name                                num avg            min           
0:00:01.054403         test_folium_runs_standalone   1 0:00:01.054403 0:00:01.054403
0:00:00.309108 test_navigation_bar_runs_standalone   1 0:00:00.309108 0:00:00.309108
0:00:01.363511                         grand total   2 0:00:00.681756 0:00:00.309108
==================================================================== test setup duration top =====================================================================
total          name                                num avg            min           
0:00:00.000622                         grand total   2 0:00:00.000311 0:00:00.000153
=================================================================== test teardown duration top ===================================================================
total          name                                num avg            min           
0:00:00.000082                         grand total   2 0:00:00.000041 0:00:00.000024
======================================================================= 2 passed in 1.54s ========================================================================
```

</details>

<details>
<summary>Playwright Test Output Without the Fix</summary>

```bash
components_without_runtime_test.py:30: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../lib/venv/lib/python3.8/site-packages/streamlit_folium/__init__.py:28: in <module>
    _component_func = components.declare_component("st_folium", path=build_dir)
../../lib/streamlit/components/v1/component_registry.py:93: in declare_component
    get_instance().component_registry.register_component(component)
../../lib/streamlit/runtime/__init__.py:28: in get_instance
    return Runtime.instance()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'streamlit.runtime.runtime.Runtime'>

    @classmethod
    def instance(cls) -> Runtime:
        """Return the singleton Runtime instance. Raise an Error if the
        Runtime hasn't been created yet.
        """
        if cls._instance is None:
>           raise RuntimeError("Runtime hasn't been created!")
E           RuntimeError: Runtime hasn't been created!

../../lib/streamlit/runtime/runtime.py:163: RuntimeError
______________________________________________________________ test_navigation_bar_runs_standalone ______________________________________________________________

    def test_navigation_bar_runs_standalone():
        import subprocess
    
        result = subprocess.run(
            ["streamlit-navigation-bar"],
            capture_output=True,  # Python >= 3.7 only
            text=True,  # Python >= 3.7 only
        )
>       assert result.stdout
E       assert ''
E        +  where '' = CompletedProcess(args=['streamlit-navigation-bar'], returncode=1, stdout='', stderr='Traceback (most recent call last)..., in instance\n    raise RuntimeError("Runtime hasn\'t been created!")\nRuntimeError: Runtime hasn\'t been created!\n').stdout

components_without_runtime_test.py:43: AssertionError
===================================================================== fixture duration top ======================================================================
total          name                                num avg            min           
0:00:00.000462                         grand total   7 0:00:00.000021 0:00:00.000013
==================================================================== test call duration top =====================================================================
total          name                                num avg            min           
0:00:01.051296         test_folium_runs_standalone   1 0:00:01.051296 0:00:01.051296
0:00:00.336194 test_navigation_bar_runs_standalone   1 0:00:00.336194 0:00:00.336194
0:00:01.387490                         grand total   2 0:00:00.693745 0:00:00.336194
==================================================================== test setup duration top ====================================================================
total          name                                num avg            min           
0:00:00.000485                         grand total   2 0:00:00.000243 0:00:00.000131
================================================================== test teardown duration top ===================================================================
total          name                                num avg            min           
0:00:00.000078                         grand total   2 0:00:00.000039 0:00:00.000023
==================================================================== short test summary info ====================================================================
FAILED components_without_runtime_test.py::test_folium_runs_standalone - RuntimeError: Runtime hasn't been created!
FAILED components_without_runtime_test.py::test_navigation_bar_runs_standalone - assert ''
======================================================================= 2 failed in 1.60s =======================================================================


```

</details>


## GitHub Issue Link

- https://github.com/streamlit/streamlit/issues/8606
- https://github.com/NathanChen198/streamlit-rsa-auth-ui/issues/1
- https://github.com/randyzwitch/streamlit-folium/pull/186

## Testing Plan

- 💹 E2E Tests
  - Extend the `e2e_playwright/custom-components` suite by adding tests that were reported in the issue
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
