### PR TITLE
Explicitly export experimental_dialog

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -72,10 +72,15 @@ from streamlit.delta_generator import (
     event_dg as _event_dg,
     bottom_dg as _bottom_dg,
 )
+
 from streamlit.elements.dialog_decorator import (
-    # rename so that it is available as st.dialog
-    dialog_decorator as experimental_dialog,
+    dialog_decorator as _dialog_decorator,
 )
+
+# assign to experimental_dialog to explicitly export it ('mypy --strict' does not complain)
+experimental_dialog = _dialog_decorator
+
+
 from streamlit.runtime.caching import (
     cache_resource as _cache_resource,
     cache_data as _cache_data,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -73,14 +73,7 @@ from streamlit.delta_generator import (
     bottom_dg as _bottom_dg,
 )
 
-from streamlit.elements.dialog_decorator import (
-    dialog_decorator as _dialog_decorator,
-)
-
-# assign to experimental_dialog to explicitly export it ('mypy --strict' does not complain)
-experimental_dialog = _dialog_decorator
-
-
+from streamlit.elements.dialog_decorator import dialog_decorator as _dialog_decorator
 from streamlit.runtime.caching import (
     cache_resource as _cache_resource,
     cache_data as _cache_data,
@@ -103,14 +96,18 @@ from streamlit.commands.experimental_query_params import (
     set_query_params as _set_query_params,
 )
 
-# Modules that the user should have access to. These are imported with "as"
-# syntax pass mypy checking with implicit_reexport disabled.
-
 import streamlit.column_config as _column_config
+
+
+# Modules that the user should have access to. These are imported with the "as" syntax and the same name; note that renaming the import with "as" does not make it an explicit export.
+# In this case, you should import it with an underscore to make clear that it is internal and then assign it to a variable with the new intended name.
+# You can check the export behavior by running 'mypy --strict example_app.py', which disables implicit_reexport, where you use the respective command in the example_app.py Streamlit app.
+
 from streamlit.echo import echo as echo
 from streamlit.runtime.legacy_caching import cache as _cache
 from streamlit.commands.logo import logo as logo
 from streamlit.elements.spinner import spinner as spinner
+
 from streamlit.commands.page_config import set_page_config as set_page_config
 from streamlit.commands.execution_control import (
     stop as stop,
@@ -241,6 +238,7 @@ column_config = _column_config
 connection = _connection
 
 # Experimental APIs
+experimental_dialog = _dialog_decorator
 experimental_fragment = _fragment
 experimental_memo = _experimental_memo
 experimental_singleton = _experimental_singleton


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/8712

The `experimental_dialog` directive was not exported explicitly by the 

```python
from streamlit.elements.dialog_decorator import (
    dialog_decorator as experimental_dialog,
)
```
import as reported by `mypy --strict` (see also [mypy's docs](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport)). The PR updates the way how to import &  export the  `experimental_dialog` so that `mypy --strict` stops complaining and also follows the way other directives are re-exported such as `experimental_fragment`:

```python
# issues-investigation/8712-strict-mypy.py
import streamlit as st


@st.experimental_dialog
def f() -> None:
    st.write("This works fine, but doesn't typecheck under strict.")


f()
```

```bash
mypy --strict issues-investigation/8712-strict-mypy.py
Success: no issues found in 1 source file
```


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
