### PR TITLE
Pin `iframe-resizer` to the last MIT licensed version

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -12055,7 +12055,7 @@ The following software may be included in this product: iframe-resizer. A copy o
 
 The MIT License (MIT)
 
-Copyright (c) 2013-2021 David J. Bradshaw
+Copyright (c) 2013-2023 David J. Bradshaw
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -37,7 +37,7 @@
     "color2k": "^2.0.2",
     "hoist-non-react-statics": "^3.3.2",
     "humanize-string": "^2.1.0",
-    "iframe-resizer": "^4.3.3",
+    "iframe-resizer": "4.3.11",
     "immer": "^9.0.19",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9568,10 +9568,10 @@ ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-iframe-resizer@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.3.tgz#0f0d7ff4bb2bc604076b64344028428b285c58a6"
-  integrity sha512-emI63nkTCaQrAoHMLpl+1gDGL4VjexameFoUKoE7bSudf2//n0KdwMyKXtvScqzps9KR68TrVLjFNw+Qo6rLaw==
+iframe-resizer@4.3.11:
+  version "4.3.11"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.11.tgz#6d13c23b19c528f3a43e301b4a0ea847cd034d90"
+  integrity sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A==
 
 ignore@^5.2.0:
   version "5.2.0"

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -50,4 +50,5 @@ pydantic>=1.0, <2.0
 
 # semver 3 renames VersionInfo so temporarily pin until we deal with it
 semver<3
-langchain>=0.0.216
+# Langchain 0.2 migrated the Streamlit integration into a dedicated community package.
+langchain>=0.0.216, <0.2


### PR DESCRIPTION
## Describe your changes

The licenses of `iframe-resizer` was changed to GPL-3 with the 4.4.0 update. We pin the version to the last version under MIT licenses.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
