### PR TITLE
Fix standalone custom-component execution

### DIFF
--- a/e2e_playwright/custom_components/popular_components_test.py
+++ b/e2e_playwright/custom_components/popular_components_test.py
@@ -94,6 +94,7 @@ def test_extra_streamlit_components(app: Page):
 def test_folium(app: Page):
     """Test that the folium component renders"""
     _select_component(app, "folium")
+    _expect_no_exception(app)
     _expect_iframe_attached(app)
 
 


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/8606

The PR allows custom component modules to be executed standalone by not registering them with Streamlit at all, which makes sense since Streamlit is not started.

It's a cherry-pick of this broader PR https://github.com/streamlit/streamlit/pull/8610, which also adds tests. However, we want to discuss our testing strategy first, so we decouple it from adding the fix (see for example also this PR https://github.com/streamlit/streamlit/pull/8616).

## GitHub Issue Link (if applicable)

- https://github.com/streamlit/streamlit/issues/8606
- https://github.com/NathanChen198/streamlit-rsa-auth-ui/issues/1
- https://github.com/randyzwitch/streamlit-folium/pull/186

## Testing Plan

- E2E Tests: tests to ensure this behavior will come in a separate PR, see https://github.com/streamlit/streamlit/pull/8616 and https://github.com/streamlit/streamlit/pull/8610

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
