### PR TITLE
Add altair-selection tests for forms, callback, and fragment

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -229,3 +229,58 @@ if (
         "Histogram chart with selection_interval:",
         str(st.session_state.histogram_interval),
     )
+
+# SELECTIONS IN FORM
+st.header("Selections in form:")
+
+with st.form(key="my_form", clear_on_submit=True):
+    selection = st.altair_chart(
+        histogram_point,
+        on_select="rerun",
+        key="histogram_point_in_form",
+        use_container_width=True,
+    )
+    st.form_submit_button("Submit")
+
+st.write("Histogram-in-form selection:", str(selection))
+if "histogram_point_in_form" in st.session_state:
+    st.write(
+        "Histogram-in-form selection in session state:",
+        str(st.session_state.histogram_point_in_form),
+    )
+
+# SELECTIONS IN CALLBACK
+st.header("Selection callback:")
+
+
+def on_selection():
+    st.write(
+        "Histogram selection callback:",
+        str(st.session_state.histogram_point_in_callback),
+    )
+
+
+selection = st.altair_chart(
+    histogram_point,
+    on_select=on_selection,
+    key="histogram_point_in_callback",
+    use_container_width=True,
+)
+
+
+# SELECTIONS IN FRAGMENT
+st.header("Selections in fragment:")
+
+
+@st.experimental_fragment
+def test_fragment():
+    selection = st.altair_chart(
+        histogram_point,
+        on_select=on_selection,
+        key="histogram_point_in_fragment",
+        use_container_width=True,
+    )
+    st.write("Histogram-in-fragment selection:", str(selection))
+
+
+test_fragment()

--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -284,3 +284,8 @@ def test_fragment():
 
 
 test_fragment()
+
+if "runs" not in st.session_state:
+    st.session_state.runs = 0
+st.session_state.runs += 1
+st.write("Runs:", st.session_state.runs)

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -290,12 +290,9 @@ def test_selection_with_callback(app: Page):
     chart = _get_callback_chart(app)
     expect(chart).to_be_visible()
 
-    markdown_prefix = "Histogram selection callback:"
-    empty_selection = "\\{'selection': \\{'param_1': \\{\\}\\}\\}"
-    _expect_written_text(app, markdown_prefix, empty_selection)
-
     _click(app, chart, _MousePosition(255, 238))
 
+    markdown_prefix = "Histogram selection callback:"
     expected_selection = "{'selection': {'param_1': \\[{'IMDB_Rating': 4.6}\\]}}"
     _expect_written_text(app, markdown_prefix, expected_selection)
 

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -105,6 +105,18 @@ def _get_selection_interval_histogram(app: Page) -> Locator:
     return app.get_by_test_id("stArrowVegaLiteChart").locator("canvas").nth(7)
 
 
+def _get_in_form_chart(app: Page) -> Locator:
+    return app.get_by_test_id("stArrowVegaLiteChart").locator("canvas").nth(8)
+
+
+def _get_callback_chart(app: Page) -> Locator:
+    return app.get_by_test_id("stArrowVegaLiteChart").locator("canvas").nth(9)
+
+
+def _get_in_fragment_chart(app: Page) -> Locator:
+    return app.get_by_test_id("stArrowVegaLiteChart").locator("canvas").nth(10)
+
+
 def test_point_bar_chart_displays_selection_text(app: Page):
     chart = _get_selection_point_bar_chart(app)
 
