### PR TITLE
Refactor page management to a PagesManager class

### DIFF
--- a/e2e_playwright/hello_app.py
+++ b/e2e_playwright/hello_app.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 
+from streamlit import source_util
 from streamlit.hello import Hello
 
 # Set random seed to always get the same results in the plotting demo
@@ -23,10 +24,9 @@ np.random.seed(0)
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 ctx = get_script_run_ctx()
-
-ctx.pages_manager._cached_pages = None
-ctx.pages_manager._cached_pages = ctx.pages_manager.get_pages(Hello.__file__)
-ctx.pages_manager._on_pages_changed.send()
+if ctx:
+    ctx.pages_manager._cached_pages = source_util.get_pages(Hello.__file__)
+    ctx.pages_manager._on_pages_changed.send()
 
 # TODO(lukasmasuch): Once we migrate the hello app to the new programmatic
 # MPA API, we can remove this workaround.

--- a/e2e_playwright/hello_app.py
+++ b/e2e_playwright/hello_app.py
@@ -14,17 +14,19 @@
 
 import numpy as np
 
-from streamlit import source_util
 from streamlit.hello import Hello
 
 # Set random seed to always get the same results in the plotting demo
 np.random.seed(0)
 
 # This is a trick to setup the MPA hello app programmatically
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 
-source_util._cached_pages = None
-source_util._cached_pages = source_util.get_pages(Hello.__file__)
-source_util._on_pages_changed.send()
+ctx = get_script_run_ctx()
+
+ctx.pages_manager._cached_pages = None
+ctx.pages_manager._cached_pages = ctx.pages_manager.get_pages(Hello.__file__)
+ctx.pages_manager._on_pages_changed.send()
 
 # TODO(lukasmasuch): Once we migrate the hello app to the new programmatic
 # MPA API, we can remove this workaround.

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -18,7 +18,6 @@ import os
 from typing import Final, NoReturn
 
 import streamlit as st
-from streamlit import source_util
 from streamlit.deprecation_util import make_deprecated_name_warning
 from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
@@ -143,7 +142,7 @@ def switch_page(page: str) -> NoReturn:  # type: ignore[misc]
 
     main_script_directory = get_main_script_directory(ctx.main_script_path)
     requested_page = os.path.realpath(normalize_path_join(main_script_directory, page))
-    all_app_pages = source_util.get_pages(ctx.main_script_path).values()
+    all_app_pages = ctx.pages_manager.get_pages().values()
 
     matched_pages = [p for p in all_app_pages if p["script_path"] == requested_page]
 

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, BinaryIO, Final, Literal, TextIO, Union, cast
 
 from typing_extensions import TypeAlias
 
-from streamlit import runtime, source_util
+from streamlit import runtime
 from streamlit.elements.form import current_form_id, is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
@@ -683,17 +683,18 @@ class ButtonMixin:
 
         ctx = get_script_run_ctx()
         ctx_main_script = ""
+        all_app_pages = {}
         if ctx:
             ctx_main_script = ctx.main_script_path
+            all_app_pages = ctx.pages_manager.get_pages()
 
         main_script_directory = get_main_script_directory(ctx_main_script)
         requested_page = os.path.realpath(
             normalize_path_join(main_script_directory, page)
         )
-        all_app_pages = source_util.get_pages(ctx_main_script).values()
 
         # Handle retrieving the page_script_hash & page
-        for page_data in all_app_pages:
+        for page_data in all_app_pages.values():
             full_path = page_data["script_path"]
             page_name = page_data["page_name"]
             if requested_page == full_path:

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -1,0 +1,147 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Callable, Final
+
+from blinker import Signal
+
+import streamlit.source_util as source_util
+from streamlit.logger import get_logger
+from streamlit.util import calc_md5
+from streamlit.watcher import watch_dir
+
+_LOGGER: Final = get_logger(__name__)
+
+
+class V1PagesManager:
+    is_watching_pages_dir: bool = False
+
+    # This is a static method because we only want to watch the pages directory
+    # once on initial load.
+    @staticmethod
+    def watch_pages_dir(pages_manager):
+        if V1PagesManager.is_watching_pages_dir:
+            return
+
+        def _on_pages_changed(_path: str) -> None:
+            pages_manager.invalidate_pages_cache()
+
+        main_script_path = Path(pages_manager.main_script_path)
+        pages_dir = main_script_path.parent / "pages"
+        watch_dir(
+            str(pages_dir),
+            _on_pages_changed,
+            glob_pattern="*.py",
+            allow_nonexistent=True,
+        )
+        V1PagesManager.is_watching_pages_dir = True
+
+
+class PagesManager:
+    _cached_pages: dict[str, dict[str, str]] | None = None
+    _pages_cache_lock = threading.RLock()
+    _on_pages_changed = Signal(doc="Emitted when the set of pages has changed")
+
+    def __init__(self, main_script_path, **kwargs):
+        self._main_script_path = main_script_path
+        self._main_script_hash = calc_md5(main_script_path)
+        self._current_page_hash = self._main_script_hash
+
+        if kwargs.get("setup_watcher", True):
+            V1PagesManager.watch_pages_dir(self)
+
+    @property
+    def main_script_path(self):
+        return self._main_script_path
+
+    def get_main_page(self):
+        return {
+            "script_path": self._main_script_path,
+            "page_script_hash": self._main_script_hash,
+        }
+
+    def get_current_page_script_hash(self):
+        return self._current_page_hash
+
+    def set_current_page_script_hash(self, page_hash):
+        self._current_page_hash = page_hash
+
+    def get_active_script(self, page_script_hash, page_name):
+        pages = self.get_pages()
+
+        if page_script_hash:
+            return pages.get(page_script_hash, None)
+        elif not page_script_hash and page_name:
+            # If a user navigates directly to a non-main page of an app, we get
+            # the first script run request before the list of pages has been
+            # sent to the frontend. In this case, we choose the first script
+            # with a name matching the requested page name.
+            return next(
+                filter(
+                    # There seems to be this weird bug with mypy where it
+                    # thinks that p can be None (which is impossible given the
+                    # types of pages), so we add `p and` at the beginning of
+                    # the predicate to circumvent this.
+                    lambda p: p and (p["page_name"] == page_name),
+                    pages.values(),
+                ),
+                None,
+            )
+
+        # If no information about what page to run is given, default to
+        # running the main page.
+        # Safe because pages will at least contain the app's main page.
+        main_page_info = list(pages.values())[0]
+        return main_page_info
+
+    def get_pages(self) -> dict[str, dict[str, str]]:
+        # Avoid taking the lock if the pages cache hasn't been invalidated.
+        pages = self._cached_pages
+        if pages is not None:
+            return pages
+
+        with self._pages_cache_lock:
+            # The cache may have been repopulated while we were waiting to grab
+            # the lock.
+            if self._cached_pages is not None:
+                return self._cached_pages
+
+            pages = source_util.get_pages(self.main_script_path)
+            self._cached_pages = pages
+
+            return pages
+
+    def invalidate_pages_cache(self) -> None:
+        _LOGGER.debug("Set of pages have changed. Invalidating cache.")
+        with self._pages_cache_lock:
+            self._cached_pages = None
+
+        self._on_pages_changed.send()
+
+    def register_pages_changed_callback(
+        self,
+        callback: Callable[[str], None],
+    ) -> Callable[[], None]:
+        def disconnect():
+            self._on_pages_changed.disconnect(callback)
+
+        # weak=False so that we have control of when the pages changed
+        # callback is deregistered.
+        self._on_pages_changed.connect(callback, weak=False)
+
+        return disconnect

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -33,6 +33,7 @@ from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 if TYPE_CHECKING:
     from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.pages_manager import PagesManager
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -60,9 +61,9 @@ class ScriptRunContext:
     session_state: SafeSessionState
     uploaded_file_mgr: UploadedFileManager
     main_script_path: str
