### PR TITLE
Retrieve pages for new session when ready to send the event

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -475,7 +475,7 @@ class AppSession:
         client_state: ClientState | None = None,
         page_script_hash: str | None = None,
         fragment_ids_this_run: set[str] | None = None,
-        pages: dict[PageHash, PageInfo] = {},
+        pages: dict[PageHash, PageInfo] | None = None,
     ) -> None:
         """Called when our ScriptRunner emits an event.
 
@@ -505,7 +505,7 @@ class AppSession:
         client_state: ClientState | None = None,
         page_script_hash: str | None = None,
         fragment_ids_this_run: set[str] | None = None,
-        pages: dict[PageHash, PageInfo] = {},
+        pages: dict[PageHash, PageInfo] | None = None,
     ) -> None:
         """Handle a ScriptRunner event.
 
@@ -674,7 +674,7 @@ class AppSession:
         self,
         page_script_hash: str,
         fragment_ids_this_run: set[str] | None = None,
-        pages: dict[PageHash, PageInfo] = {},
+        pages: dict[PageHash, PageInfo] | None = None,
     ) -> ForwardMsg:
         """Create and return a new_session ForwardMsg."""
         msg = ForwardMsg()

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -470,6 +470,7 @@ class ScriptRunner:
                 event=ScriptRunnerEvent.SCRIPT_STARTED,
                 page_script_hash=page_script_hash,
                 fragment_ids_this_run=fragment_ids_this_run,
+                pages=self._pages_manager.get_pages(),
             )
 
             # Compile the script. Any errors thrown here will be surfaced


### PR DESCRIPTION
## Describe your changes

We have found flaky situations where pages are set via `st.navigation` before the NewSession call is sent. This causes the NewSession message to retrieve pages it should not be expecting from the PagesManager. The easy solution here is to send the pages on the Script Started Event so that the NewSession has the pages at the time of the event.

I believe there's a larger discussion on how we should be managing this. Likely, we should ensure information is happening at the right moment.

## Testing Plan

- Python unit test updated. This is difficult to reproduce and therefore difficult to test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
