### PR TITLE
Ensure that column config is cloned

### DIFF
--- a/e2e_playwright/st_dataframe_selections.py
+++ b/e2e_playwright/st_dataframe_selections.py
@@ -33,6 +33,7 @@ df = pd.DataFrame(
 # set fixed column with so our pixel-clicks in the test are stable
 column_with_fixed_width = st.column_config.Column(width="small")
 column_config = {
+    "_index": column_with_fixed_width,
     "col_0": column_with_fixed_width,
     "col_1": column_with_fixed_width,
     "col_2": column_with_fixed_width,
@@ -159,9 +160,6 @@ st.write("Runs:", st.session_state.runs)
 
 st.header("Dataframe with Index:")
 
-column_config_with_index = copy.deepcopy(column_config)
-column_config_with_index["_index"] = st.column_config.Column(width="small")
-
 
 selection = st.dataframe(
     df,
@@ -169,7 +167,7 @@ selection = st.dataframe(
     on_select="rerun",
     selection_mode=["multi-column"],
     key="with_index",
-    column_config=column_config_with_index,
+    column_config=column_config,
     column_order=["col_1", "col_3"],
 )
 st.write("No selection on index column:", str(selection))

--- a/e2e_playwright/st_dataframe_selections.py
+++ b/e2e_playwright/st_dataframe_selections.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import random
 import time
 

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, Final, Literal, Mapping, Union
@@ -419,6 +420,10 @@ def process_config_mapping(
     """
     if column_config is None:
         return {}
+    else:
+        # Ensure that the column config is cloned
+        # since we will apply in-place changes to it.
+        column_config = copy.deepcopy(column_config)
 
     transformed_column_config: ColumnConfigMapping = {}
     for column, config in column_config.items():

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -421,10 +421,6 @@ def process_config_mapping(
     if column_config is None:
         return {}
 
-    # Ensure that the column config is cloned
-    # since we will apply in-place changes to it.
-    column_config = copy.deepcopy(column_config)
-
     transformed_column_config: ColumnConfigMapping = {}
     for column, config in column_config.items():
         if config is None:
@@ -432,7 +428,9 @@ def process_config_mapping(
         elif isinstance(config, str):
             transformed_column_config[column] = ColumnConfig(label=config)
         elif isinstance(config, dict):
-            transformed_column_config[column] = config
+            # Ensure that the column config objects are cloned
+            # since we will apply in-place changes to it.
+            transformed_column_config[column] = copy.deepcopy(config)
         else:
             raise StreamlitAPIException(
                 f"Invalid column config for column `{column}`. "

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -420,10 +420,10 @@ def process_config_mapping(
     """
     if column_config is None:
         return {}
-    else:
-        # Ensure that the column config is cloned
-        # since we will apply in-place changes to it.
-        column_config = copy.deepcopy(column_config)
+
+    # Ensure that the column config is cloned
+    # since we will apply in-place changes to it.
+    column_config = copy.deepcopy(column_config)
 
     transformed_column_config: ColumnConfigMapping = {}
     for column, config in column_config.items():

--- a/lib/tests/streamlit/elements/lib/column_config_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/column_config_utils_test.py
@@ -375,7 +375,7 @@ class ColumnConfigUtilsTest(unittest.TestCase):
         }
 
         processed_config = process_config_mapping(config_1)
-        processed_config["col1"] = {"label": "Changed label"}
+        processed_config["col1"]["label"] = "Changed label"
 
         self.assertNotEqual(
             processed_config["col1"]["label"],

--- a/lib/tests/streamlit/elements/lib/column_config_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/column_config_utils_test.py
@@ -362,6 +362,27 @@ class ColumnConfigUtilsTest(unittest.TestCase):
                 f"Expected list to be compatible with {data_kind}",
             )
 
+    def test_process_config_mapping_is_clone(self):
+        """Test that the process_config_mapping function clones the config object."""
+        config_1: ColumnConfigMappingInput = {
+            "index": {"label": "Index", "width": "medium"},
+            "col1": {
+                "label": "Column 1",
+                "width": "small",
+                "required": True,
+                "type_config": {"type": "link"},
+            },
+        }
+
+        processed_config = process_config_mapping(config_1)
+        processed_config["col1"] = {"label": "Changed label"}
+
+        self.assertNotEqual(
+            processed_config["col1"]["label"],
+            config_1["col1"]["label"],
+            "The labels should be different.",
+        )
+
     def test_process_config_mapping(self):
         """Test that the process_config_mapping function correctly processes a config mapping."""
         config_1: ColumnConfigMappingInput = {


### PR DESCRIPTION
## Describe your changes

We apply some changes to the column config object in place. This can lead to unexpected issues. To prevent this, we will create a deep-clone of the column config object.

## Testing Plan

- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
