### PR TITLE
Specify url path in st.Page

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
@@ -54,11 +54,11 @@ def page_9():
 
 
 page7 = st.Page(page_7)
-page8 = st.Page(page_8)
+page8 = st.Page(page_8, url_path="my_url_path")
 page9 = st.Page(page_9)
-page10 = st.Page(page_7, title="page 10")
-page11 = st.Page(page_8, title="page 11")
-page12 = st.Page(page_9, title="page 12")
+page10 = st.Page(page_7, title="page 10", url_path="page_10")
+page11 = st.Page(page_8, title="page 11", url_path="page_11")
+page12 = st.Page(page_9, title="page 12", url_path="page_12")
 
 hide_sidebar = st.checkbox("Hide sidebar")
 dynamic_nav = st.checkbox("Change navigation dynamically")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -120,12 +120,12 @@ def test_supports_navigating_to_page_directly_via_url(app: Page, app_port: int):
     expect(page_heading(app)).to_contain_text("Page 5")
 
 
-def test_supports_navigating_to_page_directly_via_url_title(app: Page, app_port: int):
-    """Test that we can navigate to a page directly via URL. using the title."""
-    app.goto(f"http://localhost:{app_port}/Different_Title")
+def test_supports_navigating_to_page_directly_via_url_path(app: Page, app_port: int):
+    """Test that we can navigate to a page directly via URL. using the url_path."""
+    app.goto(f"http://localhost:{app_port}/my_url_path")
     wait_for_app_loaded(app)
-
-    expect(page_heading(app)).to_contain_text("Page 3")
+    expect(app).to_have_url(f"http://localhost:{app_port}/my_url_path")
+    expect(page_heading(app)).to_contain_text("Page 8")
 
 
 def test_can_switch_between_pages_and_edit_widgets(app: Page):
@@ -337,3 +337,13 @@ def test_set_default_navigation(app: Page, app_port: int):
     wait_for_app_loaded(app)
 
     expect(page_heading(app)).to_contain_text("Page 6")
