### PR TITLE
Add support for numpy 2.x

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Create Wheel File
         timeout-minutes: 120
         run: |
+          sudo apt update
           sudo apt install rsync
           BUILD_AS_FAST_AS_POSSIBLE=1 make package
       - name: Store Whl File

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -33,7 +33,7 @@ INSTALL_REQUIRES = [
     "blinker>=1.0.0, <2",
     "cachetools>=4.0, <6",
     "click>=7.0, <9",
-    "numpy>=1.20, <2",
+    "numpy>=1.20, <3",
     "packaging>=20, <25",
     # Lowest version with available wheel for 3.7 + amd64 + linux
     "pandas>=1.3.0, <3",

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -4,7 +4,6 @@
 bokeh==2.4.3
 graphviz>=0.17
 matplotlib>=3.3.4
-opencv-python>=4.5.3
 plotly>=5.3.1
 pydot>=1.4.2
 scipy>=1.7.3

--- a/lib/tests/streamlit/elements/bokeh_test.py
+++ b/lib/tests/streamlit/elements/bokeh_test.py
@@ -14,10 +14,11 @@
 
 """Bokeh unit test."""
 
+import numpy as np
+import unittest
 from unittest.mock import patch
 
-from bokeh.plotting import figure
-
+from streamlit.type_util import is_version_less_than
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -26,8 +27,15 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 class BokehTest(DeltaGeneratorTestCase):
     """Test ability to marshall bokeh_chart protos."""
 
+    @unittest.skipIf(
+        is_version_less_than(np.__version__, "2.0.0") is False,
+        "This test only runs if numpy is < 2.0.0",
+    )
     def test_figure(self):
         """Test that it can be called with figure."""
+
+        from bokeh.plotting import figure
+
         plot = figure()
         plot.line([1], [1])
         st.bokeh_chart(plot)
@@ -35,8 +43,14 @@ class BokehTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.bokeh_chart
         self.assertEqual(hasattr(c, "figure"), True)
 
+    @unittest.skipIf(
+        is_version_less_than(np.__version__, "2.0.0") is False,
+        "This test only runs if numpy is < 2.0.0",
+    )
     def test_bokeh_version_failure(self):
         with patch("bokeh.__version__", return_value="2.4.0"):
+            from bokeh.plotting import figure
+
             plot = figure()
             with self.assertRaises(StreamlitAPIException):
                 st.bokeh_chart(plot)

--- a/lib/tests/streamlit/elements/bokeh_test.py
+++ b/lib/tests/streamlit/elements/bokeh_test.py
@@ -29,7 +29,8 @@ class BokehTest(DeltaGeneratorTestCase):
 
     @unittest.skipIf(
         is_version_less_than(np.__version__, "2.0.0") is False,
-        "This test only runs if numpy is < 2.0.0",
+        "This test only runs if numpy is < 2.0.0. The bokeh version supported "
+        "by Streamlit is not compatible with numpy 2.x.",
     )
     def test_figure(self):
         """Test that it can be called with figure."""
@@ -45,7 +46,8 @@ class BokehTest(DeltaGeneratorTestCase):
 
     @unittest.skipIf(
         is_version_less_than(np.__version__, "2.0.0") is False,
-        "This test only runs if numpy is < 2.0.0",
+        "This test only runs if numpy is < 2.0.0. The bokeh version supported "
+        "by Streamlit is not compatible with numpy 2.x.",
     )
     def test_bokeh_version_failure(self):
         from bokeh.plotting import figure

--- a/lib/tests/streamlit/elements/bokeh_test.py
+++ b/lib/tests/streamlit/elements/bokeh_test.py
@@ -48,9 +48,9 @@ class BokehTest(DeltaGeneratorTestCase):
         "This test only runs if numpy is < 2.0.0",
     )
     def test_bokeh_version_failure(self):
-        with patch("bokeh.__version__", return_value="2.4.0"):
-            from bokeh.plotting import figure
+        from bokeh.plotting import figure
 
+        with patch("bokeh.__version__", return_value="2.4.0"):
             plot = figure()
             with self.assertRaises(StreamlitAPIException):
                 st.bokeh_chart(plot)

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -77,6 +77,7 @@ def create_image(size, format="RGB", add_alpha=True):
     if format == "BGR":
         # Grab the indices of channel in last dimension
         np_image = np.array(image)
+        # Swap the channels to convert from RGB to BGR:
         return np_image[..., ["BGR".index(s) for s in "RGB"]]
 
     return image

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -74,6 +74,11 @@ def create_image(size, format="RGB", add_alpha=True):
         )
         image.putalpha(alpha)
 
+    if format == "BGR":
+        # Grab the indices of channel in last dimension
+        np_image = np.array(image)
+        return np_image[..., ["BGR".index(s) for s in "RGB"]]
+
     return image
 
 
@@ -116,6 +121,10 @@ IMAGES = {
         "pil": create_image(32, "RGBA"),
         "np": np.array(create_image(32, "RGBA")),
     },
