### PR TITLE
Make the main script hash optional in AppRoot.empty()

### DIFF
--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -558,7 +558,7 @@ export class AppRoot {
    * Create an empty AppRoot with a placeholder "skeleton" element.
    */
   public static empty(
-    mainScriptHash: string,
+    mainScriptHash = "",
     isInitialRender = true,
     sidebarElements?: BlockNode | undefined
   ): AppRoot {


### PR DESCRIPTION
## Describe your changes

Others (Notebooks) uses `AppRoot.empty()`. To make things easier, I make the `mainScriptHash` keyword only.

## Testing Plan

- Existing tests should be fine enough

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
