### PR TITLE
Remove default value for title of dialog_decorator

### DIFF
--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -86,13 +86,13 @@ def dialog_decorator(title: str, *, width: DialogWidth = "small") -> Callable[[F
 # The user is supposed to call it like @st.dialog("my_title") , which makes 'title' a positional arg, hence
 # this 'trick'. The overload is required to have a good type hint for the decorated function args.
 @overload
-def dialog_decorator(title: F | None, *, width: DialogWidth = "small") -> F:
+def dialog_decorator(title: F, *, width: DialogWidth = "small") -> F:
     ...
 
 
 @gather_metrics("experimental_dialog")
 def dialog_decorator(
-    title: F | None | str, *, width: DialogWidth = "small"
+    title: F | str, *, width: DialogWidth = "small"
 ) -> F | Callable[[F], F]:
     """Function decorator to create a modal dialog.
 

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -92,7 +92,7 @@ def dialog_decorator(title: F | None, *, width: DialogWidth = "small") -> F:
 
 @gather_metrics("experimental_dialog")
 def dialog_decorator(
-    title: F | None | str = "", *, width: DialogWidth = "small"
+    title: F | None | str, *, width: DialogWidth = "small"
 ) -> F | Callable[[F], F]:
     """Function decorator to create a modal dialog.
 

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -173,13 +173,7 @@ def dialog_decorator(
     """
 
     func_or_title = title
-    if func_or_title is None:
-        # Support passing the params via function decorator
-        def wrapper(f: F) -> F:
-            return _dialog_decorator(non_optional_func=f, title="", width=width)
-
-        return wrapper
-    elif type(func_or_title) is str:
+    if type(func_or_title) is str:
         # Support passing the params via function decorator
         def wrapper(f: F) -> F:
             title: str = func_or_title

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -92,7 +92,7 @@ def dialog_decorator(title: F, *, width: DialogWidth = "small") -> F:
 
 @gather_metrics("experimental_dialog")
 def dialog_decorator(
-    title: F | str, *, width: DialogWidth = "small"
+    title: F | str = "", *, width: DialogWidth = "small"
 ) -> F | Callable[[F], F]:
     """Function decorator to create a modal dialog.
 
@@ -189,3 +189,14 @@ def dialog_decorator(
 
     func: F = cast(F, func_or_title)
     return _dialog_decorator(func, "", width=width)
+
+
+# For our docs, we want to modify the default value of 'title' so that it does not look like you can pass an empty string
+# It does not have any impact on the actual function signature; only on what 'inspect.signature(dialog_decorator)' reports.
+from inspect import Parameter, signature
+
+sig = signature(dialog_decorator)
+sig_params = sig.parameters
+new_title_param = sig_params["title"].replace(default=Parameter.empty)
+sig = sig.replace(parameters=[new_title_param, *tuple(sig_params.values())[1:]])
+dialog_decorator.__signature__ = sig  # type: ignore[attr-defined]

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -92,7 +92,7 @@ def dialog_decorator(title: F, *, width: DialogWidth = "small") -> F:
 
 @gather_metrics("experimental_dialog")
 def dialog_decorator(
-    title: F | str = "", *, width: DialogWidth = "small"
+    title: F | str, *, width: DialogWidth = "small"
 ) -> F | Callable[[F], F]:
     """Function decorator to create a modal dialog.
 
@@ -183,14 +183,3 @@ def dialog_decorator(
 
     func: F = cast(F, func_or_title)
     return _dialog_decorator(func, "", width=width)
-
-
-# For our docs, we want to modify the default value of 'title' so that it does not look like you can pass an empty string
-# It does not have any impact on the actual function signature; only on what 'inspect.signature(dialog_decorator)' reports.
-from inspect import Parameter, signature
-
-sig = signature(dialog_decorator)
-sig_params = sig.parameters
-new_title_param = sig_params["title"].replace(default=Parameter.empty)
-sig = sig.replace(parameters=[new_title_param, *tuple(sig_params.values())[1:]])
-dialog_decorator.__signature__ = sig  # type: ignore[attr-defined]

--- a/lib/tests/streamlit/layouts_test.py
+++ b/lib/tests/streamlit/layouts_test.py
@@ -399,7 +399,7 @@ class DialogTest(DeltaGeneratorTestCase):
 
     def test_dialog_decorator_title_required(self):
         """Test that the title is required in decorator"""
-        with self.assertRaises(TypeError) as e:
+        with self.assertRaises(StreamlitAPIException) as e:
 
             @st.experimental_dialog()
             def dialog():
@@ -407,13 +407,9 @@ class DialogTest(DeltaGeneratorTestCase):
 
             dialog()
 
-        self.assertTrue(
-            e.exception.args[0].startswith(
-                "dialog_decorator() missing 1 required positional argument: 'title'"
-            )
-        )
+        self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
 
-        with self.assertRaises(TypeError) as e:
+        with self.assertRaises(StreamlitAPIException) as e:
 
             @st.experimental_dialog()
             def dialog_with_arguments(a, b):
@@ -421,11 +417,7 @@ class DialogTest(DeltaGeneratorTestCase):
 
             dialog_with_arguments("", "")
 
-        self.assertTrue(
-            e.exception.args[0].startswith(
-                "dialog_decorator() missing 1 required positional argument: 'title'"
-            )
-        )
+        self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
 
         with self.assertRaises(StreamlitAPIException) as e:
 

--- a/lib/tests/streamlit/layouts_test.py
+++ b/lib/tests/streamlit/layouts_test.py
@@ -399,7 +399,7 @@ class DialogTest(DeltaGeneratorTestCase):
 
     def test_dialog_decorator_title_required(self):
         """Test that the title is required in decorator"""
-        with self.assertRaises(StreamlitAPIException) as e:
+        with self.assertRaises(TypeError) as e:
 
             @st.experimental_dialog()
             def dialog():
@@ -407,15 +407,33 @@ class DialogTest(DeltaGeneratorTestCase):
 
             dialog()
 
-        self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
+        self.assertTrue(
+            e.exception.args[0].startswith(
+                "dialog_decorator() missing 1 required positional argument: 'title'"
+            )
+        )
 
-        with self.assertRaises(StreamlitAPIException) as e:
+        with self.assertRaises(TypeError) as e:
 
             @st.experimental_dialog()
             def dialog_with_arguments(a, b):
                 return None
 
             dialog_with_arguments("", "")
+
+        self.assertTrue(
+            e.exception.args[0].startswith(
+                "dialog_decorator() missing 1 required positional argument: 'title'"
+            )
+        )
+
+        with self.assertRaises(StreamlitAPIException) as e:
+
+            @st.experimental_dialog("")
+            def dialog():
+                return None
+
+            dialog()
 
         self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
 

--- a/lib/tests/streamlit/layouts_test.py
+++ b/lib/tests/streamlit/layouts_test.py
@@ -399,7 +399,7 @@ class DialogTest(DeltaGeneratorTestCase):
 
     def test_dialog_decorator_title_required(self):
         """Test that the title is required in decorator"""
-        with self.assertRaises(StreamlitAPIException) as e:
+        with self.assertRaises(TypeError) as e:
 
             @st.experimental_dialog()
             def dialog():
@@ -407,9 +407,13 @@ class DialogTest(DeltaGeneratorTestCase):
 
             dialog()
 
-        self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
+        self.assertTrue(
+            e.exception.args[0].startswith(
+                "dialog_decorator() missing 1 required positional argument: 'title'"
+            )
+        )
 
-        with self.assertRaises(StreamlitAPIException) as e:
+        with self.assertRaises(TypeError) as e:
 
             @st.experimental_dialog()
             def dialog_with_arguments(a, b):
@@ -417,7 +421,11 @@ class DialogTest(DeltaGeneratorTestCase):
 
             dialog_with_arguments("", "")
 
-        self.assertTrue(e.exception.args[0].startswith("A non-empty `title`"))
+        self.assertTrue(
+            e.exception.args[0].startswith(
+                "dialog_decorator() missing 1 required positional argument: 'title'"
+            )
+        )
 
         with self.assertRaises(StreamlitAPIException) as e:
 


### PR DESCRIPTION
## Describe your changes

The default value for the dialog_decorator title `""` looks like it is not-required. But truth is that we throw an error for `""` stating that no empty title must be provided. Hence, remove the default value.

## GitHub Issue Link (if applicable)

## Testing Plan

- Since the value `""` was never allowed, removing the default should not have an impact on users. It is mainly to improve our docs.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
