### PR TITLE
Don't notify pages change for MPAv2

### DIFF
--- a/e2e_playwright/hello_app.py
+++ b/e2e_playwright/hello_app.py
@@ -21,12 +21,9 @@ from streamlit.hello import Hello
 np.random.seed(0)
 
 # This is a trick to setup the MPA hello app programmatically
-from streamlit.runtime.scriptrunner import get_script_run_ctx
-
-ctx = get_script_run_ctx()
-if ctx:
-    ctx.pages_manager._cached_pages = source_util.get_pages(Hello.__file__)
-    ctx.pages_manager._on_pages_changed.send()
+source_util._cached_pages = None
+source_util._cached_pages = source_util.get_pages(Hello.__file__)
+source_util._on_pages_changed.send()
 
 # TODO(lukasmasuch): Once we migrate the hello app to the new programmatic
 # MPA API, we can remove this workaround.

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -145,15 +145,15 @@ class PagesStrategyV2:
         if self._pages is None:
             return None
 
-        if self.pages_manager.intent_page_script_hash:
+        if self.pages_manager.intended_page_script_hash:
             # We assume that if initial page hash is specified, that a page should
             # exist, so we check out the page script hash or the default page hash
             # as a backup
             return self._pages.get(
-                self.pages_manager.intent_page_script_hash,
+                self.pages_manager.intended_page_script_hash,
                 self._pages.get(fallback_page_hash, None),
             )
-        elif self.pages_manager.intent_page_name:
+        elif self.pages_manager.intended_page_name:
             # If a user navigates directly to a non-main page of an app, the
             # the page name can identify the page script to run
             return next(
@@ -163,7 +163,7 @@ class PagesStrategyV2:
                     # types of pages), so we add `p and` at the beginning of
                     # the predicate to circumvent this.
                     lambda p: p
-                    and (p["url_pathname"] == self.pages_manager.intent_page_name),
+                    and (p["url_pathname"] == self.pages_manager.intended_page_name),
                     self._pages.values(),
                 ),
                 None,
@@ -198,8 +198,8 @@ class PagesManager:
         self._current_page_hash: PageHash = self._main_script_hash
         self.pages_strategy = PagesManager.DefaultStrategy(self, **kwargs)
         self._script_cache: ScriptCache | None = script_cache
-        self._intent_page_script_hash: PageHash | None = None
-        self._intent_page_name: PageName | None = None
+        self._intended_page_script_hash: PageHash | None = None
+        self._intended_page_name: PageName | None = None
 
     @property
     def current_page_hash(self) -> PageHash:
@@ -214,12 +214,12 @@ class PagesManager:
         return self._main_script_hash
 
     @property
-    def intent_page_name(self) -> PageName | None:
-        return self._intent_page_name
+    def intended_page_name(self) -> PageName | None:
+        return self._intended_page_name
 
     @property
