### PR TITLE
Clarify page execution

### DIFF
--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -69,7 +69,7 @@ def navigation(
     ``streamlit run``) acts like a router or frame of common elements around
     each of your pages. Streamlit executes the entrypoint file with every app
     rerun. To execute the current page, you must call the ``.run()`` method on
-    the page object returned by ``st.navigation``.
+    the ``StreamlitPage`` object returned by ``st.navigation``.
 
     The set of available pages can be updated with each rerun for dynamic
     navigation. By default, ``st.navigation`` draws the available pages in the

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -110,7 +110,7 @@ def dialog_decorator(
     app should generally be stored in Session State.
 
     A user can dismiss a modal dialog by clicking outside of it, clicking the
-    "**X**" in its upper-right corner, or pressing``ESC`` on their keyboard.
+    "**X**" in its upper-right corner, or pressing ``ESC`` on their keyboard.
     Dismissing a modal dialog does not trigger an app rerun. To close the modal
     dialog programmatically, call ``st.rerun()`` explicitly inside of the
     dialog function.

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -95,7 +95,7 @@ class MediaMixin:
             one of the following:
 
             * ``None`` (default): The element plays from the beginning.
-            * An``int`` or ``float`` specifying the time in seconds. ``float``
+            * An ``int`` or ``float`` specifying the time in seconds. ``float``
               values are rounded down to whole seconds.
             * A string specifying the time in a format supported by `Pandas'
               Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -41,8 +41,8 @@ def Page(
     ``st.navigation`` to declare a page in your app.
 
     When a user navigates to a page, ``st.navigation`` returns the selected
-    ``StreamlitPage`` object. Call ``StreamlitPage.run()`` on the returned page
-    to execute the page. You can only run the page returned by
+    ``StreamlitPage`` object. Call ``.run()`` on the returned ``StreamlitPage``
+    object to execute the page. You can only run the page returned by
     ``st.navigation``, and you can only run it once per app rerun.
 
     A page can be defined by a Python file or ``Callable``.

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -45,9 +45,12 @@ def Page(
     object to execute the page. You can only run the page returned by
     ``st.navigation``, and you can only run it once per app rerun.
 
-    A page can be defined by a Python file or ``Callable``. Since a page is
-    executed from within the entrypoint file, page source code should not
-    include ``if __name__ == "__main__":`` blocks.
+    A page can be defined by a Python file or ``Callable``. Python files used
+    as a ``StreamlitPage`` source will have ``__name__ == "__page__"``.
+    Functions used as a ``StreamlitPage`` source will have ``__name__``
+    corresponding to the module they were imported from. Only the entrypoint
+    file and functions defined within the entrypoint file have
+    ``__name__ == "__main__"`` to adhere to Python convention.
 
     Parameters
     ----------

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -45,7 +45,9 @@ def Page(
     object to execute the page. You can only run the page returned by
     ``st.navigation``, and you can only run it once per app rerun.
 
-    A page can be defined by a Python file or ``Callable``.
+    A page can be defined by a Python file or ``Callable``. Since a page is
+    executed from within the entrypoint file, page source code should not
+    include ``if __name__ == "__main__":`` blocks.
 
     Parameters
     ----------


### PR DESCRIPTION
## Describe your changes
Clarify wording: call `.run()` as a method on the `StreamlitPage` object returned from `st.navigation`.

## GitHub Issue Link (if applicable)
Closes streamlit/docs#1102

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
