### PR TITLE
Add internal config to indicate that its running as e2e test

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -223,6 +223,8 @@ def app_server(
             "true",
             "--global.developmentMode",
             "false",
+            "--global.e2eTest",
+            "true",
             "--server.port",
             str(app_port),
             "--browser.gatherUsageStats",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -343,6 +343,14 @@ _create_option(
 )
 
 _create_option(
+    "global.e2eTest",
+    description="Are we in an e2e (playwright) test? Set automatically when our e2e tests are running.",
+    visibility="hidden",
+    default_val=False,
+    type_=bool,
+)
+
+_create_option(
     "global.unitTest",
     description="Are we in a unit test?",
     visibility="hidden",

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -175,18 +175,22 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         # developmentMode-only messages used in e2e tests to test reconnect handling and
         # disabling widgets.
         if msg.WhichOneof("type") == "debug_disconnect_websocket":
-            if config.get_option("global.developmentMode"):
+            if config.get_option("global.developmentMode") or config.get_option(
+                "global.e2eTest"
+            ):
                 self.close()
             else:
                 _LOGGER.warning(
-                    "Client tried to disconnect websocket when not in development mode."
+                    "Client tried to disconnect websocket when not in development mode or e2e testing."
                 )
         elif msg.WhichOneof("type") == "debug_shutdown_runtime":
-            if config.get_option("global.developmentMode"):
+            if config.get_option("global.developmentMode") or config.get_option(
+                "global.e2eTest"
+            ):
                 self._runtime.stop()
             else:
                 _LOGGER.warning(
-                    "Client tried to shut down runtime when not in development mode."
+                    "Client tried to shut down runtime when not in development mode or e2e testing."
                 )
         else:
             # AppSession handles all other BackMsg types.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -355,6 +355,7 @@ class ConfigTest(unittest.TestCase):
                 "global.developmentMode",
                 "global.disableWatchdogWarning",
                 "global.disableWidgetStateDuplicationWarning",
+                "global.e2eTest",
                 "global.logLevel",
                 "global.maxCachedMessageAge",
                 "global.minCachedMessageSize",


### PR DESCRIPTION
## Describe your changes

Add a new internal config option `global.e2eTest` that indicates that the app is running as part of e2e tests. This is used to activate certain internal functionality that we use for advanced e2e testing. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
