### PR TITLE
Remove unnecessary protobuf installation

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -37,11 +37,10 @@ runs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        # protobuf, dot, & graphviz dependencies
+        # dot & graphviz dependencies
         sudo apt install -y gnupg \
             graphviz \
-            libgvc6 \
-            protobuf-compiler
+            libgvc6
       shell: bash --login -eo pipefail {0}
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2023.05.03 - doesn't have recent versions

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -87,11 +87,10 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          # protobuf, dot, & graphviz dependencies
+          # dot & graphviz dependencies
           sudo apt install -y gnupg \
               graphviz \
-              libgvc6 \
-              protobuf-compiler
+              libgvc6
       # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
       # Actions are running as of 2023.05.03 - doesn't have recent versions
       # of protoc in its package repository. To work around this, we vendor in


### PR DESCRIPTION
## Describe your changes

Currently, we are installing an old version of protobuf compiler unnecessarily since we have it vendored in to use a higher version. This PR removes the unnecessary installation. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
