### PR TITLE
[WIP] Support multiple secret sources

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -984,6 +984,20 @@ _create_option(
     type_=bool,
 )
 
+# Config Section: Secrets #
+
+_create_section("secrets", "Secrets configuration.")
+
+_create_option(
+    "secrets.files",
+    description="""List of locations where secrets are searched. Entries can be a path to toml file or directory path where Kubernetes style secrets will be scanned!""",
+    default_val=[
+        # NOTE: The order here is important! Project-level secrets should overwrite global
+        # secrets.
+        file_util.get_streamlit_file_path("secrets.toml"),
+        file_util.get_project_streamlit_file_path("secrets.toml"),
+    ],
+)
 
 # Config Section: deprecations
 


### PR DESCRIPTION
## Describe your changes

This PR is a work in progress. At this stage I want to get feedback on the implementation. Once I get approval for the implementation I will add unit tests and ensure all new classes/methods are documentation.

Allow additional sources for secrets in addition to the existing toml based secrets by:
1. adding hidden config `secret.files` that allows a parent directory containing Kubernetes style secrets (see below)
2. adding internal st.secrets._add_provider() that will be used in SiS to wrap [UDF Style Secrets](https://docs.snowflake.com/en/developer-guide/external-network-access/secret-api-reference#python-api-for-secret-access). I see a future where additional secret providers are supplied and this becomes public such as AWS secret manager, etc.

**Kubernetes Style Secret:**
This secret format will allow Streamlit secrets to be used with [Snowpark Container Services secret format](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/additional-considerations-services-jobs#using-snowflake-secrets-to-pass-credentials-to-a-container) which is based on [Kubernetes Secret](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume)

In this format the secrets are expected to be placed under a directory (such as `/.streamlit/.secrets`) in the following ways:
- user_pass_secret (folder)
   - username (file), content: myuser
   - password (file), content: mypassword
- my_plain_secret (folder)
   - regular_secret (file), content: mysecret

If there are multiple files in a folder they will be available as:
```
> st.secrets['user_pass_secret']['username']
myuser
```

if there's a single file in a folder it will be folded into the folder name such as:
```
> st.secrets['my_plain_secrets']
mysecret
```

**Alternatives & Considerations:**

The provider in this PR only customize the behavior of `_parse`. So supporting credential providers such as UDF will require calling list secrets and then getting all secret values to populate the internal map. The alternative explored in this commit https://github.com/streamlit/streamlit/commit/3cef9de12cbe4b2f169437d7201acc45e0592fbb#diff-fd8979106a82cdb83f15082f9e02b74e8d739964833a9980d5d74a745f6a77fbR128 is to have every provider override the entire Mappable interface, so secret can be fetched only when calling st.secrets["secret_name"]. 

Since my goal with this change is to keep backward compatible as much as possible and reduce the amount of changes, I am proposing to only overriding parse. This is a two way door, a bigger change can be introduced in follow up PR if needed.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
