### PR TITLE
Don't immediately remove fragments added by callbacks

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -78,6 +78,7 @@ class ScriptRunContext:
     script_requests: ScriptRequests | None = None
     current_fragment_id: str | None = None
     fragment_ids_this_run: set[str] | None = None
+    new_fragment_ids: set[str] = field(default_factory=set)
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
     # If true, it indicates that we are in a cached function that disallows
@@ -117,6 +118,7 @@ class ScriptRunContext:
         self.current_fragment_id = None
         self.current_fragment_delta_path: list[int] = []
         self.fragment_ids_this_run = fragment_ids_this_run
+        self.new_fragment_ids = set()
         self.has_dialog_opened = False
         self.disallow_cached_widget_usage = False
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -566,8 +566,10 @@ class ScriptRunner:
                                     f"Could not find fragment with id {fragment_id}"
                                 )
                     else:
-                        self._fragment_storage.clear()
                         exec(code, module.__dict__)
+                        self._fragment_storage.clear(
+                            new_fragment_ids=ctx.new_fragment_ids
+                        )
 
                     self._session_state.maybe_check_serializable()
 


### PR DESCRIPTION
The reason we were seeing the bug in #8591 is due to the incorrect assumption that we can always
totally clear out a session's fragment storage before a full script run as fragments will immediately
be repopulated anyway.  This isn't quite true as a fragment can be added by a callback, and in this
case clearing out `FragmentStorage` before the full script run will lose it.

To fix this, we keep track of the fragments added throughout a script run, and on a full script run
we don't clear out fragments that were just added.

Closes #8591