### PR TITLE
Fix broken `st.navigation` docstring

### DIFF
--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -155,7 +155,7 @@ def navigation(
     >>> st.sidebar.selectbox("Foo", ["A", "B", "C"], key="foo")
     >>> st.sidebar.checkbox("Bar", key="bar")
     >>>
-    >>> pg = st.navigation(st.Page(page1), st.Page(page2))
+    >>> pg = st.navigation([st.Page(page1), st.Page(page2)])
     >>> pg.run()
 
     """


### PR DESCRIPTION
## Describe your changes

The `st.navigation` docstring third example was broken -> it lacked `[]` around the function `pages` argument.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9026

## Testing Plan

It's a minor typo in a docstring so not much testing required I guess

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
