### PR TITLE
Support `graphviz.sources.Source` object for `st.graphviz_chart`

### DIFF
--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
 
     from streamlit.delta_generator import DeltaGenerator
 
-FigureOrDot: TypeAlias = Union["graphviz.Graph", "graphviz.Digraph", str]
+FigureOrDot: TypeAlias = Union[
+    "graphviz.Graph", "graphviz.Digraph", "graphviz.Source", str
+]
 
 
 class GraphvizMixin:
@@ -46,7 +48,7 @@ class GraphvizMixin:
 
         Parameters
         ----------
-        figure_or_dot : graphviz.dot.Graph, graphviz.dot.Digraph, str
+        figure_or_dot : graphviz.dot.Graph, graphviz.dot.Digraph, graphviz.sources.Source, str
             The Graphlib graph object or dot string to display
 
         use_container_width : bool

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -459,6 +459,7 @@ def is_graphviz_chart(
         # GraphViz >= 0.18
         or is_type(obj, "graphviz.graphs.Graph")
         or is_type(obj, "graphviz.graphs.Digraph")
+        or is_type(obj, "graphviz.sources.Source")
     )
 
 

--- a/lib/tests/streamlit/elements/graphviz_test.py
+++ b/lib/tests/streamlit/elements/graphviz_test.py
@@ -73,3 +73,14 @@ class GraphvizTest(DeltaGeneratorTestCase):
             c = self.get_delta_from_queue().new_element.graphviz_chart
             self.assertEqual(hasattr(c, "engine"), True)
             self.assertEqual(c.engine, engine)
+
+    def test_source(self):
+        """Test that it can be called with graphviz.sources.Source object."""
+        graph = graphviz.Source(
+            'digraph "the holy hand grenade" { rankdir=LR; 1 -> 2 -> 3 -> lob }'
+        )
+
+        st.graphviz_chart(graph)
+
+        c = self.get_delta_from_queue().new_element.graphviz_chart
+        self.assertIn("grenade", getattr(c, "spec"))


### PR DESCRIPTION
## Describe your changes

[graphviz.Source](https://graphviz.readthedocs.io/en/stable/api.html#graphviz.Source) object holding raw DOT string, so we can just get it.

Here are related docs: https://graphviz.readthedocs.io/en/stable/manual.html#using-raw-dot

In a private project, I encountered this problem, so I fixed it to make it easier for others.

## Testing Plan

Unit tests

- Added unit test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