@@ -241,6 +253,65 @@ def _test_shift_click_point_selection_scatter_chart_displays_selection(
     _expect_written_text(app, expected_prefix, expected_selection)
 
     return chart
+
+
+def test_in_form_selection_and_session_state(app: Page):
+    chart = _get_in_form_chart(app)
+    expect(chart).to_be_visible()
+
+    _click(app, chart, _MousePosition(255, 238))
+
+    markdown_prefix = "Histogram-in-form selection:"
+    markdown_prefix_session_state = "Histogram-in-form selection in session state:"
+    empty_selection = "\\{'selection': \\{'param_1': \\{\\}\\}\\}"
+    # nothing should be shown yet because we did not submit the form
+    _expect_written_text(
+        app,
+        markdown_prefix,
+        empty_selection,
+    )
+    _expect_written_text(
+        app,
+        markdown_prefix_session_state,
+        empty_selection,
+    )
+
+    # submit the form. The selection uses a debounce of 200ms; if we click too early, the state is not updated correctly and we submit the old, unselected values
+    # app.wait_for_timeout(210)
+    app.get_by_test_id("baseButton-secondaryFormSubmit").click()
+    wait_for_app_run(app)
+
+    expected_selection = "{'selection': {'param_1': \\[{'IMDB_Rating': 4.6}\\]}}"
+    _expect_written_text(app, markdown_prefix, expected_selection)
+    _expect_written_text(app, markdown_prefix_session_state, expected_selection)
+
+
+def test_selection_with_callback(app: Page):
+    chart = _get_callback_chart(app)
+    expect(chart).to_be_visible()
+
+    markdown_prefix = "Histogram selection callback:"
+    empty_selection = "\\{'selection': \\{'param_1': \\{\\}\\}\\}"
+    _expect_written_text(app, markdown_prefix, empty_selection)
+
+    _click(app, chart, _MousePosition(255, 238))
+
+    expected_selection = "{'selection': {'param_1': \\[{'IMDB_Rating': 4.6}\\]}}"
+    _expect_written_text(app, markdown_prefix, expected_selection)
+
+
+def test_selection_in_fragment(app: Page):
+    chart = _get_in_fragment_chart(app)
+    expect(chart).to_be_visible()
+
+    markdown_prefix = "Histogram-in-fragment selection:"
+    empty_selection = "\\{'selection': \\{'param_1': \\{\\}\\}\\}"
+    _expect_written_text(app, markdown_prefix, empty_selection)
+
+    _click(app, chart, _MousePosition(255, 238))
+
+    expected_selection = "{'selection': {'param_1': \\[{'IMDB_Rating': 4.6}\\]}}"
+    _expect_written_text(app, markdown_prefix, expected_selection)
 
 
 def test_shift_click_point_selection_scatter_chart_snapshot(

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -310,6 +310,9 @@ def test_selection_in_fragment(app: Page):
     expected_selection = "{'selection': {'param_1': \\[{'IMDB_Rating': 4.6}\\]}}"
     _expect_written_text(app, markdown_prefix, expected_selection)
 
+    # Check that the main script has run once (the initial run), but not after the selection:
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+
 
 def test_shift_click_point_selection_scatter_chart_snapshot(
     app: Page, assert_snapshot: ImageCompareFunction

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -364,7 +364,7 @@ def test_multi_row_and_multi_column_selection_in_fragment(app: Page):
         "{'selection': {'rows': [0, 2], 'columns': ['col_1', 'col_3', 'col_4']}}",
     )
 
-    # Check that the main script:
+    # Check that the main script has run once (the initial run), but not after the selection:
     expect(app.get_by_text("Runs: 1")).to_be_visible()
 
 

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -300,7 +300,7 @@ def test_in_form_selection_and_session_state(app: Page):
 
     _expect_written_text(
         app,
-        _markdown_prefix,
+        "Dataframe-in-form selection in session state:",
         "{'selection': {'rows': [0, 2], 'columns': ['col_1', 'col_3', 'col_4']}}",
     )
 

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -354,6 +354,8 @@ def test_selection_state_remains_after_unmounting(
 
 def test_multi_row_and_multi_column_selection_in_fragment(app: Page):
     canvas = _get_fragment_df(app)
+    canvas.scroll_into_view_if_needed()
+    expect(canvas).to_be_visible()
     _select_some_rows_and_columns(app, canvas)
 
     _expect_written_text(


### PR DESCRIPTION
## Describe your changes

Similar to the [dataframe selection tests](https://github.com/streamlit/streamlit/blob/d26bb4d5cb630a0ac7c52b6656991dc7f3dac54d/e2e_playwright/st_dataframe_selections.py#L100-L157), we want to test chart selections with callbacks and inside forms or fragments explicitly.

Also fix two issues with the dataframe selection e2e tests.

## GitHub Issue Link (if applicable)

## Testing Plan

- E2E Tests: add tests for chart selection inside  a fragment and a form and also with a callback

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
