### PR TITLE
Implement st.rerun(scope="fragment")

### DIFF
--- a/e2e_playwright/st_rerun.py
+++ b/e2e_playwright/st_rerun.py
@@ -14,17 +14,31 @@
 
 import streamlit as st
 
+if "count" not in st.session_state:
+    st.session_state.count = 0
+    st.session_state.fragment_count = 0
 
-@st.cache_resource
-def rerun_record():
-    return [0]
+
+@st.fragment
+def my_fragment():
+    if st.button("rerun fragment"):
+        st.session_state.fragment_count += 1
+        st.rerun(scope="fragment")
+
+    st.write(f"fragment run count: {st.session_state.fragment_count}")
+
+    if st.session_state.fragment_count % 5 != 0:
+        st.session_state.fragment_count += 1
+        st.rerun(scope="fragment")
 
 
-count = rerun_record()
-count[0] += 1
+st.session_state.count += 1
 
-if count[0] < 4:
+if st.session_state.count < 4:
     st.rerun()
 
-if count[0] >= 4:
+if st.session_state.count >= 4:
     st.text("Being able to rerun a session is awesome!")
+
+my_fragment()
+st.write(f"app run count: {st.session_state.count}")

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -14,8 +14,26 @@
 
 from playwright.sync_api import Page, expect
 
+from e2e_playwright.shared.app_utils import click_button
+
 
 def test_st_rerun_restarts_the_session_when_invoked(app: Page):
     expect(app.get_by_test_id("stText")).to_have_text(
         "Being able to rerun a session is awesome!"
     )
+
+
+def test_fragment_scoped_st_rerun(app: Page):
+    expect(app.get_by_test_id("stText")).to_have_text(
+        "Being able to rerun a session is awesome!"
+    )
+
+    click_button(app, "rerun fragment")
+    expect(app.get_by_test_id("stMarkdown").first).to_have_text("fragment run count: 5")
+    expect(app.get_by_test_id("stMarkdown").last).to_have_text("app run count: 4")
+
+    click_button(app, "rerun fragment")
+    expect(app.get_by_test_id("stMarkdown").first).to_have_text(
+        "fragment run count: 10"
+    )
+    expect(app.get_by_test_id("stMarkdown").last).to_have_text("app run count: 4")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import os
-from typing import Final, NoReturn
+from itertools import dropwhile
+from typing import Final, Literal, NoReturn
 
 import streamlit as st
 from streamlit.errors import NoSessionContext, StreamlitAPIException
@@ -23,7 +24,11 @@ from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.logger import get_logger
 from streamlit.navigation.page import StreamlitPage
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner import RerunData, get_script_run_ctx
+from streamlit.runtime.scriptrunner import (
+    RerunData,
+    ScriptRunContext,
+    get_script_run_ctx,
+)
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -54,21 +59,75 @@ def stop() -> NoReturn:  # type: ignore[misc]
         st.empty()
 
 
+def _new_fragment_id_queue(
+    ctx: ScriptRunContext,
+    scope: Literal["app", "fragment"],
+) -> list[str]:
+    if scope == "app":
+        return []
+
+    else:  # scope == "fragment"
+        curr_queue = (
+            ctx.script_requests.fragment_id_queue if ctx.script_requests else []
+        )
+
+        # If st.rerun(scope="fragment") is called during a full script run, we raise an
+        # exception. This occurs, of course, if st.rerun(scope="fragment") is called
+        # outside of a fragment, but it somewhat surprisingly occurs if it gets called
+        # from within a fragment during a run of the full script. While this behvior may
+        # be surprising, it seems somewhat reasonable given that the correct behavior of
+        # calling st.rerun(scope="fragment") in this situation is unclear to me:
+        #   * Rerunning just the fragment immediately may cause weirdness down the line
+        #     as any part of the script that occurs after the fragment will not be
+        #     executed.
+        #   * Waiting until the full script run completes before rerunning the fragment
+        #     seems odd (even if we normally do this before running a fragment not
+        #     triggered by st.rerun()) because it defers the execution of st.rerun().
+        #   * Rerunning the full app feels incorrect as we're seemingly ignoring the
+        #     `scope` argument.
+        # With these issues and given that it seems pretty unnatural to have a
+        # fragment-scoped rerun happen during a full script run to begin with, it seems
+        # reasonable to just disallow this completely for now.
+        if not curr_queue:
+            raise StreamlitAPIException(
+                'scope="fragment" can only be specified from `@st.fragment`-decorated '
+                "functions during fragment reruns."
+            )
+
+        assert (
+            new_queue := list(
+                dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue)
+            )
+        ), "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+
+        return new_queue
+
+
 @gather_metrics("rerun")
