### PR TITLE
Clean up system dependencies in CI

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -34,14 +34,6 @@ runs:
         mkdir -p $(yarn cache dir)
         make react-init
       shell: bash --login -eo pipefail {0}
-    - name: Install system dependencies
-      run: |
-        sudo apt update
-        # dot & graphviz dependencies
-        sudo apt install -y gnupg \
-            graphviz \
-            libgvc6
-      shell: bash --login -eo pipefail {0}
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2024.06.04 - doesn't have recent versions
     # of protoc in its package repository. To work around this, we


### PR DESCRIPTION
## Describe your changes

We install some graphviz system dependencies as part of our make init CI action, but there is actually no need for this. All our tests run without these system dependencies. This is likely a historical artifact. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
