### PR TITLE
Don't remove session refs on fragment runs

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -426,8 +426,12 @@ class ScriptRunner:
             start_time: float = timer()
             prep_time: float = 0  # This will be overwritten once preparations are done.
 
-            # Reset DeltaGenerators, widgets, media files.
-            runtime.get_instance().media_file_mgr.clear_session_refs()
+            if not rerun_data.fragment_id_queue:
+                # Don't clear session refs for media files if we're running a fragment.
+                # Otherwise, we're likely to remove files that still have corresponding
+                # download buttons/links to them present in the app, which will result
+                # in a 404 should the user click on them.
+                runtime.get_instance().media_file_mgr.clear_session_refs()
 
             self._pages_manager.set_script_intent(
                 rerun_data.page_script_hash, rerun_data.page_name

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -88,6 +88,7 @@ class ScriptRunnerTest(AsyncTestCase):
         mock_runtime.media_file_mgr = MediaFileManager(
             MemoryMediaFileStorage("/mock/media")
         )
+        mock_runtime.media_file_mgr.clear_session_refs = MagicMock()
         Runtime._instance = mock_runtime
 
     def tearDown(self) -> None:
@@ -280,6 +281,8 @@ class ScriptRunnerTest(AsyncTestCase):
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
 
+        Runtime._instance.media_file_mgr.clear_session_refs.assert_called_once()
+
     @patch("streamlit.exception")
     def test_run_nonexistent_fragment(self, patched_st_exception):
         """Tests that we raise an exception when trying to run a nonexistent fragment."""
@@ -355,6 +358,7 @@ class ScriptRunnerTest(AsyncTestCase):
         )
 
         fragment.assert_has_calls([call(), call(), call()])
+        Runtime._instance.media_file_mgr.clear_session_refs.assert_not_called()
 
     def test_compile_error(self):
         """Tests that we get an exception event when a script can't compile."""


### PR DESCRIPTION
It turns out #8932 was simply caused by us removing files added to the `MediaFileManager` too aggressively.
In full script runs, we can always remove session refs and clear out files from previous script runs as the whole
app is about to be redrawn anyway. When running fragments, however, doing so may leave links/buttons to a
now nonexistent file in the app, and this causes the user to hit a 404 when they click on the link/button. This PR
fixes this issue by simply not clearing file session refs during fragment runs.

Closes #8932 