### PR TITLE
Migrate expect help tooltip e2e logic into shared app utils

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -225,25 +225,27 @@ def click_checkbox(
 
 
 def expect_help_tooltip(
-    app: Page, el_with_help_tooltip: Locator, tooltip_text: str | Pattern[str]
+    app: Page, element_with_help_tooltip: Locator, tooltip_text: str | Pattern[str]
 ):
     """Expect a tooltip to be displayed when hovering over the help symbol of an element.
 
     This only works for elements that have our shared help tooltip implemented.
     It doesn't work for elements with a custom tooltip implementation, e.g. st.button.
 
+    The element gets unhovered after the tooltip is checked.
+
     Parameters
     ----------
     app : Page
         The page to search for the tooltip.
 
-    el_with_help_tooltip : Locator
+    element_with_help_tooltip : Locator
         The locator of the element with the help tooltip.
 
     tooltip_text : str or Pattern[str]
         The text of the tooltip to expect.
     """
-    hover_target = el_with_help_tooltip.get_by_test_id("stTooltipHoverTarget")
+    hover_target = element_with_help_tooltip.get_by_test_id("stTooltipHoverTarget")
     expect(hover_target).to_be_visible()
 
     tooltip_content = app.get_by_test_id("stTooltipContent")

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -222,3 +222,40 @@ def click_checkbox(
     checkbox_element = get_checkbox(page, label)
     checkbox_element.click()
     wait_for_app_run(page)
+
+
+def expect_help_tooltip(
+    app: Page, el_with_help_tooltip: Locator, tooltip_text: str | Pattern[str]
+):
+    """Expect a tooltip to be displayed when hovering over the help symbol of an element.
+
+    This only works for elements that have our shared help tooltip implemented.
+    It doesn't work for elements with a custom tooltip implementation, e.g. st.button.
+
+    Parameters
+    ----------
+    app : Page
+        The page to search for the tooltip.
+
+    el_with_help_tooltip : Locator
+        The locator of the element with the help tooltip.
+
+    tooltip_text : str or Pattern[str]
+        The text of the tooltip to expect.
+    """
+    hover_target = el_with_help_tooltip.get_by_test_id("stTooltipHoverTarget")
+    expect(hover_target).to_be_visible()
+
+    tooltip_content = app.get_by_test_id("stTooltipContent")
+    expect(tooltip_content).not_to_be_attached()
+
+    hover_target.hover()
+
+    expect(tooltip_content).to_be_visible()
+    expect(tooltip_content).to_have_text(tooltip_text)
+
+    # reset the hovering in case this method is called multiple times in the same test
+    app.get_by_test_id("stApp").hover(
+        position={"x": 0, "y": 0}, no_wait_after=True, force=True
+    )
+    expect(tooltip_content).not_to_be_attached()

--- a/e2e_playwright/st_caption_test.py
+++ b/e2e_playwright/st_caption_test.py
@@ -15,6 +15,7 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import expect_help_tooltip
 
 
 def test_correct_number_of_elements(app: Page):
@@ -38,17 +39,7 @@ def test_help_tooltip_works(app: Page):
     """Test that the help tooltip is displayed on hover."""
     # The stMarkdown div is the outermost container that holds the caption and the help tooltip:
     caption_with_help = app.get_by_test_id("stMarkdown").nth(3)
-
-    hover_target = caption_with_help.get_by_test_id("stTooltipHoverTarget")
-    expect(hover_target).to_be_visible()
-
-    tooltip_content = app.get_by_test_id("stTooltipContent")
-    expect(tooltip_content).not_to_be_attached()
-
-    hover_target.hover()
-
-    expect(tooltip_content).to_be_visible()
-    expect(tooltip_content).to_have_text("This is some help tooltip!")
+    expect_help_tooltip(app, caption_with_help, "This is some help tooltip!")
 
 
 def test_match_snapshot_for_caption_with_html_and_unsafe_html_true(

--- a/e2e_playwright/st_heading_test.py
+++ b/e2e_playwright/st_heading_test.py
@@ -18,6 +18,7 @@ import pytest
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_loaded
+from e2e_playwright.shared.app_utils import expect_help_tooltip
 
 
 def _get_title_elements(app: Page) -> Locator:
@@ -33,22 +34,6 @@ def _get_header_elements(app: Page) -> Locator:
 def _get_subheader_elements(app: Page) -> Locator:
     """Subheader elements are rendered as h3 elements"""
     return app.get_by_test_id("stHeading").locator("h3")
-
-
-def _expect_tooltip(app: Page, el_with_help_tooltip: Locator):
-    hover_target = el_with_help_tooltip.get_by_test_id("stTooltipHoverTarget")
-    expect(hover_target).to_be_visible()
-
-    tooltip_content = app.get_by_test_id("stTooltipContent")
-    expect(tooltip_content).not_to_be_attached()
-
-    hover_target.hover()
-
-    expect(tooltip_content).to_be_visible()
-    expect(tooltip_content).to_have_text("Some help tooltip")
-
-    # reset the hovering in case _expect_tooltip is called multiple times in the same test
-    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
 
 
 _header_divider_filter_text = re.compile(r"[a-zA-Z]+ Header Divider:")
@@ -275,10 +260,12 @@ def test_subheader_divider_snapshot(
 def test_help_tooltip_works(app: Page):
     """Test that the help tooltip is displayed on hover."""
     header_with_help = _get_header_elements(app).nth(3)
-    _expect_tooltip(app, header_with_help)
+
+    tooltip_text = "Some help tooltip"
+    expect_help_tooltip(app, header_with_help, tooltip_text)
 
     subheader_with_help = _get_subheader_elements(app).nth(5)
-    _expect_tooltip(app, subheader_with_help)
+    expect_help_tooltip(app, subheader_with_help, tooltip_text)
 
     title_with_help = _get_title_elements(app).nth(1)
-    _expect_tooltip(app, title_with_help)
+    expect_help_tooltip(app, title_with_help, tooltip_text)

--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -15,6 +15,7 @@
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import expect_help_tooltip
 
 
 def test_different_markdown_elements_in_one_block_displayed(
@@ -187,16 +188,7 @@ def test_help_tooltip_works(app: Page):
         .get_by_test_id("stMarkdown")
         .nth(0)
     )
-    hover_target = markdown_with_help.get_by_test_id("stTooltipHoverTarget")
-    expect(hover_target).to_be_visible()
-
-    tooltip_content = app.get_by_test_id("stTooltipContent")
-    expect(tooltip_content).not_to_be_attached()
-
-    hover_target.hover()
-
-    expect(tooltip_content).to_be_visible()
-    expect(tooltip_content).to_have_text("This is a help tooltip!")
+    expect_help_tooltip(app, markdown_with_help, "This is a help tooltip!")
 
 
 def test_latex_elements(themed_app: Page, assert_snapshot: ImageCompareFunction):

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -16,6 +16,7 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import expect_help_tooltip
 
 
 def test_text_input_widget_rendering(
@@ -205,3 +206,9 @@ def test_calls_callback_on_change(app: Page):
         "text input changed: False",
         use_inner_text=True,
     )
+
+
+def test_help_tooltip_works(app: Page):
+    """Test that the help tooltip is displayed on hover."""
+    element_with_help = app.get_by_test_id("stTextInput").nth(8)
+    expect_help_tooltip(app, element_with_help, "Help text")

--- a/e2e_playwright/st_text_test.py
+++ b/e2e_playwright/st_text_test.py
@@ -15,6 +15,7 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import expect_help_tooltip
 
 
 def test_st_text_shows_correct_text(app: Page):
@@ -38,14 +39,4 @@ def test_st_text_doesnt_apply_formatting(
 def test_help_tooltip_works(app: Page):
     """Test that the help tooltip is displayed on hover."""
     text_with_help = app.get_by_test_id("stText").nth(3)
-
-    hover_target = text_with_help.get_by_test_id("stTooltipHoverTarget")
-    expect(hover_target).to_be_visible()
-
-    tooltip_content = app.get_by_test_id("stTooltipContent")
-    expect(tooltip_content).not_to_be_attached()
-
-    hover_target.hover()
-
-    expect(tooltip_content).to_be_visible()
-    expect(tooltip_content).to_have_text("This is a help tooltip!")
+    expect_help_tooltip(app, text_with_help, "This is a help tooltip!")


### PR DESCRIPTION
## Describe your changes

Migrates the `_expect_tooltip` e2e test logic into the shared `app_utils` and reuse it within a couple of elements.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
