### PR TITLE
Focus chat input after the submit button is pressed

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -120,6 +120,29 @@ describe("ChatInput widget", () => {
     expect(chatInput).toHaveTextContent("")
   })
 
+  it("ensures chat input has focus on submit by keyboard", () => {
+    const props = getProps()
+    render(<ChatInput {...props} />)
+
+    const chatInput = screen.getByTestId("stChatInputTextArea")
+    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    expect(chatInput).toHaveTextContent("1234567890")
+    fireEvent.keyDown(chatInput, { key: "Enter" })
+    expect(chatInput).toHaveFocus()
+  })
+
+  it("ensures chat input has focus on submit by button click", () => {
+    const props = getProps()
+    render(<ChatInput {...props} />)
+
+    const chatInput = screen.getByTestId("stChatInputTextArea")
+    const chatButton = screen.getByTestId("stChatInputSubmitButton")
+    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    expect(chatInput).toHaveTextContent("1234567890")
+    fireEvent.click(chatButton)
+    expect(chatInput).toHaveFocus()
+  })
+
   it("can set fragmentId when sending value", () => {
     const props = getProps(undefined, { fragmentId: "myFragmentId" })
     const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -101,6 +101,12 @@ function ChatInput({
   }
 
   const handleSubmit = (): void => {
+    // We want the chat input to always be in focus
+    // even if the user clicks the submit button
+    if (chatInputRef.current) {
+      chatInputRef.current.focus()
+    }
+
     if (!value) {
       return
     }


### PR DESCRIPTION
## Describe your changes

In mobile, for chat experiences, we want to keep the keyboard presented for usability. We accomplish this by keeping focus on the text input after submission.

## Testing Plan

- JS Unit Tests are provided

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
