### PR TITLE
Fix `use_container_width` docstring when default is `True`

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -72,7 +72,7 @@ class PydeckMixin:
         ----------
         pydeck_obj: pydeck.Deck or None
             Object specifying the PyDeck chart to draw.
-        use_container_width: bool
+        use_container_width : bool
             Whether to override the figure's native width with the width of
             the parent container. If ``use_container_width`` is ``False``
             (default), Streamlit sets the width of the chart to fit its contents

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -272,9 +272,14 @@ class FormMixin:
         disabled : bool
             An optional boolean, which disables the button if set to True. The
             default is False.
-        use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the parent container.
+        use_container_width : bool
+            Whether to expand the button's width to fill its parent container.
+            If ``use_container_width`` is ``False`` (default), Streamlit sizes
+            the button to fit its contents. If ``use_container_width`` is
+            ``True``, the width of the button matches its parent container.
 
+            In both cases, if the contents of the button are wider than the
+            parent container, the contents will line wrap.
 
         Returns
         -------

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -545,9 +545,17 @@ class LayoutsMixin:
             True. The default is False.
 
         use_container_width : bool
-            An optional boolean, which makes the popover button stretch its width
-            to match the parent container. This only affects the button and not
-            the width of the popover container.
+            Whether to expand the button's width to fill its parent container.
+            If ``use_container_width`` is ``False`` (default), Streamlit sizes
+            the button to fit its contents. If ``use_container_width`` is
+            ``True``, the width of the button matches its parent container.
+
+            In both cases, if the contents of the button are wider than the
+            parent container, the contents will line wrap.
+
+            The popover containter's minimimun width matches the width of its
+            button. The popover container may be wider than its button to fit
+            the container's contents.
 
         Examples
         --------

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -167,11 +167,11 @@ class MapMixin:
 
         use_container_width: bool
             Whether to override the map's native width with the width of
-            the parent container. If ``use_container_width`` is ``False``
-            (default), Streamlit sets the width of the chart to fit its contents
+            the parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the width of the chart to fit its contents
             according to the plotting library, up to the width of the parent
-            container. If ``use_container_width`` is ``True``, Streamlit sets
-            the width of the map to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default), Streamlit
+            sets the width of the map to match the width of the parent container.
 
         Examples
         --------

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -165,13 +165,13 @@ class MapMixin:
             Zoom level as specified in
             https://wiki.openstreetmap.org/wiki/Zoom_levels.
 
-        use_container_width: bool
+        use_container_width : bool
             Whether to override the map's native width with the width of
-            the parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the width of the chart to fit its contents
-            according to the plotting library, up to the width of the parent
-            container. If ``use_container_width`` is ``True`` (default), Streamlit
-            sets the width of the map to match the width of the parent container.
+            the parent container. If ``use_container_width`` is ``True``
+            (default), Streamlit sets the width of the map to match the width
+            of the parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the width of the chart to fit its contents according
+            to the plotting library, up to the width of the parent container.
 
         Examples
         --------

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -37,6 +37,7 @@ class PyplotMixin:
         self,
         fig: Figure | None = None,
         clear_figure: bool | None = None,
+        *,
         use_container_width: bool = True,
         **kwargs: Any,
     ) -> DeltaGenerator:
@@ -61,11 +62,11 @@ class PyplotMixin:
 
         use_container_width : bool
             Whether to override the figure's native width with the width of
-            the parent container. If ``use_container_width`` is ``False``
-            (default), Streamlit sets the width of the chart to fit its contents
+            the parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the width of the chart to fit its contents
             according to the plotting library, up to the width of the parent
-            container. If ``use_container_width`` is ``True``, Streamlit sets
-            the width of the figure to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default), Streamlit
+            sets the width of the figure to match the width of the parent container.
 
         **kwargs : any
             Arguments to pass to Matplotlib's savefig function.

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -37,7 +37,6 @@ class PyplotMixin:
         self,
         fig: Figure | None = None,
         clear_figure: bool | None = None,
