### PR TITLE
Revert "Allow protobuf v5"

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.
     # Instead, the `protoc` min version is enforced in our Makefile.)
-    "protobuf>=3.20, <6",
+    "protobuf>=3.20, <5",
     # pyarrow is not semantically versioned, gets new major versions frequently, and
     # doesn't tend to break the API on major version upgrades, so we don't put an
     # upper bound on it.


### PR DESCRIPTION
Reverts streamlit/streamlit#8624

@LukasMasuch reported seeing the CI pipeline failing in some cases (see also [this comment](https://github.com/streamlit/streamlit/pull/8624#issuecomment-2097814738)). Since we have a critical release coming up, we revert these changes for now. 