### PR TITLE
Fix Changed-Files Playwright CI workflow

### DIFF
--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -30,9 +30,10 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           path: e2e_playwright
+          # Exclude all files in custom_components folder as they require external dependencies
           files: |
-            "**/*_test.py"
-            "!**/custom_components/**/*" # ignore custom_components check in the fast-workflow as it requires additional dependencies
+            **/*_test.py
+            !custom_components/**
       - name: Check changed files
         id: check_changed_files
         env:


### PR DESCRIPTION
## Describe your changes

When multiple files are listed in the changed-files action, they are not supposed to be in quotes as of the [action's documentation](https://github.com/tj-actions/changed-files?tab=readme-ov-file#inputs-%EF%B8%8F):

>   Multiline file/directory patterns should not include quotes.  

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
