### PR TITLE
Simplify `convert_anything_to_df` utility method

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -51,7 +51,7 @@ def marshall(
     if dataframe_util.is_pandas_styler(data):
         pandas_styler_utils.marshall_styler(proto, data, default_uuid)  # type: ignore
 
-    df = dataframe_util.convert_anything_to_df(data)
+    df = dataframe_util.convert_anything_to_pandas_df(data)
     _marshall_index(proto, df.index)
     _marshall_columns(proto, df.columns)
     _marshall_data(proto, df)

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from pandas import DataFrame, Index, Series
     from pandas.core.indexing import _iLocIndexer
     from pandas.io.formats.style import Styler
-    from pandas.io.formats.style_renderer import StyleRenderer
 
 _LOGGER: Final = logger.get_logger(__name__)
 
@@ -261,11 +260,7 @@ def convert_anything_to_pandas_df(
         return data.copy() if ensure_copy else cast(pd.DataFrame, data)
 
     if is_pandas_styler(data):
-        # Every Styler is a StyleRenderer. I'm casting to StyleRenderer here rather than to the more
-        # correct Styler becayse MyPy doesn't like when we cast to Styler. It complains .data
-        # doesn't exist, when it does in fact exist in the parent class StyleRenderer!
-        sr = cast("StyleRenderer", data)
-        return cast("DataFrame", sr.data.copy() if ensure_copy else sr.data)
+        return cast("DataFrame", data.data.copy() if ensure_copy else data.data)  # type: ignore
 
     if is_type(data, "numpy.ndarray"):
         return pd.DataFrame([]) if len(data.shape) == 0 else pd.DataFrame(data)
@@ -277,8 +272,8 @@ def convert_anything_to_pandas_df(
 
         if data.shape[0] == max_unevaluated_rows:
             st.caption(
-                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
-                "Call `_to_pandas()` on the dataframe to show more."
+                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} "
+                "rows. Call `_to_pandas()` on the dataframe to show more."
             )
         return cast(pd.DataFrame, data)
 
@@ -286,8 +281,8 @@ def convert_anything_to_pandas_df(
         data = data.limit(max_unevaluated_rows).toPandas()
         if data.shape[0] == max_unevaluated_rows:
             st.caption(
-                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
-                "Call `toPandas()` on the dataframe to show more."
+                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} "
+                "rows. Call `toPandas()` on the dataframe to show more."
             )
         return cast(pd.DataFrame, data)
 
@@ -295,8 +290,8 @@ def convert_anything_to_pandas_df(
         data = data.limit(max_unevaluated_rows).to_pandas()
         if data.shape[0] == max_unevaluated_rows:
             st.caption(
-                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
-                "Call `to_pandas()` on the dataframe to show more."
+                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} "
+                "rows. Call `to_pandas()` on the dataframe to show more."
             )
         return cast(pd.DataFrame, data)
 
@@ -308,8 +303,8 @@ def convert_anything_to_pandas_df(
 
         if data.shape[0] == max_unevaluated_rows:
             st.caption(
-                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
-                "Call `to_pandas()` on the dataframe to show more."
+                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} "
+                "rows. Call `to_pandas()` on the dataframe to show more."
             )
         return cast(pd.DataFrame, data)
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -260,7 +260,7 @@ def convert_anything_to_pandas_df(
         return data.copy() if ensure_copy else cast(pd.DataFrame, data)
 
     if is_pandas_styler(data):
-        return cast("DataFrame", data.data.copy() if ensure_copy else data.data)  # type: ignore
+        return cast("DataFrame", data.data.copy() if ensure_copy else data.data)
 
     if is_type(data, "numpy.ndarray"):
         return pd.DataFrame([]) if len(data.shape) == 0 else pd.DataFrame(data)

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -246,8 +246,8 @@ def convert_anything_to_pandas_df(
         taking max_unevaluated_rows, defaults to 10k and 100 for st.table
 
     ensure_copy: bool
-        If True, make sure to always return a copy of the data. If False, it depends on the
-        type of the data. For example, a Pandas DataFrame will be returned as-is.
+        If True, make sure to always return a copy of the data. If False, it depends on
+        the type of the data. For example, a Pandas DataFrame will be returned as-is.
 
     Returns
     -------

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -705,8 +705,10 @@ def _prep_data_for_add_rows(
     add_rows_metadata: AddRowsMetadata | None,
 ) -> tuple[Data, AddRowsMetadata | None]:
     if not add_rows_metadata:
-        # When calling add_rows on st.table or st.dataframe we want styles to pass through.
-        return dataframe_util.convert_anything_to_df(data, allow_styler=True), None
+        if dataframe_util.is_pandas_styler(data):
+            # When calling add_rows on st.table or st.dataframe we want styles to pass through.
+            return data, None
+        return dataframe_util.convert_anything_to_pandas_df(data), None
 
     # If add_rows_metadata is set, it indicates that the add_rows used called
     # on a chart based on our built-in chart commands.

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -528,7 +528,9 @@ class ArrowMixin:
                 marshall_styler(proto, data, default_uuid)
 
             # Convert the input data into a pandas.DataFrame
-            data_df = dataframe_util.convert_anything_to_df(data, ensure_copy=False)
+            data_df = dataframe_util.convert_anything_to_pandas_df(
+                data, ensure_copy=False
+            )
             apply_data_specific_configs(
                 column_config_mapping,
                 data_df,
@@ -616,7 +618,9 @@ class ArrowMixin:
         # Check if data is uncollected, and collect it but with 100 rows max, instead of 10k rows, which is done in all other cases.
         # Avoid this and use 100 rows in st.table, because large tables render slowly, take too much screen space, and can crush the app.
         if dataframe_util.is_unevaluated_data_object(data):
-            data = dataframe_util.convert_anything_to_df(data, max_unevaluated_rows=100)
+            data = dataframe_util.convert_anything_to_pandas_df(
+                data, max_unevaluated_rows=100
+            )
 
         # If pandas.Styler uuid is not provided, a hash of the position
         # of the element will be used. This will cause a rerender of the table
@@ -718,5 +722,5 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
     if isinstance(data, pa.Table):
         proto.data = dataframe_util.pyarrow_table_to_bytes(data)
     else:
-        df = dataframe_util.convert_anything_to_df(data)
+        df = dataframe_util.convert_anything_to_pandas_df(data)
         proto.data = dataframe_util.data_frame_to_bytes(df)

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -135,7 +135,7 @@ def generate_chart(
     """Function to use the chart's type, data columns and indices to figure out the chart's spec."""
     import altair as alt
 
-    df = dataframe_util.convert_anything_to_df(data, ensure_copy=True)
+    df = dataframe_util.convert_anything_to_pandas_df(data, ensure_copy=True)
 
     # From now on, use "df" instead of "data". Deleting "data" to guarantee we follow this.
     del data
@@ -254,7 +254,7 @@ def prep_chart_data_for_add_rows(
     """
     import pandas as pd
 
-    df = cast(pd.DataFrame, dataframe_util.convert_anything_to_df(data))
+    df = cast(pd.DataFrame, dataframe_util.convert_anything_to_pandas_df(data))
 
     # Make range indices start at last_index.
     if isinstance(df.index, pd.RangeIndex):
@@ -394,7 +394,7 @@ def _last_index_for_melted_dataframes(
     data: DataFrameCompatible | Any,
 ) -> Hashable | None:
     if dataframe_util.is_dataframe_compatible(data):
-        data = dataframe_util.convert_anything_to_df(data)
+        data = dataframe_util.convert_anything_to_pandas_df(data)
 
         if data.index.size > 0:
             return cast(Hashable, data.index[-1])

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -263,7 +263,7 @@ def to_deckgl_json(
     if hasattr(data, "empty") and data.empty:
         return json.dumps(_DEFAULT_MAP)
 
-    df = dataframe_util.convert_anything_to_df(data)
+    df = dataframe_util.convert_anything_to_pandas_df(data)
 
     lat_col_name = _get_lat_or_lon_col_name(df, "latitude", lat, _DEFAULT_LAT_COL_NAMES)
     lon_col_name = _get_lat_or_lon_col_name(

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -282,7 +282,7 @@ def _serialize_data(data: Any) -> bytes:
     if isinstance(data, pa.Table):
         return dataframe_util.pyarrow_table_to_bytes(data)
 
-    df = dataframe_util.convert_anything_to_df(data)
+    df = dataframe_util.convert_anything_to_pandas_df(data)
     return dataframe_util.data_frame_to_bytes(df)
 
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -805,7 +805,7 @@ class DataEditorMixin:
 
         # The dataframe should always be a copy of the original data
         # since we will apply edits directly to it.
-        data_df = dataframe_util.convert_anything_to_df(data, ensure_copy=True)
+        data_df = dataframe_util.convert_anything_to_pandas_df(data, ensure_copy=True)
 
         # Check if the index is supported.
         if not _is_supported_index(data_df.index):

--- a/lib/tests/streamlit/dataframe_coercion_test.py
+++ b/lib/tests/streamlit/dataframe_coercion_test.py
@@ -29,7 +29,7 @@ class DataFrameCoercionTest(unittest.TestCase):
         of equal-length lists
         """
         d = {"a": [1], "b": [2], "c": [3]}
-        df = dataframe_util.convert_anything_to_df(d)
+        df = dataframe_util.convert_anything_to_pandas_df(d)
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(df.shape, (1, 3))
 
@@ -38,7 +38,7 @@ class DataFrameCoercionTest(unittest.TestCase):
         from an empty numpy array.
         """
         arr = np.array([])
-        df = dataframe_util.convert_anything_to_df(arr)
+        df = dataframe_util.convert_anything_to_pandas_df(arr)
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(df.shape, (0, 1))
 
@@ -46,7 +46,7 @@ class DataFrameCoercionTest(unittest.TestCase):
         """Test that a DataFrame can be constructed from a pandas.Styler"""
         d = {"a": [1], "b": [2], "c": [3]}
         styler = pd.DataFrame(d).style.format("{:.2%}")
-        df = dataframe_util.convert_anything_to_df(styler)
+        df = dataframe_util.convert_anything_to_pandas_df(styler)
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(df.shape, (1, 3))
 
@@ -54,6 +54,6 @@ class DataFrameCoercionTest(unittest.TestCase):
         """Test that a DataFrame can be constructed from a pyarrow.Table"""
         d = {"a": [1], "b": [2], "c": [3]}
         table = pa.Table.from_pandas(pd.DataFrame(d))
-        df = dataframe_util.convert_anything_to_df(table)
+        df = dataframe_util.convert_anything_to_pandas_df(table)
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(df.shape, (1, 3))

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -63,7 +63,7 @@ class TypeUtilTest(unittest.TestCase):
         """Test that `convert_anything_to_df` correctly converts
         a variety of types to a DataFrame.
         """
-        converted_df = dataframe_util.convert_anything_to_df(input_data)
+        converted_df = dataframe_util.convert_anything_to_pandas_df(input_data)
         self.assertIsInstance(converted_df, pd.DataFrame)
         self.assertEqual(converted_df.shape[0], metadata.expected_rows)
         self.assertEqual(converted_df.shape[1], metadata.expected_cols)
@@ -88,7 +88,7 @@ class TypeUtilTest(unittest.TestCase):
         the row count is > 1000.
         """
         with patch("streamlit.caption") as mock:
-            converted_df = dataframe_util.convert_anything_to_df(
+            converted_df = dataframe_util.convert_anything_to_pandas_df(
                 input_data, max_unevaluated_rows=1000
             )
             self.assertIsInstance(converted_df, pd.DataFrame)
@@ -107,7 +107,7 @@ class TypeUtilTest(unittest.TestCase):
             index=[1.0, "foo", 3],
         )
 
-        converted_df = dataframe_util.convert_anything_to_df(
+        converted_df = dataframe_util.convert_anything_to_pandas_df(
             orginal_df, ensure_copy=True
         )
         # Apply a change
@@ -115,7 +115,7 @@ class TypeUtilTest(unittest.TestCase):
         # Ensure that the original dataframe is not changed
         self.assertEqual(orginal_df["integer"].to_list(), [1, 2, 3])
 
-        converted_df = dataframe_util.convert_anything_to_df(
+        converted_df = dataframe_util.convert_anything_to_pandas_df(
             orginal_df, ensure_copy=False
         )
         # Apply a change
@@ -128,45 +128,8 @@ class TypeUtilTest(unittest.TestCase):
         key-value dicts to a dataframe.
         """
         data = {"a": 1, "b": 2}
-        df = dataframe_util.convert_anything_to_df(data)
+        df = dataframe_util.convert_anything_to_pandas_df(data)
         pd.testing.assert_frame_equal(df, pd.DataFrame.from_dict(data, orient="index"))
-
-    def test_convert_anything_to_df_passes_styler_through(self):
-        """Test that `convert_anything_to_df` correctly passes Stylers through."""
-        original_df = pd.DataFrame(
-            {
-                "integer": [1, 2, 3],
-                "float": [1.0, 2.1, 3.2],
-                "string": ["foo", "bar", None],
-            },
-            index=[1.0, "foo", 3],
-        )
-
-        original_styler = original_df.style.highlight_max(axis=0)
-
-        out = dataframe_util.convert_anything_to_df(original_styler, allow_styler=True)
-        self.assertEqual(original_styler, out)
-        self.assertEqual(id(original_df), id(out.data))
-
-    def test_convert_anything_to_df_clones_stylers(self):
-        """Test that `convert_anything_to_df` correctly clones Stylers."""
-        original_df = pd.DataFrame(
-            {
-                "integer": [1, 2, 3],
-                "float": [1.0, 2.1, 3.2],
-                "string": ["foo", "bar", None],
-            },
-            index=[1.0, "foo", 3],
-        )
-
-        original_styler = original_df.style.highlight_max(axis=0)
-
-        out = dataframe_util.convert_anything_to_df(
-            original_styler, allow_styler=True, ensure_copy=True
-        )
-        self.assertNotEqual(original_styler, out)
-        self.assertNotEqual(id(original_df), id(out.data))
-        pd.testing.assert_frame_equal(original_df, out.data)
 
     def test_convert_anything_to_df_converts_stylers(self):
         """Test that `convert_anything_to_df` correctly converts Stylers to DF, without cloning the
@@ -183,7 +146,7 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = dataframe_util.convert_anything_to_df(original_styler, allow_styler=False)
+        out = dataframe_util.convert_anything_to_pandas_df(original_styler)
         self.assertNotEqual(id(original_styler), id(out))
         self.assertEqual(id(original_df), id(out))
         pd.testing.assert_frame_equal(original_df, out)
@@ -201,8 +164,8 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = dataframe_util.convert_anything_to_df(
-            original_styler, allow_styler=False, ensure_copy=True
+        out = dataframe_util.convert_anything_to_pandas_df(
+            original_styler, ensure_copy=True
         )
         self.assertNotEqual(id(original_styler), id(out))
         self.assertNotEqual(id(original_df), id(out))
@@ -213,7 +176,7 @@ class TypeUtilTest(unittest.TestCase):
             def to_pandas(self):
                 return pd.DataFrame([])
 
-        converted = dataframe_util.convert_anything_to_df(DataFrameIsh())
+        converted = dataframe_util.convert_anything_to_pandas_df(DataFrameIsh())
         assert isinstance(converted, pd.DataFrame)
         assert converted.empty
 
@@ -494,7 +457,7 @@ class TypeUtilTest(unittest.TestCase):
         """Test that `convert_df_to_data_format` correctly converts a
         DataFrame to the specified data format.
         """
-        converted_df = dataframe_util.convert_anything_to_df(input_data)
+        converted_df = dataframe_util.convert_anything_to_pandas_df(input_data)
         self.assertEqual(converted_df.shape[0], metadata.expected_rows)
         self.assertEqual(converted_df.shape[1], metadata.expected_cols)
 
@@ -533,7 +496,7 @@ class TypeUtilTest(unittest.TestCase):
                     self.assertEqual(str(converted_data), str(input_data))
                     pd.testing.assert_frame_equal(
                         converted_df,
-                        dataframe_util.convert_anything_to_df(converted_data),
+                        dataframe_util.convert_anything_to_pandas_df(converted_data),
                     )
 
     def test_convert_df_to_data_format_with_unknown_data_format(self):

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -180,7 +180,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
 
         with patch(
-            "streamlit.dataframe_util.convert_anything_to_df"
+            "streamlit.dataframe_util.convert_anything_to_pandas_df"
         ) as convert_anything_to_df:
             convert_anything_to_df.return_value = df
 

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -119,7 +119,7 @@ class ArrowTest(DeltaGeneratorTestCase):
         df = mock_data_frame()
 
         with patch(
-            "streamlit.dataframe_util.convert_anything_to_df"
+            "streamlit.dataframe_util.convert_anything_to_pandas_df"
         ) as convert_anything_to_df:
             convert_anything_to_df.return_value = df
 

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -79,7 +79,7 @@ class StMapTest(DeltaGeneratorTestCase):
     def test_map_uses_convert_anything_to_df(self):
         """Test that st.map uses convert_anything_to_df to convert input data."""
         with mock.patch(
-            "streamlit.dataframe_util.convert_anything_to_df"
+            "streamlit.dataframe_util.convert_anything_to_pandas_df"
         ) as convert_anything_to_df:
             convert_anything_to_df.return_value = mock_df
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -128,7 +128,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
         chart = alt.Chart(df).mark_bar().encode(x="a", y="b")
 
         with mock.patch(
-            "streamlit.dataframe_util.convert_anything_to_df"
+            "streamlit.dataframe_util.convert_anything_to_pandas_df"
         ) as convert_anything_to_df:
             convert_anything_to_df.return_value = df
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -557,7 +557,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
         """Test that st.vega_lite_chart uses convert_anything_to_df to convert input data."""
 
         with patch(
-            "streamlit.dataframe_util.convert_anything_to_df"
+            "streamlit.dataframe_util.convert_anything_to_pandas_df"
         ) as convert_anything_to_df:
             convert_anything_to_df.return_value = df1
 


### PR DESCRIPTION
## Describe your changes

Simplifies the `convert_anything_to_df` utility method:
- Renames `convert_anything_to_df` to `convert_anything_to_pandas_df`
- Remove the `allow_styler` parameter since it's only used in one place. 

## Testing Plan

- No logic was changed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
