### PR TITLE
Make sure fragments maintain active page script hash on subsequent reruns

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
@@ -53,10 +53,22 @@ def page_9():
     st.header("Page 9")
 
 
+def page_10():
+    st.header("Page 10")
+
+    @st.experimental_fragment
+    def get_input():
+        st.text_input("Some input")
+        if st.button("Submit"):
+            st.rerun()
+
+    get_input()
+
+
 page7 = st.Page(page_7)
 page8 = st.Page(page_8, url_path="my_url_path")
 page9 = st.Page(page_9)
-page10 = st.Page(page_7, title="page 10", url_path="page_10")
+page10 = st.Page(page_10)
 page11 = st.Page(page_8, title="page 11", url_path="page_11")
 page12 = st.Page(page_9, title="page 12", url_path="page_12")
 

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -347,3 +347,15 @@ def test_page_url_path_appears_in_url(app: Page, app_port: int):
     link.click()
     wait_for_app_loaded(app)
     expect(app).to_have_url(f"http://localhost:{app_port}/my_url_path")
+
+
+def test_widgets_maintain_state_in_fragment(app: Page):
+    """Test that widgets maintain state in a fragment"""
+    get_page_link(app, "page 10").click()
+
+    input = app.get_by_test_id("stTextInput").locator("input").first
+    input.fill("Hello")
+    input.blur()
+    wait_for_app_run(app)
+
+    expect(input).to_have_value("Hello")

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -133,6 +133,10 @@ def _fragment(
         )
         fragment_id = h.hexdigest()
 
+        # We intentionally want to capture the active script hash here to ensure
+        # that the fragment is associated with the correct script running.
+        initialized_active_script_hash = ctx.active_script_hash
+
         def wrapped_fragment():
             import streamlit as st
 
@@ -157,8 +161,20 @@ def _fragment(
                 ctx.current_fragment_id = fragment_id
 
             try:
-                with st.container():
-                    result = non_optional_func(*args, **kwargs)
+                # Make sure we set the active script hash to the same value
+                # for the fragment run as when defined upon initialization
+                # This ensures that elements (especially widgets) are tied
+                # to a consistent active script hash
+                active_hash_context = (
+                    ctx.pages_manager.run_with_active_hash(
+                        initialized_active_script_hash
+                    )
+                    if initialized_active_script_hash != ctx.active_script_hash
+                    else contextlib.nullcontext()
+                )
+                with active_hash_context:
+                    with st.container():
+                        result = non_optional_func(*args, **kwargs)
             finally:
                 ctx.current_fragment_id = None
 

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -80,7 +80,9 @@ class PagesStrategyV1:
         return self.pages_manager.current_page_hash
 
     def set_active_script_hash(self, _page_hash: "PageHash"):
-        raise NotImplementedError("Unable to set the active script hash in V1 strategy")
+        # Intentionally do nothing as MPA v1 active_script_hash does not
+        # differentiate the active_script_hash and the page_script_hash
+        pass
 
     def get_initial_active_script(
         self, page_script_hash: "PageHash", page_name: "PageName"


### PR DESCRIPTION
## Describe your changes

Fragments do not maintain context of the active script hash. This leads to widget state loss. This change adds the active script hash to the fragment implementation on initialization, and runs the same fragment.

## Testing Plan

- Added Unit tests to show the run_with_active_script_hash is called correctly.
- Added an E2E test to show widget state is not lost.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
