### PR TITLE
Refactor and simplify the `ensure_indexable` utility method

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import contextlib
-import copy
 import math
 from enum import Enum, EnumMeta, auto
 from typing import (
@@ -31,14 +30,13 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload,
 )
 
 from typing_extensions import TypeAlias, TypeGuard
 
 import streamlit as st
 from streamlit import config, errors, logger, string_util
-from streamlit.type_util import is_iterable, is_type
+from streamlit.type_util import is_type
 
 if TYPE_CHECKING:
     import numpy as np

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -352,6 +352,8 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
         The converted sequence.
     """
     if isinstance(obj, (list, tuple, set, EnumMeta)):
+        # This also ensures that the sequence is copied to prevent
+        # potential mutations to the original object.
         return list(obj)
 
     try:
@@ -361,9 +363,7 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
         # widget affect the widget.
         # (See https://github.com/streamlit/streamlit/issues/7534)
         data_df = convert_anything_to_pandas_df(obj, ensure_copy=True)
-        # Return first column as a pd.Series
-        # The type of the elements in this column is not known up front, hence
-        # the Iterable[Any] return type.
+        # Return first column as a list:
         return (
             [] if data_df.empty else cast(Sequence[V_co], data_df.iloc[:, 0].to_list())
         )

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -352,15 +352,7 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     if obj is None:
         return []  # type: ignore
 
-    if isinstance(obj, str):
-        # String is a special case: theoretically it is iterable, but we don't want
-        # to iterate over its characters. Instead, we raise a TypeError.
-        raise TypeError(
-            "Object is not an iterable and could not be converted to one. "
-            f"Object type: {type(obj)}"
-        )
-
-    if isinstance(obj, (list, tuple, set, range, EnumMeta)):
+    if isinstance(obj, (str, list, tuple, set, range, EnumMeta)):
         # This also ensures that the sequence is copied to prevent
         # potential mutations to the original object.
         return list(obj)

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -368,8 +368,9 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     if isinstance(obj, dict):
         return list(obj.keys())
 
+    # Fallback to our DataFrame conversion logic:
     try:
-        # We use ensure_copy here because the return value of this function is saved
+        # We use ensure_copy here because the return value of this function is
         # saved in a widget serde class instance to be used in later script runs,
         # and we don't want mutations to the options object passed to a
         # widget affect the widget.

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -352,7 +352,15 @@ def convert_anything_to_sequence(obj: Any) -> Sequence[Any]:
     if obj is None:
         return []
 
-    if isinstance(obj, (str, list, tuple, set, range, EnumMeta)):
+    if isinstance(obj, str):
+        # String is a special case: theoretically it is iterable, but we don't want
+        # to iterate over its characters. Instead, we raise a TypeError.
+        raise TypeError(
+            "Object is not an iterable and could not be converted to one. "
+            f"Object type: {type(obj)}"
+        )
+
+    if isinstance(obj, (list, tuple, set, range, EnumMeta)):
         # This also ensures that the sequence is copied to prevent
         # potential mutations to the original object.
         return list(obj)

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -335,7 +335,7 @@ Offending object:
 def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     """Try to convert different formats to an indexable Sequence.
 
-    If the input is a dataframe-like object, we can just select the first
+    If the input is a dataframe-like object, we just select the first
     column to iterate over. If the input cannot be converted to a sequence,
     a TypeError is raised.
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -332,7 +332,7 @@ Offending object:
         ) from ex
 
 
-def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
+def convert_anything_to_sequence(obj: Any) -> Sequence[Any]:
     """Try to convert different formats to an indexable Sequence.
 
     If the input is a dataframe-like object, we can just select the first
@@ -349,10 +349,16 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     Sequence
         The converted sequence.
     """
-    if isinstance(obj, (list, tuple, set, EnumMeta)):
+    if obj is None:
+        return []
+
+    if isinstance(obj, (str, list, tuple, set, range, EnumMeta)):
         # This also ensures that the sequence is copied to prevent
         # potential mutations to the original object.
         return list(obj)
+
+    if isinstance(obj, dict):
+        return list(obj.keys())
 
     try:
         # We use ensure_copy here because the return value of this function is saved
@@ -363,7 +369,7 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
         data_df = convert_anything_to_pandas_df(obj, ensure_copy=True)
         # Return first column as a list:
         return (
-            [] if data_df.empty else cast(Sequence[V_co], data_df.iloc[:, 0].to_list())
+            [] if data_df.empty else cast(Sequence[Any], data_df.iloc[:, 0].to_list())
         )
     except errors.StreamlitAPIException as e:
         raise TypeError(

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -372,64 +372,44 @@ Offending object:
         ) from ex
 
 