+
+
+def test_page_url_path_appears_in_url(app: Page, app_port: int):
+    """Test that st.Page's url_path is included in the URL"""
+    link = get_page_link(app, "page 8")
+
+    expect(link).to_have_attribute("href", f"http://localhost:{app_port}/my_url_path")
+    link.click()
+    wait_for_app_loaded(app)
+    expect(app).to_have_url(f"http://localhost:{app_port}/my_url_path")

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -274,6 +274,7 @@ export class StrategyV2 {
 
         this.appNav.hostCommunicationMgr.sendMessageToHost({
           type: "SET_CURRENT_PAGE_NAME",
+          // Make sure we don't send the official page name for the main page
           currentPageName: currentPage.isDefault ? "" : currentPageName,
           currentPageScriptHash,
         })

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -274,7 +274,7 @@ export class StrategyV2 {
 
         this.appNav.hostCommunicationMgr.sendMessageToHost({
           type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: currentPageName,
+          currentPageName: currentPage.isDefault ? "" : currentPageName,
           currentPageScriptHash,
         })
       },

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -275,6 +275,8 @@ export class StrategyV2 {
         this.appNav.hostCommunicationMgr.sendMessageToHost({
           type: "SET_CURRENT_PAGE_NAME",
           // Make sure we don't send the official page name for the main page
+          // This command is used to update the URL in the url bar, so the main page
+          // should not have a page name in the URL.
           currentPageName: currentPage.isDefault ? "" : currentPageName,
           currentPageScriptHash,
         })

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -126,10 +126,12 @@ def navigation(
 
             script_hash = page._script_hash
             if script_hash in pagehash_to_pageinfo:
+                # The page script hash is soley based on the url path
+                # So duplicate page script hashes are due to duplicate url paths
                 raise StreamlitAPIException(
-                    f"Multiple Pages specified with title {page.title}. "
-                    "Page titles should be unique. If not specified, the "
-                    "title is inferred from the file path or callable name."
+                    f"Multiple Pages specified with URL pathname {page.url_path}. "
+                    "URL pathnames must be unique. The url pathname may be "
+                    "inferred from the filename, callable name, or title."
                 )
 
             pagehash_to_pageinfo[script_hash] = {
@@ -137,7 +139,7 @@ def navigation(
                 "page_name": page.title,
                 "icon": page.icon,
                 "script_path": script_path,
-                "url_pathname": page.title.replace(" ", "_"),
+                "url_pathname": page.url_path,
             }
 
     if default_page is None:
@@ -158,7 +160,7 @@ def navigation(
             p.icon = page.icon
             p.is_default = page._default
             p.section_header = section_header
-            p.url_pathname = page.title.replace(" ", "_")
+            p.url_pathname = page.url_path
 
     # Inform our page manager about the set of pages we have
     ctx.pages_manager.set_pages(pagehash_to_pageinfo)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -683,7 +683,7 @@ class ButtonMixin:
 
         if isinstance(page, StreamlitPage):
             page_link_proto.page_script_hash = page._script_hash
-            page_link_proto.page = page._url_path
+            page_link_proto.page = page.url_path
             if label is None:
                 page_link_proto.label = page.title
         else:

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -683,7 +683,7 @@ class ButtonMixin:
 
         if isinstance(page, StreamlitPage):
             page_link_proto.page_script_hash = page._script_hash
-            page_link_proto.page = page.title.replace(" ", "_")
+            page_link_proto.page = page._url_path
             if label is None:
                 page_link_proto.label = page.title
         else:

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -132,6 +132,11 @@ class StreamlitPage:
         self._page: Path | Callable[[], None] = page
         self._title: str = title or inferred_name.replace("_", " ")
         self._icon: str = icon or inferred_icon
+        if url_path is not None and url_path.strip() == "" and not default:
+            raise StreamlitAPIException(
+                "The URL path cannot be an empty string unless the page is the default page."
+            )
+
         self._url_path: str = (
             (url_path and url_path.lstrip("/"))
             or inferred_name
@@ -155,7 +160,7 @@ class StreamlitPage:
 
     @property
     def url_path(self) -> str:
-        return self._url_path
+        return "" if self._default else self._url_path
 
     def run(self) -> None:
         if not self._can_be_called:

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -32,6 +32,7 @@ def Page(
     *,
     title: str | None = None,
     icon: str | None = None,
+    url_path: str | None = None,
     default: bool = False,
 ):
     """Configure a page in `st.navigation` in a multipage app.
@@ -71,6 +72,10 @@ def Page(
             <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Outlined>`_
             font library.
 
+    url_path: str or None
+        The URL pathname associated with a page. If None, the URL pathname will be
+        inferred from the file name, callable name, or the title (in that order).
+
     default: bool
         Whether this page is the default page to be shown when the app is
         loaded. Only one page can be marked default. If no default page is
@@ -88,7 +93,9 @@ def Page(
     >>> ])
     >>> pg.run()
     """
-    return StreamlitPage(page, title=title, icon=icon, default=default)
+    return StreamlitPage(
+        page, title=title, icon=icon, url_path=url_path, default=default
+    )
 
 
 class StreamlitPage:
@@ -98,6 +105,7 @@ class StreamlitPage:
         *,
         title: str | None = None,
         icon: str | None = None,
+        url_path: str | None = None,
         default: bool = False,
     ):
         ctx = get_script_run_ctx()
@@ -114,17 +122,21 @@ class StreamlitPage:
         inferred_icon = ""
         if isinstance(page, Path):
             inferred_icon, inferred_name = page_icon_and_name(page)
+        elif hasattr(page, "__name__"):
+            inferred_name = str(page.__name__)
         elif title is None:
-            if hasattr(page, "__name__"):
-                inferred_name = str(page.__name__)
-            else:
-                raise StreamlitAPIException(
-                    "Cannot infer page title for Callable. Set the `title=` keyword argument."
-                )
+            raise StreamlitAPIException(
+                "Cannot infer page title for Callable. Set the `title=` keyword argument."
+            )
 
         self._page: Path | Callable[[], None] = page
         self._title: str = title or inferred_name.replace("_", " ")
         self._icon: str = icon or inferred_icon
+        self._url_path: str = (
+            (url_path and url_path.lstrip("/"))
+            or inferred_name
+            or self.title.replace(" ", "_")
+        )
 
         if self._icon:
             validate_icon_or_emoji(self._icon)
@@ -140,6 +152,10 @@ class StreamlitPage:
     @property
     def icon(self) -> str:
         return self._icon
+
+    @property
+    def url_path(self) -> str:
+        return self._url_path
 
     def run(self) -> None:
         if not self._can_be_called:
@@ -169,8 +185,4 @@ class StreamlitPage:
 
     @property
     def _script_hash(self) -> str:
-        if isinstance(self._page, Path):
-            h = calc_md5(str(self._page))
-        else:
-            h = calc_md5(self._title)
-        return h
+        return calc_md5(self._url_path)

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -74,7 +74,8 @@ def Page(
 
     url_path: str or None
         The URL pathname associated with a page. If None, the URL pathname will be
-        inferred from the file name, callable name, or the title (in that order).
+        inferred from the file name, callable name. The default page will have
+        a url_path of "" to indicate the root url and ignore the value of url_path
 
     default: bool
         Whether this page is the default page to be shown when the app is
@@ -125,6 +126,11 @@ class StreamlitPage:
         elif hasattr(page, "__name__"):
             inferred_name = str(page.__name__)
         elif title is None:
+            # At this point, we know the page is not a string or a path, so it
+            # must be a callable. We expect it to have a __name__ attribute,
+            # but in special cases (e.g. a callable class instance), one may
+            # not exist. In that case, we should inform the user the title is
+            # mandatory.
             raise StreamlitAPIException(
                 "Cannot infer page title for Callable. Set the `title=` keyword argument."
             )
@@ -137,11 +143,9 @@ class StreamlitPage:
                 "The URL path cannot be an empty string unless the page is the default page."
             )
 
-        self._url_path: str = (
-            (url_path and url_path.lstrip("/"))
-            or inferred_name
-            or self.title.replace(" ", "_")
-        )
+        self._url_path: str = inferred_name
+        if url_path is not None:
+            self._url_path = url_path.lstrip("/")
 
         if self._icon:
             validate_icon_or_emoji(self._icon)

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -55,6 +55,26 @@ class NavigationTest(DeltaGeneratorTestCase):
                 [st.Page("page1.py", default=True), st.Page("page2.py", default=True)]
             )
 
+    def test_same_url_paths_raises_APIException(self):
+        """Test that an error is thrown if multiple defaults are specified"""
+        with pytest.raises(StreamlitAPIException):
+            st.navigation(
+                [
+                    st.Page("page1.py", url_path="foo"),
+                    st.Page("page2.py", url_path="foo"),
+                ]
+            )
+
+    def test_same_inferred_url_paths_raises_APIException(self):
+        """Test that an error is thrown if multiple defaults are specified"""
+        with pytest.raises(StreamlitAPIException):
+            st.navigation(
+                [
+                    st.Page("page1.py", url_path="foo"),
+                    st.Page("foo.py"),
+                ]
+            )
+
     def test_page_found_by_hash(self):
         found_page = st.Page("page2.py")
         self.script_run_ctx.pages_manager.set_script_intent(found_page._script_hash, "")

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -56,7 +56,7 @@ class NavigationTest(DeltaGeneratorTestCase):
             )
 
     def test_same_url_paths_raises_APIException(self):
-        """Test that an error is thrown if multiple defaults are specified"""
+        """Test that an error is thrown if same url_paths are specified"""
         with pytest.raises(StreamlitAPIException):
             st.navigation(
                 [
@@ -66,7 +66,7 @@ class NavigationTest(DeltaGeneratorTestCase):
             )
 
     def test_same_inferred_url_paths_raises_APIException(self):
-        """Test that an error is thrown if multiple defaults are specified"""
+        """Test that an error is thrown if the same inferred url_paths are specified"""
         with pytest.raises(StreamlitAPIException):
             st.navigation(
                 [

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -115,7 +115,7 @@ class PageLinkTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.page_link
         assert c.label == "Foo Test"
         assert c.page_script_hash == page._script_hash
-        assert c.page == "Bar_Test"
+        assert c.page == "foo"
         assert not c.external
         assert not c.disabled
         assert c.icon == ""
@@ -129,7 +129,21 @@ class PageLinkTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.page_link
         assert c.label == "Bar Test"
         assert c.page_script_hash == page._script_hash
-        assert c.page == "Bar_Test"
+        assert c.page == "foo"
+        assert not c.external
+        assert not c.disabled
+        assert c.icon == ""
+        assert c.help == ""
+
+    def test_st_page_with_url_path(self):
+        """Test that st.page_link accepts an st.Page, but will use the url_path if necessary"""
+        page = st.Page("foo.py", title="Bar Test", url_path="bar")
+        st.page_link(page=page)
+
+        c = self.get_delta_from_queue().new_element.page_link
+        assert c.label == "Bar Test"
+        assert c.page_script_hash == page._script_hash
+        assert c.page == "bar"
         assert not c.external
         assert not c.disabled
         assert c.icon == ""

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -45,6 +45,11 @@ class StPagesTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.Page(Foo())
 
+        try:
+            st.Page(Foo(), title="Hello")
+        except Exception:
+            pytest.fail("Should not raise exception")
+
     def test_invalid_icon_raises_exception(self):
         """Test that passing an invalid icon raises an exception."""
 
@@ -59,11 +64,36 @@ class StPagesTest(DeltaGeneratorTestCase):
         assert True
 
     def test_script_hash_for_paths_are_different(self):
+        """Tests that script hashes are different when url path (inferred or not) is unique"""
         assert st.Page("page1.py")._script_hash != st.Page("page2.py")._script_hash
         assert (
-            st.Page(lambda: True, title="Title 1")._script_hash
-            != st.Page(lambda: True, title="Title 2")._script_hash
+            st.Page(lambda: True, url_path="path_1")._script_hash
+            != st.Page(lambda: True, url_path="path_2")._script_hash
         )
+
+    def test_url_path_is_inferred_from_filename(self):
+        """Tests that url path is inferred from filename if not provided"""
+        page = st.Page("page_8.py")
+        assert page.url_path == "page_8"
+
+    def test_url_path_is_inferred_from_function_name(self):
+        """Tests that url path is inferred from function name if not provided"""
+
+        def page_9():
+            pass
+
+        page = st.Page(page_9)
+        assert page.url_path == "page_9"
+
+    def test_url_path_overrides_if_specified(self):
+        """Tests that url path specified directly overrides inferred path"""
+        page = st.Page("page_8.py", url_path="my_url_path")
+        assert page.url_path == "my_url_path"
+
+    def test_url_path_strips_leading_slash(self):
+        """Tests that url path strips leading slash if provided"""
+        page = st.Page("page_8.py", url_path="/my_url_path")
+        assert page.url_path == "my_url_path"
 
     def test_page_run_cannot_run_standalone(self):
         """Test that a page cannot run standalone."""

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -95,6 +95,33 @@ class StPagesTest(DeltaGeneratorTestCase):
         page = st.Page("page_8.py", url_path="/my_url_path")
         assert page.url_path == "my_url_path"
 
+    def test_url_path_is_empty_string_if_default(self):
+        """Tests that url path is "" if the page is the default page"""
+
+        def page_9():
+            pass
+
+        page = st.Page(page_9, default=True)
+        assert page.url_path == ""
+
+    def test_url_path_is_empty_string_if_default(self):
+        """Tests that url path is "" if the page is the default page"""
+
+        def page_9():
+            pass
+
+        page = st.Page(page_9, default=True)
+        assert page.url_path == ""
+
+    def test_non_default_pages_cannot_have_empty_url_path(self):
+        """Tests that an error is raised if the empty url path is provided for a non-default page"""
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            page = st.Page(page_9, url_path="")
+
     def test_page_run_cannot_run_standalone(self):
         """Test that a page cannot run standalone."""
         with pytest.raises(StreamlitAPIException):


### PR DESCRIPTION
## Describe your changes

Adds `url_path` as a feature of `st.Page`. This change does three things:
1. Offers the ability to specify the `url_path` (it will strip any preceding slashes).
2. If not specified, the `url_path` will be inferred first from the file or function name, then from the title
3. The script hash is based on the url_path, which simplifies everything. Note: I intentionally kept the default page as defined rather than a hash of "" to avoid any potential issues.

## Testing Plan

- Unit Tests and E2E Tests are updated and include tests for the url_path.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