-def rerun() -> NoReturn:  # type: ignore[misc]
+def rerun(  # type: ignore[misc]
+    *,  # The scope argument can only be passed via keyword.
+    scope: Literal["app", "fragment"] = "app",
+) -> NoReturn:
     """Rerun the script immediately.
 
     When ``st.rerun()`` is called, the script is halted - no more statements will
-    be run, and the script will be queued to re-run from the top.
+    be run, and the script will be queued to re-run.
+
+    Parameters
+    ----------
+    scope : Literal["app", "fragment"]
+        Specifies what part of the app should rerun. Setting scope="app" reruns the
+        full script; scope="fragment" limits the rerun to only the fragment from which
+        this function is called. If unspecified, defaults to "app".
+
+        Note that setting scope="fragment" is only valid
+            * inside of a fragment
+            * *not* during a full script run.
+        Passing this argument to ``st.rerun()`` from outside of a fragment or within a
+        fragment but when the full script is running raises a ``StreamlitAPIException``.
     """
 
     ctx = get_script_run_ctx()
-
-    # TODO: (rerun[scope] project): in order to make it a fragment-scoped rerun, pass
-    # the fragment_id_queue to the RerunData object and add the following line:
-    # fragment_id_queue=[ctx.current_fragment_id] if scope == "fragment" else []
-    # The script_runner RerunException is checking for the fragment_id_queue to decide
-    # whether or not to reset the dg_stack.
 
     if ctx and ctx.script_requests:
         query_string = ctx.query_string
@@ -78,6 +137,8 @@ def rerun() -> NoReturn:  # type: ignore[misc]
             RerunData(
                 query_string=query_string,
                 page_script_hash=page_script_hash,
+                fragment_id_queue=_new_fragment_id_queue(ctx, scope),
+                is_fragment_scoped_rerun=True,
             )
         )
         # Force a yield point so the runner can do the rerun

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -122,6 +122,7 @@ class AppSession:
             service that a Streamlit Runtime is running in wants to tie the lifecycle of
             a Streamlit session to some other session-like object that it manages.
         """
+
         # Each AppSession has a unique string ID.
         self.id = session_id_override or str(uuid.uuid4())
 
@@ -363,7 +364,7 @@ class AppSession:
                 client_state.widget_states,
                 client_state.page_script_hash,
                 client_state.page_name,
-                fragment_id_queue=[fragment_id] if fragment_id else [],
+                fragment_id=fragment_id if fragment_id else None,
             )
         else:
             rerun_data = RerunData()
@@ -371,7 +372,7 @@ class AppSession:
         if self._scriptrunner is not None:
             if (
                 bool(config.get_option("runner.fastReruns"))
-                and not rerun_data.fragment_id_queue
+                and not rerun_data.fragment_id
             ):
                 # If fastReruns is enabled and this is *not* a rerun of a fragment,
                 # we don't send rerun requests to our existing ScriptRunner. Instead, we
@@ -481,6 +482,7 @@ class AppSession:
         page_script_hash: str | None = None,
         fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
+        clear_forward_msg_queue: bool = True,
     ) -> None:
         """Called when our ScriptRunner emits an event.
 
@@ -498,6 +500,7 @@ class AppSession:
                 page_script_hash,
                 fragment_ids_this_run,
                 pages,
+                clear_forward_msg_queue,
             )
         )
 
@@ -511,6 +514,7 @@ class AppSession:
         page_script_hash: str | None = None,
         fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
+        clear_forward_msg_queue: bool = True,
     ) -> None:
         """Handle a ScriptRunner event.
 
@@ -546,6 +550,10 @@ class AppSession:
             The fragment IDs of the fragments being executed in this script run. Only
             set for the SCRIPT_STARTED event. If this value is falsy, this script run
             must be for the full script.
+
+        clear_forward_msg_queue : bool
+            If set (the default), clears the queue of forward messages to be sent to the
+            browser. Set only for the SCRIPT_STARTED event.
         """
 
         assert (
@@ -571,13 +579,7 @@ class AppSession:
                 page_script_hash is not None
             ), "page_script_hash must be set for the SCRIPT_STARTED event"
 
