### PR TITLE
[WIP] Add react keys to tabs and expanders

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -226,7 +226,8 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
                 node: node as BlockNode,
               }
 
-              return <BlockNodeRenderer key={index} {...childProps} />
+              const key = getElementWidgetID(node.deltaBlock) || index
+              return <BlockNodeRenderer key={key} {...childProps} />
             }
 
             // We don't have any other node types!

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -16,6 +16,7 @@
 
 import {
   Alert as AlertProto,
+  Block as BlockProto,
   LabelVisibilityMessage as LabelVisibilityMessageProto,
   Element,
   Skeleton as SkeletonProto,
@@ -342,9 +343,18 @@ export function setCookie(
   document.cookie = `${name}=${value};${expirationStr}path=/`
 }
 
-/** Return an Element's widget ID if it's a widget, and undefined otherwise. */
-export function getElementWidgetID(element: Element): string | undefined {
-  return get(element as any, [requireNonNull(element.type), "id"])
+/** Return an Element's widget ID if it's a widget and undefined otherwise.
+ *
+ * Note that this function is named getElementWidgetID (with no mention of
+ * Blocks) for backwards compatibility reasons.
+ */
+export function getElementWidgetID(
+  elementOrBlock: BlockProto | Element
+): string | undefined {
+  return get(elementOrBlock as any, [
+    requireNonNull(elementOrBlock.type),
+    "id",
+  ])
 }
 
 /** True if the given form ID is non-null and non-empty. */

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -54,6 +54,7 @@ message Block {
     string label = 1;
     optional bool expanded = 2;
     string icon = 3;
+    string id = 4;
   }
 
   message Dialog {
@@ -75,6 +76,7 @@ message Block {
   }
 
   message TabContainer {
+    string id = 1;
   }
 
   message Tab {


### PR DESCRIPTION
Expanders and tabs currently drop their state when unmounted/remounted (most often due to a new
element being inserted before the expander/tabs). This PR attempts to fix this by setting react keys
so that the components are retained across rerenders and thus don't lose their state.

Note this solution currently doesn't quite work because for whatever reason react is still dropping state
every now and then 😕. Currently trying to figure out why this is the case.

Closes #8239