### PR TITLE
Throw/expect more specific error when hitting KeyErrors in FragmentStorage methods

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -38,6 +38,13 @@ class DeprecationError(Error):
     pass
 
 
+class FragmentStorageKeyError(Error, KeyError):
+    """A KeyError raised when a KeyError is encountered during a FragmentStorage
+    operation."""
+
+    pass
+
+
 class NoStaticFiles(Error):
     pass
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, overload
 
+from streamlit.errors import FragmentStorageKeyError
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
@@ -103,13 +104,19 @@ class MemoryFragmentStorage(FragmentStorage):
                 del self._fragments[fid]
 
     def get(self, key: str) -> Fragment:
-        return self._fragments[key]
+        try:
+            return self._fragments[key]
+        except KeyError as e:
+            raise FragmentStorageKeyError(str(e))
 
     def set(self, key: str, value: Fragment) -> None:
         self._fragments[key] = value
 
     def delete(self, key: str) -> None:
-        del self._fragments[key]
+        try:
+            del self._fragments[key]
+        except KeyError as e:
+            raise FragmentStorageKeyError(str(e))
 
     def contains(self, key: str) -> bool:
         return key in self._fragments

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Callable, Final
 from blinker import Signal
 
 from streamlit import config, runtime, util
+from streamlit.errors import FragmentStorageKeyError
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -572,7 +573,7 @@ class ScriptRunner:
                                 )
                                 wrapped_fragment()
 
-                            except KeyError:
+                            except FragmentStorageKeyError:
                                 raise RuntimeError(
                                     f"Could not find fragment with id {fragment_id}"
                                 )

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator, dg_stack
+from streamlit.errors import FragmentStorageKeyError
 from streamlit.runtime.fragment import MemoryFragmentStorage, fragment
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner.exceptions import RerunException
@@ -48,8 +49,8 @@ class MemoryFragmentStorageTest(unittest.TestCase):
     def test_get(self):
         assert self._storage.get("some_key") == "some_fragment"
 
-    def test_get_KeyError(self):
-        with pytest.raises(KeyError):
+    def test_get_FragmentStorageKeyError(self):
+        with pytest.raises(FragmentStorageKeyError):
             self._storage.get("nonexistent_key")
 
     def test_set(self):
@@ -61,11 +62,11 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
     def test_delete(self):
         self._storage.delete("some_key")
-        with pytest.raises(KeyError):
+        with pytest.raises(FragmentStorageKeyError):
             self._storage.get("nonexistent_key")
 
-    def test_del_KeyError(self):
-        with pytest.raises(KeyError):
+    def test_del_FragmentStorageKeyError(self):
+        with pytest.raises(FragmentStorageKeyError):
             self._storage.delete("nonexistent_key")
 
     def test_clear(self):

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -26,6 +26,7 @@ import pytest
 from parameterized import parameterized
 from tornado.testing import AsyncTestCase
 
+from streamlit.errors import FragmentStorageKeyError
 from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.Element_pb2 import Element
@@ -363,6 +364,38 @@ class ScriptRunnerTest(AsyncTestCase):
 
         fragment.assert_has_calls([call(), call(), call()])
         Runtime._instance.media_file_mgr.clear_session_refs.assert_not_called()
+
+    @patch("streamlit.runtime.scriptrunner.exec_code.handle_uncaught_app_exception")
+    def test_FragmentStorageKeyError_becomes_RuntimeError(
+        self, patched_handle_exception
+    ):
+        fragment = MagicMock()
+        fragment.side_effect = FragmentStorageKeyError("kaboom")
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.set("my_fragment", fragment)
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        ex = patched_handle_exception.call_args[0][0]
+        assert isinstance(ex, RuntimeError)
+
+    @patch("streamlit.runtime.scriptrunner.exec_code.handle_uncaught_app_exception")
+    def test_regular_KeyError_is_rethrown(self, patched_handle_exception):
+        fragment = MagicMock()
+        fragment.side_effect = KeyError("kaboom")
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.set("my_fragment", fragment)
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        ex = patched_handle_exception.call_args[0][0]
+        assert isinstance(ex, KeyError)
 
     def test_compile_error(self):
         """Tests that we get an exception event when a script can't compile."""


### PR DESCRIPTION
A source of many (but potentially not all) of the reports in #8494 involve a silly mistake that I made
where we're catching all `KeyError`s that may be thrown from a fragment and interpreting them as
coming from when we attempted to fetch the fragment from our `FragmentStorage`. Of course, they
could also be coming from the fragment function itself, and in these cases we're currently raising an
error with a misleading / incorrect / opaque message.

This PR fixes this issue by throwing and expecting a more specific subclass of `KeyError` in
`FragmentStorage` operations