### PR TITLE
Update scroll-margin-top

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -154,7 +154,7 @@ export const StyledLinkIcon = styled.a(({ theme }) => ({
 
 export const StyledHeadingWithActionElements = styled.div(({ theme }) => ({
   "h1, h2, h3, h4, h5, h6, span": {
-    scrollMarginTop: theme.spacing.threeXL,
+    scrollMarginTop: theme.sizes.headerHeight,
   },
   ...sharedMarkdownStyle(theme),
 


### PR DESCRIPTION
## Describe your changes

The app header bar height changed in https://github.com/streamlit/streamlit/pull/8554 and now the heading can be overlayed by it when clicking on the anchor. This PR fixes this by using the correct height.

Before:
<img width="1728" alt="Screenshot 2024-05-11 at 00 02 46" src="https://github.com/streamlit/streamlit/assets/3775781/df75b3eb-1c36-486d-a2c3-835eb1fe83d7">


After:
<img width="1725" alt="Screenshot 2024-05-11 at 00 03 10" src="https://github.com/streamlit/streamlit/assets/3775781/6dcaede8-1cdd-4fa5-b6a6-374052d9adb2">


## GitHub Issue Link (if applicable)

## Testing Plan

- manual tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
