### PR TITLE
Fix: MPA duplicate page name key error

### DIFF
--- a/frontend/app/src/components/Sidebar/SidebarNav.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.tsx
@@ -67,14 +67,14 @@ const SidebarNav = ({
   }, [expanded])
 
   const generateNavLinks = useCallback(
-    (page: IAppPage) => {
+    (page: IAppPage, index: number) => {
       const pageUrl = endpoints.buildAppPageURL(pageLinkBaseUrl, page)
       const pageName = page.pageName as string
       const tooltipContent = pageName.replace(/_/g, " ")
       const isActive = page.pageScriptHash === currentPageScriptHash
 
       return (
-        <li key={pageName}>
+        <li key={`${pageName}-${index}`}>
           <SidebarNavLink
             isActive={isActive}
             pageUrl={pageUrl}


### PR DESCRIPTION
## Describe your changes
PR appends an index to the `pageName` passed as the React key when rendering page links in the sidebar navigation in order to resolve a bug encountered trying to write e2e test for MPAv2 custom theme fix.

Handles edge case where if an app runs MPAv2 and there are duplicate page names in the pages folder (transitioning from MPAv1 for example), one of the pages remains in the sidebar page navigation menu:

<img width="300" src="https://github.com/streamlit/streamlit/assets/63436329/8f6888e5-a2cf-4f90-bda7-73dc34cae2d3">

## GitHub Issue Link (if applicable)
Closes #9006
