### PR TITLE
Fix is_fragment_run page profile field

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -739,8 +739,10 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageProfileMsg = (pageProfile: PageProfile): void => {
+    const pageProfileObj = PageProfile.toObject(pageProfile)
     this.metricsMgr.enqueue("pageProfile", {
-      ...PageProfile.toObject(pageProfile),
+      ...pageProfileObj,
+      isFragmentRun: Boolean(pageProfileObj.isFragmentRun),
       appId: this.sessionInfo.current.appId,
       numPages: this.state.appPages?.length,
       sessionId: this.sessionInfo.current.sessionId,

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -469,6 +469,6 @@ def create_page_profile_message(
         page_profile.uncaught_exception = uncaught_exception
 
     if ctx := get_script_run_ctx():
-        page_profile.is_fragment_run = bool(ctx.current_fragment_id)
+        page_profile.is_fragment_run = bool(ctx.fragment_ids_this_run)
 
     return msg

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -176,7 +176,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
 
     def test_create_page_profile_message_is_fragment_run(self):
         ctx = get_script_run_ctx()
-        ctx.current_fragment_id = "some_fragment_id"
+        ctx.fragment_ids_this_run = {"some_fragment_id"}
 
         forward_msg = metrics_util.create_page_profile_message(
             commands=[


### PR DESCRIPTION
It turns out setting the `is_fragment_run` field using whether `ctx.current_fragment_id` is set doesn't
work correctly since page profile messages are created after `ctx.current_fragment_id` has already
been reset. This PR fixes the field by instead setting it to true if the `ctx.fragment_ids_this_run` set is
truthy.