### PR TITLE
[WIP] Fix temporary pytest pin

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -17,7 +17,7 @@ vega_datasets
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized
-pytest
+pytest<8.2
 pytest-cov
 requests-mock
 testfixtures

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -17,9 +17,7 @@ vega_datasets
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized
-# Pinned for now because AsyncTest doesn't work with pytest 8.2.0
-# https://github.com/pytest-dev/pytest/issues/12263
-pytest<8.2.0
+pytest
 pytest-cov
 requests-mock
 testfixtures

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -26,7 +26,6 @@ from tornado.testing import AsyncTestCase
 
 from streamlit import source_util
 from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
-from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -58,6 +57,10 @@ text_utf = "complete! 👨‍🎤"
 text_utf2 = "complete2! 👨‍🎤"
 text_no_encoding = text_utf
 text_latin = "complete! ð\x9f\x91¨â\x80\x8dð\x9f\x8e¤"
+
+
+# Workaround for https://github.com/pytest-dev/pytest/issues/12263.
+AsyncTestCase.runTest = lambda self: ...
 
 
 def _create_widget(id: str, states: WidgetStates) -> WidgetState:
@@ -92,10 +95,6 @@ class ScriptRunnerTest(AsyncTestCase):
     def tearDown(self) -> None:
         super().tearDown()
         Runtime._instance = None
-
-    def runTest(self):
-        """Workaround for https://github.com/pytest-dev/pytest/issues/12263."""
-        pass
 
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -93,6 +93,10 @@ class ScriptRunnerTest(AsyncTestCase):
         super().tearDown()
         Runtime._instance = None
 
+    def runTest(self):
+        """Workaround for https://github.com/pytest-dev/pytest/issues/12263."""
+        pass
+
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""
         scriptrunner = TestScriptRunner("good_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -59,8 +59,12 @@ text_no_encoding = text_utf
 text_latin = "complete! ð\x9f\x91¨â\x80\x8dð\x9f\x8e¤"
 
 
-# Workaround for https://github.com/pytest-dev/pytest/issues/12263.
-AsyncTestCase.runTest = lambda self: ...
+# Workaround for https://github.com/pytest-dev/pytest/issues/12263:
+def runTest(*args, **kwargs):
+    pass
+
+
+AsyncTestCase.runTest = runTest
 
 
 def _create_widget(id: str, states: WidgetStates) -> WidgetState:


### PR DESCRIPTION
## Describe your changes

The `AsyncTestCase` of tornado is broken (see https://github.com/pytest-dev/pytest/issues/12263). This PR fixes the issue by adding a workaround and unpinning Pytest again. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