-            # When running the full script, we clear the browser ForwardMsg queue since
-            # anything from a previous script run that has yet to be sent to the browser
-            # will be overwritten. For fragment runs, however, we don't want to do this
-            # as the ForwardMsgs in the queue may not correspond to the running
-            # fragment, so dropping the messages may result in the app missing
-            # information.
-            if not fragment_ids_this_run:
+            if clear_forward_msg_queue:
                 self._clear_queue()
 
             self._enqueue_forward_msg(

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -98,6 +98,7 @@ class ForwardMsgQueue:
                 for msg in self._queue
                 if msg.WhichOneof("type")
                 in {
+                    "new_session",
                     "script_finished",
                     "session_status_changed",
                     "parent_message",

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -631,6 +631,7 @@ class Runtime:
 
                     for active_session_info in self._session_mgr.list_active_sessions():
                         msg_list = active_session_info.session.flush_browser_queue()
+
                         for msg in msg_list:
                             try:
                                 self._send_message(active_session_info, msg)

--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import TYPE_CHECKING, cast
 
@@ -48,7 +48,12 @@ class RerunData:
     widget_states: WidgetStates | None = None
     page_script_hash: str = ""
     page_name: str = ""
+
+    # A single fragment_id to append to fragment_id_queue.
+    fragment_id: str | None = None
+    # The queue of fragment_ids waiting to be run.
     fragment_id_queue: list[str] = field(default_factory=list)
+    is_fragment_scoped_rerun: bool = False
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -69,6 +74,20 @@ class ScriptRequest:
 
     def __repr__(self) -> str:
         return util.repr_(self)
+
+
+def _fragment_run_should_not_preempt_script(
+    fragment_id_queue: list[str],
+    is_fragment_scoped_rerun: bool,
+) -> bool:
+    """Returns whether the currently running script should be preempted due to a
+    fragment rerun.
+
+    Reruns corresponding to fragment runs that weren't caused by calls to
+    `st.rerun(scope="fragment")` should *not* cancel the current script run
+    as doing so will affect elements outside of the fragment.
+    """
+    return bool(fragment_id_queue) and not is_fragment_scoped_rerun
 
 
 class ScriptRequests:
@@ -117,6 +136,15 @@ class ScriptRequests:
                 # rerun it as of yet. We can handle a rerun request unconditionally so
                 # just change self._state and set self._rerun_data.
                 self._state = ScriptRequestType.RERUN
+
+                # Convert from a single fragment_id into fragment_id_queue.
+                if new_data.fragment_id:
+                    new_data = replace(
+                        new_data,
+                        fragment_id=None,
+                        fragment_id_queue=[new_data.fragment_id],
+                    )
+
                 self._rerun_data = new_data
                 return True
 
@@ -128,17 +156,17 @@ class ScriptRequests:
                     self._rerun_data.widget_states, new_data.widget_states
                 )
 
-                if new_data.fragment_id_queue:
-                    # This RERUN request corresponds to a fragment run. We append the
-                    # new fragment ID to the end of the current fragment_id_queue if it
-                    # isn't already contained in it.
+                if new_data.fragment_id:
+                    # This RERUN request corresponds to a new fragment run. We append
+                    # the new fragment ID to the end of the current fragment_id_queue if
+                    # it isn't already contained in it.
                     fragment_id_queue = [*self._rerun_data.fragment_id_queue]
-                    if (
-                        # new_data.fragment_id_queue is always a singleton
-                        (new_fragment_id := new_data.fragment_id_queue[0])
-                        not in fragment_id_queue
-                    ):
-                        fragment_id_queue.append(new_fragment_id)
+
+                    if new_data.fragment_id not in fragment_id_queue:
+                        fragment_id_queue.append(new_data.fragment_id)
+                elif new_data.fragment_id_queue:
+                    # new_data contains a new fragment_id_queue, so we just use it.
+                    fragment_id_queue = new_data.fragment_id_queue
                 else:
                     # Otherwise, this is a request to rerun the full script, so we want
                     # to clear out any fragments we have queued to run since they'll all
@@ -151,6 +179,7 @@ class ScriptRequests:
                     page_script_hash=new_data.page_script_hash,
                     page_name=new_data.page_name,
                     fragment_id_queue=fragment_id_queue,
+                    is_fragment_scoped_rerun=new_data.is_fragment_scoped_rerun,
                 )
 
                 return True
