### PR TITLE
Use non-metric emitting fragment function in dialog

### DIFF
--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -20,7 +20,7 @@ from typing import Callable, TypeVar, cast, overload
 from streamlit.delta_generator import event_dg, get_last_dg_added_to_context_stack
 from streamlit.elements.lib.dialog import DialogWidth
 from streamlit.errors import StreamlitAPIException
-from streamlit.runtime.fragment import fragment as _fragment
+from streamlit.runtime.fragment import _fragment
 from streamlit.runtime.metrics_util import gather_metrics
 
 

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -64,14 +64,16 @@ def _dialog_decorator(
         dialog = event_dg._dialog(title=title, dismissible=True, width=width)
         dialog.open()
 
-        @_fragment
         def dialog_content() -> None:
             # if the dialog should be closed, st.rerun() has to be called (same behavior as with st.fragment)
             _ = non_optional_func(*args, **kwargs)
             return None
 
+        # the fragment decorator has multiple return types so that you can pass arguments to it. Here we know the return type, so we cast
+        fragmented_dialog_content = cast(Callable[[], None], _fragment(dialog_content))
         with dialog:
-            return dialog_content()
+            fragmented_dialog_content()
+            return None
 
     return cast(F, wrap)
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -93,6 +93,96 @@ class MemoryFragmentStorage(FragmentStorage):
         self._fragments.clear()
 
 
+def _fragment(
+    func: F | None = None, *, run_every: int | float | timedelta | str | None = None
+) -> Callable[[F], F] | F:
+    """Contains the actual fragment logic.
+
+    This function should be used by our internal functions that use fragments under-the-hood,
+    so that fragment metrics are not tracked for those elements (note that the @gather_metrics annotation is only on the publicly exposed function)
+    """
+
+    if func is None:
+        # Support passing the params via function decorator
+        def wrapper(f: F) -> F:
+            return fragment(
+                func=f,
+                run_every=run_every,
+            )
+
+        return wrapper
+    else:
+        non_optional_func = func
+
+    @wraps(non_optional_func)
+    def wrap(*args, **kwargs):
+        from streamlit.delta_generator import dg_stack
+
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return
+
+        cursors_snapshot = deepcopy(ctx.cursors)
+        dg_stack_snapshot = deepcopy(dg_stack.get())
+        active_dg = dg_stack_snapshot[-1]
+        h = hashlib.new("md5")
+        h.update(
+            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{active_dg._get_delta_path_str()}".encode(
+                "utf-8"
+            )
+        )
+        fragment_id = h.hexdigest()
+
+        def wrapped_fragment():
+            import streamlit as st
+
+            # NOTE: We need to call get_script_run_ctx here again and can't just use the
+            # value of ctx from above captured by the closure because subsequent
+            # fragment runs will generally run in a new script run, thus we'll have a
+            # new ctx.
+            ctx = get_script_run_ctx(suppress_warning=True)
+            assert ctx is not None
+
+            if ctx.fragment_ids_this_run:
+                # This script run is a run of one or more fragments. We restore the
+                # state of ctx.cursors and dg_stack to the snapshots we took when this
+                # fragment was declared.
+                ctx.cursors = deepcopy(cursors_snapshot)
+                dg_stack.set(deepcopy(dg_stack_snapshot))
+            else:
+                # Otherwise, we must be in a full script run. We need to temporarily set
+                # ctx.current_fragment_id so that elements corresponding to this
+                # fragment get tagged with the appropriate ID. ctx.current_fragment_id
+                # gets reset after the fragment function finishes running.
+                ctx.current_fragment_id = fragment_id
+
+            try:
+                with st.container():
+                    result = non_optional_func(*args, **kwargs)
+            finally:
+                ctx.current_fragment_id = None
+
+            return result
+
+        ctx.fragment_storage.set(fragment_id, wrapped_fragment)
+
+        if run_every:
+            msg = ForwardMsg()
+            msg.auto_rerun.interval = time_to_seconds(run_every)
+            msg.auto_rerun.fragment_id = fragment_id
+            ctx.enqueue(msg)
+
+        return wrapped_fragment()
+
+    with contextlib.suppress(AttributeError):
+        # Make this a well-behaved decorator by preserving important function
+        # attributes.
+        wrap.__dict__.update(non_optional_func.__dict__)
+        wrap.__signature__ = inspect.signature(non_optional_func)  # type: ignore
+
+    return wrap
+
+
 @overload
 def fragment(
     func: F,
@@ -228,83 +318,4 @@ def fragment(
         height: 400px
 
     """
-
-    if func is None:
-        # Support passing the params via function decorator
-        def wrapper(f: F) -> F:
-            return fragment(
-                func=f,
-                run_every=run_every,
-            )
-
-        return wrapper
-    else:
-        non_optional_func = func
-
-    @wraps(non_optional_func)
-    def wrap(*args, **kwargs):
-        from streamlit.delta_generator import dg_stack
-
-        ctx = get_script_run_ctx()
-        if ctx is None:
-            return
-
-        cursors_snapshot = deepcopy(ctx.cursors)
-        dg_stack_snapshot = deepcopy(dg_stack.get())
-        active_dg = dg_stack_snapshot[-1]
-        h = hashlib.new("md5")
-        h.update(
-            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{active_dg._get_delta_path_str()}".encode(
-                "utf-8"
-            )
-        )
-        fragment_id = h.hexdigest()
-
-        def wrapped_fragment():
-            import streamlit as st
-
-            # NOTE: We need to call get_script_run_ctx here again and can't just use the
-            # value of ctx from above captured by the closure because subsequent
-            # fragment runs will generally run in a new script run, thus we'll have a
-            # new ctx.
-            ctx = get_script_run_ctx(suppress_warning=True)
-            assert ctx is not None
-
-            if ctx.fragment_ids_this_run:
-                # This script run is a run of one or more fragments. We restore the
-                # state of ctx.cursors and dg_stack to the snapshots we took when this
-                # fragment was declared.
-                ctx.cursors = deepcopy(cursors_snapshot)
-                dg_stack.set(deepcopy(dg_stack_snapshot))
-            else:
-                # Otherwise, we must be in a full script run. We need to temporarily set
-                # ctx.current_fragment_id so that elements corresponding to this
-                # fragment get tagged with the appropriate ID. ctx.current_fragment_id
-                # gets reset after the fragment function finishes running.
-                ctx.current_fragment_id = fragment_id
-
-            try:
-                with st.container():
-                    result = non_optional_func(*args, **kwargs)
-            finally:
-                ctx.current_fragment_id = None
-
-            return result
-
-        ctx.fragment_storage.set(fragment_id, wrapped_fragment)
-
-        if run_every:
-            msg = ForwardMsg()
-            msg.auto_rerun.interval = time_to_seconds(run_every)
-            msg.auto_rerun.fragment_id = fragment_id
-            ctx.enqueue(msg)
-
-        return wrapped_fragment()
-
-    with contextlib.suppress(AttributeError):
-        # Make this a well-behaved decorator by preserving important function
-        # attributes.
-        wrap.__dict__.update(non_optional_func.__dict__)
-        wrap.__signature__ = inspect.signature(non_optional_func)  # type: ignore
-
-    return wrap
+    return _fragment(func, run_every=run_every)


### PR DESCRIPTION
## Describe your changes

When dialog is used, a metric is also emitted for fragment. This convolutes metrics for pure-fragments. Hence, we don't want to track fragment-metrics when it is used by another element such as dialog (and in the future potentially by server-side-loading elements).

Before:
![Screenshot 2024-05-23 at 14 36 18](https://github.com/streamlit/streamlit/assets/3775781/f5cc2b62-ae9b-453b-92e4-67fdb8abdc05)

After:
![Screenshot 2024-05-23 at 14 46 43](https://github.com/streamlit/streamlit/assets/3775781/3d3aeec3-59cd-4e32-b088-79513355d8e0)


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
   - manually tested

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
