### PR TITLE
Update links to "Streamlit Components" in the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Streamlit comes in with [a ton of additional powerful elements](https://docs.str
 </table>
 
 
-Our vibrant creators community also extends Streamlit capabilities using  🧩 [Streamlit Components](http://components.streamlit.app).
+Our vibrant creators community also extends Streamlit capabilities using  🧩 [Streamlit Components](https://streamlit.io/components).
 
 ## Get inspired
 
@@ -121,7 +121,7 @@ Deploy, manage and share your apps for free using our [Community Cloud](https://
 - Explore our [docs](https://docs.streamlit.io) to learn how Streamlit works.
 - Ask questions and get help in our [community forum](https://discuss.streamlit.io).
 - Read our [blog](https://blog.streamlit.io) for tips from developers and creators.
-- Extend Streamlit's capabilities by installing or creating your own [Streamlit Components](http://components.streamlit.app/).
+- Extend Streamlit's capabilities by installing or creating your own [Streamlit Components](https://streamlit.io/components).
 - Help others find and play with your app by using the Streamlit GitHub badge in your repository:
 ```markdown
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](URL_TO_YOUR_APP)


### PR DESCRIPTION
## Describe your changes
The current link leads to an app that says: 
> This app is deprecated and unmaintained. You can now find all components at https://streamlit.io/components

## GitHub Issue Link (if applicable)
N/A 
## Testing Plan
Unnecessary since doc-only change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
