### PR TITLE
Migrate frontend navigation to App Navigation Abstraction

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -70,7 +70,6 @@ import {
   StreamlitEndpoints,
   ensureError,
   LibContext,
-  AppPage,
   AutoRerun,
   BackMsg,
   Config,
@@ -124,6 +123,7 @@ import withScreencast, {
 import "@streamlit/app/src/assets/css/theme.scss"
 import { preserveEmbedQueryParams } from "@streamlit/lib/src/util/utils"
 import { ThemeManager } from "./util/useThemeManager"
+import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -232,6 +232,8 @@ export class App extends PureComponent<Props, State> {
   private readonly componentRegistry: ComponentRegistry
 
   private readonly embeddingId: string = generateUID()
+
+  private readonly appNavigation: AppNavigation
 
   public constructor(props: Props) {
     super(props)
@@ -360,6 +362,12 @@ export class App extends PureComponent<Props, State> {
 
     this.pendingElementsTimerRunning = false
     this.pendingElementsBuffer = this.state.elements
+    this.appNavigation = new AppNavigation(
+      this.hostCommunicationMgr,
+      this.metricsMgr,
+      this.maybeUpdatePageUrl,
+      this.onPageNotFound
+    )
 
     window.streamlitDebug = {
       clearForwardMsgCache: this.debugClearForwardMsgCache,
@@ -709,28 +717,11 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
-    const { pageName } = pageNotFound
-
-    this.onPageNotFound(pageName)
-
-    const currentPageScriptHash = this.state.appPages[0]?.pageScriptHash || ""
-    this.setState({ currentPageScriptHash }, () => {
-      this.hostCommunicationMgr.sendMessageToHost({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash,
-      })
-    })
+    this.maybeSetState(this.appNavigation.handlePageNotFound(pageNotFound))
   }
 
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
-    const { appPages } = pagesChangedMsg
-    this.setState({ appPages }, () => {
-      this.hostCommunicationMgr.sendMessageToHost({
-        type: "SET_APP_PAGES",
-        appPages,
-      })
-    })
+    this.maybeSetState(this.appNavigation.handlePagesChanged(pagesChangedMsg))
   }
 
   handlePageProfileMsg = (pageProfile: PageProfile): void => {
@@ -884,6 +875,14 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
+  maybeSetState(stateUpdate: MaybeStateUpdate): void {
+    if (stateUpdate) {
+      const [newState, callback] = stateUpdate
+
+      this.setState(newState as State, callback)
+    }
+  }
+
   /**
    * Handler for ForwardMsg.newSession messages. This runs on each rerun
    * @param newSessionProto a NewSession protobuf
@@ -913,18 +912,6 @@ export class App extends PureComponent<Props, State> {
       pageScriptHash: newPageScriptHash,
     } = newSessionProto
 
-    // mainPage must be a string as we're guaranteed at this point that
-    // newSessionProto.appPages is nonempty and has a truthy pageName.
-    // Otherwise, we'd either have no main script or a nameless main script,
-    // neither of which can happen.
-    const mainPage = newSessionProto.appPages[0] as AppPage
-    // We're similarly guaranteed that newPageName will be found / truthy
-    // here.
-    const newPageName = newSessionProto.appPages.find(
-      p => p.pageScriptHash === newPageScriptHash
-    )?.pageName as string
-    const viewingMainPage = newPageScriptHash === mainPage.pageScriptHash
-
     if (!fragmentIdsThisRun.length) {
       // This is a normal rerun, remove all the auto reruns intervals
       this.state.autoReruns.forEach((value: NodeJS.Timer) => {
@@ -935,7 +922,6 @@ export class App extends PureComponent<Props, State> {
       const config = newSessionProto.config as Config
       const themeInput = newSessionProto.customTheme as CustomThemeConfig
 
-      this.maybeUpdatePageUrl(mainPage.pageName, newPageName, viewingMainPage)
       this.processThemeInput(themeInput)
       this.setState({
         allowRunOnSave: config.allowRunOnSave,
@@ -946,33 +932,9 @@ export class App extends PureComponent<Props, State> {
         // empty array.
         fragmentIdsThisRun,
       })
+      this.maybeSetState(this.appNavigation.handleNewSession(newSessionProto))
 
-      // We separate the state of the navigation as we intend to perform
-      // this work through an abstraction of multipage apps in advance
-      // of supporting v2.
-      this.setState(
-        {
-          hideSidebarNav: config.hideSidebarNav,
-          appPages: newSessionProto.appPages,
-          currentPageScriptHash: newPageScriptHash,
-        },
-        () => {
-          this.hostCommunicationMgr.sendMessageToHost({
-            type: "SET_APP_PAGES",
-            appPages: newSessionProto.appPages,
-          })
-
-          this.hostCommunicationMgr.sendMessageToHost({
-            type: "SET_CURRENT_PAGE_NAME",
-            currentPageName: viewingMainPage ? "" : newPageName,
-            currentPageScriptHash: newPageScriptHash,
-          })
-        }
-      )
-
-      // Set the title and favicon to their default values if we are not running
-      // a fragment.
-      document.title = `${newPageName} · Streamlit`
+      // Set the favicon to its default values
       handleFavicon(
         `${process.env.PUBLIC_URL}/favicon.png`,
         this.hostCommunicationMgr.sendMessageToHost,
@@ -992,10 +954,7 @@ export class App extends PureComponent<Props, State> {
     this.metricsMgr.setMetadata(this.state.deployedAppMetadata)
     this.metricsMgr.setAppHash(newSessionHash)
 
-    this.metricsMgr.enqueue("updateReport", {
-      numPages: newSessionProto.appPages.length,
-      isMainPage: viewingMainPage,
-    })
+    this.appNavigation.sendMPAMetricsOnInitialization()
 
     if (
       appHash === newSessionHash &&
@@ -1031,12 +990,9 @@ export class App extends PureComponent<Props, State> {
    * Handler called when the history state changes, e.g. `popstate` event.
    */
   onHistoryChange = (): void => {
-    const targetAppPage =
-      this.state.appPages.find(appPage =>
-        // The page name is embedded at the end of the URL path, and if not, we are in the main page.
-        // See https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/App.tsx#L740
-        document.location.pathname.endsWith("/" + appPage.pageName)
-      ) ?? this.state.appPages[0]
+    const targetAppPage = this.appNavigation.findPageByUrlPath(
+      document.location.pathname
+    )
 
     // do not cause a rerun when an anchor is clicked and we aren't changing pages
     const hasAnchor = document.location.toString().includes("#")

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import {
   HostCommunicationManager,
@@ -150,7 +151,6 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handleNewSession(generateNewSession())
       expect(maybeState).not.toBeUndefined()
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const [newState] = maybeState!
       expect(newState.appPages).toEqual([
         { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
@@ -161,7 +161,6 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handleNewSession(generateNewSession())
       expect(maybeState).not.toBeUndefined()
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const [newState] = maybeState!
       expect(newState.currentPageScriptHash).toEqual("page_script_hash")
     })
@@ -170,7 +169,6 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handleNewSession(generateNewSession({}))
       expect(maybeState).not.toBeUndefined()
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const callback = maybeState![1]
 
       callback()
@@ -208,7 +206,6 @@ describe("AppNavigation", () => {
     )
     expect(maybeState).not.toBeUndefined()
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const [newState] = maybeState!
     expect(newState.appPages).toEqual([
       { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
@@ -225,7 +222,6 @@ describe("AppNavigation", () => {
     )
     expect(maybeState).not.toBeUndefined()
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const callback = maybeState![1]
 
     callback()
@@ -245,7 +241,6 @@ describe("AppNavigation", () => {
     )
     expect(maybeState).not.toBeUndefined()
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const [newState] = maybeState!
     expect(newState.currentPageScriptHash).toEqual("page_script_hash")
   })
@@ -258,7 +253,6 @@ describe("AppNavigation", () => {
     )
     expect(maybeState).not.toBeUndefined()
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const callback = maybeState![1]
 
     callback()

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HostCommunicationManager, SessionInfo } from "@streamlit/lib"
+import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import {
+  AppNavigation,
+  PageUrlUpdateCallback,
+  PageNotFoundCallback,
+} from "./AppNavigation"
+
+describe("AppNavigation", () => {
+  let hostCommunicationMgr: HostCommunicationManager
+  let metricsMgr: SegmentMetricsManager
+  let onUpdatePageUrl: PageUrlUpdateCallback
+  let onPageNotFound: PageNotFoundCallback
+
+  beforeEach(() => {
+    hostCommunicationMgr = new HostCommunicationManager({
+      sendRerunBackMsg: () => {},
+      closeModal: () => {},
+      stopScript: () => {},
+      rerunScript: () => {},
+      clearCache: () => {},
+      sendAppHeartbeat: () => {},
+      setInputsDisabled: () => {},
+      themeChanged: () => {},
+      pageChanged: () => {},
+      isOwnerChanged: () => {},
+      jwtHeaderChanged: () => {},
+      hostMenuItemsChanged: () => {},
+      hostToolbarItemsChanged: () => {},
+      hostHideSidebarNavChanged: () => {},
+      sidebarChevronDownshiftChanged: () => {},
+      pageLinkBaseUrlChanged: () => {},
+      queryParamsChanged: () => {},
+      deployedAppMetadataChanged: () => {},
+    })
+    metricsMgr = new SegmentMetricsManager(new SessionInfo())
+    onUpdatePageUrl = jest.fn()
+    onPageNotFound = jest.fn()
+  })
+
+  // it("generates the correc state on new session", () => {
+  //   const appNavigation = new AppNavigation(
+  //     hostCommunicationMgr,
+  //     metricsMgr,
+  //     onUpdatePageUrl,
+  //     onPageNotFound
+  //   )
+
+  //   const { hideSidebarNav, appPages, currentPageScriptHash } = appNavigation.handleNewSession({
+
+  // })
+})

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { HostCommunicationManager, SessionInfo } from "@streamlit/lib"
+import {
+  HostCommunicationManager,
+  NewSession,
+  SessionInfo,
+  PagesChanged,
+  PageNotFound,
+} from "@streamlit/lib"
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 import {
   AppNavigation,
@@ -22,11 +28,90 @@ import {
   PageNotFoundCallback,
 } from "./AppNavigation"
 
+jest.mock("@streamlit/lib/src/hostComm/HostCommunicationManager", () => {
+  const actualModule = jest.requireActual(
+    "@streamlit/lib/src/hostComm/HostCommunicationManager"
+  )
+
+  const MockedClass = jest.fn().mockImplementation((...props) => {
+    const hostCommunicationMgr = new actualModule.default(...props)
+    jest.spyOn(hostCommunicationMgr, "sendMessageToHost")
+    return hostCommunicationMgr
+  })
+
+  return {
+    __esModule: true,
+    ...actualModule,
+    default: MockedClass,
+  }
+})
+
+jest.mock("@streamlit/app/src/SegmentMetricsManager", () => {
+  const actualModule = jest.requireActual(
+    "@streamlit/app/src/SegmentMetricsManager"
+  )
+
+  const MockedClass = jest.fn().mockImplementation((...props) => {
+    const metricsMgr = new actualModule.SegmentMetricsManager(...props)
+    jest.spyOn(metricsMgr, "enqueue")
+
+    return metricsMgr
+  })
+
+  return {
+    ...actualModule,
+    SegmentMetricsManager: MockedClass,
+  }
+})
+
+function generateNewSession(changes = {}): NewSession {
+  return new NewSession({
+    name: "scriptName",
+    config: {
+      gatherUsageStats: false,
+      maxCachedMessageAge: 0,
+      mapboxToken: "mapboxToken",
+      allowRunOnSave: false,
+      hideSidebarNav: false,
+      hideTopBar: false,
+    },
+    customTheme: {
+      primaryColor: "red",
+      fontFaces: [],
+    },
+    initialize: {
+      userInfo: {
+        installationId: "installationId",
+        installationIdV3: "installationIdV3",
+      },
+      environmentInfo: {
+        streamlitVersion: "streamlitVersion",
+        pythonVersion: "pythonVersion",
+      },
+      sessionStatus: {
+        runOnSave: false,
+        scriptIsRunning: false,
+      },
+      sessionId: "sessionId",
+      isHello: false,
+    },
+    appPages: [
+      { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+    ],
+    pageScriptHash: "page_script_hash",
+    mainScriptPath: "path/to/file.py",
+    scriptRunId: "script_run_id",
+    fragmentIdsThisRun: [],
+    ...changes,
+  })
+}
+
 describe("AppNavigation", () => {
   let hostCommunicationMgr: HostCommunicationManager
   let metricsMgr: SegmentMetricsManager
   let onUpdatePageUrl: PageUrlUpdateCallback
   let onPageNotFound: PageNotFoundCallback
+  let appNavigation: AppNavigation
 
   beforeEach(() => {
     hostCommunicationMgr = new HostCommunicationManager({
@@ -52,17 +137,171 @@ describe("AppNavigation", () => {
     metricsMgr = new SegmentMetricsManager(new SessionInfo())
     onUpdatePageUrl = jest.fn()
     onPageNotFound = jest.fn()
+    appNavigation = new AppNavigation(
+      hostCommunicationMgr,
+      metricsMgr,
+      onUpdatePageUrl,
+      onPageNotFound
+    )
   })
 
-  // it("generates the correc state on new session", () => {
-  //   const appNavigation = new AppNavigation(
-  //     hostCommunicationMgr,
-  //     metricsMgr,
-  //     onUpdatePageUrl,
-  //     onPageNotFound
-  //   )
+  describe("MPA v1", () => {
+    it("sets appPages on new session", () => {
+      const maybeState = appNavigation.handleNewSession(generateNewSession())
+      expect(maybeState).not.toBeUndefined()
 
-  //   const { hideSidebarNav, appPages, currentPageScriptHash } = appNavigation.handleNewSession({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const [newState] = maybeState!
+      expect(newState.appPages).toEqual([
+        { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+      ])
+    })
 
-  // })
+    it("sets currentPageScriptHash on new session", () => {
+      const maybeState = appNavigation.handleNewSession(generateNewSession())
+      expect(maybeState).not.toBeUndefined()
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const [newState] = maybeState!
+      expect(newState.currentPageScriptHash).toEqual("page_script_hash")
+    })
+
+    it("calls host communication on new session", () => {
+      const maybeState = appNavigation.handleNewSession(generateNewSession({}))
+      expect(maybeState).not.toBeUndefined()
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const callback = maybeState![1]
+
+      callback()
+      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+        type: "SET_APP_PAGES",
+        appPages: [
+          { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+        ],
+      })
+
+      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+        type: "SET_CURRENT_PAGE_NAME",
+        currentPageName: "",
+        currentPageScriptHash: "page_script_hash",
+      })
+    })
+  })
+
+  it("calls onUpdatePageUrl with the right information", () => {
+    appNavigation.handleNewSession(generateNewSession())
+    expect(onUpdatePageUrl).toHaveBeenCalledWith(
+      "streamlit_app",
+      "streamlit_app",
+      true
+    )
+  })
+
+  it("sets appPages on pages changed", () => {
+    const maybeState = appNavigation.handlePagesChanged(
+      new PagesChanged({
+        appPages: [
+          { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+        ],
+      })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [newState] = maybeState!
+    expect(newState.appPages).toEqual([
+      { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+    ])
+  })
+
+  it("calls host communication on pages changed", () => {
+    const maybeState = appNavigation.handlePagesChanged(
+      new PagesChanged({
+        appPages: [
+          { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+        ],
+      })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const callback = maybeState![1]
+
+    callback()
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_APP_PAGES",
+      appPages: [
+        { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+      ],
+    })
+  })
+
+  it("sets currentPageScriptHash on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "foo" })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [newState] = maybeState!
+    expect(newState.currentPageScriptHash).toEqual("page_script_hash")
+  })
+
+  it("calls host communication on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "foo" })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const callback = maybeState![1]
+
+    callback()
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "page_script_hash",
+    })
+  })
+
+  it("calls onPageNotFound when page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    appNavigation.handlePageNotFound(new PageNotFound({ pageName: "foo" }))
+    expect(onPageNotFound).toHaveBeenCalledWith("foo")
+  })
+
+  it("sends metrics when initialized", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    appNavigation.sendMPAMetricsOnInitialization()
+
+    expect(metricsMgr.enqueue).toHaveBeenCalledWith("updateReport", {
+      numPages: 1,
+      isMainPage: true,
+    })
+  })
+
+  it("finds url by path when path is valid", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const page = appNavigation.findPageByUrlPath("streamlit_app")
+
+    expect(page.pageScriptHash).toEqual("page_script_hash")
+    expect(page.pageName).toEqual("streamlit_app")
+  })
+
+  it("returns default url by path when path is invalid", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const page = appNavigation.findPageByUrlPath("foo")
+
+    expect(page.pageScriptHash).toEqual("page_script_hash")
+    expect(page.pageName).toEqual("streamlit_app")
+  })
 })

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -149,6 +149,10 @@ export class AppNavigation {
 
   sendMPAMetricsOnInitialization(): void {
     const { appPages, currentPageScriptHash } = this
+    if (appPages.length === 0) {
+      return
+    }
+
     this.metricsMgr.enqueue("updateReport", {
       numPages: appPages.length,
       isMainPage: appPages[0].pageScriptHash === currentPageScriptHash,

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HostCommunicationManager,
+  IAppPage,
+  NewSession,
+  PagesChanged,
+  PageNotFound,
+} from "@streamlit/lib"
+import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+
+interface AppNavigationState {
+  hideSidebarNav: boolean
+  appPages: IAppPage[]
+  currentPageScriptHash: string
+}
+
+export type MaybeStateUpdate =
+  | [Partial<AppNavigationState>, () => void]
+  | undefined
+export type PageUrlUpdateCallback = (
+  mainPageName: string,
+  newPageName: string,
+  isViewingMainPage: boolean
+) => void
+export type PageNotFoundCallback = (pageName?: string) => void
+
+export class AppNavigation {
+  readonly hostCommunicationMgr: HostCommunicationManager
+
+  readonly metricsMgr: SegmentMetricsManager
+
+  readonly onUpdatePageUrl: PageUrlUpdateCallback
+
+  readonly onPageNotFound: PageNotFoundCallback
+
+  private appPages: IAppPage[]
+
+  private currentPageScriptHash: string | null
+
+  private hideSidebarNav: boolean | null
+
+  constructor(
+    hostCommunicationMgr: HostCommunicationManager,
+    metricsMgr: SegmentMetricsManager,
+    onUpdatePageUrl: PageUrlUpdateCallback,
+    onPageNotFound: PageNotFoundCallback
+  ) {
+    this.hostCommunicationMgr = hostCommunicationMgr
+    this.metricsMgr = metricsMgr
+    this.onUpdatePageUrl = onUpdatePageUrl
+    this.onPageNotFound = onPageNotFound
+
+    this.appPages = []
+    this.currentPageScriptHash = null
+    this.hideSidebarNav = null
+  }
+
+  handleNewSession(newSession: NewSession): MaybeStateUpdate {
+    this.appPages = newSession.appPages
+    this.currentPageScriptHash = newSession.pageScriptHash
+    this.hideSidebarNav = newSession.config?.hideSidebarNav ?? false
+
+    // mainPage must be a string as we're guaranteed at this point that
+    // newSessionProto.appPages is nonempty and has a truthy pageName.
+    // Otherwise, we'd either have no main script or a nameless main script,
+    // neither of which can happen.
+    const mainPage = this.appPages[0] as IAppPage
+    const mainPageName = mainPage.pageName ?? ""
+    // We're similarly guaranteed that newPageName will be found / truthy
+    // here.
+    const newPageName =
+      this.appPages.find(
+        page => page.pageScriptHash === this.currentPageScriptHash
+      )?.pageName ?? ""
+
+    const isViewingMainPage =
+      mainPage.pageScriptHash === this.currentPageScriptHash
+    this.onUpdatePageUrl(mainPageName, newPageName, isViewingMainPage)
+
+    // Set the title to its default value
+    document.title = `${newPageName ?? ""} · Streamlit`
+
+    return [
+      {
+        hideSidebarNav: this.hideSidebarNav,
+        appPages: this.appPages,
+        currentPageScriptHash: this.currentPageScriptHash,
+      },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_APP_PAGES",
+          appPages: this.appPages,
+        })
+
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_CURRENT_PAGE_NAME",
+          currentPageName: isViewingMainPage ? "" : newPageName,
+          currentPageScriptHash: this.currentPageScriptHash as string,
+        })
+      },
+    ]
+  }
+
+  handlePagesChanged(pagesChangedMsg: PagesChanged): MaybeStateUpdate {
+    const { appPages } = pagesChangedMsg
+    return [
+      { appPages },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_APP_PAGES",
+          appPages,
+        })
+      },
+    ]
+  }
+
+  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
+    const { pageName } = pageNotFound
+    this.onPageNotFound(pageName)
+    const currentPageScriptHash = this.appPages[0]?.pageScriptHash ?? ""
+    this.currentPageScriptHash = currentPageScriptHash
+
+    return [
+      { currentPageScriptHash },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_CURRENT_PAGE_NAME",
+          currentPageName: "",
+          currentPageScriptHash,
+        })
+      },
+    ]
+  }
+
+  sendMPAMetricsOnInitialization(): void {
+    const { appPages, currentPageScriptHash } = this
+    this.metricsMgr.enqueue("updateReport", {
+      numPages: appPages.length,
+      isMainPage: appPages[0].pageScriptHash === currentPageScriptHash,
+    })
+  }
+
+  findPageByUrlPath(pathname: string): IAppPage {
+    return (
+      this.appPages.find(appPage =>
+        // The page name is embedded at the end of the URL path, and if not, we are in the main page.
+        // See https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/App.tsx#L740
+        pathname.endsWith("/" + appPage.pageName)
+      ) ?? this.appPages[0]
+    )
+  }
+}


### PR DESCRIPTION
## Describe your changes

Combine all logic of the navigation (page url updates, mpa management), and put it in a class (V1AppNavigation). We create a layer above it that essentially pulls from the V1AppNavigation as an overengineering effort to set up for AppNavigation V2

## Testing Plan

- Original tests should pass
- unit tests for AppNavigation.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
