### PR TITLE
Extract dataframe e2e test selection utility

### DIFF
--- a/e2e_playwright/shared/dataframe_utils.py
+++ b/e2e_playwright/shared/dataframe_utils.py
@@ -46,6 +46,7 @@ def calc_middle_cell_position(
 
     col_pos : int
         The column number to use for the calculation. Starts with 0 with the first column.
+        If has_row_marker_col is True, the first column is the row marker column.
 
     column_width : "small" | "medium" | "large"
         The shared width setting of all columns. Can be "small", "medium" or "large".
@@ -102,6 +103,7 @@ def click_on_cell(
 
     col_pos : int
         The column number to click on. Starts with 0 with the first column.
+        If has_row_marker_col is True, the first column is the row marker column.
 
     column_width : "small" | "medium" | "large"
         The shared width setting of all columns. Can be "small", "medium" or "large".
@@ -131,6 +133,8 @@ def select_row(
 ) -> None:
     """Select the specified row in the dataframe.
 
+    This expects row selections to be activated.
+
     Parameters
     ----------
 
@@ -147,13 +151,13 @@ def select_row(
     click_on_cell(dataframe_element, row_pos, 0, column_width, has_row_marker_col=True)
 
 
-def select_column(
+def sort_column(
     dataframe_element: Locator,
     col_pos: int,
     column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
     has_row_marker_col: bool = False,
 ) -> None:
-    """Select the specified column in the dataframe.
+    """Sort the specified column in the dataframe.
 
     Parameters
     ----------
@@ -163,6 +167,43 @@ def select_column(
 
     col_pos : int
         The column number to select. Starts with 0 with the first column.
+        If has_row_marker_col is True, the first column is the row marker column.
+
+    column_width : "small" | "medium" | "large"
+        The shared width setting of all columns. Can be "small", "medium" or "large".
+        This needs to be enforced in the dataframe via column config.
+
+    has_row_marker_col : bool
+        Whether the dataframe has a row marker column (used when row selections are activated).
+    """
+    click_on_cell(
+        dataframe_element,
+        0,
+        col_pos,
+        column_width,
+        has_row_marker_col=has_row_marker_col,
+    )
+
+
+def select_column(
+    dataframe_element: Locator,
+    col_pos: int,
+    column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
+    has_row_marker_col: bool = False,
+) -> None:
+    """Select the specified column in the dataframe.
+
+    This expects column selections to be activated.
+
+    Parameters
+    ----------
+
+    dataframe_element : Locator
+        The dataframe element to select the column in.
+
+    col_pos : int
+        The column number to select. Starts with 0 with the first column.
+        If has_row_marker_col is True, the first column is the row marker column.
 
     column_width : "small" | "medium" | "large"
         The shared width setting of all columns. Can be "small", "medium" or "large".

--- a/e2e_playwright/shared/dataframe_utils.py
+++ b/e2e_playwright/shared/dataframe_utils.py
@@ -1,0 +1,180 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from playwright.sync_api import Locator
+
+# Determined by measuring a screenshot
+ROW_MARKER_COLUMN_WIDTH_PX: Final = 30
+
+# These values are defined in useColumnLoader of the DataFrame component:
+COLUMN_SMALL_WIDTH_PX: Final = 75
+COLUMN_MEDIUM_WIDTH_PX: Final = 200
+COLUMN_LARGE_WIDTH_PX: Final = 400
+
+# This value is defined in useTableSizer of the DataFrame component:
+ROW_HEIGHT_PX: Final = 35
+
+
+def calc_middle_cell_position(
+    row_pos: int,
+    col_pos: int,
+    column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
+    has_row_marker_col: bool = False,
+) -> tuple[int, int]:
+    """Calculate the middle position of a cell in the dataframe.
+
+    Parameters
+    ----------
+
+    row_pos : int
+        The row number to use for the calculation. Starts at 0 with the header row.
+
+    col_pos : int
+        The column number to use for the calculation. Starts with 0 with the first column.
+
+    column_width : "small" | "medium" | "large"
+        The shared width setting of all columns. Can be "small", "medium" or "large".
+        This needs to be enforced in the dataframe via column config.
+
+    has_row_marker_col : bool
+        Whether the dataframe has a row marker column (used when row selections are activated).
+
+
+    Returns
+    -------
+    tuple[int, int]
+        The x and y positions of the middle of the cell.
+    """
+    column_width_px = COLUMN_MEDIUM_WIDTH_PX
+    if column_width == "small":
+        column_width_px = COLUMN_SMALL_WIDTH_PX
+    elif column_width == "large":
+        column_width_px = COLUMN_LARGE_WIDTH_PX
+
+    row_middle_height_px = row_pos * ROW_HEIGHT_PX + (ROW_HEIGHT_PX / 2)
+    if has_row_marker_col:
+        if col_pos == 0:
+            column_middle_width_px = ROW_MARKER_COLUMN_WIDTH_PX / 2
+        else:
+            column_middle_width_px = (
+                ROW_MARKER_COLUMN_WIDTH_PX
+                + max(col_pos - 1, 0) * column_width_px
+                + (column_width_px / 2)
+            )
+    else:
+        column_middle_width_px = col_pos * column_width_px + (column_width_px / 2)
+
+    return column_middle_width_px, row_middle_height_px
+
+
+def click_on_cell(
+    dataframe_element: Locator,
+    row_pos: int,
+    col_pos: int,
+    column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
+    has_row_marker_col: bool = False,
+    double_click: bool = False,
+) -> None:
+    """Click on the middle of the specified cell.
+
+    Parameters
+    ----------
+    dataframe_element : Locator
+        The dataframe element to click on.
+
+    row_pos : int
+        The row number to click on. Starts at 0 with the header row.
+
+    col_pos : int
+        The column number to click on. Starts with 0 with the first column.
+
+    column_width : "small" | "medium" | "large"
+        The shared width setting of all columns. Can be "small", "medium" or "large".
+        This needs to be enforced in the dataframe via column config.
+
+    has_row_marker_col : bool
+        Whether the dataframe has a row marker column (used when row selections are activated).
+
+    double_click : bool
+        Whether to double click on the cell.
+    """
+    column_middle_width_px, row_middle_height_px = calc_middle_cell_position(
+        row_pos, col_pos, column_width, has_row_marker_col
+    )
+    position = {"x": column_middle_width_px, "y": row_middle_height_px}
+
+    if double_click:
+        dataframe_element.dblclick(position=position)
+    else:
+        dataframe_element.click(position=position)
+
+
+def select_row(
+    dataframe_element: Locator,
+    row_pos: int,
+    column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
+) -> None:
+    """Select the specified row in the dataframe.
+
+    Parameters
+    ----------
+
+    dataframe_element : Locator
+        The dataframe element to select the row in.
+
+    row_pos : int
+        The row number to select. Starts at 0 with the header row.
+
+    column_width : "small" | "medium" | "large"
+        The shared width setting of all columns. Can be "small", "medium" or "large".
+        This needs to be enforced in the dataframe via column config.
+    """
+    click_on_cell(dataframe_element, row_pos, 0, column_width, has_row_marker_col=True)
+
+
+def select_column(
+    dataframe_element: Locator,
+    col_pos: int,
+    column_width: Literal["small"] | Literal["medium"] | Literal["large"] = "small",
+    has_row_marker_col: bool = False,
+) -> None:
+    """Select the specified column in the dataframe.
+
+    Parameters
+    ----------
+
+    dataframe_element : Locator
+        The dataframe element to select the column in.
+
+    col_pos : int
+        The column number to select. Starts with 0 with the first column.
+
+    column_width : "small" | "medium" | "large"
+        The shared width setting of all columns. Can be "small", "medium" or "large".
+        This needs to be enforced in the dataframe via column config.
+
+    has_row_marker_col : bool
+        Whether the dataframe has a row marker column (used when row selections are activated).
+    """
+    click_on_cell(
+        dataframe_element,
+        0,
+        col_pos,
+        column_width,
+        has_row_marker_col=has_row_marker_col,
+    )

--- a/e2e_playwright/shared/dataframe_utils.py
+++ b/e2e_playwright/shared/dataframe_utils.py
@@ -29,6 +29,9 @@ COLUMN_LARGE_WIDTH_PX: Final = 400
 # This value is defined in useTableSizer of the DataFrame component:
 ROW_HEIGHT_PX: Final = 35
 
+# The column headers are in row 0
+HEADER_ROW_INDEX: Final = 0
+
 
 def calc_middle_cell_position(
     row_pos: int,
@@ -178,7 +181,7 @@ def sort_column(
     """
     click_on_cell(
         dataframe_element,
-        0,
+        HEADER_ROW_INDEX,
         col_pos,
         column_width,
         has_row_marker_col=has_row_marker_col,
@@ -214,7 +217,7 @@ def select_column(
     """
     click_on_cell(
         dataframe_element,
-        0,
+        HEADER_ROW_INDEX,
         col_pos,
         column_width,
         has_row_marker_col=has_row_marker_col,

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -26,7 +26,7 @@ from e2e_playwright.shared.dataframe_utils import (
 )
 
 # Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
-_command_key = "Meta" if platform.system() == "Darwin" else "Control"
+_COMMAND_KEY = "Meta" if platform.system() == "Darwin" else "Control"
 
 
 def _expect_written_text(app: Page, expected_prefix: str, expected_selection: str):
@@ -214,10 +214,10 @@ def test_multi_column_select(app: Page):
     canvas = _get_multi_column_select_df(app)
 
     select_column(canvas, 1)
-    app.keyboard.down(_command_key)
+    app.keyboard.down(_COMMAND_KEY)
     select_column(canvas, 3)
     select_column(canvas, 4)
-    app.keyboard.up(_command_key)
+    app.keyboard.up(_COMMAND_KEY)
     wait_for_app_run(app)
 
     _expect_written_text(
@@ -231,10 +231,10 @@ def _select_some_rows_and_columns(app: Page, canvas: Locator):
     select_row(canvas, 1)
     # Column 0 is the row marker column
     select_column(canvas, 2, has_row_marker_col=True)
-    app.keyboard.down(_command_key)
+    app.keyboard.down(_COMMAND_KEY)
     select_column(canvas, 4, has_row_marker_col=True)
     select_column(canvas, 5, has_row_marker_col=True)
-    app.keyboard.up(_command_key)
+    app.keyboard.up(_COMMAND_KEY)
     select_row(canvas, 3)
     wait_for_app_run(app)
 

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -22,6 +22,7 @@ from e2e_playwright.shared.dataframe_utils import (
     calc_middle_cell_position,
     select_column,
     select_row,
+    sort_column,
 )
 
 # Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
@@ -113,9 +114,9 @@ def test_single_row_select_with_sorted_column(app: Page):
     selection_text = app.get_by_test_id("stMarkdownContainer").filter(has_text=expected)
     expect(selection_text).to_have_count(1)
 
-    # Click on the column header to sort the column.
+    # Sort the first column
     # this is expected to clear the previous row selection:
-    select_column(canvas, 1, has_row_marker_col=True)
+    sort_column(canvas, 1, has_row_marker_col=True)
     wait_for_app_run(app)
 
     # The dataframe selection should be cleared

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -18,7 +18,11 @@ import pytest
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
-from shared.dataframe_utils import calc_middle_cell_position, select_column, select_row
+from e2e_playwright.shared.dataframe_utils import (
+    calc_middle_cell_position,
+    select_column,
+    select_row,
+)
 
 # Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
 _command_key = "Meta" if platform.system() == "Darwin" else "Control"

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -228,10 +228,11 @@ def test_multi_column_select(app: Page):
 
 def _select_some_rows_and_columns(app: Page, canvas: Locator):
     select_row(canvas, 1)
-    select_column(canvas, 1, has_row_marker_col=True)
+    # Column 0 is the row marker column
+    select_column(canvas, 2, has_row_marker_col=True)
     app.keyboard.down(_command_key)
-    select_column(canvas, 3, has_row_marker_col=True)
     select_column(canvas, 4, has_row_marker_col=True)
+    select_column(canvas, 5, has_row_marker_col=True)
     app.keyboard.up(_command_key)
     select_row(canvas, 3)
     wait_for_app_run(app)


### PR DESCRIPTION
## Describe your changes

This PR extracts and refactors the dataframe interaction methods from the selection test into a shared utility module that can be reused in other dataframe e2e tests.

## Testing Plan

- This only applies changes to tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
