### PR TITLE
Bundle policy checks in convenient function for widget checks

### DIFF
--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -43,11 +43,7 @@ from streamlit.elements.lib.column_config_utils import (
 )
 from streamlit.elements.lib.event_utils import AttributeDictionary
 from streamlit.elements.lib.pandas_styler_utils import marshall_styler
-from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_session_state_rules,
-)
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
@@ -489,10 +485,15 @@ class ArrowMixin:
 
         if is_selection_activated:
             # Run some checks that are only relevant when selections are activated
-            check_cache_replay_rules()
-            if callable(on_select):
-                check_callback_rules(self.dg, on_select)
-            check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+            is_callback = callable(on_select)
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=cast(WidgetCallback, on_select) if is_callback else None,
+                default_value=None,
+                writes_allowed=False,
+                enable_check_callback_rules=is_callback,
+            )
 
         # Convert the user provided column config into the frontend compatible format:
         column_config_mapping = process_config_mapping(column_config)

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -30,8 +30,8 @@ _LOGGER: Final = logger.get_logger(__name__)
 
 
 def check_callback_rules(dg: DeltaGenerator, on_change: WidgetCallback | None) -> None:
-    """Ensures that widgets other than `st.form_submit` within a form don't have an \
-        on_change callback set.
+    """Ensures that widgets other than `st.form_submit_button` within a form don't have
+    an on_change callback set.
 
     Raises
     ------
@@ -52,12 +52,11 @@ _shown_default_value_warning: bool = False
 def check_session_state_rules(
     default_value: Any, key: str | None, writes_allowed: bool = True
 ) -> None:
-    """Ensures that no values are set for widgets with the given key when writing \
-        is not allowed.
+    """Ensures that no values are set for widgets with the given key when writing
+    is not allowed.
 
     Additionally, if `global.disableWidgetStateDuplicationWarning` is False a warning is
-      shown when a widget has a default value but its value is also set via
-      session state.
+    shown when a widget has a default value but its value is also set via session state.
 
     Raises
     ------
@@ -75,8 +74,8 @@ def check_session_state_rules(
 
     if not writes_allowed:
         raise StreamlitAPIException(
-            f'Values for the widget with key "{key}" cannot be set using \
-                `st.session_state`.'
+            f"Values for the widget with key '{key}' cannot be set using"
+            " `st.session_state`."
         )
 
     if (
@@ -131,7 +130,7 @@ _fragment_writes_widget_to_outside_error = (
 
 
 def check_fragment_path_policy(dg: DeltaGenerator):
-    """Ensures that the current widget is not written outside of the \
+    """Ensures that the current widget is not written outside of the
     fragment's delta path.
 
     Should be called by ever element that acts as a widget.

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -168,13 +168,19 @@ def check_widget_policies(
     dg: DeltaGenerator,
     key: str | None,
     on_change: WidgetCallback | None = None,
-    default: Sequence[Any] | Any | None = None,
+    *,
+    default_value: Sequence[Any] | Any | None = None,
+    writes_allowed: bool = True,
+    enable_check_callback_rules: bool = True,
 ):
     """Check all widget policies for the given DeltaGenerator."""
     check_fragment_path_policy(dg)
     check_cache_replay_rules()
-    check_callback_rules(dg, on_change)
-    check_session_state_rules(default_value=default, key=key, writes_allowed=True)
+    if enable_check_callback_rules:
+        check_callback_rules(dg, on_change)
+    check_session_state_rules(
+        default_value=default_value, key=key, writes_allowed=writes_allowed
+    )
 
 
 def maybe_raise_label_warnings(label: str | None, label_visibility: str | None):

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -38,12 +38,7 @@ from streamlit import type_util
 from streamlit.deprecation_util import show_deprecation_warning
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.event_utils import AttributeDictionary
-from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
-)
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.streamlit_plotly_theme import (
     configure_streamlit_plotly_theme,
 )
@@ -467,11 +462,15 @@ class PlotlyMixin:
         if is_selection_activated:
             # Run some checks that are only relevant when selections are activated
 
-            check_fragment_path_policy(self.dg)
-            check_cache_replay_rules()
-            if callable(on_select):
-                check_callback_rules(self.dg, on_select)
-            check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+            is_callback = callable(on_select)
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=cast(WidgetCallback, on_select) if is_callback else None,
+                default_value=None,
+                writes_allowed=False,
+                enable_check_callback_rules=is_callback,
+            )
 
         if type_util.is_type(figure_or_data, "matplotlib.figure.Figure"):
             # Convert matplotlib figure to plotly figure:

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -24,12 +24,7 @@ from typing_extensions import TypeAlias
 
 from streamlit import runtime
 from streamlit.elements.form import current_form_id, is_in_form
-from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
-)
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
@@ -600,9 +595,13 @@ class ButtonMixin:
     ) -> bool:
         key = to_key(key)
 
