### PR TITLE
Refactor Local Sources Watcher to not be instantiated in multiple places.

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -83,7 +83,6 @@ class AppSession:
         uploaded_file_manager: UploadedFileManager,
         script_cache: ScriptCache,
         message_enqueued_callback: Callable[[], None] | None,
-        local_sources_watcher: LocalSourcesWatcher,
         user_info: dict[str, str | None],
         session_id_override: str | None = None,
     ) -> None:
@@ -104,9 +103,6 @@ class AppSession:
 
         message_enqueued_callback
             After enqueuing a message, this callable notification will be invoked.
-
-        local_sources_watcher
-            The file watcher that lets the session know local files have changed.
 
         user_info
             A dict that contains information about the current user. For now,
@@ -144,7 +140,7 @@ class AppSession:
         # due to the source code changing we need to pass in the previous client state.
         self._client_state = ClientState()
 
-        self._local_sources_watcher: LocalSourcesWatcher | None = local_sources_watcher
+        self._local_sources_watcher: LocalSourcesWatcher | None = None
         self._stop_config_listener: Callable[[], bool] | None = None
         self._stop_pages_listener: Callable[[], None] | None = None
 

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -61,7 +61,6 @@ from streamlit.runtime.state import (
 from streamlit.runtime.stats import StatsManager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
-from streamlit.watcher import LocalSourcesWatcher
 
 if TYPE_CHECKING:
     from streamlit.runtime.caching.storage import CacheStorageManager
@@ -563,7 +562,6 @@ class Runtime:
             uploaded_file_manager=self._uploaded_file_mgr,
             script_cache=self._script_cache,
             message_enqueued_callback=self._enqueued_some_message,
-            local_sources_watcher=LocalSourcesWatcher(self._main_script_path),
             user_info={"email": "test@test.com"},
         )
 

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -28,7 +28,6 @@ from streamlit.runtime.session_manager import (
     SessionStorage,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
-from streamlit.watcher import LocalSourcesWatcher
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -100,7 +99,6 @@ class WebsocketSessionManager(SessionManager):
             uploaded_file_manager=self._uploaded_file_mgr,
             script_cache=self._script_cache,
             message_enqueued_callback=self._message_enqueued_callback,
-            local_sources_watcher=LocalSourcesWatcher(script_data.main_script_path),
             user_info=user_info,
             session_id_override=session_id_override,
         )

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -73,22 +73,20 @@ def _create_test_session(
     with patch(
         "streamlit.runtime.app_session.asyncio.get_running_loop",
         return_value=event_loop,
+    ), patch(
+        "streamlit.runtime.app_session.LocalSourcesWatcher",
+        MagicMock(spec=LocalSourcesWatcher),
     ):
         return AppSession(
             script_data=ScriptData("/fake/script_path.py", is_hello=False),
             uploaded_file_manager=MagicMock(),
             script_cache=MagicMock(),
             message_enqueued_callback=None,
-            local_sources_watcher=MagicMock(),
             user_info={"email": "test@test.com"},
             session_id_override=session_id_override,
         )
 
 
-@patch(
-    "streamlit.runtime.app_session.LocalSourcesWatcher",
-    MagicMock(spec=LocalSourcesWatcher),
-)
 class AppSessionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -75,7 +75,6 @@ class RuntimeConfigTests(unittest.TestCase):
         self.assertIsInstance(config.session_storage, MemorySessionStorage)
 
 
-@patch("streamlit.runtime.runtime.LocalSourcesWatcher", MagicMock())
 class RuntimeSingletonTest(unittest.TestCase):
     def tearDown(self) -> None:
         Runtime._instance = None

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -73,7 +73,6 @@ class MockSessionManager(SessionManager):
                 uploaded_file_manager=self._uploaded_file_mgr,
                 script_cache=self._script_cache,
                 message_enqueued_callback=self._message_enqueued_callback,
-                local_sources_watcher=mock.MagicMock(),
                 user_info=user_info,
                 session_id_override=session_id_override,
             )

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -57,11 +57,6 @@ def _create_script_finished_msg(status) -> ForwardMsg:
     return msg
 
 
-def _patch_local_sources_watcher():
-    """Return a mock.patch for LocalSourcesWatcher"""
-    return patch("streamlit.runtime.runtime.LocalSourcesWatcher")
-
-
 class ServerTest(ServerTestCase):
     def setUp(self) -> None:
         self.original_ws_compression = config.get_option(
@@ -78,7 +73,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_start_stop(self):
         """Test that we can start and stop the server."""
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
             self.assertEqual(
                 RuntimeState.NO_SESSIONS_CONNECTED, self.server._runtime._state
@@ -99,7 +94,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_websocket_connect(self):
         """Test that we can connect to the server via websocket."""
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
 
             self.assertFalse(self.server.browser_is_connected)
@@ -125,7 +120,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_connect_to_nonexistent_session(self):
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
 
             ws_client = await self.ws_connect(existing_session_id="nonexistent_session")
@@ -139,7 +134,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_disconnect_and_reconnect(self):
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
 
             ws_client = await self.ws_connect()
@@ -168,7 +163,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_multiple_connections(self):
         """Test multiple websockets can connect simultaneously."""
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
 
             self.assertFalse(self.server.browser_is_connected)
@@ -201,7 +196,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_compression(self):
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", True, "test")
             await self.server.start()
 
@@ -217,7 +212,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_compression_disabled(self):
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", False, "test")
             await self.server.start()
 
@@ -235,7 +230,7 @@ class ServerTest(ServerTestCase):
         """Sending a message to a disconnected SessionClient raises an error.
         We should gracefully handle the error by cleaning up the session.
         """
-        with _patch_local_sources_watcher(), self._patch_app_session():
+        with self._patch_app_session():
             await self.server.start()
             await self.ws_connect()
 


### PR DESCRIPTION
## Describe your changes

This is a small refactor for the local sources watcher to not be in multiple places. Here's the explanation:

- LocalSourcesWatcher is a parameter for AppSession and [saves it.](https://github.com/streamlit/streamlit/blob/b30488a8cd8032fce7148fbaf7fbb162dd752a4a/lib/streamlit/runtime/app_session.py#L147)
- However, it's immediately instantiated in [register_file_watchers](https://github.com/streamlit/streamlit/blob/b30488a8cd8032fce7148fbaf7fbb162dd752a4a/lib/streamlit/runtime/app_session.py#L151), which will [instantiate it on its own](https://github.com/streamlit/streamlit/blob/b30488a8cd8032fce7148fbaf7fbb162dd752a4a/lib/streamlit/runtime/app_session.py#L187).
- It is provided in two places that don't utilize it for any other reason.
  - [Websocket Session Manager](https://github.com/streamlit/streamlit/blob/b30488a8cd8032fce7148fbaf7fbb162dd752a4a/lib/streamlit/runtime/websocket_session_manager.py#L103)
  - [Runtime](https://github.com/streamlit/streamlit/blob/b30488a8cd8032fce7148fbaf7fbb162dd752a4a/lib/streamlit/runtime/runtime.py#L566) (which I don't understand why it exists, but at least does not use the instantiated watcher.

This change essentially removes it as a requirement for instantiation, which simplifies the references and allows LocalSourcesWatcher to be understood in the right location.

## Testing Plan

- Updated Python Unit Tests, which test this thoroughly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
