### PR TITLE
set_page_config should override mpa-v2 Page properties

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -368,7 +368,8 @@ export class App extends PureComponent<Props, State> {
     this.appNavigation = new AppNavigation(
       this.hostCommunicationMgr,
       this.maybeUpdatePageUrl,
-      this.onPageNotFound
+      this.onPageNotFound,
+      this.onPageIconChanged
     )
 
     window.streamlitDebug = {
@@ -676,6 +677,8 @@ export class App extends PureComponent<Props, State> {
     const { title, favicon, layout, initialSidebarState, menuItems } =
       pageConfig
 
+    this.appNavigation.handlePageConfigChanged(pageConfig)
+
     if (title) {
       this.hostCommunicationMgr.sendMessageToHost({
         type: "SET_PAGE_TITLE",
@@ -686,11 +689,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     if (favicon) {
-      handleFavicon(
-        favicon,
-        this.hostCommunicationMgr.sendMessageToHost,
-        this.endpoints
-      )
+      this.onPageIconChanged(favicon)
     }
 
     // Only change layout/sidebar when the page config has changed.
@@ -734,6 +733,14 @@ export class App extends PureComponent<Props, State> {
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
     this.maybeSetState(this.appNavigation.handlePageNotFound(pageNotFound))
+  }
+
+  onPageIconChanged = (iconUrl: string): void => {
+    handleFavicon(
+      iconUrl,
+      this.hostCommunicationMgr.sendMessageToHost,
+      this.endpoints
+    )
   }
 
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
@@ -957,11 +964,7 @@ export class App extends PureComponent<Props, State> {
       this.maybeSetState(this.appNavigation.handleNewSession(newSessionProto))
 
       // Set the favicon to its default values
-      handleFavicon(
-        `${process.env.PUBLIC_URL}/favicon.png`,
-        this.hostCommunicationMgr.sendMessageToHost,
-        this.endpoints
-      )
+      this.onPageIconChanged(`${process.env.PUBLIC_URL}/favicon.png`)
     } else {
       this.setState({
         fragmentIdsThisRun,

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -331,7 +331,6 @@ export class AppNavigation {
   }
 
   handleNewSession(newSession: NewSession): MaybeStateUpdate {
-    // Reset the page title and icon
     this.isPageTitleSet = false
     this.isPageIconSet = false
 


### PR DESCRIPTION
## Describe your changes

If `st.set_page_config` is called, we should disregard the page information in the navigation call.

## Testing Plan

- JS Unit Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