-    def intent_page_script_hash(self) -> PageHash | None:
-        return self._intent_page_script_hash
+    def intended_page_script_hash(self) -> PageHash | None:
+        return self._intended_page_script_hash
 
     def get_main_page(self) -> PageInfo:
         return {
@@ -242,8 +242,8 @@ class PagesManager:
     def set_script_intent(
         self, page_script_hash: PageHash, page_name: PageName
     ) -> None:
-        self._intent_page_script_hash = page_script_hash
-        self._intent_page_name = page_name
+        self._intended_page_script_hash = page_script_hash
+        self._intended_page_name = page_name
 
     def get_initial_active_script(
         self, page_script_hash: PageHash, page_name: PageName

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -214,11 +214,11 @@ class PagesManager:
         return self._main_script_hash
 
     @property
-    def intent_page_name(self) -> PageName:
+    def intent_page_name(self) -> PageName | None:
         return self._intent_page_name
 
     @property
-    def intent_page_script_hash(self) -> PageHash:
+    def intent_page_script_hash(self) -> PageHash | None:
         return self._intent_page_script_hash
 
     def get_main_page(self) -> PageInfo:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -429,7 +429,7 @@ class ScriptRunner:
             # Reset DeltaGenerators, widgets, media files.
             runtime.get_instance().media_file_mgr.clear_session_refs()
 
-            self._pages_manager.set_initial_script(
+            self._pages_manager.set_script_intent(
                 rerun_data.page_script_hash, rerun_data.page_name
             )
             active_script = self._pages_manager.get_initial_active_script(

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -323,9 +323,9 @@ class AppTest:
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
         Runtime._instance = mock_runtime
         pages_manager = PagesManager(self._script_path, setup_watcher=False)
-        with pages_manager._pages_cache_lock:
-            saved_cached_pages = pages_manager._cached_pages
-            pages_manager._cached_pages = None
+        with source_util._pages_cache_lock:
+            saved_cached_pages = source_util._cached_pages
+            source_util._cached_pages = None
 
         saved_secrets: Secrets = st.secrets
         # Only modify global secrets stuff if we have been given secrets
@@ -351,8 +351,8 @@ class AppTest:
         self.query_params = parse.parse_qs(query_string)
 
         # teardown
-        with pages_manager._pages_cache_lock:
-            pages_manager._cached_pages = saved_cached_pages
+        with source_util._pages_cache_lock:
+            source_util._cached_pages = saved_cached_pages
 
         if self.secrets:
             if st.secrets._secrets is not None:

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -99,6 +99,11 @@ def pytest_configure(config: pytest.Config):
 
 
 def pytest_runtest_setup(item: pytest.Item):
+    # Ensure Default Strategy is V1 to start
+    from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV1
+
+    PagesManager.DefaultStrategy = PagesStrategyV1
+
     is_require_snowflake = item.config.getoption("--require-snowflake", default=False)
     has_require_snowflake_marker = bool(
         list(item.iter_markers(name="require_snowflake"))

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -57,21 +57,19 @@ class NavigationTest(DeltaGeneratorTestCase):
 
     def test_page_found_by_hash(self):
         found_page = st.Page("page2.py")
-        self.script_run_ctx.pages_manager.get_initial_active_script(
-            found_page._script_hash, ""
-        )
+        self.script_run_ctx.pages_manager.set_script_intent(found_page._script_hash, "")
         page = st.navigation([st.Page("page1.py"), found_page, st.Page("page3.py")])
         assert page == found_page
 
     def test_page_found_by_name(self):
         found_page = st.Page("page2.py")
-        self.script_run_ctx.pages_manager.get_initial_active_script("", "page2")
+        self.script_run_ctx.pages_manager.set_script_intent("", "page2")
         page = st.navigation([st.Page("page1.py"), found_page, st.Page("page3.py")])
         assert page == found_page
 
     def test_page_not_found_by_name(self):
         default_page = st.Page("page1.py")
-        self.script_run_ctx.pages_manager.get_initial_active_script("", "bad_page")
+        self.script_run_ctx.pages_manager.set_script_intent("", "bad_page")
         page = st.navigation([default_page, st.Page("page2.py"), st.Page("page3.py")])
 
         c = self.get_message_from_queue(-2)
@@ -80,7 +78,7 @@ class NavigationTest(DeltaGeneratorTestCase):
 
     def test_page_not_found_by_hash_returns_default(self):
         default_page = st.Page("page1.py")
-        self.script_run_ctx.pages_manager.get_initial_active_script("bad_hash", "")
+        self.script_run_ctx.pages_manager.set_script_intent("bad_hash", "")
         page = st.navigation([default_page, st.Page("page2.py"), st.Page("page3.py")])
         assert page == default_page
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -732,6 +732,11 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
     )
+    @patch.object(
+        PagesManager,
+        "register_pages_changed_callback",
+        MagicMock(return_value=lambda: None),
+    )
     async def test_new_session_message_includes_fragment_ids(self):
         session = _create_test_session(asyncio.get_running_loop())
 
@@ -825,6 +830,11 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
     @patch(
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
+    )
+    @patch.object(
+        PagesManager,
+        "register_pages_changed_callback",
+        MagicMock(return_value=lambda: None),
     )
     async def test_handle_backmsg_exception(self):
         """handle_backmsg_exception is a bit of a hack. Test that it does

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -18,58 +18,34 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
+import streamlit.source_util as source_util
 from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV1
 from streamlit.util import calc_md5
 
 
 class PagesManagerTest(unittest.TestCase):
-    def test_pages_cache(self):
-        """Test that the pages cache is correctly set and invalidated"""
-        pages_manager = PagesManager("main_script_path")
-        with patch.object(pages_manager, "_on_pages_changed", MagicMock()):
-            assert pages_manager._cached_pages is None
-
-            pages = pages_manager.get_pages()
-
-            assert pages_manager._cached_pages is not None
-
-            new_pages = pages_manager.get_pages()
-            # Assert address-equality to verify the cache is used the second time
-            # get_pages is called.
-            assert new_pages is pages
-
-            pages_manager._on_pages_changed.send.assert_called_once()
-
-            pages_manager._on_pages_changed.reset_mock()
-            pages_manager.invalidate_pages_cache()
-            assert pages_manager._cached_pages is None
-
-            pages_manager._on_pages_changed.send.assert_called_once()
-            another_new_set_of_pages = pages_manager.get_pages()
-            assert another_new_set_of_pages is not pages
-
     def test_register_pages_changed_callback(self):
         """Test that the pages changed callback is correctly registered and unregistered"""
         pages_manager = PagesManager("main_script_path")
-        with patch.object(pages_manager, "_on_pages_changed", MagicMock()):
+        with patch.object(source_util, "_on_pages_changed", MagicMock()):
             callback = lambda: None
 
             disconnect = pages_manager.register_pages_changed_callback(callback)
 
-            pages_manager._on_pages_changed.connect.assert_called_once_with(
+            source_util._on_pages_changed.connect.assert_called_once_with(
                 callback, weak=False
             )
 
             disconnect()
-            pages_manager._on_pages_changed.disconnect.assert_called_once_with(callback)
+            source_util._on_pages_changed.disconnect.assert_called_once_with(callback)
 
     @patch("streamlit.runtime.pages_manager.watch_dir")
-    @patch.object(PagesManager, "invalidate_pages_cache", MagicMock())
+    @patch.object(source_util, "invalidate_pages_cache", MagicMock())
     def test_install_pages_watcher(self, patched_watch_dir):
         """Test that the pages watcher is correctly installed and uninstalled"""
         # Ensure PagesStrategyV1.is_watching_pages_dir is False to start
         PagesStrategyV1.is_watching_pages_dir = False
-        pages_manager = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
+        PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
 
         patched_watch_dir.assert_called_once()
         args, _ = patched_watch_dir.call_args_list[0]
@@ -88,7 +64,7 @@ class PagesManagerTest(unittest.TestCase):
         patched_watch_dir.assert_not_called()
 
         on_pages_changed("/foo/bar/pages")
-        pages_manager.invalidate_pages_cache.assert_called_once()
+        source_util.invalidate_pages_cache.assert_called_once()
 
 
 class PagesManagerV2Test(unittest.TestCase):
@@ -176,35 +152,12 @@ class PagesManagerV2Test(unittest.TestCase):
             {"script_path": "main_script_path", "page_script_hash": "page_hash"},
         )
 
-    def test_does_not_call_pages_change(self):
-        """Test that the V2 Strategy does not call the pages changed callback"""
-        with patch.object(self.pages_manager, "_on_pages_changed", MagicMock()):
-            # pages should be cached from setUp
-            assert self.pages_manager._cached_pages is not None
-
-            pages = self.pages_manager.get_pages()
-
-            assert self.pages_manager._cached_pages is not None
-
-            new_pages = self.pages_manager.get_pages()
-            # Assert address-equality to verify the cache is used the second time
-            # get_pages is called.
-            assert new_pages is pages
-
-            assert not self.pages_manager._on_pages_changed.send.called
-
-            self.pages_manager._on_pages_changed.reset_mock()
-            self.pages_manager.set_pages({})
-
-            assert not self.pages_manager._on_pages_changed.send.called
-            another_new_set_of_pages = self.pages_manager.get_pages()
-            assert another_new_set_of_pages is not pages
-
 
 # NOTE: We write this test function using pytest conventions (as opposed to
 # using unittest.TestCase like in the rest of the codebase) because the tmpdir
 # pytest fixture is so useful for writing this test it's worth having the
 # slight inconsistency.
+@patch("streamlit.source_util._cached_pages", new=None)
 def test_get_initial_active_script_v1(tmpdir):
     # Write an empty string to create a file.
     tmpdir.join("streamlit_app.py").write("")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -80,6 +80,7 @@ def _is_control_event(event: ScriptRunnerEvent) -> bool:
     return event != ScriptRunnerEvent.ENQUEUE_FORWARD_MSG
 
 
+@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -842,7 +843,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # Set _cached_pages to None manually (instead of using
         # source_util.invalidate_pages_cache) to avoid firing on_pages_changed
         # events.
-        runner._pages_manager._cached_pages = None
+        source_util._cached_pages = None
 
         # Run a slightly different script on a second runner.
         runner = TestScriptRunner("st_cache_script_changed.py")


### PR DESCRIPTION
## Describe your changes

Page Changes in MPAv2 are done via the `st.navigation` call. Informing of Pages Change is not helpful for the UI display. We also came to the conclusion that the concept of cache pages did not matter for PagesManager as well. So I moved everything back to source_util to produce a cleaner system.

In testing this, I noticed some inconsistencies due to the fact that the default strategy of the PagesManager is not resetting. So I did the following:

1. I moved the DefaultStrategy reset to be set on every every test to make things easy.
2. I then found out that when MPA switches from V1->V2 the initial script information (page hash and page name) got lost, which suggested this should be in the root PagesManager and not tied to just the V2 strategy.
3. I found a better name than "initial" I would describe it better as the "intent", which is to indicate to the PagesManager a page is being requested.

## Testing Plan

- Python Tests for both strategies

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
