### PR TITLE
feature: add server.init

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -829,6 +829,15 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "server.init",
+    description="""
+        Call specified function on startup.
+        """,
+    default_val="",
+    type_=str,
+)
+
 # Config Section: Browser #
 
 _create_section("browser", "Configuration of non-UI browser options.")

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -18,6 +18,7 @@ import asyncio
 import os
 import signal
 import sys
+import importlib
 from typing import Any, Final
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets, util
@@ -315,6 +316,13 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
             watch_file(filename, on_config_changed)
 
 
+def _run_init_script():
+    init = config.get_option("server.init")
+    if init:
+        mod, func = init.split(":")
+        getattr(importlib.import_module(mod), func)()
+
+
 def run(
     main_script_path: str,
     is_hello: bool,
@@ -331,6 +339,7 @@ def run(
     _fix_pydeck_mapbox_api_warning()
     _fix_pydantic_duplicate_validators_error()
     _install_config_watchers(flag_options)
+    _run_init_script()
 
     # Create the server. It won't start running yet.
     server = Server(main_script_path, is_hello)


### PR DESCRIPTION
## Describe your changes

Add --server.init option which loads a specific user specified function on startup.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/8991

## Testing Plan

- Explanation of why no additional tests are needed
   - I do not know how to add them. Please assist me.
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

I cloned my repository and executed `make develop`. Then I created a file named `main.py`:

```
import streamlit as st

def init():
    print("initialize")

st.write("hello world")
```

and then executed streamlit with it:

```
$ streamlit run --server.init=main:init ./main.py 
2024-07-02 13:18:00.367 WARNING streamlit.config: 
Warning: the config option 'server.enableCORS=false' is not compatible with 'server.enableXsrfProtection=true'.
As a result, 'server.enableCORS' is being overridden to 'true'.

More information:
In order to protect against CSRF attacks, we send a cookie with each request.
To do so, we must specify allowable origins, which places a restriction on
cross-origin resource sharing.

If cross origin resource sharing is required, please disable server.enableXsrfProtection.
            
2024-07-02 13:18:00.383 WARNING streamlit: 
  Warning: to view this Streamlit app on a browser, run it with the following
  command:

    streamlit run ./main.py [ARGUMENTS]
initialize
2024-07-02 13:18:00.383 DEBUG   streamlit.web.server.server: Starting server...
2024-07-02 13:18:00.383 DEBUG   streamlit.web.server.server: Serving static content from the Node dev server
2024-07-02 13:18:00.385 DEBUG   streamlit.web.server.server: Server started on port 8501
2024-07-02 13:18:00.385 DEBUG   streamlit.runtime.runtime: Runtime state: RuntimeState.INITIAL -> RuntimeState.NO_SESSIONS_CONNECTED

  You can now view your Streamlit app in your browser.

  Local URL: http://localhost:3000
  Network URL: http://192.168.1.17:3000

2024-07-02 13:18:00.410 DEBUG   streamlit.web.bootstrap: Setting up signal handler
```

and there is initialize printed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
