### PR TITLE
Remove fragment_ids_this_run from script run context

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -479,7 +479,7 @@ class AppSession:
         exception: BaseException | None = None,
         client_state: ClientState | None = None,
         page_script_hash: str | None = None,
-        fragment_ids_this_run: set[str] | None = None,
+        fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
     ) -> None:
         """Called when our ScriptRunner emits an event.
@@ -509,7 +509,7 @@ class AppSession:
         exception: BaseException | None = None,
         client_state: ClientState | None = None,
         page_script_hash: str | None = None,
-        fragment_ids_this_run: set[str] | None = None,
+        fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
     ) -> None:
         """Handle a ScriptRunner event.
@@ -542,7 +542,7 @@ class AppSession:
             A hash of the script path corresponding to the page currently being
             run. Set only for the SCRIPT_STARTED event.
 
-        fragment_ids_this_run : set[str] | None
+        fragment_ids_this_run : list[str] | None
             The fragment IDs of the fragments being executed in this script run. Only
             set for the SCRIPT_STARTED event. If this value is falsy, this script run
             must be for the full script.
@@ -679,7 +679,7 @@ class AppSession:
     def _create_new_session_message(
         self,
         page_script_hash: str,
-        fragment_ids_this_run: set[str] | None = None,
+        fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
     ) -> ForwardMsg:
         """Create and return a new_session ForwardMsg."""

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -169,7 +169,7 @@ def _fragment(
             ctx = get_script_run_ctx(suppress_warning=True)
             assert ctx is not None
 
-            if ctx.fragment_ids_this_run:
+            if ctx.script_requests and ctx.script_requests.fragment_id_queue:
                 # This script run is a run of one or more fragments. We restore the
                 # state of ctx.cursors and dg_stack to the snapshots we took when this
                 # fragment was declared.

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -482,6 +482,8 @@ def create_page_profile_message(
         page_profile.uncaught_exception = uncaught_exception
 
     if ctx := get_script_run_ctx():
-        page_profile.is_fragment_run = bool(ctx.fragment_ids_this_run)
+        page_profile.is_fragment_run = bool(
+            ctx.script_requests and ctx.script_requests.fragment_id_queue
+        )
 
     return msg

--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -83,6 +83,13 @@ class ScriptRequests:
         self._state = ScriptRequestType.CONTINUE
         self._rerun_data = RerunData()
 
+    @property
+    def fragment_id_queue(self) -> list[str]:
+        if not self._rerun_data:
+            return []
+
+        return self._rerun_data.fragment_id_queue
+
     def request_stop(self) -> None:
         """Request that the ScriptRunner stop running. A stopped ScriptRunner
         can't be used anymore. STOP requests succeed unconditionally.

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -77,7 +77,6 @@ class ScriptRunContext:
     cursors: dict[int, RunningCursor] = field(default_factory=dict)
     script_requests: ScriptRequests | None = None
     current_fragment_id: str | None = None
-    fragment_ids_this_run: set[str] | None = None
     new_fragment_ids: set[str] = field(default_factory=set)
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
@@ -101,7 +100,6 @@ class ScriptRunContext:
         self,
         query_string: str = "",
         page_script_hash: str = "",
-        fragment_ids_this_run: set[str] | None = None,
     ) -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
@@ -117,7 +115,6 @@ class ScriptRunContext:
         self.tracked_commands_counter = collections.Counter()
         self.current_fragment_id = None
         self.current_fragment_delta_path: list[int] = []
-        self.fragment_ids_this_run = fragment_ids_this_run
         self.new_fragment_ids = set()
         self.has_dialog_opened = False
         self.disallow_cached_widget_usage = False

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -444,8 +444,6 @@ class ScriptRunner:
                 else main_page_info["page_script_hash"]
             )
 
-            fragment_ids_this_run = set(rerun_data.fragment_id_queue)
-
             ctx = self._get_script_run_ctx()
             # Clear widget state on page change. This normally happens implicitly
             # in the script run cleanup steps, but doing it explicitly ensures
@@ -470,7 +468,6 @@ class ScriptRunner:
             ctx.reset(
                 query_string=rerun_data.query_string,
                 page_script_hash=page_script_hash,
-                fragment_ids_this_run=fragment_ids_this_run,
             )
             self._pages_manager.reset_active_script_hash()
 
@@ -478,7 +475,7 @@ class ScriptRunner:
                 self,
                 event=ScriptRunnerEvent.SCRIPT_STARTED,
                 page_script_hash=page_script_hash,
-                fragment_ids_this_run=fragment_ids_this_run,
+                fragment_ids_this_run=rerun_data.fragment_id_queue,
                 pages=self._pages_manager.get_pages(),
             )
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -578,9 +578,13 @@ class SessionState:
         if ctx is None:
             return
 
+        fragment_ids_this_run = (
+            set(ctx.script_requests.fragment_id_queue) if ctx.script_requests else set()
+        )
+
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,
-            ctx.fragment_ids_this_run,
+            fragment_ids_this_run,
         )
 
         # Remove entries from _old_state corresponding to
@@ -593,7 +597,7 @@ class SessionState:
                 or not _is_stale_widget(
                     self._new_widget_state.widget_metadata.get(k),
                     active_widget_ids,
-                    ctx.fragment_ids_this_run,
+                    fragment_ids_this_run,
                 )
             )
         }

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -396,7 +396,8 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
     def test_enqueue_explodes_if_fragment_writes_to_sidebar(self):
         ctx = get_script_run_ctx()
         ctx.current_fragment_id = "my_fragment_id"
-        ctx.fragment_ids_this_run = {"my_fragment_id"}
+        ctx.script_requests = MagicMock()
+        ctx.script_requests.fragment_id_queue = ["my_fragment_id"]
 
         exc = "is not supported"
         with pytest.raises(StreamlitAPIException, match=exc):
@@ -405,7 +406,8 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
     def test_enqueue_can_write_to_container_in_sidebar(self):
         ctx = get_script_run_ctx()
         ctx.current_fragment_id = "my_fragment_id"
-        ctx.fragment_ids_this_run = {"my_fragment_id"}
+        ctx.script_requests = MagicMock()
+        ctx.script_requests.fragment_id_queue = ["my_fragment_id"]
 
         delta_generator.sidebar_dg.container().write("Hello world")
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -761,7 +761,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             sender=mock_scriptrunner,
             event=ScriptRunnerEvent.SCRIPT_STARTED,
             page_script_hash="",
-            fragment_ids_this_run={"my_fragment_id"},
+            fragment_ids_this_run=["my_fragment_id"],
         )
 
         # Yield to let the AppSession's callbacks run.

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -175,11 +175,11 @@ class FragmentTest(unittest.TestCase):
         ctx.fragment_storage.set.assert_called_once()
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
-    def test_sets_dg_stack_and_cursor_to_snapshots_if_fragment_ids_this_run(
+    def test_sets_dg_stack_and_cursor_to_snapshots_if_fragment_id_queue(
         self, patched_get_script_run_ctx
     ):
         ctx = MagicMock()
-        ctx.fragment_ids_this_run = {"my_fragment_id"}
+        ctx.script_requests.fragment_id_queue = ["my_fragment_id"]
         ctx.fragment_storage = MemoryFragmentStorage()
         patched_get_script_run_ctx.return_value = ctx
 
@@ -230,7 +230,7 @@ class FragmentTest(unittest.TestCase):
         self, patched_get_script_run_ctx
     ):
         ctx = MagicMock()
-        ctx.fragment_ids_this_run = set()
+        ctx.script_requests.fragment_id_queue = []
         ctx.new_fragment_ids = set()
         ctx.current_fragment_id = None
         ctx.fragment_storage = MemoryFragmentStorage()

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -175,7 +175,8 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
 
     def test_create_page_profile_message_is_fragment_run(self):
         ctx = get_script_run_ctx()
-        ctx.fragment_ids_this_run = {"some_fragment_id"}
+        ctx.script_requests = MagicMock()
+        ctx.script_requests.fragment_id_queue = ["some_fragment_id"]
 
         forward_msg = metrics_util.create_page_profile_message(
             commands=[

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -677,6 +677,10 @@ class SessionStateMethodTests(unittest.TestCase):
         assert not self.session_state._widget_changed("foo")
 
     def test_remove_stale_widgets(self):
+        ctx = get_script_run_ctx()
+        ctx.script_requests = MagicMock()
+        ctx.script_requests.fragment_id_queue = []
+
         existing_widget_key = f"{GENERATED_WIDGET_ID_PREFIX}-existing_widget"
         generated_widget_key = f"{GENERATED_WIDGET_ID_PREFIX}-removed_widget"
 


### PR DESCRIPTION
I realized while working on the `st.rerun(scope="fragment")` feature that `ctx. fragment_ids_this_run`
should always be `rerun_data.fragment_id_queue` in set form. We still want to keep the distinction
around since the frontend isn't aware of the order fragments will be run, but we should simplify things
to not needlessly copy around the same information in a slightly different representation.