-    page_script_hash: str
     user_info: UserInfo
     fragment_storage: "FragmentStorage"
+    pages_manager: "PagesManager"
 
     gather_usage_stats: bool = False
     command_tracking_deactivated: bool = False
@@ -87,6 +88,10 @@ class ScriptRunContext:
     _experimental_query_params_used = False
     _production_query_params_used = False
 
+    @property
+    def page_script_hash(self):
+        return self.pages_manager.get_current_page_script_hash()
+
     def reset(
         self,
         query_string: str = "",
@@ -98,7 +103,7 @@ class ScriptRunContext:
         self.widget_user_keys_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
-        self.page_script_hash = page_script_hash
+        self.pages_manager.set_current_page_script_hash(page_script_hash)
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -16,10 +16,19 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
+
+from typing_extensions import NotRequired
 
 from streamlit.string_util import extract_leading_emoji
 from streamlit.util import calc_md5
+
+
+class PageInfo(TypedDict):
+    script_path: str
+    page_script_hash: str
+    icon: NotRequired[str]
+    page_name: NotRequired[str]
 
 
 def open_python_file(filename: str):
@@ -84,7 +93,7 @@ def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     return extract_leading_emoji(icon_and_name)
 
 
-def get_pages(main_script_path_str: str) -> dict[str, dict[str, str]]:
+def get_pages(main_script_path_str: str) -> dict[str, PageInfo]:
     main_script_path = Path(main_script_path_str)
     main_page_icon, main_page_name = page_icon_and_name(main_script_path)
     main_script_hash = calc_md5(main_script_path_str)
@@ -92,7 +101,7 @@ def get_pages(main_script_path_str: str) -> dict[str, dict[str, str]]:
     # NOTE: We include the script_hash in the dict even though it is
     #       already used as the key because that occasionally makes things
     #       easier for us when we need to iterate over pages.
-    pages = {
+    pages: dict[str, PageInfo] = {
         main_script_hash: {
             "page_script_hash": main_script_hash,
             "page_name": main_page_name,

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -15,17 +15,11 @@
 from __future__ import annotations
 
 import re
-import threading
 from pathlib import Path
-from typing import Any, Callable, Final, cast
+from typing import Any, cast
 
-from blinker import Signal
-
-from streamlit.logger import get_logger
 from streamlit.string_util import extract_leading_emoji
 from streamlit.util import calc_md5
-
-_LOGGER: Final = get_logger(__name__)
 
 
 def open_python_file(filename: str):
@@ -90,86 +84,43 @@ def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     return extract_leading_emoji(icon_and_name)
 
 
-_pages_cache_lock = threading.RLock()
-_cached_pages: dict[str, dict[str, str]] | None = None
-_on_pages_changed = Signal(doc="Emitted when the pages directory is changed")
-
-
-def invalidate_pages_cache() -> None:
-    global _cached_pages
-
-    _LOGGER.debug("Pages directory changed")
-    with _pages_cache_lock:
-        _cached_pages = None
-
-    _on_pages_changed.send()
-
-
 def get_pages(main_script_path_str: str) -> dict[str, dict[str, str]]:
-    global _cached_pages
+    main_script_path = Path(main_script_path_str)
+    main_page_icon, main_page_name = page_icon_and_name(main_script_path)
+    main_script_hash = calc_md5(main_script_path_str)
 
-    # Avoid taking the lock if the pages cache hasn't been invalidated.
-    pages = _cached_pages
-    if pages is not None:
-        return pages
+    # NOTE: We include the script_hash in the dict even though it is
+    #       already used as the key because that occasionally makes things
+    #       easier for us when we need to iterate over pages.
+    pages = {
+        main_script_hash: {
+            "page_script_hash": main_script_hash,
+            "page_name": main_page_name,
+            "icon": main_page_icon,
+            "script_path": str(main_script_path.resolve()),
+        }
+    }
 
-    with _pages_cache_lock:
-        # The cache may have been repopulated while we were waiting to grab
-        # the lock.
-        if _cached_pages is not None:
-            return _cached_pages
+    pages_dir = main_script_path.parent / "pages"
+    page_scripts = sorted(
+        [
+            f
+            for f in pages_dir.glob("*.py")
+            if not f.name.startswith(".") and not f.name == "__init__.py"
+        ],
+        key=page_sort_key,
+    )
 
-        main_script_path = Path(main_script_path_str)
-        main_page_icon, main_page_name = page_icon_and_name(main_script_path)
-        main_page_script_hash = calc_md5(main_script_path_str)
+    for script_path in page_scripts:
+        script_path_str = str(script_path.resolve())
+        pi, pn = page_icon_and_name(script_path)
+        psh = calc_md5(script_path_str)
 
-        # NOTE: We include the page_script_hash in the dict even though it is
-        #       already used as the key because that occasionally makes things
-        #       easier for us when we need to iterate over pages.
-        pages = {
-            main_page_script_hash: {
-                "page_script_hash": main_page_script_hash,
-                "page_name": main_page_name,
-                "icon": main_page_icon,
-                "script_path": str(main_script_path.resolve()),
-            }
+        pages[psh] = {
+            "page_script_hash": psh,
+            "page_name": pn,
+            "icon": pi,
+            "script_path": script_path_str,
         }
 
-        pages_dir = main_script_path.parent / "pages"
-        page_scripts = sorted(
-            [
-                f
-                for f in pages_dir.glob("*.py")
-                if not f.name.startswith(".") and not f.name == "__init__.py"
-            ],
-            key=page_sort_key,
-        )
-
-        for script_path in page_scripts:
-            script_path_str = str(script_path.resolve())
-            pi, pn = page_icon_and_name(script_path)
-            psh = calc_md5(script_path_str)
-
-            pages[psh] = {
-                "page_script_hash": psh,
-                "page_name": pn,
-                "icon": pi,
-                "script_path": script_path_str,
-            }
-
-        _cached_pages = pages
-
-        return pages
-
-
-def register_pages_changed_callback(
-    callback: Callable[[str], None],
-) -> Callable[[], None]:
-    def disconnect():
-        _on_pages_changed.disconnect(callback)
-
-    # weak=False so that we have control of when the pages changed
-    # callback is deregistered.
-    _on_pages_changed.connect(callback, weak=False)
-
-    return disconnect
+    return pages

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 import time
 import types
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib import parse
 
 from streamlit import runtime
@@ -31,6 +31,9 @@ from streamlit.runtime.scriptrunner.script_run_context import ScriptRunContext
 from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.testing.v1.element_tree import ElementTree, parse_tree_from_messages
 
+if TYPE_CHECKING:
+    from streamlit.runtime.pages_manager import PagesManager
+
 
 class LocalScriptRunner(ScriptRunner):
     """Subclasses ScriptRunner to provide some testing features."""
@@ -39,6 +42,7 @@ class LocalScriptRunner(ScriptRunner):
         self,
         script_path: str,
         session_state: SafeSessionState,
+        pages_manager: "PagesManager",
         args=None,
         kwargs=None,
     ):
@@ -61,6 +65,7 @@ class LocalScriptRunner(ScriptRunner):
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=pages_manager,
         )
 
         # Accumulates all ScriptRunnerEvents emitted by us.

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -19,16 +19,18 @@ import os
 import sys
 import types
 from pathlib import Path
-from typing import Callable, Final
+from typing import TYPE_CHECKING, Callable, Final
 
 from streamlit import config, file_util
 from streamlit.folder_black_list import FolderBlackList
 from streamlit.logger import get_logger
-from streamlit.source_util import get_pages
 from streamlit.watcher.path_watcher import (
     NoOpPathWatcher,
     get_default_path_watcher_class,
 )
+
+if TYPE_CHECKING:
+    from streamlit.runtime.pages_manager import PagesManager
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -40,8 +42,9 @@ PathWatcher = None
 
 
 class LocalSourcesWatcher:
-    def __init__(self, main_script_path: str):
-        self._main_script_path = os.path.abspath(main_script_path)
+    def __init__(self, pages_manager: "PagesManager"):
+        self._pages_manager = pages_manager
+        self._main_script_path = os.path.abspath(self._pages_manager.main_script_path)
         self._script_folder = os.path.dirname(self._main_script_path)
         self._on_file_changed: list[Callable[[str], None]] = []
         self._is_closed = False
@@ -61,7 +64,7 @@ class LocalSourcesWatcher:
         old_watched_pages = self._watched_pages
         new_pages_paths: set[str] = set()
 
-        for page_info in get_pages(self._main_script_path).values():
+        for page_info in self._pages_manager.get_pages().values():
             new_pages_paths.add(page_info["script_path"])
             if page_info["script_path"] not in old_watched_pages:
                 self._register_watcher(
@@ -71,7 +74,11 @@ class LocalSourcesWatcher:
 
         for old_page_path in old_watched_pages:
             if old_page_path not in new_pages_paths:
-                self._deregister_watcher(old_page_path)
+                if _is_valid_path(old_page_path):
+                    # file still exists, so we will continue to watch it
+                    new_pages_paths.add(old_page_path)
+                else:
+                    self._deregister_watcher(old_page_path)
 
         self._watched_pages = new_pages_paths
 

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -74,11 +74,7 @@ class LocalSourcesWatcher:
 
         for old_page_path in old_watched_pages:
             if old_page_path not in new_pages_paths:
-                if _is_valid_path(old_page_path):
-                    # file still exists, so we will continue to watch it
-                    new_pages_paths.add(old_page_path)
-                else:
-                    self._deregister_watcher(old_page_path)
+                self._deregister_watcher(old_page_path)
 
         self._watched_pages = new_pages_paths
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -18,7 +18,6 @@ import asyncio
 import os
 import signal
 import sys
-from pathlib import Path
 from typing import Any, Final
 
 from streamlit import (
@@ -34,8 +33,7 @@ from streamlit import (
 from streamlit.config import CONFIG_FILENAMES
 from streamlit.git_util import MIN_GIT_VERSION, GitRepo
 from streamlit.logger import get_logger
-from streamlit.source_util import invalidate_pages_cache
-from streamlit.watcher import report_watchdog_availability, watch_dir, watch_file
+from streamlit.watcher import report_watchdog_availability, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket, server_util
 
 _LOGGER: Final = get_logger(__name__)
@@ -352,21 +350,6 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
             watch_file(filename, on_config_changed)
 
 
-def _install_pages_watcher(main_script_path_str: str) -> None:
-    def _on_pages_changed(_path: str) -> None:
-        invalidate_pages_cache()
-
-    main_script_path = Path(main_script_path_str)
-    pages_dir = main_script_path.parent / "pages"
-
-    watch_dir(
-        str(pages_dir),
-        _on_pages_changed,
-        glob_pattern="*.py",
-        allow_nonexistent=True,
-    )
-
-
 def run(
     main_script_path: str,
     is_hello: bool,
@@ -383,7 +366,6 @@ def run(
     _fix_pydeck_mapbox_api_warning()
     _fix_pydantic_duplicate_validators_error()
     _install_config_watchers(flag_options)
-    _install_pages_watcher(main_script_path)
 
     # Create the server. It won't start running yet.
     server = Server(main_script_path, is_hello)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -61,7 +61,7 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             # If the file is not found, we try to serve the default file
             # and allow the frontend to handle the issue.
             if e.status_code == 404:
-                self.path = self.parse_url_path(self.default_filename)
+                self.path = self.parse_url_path(self.default_filename or "index.html")
                 absolute_path = self.get_absolute_path(self.root, self.path)
                 return super().validate_absolute_path(root, absolute_path)
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-from typing import Final
+from typing import Final, Optional
 
 import tornado.web
 
@@ -41,11 +41,6 @@ def allow_cross_origin_requests() -> bool:
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
-    def initialize(self, path, default_filename, get_pages):
-        self._pages = get_pages()
-
-        super().initialize(path=path, default_filename=default_filename)
-
     def set_extra_headers(self, path: str) -> None:
         """Disable cache for HTML files.
 
@@ -59,28 +54,18 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         else:
             self.set_header("Cache-Control", "public")
 
-    def parse_url_path(self, url_path: str) -> str:
-        url_parts = url_path.split("/")
+    def validate_absolute_path(self, root: str, absolute_path: str) -> Optional[str]:
+        try:
+            return super().validate_absolute_path(root, absolute_path)
+        except tornado.web.HTTPError as e:
+            # If the file is not found, we try to serve the default file
+            # and allow the frontend to handle the issue.
+            if e.status_code == 404:
+                self.path = self.parse_url_path(self.default_filename)
+                absolute_path = self.get_absolute_path(self.root, self.path)
+                return super().validate_absolute_path(root, absolute_path)
 
-        maybe_page_name = url_parts[0]
-        if maybe_page_name in self._pages:
-            # If we're trying to navigate to a page, we return "index.html"
-            # directly here instead of deferring to the superclass below after
-            # modifying the url_path. The reason why is that tornado handles
-            # requests to "directories" (which is what navigating to a page
-            # looks like) by appending a trailing '/' if there is none and
-            # redirecting.
-            #
-            # This would work, but it
-            #   * adds an unnecessary redirect+roundtrip
-            #   * adds a trailing '/' to the URL appearing in the browser, which
-            #     looks bad
-            if len(url_parts) == 1:
-                return "index.html"
-
-            url_path = "/".join(url_parts[1:])
-
-        return super().parse_url_path(url_path)
+            raise e
 
     def write_error(self, status_code: int, **kwargs) -> None:
         if status_code == 404:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -28,7 +28,7 @@ import tornado.web
 import tornado.websocket
 from tornado.httpserver import HTTPServer
 
-from streamlit import cli_util, config, file_util, source_util, util
+from streamlit import cli_util, config, file_util, util
 from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
@@ -86,7 +86,8 @@ UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"
 MESSAGE_ENDPOINT: Final = r"_stcore/message"
-HEALTH_ENDPOINT: Final = r"(?:healthz|_stcore/health)"
+NEW_HEALTH_ENDPOINT: Final = "_stcore/health"
+HEALTH_ENDPOINT: Final = rf"(?:healthz|{NEW_HEALTH_ENDPOINT})"
 HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
     r"(?:script-health-check|_stcore/script-health-check)"
@@ -365,7 +366,16 @@ class Server:
                     (
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
-                        {"path": "%s/" % static_path, "default_filename": "index.html"},
+                        {
+                            "path": "%s/" % static_path,
+                            "default_filename": "index.html",
+                            "reserved_paths": [
+                                # These paths are required for identifying
+                                # the base url path.
+                                NEW_HEALTH_ENDPOINT,
+                                HOST_CONFIG_ENDPOINT,
+                            ],
+                        },
                     ),
                     (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
                 ]

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -365,16 +365,7 @@ class Server:
                     (
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
-                        {
-                            "path": "%s/" % static_path,
-                            "default_filename": "index.html",
-                            "get_pages": lambda: {
-                                page_info["page_name"]
-                                for page_info in source_util.get_pages(
-                                    self.main_script_path
-                                ).values()
-                            },
-                        },
+                        {"path": "%s/" % static_path, "default_filename": "index.html"},
                     ),
                     (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
                 ]

--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -30,6 +30,7 @@ from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import (
     ScriptRunContext,
     add_script_run_ctx,
@@ -55,10 +56,10 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager(UPLOAD_FILE_ENDPOINT),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             script_requests=ScriptRequests(),
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         add_script_run_ctx(threading.current_thread(), self.script_run_ctx)
 

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import ScriptRunContext, add_script_run_ctx
 from streamlit.runtime.state import SafeSessionState, SessionState
 
@@ -66,9 +67,9 @@ def call_on_threads(
                 session_state=SafeSessionState(SessionState(), lambda: None),
                 uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
                 main_script_path="",
-                page_script_hash="",
                 user_info={"email": "test@test.com"},
                 fragment_storage=MemoryFragmentStorage(),
+                pages_manager=PagesManager(""),
             )
             thread = threads[ii]
             add_script_run_ctx(thread, ctx)

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -323,7 +323,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         # Generate widget id and reset context
         st.number_input("a number", min_value=1, max_value=100, key="number")
         widget_id = self.script_run_ctx.session_state.get_widget_states()[0].id
-        self.script_run_ctx.reset()
+        self.script_run_ctx.reset(page_script_hash=self.script_run_ctx.page_script_hash)
 
         # Set the state of the widgets to the test state
         widget_state = WidgetState()

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -453,14 +453,17 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         patched_register_callback.assert_called_once_with(session._on_pages_changed)
 
-    @patch.object(PagesManager, "_on_pages_changed")
-    def test_deregisters_pages_watcher_on_shutdown(self, patched_on_pages_changed):
-        session = _create_test_session()
-        session.shutdown()
+    def test_deregisters_pages_watcher_on_shutdown(self):
+        disconnect_mock = MagicMock()
+        with patch.object(
+            PagesManager,
+            "register_pages_changed_callback",
+            return_value=disconnect_mock,
+        ):
+            session = _create_test_session()
+            session.shutdown()
 
-        patched_on_pages_changed.disconnect.assert_called_once_with(
-            session._on_pages_changed
-        )
+            disconnect_mock.assert_called_once()
 
     def test_tags_fwd_msgs_with_last_backmsg_id_if_set(self):
         session = _create_test_session()

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -19,7 +19,7 @@ import unittest
 from asyncio import AbstractEventLoop
 from typing import Any, Callable, List, Optional, cast
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 
@@ -39,6 +39,7 @@ from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner import (
     RerunData,
@@ -316,6 +317,7 @@ class AppSessionTest(unittest.TestCase):
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
             fragment_storage=session._fragment_storage,
+            pages_manager=session._pages_manager,
         )
 
         self.assertIsNotNone(session._scriptrunner)
@@ -421,8 +423,9 @@ class AppSessionTest(unittest.TestCase):
 
         self.assertEqual(session.request_rerun.called, False)
 
-    @patch(
-        "streamlit.runtime.app_session.source_util.get_pages",
+    @patch.object(
+        PagesManager,
+        "get_pages",
         MagicMock(
             return_value={
                 "hash1": {"page_name": "page1", "icon": "", "script_path": "script1"},
@@ -445,14 +448,12 @@ class AppSessionTest(unittest.TestCase):
 
         mock_enqueue.assert_called_once_with(expected_msg)
 
-    @patch(
-        "streamlit.runtime.app_session.source_util.register_pages_changed_callback",
-    )
+    @patch.object(PagesManager, "register_pages_changed_callback")
     def test_installs_pages_watcher_on_init(self, patched_register_callback):
         session = _create_test_session()
         patched_register_callback.assert_called_once_with(session._on_pages_changed)
 
-    @patch("streamlit.runtime.app_session.source_util._on_pages_changed")
+    @patch.object(PagesManager, "_on_pages_changed")
     def test_deregisters_pages_watcher_on_shutdown(self, patched_on_pages_changed):
         session = _create_test_session()
         session.shutdown()
@@ -471,15 +472,19 @@ class AppSessionTest(unittest.TestCase):
         self.assertEqual(msg.debug_last_backmsg_id, "some backmsg id")
 
     @patch("streamlit.runtime.app_session.config.on_config_parsed")
-    @patch("streamlit.runtime.app_session.source_util.register_pages_changed_callback")
     @patch(
         "streamlit.runtime.app_session.secrets_singleton.file_change_listener.connect"
+    )
+    @patch.multiple(
+        PagesManager,
+        register_pages_changed_callback=DEFAULT,
+        get_pages=MagicMock(return_value={}),
     )
     def test_registers_file_watchers(
         self,
         patched_secrets_connect,
-        patched_register_pages_changed_callback,
         patched_on_config_parsed,
+        register_pages_changed_callback,
     ):
         session = _create_test_session()
 
@@ -489,13 +494,18 @@ class AppSessionTest(unittest.TestCase):
         patched_on_config_parsed.assert_called_once_with(
             session._on_source_file_changed, force_connect=True
         )
-        patched_register_pages_changed_callback.assert_called_once_with(
+        register_pages_changed_callback.assert_called_once_with(
             session._on_pages_changed
         )
         patched_secrets_connect.assert_called_once_with(
             session._on_secrets_file_changed
         )
 
+    @patch.object(
+        PagesManager,
+        "get_pages",
+        MagicMock(return_value={}),
+    )
     def test_recreates_local_sources_watcher_if_none(self):
         session = _create_test_session()
         session._local_sources_watcher = None
@@ -637,8 +647,9 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         "streamlit.runtime.app_session.config.get_options_for_section",
         MagicMock(side_effect=_mock_get_options_for_section()),
     )
-    @patch(
-        "streamlit.runtime.app_session.source_util.get_pages",
+    @patch.object(
+        PagesManager,
+        "get_pages",
         MagicMock(
             return_value={
                 "hash1": {"page_name": "page1", "icon": "", "script_path": "script1"},
@@ -662,9 +673,9 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             session_state=MagicMock(),
             uploaded_file_mgr=MagicMock(),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         add_script_run_ctx(ctx=ctx)
 
@@ -729,9 +740,9 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             session_state=MagicMock(),
             uploaded_file_mgr=MagicMock(),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         add_script_run_ctx(ctx=ctx)
 
@@ -1014,8 +1025,9 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         )
 
 
-@patch(
-    "streamlit.runtime.app_session.source_util.get_pages",
+@patch.object(
+    PagesManager,
+    "get_pages",
     MagicMock(
         return_value={
             "hash1": {"page_name": "page1", "script_path": "page1.py"},

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -39,6 +39,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import (
     ScriptRunContext,
     add_script_run_ctx,
@@ -254,9 +255,9 @@ class CommonCacheTest(DeltaGeneratorTestCase):
                 session_state=SafeSessionState(SessionState(), lambda: None),
                 uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
                 main_script_path="",
-                page_script_hash="",
                 user_info={"email": "test@test.com"},
                 fragment_storage=MemoryFragmentStorage(),
+                pages_manager=PagesManager(""),
             ),
         )
 

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -23,42 +23,42 @@ from streamlit.util import calc_md5
 
 
 class PagesManagerTest(unittest.TestCase):
-    @patch.object(PagesManager, "_on_pages_changed", MagicMock())
     def test_pages_cache(self):
         """Test that the pages cache is correctly set and invalidated"""
         pages_manager = PagesManager("main_script_path")
-        assert pages_manager._cached_pages is None
+        with patch.object(pages_manager, "_on_pages_changed", MagicMock()):
+            assert pages_manager._cached_pages is None
 
-        pages = pages_manager.get_pages()
+            pages = pages_manager.get_pages()
 
-        assert pages_manager._cached_pages is not None
+            assert pages_manager._cached_pages is not None
 
-        new_pages = pages_manager.get_pages()
-        # Assert address-equality to verify the cache is used the second time
-        # get_pages is called.
-        assert new_pages is pages
+            new_pages = pages_manager.get_pages()
+            # Assert address-equality to verify the cache is used the second time
+            # get_pages is called.
+            assert new_pages is pages
 
-        pages_manager.invalidate_pages_cache()
-        assert pages_manager._cached_pages is None
+            pages_manager.invalidate_pages_cache()
+            assert pages_manager._cached_pages is None
 
-        pages_manager._on_pages_changed.send.assert_called_once()
-        another_new_set_of_pages = pages_manager.get_pages()
-        assert another_new_set_of_pages is not pages
+            pages_manager._on_pages_changed.send.assert_called_once()
+            another_new_set_of_pages = pages_manager.get_pages()
+            assert another_new_set_of_pages is not pages
 
-    @patch.object(PagesManager, "_on_pages_changed", MagicMock())
     def test_register_pages_changed_callback(self):
         """Test that the pages changed callback is correctly registered and unregistered"""
         pages_manager = PagesManager("main_script_path")
-        callback = lambda: None
+        with patch.object(pages_manager, "_on_pages_changed", MagicMock()):
+            callback = lambda: None
 
-        disconnect = pages_manager.register_pages_changed_callback(callback)
+            disconnect = pages_manager.register_pages_changed_callback(callback)
 
-        pages_manager._on_pages_changed.connect.assert_called_once_with(
-            callback, weak=False
-        )
+            pages_manager._on_pages_changed.connect.assert_called_once_with(
+                callback, weak=False
+            )
 
-        disconnect()
-        pages_manager._on_pages_changed.disconnect.assert_called_once_with(callback)
+            disconnect()
+            pages_manager._on_pages_changed.disconnect.assert_called_once_with(callback)
 
     @patch("streamlit.runtime.pages_manager.watch_dir")
     @patch.object(PagesManager, "invalidate_pages_cache", MagicMock())

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -1,0 +1,134 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for PagesManager"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from streamlit.runtime.pages_manager import PagesManager, V1PagesManager
+from streamlit.util import calc_md5
+
+
+class PagesManagerTest(unittest.TestCase):
+    @patch.object(PagesManager, "_on_pages_changed", MagicMock())
+    def test_pages_cache(self):
+        """Test that the pages cache is correctly set and invalidated"""
+        pages_manager = PagesManager("main_script_path")
+        assert pages_manager._cached_pages is None
+
+        pages = pages_manager.get_pages()
+
+        assert pages_manager._cached_pages is not None
+
+        new_pages = pages_manager.get_pages()
+        # Assert address-equality to verify the cache is used the second time
+        # get_pages is called.
+        assert new_pages is pages
+
+        pages_manager.invalidate_pages_cache()
+        assert pages_manager._cached_pages is None
+
+        pages_manager._on_pages_changed.send.assert_called_once()
+        another_new_set_of_pages = pages_manager.get_pages()
+        assert another_new_set_of_pages is not pages
+
+    @patch.object(PagesManager, "_on_pages_changed", MagicMock())
+    def test_register_pages_changed_callback(self):
+        """Test that the pages changed callback is correctly registered and unregistered"""
+        pages_manager = PagesManager("main_script_path")
+        callback = lambda: None
+
+        disconnect = pages_manager.register_pages_changed_callback(callback)
+
+        pages_manager._on_pages_changed.connect.assert_called_once_with(
+            callback, weak=False
+        )
+
+        disconnect()
+        pages_manager._on_pages_changed.disconnect.assert_called_once_with(callback)
+
+    @patch("streamlit.runtime.pages_manager.watch_dir")
+    @patch.object(PagesManager, "invalidate_pages_cache", MagicMock())
+    def test_install_pages_watcher(self, patched_watch_dir):
+        """Test that the pages watcher is correctly installed and uninstalled"""
+        pages_manager = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
+
+        patched_watch_dir.assert_called_once()
+        args, _ = patched_watch_dir.call_args_list[0]
+        on_pages_changed = args[1]
+
+        patched_watch_dir.assert_called_once_with(
+            os.path.normpath("/foo/bar/pages"),
+            on_pages_changed,
+            glob_pattern="*.py",
+            allow_nonexistent=True,
+        )
+
+        patched_watch_dir.reset_mock()
+
+        _ = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
+        patched_watch_dir.assert_not_called()
+
+        on_pages_changed("/foo/bar/pages")
+        pages_manager.invalidate_pages_cache.assert_called_once()
+
+
+# NOTE: We write this test function using pytest conventions (as opposed to
+# using unittest.TestCase like in the rest of the codebase) because the tmpdir
+# pytest fixture is so useful for writing this test it's worth having the
+# slight inconsistency.
+def test_get_active_script(tmpdir):
+    # Write an empty string to create a file.
+    tmpdir.join("streamlit_app.py").write("")
+
+    pages_dir = tmpdir.mkdir("pages")
+    pages = [
+        "03_other_page.py",
+        "04 last numbered page.py",
+        "01-page.py",
+    ]
+    for p in pages:
+        pages_dir.join(p).write("")
+
+    main_script_path = str(tmpdir / "streamlit_app.py")
+    pages_manager = PagesManager(main_script_path)
+
+    example_page_script_hash = calc_md5(str(pages_dir / "01-page.py"))
+
+    # positive case - get by hash
+    page = pages_manager.get_active_script(example_page_script_hash, None)
+    assert page["page_script_hash"] == example_page_script_hash
+
+    # bad hash should not return a page
+    page = pages_manager.get_active_script("random_hash", None)
+    assert page is None
+
+    # Even if the page name is specified, we detect via the hash only
+    page = pages_manager.get_active_script("random_hash", "page")
+    assert page is None
+
+    # Find by page name works
+    page = pages_manager.get_active_script("", "page")
+    assert page["page_script_hash"] == example_page_script_hash
+
+    # Try different page name
+    alternate_page_script_hash = calc_md5(str(pages_dir / "03_other_page.py"))
+    page = pages_manager.get_active_script("", "other_page")
+    assert page["page_script_hash"] == alternate_page_script_hash
+
+    # Even if the valid page name is specified, we detect via the hash only
+    page = pages_manager.get_active_script(alternate_page_script_hash, "page")
+    assert page["page_script_hash"] == alternate_page_script_hash

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -18,7 +18,7 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-from streamlit.runtime.pages_manager import PagesManager, V1PagesManager
+from streamlit.runtime.pages_manager import PagesManager, PagesManagerV1
 from streamlit.util import calc_md5
 
 
@@ -64,8 +64,8 @@ class PagesManagerTest(unittest.TestCase):
     @patch.object(PagesManager, "invalidate_pages_cache", MagicMock())
     def test_install_pages_watcher(self, patched_watch_dir):
         """Test that the pages watcher is correctly installed and uninstalled"""
-        # Ensure V1PagesManager.is_watching_pages_dir is False to start
-        V1PagesManager.is_watching_pages_dir = False
+        # Ensure PagesManagerV1.is_watching_pages_dir is False to start
+        PagesManagerV1.is_watching_pages_dir = False
         pages_manager = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
 
         patched_watch_dir.assert_called_once()

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -64,6 +64,8 @@ class PagesManagerTest(unittest.TestCase):
     @patch.object(PagesManager, "invalidate_pages_cache", MagicMock())
     def test_install_pages_watcher(self, patched_watch_dir):
         """Test that the pages watcher is correctly installed and uninstalled"""
+        # Ensure V1PagesManager.is_watching_pages_dir is False to start
+        V1PagesManager.is_watching_pages_dir = False
         pages_manager = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
 
         patched_watch_dir.assert_called_once()

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -25,6 +25,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
 )
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.session_manager import (
@@ -67,6 +68,8 @@ class MockSessionManager(SessionManager):
     ) -> str:
         with mock.patch(
             "streamlit.runtime.scriptrunner.ScriptRunner", new=mock.MagicMock()
+        ), mock.patch.object(
+            PagesManager, "get_pages", mock.MagicMock(return_value={})
         ):
             session = AppSession(
                 script_data=script_data,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -685,7 +685,7 @@ class ScriptRunnerTest(AsyncTestCase):
             self._assert_no_exceptions(scriptrunner)
 
     @patch(
-        "streamlit.source_util.get_pages",
+        "streamlit.runtime.pages_manager.get_pages",
         MagicMock(
             return_value={
                 "hash1": {
@@ -860,7 +860,7 @@ class ScriptRunnerTest(AsyncTestCase):
         )
 
     @patch(
-        "streamlit.source_util.get_pages",
+        "streamlit.runtime.pages_manager.get_pages",
         MagicMock(
             return_value={
                 "hash2": {

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -38,6 +38,7 @@ from streamlit.runtime.legacy_caching import caching
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import (
     RerunData,
     RerunException,
@@ -79,7 +80,6 @@ def _is_control_event(event: ScriptRunnerEvent) -> bool:
     return event != ScriptRunnerEvent.ENQUEUE_FORWARD_MSG
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -842,7 +842,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # Set _cached_pages to None manually (instead of using
         # source_util.invalidate_pages_cache) to avoid firing on_pages_changed
         # events.
-        source_util._cached_pages = None
+        runner._pages_manager._cached_pages = None
 
         # Run a slightly different script on a second runner.
         runner = TestScriptRunner("st_cache_script_changed.py")
@@ -1059,6 +1059,7 @@ class TestScriptRunner(ScriptRunner):
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(main_script_path),
         )
 
         # Accumulates uncaught exceptions thrown by our run thread.

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -20,6 +20,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import ScriptRunContext
 from streamlit.runtime.state import SafeSessionState, SessionState
 
@@ -36,9 +37,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
 
         msg = ForwardMsg()
@@ -60,9 +61,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
 
         ctx.on_script_start()
@@ -88,9 +89,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
 
         ctx.on_script_start()
@@ -115,9 +116,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
 
         ctx.on_script_start()
@@ -152,9 +153,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         ctx._experimental_query_params_used = experimental_used
         ctx._production_query_params_used = production_used
@@ -174,9 +175,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         ctx.mark_experimental_query_params_used()
         assert ctx._experimental_query_params_used == True
@@ -190,9 +191,9 @@ class ScriptRunContextTest(unittest.TestCase):
             session_state=SafeSessionState(SessionState(), lambda: None),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             main_script_path="",
-            page_script_hash="",
             user_info={"email": "test@test.com"},
             fragment_storage=MemoryFragmentStorage(),
+            pages_manager=PagesManager(""),
         )
         ctx.mark_production_query_params_used()
         assert ctx._production_query_params_used == True

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -14,7 +14,6 @@
 
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -93,33 +92,11 @@ class PageHelperFunctionTests(unittest.TestCase):
     def test_page_icon_and_name(self, path_str, expected):
         assert source_util.page_icon_and_name(Path(path_str)) == expected
 
-    @patch("streamlit.source_util._on_pages_changed", MagicMock())
-    @patch("streamlit.source_util._cached_pages", new="Some pages")
-    def test_invalidate_pages_cache(self):
-        source_util.invalidate_pages_cache()
-
-        assert source_util._cached_pages is None
-        source_util._on_pages_changed.send.assert_called_once()
-
-    @patch("streamlit.source_util._on_pages_changed", MagicMock())
-    def test_register_pages_changed_callback(self):
-        callback = lambda: None
-
-        disconnect = source_util.register_pages_changed_callback(callback)
-
-        source_util._on_pages_changed.connect.assert_called_once_with(
-            callback, weak=False
-        )
-
-        disconnect()
-        source_util._on_pages_changed.disconnect.assert_called_once_with(callback)
-
 
 # NOTE: We write this test function using pytest conventions (as opposed to
 # using unittest.TestCase like in the rest of the codebase) because the tmpdir
 # pytest fixture is so useful for writing this test it's worth having the
 # slight inconsistency.
-@patch("streamlit.source_util._cached_pages", new=None)
 def test_get_pages(tmpdir):
     # Write an empty string to create a file.
     tmpdir.join("streamlit_app.py").write("")
@@ -178,7 +155,3 @@ def test_get_pages(tmpdir):
             "icon": "",
         },
     }
-
-    # Assert address-equality to verify the cache is used the second time
-    # get_pages is called.
-    assert source_util.get_pages(main_script_path) is received_pages

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -227,7 +227,6 @@ def test_trigger_recursion():
         import streamlit as st
 
         if st.button(label="Submit"):
-            print("CLICKED!")
             time.sleep(1)
             st.rerun()
 

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -18,6 +18,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import (
     ScriptRunContext,
     add_script_run_ctx,
@@ -104,9 +105,9 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
                     session_state=SafeSessionState(SessionState(), lambda: None),
                     uploaded_file_mgr=None,
                     main_script_path="",
-                    page_script_hash="",
                     user_info={"email": "something@else.com"},
                     fragment_storage=MemoryFragmentStorage(),
+                    pages_manager=PagesManager(""),
                 ),
             )
 

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -70,8 +70,8 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_just_script(self, fob):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
         args, _ = fob.call_args
@@ -80,23 +80,23 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(type(args[1]), method_type)
 
         fob.reset_mock()
-        lso.update_watched_modules()
-        lso.update_watched_modules()
-        lso.update_watched_modules()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
+        lsw.update_watched_modules()
+        lsw.update_watched_modules()
+        lsw.update_watched_modules()
 
         self.assertEqual(fob.call_count, 1)  # __init__.py
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_permission_error(self, fob):
         fob.side_effect = PermissionError("This error should be caught!")
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_script_and_2_modules_at_once(self, fob):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
 
@@ -104,7 +104,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         sys.modules["DUMMY_MODULE_2"] = DUMMY_MODULE_2
 
         fob.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         self.assertEqual(fob.call_count, 3)  # dummy modules and __init__.py
 
@@ -122,21 +122,21 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(type(args[1]), method_type)
 
         fob.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         self.assertEqual(fob.call_count, 0)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_script_and_2_modules_in_series(self, fob):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
 
         sys.modules["DUMMY_MODULE_1"] = DUMMY_MODULE_1
         fob.reset_mock()
 
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         self.assertEqual(fob.call_count, 2)  # dummy module and __init__.py
 
@@ -153,7 +153,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         sys.modules["DUMMY_MODULE_2"] = DUMMY_MODULE_2
         fob.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         args, _ = fob.call_args
         self.assertEqual(args[0], DUMMY_MODULE_2_FILE)
@@ -164,14 +164,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher._LOGGER")
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_misbehaved_module(self, fob, patched_logger):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
 
         sys.modules["MISBEHAVED_MODULE"] = MISBEHAVED_MODULE.MisbehavedModule
         fob.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         fob.assert_called_once()  # Just __init__.py
 
@@ -181,8 +181,8 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_nested_module_parent_unloaded(self, fob):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
 
@@ -194,10 +194,10 @@ class LocalSourcesWatcherTest(unittest.TestCase):
                 "NESTED_MODULE_CHILD": NESTED_MODULE_CHILD,
             },
         ):
-            lso.update_watched_modules()
+            lsw.update_watched_modules()
 
             # Simulate a change to the child module
-            lso.on_file_changed(NESTED_MODULE_CHILD_FILE)
+            lsw.on_file_changed(NESTED_MODULE_CHILD_FILE)
 
             # Assert that both the parent and child are unloaded, ready for reload
             self.assertNotIn("NESTED_MODULE_CHILD", sys.modules)
@@ -212,15 +212,15 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             "server.folderWatchBlacklist", [os.path.dirname(DUMMY_MODULE_1.__file__)]
         )
 
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
 
         sys.modules["DUMMY_MODULE_1"] = DUMMY_MODULE_1
         fob.reset_mock()
 
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
 
         fob.assert_not_called()
 
@@ -293,30 +293,30 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_module_caching(self, _fob):
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(NOOP_CALLBACK)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
 
         register = MagicMock()
-        lso._register_necessary_watchers = register
+        lsw._register_necessary_watchers = register
 
         # Updates modules on first run
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
         register.assert_called_once()
 
         # Skips update when module list hasn't changed
         register.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
         register.assert_not_called()
 
         # Invalidates cache when a new module is imported
         register.reset_mock()
         sys.modules["DUMMY_MODULE_2"] = DUMMY_MODULE_2
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
         register.assert_called_once()
 
         # Skips update when new module is part of cache
         register.reset_mock()
-        lso.update_watched_modules()
+        lsw.update_watched_modules()
         register.assert_not_called()
 
     @patch(
@@ -431,11 +431,11 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
             saved_filepath = filepath
 
-        lso = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        lso.register_file_change_callback(callback)
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(callback)
 
         # Simulate a change to the report script
-        lso.on_file_changed(SCRIPT_PATH)
+        lsw.on_file_changed(SCRIPT_PATH)
 
         self.assertEqual(saved_filepath, SCRIPT_PATH)
 

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -460,23 +460,3 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
                 "server.port": 8502,
             },
         )
-
-    @patch("streamlit.web.bootstrap.invalidate_pages_cache")
-    @patch("streamlit.web.bootstrap.watch_dir")
-    def test_install_pages_watcher(
-        self, patched_watch_dir, patched_invalidate_pages_cache
-    ):
-        bootstrap._install_pages_watcher(os.path.normpath("/foo/bar/streamlit_app.py"))
-
-        args, _ = patched_watch_dir.call_args_list[0]
-        on_pages_changed = args[1]
-
-        patched_watch_dir.assert_called_once_with(
-            os.path.normpath("/foo/bar/pages"),
-            on_pages_changed,
-            glob_pattern="*.py",
-            allow_nonexistent=True,
-        )
-
-        on_pages_changed("/foo/bar/pages")
-        patched_invalidate_pages_cache.assert_called_once()

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -29,6 +29,7 @@ from streamlit.web.server.server import (
     HEALTH_ENDPOINT,
     HOST_CONFIG_ENDPOINT,
     MESSAGE_ENDPOINT,
+    NEW_HEALTH_ENDPOINT,
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
@@ -144,6 +145,10 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     {
                         "path": self._tmpdir.name,
                         "default_filename": self._filename,
+                        "reserved_paths": [
+                            NEW_HEALTH_ENDPOINT,
+                            HOST_CONFIG_ENDPOINT,
+                        ],
                     },
                 )
             ]
@@ -162,7 +167,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         for r in responses:
             assert r.code == 200
 
-    def test_parse_url_path_404_return_default(self):
+    def test_most_404_return_default(self):
         responses = [
             self.fetch("/nonexistent"),
             self.fetch("/page2/nonexistent"),
@@ -171,6 +176,15 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         for r in responses:
             assert r.code == 200
+
+    def test_reserved_paths_serve_404(self):
+        responses = [
+            self.fetch("/nonexistent/_stcore/health"),
+            self.fetch("/page2/_stcore/host-config"),
+        ]
+
+        for r in responses:
+            assert r.code == 404
 
 
 class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -135,9 +135,6 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmpfile.close()
         self._tmpdir.cleanup()
 
-    def get_pages(self):
-        return {"page1": "page_info1", "page2": "page_info2"}
-
     def get_app(self):
         return tornado.web.Application(
             [
@@ -147,7 +144,6 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     {
                         "path": self._tmpdir.name,
                         "default_filename": self._filename,
-                        "get_pages": self.get_pages,
                     },
                 )
             ]
@@ -166,7 +162,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         for r in responses:
             assert r.code == 200
 
-    def test_parse_url_path_404(self):
+    def test_parse_url_path_404_return_default(self):
         responses = [
             self.fetch("/nonexistent"),
             self.fetch("/page2/nonexistent"),
@@ -174,7 +170,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         ]
 
         for r in responses:
-            assert r.code == 404
+            assert r.code == 200
 
 
 class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from streamlit import config
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import ScriptRunContext
 from streamlit.runtime.state import SafeSessionState, SessionState
 from tests.constants import SNOWFLAKE_CREDENTIAL_FILE
@@ -53,9 +54,9 @@ def create_mock_script_run_ctx() -> ScriptRunContext:
         session_state=SafeSessionState(SessionState(), lambda: None),
         uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
         main_script_path="",
-        page_script_hash="mock_page_script_hash",
         user_info={"email": "mock@test.com"},
         fragment_storage=MemoryFragmentStorage(),
+        pages_manager=PagesManager(""),
     )
 
 


### PR DESCRIPTION
## Describe your changes

Migrates pages are primarily managed in the `source_util` module to a `PagesManager` class. Because V2 can have a dynamic set of pages per session, the Pages Manager instance will live on the `AppSession`. For V1, we will leverage static variables/methods for page watching.

## Testing Plan

- Original Unit tests are applied (with patches adjusted)
- Unit tests are applied for the PagesManager component

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