@@ -161,30 +190,35 @@ class ScriptRequests:
     def on_scriptrunner_yield(self) -> ScriptRequest | None:
         """Called by the ScriptRunner when it's at a yield point.
 
-        If we have no request or a RERUN request corresponding to one or more fragments,
-        return None.
+        If we have no request or a RERUN request corresponding to one or more fragments
+        (that is not a fragment-scoped rerun), return None.
 
-        If we have a (full script) RERUN request, return the request and set our internal
-        state to CONTINUE.
+        If we have a (full script or fragment-scoped) RERUN request, return the request
+        and set our internal state to CONTINUE.
 
         If we have a STOP request, return the request and remain stopped.
         """
         if self._state == ScriptRequestType.CONTINUE or (
-            # Reruns corresponding to fragments should *not* cancel the current script
-            # run as doing so will affect elements outside of the fragment.
             self._state == ScriptRequestType.RERUN
-            and self._rerun_data.fragment_id_queue
+            and _fragment_run_should_not_preempt_script(
+                self._rerun_data.fragment_id_queue,
+                self._rerun_data.is_fragment_scoped_rerun,
+            )
         ):
-            # We avoid taking the lock in the common cases of having no request and
-            # having a RERUN request corresponding to >=1 fragments. If a STOP or
-            # (full script) RERUN request is received between the `if` and `return`, it
+            # We avoid taking the lock in the common cases described above. If a STOP or
+            # preempting RERUN request is received after we've taken this code path, it
             # will be handled at the next `on_scriptrunner_yield`, or when
             # `on_scriptrunner_ready` is called.
             return None
 
         with self._lock:
             if self._state == ScriptRequestType.RERUN:
-                if self._rerun_data.fragment_id_queue:
+                # We already made this check in the fast-path above but need to do so
+                # again in case our state changed while we were waiting on the lock.
+                if _fragment_run_should_not_preempt_script(
+                    self._rerun_data.fragment_id_queue,
+                    self._rerun_data.is_fragment_scoped_rerun,
+                ):
                     return None
 
                 self._state = ScriptRequestType.CONTINUE

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -471,12 +471,22 @@ class ScriptRunner:
             )
             self._pages_manager.reset_active_script_hash()
 
+            # We want to clear the forward_msg_queue during full script runs and
+            # fragment-scoped fragment reruns. For normal fragment runs, clearing the
+            # forward_msg_queue may cause us to drop messages either corresponding to
+            # other, unrelated fragments or that this fragment run depends on.
+            fragment_ids_this_run = rerun_data.fragment_id_queue
+            clear_forward_msg_queue = (
+                not fragment_ids_this_run or rerun_data.is_fragment_scoped_rerun
+            )
+
             self.on_event.send(
                 self,
                 event=ScriptRunnerEvent.SCRIPT_STARTED,
                 page_script_hash=page_script_hash,
-                fragment_ids_this_run=rerun_data.fragment_id_queue,
+                fragment_ids_this_run=fragment_ids_this_run,
                 pages=self._pages_manager.get_pages(),
+                clear_forward_msg_queue=clear_forward_msg_queue,
             )
 
             # Compile the script. Any errors thrown here will be surfaced

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -1,0 +1,59 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+from streamlit.commands.execution_control import _new_fragment_id_queue
+from streamlit.errors import StreamlitAPIException
+
+
+class NewFragmentIdQueueTest(unittest.TestCase):
+    def test_returns_empty_list_if_scope_is_app(self):
+        assert _new_fragment_id_queue(None, scope="app") == []
+
+    def test_raises_exception_if_no_fragment_id_queue(self):
+        ctx = MagicMock()
+        ctx.script_requests.fragment_id_queue = []
+
+        with pytest.raises(StreamlitAPIException):
+            _new_fragment_id_queue(ctx, scope="fragment")
+
+    def test_asserts_if_curr_id_not_in_queue(self):
+        ctx = MagicMock()
+        ctx.script_requests.fragment_id_queue = ["some_fragment_id"]
+        ctx.current_fragment_id = "some_other_fragment_id"
+
+        with pytest.raises(AssertionError):
+            _new_fragment_id_queue(ctx, scope="fragment")
+
+    def test_drops_items_in_queue_until_curr_id(self):
+        ctx = MagicMock()
+        ctx.script_requests.fragment_id_queue = [
+            "id1",
+            "id2",
+            "id3",
+            "curr_id",
+            "id4",
+            "id5",
+        ]
+        ctx.current_fragment_id = "curr_id"
+
+        assert _new_fragment_id_queue(ctx, scope="fragment") == [
+            "curr_id",
+            "id4",
+            "id5",
+        ]

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -762,6 +762,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             event=ScriptRunnerEvent.SCRIPT_STARTED,
             page_script_hash="",
             fragment_ids_this_run=["my_fragment_id"],
+            clear_forward_msg_queue=False,
         )
 
         # Yield to let the AppSession's callbacks run.
@@ -775,6 +776,26 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         assert new_session_msg.fragment_ids_this_run == ["my_fragment_id"]
 
         add_script_run_ctx(ctx=orig_ctx)