-        *,
         use_container_width: bool = True,
         **kwargs: Any,
     ) -> DeltaGenerator:

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -61,11 +61,12 @@ class PyplotMixin:
 
         use_container_width : bool
             Whether to override the figure's native width with the width of
-            the parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the width of the chart to fit its contents
-            according to the plotting library, up to the width of the parent
-            container. If ``use_container_width`` is ``True`` (default), Streamlit
-            sets the width of the figure to match the width of the parent container.
+            the parent container. If ``use_container_width`` is ``True``
+            (default), Streamlit sets the width of the figure to match the
+            width of the parent container. If ``use_container_width`` is
+            ``False``, Streamlit sets the width of the chart to fit its
+            contents according to the plotting library, up to the width of the
+            parent container.
 
         **kwargs : any
             Arguments to pass to Matplotlib's savefig function.

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -641,6 +641,8 @@ class VegaChartsMixin:
             parent container, Streamlit sets the chart width to match the width
             of the parent container.
 
+            To use ``width``, you must set ``use_container_width=False``.
+
         height : int or None
             Desired height of the chart expressed in pixels. If ``height`` is
             ``None`` (default), Streamlit sets the height of the chart to fit
@@ -648,10 +650,10 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False``, Streamlit sets
-            the chart's width according to ``width``. If ``use_container_width``
-            is ``True`` (default), Streamlit sets the width of
-            the chart to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default),
+            Streamlit sets the width of the chart to match the width of the
+            parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the chart's width according to ``width``.
 
         Examples
         --------
@@ -813,6 +815,8 @@ class VegaChartsMixin:
             parent container, Streamlit sets the chart width to match the width
             of the parent container.
 
+            To use ``width``, you must set ``use_container_width=False``.
+
         height : int or None
             Desired height of the chart expressed in pixels. If ``height`` is
             ``None`` (default), Streamlit sets the height of the chart to fit
@@ -820,10 +824,10 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False``, Streamlit sets
-            the chart's width according to ``width``. If ``use_container_width``
-            is ``True`` (default), Streamlit sets the width of
-            the chart to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default),
+            Streamlit sets the width of the chart to match the width of the
+            parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the chart's width according to ``width``.
 
         Examples
         --------
@@ -985,6 +989,8 @@ class VegaChartsMixin:
             parent container, Streamlit sets the chart width to match the width
             of the parent container.
 
+            To use ``width``, you must set ``use_container_width=False``.
+
         height : int or None
             Desired height of the chart expressed in pixels. If ``height`` is
             ``None`` (default), Streamlit sets the height of the chart to fit
@@ -992,10 +998,10 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False``, Streamlit sets
-            the chart's width according to ``width``. If ``use_container_width``
-            is ``True`` (default), Streamlit sets the width of
-            the chart to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default),
+            Streamlit sets the width of the chart to match the width of the
+            parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the chart's width according to ``width``.
 
         Examples
         --------
@@ -1169,6 +1175,8 @@ class VegaChartsMixin:
             parent container, Streamlit sets the chart width to match the width
             of the parent container.
 
+            To use ``width``, you must set ``use_container_width=False``.
+
         height : int or None
             Desired height of the chart expressed in pixels. If ``height`` is
             ``None`` (default), Streamlit sets the height of the chart to fit
@@ -1176,10 +1184,10 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False``, Streamlit sets
-            the chart's width according to ``width``. If ``use_container_width``
-            is ``True`` (default), Streamlit sets the width of
-            the chart to match the width of the parent container.
+            container. If ``use_container_width`` is ``True`` (default),
+            Streamlit sets the width of the chart to match the width of the
+            parent container. If ``use_container_width`` is ``False``,
+            Streamlit sets the chart's width according to ``width``.
 
         Examples
         --------

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -648,9 +648,9 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False`` (default),
-            Streamlit sets the chart's width according to ``width``. If
-            ``use_container_width`` is ``True``, Streamlit sets the width of
+            container. If ``use_container_width`` is ``False``, Streamlit sets
+            the chart's width according to ``width``. If ``use_container_width``
+            is ``True`` (default), Streamlit sets the width of
             the chart to match the width of the parent container.
 
         Examples
