### PR TITLE
Move all type-only imports to type checking condition

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -47,7 +47,6 @@ ignore = [
   "PYI041", # Checks for parameter annotations that contain redundant unions between builtin numeric types (e.g., int | float).
   "PYI051", # Checks for redundant unions between a Literal and a builtin supertype of that Literal.
   "UP031", # Checks for printf-style string formatting, and offers to replace it with str.format calls.
-  "PD901"
 ]
 # Do not lint files in tests, scripts, and vendor directory:
 exclude = ["lib/tests/**", "lib/streamlit/vendor/**", "scripts/**", ".github/**"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -35,6 +35,7 @@ select = [
   "TID", # Helps you write tidier imports.
   "UP", # pyupgrade
   "W", # pycodestyle warnings
+  "TCH"
 ]
 ignore = [
   "B008", # Checks for function calls in default function arguments.
@@ -46,6 +47,7 @@ ignore = [
   "PYI041", # Checks for parameter annotations that contain redundant unions between builtin numeric types (e.g., int | float).
   "PYI051", # Checks for redundant unions between a Literal and a builtin supertype of that Literal.
   "UP031", # Checks for printf-style string formatting, and offers to replace it with str.format calls.
+  "PD901"
 ]
 # Do not lint files in tests, scripts, and vendor directory:
 exclude = ["lib/tests/**", "lib/streamlit/vendor/**", "scripts/**", ".github/**"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -14,42 +14,52 @@
 
 # In addition to the standard set of exclusions, omit all tests:
 extend-exclude = ["lib/streamlit/proto", "lib/streamlit/emojis.py"]
-include = ["lib/**/*.py", "lib/**/*.pyi", "e2e_playwright/**/*.py", "scripts/**/*.py"]
+include = [
+  "lib/**/*.py",
+  "lib/**/*.pyi",
+  "e2e_playwright/**/*.py",
+  "scripts/**/*.py",
+]
 target-version = 'py38'
 line-length = 88
 
 [lint]
 select = [
-  "B", # flake8-bugbear
-  "C4", # Helps you write better list/set/dict comprehensions.
-  "E", # pycodestyle errors
-  "FA", # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
-  "F", # pyflakes
-  "I", # isort - Import sorting
-  "ISC", # Encourage correct string literal concatenation.
-  "LOG", # Checks for issues using the standard library logging module.
-  "NPY", # Linting rules for numpy
-  "Q", # Linting rules for quites
+  "B",      # flake8-bugbear
+  "C4",     # Helps you write better list/set/dict comprehensions.
+  "E",      # pycodestyle errors
+  "FA",     # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
+  "F",      # pyflakes
+  "I",      # isort - Import sorting
+  "ISC",    # Encourage correct string literal concatenation.
+  "LOG",    # Checks for issues using the standard library logging module.
+  "NPY",    # Linting rules for numpy
+  "Q",      # Linting rules for quites
   "RUF100", # Unused noqa directive
-  "T20", # Check for Print statements in python files.
-  "TID", # Helps you write tidier imports.
-  "UP", # pyupgrade
-  "W", # pycodestyle warnings
-  "TCH", # Move type only imports to type-checking condition.
+  "T20",    # Check for Print statements in python files.
+  "TCH",    # Move type only imports to type-checking condition.
+  "TID",    # Helps you write tidier imports.
+  "UP",     # pyupgrade
+  "W",      # pycodestyle warnings
 ]
 ignore = [
-  "B008", # Checks for function calls in default function arguments.
-  "B904", # Checks for raise statements in exception handlers that lack a from clause.
-  "E501", # Checks for lines that exceed the specified maximum character length.
+  "B008",   # Checks for function calls in default function arguments.
+  "B904",   # Checks for raise statements in exception handlers that lack a from clause.
+  "E501",   # Checks for lines that exceed the specified maximum character length.
   "ISC001", # Checks for implicitly concatenated strings on a single line.
   "NPY002", # Checks for the use of legacy np.random function calls.
   "PYI036", # Checks for incorrect function signatures on __exit__ and __aexit__ methods.
   "PYI041", # Checks for parameter annotations that contain redundant unions between builtin numeric types (e.g., int | float).
   "PYI051", # Checks for redundant unions between a Literal and a builtin supertype of that Literal.
-  "UP031", # Checks for printf-style string formatting, and offers to replace it with str.format calls.
+  "UP031",  # Checks for printf-style string formatting, and offers to replace it with str.format calls.
 ]
 # Do not lint files in tests, scripts, and vendor directory:
-exclude = ["lib/tests/**", "lib/streamlit/vendor/**", "scripts/**", ".github/**"]
+exclude = [
+  "lib/tests/**",
+  "lib/streamlit/vendor/**",
+  "scripts/**",
+  ".github/**",
+]
 
 [lint.per-file-ignores]
 "e2e_playwright/**" = ["T20", "B018"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -35,7 +35,7 @@ select = [
   "TID", # Helps you write tidier imports.
   "UP", # pyupgrade
   "W", # pycodestyle warnings
-  "TCH"
+  "TCH", # Move type only imports to type-checking condition.
 ]
 ignore = [
   "B008", # Checks for function calls in default function arguments.

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -33,22 +33,25 @@ from io import BytesIO
 from pathlib import Path
 from random import randint
 from tempfile import TemporaryFile
-from types import ModuleType
-from typing import Any, Callable, Generator, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Generator, Literal, Protocol
 from urllib import parse
 
 import pytest
 import requests
 from PIL import Image
-from playwright.sync_api import (
-    ElementHandle,
-    FrameLocator,
-    Locator,
-    Page,
-    Response,
-    Route,
-)
 from pytest import FixtureRequest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from playwright.sync_api import (
+        ElementHandle,
+        FrameLocator,
+        Locator,
+        Page,
+        Response,
+        Route,
+    )
 
 
 def reorder_early_fixtures(metafunc: pytest.Metafunc):

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -15,12 +15,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import TypeAlias
 
 from streamlit.errors import StreamlitAPIException
-from streamlit.navigation.page import StreamlitPage
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.Navigation_pb2 import Navigation as NavigationProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -28,7 +27,10 @@ from streamlit.runtime.scriptrunner.script_run_context import (
     ScriptRunContext,
     get_script_run_ctx,
 )
-from streamlit.source_util import PageHash, PageInfo
+
+if TYPE_CHECKING:
+    from streamlit.navigation.page import StreamlitPage
+    from streamlit.source_util import PageHash, PageInfo
 
 SectionHeader: TypeAlias = str
 

--- a/lib/streamlit/components/lib/local_component_registry.py
+++ b/lib/streamlit/components/lib/local_component_registry.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import os
 import threading
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from streamlit import util
 from streamlit.components.types.base_component_registry import BaseComponentRegistry
-from streamlit.components.types.base_custom_component import BaseCustomComponent
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from streamlit.components.types.base_custom_component import BaseCustomComponent
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/components/types/base_component_registry.py
+++ b/lib/streamlit/components/types/base_component_registry.py
@@ -15,9 +15,10 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from streamlit.components.types.base_custom_component import BaseCustomComponent
+if TYPE_CHECKING:
+    from streamlit.components.types.base_custom_component import BaseCustomComponent
 
 
 class BaseComponentRegistry(Protocol):

--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -22,10 +22,11 @@ from typing import TYPE_CHECKING, Any
 
 from streamlit import type_util
 from streamlit.elements.lib import pandas_styler_utils
-from streamlit.proto.Components_pb2 import ArrowTable as ArrowTableProto
 
 if TYPE_CHECKING:
     from pandas import DataFrame, Index, Series
+
+    from streamlit.proto.Components_pb2 import ArrowTable as ArrowTableProto
 
 
 def marshall(

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -16,12 +16,16 @@ from __future__ import annotations
 
 import inspect
 import os
-from types import FrameType
+from typing import TYPE_CHECKING
 
-from streamlit.components.types.base_component_registry import BaseComponentRegistry
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.runtime import get_instance
 from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+if TYPE_CHECKING:
+    from types import FrameType
+
+    from streamlit.components.types.base_component_registry import BaseComponentRegistry
 
 
 def _get_module_name(caller_frame: FrameType) -> str:

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
 from streamlit.connections import BaseConnection
@@ -29,6 +28,8 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from pandas import DataFrame
     from snowflake.connector.cursor import SnowflakeCursor  # type:ignore[import]
     from snowflake.snowpark.session import Session  # type:ignore[import]

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import threading
 from collections import ChainMap
 from contextlib import contextmanager
-from datetime import timedelta
 from typing import TYPE_CHECKING, Iterator, cast
 
 from streamlit.connections import BaseConnection
@@ -36,6 +35,8 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from pandas import DataFrame
     from snowflake.snowpark.session import Session  # type:ignore[import]
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from collections import ChainMap
 from copy import deepcopy
-from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
 from streamlit.connections import BaseConnection
@@ -25,6 +24,8 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from pandas import DataFrame
     from sqlalchemy.engine import Connection as SQLAlchemyConnection
     from sqlalchemy.engine.base import Engine

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -44,7 +44,6 @@ from streamlit import (
     type_util,
     util,
 )
-from streamlit.cursor import Cursor
 from streamlit.elements.alert import AlertMixin
 from streamlit.elements.arrow import ArrowMixin
 from streamlit.elements.balloons import BalloonsMixin
@@ -100,6 +99,7 @@ if TYPE_CHECKING:
     from numpy import typing as npt
     from pandas import DataFrame
 
+    from streamlit.cursor import Cursor
     from streamlit.elements.arrow import Data
     from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
 

--- a/lib/streamlit/elements/code.py
+++ b/lib/streamlit/elements/code.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING, cast
 from streamlit.proto.Code_pb2 import Code as CodeProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
-from streamlit.type_util import SupportsStr
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.type_util import SupportsStr
 
 
 class CodeMixin:

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -15,13 +15,15 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Callable, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
 
 from streamlit.delta_generator import event_dg, get_last_dg_added_to_context_stack
-from streamlit.elements.lib.dialog import DialogWidth
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.fragment import _fragment
 from streamlit.runtime.metrics_util import gather_metrics
+
+if TYPE_CHECKING:
+    from streamlit.elements.lib.dialog import DialogWidth
 
 
 def _assert_no_nested_dialogs() -> None:

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -21,10 +21,10 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
-from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
 
 
 class FormData(NamedTuple):

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -23,10 +23,10 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
-from streamlit.type_util import SupportsStr
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.type_util import SupportsStr
 
 
 class HeadingProtoTag(Enum):

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -24,12 +24,13 @@ from typing_extensions import TypeAlias
 from streamlit.elements.lib.column_types import ColumnConfig, ColumnType
 from streamlit.elements.lib.dicttools import remove_none_values
 from streamlit.errors import StreamlitAPIException
-from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from streamlit.type_util import DataFormat, is_colum_type_arrow_incompatible
 
 if TYPE_CHECKING:
     import pyarrow as pa
     from pandas import DataFrame, Index, Series
+
+    from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 
 
 # The index identifier can be used to apply configuration options

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -15,17 +15,20 @@
 from __future__ import annotations
 
 import time
-from types import TracebackType
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
 
-from streamlit.cursor import Cursor
 from streamlit.delta_generator import DeltaGenerator, _enqueue_message
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from streamlit.cursor import Cursor
 
 DialogWidth: TypeAlias = Literal["small", "large"]
 

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -15,16 +15,19 @@
 from __future__ import annotations
 
 import time
-from types import TracebackType
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
 
-from streamlit.cursor import Cursor
 from streamlit.delta_generator import DeltaGenerator, _enqueue_message
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from streamlit.cursor import Cursor
 
 States: TypeAlias = Literal["running", "complete", "error"]
 

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -18,11 +18,12 @@ from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
-from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 
 if TYPE_CHECKING:
     from pandas import DataFrame
     from pandas.io.formats.style import Styler
+
+    from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 
 
 def marshall_styler(proto: ArrowProto, styler: Styler, default_uuid: str) -> None:

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -15,12 +15,14 @@
 from __future__ import annotations
 
 from enum import Enum, EnumMeta
-from typing import Any, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Any, Iterable, Sequence, overload
 
 from streamlit import type_util
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.runtime.state.common import RegisterWidgetResult
-from streamlit.type_util import T
+
+if TYPE_CHECKING:
+    from streamlit.type_util import T
 
 
 def get_label_visibility_proto_value(

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -20,10 +20,10 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Toast_pb2 import Toast as ToastProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text, validate_icon_or_emoji
-from streamlit.type_util import SupportsStr
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.type_util import SupportsStr
 
 
 def validate_text(toast_text: SupportsStr) -> SupportsStr:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
-import streamlit
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
@@ -40,6 +39,9 @@ from streamlit.runtime.state import (
 )
 from streamlit.runtime.state.common import compute_widget_id
 from streamlit.type_util import Key, LabelVisibility, maybe_raise_label_warnings, to_key
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
 
 
 @dataclass
@@ -253,6 +255,6 @@ class ColorPickerMixin:
         return widget_state.value
 
     @property
-    def dg(self) -> streamlit.delta_generator.DeltaGenerator:
+    def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -24,7 +24,6 @@ import streamlit.elements.exception as exception_utils
 from streamlit import config, runtime
 from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
-from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.Common_pb2 import FileURLs, FileURLsRequest
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -35,23 +34,24 @@ from streamlit.proto.NewSession_pb2 import (
     NewSession,
     UserInfo,
 )
-from streamlit.proto.PagesChanged_pb2 import PagesChanged
 from streamlit.runtime import caching
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import FragmentStorage, MemoryFragmentStorage
 from streamlit.runtime.metrics_util import Installation
 from streamlit.runtime.pages_manager import PagesManager
-from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner import RerunData, ScriptRunner, ScriptRunnerEvent
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.secrets import secrets_singleton
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
-from streamlit.source_util import PageHash, PageInfo
 from streamlit.version import STREAMLIT_VERSION_STRING
 from streamlit.watcher import LocalSourcesWatcher
 
 if TYPE_CHECKING:
+    from streamlit.proto.BackMsg_pb2 import BackMsg
+    from streamlit.proto.PagesChanged_pb2 import PagesChanged
+    from streamlit.runtime.script_data import ScriptData
+    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.state import SessionState
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+    from streamlit.source_util import PageHash, PageInfo
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -14,11 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from google.protobuf.message import Message
-
-from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.caching.cache_data_api import (
     CACHE_DATA_MESSAGE_REPLAY_CTX,
     CacheDataAPI,
@@ -31,7 +28,12 @@ from streamlit.runtime.caching.cache_resource_api import (
     get_resource_cache_stats_provider,
 )
 from streamlit.runtime.caching.legacy_cache_api import cache as _cache
-from streamlit.runtime.state.common import WidgetMetadata
+
+if TYPE_CHECKING:
+    from google.protobuf.message import Message
+
+    from streamlit.proto.Block_pb2 import Block
+    from streamlit.runtime.state.common import WidgetMetadata
 
 
 def save_element_message(

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -19,8 +19,17 @@ from __future__ import annotations
 import pickle
 import threading
 import types
-from datetime import timedelta
-from typing import Any, Callable, Final, Literal, TypeVar, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Final,
+    Literal,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from typing_extensions import TypeAlias
 
@@ -44,7 +53,6 @@ from streamlit.runtime.caching.cached_message_replay import (
     MultiCacheResults,
     show_widget_replay_deprecation,
 )
-from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.caching.storage import (
     CacheStorage,
     CacheStorageContext,
@@ -62,6 +70,11 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 from streamlit.time_util import time_to_seconds
+
+if TYPE_CHECKING:
+    from datetime import timedelta
+
+    from streamlit.runtime.caching.hashing import HashFuncsDict
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -14,12 +14,14 @@
 
 from __future__ import annotations
 
-import types
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from streamlit import type_util
 from streamlit.errors import MarkdownFormattedException, StreamlitAPIException
 from streamlit.runtime.caching.cache_type import CacheType, get_decorator_api_name
+
+if TYPE_CHECKING:
+    from types import FunctionType
 
 CACHE_DOCS_URL = "https://docs.streamlit.io/library/advanced-features/caching"
 
@@ -47,7 +49,7 @@ class UnhashableParamError(StreamlitAPIException):
     def __init__(
         self,
         cache_type: CacheType,
-        func: types.FunctionType,
+        func: FunctionType,
         arg_name: str | None,
         arg_value: Any,
         orig_exc: BaseException,
@@ -59,7 +61,7 @@ class UnhashableParamError(StreamlitAPIException):
     @staticmethod
     def _create_message(
         cache_type: CacheType,
-        func: types.FunctionType,
+        func: FunctionType,
         arg_name: str | None,
         arg_value: Any,
     ) -> str:
@@ -96,7 +98,7 @@ class CacheReplayClosureError(StreamlitAPIException):
     def __init__(
         self,
         cache_type: CacheType,
-        cached_func: types.FunctionType,
+        cached_func: FunctionType,
     ):
         func_name = get_cached_func_name_md(cached_func)
         decorator_name = get_decorator_api_name(cache_type)
@@ -118,7 +120,7 @@ How to fix this:
 
 
 class UnserializableReturnValueError(MarkdownFormattedException):
-    def __init__(self, func: types.FunctionType, return_value: types.FunctionType):
+    def __init__(self, func: FunctionType, return_value: FunctionType):
         MarkdownFormattedException.__init__(
             self,
             f"""

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import math
 import threading
 import types
-from datetime import timedelta
-from typing import Any, Callable, Final, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Final, TypeVar, cast, overload
 
 from cachetools import TTLCache
 from typing_extensions import TypeAlias
@@ -44,11 +43,15 @@ from streamlit.runtime.caching.cached_message_replay import (
     MultiCacheResults,
     show_widget_replay_deprecation,
 )
-from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 from streamlit.time_util import time_to_seconds
+
+if TYPE_CHECKING:
+    from datetime import timedelta
+
+    from streamlit.runtime.caching.hashing import HashFuncsDict
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -21,10 +21,9 @@ import hashlib
 import inspect
 import threading
 import time
-import types
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Final
+from typing import TYPE_CHECKING, Any, Callable, Final
 
 from streamlit import type_util
 from streamlit.elements.spinner import spinner
@@ -38,7 +37,6 @@ from streamlit.runtime.caching.cache_errors import (
     UnserializableReturnValueError,
     get_cached_func_name_md,
 )
-from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.cached_message_replay import (
     CachedMessageReplayContext,
     CachedResult,
@@ -48,6 +46,11 @@ from streamlit.runtime.caching.cached_message_replay import (
 from streamlit.runtime.caching.hashing import HashFuncsDict, update_hash
 from streamlit.type_util import UNEVALUATED_DATAFRAME_TYPES
 from streamlit.util import HASHLIB_KWARGS
+
+if TYPE_CHECKING:
+    from types import FunctionType
+
+    from streamlit.runtime.caching.cache_type import CacheType
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -120,7 +123,7 @@ class CachedFuncInfo:
 
     def __init__(
         self,
-        func: types.FunctionType,
+        func: FunctionType,
         show_spinner: bool | str,
         allow_widgets: bool,
         hash_funcs: HashFuncsDict | None,
@@ -354,7 +357,7 @@ class CachedFunc:
 
 def _make_value_key(
     cache_type: CacheType,
-    func: types.FunctionType,
+    func: FunctionType,
     func_args: tuple[Any, ...],
     func_kwargs: dict[str, Any],
     hash_funcs: HashFuncsDict | None,
@@ -419,7 +422,7 @@ def _make_value_key(
     return value_key
 
 
-def _make_function_key(cache_type: CacheType, func: types.FunctionType) -> str:
+def _make_function_key(cache_type: CacheType, func: FunctionType) -> str:
     """Create the unique key for a function's cache.
 
     A function's key is stable across reruns of the app, and changes when
@@ -458,7 +461,7 @@ def _make_function_key(cache_type: CacheType, func: types.FunctionType) -> str:
     return cache_key
 
 
-def _get_positional_arg_name(func: types.FunctionType, arg_index: int) -> str | None:
+def _get_positional_arg_name(func: FunctionType, arg_index: int) -> str | None:
     """Return the name of a function's positional argument.
 
     If arg_index is out of range, or refers to a parameter that is not a

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -17,28 +17,29 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import threading
-import types
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Union
-
-from google.protobuf.message import Message
 
 import streamlit as st
 from streamlit import runtime, util
 from streamlit.deprecation_util import show_deprecation_warning
-from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.caching.cache_errors import CacheReplayClosureError
-from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import update_hash
 from streamlit.runtime.scriptrunner.script_run_context import (
     ScriptRunContext,
     get_script_run_ctx,
 )
-from streamlit.runtime.state.common import WidgetMetadata
 from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
+    from types import FunctionType
+
+    from google.protobuf.message import Message
+
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.proto.Block_pb2 import Block
+    from streamlit.runtime.caching.cache_type import CacheType
+    from streamlit.runtime.state.common import WidgetMetadata
 
 
 @dataclass(frozen=True)
@@ -233,7 +234,7 @@ class CachedMessageReplayContext(threading.local):
 
     @contextlib.contextmanager
     def calling_cached_function(
-        self, func: types.FunctionType, allow_widgets: bool
+        self, func: FunctionType, allow_widgets: bool
     ) -> Iterator[None]:
         """Context manager that should wrap the invocation of a cached function.
         It allows us to track any `st.foo` messages that are generated from inside the function
@@ -364,7 +365,7 @@ class CachedMessageReplayContext(threading.local):
 
 
 def replay_cached_messages(
-    result: CachedResult, cache_type: CacheType, cached_func: types.FunctionType
+    result: CachedResult, cache_type: CacheType, cached_func: FunctionType
 ) -> None:
     """Replay the st element function calls that happened when executing a
     cache-decorated function.

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import os
 import re
-from datetime import timedelta
-from typing import Any, Final, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, overload
 
 from streamlit.connections import (
     BaseConnection,
@@ -30,6 +29,9 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.secrets import secrets_singleton
+
+if TYPE_CHECKING:
+    from datetime import timedelta
 
 # NOTE: Adding support for a new first party connection requires:
 #   1. Adding the new connection name and class to this dict.

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+if TYPE_CHECKING:
+    from streamlit.proto.Delta_pb2 import Delta
 
 
 class ForwardMsgQueue:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -19,14 +19,16 @@ import hashlib
 import inspect
 from abc import abstractmethod
 from copy import deepcopy
-from datetime import timedelta
 from functools import wraps
-from typing import Any, Callable, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, overload
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.time_util import time_to_seconds
+
+if TYPE_CHECKING:
+    from datetime import timedelta
 
 F = TypeVar("F", bound=Callable[..., Any])
 Fragment = Callable[[], Any]

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -22,11 +22,11 @@ from typing import TYPE_CHECKING, Any, Callable, Final
 
 from streamlit import source_util
 from streamlit.logger import get_logger
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.util import calc_md5
 from streamlit.watcher import watch_dir
 
 if TYPE_CHECKING:
+    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.source_util import PageHash, PageInfo, PageName, ScriptPath
 
 _LOGGER: Final = get_logger(__name__)

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -23,9 +23,7 @@ from typing import TYPE_CHECKING, Awaitable, Final, NamedTuple
 
 from streamlit import config
 from streamlit.components.lib.local_component_registry import LocalComponentRegistry
-from streamlit.components.types.base_component_registry import BaseComponentRegistry
 from streamlit.logger import get_logger
-from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.caching import (
@@ -41,7 +39,6 @@ from streamlit.runtime.forward_msg_cache import (
     populate_hash_if_needed,
 )
 from streamlit.runtime.media_file_manager import MediaFileManager
-from streamlit.runtime.media_file_storage import MediaFileStorage
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.runtime.script_data import ScriptData
@@ -58,11 +55,14 @@ from streamlit.runtime.state import (
     SessionStateStatProvider,
 )
 from streamlit.runtime.stats import StatsManager
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 
 if TYPE_CHECKING:
+    from streamlit.components.types.base_component_registry import BaseComponentRegistry
+    from streamlit.proto.BackMsg_pb2 import BackMsg
     from streamlit.runtime.caching.storage import CacheStorageManager
+    from streamlit.runtime.media_file_storage import MediaFileStorage
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 # Wait for the script run result for 60s and if no result is available give up
 SCRIPT_RUN_CHECK_TIMEOUT: Final = 60

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -16,12 +16,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from streamlit import config
 from streamlit.errors import MarkdownFormattedException, StreamlitAPIException
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
+
+if TYPE_CHECKING:
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 
 class MessageSizeError(MarkdownFormattedException):

--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from streamlit import util
-from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.state import coalesce_widget_states
+
+if TYPE_CHECKING:
+    from streamlit.proto.WidgetStates_pb2 import WidgetStates
 
 
 class ScriptRequestType(Enum):

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -25,16 +25,16 @@ from typing_extensions import TypeAlias
 from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.proto.PageProfile_pb2 import Command
-from streamlit.runtime.scriptrunner.script_requests import ScriptRequests
-from streamlit.runtime.state import SafeSessionState
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 if TYPE_CHECKING:
     from streamlit.cursor import RunningCursor
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    from streamlit.proto.PageProfile_pb2 import Command
     from streamlit.runtime.fragment import FragmentStorage
     from streamlit.runtime.pages_manager import PagesManager
+    from streamlit.runtime.scriptrunner.script_requests import ScriptRequests
+    from streamlit.runtime.state import SafeSessionState
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 _LOGGER: Final = get_logger(__name__)
 
 UserInfo: TypeAlias = Dict[str, Union[str, None]]

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -30,7 +30,6 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.scriptrunner.script_requests import (
     RerunData,
     ScriptRequests,
@@ -46,12 +45,13 @@ from streamlit.runtime.state import (
     SafeSessionState,
     SessionState,
 )
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.vendor.ipython.modified_sys_path import modified_sys_path
 
 if TYPE_CHECKING:
     from streamlit.runtime.fragment import FragmentStorage
     from streamlit.runtime.pages_manager import PagesManager
+    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Protocol, cast
+from typing import TYPE_CHECKING, Callable, Protocol, cast
 
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.app_session import AppSession
-from streamlit.runtime.script_data import ScriptData
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+if TYPE_CHECKING:
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    from streamlit.runtime.app_session import AppSession
+    from streamlit.runtime.script_data import ScriptData
+    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 
 class SessionClientDisconnectedError(Exception):

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -57,7 +57,6 @@ from streamlit.proto.Slider_pb2 import Slider
 from streamlit.proto.TextArea_pb2 import TextArea
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.proto.TimeInput_pb2 import TimeInput
-from streamlit.type_util import ValueFieldName
 from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
@@ -65,6 +64,7 @@ if TYPE_CHECKING:
 
     from streamlit.runtime.scriptrunner.script_run_context import ScriptRunContext
     from streamlit.runtime.state.widgets import NoValue
+    from streamlit.type_util import ValueFieldName
 
 
 # Protobuf types for all widgets.

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 import threading
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
-from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
-from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
-from streamlit.runtime.state.common import RegisterWidgetResult, T, WidgetMetadata
-from streamlit.runtime.state.query_params import QueryParams
-from streamlit.runtime.state.session_state import SessionState
+if TYPE_CHECKING:
+    from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
+    from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
+    from streamlit.runtime.state.common import RegisterWidgetResult, T, WidgetMetadata
+    from streamlit.runtime.state.query_params import QueryParams
+    from streamlit.runtime.state.session_state import SessionState
 
 
 class SafeSessionState:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -34,10 +34,10 @@ from streamlit.runtime.state.common import (
     WidgetSerializer,
     user_key_from_widget_id,
 )
-from streamlit.type_util import ValueFieldName
 
 if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner import ScriptRunContext
+    from streamlit.type_util import ValueFieldName
 
 
 ElementType: TypeAlias = str

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import io
 from abc import abstractmethod
-from typing import NamedTuple, Protocol, Sequence
+from typing import TYPE_CHECKING, NamedTuple, Protocol, Sequence
 
 from streamlit import util
-from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.runtime.stats import CacheStatsProvider
+
+if TYPE_CHECKING:
+    from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 
 
 class UploadedFileRec(NamedTuple):

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -14,12 +14,10 @@
 
 from __future__ import annotations
 
-from typing import Callable, Final, List, cast
+from typing import TYPE_CHECKING, Callable, Final, List, cast
 
 from streamlit.logger import get_logger
 from streamlit.runtime.app_session import AppSession
-from streamlit.runtime.script_data import ScriptData
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.session_manager import (
     ActiveSessionInfo,
     SessionClient,
@@ -27,7 +25,11 @@ from streamlit.runtime.session_manager import (
     SessionManager,
     SessionStorage,
 )
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+
+if TYPE_CHECKING:
+    from streamlit.runtime.script_data import ScriptData
+    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -19,12 +19,11 @@ import tempfile
 import textwrap
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 from unittest.mock import MagicMock
 from urllib import parse
 
 from streamlit import source_util
-from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
@@ -86,6 +85,9 @@ from streamlit.testing.v1.element_tree import (
 from streamlit.testing.v1.local_script_runner import LocalScriptRunner
 from streamlit.testing.v1.util import patch_config_options
 from streamlit.util import HASHLIB_KWARGS, calc_md5
+
+if TYPE_CHECKING:
+    from streamlit.proto.WidgetStates_pb2 import WidgetStates
 
 TMP_DIR = tempfile.TemporaryDirectory()
 

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -48,38 +48,38 @@ from streamlit.elements.widgets.time_widgets import (
     _parse_date_value,
 )
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
-from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
-from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from streamlit.proto.Code_pb2 import Code as CodeProto
-from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
-from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
-from streamlit.proto.Element_pb2 import Element as ElementProto
-from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.proto.Heading_pb2 import Heading as HeadingProto
-from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
-from streamlit.proto.Metric_pb2 import Metric as MetricProto
-from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
-from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from streamlit.proto.Radio_pb2 import Radio as RadioProto
-from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from streamlit.proto.Text_pb2 import Text as TextProto
-from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
-from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from streamlit.proto.Toast_pb2 import Toast as ToastProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.state.common import TESTING_KEY, user_key_from_widget_id
-from streamlit.runtime.state.safe_session_state import SafeSessionState
 
 if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataframe
 
+    from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
+    from streamlit.proto.Block_pb2 import Block as BlockProto
+    from streamlit.proto.Button_pb2 import Button as ButtonProto
+    from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
+    from streamlit.proto.Code_pb2 import Code as CodeProto
+    from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
+    from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
+    from streamlit.proto.Element_pb2 import Element as ElementProto
+    from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    from streamlit.proto.Heading_pb2 import Heading as HeadingProto
+    from streamlit.proto.Json_pb2 import Json as JsonProto
+    from streamlit.proto.Metric_pb2 import Metric as MetricProto
+    from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
+    from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
+    from streamlit.proto.Radio_pb2 import Radio as RadioProto
+    from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
+    from streamlit.proto.Text_pb2 import Text as TextProto
+    from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
+    from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
+    from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
+    from streamlit.proto.Toast_pb2 import Toast as ToastProto
+    from streamlit.runtime.state.safe_session_state import SafeSessionState
     from streamlit.testing.v1.app_test import AppTest
 
 T = TypeVar("T")

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -20,19 +20,19 @@ from typing import TYPE_CHECKING, Any
 from urllib import parse
 
 from streamlit import runtime
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import RerunData, ScriptRunner, ScriptRunnerEvent
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
-from streamlit.runtime.scriptrunner.script_run_context import ScriptRunContext
-from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.testing.v1.element_tree import ElementTree, parse_tree_from_messages
 
 if TYPE_CHECKING:
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    from streamlit.proto.WidgetStates_pb2 import WidgetStates
     from streamlit.runtime.pages_manager import PagesManager
+    from streamlit.runtime.scriptrunner.script_run_context import ScriptRunContext
+    from streamlit.runtime.state.safe_session_state import SafeSessionState
 
 
 class LocalScriptRunner(ScriptRunner):

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
-from typing import Iterator, Mapping, NoReturn, Union
+from typing import TYPE_CHECKING, Iterator, Mapping, NoReturn, Union
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.scriptrunner import get_script_run_ctx as _get_script_run_ctx
-from streamlit.runtime.scriptrunner.script_run_context import UserInfo
+
+if TYPE_CHECKING:
+    from streamlit.runtime.scriptrunner.script_run_context import UserInfo
 
 
 def _get_user_info() -> UserInfo:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -39,17 +39,19 @@ from __future__ import annotations
 
 import os
 import threading
-from typing import Callable, Final, cast
+from typing import TYPE_CHECKING, Callable, Final, cast
 
 from blinker import ANY, Signal
 from typing_extensions import Self
 from watchdog import events
 from watchdog.observers import Observer
-from watchdog.observers.api import ObservedWatch
 
 from streamlit.logger import get_logger
 from streamlit.util import repr_
 from streamlit.watcher import util
+
+if TYPE_CHECKING:
+    from watchdog.observers.api import ObservedWatch
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import os
 import sys
-import types
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Final, NamedTuple
 
@@ -29,6 +28,8 @@ from streamlit.watcher.path_watcher import (
 )
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from streamlit.runtime.pages_manager import PagesManager
 
 _LOGGER: Final = get_logger(__name__)
@@ -185,7 +186,7 @@ class LocalSourcesWatcher:
         return {p for p in paths if not self._folder_black_list.is_blacklisted(p)}
 
 
-def get_module_paths(module: types.ModuleType) -> set[str]:
+def get_module_paths(module: ModuleType) -> set[str]:
     paths_extractors = [
         # https://docs.python.org/3/reference/datamodel.html
         # __file__ is the pathname of the file from which the module was loaded

--- a/lib/streamlit/web/cache_storage_manager_config.py
+++ b/lib/streamlit/web/cache_storage_manager_config.py
@@ -14,10 +14,14 @@
 
 from __future__ import annotations
 
-from streamlit.runtime.caching.storage import CacheStorageManager
+from typing import TYPE_CHECKING
+
 from streamlit.runtime.caching.storage.local_disk_cache_storage import (
     LocalDiskCacheStorageManager,
 )
+
+if TYPE_CHECKING:
+    from streamlit.runtime.caching.storage import CacheStorageManager
 
 
 def create_default_cache_storage_manager() -> CacheStorageManager:

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 # We cannot lazy-load click here because its used via decorators.
 import click
@@ -26,11 +26,13 @@ import click
 import streamlit.runtime.caching as caching
 import streamlit.web.bootstrap as bootstrap
 from streamlit import config as _config
-from streamlit.config_option import ConfigOption
 from streamlit.runtime.credentials import Credentials, check_credentials
 from streamlit.web.cache_storage_manager_config import (
     create_default_cache_storage_manager,
 )
+
+if TYPE_CHECKING:
+    from streamlit.config_option import ConfigOption
 
 ACCEPTED_FILE_EXTENSIONS = ("py", "py3")
 

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 import binascii
 import json
-from typing import Any, Awaitable, Final
+from typing import TYPE_CHECKING, Any, Awaitable, Final
 
 import tornado.concurrent
 import tornado.locks
@@ -29,10 +29,12 @@ from tornado.websocket import WebSocketHandler
 from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime, SessionClient, SessionClientDisconnectedError
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.web.server.server_util import is_url_from_allowed_origins
+
+if TYPE_CHECKING:
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import mimetypes
 import os
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import tornado.web
 
 import streamlit.web.server.routes
-from streamlit.components.types.base_component_registry import BaseComponentRegistry
 from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from streamlit.components.types.base_component_registry import BaseComponentRegistry
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -16,12 +16,13 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 from urllib.parse import urljoin
 
-import tornado.web
-
 from streamlit import config, net_util, url_util
+
+if TYPE_CHECKING:
+    from tornado.web import RequestHandler
 
 # The port reserved for internal development.
 DEVELOPMENT_PORT: Final = 3000
@@ -120,9 +121,7 @@ def _get_browser_address_bar_port() -> int:
     return int(config.get_option("browser.serverPort"))
 
 
-def emit_endpoint_deprecation_notice(
-    handler: tornado.web.RequestHandler, new_path: str
-) -> None:
+def emit_endpoint_deprecation_notice(handler: RequestHandler, new_path: str) -> None:
     """
     Emits the warning about deprecation of HTTP endpoint in the HTTP header.
     """

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -18,11 +18,11 @@ from typing import TYPE_CHECKING
 
 import tornado.web
 
-from streamlit.runtime.stats import CacheStat, StatsManager
 from streamlit.web.server.server_util import emit_endpoint_deprecation_notice
 
 if TYPE_CHECKING:
     from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
+    from streamlit.runtime.stats import CacheStat, StatsManager
 
 
 class StatsRequestHandler(tornado.web.RequestHandler):

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -14,15 +14,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import tornado.httputil
 import tornado.web
 
 from streamlit import config
-from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.web.server import routes, server_util
+
+if TYPE_CHECKING:
+    from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 
 
 class UploadFileRequestHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
## Describe your changes

Activates the [TCH](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch) type-checking rules, which make sure that type-only imports are under the `if TYPE_CHECKING:` condition.

## Testing Plan

- No logical changes -> no tests required. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