+
+    async def test_clears_forward_msg_queue_by_default(self):
+        session = _create_test_session(asyncio.get_running_loop())
+
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+        session._clear_queue = MagicMock()
+
+        # Send a mock SCRIPT_STARTED event.
+        session._on_scriptrunner_event(
+            sender=mock_scriptrunner,
+            event=ScriptRunnerEvent.SCRIPT_STARTED,
+            page_script_hash="",
+            fragment_ids_this_run=["my_fragment_id"],
+        )
+
+        # Yield to let the AppSession's callbacks run.
+        await asyncio.sleep(0)
+
+        session._clear_queue.assert_called_once()
 
     async def test_events_handled_on_event_loop(self):
         """ScriptRunner events should be handled on the main thread only."""

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -226,6 +226,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         fmq.clear(retain_lifecycle_msgs=True)
         assert fmq._queue == [
+            NEW_SESSION_MSG,
             script_finished_msg,
             session_status_changed_msg,
             parent_msg,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_requests_test.py
@@ -166,15 +166,15 @@ class ScriptRequestsTest(unittest.TestCase):
     def test_request_rerun_appends_new_fragment_ids_to_queue(self):
         reqs = ScriptRequests()
 
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
+        reqs.request_rerun(RerunData(fragment_id="my_fragment1"))
 
         # Sanity check
         self.assertEqual(reqs._rerun_data.fragment_id_queue, ["my_fragment1"])
 
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment2"]))
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment3"]))
+        reqs.request_rerun(RerunData(fragment_id="my_fragment2"))
+        reqs.request_rerun(RerunData(fragment_id="my_fragment3"))
         # Test that duplicate fragment_id isn't appended to queue.
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
+        reqs.request_rerun(RerunData(fragment_id="my_fragment1"))
 
         self.assertEqual(
             reqs._rerun_data.fragment_id_queue,
@@ -187,9 +187,15 @@ class ScriptRequestsTest(unittest.TestCase):
 
     def test_request_rerun_appends_clears_fragment_queue_on_full_rerun(self):
         reqs = ScriptRequests()
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment2"]))
-        reqs.request_rerun(RerunData(fragment_id_queue=["my_fragment3"]))
+        reqs.request_rerun(
+            RerunData(
+                fragment_id_queue=[
+                    "my_fragment1",
+                    "my_fragment2",
+                    "my_fragment3",
+                ]
+            )
+        )
 
         # Sanity check
         self.assertEqual(
@@ -221,6 +227,24 @@ class ScriptRequestsTest(unittest.TestCase):
         self.assertEqual(ScriptRequestType.RERUN, reqs._state)
         self.assertEqual(
             reqs._rerun_data, RerunData(fragment_id_queue=["my_fragment_id"])
+        )
+
+    def test_on_script_yield_with_is_fragment_scoped_rerun(self):
+        """Return RERUN; transition to the CONTINUE state."""
+        rerun_data = RerunData(
+            fragment_id_queue=["my_fragment_id"], is_fragment_scoped_rerun=True
+        )
+        reqs = ScriptRequests()
+        reqs.request_rerun(rerun_data)
+
+        result = reqs.on_scriptrunner_yield()
+        self.assertEqual(ScriptRequest(ScriptRequestType.RERUN, rerun_data), result)
+        self.assertEqual(ScriptRequestType.CONTINUE, reqs._state)
+        self.assertEqual(
+            reqs._rerun_data,
+            RerunData(
+                fragment_id_queue=["my_fragment_id"], is_fragment_scoped_rerun=True
+            ),
         )
 
     def test_on_script_yield_with_stop_request(self):

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -337,11 +337,15 @@ class ScriptRunnerTest(AsyncTestCase):
         scriptrunner._fragment_storage.set("my_fragment2", fragment)
         scriptrunner._fragment_storage.set("my_fragment3", fragment)
 
-        # scriptrunner.request_rerun assumes that fragments will only ever be enqueued
-        # one at a time as that's what happens with real rerun requests.
-        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
-        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment2"]))
-        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment3"]))
+        scriptrunner.request_rerun(
+            RerunData(
+                fragment_id_queue=[
+                    "my_fragment1",
+                    "my_fragment2",
+                    "my_fragment3",
+                ]
+            )
+        )
         scriptrunner.start()
         scriptrunner.join()
 


### PR DESCRIPTION
This PR adds the new `scope` kwarg to the `st.rerun()` function. With `scope="app"` (the default),
`st.rerun()` work as before. If you set `scope="fragment"` within a fragment, however, it's now possible
to specify that only the currently running fragment reruns.