### PR TITLE
Revert accidental rich deprecation

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -465,9 +465,6 @@ _create_option(
     visibility="hidden",
     type_=bool,
     scriptable=True,
-    deprecated=True,
-    deprecation_text="logger.enableRich has been deprecated and will be removed in a future version. Exception formatting via rich will be automatically used if rich is enable.",
-    expiration_date="2024-09-10",
 )
 
 # Config Section: Client #


### PR DESCRIPTION
## Describe your changes

A config deprecation accidentally got into develop to early. This still requires a change from Community Cloud before we should deprecate this.   

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
