### PR TITLE
Only populate pages in V1 for NewSession and PagesChanged

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -29,13 +29,7 @@ from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.Common_pb2 import FileURLs, FileURLsRequest
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
-from streamlit.proto.NewSession_pb2 import (
-    Config,
-    CustomThemeConfig,
-    NewSession,
-    UserInfo,
-)
-from streamlit.proto.PagesChanged_pb2 import PagesChanged
+from streamlit.proto.NewSession_pb2 import Config, CustomThemeConfig, UserInfo
 from streamlit.runtime import caching, legacy_caching
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import FragmentStorage, MemoryFragmentStorage
@@ -456,7 +450,7 @@ class AppSession:
 
     def _on_pages_changed(self, _) -> None:
         msg = ForwardMsg()
-        self._populate_app_pages(msg.pages_changed)
+        self._pages_manager.populate_app_pages(msg.pages_changed)
         self._enqueue_forward_msg(msg)
 
         if self._local_sources_watcher is not None:
@@ -681,7 +675,7 @@ class AppSession:
         if fragment_ids_this_run:
             msg.new_session.fragment_ids_this_run.extend(fragment_ids_this_run)
 
-        self._populate_app_pages(msg.new_session)
+        self._pages_manager.populate_app_pages(msg.new_session)
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
 
@@ -831,14 +825,6 @@ class AppSession:
             )
 
         self._enqueue_forward_msg(msg)
-
-    def _populate_app_pages(self, msg: NewSession | PagesChanged) -> None:
-        for page_script_hash, page_info in self._pages_manager.get_pages().items():
-            page_proto = msg.app_pages.add()
-
-            page_proto.page_script_hash = page_script_hash
-            page_proto.page_name = page_info["page_name"]
-            page_proto.icon = page_info["icon"]
 
 
 # Config.ToolbarMode.ValueType does not exist at runtime (only in the pyi stubs), so

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -39,7 +39,7 @@ from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV1
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner import (
     RerunData,
@@ -97,6 +97,7 @@ class AppSessionTest(unittest.TestCase):
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
         Runtime._instance = mock_runtime
+        PagesManager.DefaultStrategy = PagesStrategyV1
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -441,7 +442,12 @@ class AppSessionTest(unittest.TestCase):
         expected_msg = ForwardMsg()
         expected_msg.pages_changed.app_pages.extend(
             [
-                AppPage(page_script_hash="hash1", page_name="page1", icon=""),
+                AppPage(
+                    page_script_hash="hash1",
+                    page_name="page1",
+                    icon="",
+                    is_default=True,
+                ),
                 AppPage(page_script_hash="hash2", page_name="page2", icon="🎉"),
             ]
         )
@@ -721,7 +727,12 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         self.assertEqual(
             list(new_session_msg.app_pages),
             [
-                AppPage(page_script_hash="hash1", page_name="page1", icon=""),
+                AppPage(
+                    page_script_hash="hash1",
+                    page_name="page1",
+                    icon="",
+                    is_default=True,
+                ),
                 AppPage(page_script_hash="hash2", page_name="page2", icon="🎉"),
             ],
         )


### PR DESCRIPTION
## Describe your changes

The navbar can appear at the beginning of initial load due to two things:
 - PagesChanged is being sent from the navigation call (through the on_pages_changed callback)
 - The NewSession is using the provided pages. I believe this is a race condition due to the caching mechanism of pages and app session.

The solution here is to let the strategies populate these fields directly where V2 decided to only send one page (the main page).

## Testing Plan

- Python Unit Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