+    "img_32_32_3_bgr": {
+        "pil": create_image(32, "BGR"),
+        "np": np.array(create_image(32, "BGR")),
+    },
     "img_64_64_rgb": {
         "pil": Image.new("RGB", (64, 64), color="red"),
         "np": np.array(Image.new("RGB", (64, 64), color="red")),
@@ -132,6 +141,7 @@ class ImageProtoTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (IMAGES["img_32_32_3_rgb"]["np"], "png"),
+            (IMAGES["img_32_32_3_bgr"]["np"], "png"),
             (IMAGES["img_64_64_rgb"]["np"], "jpeg"),
             (IMAGES["img_32_32_3_rgba"]["np"], "jpeg"),
             (IMAGES["gif_64_64"]["gif"], "gif"),
@@ -172,9 +182,11 @@ class ImageProtoTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (IMAGES["img_32_32_3_rgb"]["np"], ".jpg"),
+            (IMAGES["img_32_32_3_bgr"]["np"], ".jpg"),
             (IMAGES["img_64_64_rgb"]["np"], ".jpg"),
             (IMAGES["img_32_32_3_rgba"]["np"], ".png"),
             (IMAGES["img_32_32_3_rgb"]["pil"], ".jpg"),
+            (IMAGES["img_32_32_3_bgr"]["pil"], ".jpg"),
             (IMAGES["img_64_64_rgb"]["pil"], ".jpg"),
             (IMAGES["img_32_32_3_rgba"]["pil"], ".png"),
             (IMAGES["gif_64_64"]["gif"], ".gif"),

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -18,7 +18,6 @@ import io
 import random
 from unittest import mock
 
-import cv2
 import numpy as np
 import PIL.Image as Image
 import pytest
@@ -75,10 +74,7 @@ def create_image(size, format="RGB", add_alpha=True):
         )
         image.putalpha(alpha)
 
-    if format == "BGR":
-        return cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
-    else:
-        return image
+    return image
 
 
 def create_gif(size):
@@ -120,10 +116,6 @@ IMAGES = {
         "pil": create_image(32, "RGBA"),
         "np": np.array(create_image(32, "RGBA")),
     },
-    "img_32_32_3_bgr": {
-        "pil": create_image(32, "BGR"),
-        "np": np.array(create_image(32, "BGR")),
-    },
     "img_64_64_rgb": {
         "pil": Image.new("RGB", (64, 64), color="red"),
         "np": np.array(Image.new("RGB", (64, 64), color="red")),
@@ -140,7 +132,6 @@ class ImageProtoTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (IMAGES["img_32_32_3_rgb"]["np"], "png"),
-            (IMAGES["img_32_32_3_bgr"]["np"], "png"),
             (IMAGES["img_64_64_rgb"]["np"], "jpeg"),
             (IMAGES["img_32_32_3_rgba"]["np"], "jpeg"),
             (IMAGES["gif_64_64"]["gif"], "gif"),
@@ -181,11 +172,9 @@ class ImageProtoTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (IMAGES["img_32_32_3_rgb"]["np"], ".jpg"),
-            (IMAGES["img_32_32_3_bgr"]["np"], ".jpg"),
             (IMAGES["img_64_64_rgb"]["np"], ".jpg"),
             (IMAGES["img_32_32_3_rgba"]["np"], ".png"),
             (IMAGES["img_32_32_3_rgb"]["pil"], ".jpg"),
-            (IMAGES["img_32_32_3_bgr"]["pil"], ".jpg"),
             (IMAGES["img_64_64_rgb"]["pil"], ".jpg"),
             (IMAGES["img_32_32_3_rgba"]["pil"], ".png"),
             (IMAGES["gif_64_64"]["gif"], ".gif"),


### PR DESCRIPTION
## Describe your changes

Numpy 2.0 was released a couple of days ago. This PR adds support for numpy 2.x.

Streamlit not supporting numpy 2.0 likely leads to the side-effect that Streamlit 1.19 gets installed by the resolver if Streamlit & numpy are unpinned. The reason:

We added major version pins in Streamlit >= 1.23. This can lead to the interpretation (by the resolver) that Streamlit < 1.23 is compatible with numpy 2.0, but >= 1.23 isn't. So maybe the resolver selects Numpy 2.0, and then resolves to a compatible Streamlit version which would be < 1.23. But the version that actually gets selected is 1.19 because we added a major version pin to altair <5 in 1.20. Thereby, the latest Streamlit version that is semantically compatible with Numpy 2.x and Altair 5.x is 1.19.

## GitHub Issue Link (if applicable)

- https://github.com/streamlit/streamlit/issues/8927
- https://github.com/streamlit/streamlit/issues/8917
- https://github.com/streamlit/streamlit/issues/8935
- https://github.com/streamlit/streamlit/issues/8936
- https://github.com/streamlit/streamlit/issues/8937


## Testing Plan

- Not logic changed -> no tests are required. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
