### PR TITLE
Support non-unix style paths for MPA loading

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -71,7 +71,10 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             # If the file is not found, and there are no reserved paths,
             # we try to serve the default file and allow the frontend to handle the issue.
             if e.status_code == 404:
-                if any(self.path.endswith(x) for x in self._reserved_paths):
+                url_path = self.path
+                if os.path.sep != "/":
+                    url_path = url_path.replace(os.path.sep, "/")
+                if any(url_path.endswith(x) for x in self._reserved_paths):
                     raise e
 
                 self.path = self.parse_url_path(self.default_filename or "index.html")

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -72,6 +72,8 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             # we try to serve the default file and allow the frontend to handle the issue.
             if e.status_code == 404:
                 url_path = self.path
+                # self.path is OS specific file path, we convert it to a URL path
+                # for checking it against reserved paths.
                 if os.path.sep != "/":
                     url_path = url_path.replace(os.path.sep, "/")
                 if any(url_path.endswith(x) for x in self._reserved_paths):


### PR DESCRIPTION
## Describe your changes

The Tornado StaticFileHandler converts `self.path` to an OS specific path. This caused issues notably on Windows computers for using `\` instead of `/` in detecting . 

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8958

## Testing Plan

- Our automated tests do not support Windows formats, but we have tested it manually on a windows computer and with a wheel file to our contributors.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
