### PR TITLE
Fix lag when closing dialog

### DIFF
--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -70,9 +70,14 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     [width, theme]
   )
 
+  // don't use the Modal's isOpen prop as it feels laggy when using it
+  if (!isOpen) {
+    return <></>
+  }
+
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       closeable={dismissible}
       onClose={() => setIsOpen(false)}
       size={size}


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/8747

Instead of using Baseweb Modal's `isOpen` prop, we return an empty element when `isOpen` is set. This fixes the issue, see video:

https://github.com/streamlit/streamlit/assets/3775781/84149d04-6b80-4922-baa2-cd0b007a5f83


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
