### PR TITLE
Introduce concept of active script hash

### DIFF
--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -52,6 +52,8 @@ class ResizeObserver {
 }
 window.ResizeObserver = ResizeObserver
 
+const FAKE_SCRIPT_HASH = "fake_script_hash"
+
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
     wideMode: false,
@@ -125,20 +127,36 @@ describe("AppView element", () => {
     const sidebarElement = new ElementNode(
       makeElementWithInfoText("sidebar!"),
       ForwardMsgMetadata.create({}),
-      "no script run id"
+      "no script run id",
+      FAKE_SCRIPT_HASH
     )
 
     const sidebar = new BlockNode(
+      FAKE_SCRIPT_HASH,
       [sidebarElement],
       new BlockProto({ allowEmpty: true })
     )
 
-    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const event = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const bottom = new BlockNode([], new BlockProto({ allowEmpty: true }))
+    const main = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const event = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const bottom = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
 
     const props = getProps({
-      elements: new AppRoot(new BlockNode([main, sidebar, event, bottom])),
+      elements: new AppRoot(
+        new BlockNode(FAKE_SCRIPT_HASH, [main, sidebar, event, bottom])
+      ),
     })
     render(<AppView {...props} />)
 
@@ -172,24 +190,40 @@ describe("AppView element", () => {
     const sidebarElement = new ElementNode(
       makeElementWithInfoText("sidebar!"),
       ForwardMsgMetadata.create({}),
-      "no script run id"
+      "no script run id",
+      FAKE_SCRIPT_HASH
     )
 
     const sidebar = new BlockNode(
+      FAKE_SCRIPT_HASH,
       [sidebarElement],
       new BlockProto({ allowEmpty: true })
     )
 
-    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const event = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const bottom = new BlockNode([], new BlockProto({ allowEmpty: true }))
+    const main = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const event = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const bottom = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
 
     const appPages = [
       { pageName: "streamlit_app", pageScriptHash: "page_hash" },
       { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const props = getProps({
-      elements: new AppRoot(new BlockNode([main, sidebar, event, bottom])),
+      elements: new AppRoot(
+        new BlockNode(FAKE_SCRIPT_HASH, [main, sidebar, event, bottom])
+      ),
       appPages,
     })
     render(<AppView {...props} />)
@@ -223,13 +257,31 @@ describe("AppView element", () => {
       return realUseContext(input)
     })
 
-    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const sidebar = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const event = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const bottom = new BlockNode([], new BlockProto({ allowEmpty: true }))
+    const main = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const sidebar = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const event = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const bottom = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
 
     const props = getProps({
-      elements: new AppRoot(new BlockNode([main, sidebar, event, bottom])),
+      elements: new AppRoot(
+        new BlockNode(FAKE_SCRIPT_HASH, [main, sidebar, event, bottom])
+      ),
     })
     render(<AppView {...props} />)
 
@@ -354,19 +406,35 @@ describe("AppView element", () => {
         },
       }),
       ForwardMsgMetadata.create({}),
-      "no script run id"
+      "no script run id",
+      FAKE_SCRIPT_HASH
     )
 
-    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const sidebar = new BlockNode([], new BlockProto({ allowEmpty: true }))
-    const event = new BlockNode([], new BlockProto({ allowEmpty: true }))
+    const main = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const sidebar = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
+    const event = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true })
+    )
     const bottom = new BlockNode(
+      FAKE_SCRIPT_HASH,
       [chatInputElement],
       new BlockProto({ allowEmpty: true })
     )
 
     const props = getProps({
-      elements: new AppRoot(new BlockNode([main, sidebar, event, bottom])),
+      elements: new AppRoot(
+        new BlockNode(FAKE_SCRIPT_HASH, [main, sidebar, event, bottom])
+      ),
     })
 
     render(<AppView {...props} />)

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -29,7 +29,7 @@ import { Writer } from "protobufjs"
 import { vectorFromArray } from "apache-arrow"
 
 const NO_SCRIPT_RUN_ID = "NO_SCRIPT_RUN_ID"
-
+const FAKE_SCRIPT_HASH = "fake_script_hash"
 // prettier-ignore
 const BLOCK = block([
   text("1"),
@@ -40,7 +40,12 @@ const BLOCK = block([
 
 // Initialize new AppRoot with a main block node and three child block nodes - sidebar, events and bottom.
 const ROOT = new AppRoot(
-  new BlockNode([BLOCK, new BlockNode(), new BlockNode(), new BlockNode()])
+  new BlockNode(FAKE_SCRIPT_HASH, [
+    BLOCK,
+    new BlockNode(FAKE_SCRIPT_HASH),
+    new BlockNode(FAKE_SCRIPT_HASH),
+    new BlockNode(FAKE_SCRIPT_HASH),
+  ])
 )
 
 describe("AppNode.getIn", () => {
@@ -899,6 +904,7 @@ describe("AppRoot.applyDelta", () => {
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
+    expect(newNode.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
     expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
   })
 
@@ -920,7 +926,44 @@ describe("AppRoot.applyDelta", () => {
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
+    expect(newNode.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
     expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
+  })
+
+  it("specifies active script hash on 'newElement' deltas", () => {
+    const delta = makeProto(DeltaProto, {
+      newElement: { text: { body: "newElement!" } },
+    })
+    const NEW_FAKE_SCRIPT_HASH = "new_fake_script_hash"
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1], NEW_FAKE_SCRIPT_HASH)
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+    expect(newNode).toBeDefined()
+
+    // Check that our new other nodes are not affected by the new script hash
+    expect(newRoot.main.getIn([1, 0])?.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
+    expect(newNode.activeScriptHash).toBe(NEW_FAKE_SCRIPT_HASH)
+  })
+
+  it("specifies active script hash on 'addBlock' deltas", () => {
+    const delta = makeProto(DeltaProto, { addBlock: {} })
+    const NEW_FAKE_SCRIPT_HASH = "new_fake_script_hash"
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1], NEW_FAKE_SCRIPT_HASH)
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+    expect(newNode).toBeDefined()
+
+    // Check that our new scriptRunId has been set only on the touched nodes
+    expect(newRoot.main.getIn([1, 0])?.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
+    expect(newNode.activeScriptHash).toBe(NEW_FAKE_SCRIPT_HASH)
   })
 
   it("can set fragmentId in 'newElement' deltas", () => {
@@ -1062,7 +1105,12 @@ describe("AppRoot.getElements", () => {
 /** Create a `Text` element node with the given properties. */
 function text(text: string, scriptRunId = NO_SCRIPT_RUN_ID): ElementNode {
   const element = makeProto(Element, { text: { body: text } })
-  return new ElementNode(element, ForwardMsgMetadata.create(), scriptRunId)
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
 }
 
 /** Create a BlockNode with the given properties. */
@@ -1070,19 +1118,34 @@ function block(
   children: AppNode[] = [],
   scriptRunId = NO_SCRIPT_RUN_ID
 ): BlockNode {
-  return new BlockNode(children, makeProto(BlockProto, {}), scriptRunId)
+  return new BlockNode(
+    FAKE_SCRIPT_HASH,
+    children,
+    makeProto(BlockProto, {}),
+    scriptRunId
+  )
 }
 
 /** Create an arrowTable element node with the given properties. */
 function arrowTable(scriptRunId = NO_SCRIPT_RUN_ID): ElementNode {
   const element = makeProto(Element, { arrowTable: { data: UNICODE } })
-  return new ElementNode(element, ForwardMsgMetadata.create(), scriptRunId)
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
 }
 
 /** Create an arrowDataFrame element node with the given properties. */
 function arrowDataFrame(scriptRunId = NO_SCRIPT_RUN_ID): ElementNode {
   const element = makeProto(Element, { arrowDataFrame: { data: UNICODE } })
-  return new ElementNode(element, ForwardMsgMetadata.create(), scriptRunId)
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
 }
 
 /** Create an arrowVegaLiteChart element node with the given properties. */
@@ -1091,13 +1154,21 @@ function arrowVegaLiteChart(
   scriptRunId = NO_SCRIPT_RUN_ID
 ): ElementNode {
   const element = makeProto(Element, { arrowVegaLiteChart: data })
-  return new ElementNode(element, ForwardMsgMetadata.create(), scriptRunId)
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
 }
 
 /** Create a ForwardMsgMetadata with the given container and path */
-function forwardMsgMetadata(deltaPath: number[]): ForwardMsgMetadata {
+function forwardMsgMetadata(
+  deltaPath: number[],
+  activeScriptHash = FAKE_SCRIPT_HASH
+): ForwardMsgMetadata {
   expect(deltaPath.length).toBeGreaterThanOrEqual(2)
-  return makeProto(ForwardMsgMetadata, { deltaPath })
+  return makeProto(ForwardMsgMetadata, { deltaPath, activeScriptHash })
 }
 
 /**

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -97,6 +97,11 @@ export interface AppNode {
   readonly fragmentId?: string
 
   /**
+   * The hash of the script that created this node.
+   */
+  readonly activeScriptHash?: string
+
+  /**
    * Return the AppNode for the given index path, or undefined if the path
    * is invalid.
    */
@@ -142,16 +147,21 @@ export class ElementNode implements AppNode {
 
   private lazyVegaLiteChartElement?: VegaLiteChartElement
 
+  // The hash of the script that created this element.
+  public readonly activeScriptHash: string
+
   /** Create a new ElementNode. */
   public constructor(
     element: Element,
     metadata: ForwardMsgMetadata,
     scriptRunId: string,
+    activeScriptHash: string,
     fragmentId?: string
   ) {
     this.element = element
     this.metadata = metadata
     this.scriptRunId = scriptRunId
+    this.activeScriptHash = activeScriptHash
     this.fragmentId = fragmentId
   }
 
@@ -258,6 +268,7 @@ export class ElementNode implements AppNode {
       this.element,
       this.metadata,
       scriptRunId,
+      this.activeScriptHash,
       this.fragmentId
     )
 
@@ -353,12 +364,17 @@ export class BlockNode implements AppNode {
 
   public readonly fragmentId?: string
 
+  // The hash of the script that created this block.
+  public readonly activeScriptHash: string
+
   public constructor(
+    activeScriptHash: string,
     children?: AppNode[],
     deltaBlock?: BlockProto,
     scriptRunId?: string,
     fragmentId?: string
   ) {
+    this.activeScriptHash = activeScriptHash
     this.children = children ?? []
     this.deltaBlock = deltaBlock ?? new BlockProto({})
     this.scriptRunId = scriptRunId ?? NO_SCRIPT_RUN_ID
@@ -413,6 +429,7 @@ export class BlockNode implements AppNode {
     }
 
     return new BlockNode(
+      this.activeScriptHash,
       newChildren,
       this.deltaBlock,
       scriptRunId,
@@ -464,6 +481,7 @@ export class BlockNode implements AppNode {
       .filter(notUndefined)
 
     return new BlockNode(
+      this.activeScriptHash,
       newChildren,
       this.deltaBlock,
       currentScriptRunId,
@@ -483,6 +501,11 @@ export class BlockNode implements AppNode {
     return elementSet
   }
 }
+
+// TODO(mpav2): The active script hash for the root nodes will
+// be the main script hash. This is a temporary solution until we
+// provide the main script hash.
+const DEFAULT_ACTIVE_SCRIPT_HASH = ""
 
 /**
  * The root of our data tree. It contains the app's top-level BlockNodes.
@@ -523,12 +546,14 @@ export class AppRoot {
         new ElementNode(
           waitElement,
           ForwardMsgMetadata.create({}),
-          NO_SCRIPT_RUN_ID
+          NO_SCRIPT_RUN_ID,
+          DEFAULT_ACTIVE_SCRIPT_HASH
         )
       )
     }
 
     const main = new BlockNode(
+      DEFAULT_ACTIVE_SCRIPT_HASH,
       mainNodes,
       new BlockProto({ allowEmpty: true }),
       NO_SCRIPT_RUN_ID
@@ -536,21 +561,30 @@ export class AppRoot {
 
     const sidebar =
       sidebarElements ||
-      new BlockNode([], new BlockProto({ allowEmpty: true }), NO_SCRIPT_RUN_ID)
+      new BlockNode(
+        DEFAULT_ACTIVE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true }),
+        NO_SCRIPT_RUN_ID
+      )
 
     const event = new BlockNode(
+      DEFAULT_ACTIVE_SCRIPT_HASH,
       [],
       new BlockProto({ allowEmpty: true }),
       NO_SCRIPT_RUN_ID
     )
 
     const bottom = new BlockNode(
+      DEFAULT_ACTIVE_SCRIPT_HASH,
       [],
       new BlockProto({ allowEmpty: true }),
       NO_SCRIPT_RUN_ID
     )
 
-    return new AppRoot(new BlockNode([main, sidebar, event, bottom]))
+    return new AppRoot(
+      new BlockNode(DEFAULT_ACTIVE_SCRIPT_HASH, [main, sidebar, event, bottom])
+    )
   }
 
   public constructor(root: BlockNode) {
@@ -596,7 +630,7 @@ export class AppRoot {
   ): AppRoot {
     // The full path to the AppNode within the element tree.
     // Used to find and update the element node specified by this Delta.
-    const { deltaPath } = metadata
+    const { deltaPath, activeScriptHash } = metadata
 
     switch (delta.type) {
       case "newElement": {
@@ -606,6 +640,7 @@ export class AppRoot {
           scriptRunId,
           element,
           metadata,
+          activeScriptHash,
           delta.fragmentId
         )
       }
@@ -615,6 +650,7 @@ export class AppRoot {
           deltaPath,
           delta.addBlock as BlockProto,
           scriptRunId,
+          activeScriptHash,
           delta.fragmentId
         )
       }
@@ -634,7 +670,8 @@ export class AppRoot {
             deltaPath,
             scriptRunId,
             errorElement,
-            metadata
+            metadata,
+            activeScriptHash
           )
         }
       }
@@ -651,19 +688,20 @@ export class AppRoot {
   ): AppRoot {
     const main =
       this.main.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode()
+      new BlockNode(DEFAULT_ACTIVE_SCRIPT_HASH)
     const sidebar =
       this.sidebar.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode()
+      new BlockNode(DEFAULT_ACTIVE_SCRIPT_HASH)
     const event =
       this.event.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode()
+      new BlockNode(DEFAULT_ACTIVE_SCRIPT_HASH)
     const bottom =
       this.bottom.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode()
+      new BlockNode(DEFAULT_ACTIVE_SCRIPT_HASH)
 
     return new AppRoot(
       new BlockNode(
+        DEFAULT_ACTIVE_SCRIPT_HASH,
         [main, sidebar, event, bottom],
         new BlockProto({ allowEmpty: true }),
         currentScriptRunId
@@ -686,12 +724,14 @@ export class AppRoot {
     scriptRunId: string,
     element: Element,
     metadata: ForwardMsgMetadata,
+    activeScriptHash: string,
     fragmentId?: string
   ): AppRoot {
     const elementNode = new ElementNode(
       element,
       metadata,
       scriptRunId,
+      activeScriptHash,
       fragmentId
     )
     return new AppRoot(this.root.setIn(deltaPath, elementNode, scriptRunId))
@@ -701,6 +741,7 @@ export class AppRoot {
     deltaPath: number[],
     block: BlockProto,
     scriptRunId: string,
+    activeScriptHash: string,
     fragmentId?: string
   ): AppRoot {
     const existingNode = this.root.getIn(deltaPath)
@@ -711,7 +752,13 @@ export class AppRoot {
     const children: AppNode[] =
       existingNode instanceof BlockNode ? existingNode.children : []
 
-    const blockNode = new BlockNode(children, block, scriptRunId, fragmentId)
+    const blockNode = new BlockNode(
+      activeScriptHash,
+      children,
+      block,
+      scriptRunId,
+      fragmentId
+    )
     return new AppRoot(this.root.setIn(deltaPath, blockNode, scriptRunId))
   }
 

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -26,6 +26,7 @@ import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
 
 import VerticalBlock from "./Block"
 
+const FAKE_SCRIPT_HASH = "fake_script_hash"
 class ResizeObserver {
   observe(): void {}
 
@@ -36,6 +37,7 @@ class ResizeObserver {
 
 function makeColumn(weight: number, children: BlockNode[] = []): BlockNode {
   return new BlockNode(
+    FAKE_SCRIPT_HASH,
     children,
     new BlockProto({ allowEmpty: true, column: { weight } })
   )
@@ -45,6 +47,7 @@ function makeHorizontalBlock(numColumns: number): BlockNode {
   const weight = 1 / numColumns
 
   return new BlockNode(
+    FAKE_SCRIPT_HASH,
     Array.from({ length: numColumns }, () => makeColumn(weight)),
     new BlockProto({ allowEmpty: true, horizontal: { gap: "small" } })
   )
@@ -55,6 +58,7 @@ function makeVerticalBlock(
   additionalProps: Partial<BlockProto> = {}
 ): BlockNode {
   return new BlockNode(
+    FAKE_SCRIPT_HASH,
     children,
     new BlockProto({ allowEmpty: true, ...additionalProps })
   )

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -37,13 +37,16 @@ import ElementNodeRenderer, {
   ElementNodeRendererProps,
 } from "./ElementNodeRenderer"
 
+const FAKE_SCRIPT_HASH = "fake_script_hash"
+
 function createBalloonNode(scriptRunId: string): ElementNode {
   const node = new ElementNode(
     new BalloonsProto({
       show: true,
     }),
     ForwardMsgMetadata.create({}),
-    scriptRunId
+    scriptRunId,
+    FAKE_SCRIPT_HASH
   )
   node.element.type = "balloons"
   return node
@@ -55,7 +58,8 @@ function createSnowNode(scriptRunId: string): ElementNode {
       show: true,
     }),
     ForwardMsgMetadata.create({}),
-    scriptRunId
+    scriptRunId,
+    FAKE_SCRIPT_HASH
   )
   node.element.type = "snow"
   return node

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -20,8 +20,8 @@ import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
 import { isElementStale } from "./utils"
 
 describe("isElementStale", () => {
-  // @ts-expect-error
   const node = new ElementNode(
+    // @ts-expect-error
     null,
     null,
     "myScriptRunId",

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -21,7 +21,13 @@ import { isElementStale } from "./utils"
 
 describe("isElementStale", () => {
   // @ts-expect-error
-  const node = new ElementNode(null, null, "myScriptRunId", "myFragmentId")
+  const node = new ElementNode(
+    null,
+    null,
+    "myScriptRunId",
+    "activeScriptHash",
+    "myFragmentId"
+  )
 
   it("returns true if scriptRunState is RERUN_REQUESTED", () => {
     expect(

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -24,8 +24,11 @@ import { Block as BlockProto } from "@streamlit/lib/src/proto"
 
 import Tabs, { TabProps } from "./Tabs"
 
+const FAKE_SCRIPT_HASH = "fake_script_hash"
+
 function makeTab(label: string, children: BlockNode[] = []): BlockNode {
   return new BlockNode(
+    FAKE_SCRIPT_HASH,
     children,
     new BlockProto({ allowEmpty: true, tab: { label } })
   )
@@ -33,6 +36,7 @@ function makeTab(label: string, children: BlockNode[] = []): BlockNode {
 
 function makeTabsNode(tabs: number): BlockNode {
   return new BlockNode(
+    FAKE_SCRIPT_HASH,
     Array.from({ length: tabs }, (_element, index) => makeTab(`Tab ${index}`)),
     new BlockProto({ allowEmpty: true })
   )

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -169,7 +169,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                     key=key,
                     json_args=serialized_json_args,
                     special_args=special_args,
-                    page=ctx.page_script_hash if ctx else None,
+                    page=ctx.active_script_hash if ctx else None,
                 )
             else:
                 computed_id = compute_widget_id(
@@ -179,7 +179,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                     form_id=current_form_id(dg),
                     url=self.url,
                     key=key,
-                    page=ctx.page_script_hash if ctx else None,
+                    page=ctx.active_script_hash if ctx else None,
                 )
             element.component_instance.id = computed_id
 

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -576,7 +576,7 @@ def marshall_video(
             loop=loop,
             autoplay=autoplay,
             muted=muted,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         proto.id = id
@@ -752,6 +752,6 @@ def marshall_audio(
             end_time=end_time,
             loop=loop,
             autoplay=autoplay,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
         proto.id = id

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -189,7 +189,11 @@ class PlotlyMixin:
         key: Key | None = None,
         on_select: Literal["ignore"],  # No default value here to make it work with mypy
         selection_mode: SelectionMode
-        | Iterable[SelectionMode] = ("points", "box", "lasso"),
+        | Iterable[SelectionMode] = (
+            "points",
+            "box",
+            "lasso",
+        ),
         **kwargs: Any,
     ) -> DeltaGenerator:
         ...
@@ -204,7 +208,11 @@ class PlotlyMixin:
         key: Key | None = None,
         on_select: Literal["rerun"] | WidgetCallback = "rerun",
         selection_mode: SelectionMode
-        | Iterable[SelectionMode] = ("points", "box", "lasso"),
+        | Iterable[SelectionMode] = (
+            "points",
+            "box",
+            "lasso",
+        ),
         **kwargs: Any,
     ) -> PlotlyState:
         ...
@@ -219,7 +227,11 @@ class PlotlyMixin:
         key: Key | None = None,
         on_select: Literal["rerun", "ignore"] | WidgetCallback = "ignore",
         selection_mode: SelectionMode
-        | Iterable[SelectionMode] = ("points", "box", "lasso"),
+        | Iterable[SelectionMode] = (
+            "points",
+            "box",
+            "lasso",
+        ),
         **kwargs: Any,
     ) -> DeltaGenerator | PlotlyState:
         """Display an interactive Plotly chart.
@@ -381,7 +393,7 @@ class PlotlyMixin:
             theme=theme,
             form_id=plotly_chart_proto.form_id,
             use_container_width=use_container_width,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         if is_selection_activated:

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -584,7 +584,7 @@ class ButtonMixin:
             help=help,
             type=type,
             use_container_width=use_container_width,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         if is_in_form(self.dg):
@@ -749,7 +749,7 @@ class ButtonMixin:
             is_form_submitter=is_form_submitter,
             type=type,
             use_container_width=use_container_width,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         # It doesn't make sense to create a button inside a form (except

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -212,7 +212,7 @@ class CameraInputMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         camera_input_proto = CameraInputProto()

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -328,7 +328,7 @@ class ChatMixin:
             key=key,
             placeholder=placeholder,
             max_chars=max_chars,
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         # It doesn't make sense to create a chat input inside a form.

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -297,7 +297,7 @@ class CheckboxMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         checkbox_proto = CheckboxProto()

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -187,7 +187,7 @@ class ColorPickerMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         # set value default

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -874,7 +874,7 @@ class DataEditorMixin:
             num_rows=num_rows,
             key=key,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         proto = ArrowProto()

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -417,7 +417,7 @@ class FileUploaderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         if type:

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -312,7 +312,7 @@ class MultiSelectMixin:
             max_selections=max_selections,
             placeholder=placeholder,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         default_value: list[int] = [] if indices is None else indices

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -303,7 +303,7 @@ class NumberInputMixin:
             help=help,
             placeholder=None if placeholder is None else str(placeholder),
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         # Ensure that all arguments are of the same type.

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -274,7 +274,7 @@ class RadioMixin:
             horizontal=horizontal,
             captions=captions,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         if not isinstance(index, int) and index is not None:

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -301,7 +301,7 @@ class SelectSliderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         slider_proto = SliderProto()

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -253,7 +253,7 @@ class SelectboxMixin:
             help=help,
             placeholder=placeholder,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         if not isinstance(index, int) and index is not None:

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -386,7 +386,7 @@ class SliderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         SUPPORTED_TYPES = {

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -279,7 +279,7 @@ class TextWidgetsMixin:
             autocomplete=autocomplete,
             placeholder=str(placeholder),
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         session_state = get_session_state().filtered_state
@@ -546,7 +546,7 @@ class TextWidgetsMixin:
             help=help,
             placeholder=str(placeholder),
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
 
         session_state = get_session_state().filtered_state

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -458,7 +458,7 @@ class TimeWidgetsMixin:
             help=help,
             step=step,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
         del value
 
@@ -731,7 +731,7 @@ class TimeWidgetsMixin:
             help=help,
             format=format,
             form_id=current_form_id(self.dg),
-            page=ctx.page_script_hash if ctx else None,
+            page=ctx.active_script_hash if ctx else None,
         )
         if not bool(ALLOWED_DATE_FORMATS.match(format)):
             raise StreamlitAPIException(

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -83,11 +83,11 @@ class PagesManager:
         self._current_page_hash = page_hash
 
     def get_active_script_hash(self) -> PageHash:
-        # TODO(kmcgrady): Temporary - for MPA v2, this will be a new variable
+        # TODO(mpav2): Temporary - for MPA v2, this will be a new variable
         return self._current_page_hash
 
     def set_active_script_hash(self, page_hash: PageHash):
-        # TODO(kmcgrady): Temporary - for MPA v2, this will set a new variable
+        # TODO(mpav2): Temporary - for MPA v2, this will set a new variable
         pass
 
     def get_active_script(self, page_script_hash: PageHash, page_name: PageName):

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -82,6 +82,14 @@ class PagesManager:
     def set_current_page_script_hash(self, page_hash: PageHash) -> None:
         self._current_page_hash = page_hash
 
+    def get_active_script_hash(self) -> PageHash:
+        # TODO(kmcgrady): Temporary - for MPA v2, this will be a new variable
+        return self._current_page_hash
+
+    def set_active_script_hash(self, page_hash: PageHash):
+        # TODO(kmcgrady): Temporary - for MPA v2, this will set a new variable
+        pass
+
     def get_active_script(self, page_script_hash: PageHash, page_name: PageName):
         pages = self.get_pages()
 

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -92,6 +92,10 @@ class ScriptRunContext:
     def page_script_hash(self):
         return self.pages_manager.get_current_page_script_hash()
 
+    @property
+    def active_script_hash(self):
+        return self.pages_manager.get_active_script_hash()
+
     def reset(
         self,
         query_string: str = "",
@@ -146,6 +150,8 @@ class ScriptRunContext:
             msg.HasField("delta") and self._has_script_started
         ):
             self._set_page_config_allowed = False
+
+        msg.metadata.active_script_hash = self.pages_manager.get_active_script_hash()
 
         # Pass the message up to our associated ScriptRunner.
         self._enqueue(msg)

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -151,7 +151,7 @@ class ScriptRunContext:
         ):
             self._set_page_config_allowed = False
 
-        msg.metadata.active_script_hash = self.pages_manager.get_active_script_hash()
+        msg.metadata.active_script_hash = self.active_script_hash
 
         # Pass the message up to our associated ScriptRunner.
         self._enqueue(msg)

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -23,7 +23,6 @@ from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileMan
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import ScriptRunContext
 from streamlit.runtime.state import SafeSessionState, SessionState
-from streamlit.util import calc_md5
 
 
 class ScriptRunContextTest(unittest.TestCase):

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -118,7 +118,7 @@ message ForwardMsgMetadata {
   ElementDimensionSpec element_dimension_spec = 3;
 
   // active_script_hash the forward message is associated from.
-  // For multipage apps v1, this will always be the script running
+  // For multipage apps v1, this will always be the page file running
   // For multipage apps v2, this can be the main script or the page script
   string active_script_hash = 4;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -116,6 +116,11 @@ message ForwardMsgMetadata {
 
   // DEPRECATED: This is not used anymore.
   ElementDimensionSpec element_dimension_spec = 3;
+
+  // active_script_hash the forward message is associated from.
+  // For multipage apps v1, this will always be the script running
+  // For multipage apps v2, this can be the main script or the page script
+  string active_script_hash = 4;
 }
 
 // DEPRECATED: This is not used anymore.


### PR DESCRIPTION
## Describe your changes

MPA v2 will introduce the concept of an active script hash where the active script is the current script running. This change does the following:

- Adds the concept of Active Script Hash to the Pages Manager. By default, it returns the current page hash and doesn't set anything.
- All widgets will leverage the Active Script Hash in calculating their id. We do this so that widgets can be associated with the script (and avoid duplicate issues where possible).
- We will provide the active script hash as part of the forward message metadata. That way, we can associate the active script hash with every call (this is especially important for `Delta` messages.
- Frontend will store the active script hash in the nodes

## Testing Plan

- Added a python unit test for the active script hash setting in the forward message.
- Open to ideas on how to test the widget id updates, but I think it's not quite feasible.
- Frontend tests storage of active script hash in nodes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
