### PR TITLE
Implement MarkdownColumn

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/MarkdownColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MarkdownColumn.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
+
+import { GridCellKind, MarkdownCell } from "@glideapps/glide-data-grid"
+
+import MarkdownColumn from "./MarkdownColumn"
+
+const MOCK_MARKDOWN_COLUMN_PROPS = {
+  id: "1",
+  name: "markdown_column",
+  title: "Markdown column",
+  indexNumber: 0,
+  isEditable: false,
+  isHidden: false,
+  isIndex: false,
+  isStretched: false,
+  arrowType: {
+    // The arrow type of the underlying data is
+    // not used for anything inside the column.
+    pandas_type: "unicode",
+    numpy_type: "object",
+  },
+}
+
+describe("MarkdownColumn", () => {
+  it("creates a valid column instance", () => {
+    const mockColumn = MarkdownColumn(MOCK_MARKDOWN_COLUMN_PROPS)
+    expect(mockColumn.kind).toEqual("markdown")
+    expect(mockColumn.title).toEqual(MOCK_MARKDOWN_COLUMN_PROPS.title)
+    expect(mockColumn.id).toEqual(MOCK_MARKDOWN_COLUMN_PROPS.id)
+    expect(mockColumn.sortMode).toEqual("default")
+
+    const mockCell = mockColumn.getCell("*streamlit*") as MarkdownCell
+    expect(mockCell.kind).toEqual(GridCellKind.Markdown)
+    expect(mockCell.data).toEqual("*streamlit*")
+  })
+
+  it.each([
+    ["foo", "foo"],
+    ["*streamlit*", "*streamlit*"],
+    ["/path/to/file", "/path/to/file"],
+    [null, null],
+    [undefined, null],
+    // All the values that are supported by the TextColumn
+    // should also be supported by the UrlColumn.
+  ])(
+    "supports string-compatible value (%p parsed as %p)",
+    (input: any, value: any | null) => {
+      const mockColumn = MarkdownColumn(MOCK_MARKDOWN_COLUMN_PROPS)
+      const cell = mockColumn.getCell(input)
+      expect(mockColumn.getCellValue(cell)).toEqual(value)
+    }
+  )
+
+  it("validates input based on max_chars", () => {
+    const mockColumn = MarkdownColumn({
+      ...MOCK_MARKDOWN_COLUMN_PROPS,
+      columnTypeOptions: { max_chars: 5 },
+    })
+
+    expect(mockColumn.validateInput!("12345")).toBe(true)
+    expect(mockColumn.validateInput!("123456")).toBe(false)
+    expect(mockColumn.validateInput!("1234567890")).toBe(false)
+  })
+})

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MarkdownColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MarkdownColumn.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GridCell, GridCellKind, MarkdownCell } from "@glideapps/glide-data-grid"
+
+import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
+
+import {
+  BaseColumn,
+  BaseColumnProps,
+  toSafeString,
+} from "./utils"
+
+export interface MarkdownColumnParams {
+  // The maximum number of characters the user can enter into the text input.
+  readonly max_chars?: number
+  // a value to display in the link cell. Can be a regex to parse out a specific substring of the url to be displayed
+  readonly markdown?: string
+}
+
+/**
+ * The link column is a special column that interprets the cell content as
+ * an hyperlink / url and allows the user to click on it.
+ */
+function LinkColumn(props: BaseColumnProps): BaseColumn {
+  const parameters = (props.columnTypeOptions as MarkdownColumnParams) || {}
+
+  const cellTemplate = {
+    kind: GridCellKind.Markdown,
+    readonly: !props.isEditable,
+    allowOverlay: true,
+    contentAlign: props.contentAlignment,
+    style: props.isIndex ? "faded" : "normal",
+    hoverEffect: true,
+    data: "",
+    copyData: "",
+  } as MarkdownCell
+
+  const validateInput = (markdown?: string): boolean => {
+    if (isNullOrUndefined(markdown)) {
+      if (props.isRequired) {
+        return false
+      }
+      return true
+    }
+
+    const cellMarkdown = toSafeString(markdown)
+
+    if (parameters.max_chars && cellMarkdown.length > parameters.max_chars) {
+      // value is too long
+      return false
+    }
+
+    return true
+  }
+
+  return {
+    ...props,
+    kind: "markdown",
+    sortMode: "default",
+    validateInput,
+    getCell(data?: any): GridCell {
+      if (!data) {
+        return {
+          ...cellTemplate,
+          data: null as any,
+          isMissingValue: true,
+        } as MarkdownCell
+      }
+
+      const markdown: string = toSafeString(data)
+
+      return {
+        ...cellTemplate,
+        data: markdown,
+        isMissingValue: false,
+        copyData: markdown,
+      } as MarkdownCell
+    },
+    getCellValue(cell: MarkdownCell): string | null {
+      return isNullOrUndefined(cell.data) ? null : cell.data
+    },
+  }
+}
+
+LinkColumn.isEditableType = true
+
+export default LinkColumn

--- a/frontend/lib/src/components/widgets/DataFrame/columns/index.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/index.ts
@@ -29,6 +29,7 @@ import {
   BarChartColumn,
   AreaChartColumn,
 } from "./ChartColumn"