-@overload
-def ensure_iterable(obj: Iterable[V_co]) -> Iterable[V_co]: ...
+def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
+    """Try to convert different formats to an indexable Sequence.
 
-
-@overload
-def ensure_iterable(obj: OptionSequence[V_co]) -> Iterable[Any]: ...
-
-
-def ensure_iterable(obj: OptionSequence[V_co] | Iterable[V_co]) -> Iterable[Any]:
-    """Try to convert different formats to something iterable. Most inputs
-    are assumed to be iterable, but if we have a DataFrame, we can just
-    select the first column to iterate over. If the input is not iterable,
+    If the input is a dataframe-like object, we can just select the first
+    column to iterate over. If the input cannot be converted to a sequence,
     a TypeError is raised.
 
     Parameters
     ----------
-    obj : list, tuple, numpy.ndarray, pandas.Series, pandas.DataFrame, pyspark.sql.DataFrame, snowflake.snowpark.dataframe.DataFrame or snowflake.snowpark.table.Table
+    obj : OptionSequence
+        The object to convert to a sequence.
 
     Returns
     -------
-    iterable
-
+    Sequence
+        The converted sequence.
     """
+    if isinstance(obj, (list, tuple, set, EnumMeta)):
+        return list(obj)
 
-    if is_unevaluated_data_object(obj):
-        obj = convert_anything_to_df(obj)
-
-    if is_dataframe(obj):
+    try:
+        # We use ensure_copy here because the return value of this function is saved
+        # saved in a widget serde class instance to be used in later script runs,
+        # and we don't want mutations to the options object passed to a
+        # widget affect the widget.
+        # (See https://github.com/streamlit/streamlit/issues/7534)
+        data_df = convert_anything_to_df(obj, ensure_copy=True)
         # Return first column as a pd.Series
         # The type of the elements in this column is not known up front, hence
         # the Iterable[Any] return type.
-        return cast(Iterable[Any], obj.iloc[:, 0])
-
-    if is_iterable(obj):
-        return obj
-
-    raise TypeError(
-        f"Object is not an iterable and could not be converted to one. Object: {obj}"
-    )
-
-
-def ensure_indexable(obj: OptionSequence[V_co]) -> Sequence[V_co]:
-    """Try to ensure a value is an indexable Sequence. If the collection already
-    is one, it has the index method that we need. Otherwise, convert it to a list.
-    """
-    it = ensure_iterable(obj)
-    # This is an imperfect check because there is no guarantee that an `index`
-    # function actually does the thing we want.
-    index_fn = getattr(it, "index", None)
-    if callable(index_fn) and type(it) != EnumMeta:
-        # We return a shallow copy of the Sequence here because the return value of
-        # this function is saved in a widget serde class instance to be used in later
-        # script runs, and we don't want mutations to the options object passed to a
-        # widget affect the widget.
-        # (See https://github.com/streamlit/streamlit/issues/7534)
-        return copy.copy(cast(Sequence[V_co], it))
-    else:
-        return list(it)
+        return (
+            [] if data_df.empty else cast(Sequence[V_co], data_df.iloc[:, 0].to_list())
+        )
+    except errors.StreamlitAPIException as e:
+        raise TypeError(
+            "Object is not an iterable and could not be converted to one. "
+            f"Object type: {type(obj)}"
+        ) from e
 
 
 def _maybe_truncate_table(

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -332,7 +332,7 @@ Offending object:
         ) from ex
 
 
-def convert_anything_to_sequence(obj: Any) -> Sequence[Any]:
+def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     """Try to convert different formats to an indexable Sequence.
 
     If the input is a dataframe-like object, we can just select the first
