### PR TITLE
Simplify updateReport call to remove properties

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -163,7 +163,9 @@ jest.mock("@streamlit/app/src/SegmentMetricsManager", () => {
   )
 
   const MockedClass = jest.fn().mockImplementation((...props) => {
-    return new actualModule.SegmentMetricsManager(...props)
+    const metricsMgr = new actualModule.SegmentMetricsManager(...props)
+    jest.spyOn(metricsMgr, "enqueue")
+    return metricsMgr
   })
 
   return {
@@ -397,6 +399,18 @@ describe("App", () => {
 
     expect(screen.getByTestId("stStatusWidget")).toBeInTheDocument()
     expect(screen.getByTestId("stToolbarActions")).toBeInTheDocument()
+  })
+
+  it("sends updateReport to our metrics manager", () => {
+    renderApp(getProps())
+
+    const metricsManager = getStoredValue<SegmentMetricsManager>(
+      SegmentMetricsManager
+    )
+
+    sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("updateReport")
   })
 
   describe("App.handleNewSession", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -364,7 +364,6 @@ export class App extends PureComponent<Props, State> {
     this.pendingElementsBuffer = this.state.elements
     this.appNavigation = new AppNavigation(
       this.hostCommunicationMgr,
-      this.metricsMgr,
       this.maybeUpdatePageUrl,
       this.onPageNotFound
     )
@@ -954,7 +953,7 @@ export class App extends PureComponent<Props, State> {
     this.metricsMgr.setMetadata(this.state.deployedAppMetadata)
     this.metricsMgr.setAppHash(newSessionHash)
 
-    this.appNavigation.sendMPAMetricsOnInitialization()
+    this.metricsMgr.enqueue("updateReport")
 
     if (
       appHash === newSessionHash &&

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -18,7 +18,6 @@
 import {
   HostCommunicationManager,
   NewSession,
-  SessionInfo,
   PagesChanged,
   PageNotFound,
 } from "@streamlit/lib"

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -22,7 +22,6 @@ import {
   PagesChanged,
   PageNotFound,
 } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 import {
   AppNavigation,
   PageUrlUpdateCallback,
@@ -44,24 +43,6 @@ jest.mock("@streamlit/lib/src/hostComm/HostCommunicationManager", () => {
     __esModule: true,
     ...actualModule,
     default: MockedClass,
-  }
-})
-
-jest.mock("@streamlit/app/src/SegmentMetricsManager", () => {
-  const actualModule = jest.requireActual(
-    "@streamlit/app/src/SegmentMetricsManager"
-  )
-
-  const MockedClass = jest.fn().mockImplementation((...props) => {
-    const metricsMgr = new actualModule.SegmentMetricsManager(...props)
-    jest.spyOn(metricsMgr, "enqueue")
-
-    return metricsMgr
-  })
-
-  return {
-    ...actualModule,
-    SegmentMetricsManager: MockedClass,
   }
 })
 
@@ -109,7 +90,6 @@ function generateNewSession(changes = {}): NewSession {
 
 describe("AppNavigation", () => {
   let hostCommunicationMgr: HostCommunicationManager
-  let metricsMgr: SegmentMetricsManager
   let onUpdatePageUrl: PageUrlUpdateCallback
   let onPageNotFound: PageNotFoundCallback
   let appNavigation: AppNavigation
@@ -135,12 +115,10 @@ describe("AppNavigation", () => {
       queryParamsChanged: () => {},
       deployedAppMetadataChanged: () => {},
     })
-    metricsMgr = new SegmentMetricsManager(new SessionInfo())
     onUpdatePageUrl = jest.fn()
     onPageNotFound = jest.fn()
     appNavigation = new AppNavigation(
       hostCommunicationMgr,
-      metricsMgr,
       onUpdatePageUrl,
       onPageNotFound
     )
@@ -268,17 +246,6 @@ describe("AppNavigation", () => {
     appNavigation.handleNewSession(generateNewSession())
     appNavigation.handlePageNotFound(new PageNotFound({ pageName: "foo" }))
     expect(onPageNotFound).toHaveBeenCalledWith("foo")
-  })
-
-  it("sends metrics when initialized", () => {
-    // Initialize navigation from the new session proto
-    appNavigation.handleNewSession(generateNewSession())
-    appNavigation.sendMPAMetricsOnInitialization()
-
-    expect(metricsMgr.enqueue).toHaveBeenCalledWith("updateReport", {
-      numPages: 1,
-      isMainPage: true,
-    })
   })
 
   it("finds url by path when path is valid", () => {

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -21,7 +21,6 @@ import {
   PagesChanged,
   PageNotFound,
 } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 interface AppNavigationState {
   hideSidebarNav: boolean
@@ -42,8 +41,6 @@ export type PageNotFoundCallback = (pageName?: string) => void
 export class AppNavigation {
   readonly hostCommunicationMgr: HostCommunicationManager
 
-  readonly metricsMgr: SegmentMetricsManager
-
   readonly onUpdatePageUrl: PageUrlUpdateCallback
 
   readonly onPageNotFound: PageNotFoundCallback
@@ -56,12 +53,10 @@ export class AppNavigation {
 
   constructor(
     hostCommunicationMgr: HostCommunicationManager,
-    metricsMgr: SegmentMetricsManager,
     onUpdatePageUrl: PageUrlUpdateCallback,
     onPageNotFound: PageNotFoundCallback
   ) {
     this.hostCommunicationMgr = hostCommunicationMgr
-    this.metricsMgr = metricsMgr
     this.onUpdatePageUrl = onUpdatePageUrl
     this.onPageNotFound = onPageNotFound
 
@@ -145,18 +140,6 @@ export class AppNavigation {
         })
       },
     ]
-  }
-
-  sendMPAMetricsOnInitialization(): void {
-    const { appPages, currentPageScriptHash } = this
-    if (appPages.length === 0) {
-      return
-    }
-
-    this.metricsMgr.enqueue("updateReport", {
-      numPages: appPages.length,
-      isMainPage: appPages[0].pageScriptHash === currentPageScriptHash,
-    })
   }
 
   findPageByUrlPath(pathname: string): IAppPage {

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -135,7 +135,7 @@ class ScriptRunContextTest(unittest.TestCase):
             self.fail("set_page_config should have succeeded after reset!")
 
     def test_active_script_hash(self):
-        """st.set_page_config should be allowed after a rerun"""
+        """ensures active script hash is set correctly when enqueueing messages"""
 
         fake_path = "my/custom/script/path"
         pg_mgr = PagesManager(fake_path)


### PR DESCRIPTION
## Describe your changes

Confirmed that the properties associated with the `updateReport` call are not needed.

## Testing Plan

- Added a unit test to ensure the value is sent on new session

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
