### PR TITLE
fix: #8500 bypass StrEnum 'index' to make position-indexable

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -741,7 +741,7 @@ def ensure_indexable(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     # This is an imperfect check because there is no guarantee that an `index`
     # function actually does the thing we want.
     index_fn = getattr(it, "index", None)
-    if callable(index_fn):
+    if callable(index_fn) and type(it) != EnumMeta:
         # We return a shallow copy of the Sequence here because the return value of
         # this function is saved in a widget serde class instance to be used in later
         # script runs, and we don't want mutations to the options object passed to a

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -721,6 +721,23 @@ class TypeUtilTest(unittest.TestCase):
         self.assertIn("b", l)
         self.assertIn("c", l)
 
+    def test_ensure_indexable_enum_is_indexable(self):
+        """Test Enums are indexable"""
+
+        class Opt(enum.Enum):
+            OPT1 = 1
+            OPT2 = 2
+
+        class StrOpt(str, enum.Enum):
+            OPT1 = "a"
+            OPT2 = "b"
+
+        l = type_util.ensure_indexable(Opt)
+        self.assertEqual(list(Opt), l)
+
+        l = type_util.ensure_indexable(StrOpt)
+        self.assertEqual(list(StrOpt), l)
+
 
 class TestArrowTruncation(DeltaGeneratorTestCase):
     """Test class for the automatic arrow truncation feature."""


### PR DESCRIPTION
## Describe your changes
Patch to ensure StrEnum doesn't get messed up because of str `index`

## GitHub Issue Link (if applicable)
Closes #8500 



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