-        check_cache_replay_rules()
-        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
-        check_callback_rules(self.dg, on_click)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_click,
+            default_value=None,
+            writes_allowed=False,
+        )
 
         id = compute_widget_id(
             "download_button",
@@ -764,11 +763,14 @@ class ButtonMixin:
     ) -> bool:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        if not is_form_submitter:
-            check_callback_rules(self.dg, on_click)
-        check_cache_replay_rules()
-        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_click,
+            default_value=None,
+            writes_allowed=False,
+            enable_check_callback_rules=not is_form_submitter,
+        )
 
         id = compute_widget_id(
             "button",

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -22,10 +22,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -206,10 +203,13 @@ class CameraInputMixin:
     ) -> UploadedFile | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None,
+            writes_allowed=False,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -21,12 +21,7 @@ from typing import TYPE_CHECKING, Literal, cast
 from streamlit import runtime
 from streamlit.elements.form import is_in_form
 from streamlit.elements.image import AtomicImage, WidthBehaviour, image_to_url
-from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
-)
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
@@ -317,10 +312,13 @@ class ChatMixin:
         default = ""
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_submit)
-        check_session_state_rules(default_value=default, key=key, writes_allowed=False)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_submit,
+            default_value=default,
+            writes_allowed=False,
+        )
 
         ctx = get_script_run_ctx()
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -288,11 +285,11 @@ class CheckboxMixin:
     ) -> bool:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(
-            default_value=None if value is False else value, key=key
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None if value is False else value,
         )
         maybe_raise_label_warnings(label, label_visibility)
 

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -21,10 +21,7 @@ from typing import TYPE_CHECKING, cast
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -182,10 +179,12 @@ class ColorPickerMixin:
     ) -> str:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=value, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -54,12 +54,7 @@ from streamlit.elements.lib.column_config_utils import (
     update_column_config,
 )
 from streamlit.elements.lib.pandas_styler_utils import marshall_styler
-from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
-)
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
@@ -786,10 +781,13 @@ class DataEditorMixin:
 
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None,
+            writes_allowed=False,
+        )
 
         if column_order is not None:
             column_order = list(column_order)

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -23,10 +23,7 @@ from typing_extensions import TypeAlias
 from streamlit import config
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -405,10 +402,13 @@ class FileUploaderMixin:
     ) -> UploadedFile | list[UploadedFile] | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None,
+            writes_allowed=False,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -21,10 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast, overlo
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -291,10 +288,12 @@ class MultiSelectMixin:
     ) -> list[T]:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=default, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=default,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_sequence(options)

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -23,10 +23,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -289,11 +286,11 @@ class NumberInputMixin:
     ) -> Number | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(
-            default_value=value if value != "min" else None, key=key
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value if value != "min" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -21,10 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -257,10 +254,12 @@ class RadioMixin:
     ) -> T | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None if index == 0 else index, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None if index == 0 else index,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_sequence(options)

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -23,9 +23,7 @@ from typing_extensions import TypeGuard
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -262,9 +260,12 @@ class SelectSliderMixin:
     ) -> T | tuple[T, T]:
         key = to_key(key)
 
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=value, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_sequence(options)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -237,10 +234,12 @@ class SelectboxMixin:
     ) -> T | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None if index == 0 else index, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None if index == 0 else index,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_sequence(options)

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -24,10 +24,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -375,10 +372,12 @@ class SliderMixin:
     ) -> SliderReturn:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=value, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING, Literal, cast, overload
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -264,10 +261,12 @@ class TextWidgetsMixin:
     ) -> str | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None if value == "" else value, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None if value == "" else value,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         # Make sure value is always string or None:
