### PR TITLE
Reconnect to existing sessions

### DIFF
--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -73,9 +73,12 @@ class WebsocketSessionManager(SessionManager):
 
         if existing_session_id in self._active_session_info_by_id:
             _LOGGER.warning(
-                "Session with id %s is already connected! Connecting to a new session.",
+                "Session with id %s is already connected! Reconnecting!",
                 existing_session_id,
             )
+            # If the session is already active, disconnect it first so that we can
+            # reconnect to it with the new SessionClient.
+            self.disconnect_session(existing_session_id)
 
         session_info = (
             existing_session_id

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -133,6 +133,11 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     def on_close(self) -> None:
         if not self._session_id:
             return
+
+        if not self.close_code or self.close_code not in [1000, 1001]:
+            # Unclean close. We may have already reconnected so do not disconnect.
+            return
+
         self._runtime.disconnect_session(self._session_id)
         self._session_id = None
 


### PR DESCRIPTION
## Describe your changes

Fixes #8901 

Preemptively disconnect from existing session so that a reconnect occurs instead of creating a new session. Also do not disconnect upon unclean websocket close to avoid affecting already reconnected sessions.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/8901

## Testing Plan

See issue comment for why this is just a naive PR to serve as a proposal for a proper fix.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
