### PR TITLE
Ensure SessionInfo is set before performing an action

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1522,6 +1522,56 @@ describe("App", () => {
     })
   })
 
+  describe("App.handleScriptFinished", () => {
+    it("will not increment cache count if session info is not set", () => {
+      renderApp(getProps())
+
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+      )
+
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.incrementMessageCacheRunCount).not.toBeCalled()
+    })
+
+    it("will not increment cache count if session info is not set and the script finished early", () => {
+      renderApp(getProps())
+
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+      )
+
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.incrementMessageCacheRunCount).not.toBeCalled()
+    })
+
+    it("will not increment cache count if session info is set and the script finished early", () => {
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+      )
+
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.incrementMessageCacheRunCount).not.toBeCalled()
+    })
+
+    it("will increment cache count if session info is set", () => {
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+      )
+
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.incrementMessageCacheRunCount).toBeCalled()
+    })
+  })
+
   //   * handlePageNotFound has branching error messages depending on pageName
   describe("App.handlePageNotFound", () => {
     it("includes the missing page name in error modal message if available", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1168,8 +1168,20 @@ export class App extends PureComponent<Props, State> {
 
       // Tell the ConnectionManager to increment the message cache run
       // count. This will result in expired ForwardMsgs being removed from
-      // the cache.
-      if (this.connectionManager !== null) {
+      // the cache. We expect the sessionInfo to be populated at this point,
+      // but we have observed race conditions tied to a rerun occurring
+      // before a NewSession message is processed. This issue should not
+      // disrupt users and is not a critical need for the message cache
+      console.log(this.connectionManager !== null)
+      console.log(
+        status !== ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+      )
+      console.log(this.sessionInfo.isSet)
+      if (
+        this.connectionManager !== null &&
+        status !== ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN &&
+        this.sessionInfo.isSet
+      ) {
         this.connectionManager.incrementMessageCacheRunCount(
           this.sessionInfo.current.maxCachedMessageAge
         )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1172,11 +1172,6 @@ export class App extends PureComponent<Props, State> {
       // but we have observed race conditions tied to a rerun occurring
       // before a NewSession message is processed. This issue should not
       // disrupt users and is not a critical need for the message cache
-      console.log(this.connectionManager !== null)
-      console.log(
-        status !== ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
-      )
-      console.log(this.sessionInfo.isSet)
       if (
         this.connectionManager !== null &&
         status !== ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN &&


### PR DESCRIPTION
## Describe your changes

Reports of SessionInfo not being set have increased. Latest findings suggest the ScriptFinished task is still being run despite the NewSession request not running first. I suspect this may be due to #8599 filtering out messages and keeping the ScriptFinished but not keeping the NewSession.

In _any_ case, this is an error we should not be surfacing to users. This change guards the bad code, and sends a metric for an error otherwise so that we can continue to track the issue and find a better solution.

## GitHub Issue Link (if applicable)
closes https://github.com/streamlit/streamlit/issues/8321
closes https://github.com/streamlit/streamlit/issues/7549

## Testing Plan

- Updated JS Unit Tests to ensure no issues occur

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