+import MarkdownColumn from "./MarkdownColumn"
 
 export { ImageCellEditor } from "./cells/ImageCellEditor"
 
@@ -58,6 +59,7 @@ export const ColumnTypes = new Map<string, ColumnCreator>(
     area_chart: AreaChartColumn,
     image: ImageColumn,
     progress: ProgressColumn,
+    markdown: MarkdownColumn,
   })
 )
 
@@ -79,4 +81,5 @@ export {
   AreaChartColumn,
   ImageColumn,
   ProgressColumn,
+  MarkdownColumn,
 }

--- a/lib/streamlit/column_config.py
+++ b/lib/streamlit/column_config.py
@@ -32,6 +32,7 @@ __all__ = [
     "ListColumn",
     "DateColumn",
     "TimeColumn",
+    "MarkdownColumn",
 ]
 
 
@@ -51,4 +52,5 @@ from streamlit.elements.lib.column_types import (
     SelectboxColumn,
     TextColumn,
     TimeColumn,
+    MarkdownColumn,
 )

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -102,6 +102,7 @@ _EDITING_COMPATIBILITY_MAPPING: Final[dict[ColumnType, list[ColumnDataKind]]] = 
         ColumnDataKind.EMPTY,
     ],
     "link": [ColumnDataKind.STRING, ColumnDataKind.EMPTY],
+    "markdown": [ColumnDataKind.STRING, ColumnDataKind.EMPTY],
 }
 
 

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -132,6 +132,12 @@ class ProgressColumnConfig(TypedDict):
     max_value: NotRequired[int | float | None]
 
 
+class MarkdownColumnConfig(TypedDict):
+    type: Literal["markdown"]
+    max_chars: NotRequired[int | None]
+    markdown: NotRequired[str | None]
+
+
 class ColumnConfig(TypedDict, total=False):
     """Configuration options for columns in ``st.dataframe`` and ``st.data_editor``.
 
@@ -1593,5 +1599,97 @@ def ProgressColumn(
             format=format,
             min_value=min_value,
             max_value=max_value,
+        ),
+    )
+
+
+@gather_metrics("column_config.MarkdownColumn")
+def MarkdownColumn(
+    label: str | None = None,
+    *,
+    width: ColumnWidth | None = None,
+    help: str | None = None,
+    disabled: bool | None = None,
+    required: bool | None = None,
+    default: str | None = None,
+    max_chars: int | None = None,
+) -> ColumnConfig:
+    """Configure a link column in ``st.dataframe`` or ``st.data_editor``.
+
+    The cell values need to be string and will be shown as clickable links.
+    This command needs to be used in the column_config parameter of ``st.dataframe``
+    or ``st.data_editor``. When used with ``st.data_editor``, editing will be enabled
+    with a text input widget.
+
+    Parameters
+    ----------
+
+    label: str or None
+        The label shown at the top of the column. If None (default),
+        the column name is used.
+
+    width: "small", "medium", "large", or None
+        The display width of the column. Can be one of "small", "medium", or "large".
+        If None (default), the column will be sized to fit the cell contents.
+
+    help: str or None
+        An optional tooltip that gets displayed when hovering over the column label.
+
+    disabled: bool or None
+        Whether editing should be disabled for this column. Defaults to False.
+
+    required: bool or None
+        Whether edited cells in the column need to have a value. If True, an edited cell
+        can only be submitted if it has a value other than None. Defaults to False.
+
+    default: str or None
+        Specifies the default value in this column when a new row is added by the user.
+
+    max_chars: int or None
+        The maximum number of characters that can be entered. If None (default),
+        there will be no maximum.
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> import streamlit as st
+    >>>
+    >>> data_df = pd.DataFrame(
+    >>>     {
+    >>>         "markdown": [
+    >>>             "**bold**",
+    >>>             "*italic*",
+    >>>             "_underline_",
+    >>>         ],
+    >>>     }
+    >>> )
+    >>>
+    >>> st.data_editor(
+    >>>     data_df,
+    >>>     column_config={
+    >>>         "markdown": st.column_config.MarkdownColumn(
+    >>>             "Markdown",
+    >>>             max_chars=100,
+    >>>         ),
+    >>>     },
+    >>>     hide_index=True,
+    >>> )
+
+    .. output::
+        https://doc-markdown-column.streamlit.app/
+        height: 300px
+    """
+
+    return ColumnConfig(
+        label=label,
+        width=width,
+        help=help,
+        disabled=disabled,
+        required=required,
+        default=default,
+        type_config=MarkdownColumnConfig(
+            type="markdown",
+            max_chars=max_chars,
         ),
     )


### PR DESCRIPTION
## Describe your changes

I want to display bolded/italicized/underlined parts of text in my dataframe table. So we can use the [MarkdownCell](https://docs.grid.glideapps.com/api/cells/markdowncell) from Glide Data Grid.

Others also have similar requests - https://discuss.streamlit.io/t/how-to-display-st-markdown-in-a-column-of-st-dataframe/59301.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