@@ -350,7 +350,7 @@ def convert_anything_to_sequence(obj: Any) -> Sequence[Any]:
         The converted sequence.
     """
     if obj is None:
-        return []
+        return []  # type: ignore
 
     if isinstance(obj, str):
         # String is a special case: theoretically it is iterable, but we don't want
@@ -377,7 +377,7 @@ def convert_anything_to_sequence(obj: Any) -> Sequence[Any]:
         data_df = convert_anything_to_pandas_df(obj, ensure_copy=True)
         # Return first column as a list:
         return (
-            [] if data_df.empty else cast(Sequence[Any], data_df.iloc[:, 0].to_list())
+            [] if data_df.empty else cast(Sequence[V_co], data_df.iloc[:, 0].to_list())
         )
     except errors.StreamlitAPIException as e:
         raise TypeError(

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast, overload
 
-from streamlit.dataframe_util import OptionSequence, ensure_indexable
+from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
@@ -297,7 +297,7 @@ class MultiSelectMixin:
         check_session_state_rules(default_value=default, key=key)
         maybe_raise_label_warnings(label, label_visibility)
 
-        opt = ensure_indexable(options)
+        opt = convert_anything_to_sequence(options)
         check_python_comparable(opt)
 
         indices = _check_and_convert_to_indices(opt, default)

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 
-from streamlit.dataframe_util import OptionSequence, ensure_indexable
+from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
@@ -263,7 +263,7 @@ class RadioMixin:
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
         maybe_raise_label_warnings(label, label_visibility)
 
-        opt = ensure_indexable(options)
+        opt = convert_anything_to_sequence(options)
         check_python_comparable(opt)
 
         id = compute_widget_id(

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, Tuple, cast
 
 from typing_extensions import TypeGuard
 
-from streamlit.dataframe_util import OptionSequence, ensure_indexable
+from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
@@ -267,7 +267,7 @@ class SelectSliderMixin:
         check_session_state_rules(default_value=value, key=key)
         maybe_raise_label_warnings(label, label_visibility)
 
-        opt = ensure_indexable(options)
+        opt = convert_anything_to_sequence(options)
         check_python_comparable(opt)
 
         if len(opt) == 0:

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 
-from streamlit.dataframe_util import OptionSequence, ensure_indexable
+from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
@@ -243,7 +243,7 @@ class SelectboxMixin:
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
         maybe_raise_label_warnings(label, label_visibility)
 
-        opt = ensure_indexable(options)
+        opt = convert_anything_to_sequence(options)
         check_python_comparable(opt)
 
         id = compute_widget_id(

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import random
 from datetime import date
 from typing import NamedTuple
@@ -215,3 +216,21 @@ SHARED_TEST_CASES = [
 class TestObject(object):
     def __str__(self):
         return "TestObject"
+
+
+class StrTestEnum(str, enum.Enum):
+    NUMBER_INPUT = "st.number_input"
+    TEXT_AREA = "st.text_area"
+    TEXT_INPUT = "st.text_input"
+
+
+class TestEnum(enum.Enum):
+    NUMBER_INPUT = "st.number_input"
+    TEXT_AREA = "st.text_area"
+    TEXT_INPUT = "st.text_input"
+
+
+def data_generator():
+    yield "st.number_input"
+    yield "st.text_area"
+    yield "st.text_input"

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -698,6 +698,8 @@ class DataframeUtilTest(unittest.TestCase):
             (StrTestEnum, ["st.number_input", "st.text_area", "st.text_input"]),
             # Generator:
             (data_generator(), ["st.number_input", "st.text_area", "st.text_input"]),
+            # String:
+            ("abc", ["a", "b", "c"]),
             # Enumerate:
             (
                 enumerate(["st.number_input", "st.text_area", "st.text_input"]),

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -705,8 +705,6 @@ class DataframeUtilTest(unittest.TestCase):
                 enumerate(["st.number_input", "st.text_area", "st.text_input"]),
                 [0, 1, 2],
             ),
-            # String:
-            ("abc", ["a", "b", "c"]),
             # Range:
             (range(3), [0, 1, 2]),
             # Pandas Dataframe:

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -620,14 +620,14 @@ class TypeUtilTest(unittest.TestCase):
 
     def test_ensure_indexable_object_is_indexable(self):
         l1 = ["a", "b", "c"]
-        l2 = dataframe_util.ensure_indexable(l1)
+        l2 = dataframe_util.convert_anything_to_sequence(l1)
 
         # Assert that l1 was shallow copied into l2.
         self.assertFalse(l1 is l2)
         self.assertEqual(l1, l2)
 
     def test_ensure_indexable_object_not_indexable(self):
-        l = dataframe_util.ensure_indexable({"a", "b", "c"})
+        l = dataframe_util.convert_anything_to_sequence({"a", "b", "c"})
         self.assertIn("a", l)
         self.assertIn("b", l)
         self.assertIn("c", l)
@@ -643,10 +643,10 @@ class TypeUtilTest(unittest.TestCase):
             OPT1 = "a"
             OPT2 = "b"
 
-        l = dataframe_util.ensure_indexable(Opt)
+        l = dataframe_util.convert_anything_to_sequence(Opt)
         self.assertEqual(list(Opt), l)
 
-        l = dataframe_util.ensure_indexable(StrOpt)
+        l = dataframe_util.convert_anything_to_sequence(StrOpt)
         self.assertEqual(list(StrOpt), l)
 
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -722,6 +722,8 @@ class DataframeUtilTest(unittest.TestCase):
                 pd.DataFrame(["st.number_input", "st.text_area", "st.text_input"]),
                 ["st.number_input", "st.text_area", "st.text_input"],
             ),
+            # Dataframe with multiple columns (widgets & types)
+            # The first column is expected to be selected as the sequence.
             (
                 pd.DataFrame(
                     {

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -858,6 +858,8 @@ class DataframeUtilTest(unittest.TestCase):
         a variety of types to a sequence.
         """
         converted_sequence = dataframe_util.convert_anything_to_sequence(input_data)
