### PR TITLE
Improve chat input docstring for fragment usage

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -298,8 +298,8 @@ class ChatMixin:
             height: 350px
 
         The chat input can also be used inline by nesting it inside any layout
-        container (container, columns, tabs, sidebar, etc) or fragment. Create 
-        chat interfaces embedded next to other content or have multiple 
+        container (container, columns, tabs, sidebar, etc) or fragment. Create
+        chat interfaces embedded next to other content or have multiple
         chatbots!
 
         >>> import streamlit as st

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -298,8 +298,9 @@ class ChatMixin:
             height: 350px
 
         The chat input can also be used inline by nesting it inside any layout
-        container (container, columns, tabs, sidebar, etc). Create chat
-        interfaces embedded next to other content or have multiple chat bots!
+        container (container, columns, tabs, sidebar, etc) or fragment. Create 
+        chat interfaces embedded next to other content or have multiple 
+        chatbots!
 
         >>> import streamlit as st
         >>>


### PR DESCRIPTION
## Describe your changes

Using a fragment via `@st.experimental_fragment` implicitly creates a container, so using `st.chat_input` inside a fragment will make the fragment not show up at the bottom of the screen. This PR slightly updates the docstring of `st.chat_input` to make that a bit more explicit. 

## GitHub Issue Link (if applicable)

## Testing Plan

Only docstring change. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
