### PR TITLE
Remove fullscreen button for `st.table`

### DIFF
--- a/frontend/lib/src/components/elements/ArrowTable/ArrowTable.tsx
+++ b/frontend/lib/src/components/elements/ArrowTable/ArrowTable.tsx
@@ -17,7 +17,6 @@
 import range from "lodash/range"
 import React, { ReactElement } from "react"
 
-import { withFullScreenWrapper } from "@streamlit/lib/src/components/shared/FullScreenWrapper"
 import { Quiver } from "@streamlit/lib/src/dataframes/Quiver"
 import {
   StyledEmptyTableCell,
@@ -162,4 +161,4 @@ function generateTableCell(
   }
 }
 
-export default withFullScreenWrapper(ArrowTable)
+export default ArrowTable


### PR DESCRIPTION
## Describe your changes

We are migrating the fullscreen button to our new toolbar to prevent horizontal scrolling. For `st.table`, we decided to remove it (temporarily?) since it is already quite buggy.

## GitHub Issue Link (if applicable)

- Related #2358 

## Testing Plan

- Just removes logic that wasn't yet tested.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