+        # We convert to a set for the check since some of the formats don't
+        # have a guaranteed order.
         self.assertEqual(set(converted_sequence), set(result_sequence))
         # Check that it is a new object and not the same as the input:
         assert converted_sequence is not input_data

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -598,8 +598,8 @@ class DataframeUtilTest(unittest.TestCase):
         self.assertFalse(l1 is l2)
         self.assertEqual(l1, l2)
 
-    def test_ensure_indexable_object_not_indexable(self):
-        converted_list = dataframe_util.ensure_indexable({"a", "b", "c"})
+    def test_convert_anything_to_sequence_object_not_indexable(self):
+        converted_list = dataframe_util.convert_anything_to_sequence({"a", "b", "c"})
         self.assertIn("a", converted_list)
         self.assertIn("b", converted_list)
         self.assertIn("c", converted_list)
@@ -615,10 +615,10 @@ class DataframeUtilTest(unittest.TestCase):
             OPT1 = "a"
             OPT2 = "b"
 
-        converted_list = dataframe_util.ensure_indexable(Opt)
+        converted_list = dataframe_util.convert_anything_to_sequence(Opt)
         self.assertEqual(list(Opt), converted_list)
 
-        converted_list = dataframe_util.ensure_indexable(StrOpt)
+        converted_list = dataframe_util.convert_anything_to_sequence(StrOpt)
         self.assertEqual(list(StrOpt), converted_list)
 
     @parameterized.expand(

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -856,7 +856,7 @@ class DataframeUtilTest(unittest.TestCase):
         a variety of types to a sequence.
         """
         converted_sequence = dataframe_util.convert_anything_to_sequence(input_data)
-        self.assertEquals(set(converted_sequence), set(result_sequence))
+        self.assertEqual(set(converted_sequence), set(result_sequence))
         # Check that it is a new object and not the same as the input:
         assert converted_sequence is not input_data
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -835,6 +835,20 @@ class DataframeUtilTest(unittest.TestCase):
                 ),
                 ["st.number_input", "st.text_area", "st.text_input"],
             ),
+            # Modin Dataframe:
+            (
+                ModinDataFrame(
+                    pd.DataFrame(["st.number_input", "st.text_area", "st.text_input"])
+                ),
+                ["st.number_input", "st.text_area", "st.text_input"],
+            ),
+            # Modin Series:
+            (
+                ModinSeries(
+                    pd.Series(["st.number_input", "st.text_area", "st.text_input"])
+                ),
+                ["st.number_input", "st.text_area", "st.text_input"],
+            ),
         ]
     )
     def test_convert_anything_to_sequence(

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -135,7 +135,7 @@ class Multiselectbox(DeltaGeneratorTestCase):
         self.assertListEqual(c.default[:], [])
         self.assertEqual(c.options, [])
 
-    @parameterized.expand([(15, TypeError), ("str", TypeError)])
+    @parameterized.expand([(15, TypeError)])
     def test_invalid_options(self, options, expected):
         """Test that it handles invalid options."""
         with self.assertRaises(expected):


### PR DESCRIPTION
## Describe your changes

Refactors and simplifies the `ensure_indexable` utility method used to process options in `multiselect`, `radio`, `select_slider`, and `selectbox`:

- Renames from `ensure_indexable` to `convert_anything_to_sequence` to better align with the `convert_anything_to_pandas_df` method. 
- Refactors the logic as preparation to support more data formats.
- Adds a parameterized test to test against a variety of data formats.

## Testing Plan

- Add a huge selection of data formats to test against in unit tests to extend coverage. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