@@ -534,10 +533,12 @@ class TextWidgetsMixin:
     ) -> str | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=None if value == "" else value, key=key)
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None if value == "" else value,
+        )
         maybe_raise_label_warnings(label, label_visibility)
 
         value = str(value) if value is not None else None

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -34,10 +34,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
-    check_cache_replay_rules,
-    check_callback_rules,
-    check_fragment_path_policy,
-    check_session_state_rules,
+    check_widget_policies,
     maybe_raise_label_warnings,
 )
 from streamlit.elements.lib.utils import (
@@ -434,11 +431,11 @@ class TimeWidgetsMixin:
     ) -> time | None:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(
-            default_value=value if value != "now" else None, key=key
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value if value != "now" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
 
@@ -699,11 +696,11 @@ class TimeWidgetsMixin:
     ) -> DateWidgetReturn:
         key = to_key(key)
 
-        check_fragment_path_policy(self.dg)
-        check_cache_replay_rules()
-        check_callback_rules(self.dg, on_change)
-        check_session_state_rules(
-            default_value=value if value != "default_value_today" else None, key=key
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value if value != "default_value_today" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
 

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -26,7 +26,9 @@ from streamlit.type_util import is_altair_version_less_than
 ELEMENT_PRODUCER = Callable[[], Any]
 
 WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
+    # buttons
     ("button", lambda: st.button("Click me")),
+    ("download_button", lambda: st.download_button("Download me", b"")),
     ("camera_input", lambda: st.camera_input("Take a picture")),
     ("chat_input", lambda: st.chat_input("Chat with me")),
     # checkboxes
@@ -41,6 +43,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("radio", lambda: st.radio("Choose me", ["a", "b", "c"])),
     ("slider", lambda: st.slider("Slide me")),
     ("selectbox", lambda: st.selectbox("Select me", ["a", "b", "c"])),
+    ("select_slider", lambda: st.select_slider("Select me", ["a", "b", "c"])),
     # text_widgets
     ("text_area", lambda: st.text_area("Write me")),
     ("text_input", lambda: st.text_input("Write me")),

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -36,8 +36,12 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("toggle", lambda: st.toggle("Toggle me")),
     # end checkboxes
     ("color_picker", lambda: st.color_picker("Pick a color")),
+    # arrows
     ("data_editor", lambda: st.data_editor(pd.DataFrame())),
+    ("dataframe", lambda: st.dataframe(pd.DataFrame(), on_select="rerun")),
+    # media manager
     ("file_uploader", lambda: st.file_uploader("Upload me")),
+    # selectors
     ("multiselect", lambda: st.multiselect("Show me", ["a", "b", "c"])),
     ("number_input", lambda: st.number_input("Enter a number")),
     ("radio", lambda: st.radio("Choose me", ["a", "b", "c"])),

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -121,7 +121,7 @@ class CheckSessionStateRules(ElementPoliciesTest):
         with pytest.raises(StreamlitAPIException) as e:
             check_session_state_rules(5, key=_KEY, writes_allowed=False)
 
-        assert 'Values for the widget with key "the key"' in str(e.value)
+        assert "Values for the widget with key 'the key'" in str(e.value)
 
 
 class SpecialSessionStatesTest(ElementPoliciesTest):


### PR DESCRIPTION
## Describe your changes

We run the following checks for all widgets:
- `check_fragment_path_policy`
- `check_cache_replay_rules`
- `check_callback_rules`
- `check_session_state_rules` 

This PR introduces that instead of calling them individually, we call a convenient function. This prevents missing any checks for new widgets.
Also, the `check_fragment_path` call was missing in `select_slider` and `download_button` and `dataframe`.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
 - Add a unit test to ensure that all relevant path policies are called when calling the new function
 - Add missing check_fragment_path checks for `select_slider` and `download_button` and `dataframe`
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
