### PR TITLE
Set theme hash properly on load if a custom theme is active to start

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -547,6 +547,36 @@ describe("App", () => {
       expect(props.theme.addThemes.mock.calls[1][0]).toEqual([])
     })
 
+    it("removes the cached custom theme from theme options", () => {
+      window.localStorage.setItem(
+        LocalStore.ACTIVE_THEME,
+        JSON.stringify({ name: CUSTOM_THEME_NAME, themeInput: {} })
+      )
+      const props = getProps({
+        theme: {
+          activeTheme: {
+            ...lightTheme,
+            name: CUSTOM_THEME_NAME,
+          },
+          availableThemes: [],
+          setTheme: jest.fn(),
+          addThemes: jest.fn(),
+          setImportedTheme: jest.fn(),
+        },
+      })
+      renderApp(props)
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: null,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      // @ts-expect-error
+      expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
+    })
+
     it("Does not change dark/light/auto user preferences when removing a custom theme", () => {
       const props = getProps()
       renderApp(props)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -65,6 +65,7 @@ import {
   CUSTOM_THEME_NAME,
   getCachedTheme,
   isPresetTheme,
+  toThemeInput,
   ThemeConfig,
   toExportedTheme,
   StreamlitEndpoints,
@@ -248,6 +249,16 @@ export class App extends PureComponent<Props, State> {
     // Initialize immerjs
     enableImmerPlugins()
 
+    // Theme hashes are only created for custom theme, and the custom theme
+    // may come from localStorage. We need to create the hash here to ensure
+    // that the theme is correctly represented.
+    let themeHash = this.createThemeHash()
+    if (!isPresetTheme(props.theme.activeTheme)) {
+      themeHash = this.createThemeHash(
+        toThemeInput(props.theme.activeTheme.emotion) as CustomThemeConfig
+      )
+    }
+
     this.state = {
       connectionState: ConnectionState.INITIAL,
       elements: AppRoot.empty("", true), // Blank Main Script Hash for initial render
@@ -265,7 +276,7 @@ export class App extends PureComponent<Props, State> {
       menuItems: undefined,
       allowRunOnSave: true,
       scriptFinishedHandlers: [],
-      themeHash: this.createThemeHash(),
+      themeHash,
       gitInfo: null,
       formsData: createFormsData(),
       appPages: [],


### PR DESCRIPTION
## Describe your changes

If someone where to remove a theme configuration and restart the server, the custom theme won't be removed. This is because the initial theme hash and the theme config hash (which is the default `null` hash) are the same. This PR sets the theme hash correctly to start, so that a custom theme will be unset if the theme configuration is removed.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/8962

## Testing Plan

- Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