@@ -820,9 +820,9 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False`` (default),
-            Streamlit sets the chart's width according to ``width``. If
-            ``use_container_width`` is ``True``, Streamlit sets the width of
+            container. If ``use_container_width`` is ``False``, Streamlit sets
+            the chart's width according to ``width``. If ``use_container_width``
+            is ``True`` (default), Streamlit sets the width of
             the chart to match the width of the parent container.
 
         Examples
@@ -992,9 +992,9 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False`` (default),
-            Streamlit sets the chart's width according to ``width``. If
-            ``use_container_width`` is ``True``, Streamlit sets the width of
+            container. If ``use_container_width`` is ``False``, Streamlit sets
+            the chart's width according to ``width``. If ``use_container_width``
+            is ``True`` (default), Streamlit sets the width of
             the chart to match the width of the parent container.
 
         Examples
@@ -1176,9 +1176,9 @@ class VegaChartsMixin:
 
         use_container_width : bool
             Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``False`` (default),
-            Streamlit sets the chart's width according to ``width``. If
-            ``use_container_width`` is ``True``, Streamlit sets the width of
+            container. If ``use_container_width`` is ``False``, Streamlit sets
+            the chart's width according to ``width``. If ``use_container_width``
+            is ``True`` (default), Streamlit sets the width of
             the chart to match the width of the parent container.
 
         Examples

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -135,8 +135,14 @@ class ButtonMixin:
         disabled : bool
             An optional boolean, which disables the button if set to True. The
             default is False.
-        use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the parent container.
+        use_container_width : bool
+            Whether to expand the button's width to fill its parent container.
+            If ``use_container_width`` is ``False`` (default), Streamlit sizes
+            the button to fit its contents. If ``use_container_width`` is
+            ``True``, the width of the button matches its parent container.
+
+            In both cases, if the contents of the button are wider than the
+            parent container, the contents will line wrap.
 
         Returns
         -------
@@ -269,10 +275,14 @@ class ButtonMixin:
         disabled : bool
             An optional boolean, which disables the download button if set to
             True. The default is False.
-        use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the
-            parent container.
+        use_container_width : bool
+            Whether to expand the button's width to fill its parent container.
+            If ``use_container_width`` is ``False`` (default), Streamlit sizes
+            the button to fit its contents. If ``use_container_width`` is
+            ``True``, the width of the button matches its parent container.
 
+            In both cases, if the contents of the button are wider than the
+            parent container, the contents will line wrap.
 
         Returns
         -------
@@ -411,9 +421,14 @@ class ButtonMixin:
         disabled : bool
             An optional boolean, which disables the link button if set to
             True. The default is False.
-        use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the
-            parent container.
+        use_container_width : bool
+            Whether to expand the button's width to fill its parent container.
+            If ``use_container_width`` is ``False`` (default), Streamlit sizes
+            the button to fit its contents. If ``use_container_width`` is
+            ``True``, the width of the button matches its parent container.
+
+            In both cases, if the contents of the button are wider than the
+            parent container, the contents will line wrap.
 
         Example
         -------
@@ -517,9 +532,9 @@ class ButtonMixin:
             An optional boolean, which disables the page link if set to
             ``True``. The default is ``False``.
         use_container_width : bool
-            An optional boolean, which makes the link stretch its width to
-            match the parent container. The default is ``True`` for page links
-            in the sidebar, and ``False`` for those in the main app.
+            Whether to expand the link's width to fill its parent container.
+            The default is ``True`` for page links in the sidebar and ``False``
+            for those in the main app.
 
         Example
         -------


### PR DESCRIPTION
## Describe your changes

https://github.com/streamlit/streamlit/pull/8740 unified our docstrings for `use_container_width`. However, some commands have it on `True` as default which wasn't reflected in the updated docstrings. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
