### PR TITLE
Update address output in headless mode

### DIFF
--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -250,15 +250,6 @@ def _print_url(is_running_hello: bool) -> None:
             ("Unix Socket", config.get_option("server.address")),
         ]
 
-    elif config.get_option("server.headless"):
-        internal_ip = net_util.get_internal_ip()
-        if internal_ip:
-            named_urls.append(("Network URL", server_util.get_url(internal_ip)))
-
-        external_ip = net_util.get_external_ip()
-        if external_ip:
-            named_urls.append(("External URL", server_util.get_url(external_ip)))
-
     else:
         named_urls = [
             ("Local URL", server_util.get_url("localhost")),
@@ -267,6 +258,11 @@ def _print_url(is_running_hello: bool) -> None:
         internal_ip = net_util.get_internal_ip()
         if internal_ip:
             named_urls.append(("Network URL", server_util.get_url(internal_ip)))
+
+        if config.get_option("server.headless"):
+            external_ip = net_util.get_external_ip()
+            if external_ip:
+                named_urls.append(("External URL", server_util.get_url(external_ip)))
 
     cli_util.print_to_cli("")
     cli_util.print_to_cli("  %s" % title_message, fg="blue", bold=True)

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -151,6 +151,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
+        self.assertIn("Local URL: http://localhost", out)
         self.assertIn("Network URL: http://internal-ip", out)
         self.assertIn("External URL: http://external-ip", out)
 
@@ -175,6 +176,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
+        self.assertIn("Local URL: http://localhost", out)
         self.assertIn("Network URL: http://internal-ip", out)
         self.assertNotIn("External URL: http://external-ip", out)
 
@@ -199,6 +201,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
+        self.assertIn("Local URL: http://localhost", out)
         self.assertNotIn("Network URL: http://internal-ip", out)
         self.assertIn("External URL: http://external-ip", out)
 


### PR DESCRIPTION
## Describe your changes

Closes #8629

When Streamlit is started via `server.headless=true`, the address output does not contain `localhost`, although the server can still be reached via `localhost`. The `headless` mode just defines whether a browser is started, not what the address binding is. So, the idea is to show `localhost` also in case when  `server.headless=true` is set.

Output before:

```shell
2024-05-13 11:50:29.589 DEBUG   streamlit.runtime.runtime: Runtime state: RuntimeState.INITIAL -> RuntimeState.NO_SESSIONS_CONNECTED

  You can now view your Streamlit app in your browser.

  Network URL: http://0.1.2.3:3000/
  External URL: http://4.5.6.7:3000/

2024-05-13 11:50:29.892 DEBUG   streamlit.version: Skipping PyPI version check
```

Output after:

```shell
2024-05-13 11:51:12.599 DEBUG   streamlit.runtime.runtime: Runtime state: RuntimeState.INITIAL -> RuntimeState.NO_SESSIONS_CONNECTED

  You can now view your Streamlit app in your browser.

  Local URL: http://localhost:3000/
  Network URL: http://0.1.2.3:3000/
  External URL: http://4.5.6.7:3000/

2024-05-13 11:51:12.836 DEBUG   streamlit.version: Skipping PyPI version check
```


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
