### PR TITLE
Allow custom theme to be inserted before our theme

### DIFF
--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -654,3 +654,44 @@ describe("getWrappedHeadersStyle", () => {
     })
   })
 })
+
+describe("theme overrides", () => {
+  beforeEach(async () => {
+    jest.resetModules()
+    window.__streamlit = undefined
+  })
+
+  afterEach(() => {
+    jest.resetModules()
+    window.__streamlit = undefined
+  })
+
+  it("honors the window variables set", async () => {
+    window.__streamlit = {
+      LIGHT_THEME: {
+        primaryColor: "purple",
+      },
+      DARK_THEME: {
+        primaryColor: "yellow",
+      },
+    }
+
+    const module = await import("./utils")
+    // Ensure we are not working with the same object
+    expect(module.getMergedLightTheme()).not.toEqual(lightTheme)
+    expect(module.getMergedDarkTheme()).not.toEqual(darkTheme)
+
+    expect(module.getMergedLightTheme().emotion.colors.primary).toEqual(
+      "purple"
+    )
+    expect(module.getMergedDarkTheme().emotion.colors.primary).toEqual(
+      "yellow"
+    )
+  })
+
+  it("maintains original theme if no global themes are specified", async () => {
+    const module = await import("./utils")
+    expect(module.getMergedLightTheme()).toEqual(lightTheme)
+    expect(module.getMergedDarkTheme()).toEqual(darkTheme)
+  })
+})


### PR DESCRIPTION
## Describe your changes

Some providers want to set the initial theme at the beginning. This change allows a global variable that needs to be set prior to loading of the JS code to supplement our light and dark theme.

## Testing Plan

- Unit Tests are provided to ensure no issues happen:
   - if the window variables are not set
   - if the window variables are a full change
   - if the window variables are a partial change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
