### PR TITLE
Refactor and simplify dataframe related type checks

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -74,7 +74,7 @@ def _marshall_index(proto: ArrowTableProto, index: Index) -> None:
 
     index = map(_maybe_tuple_to_list, index.values)
     index_df = pd.DataFrame(index)
-    proto.index = dataframe_util.data_frame_to_bytes(index_df)
+    proto.index = dataframe_util.convert_pandas_df_to_arrow_bytes(index_df)
 
 
 def _marshall_columns(proto: ArrowTableProto, columns: Series) -> None:
@@ -94,7 +94,7 @@ def _marshall_columns(proto: ArrowTableProto, columns: Series) -> None:
 
     columns = map(_maybe_tuple_to_list, columns.values)
     columns_df = pd.DataFrame(columns)
-    proto.columns = dataframe_util.data_frame_to_bytes(columns_df)
+    proto.columns = dataframe_util.convert_pandas_df_to_arrow_bytes(columns_df)
 
 
 def _marshall_data(proto: ArrowTableProto, df: DataFrame) -> None:
@@ -109,7 +109,7 @@ def _marshall_data(proto: ArrowTableProto, df: DataFrame) -> None:
         A dataframe to marshall.
 
     """
-    proto.data = dataframe_util.data_frame_to_bytes(df)
+    proto.data = dataframe_util.convert_pandas_df_to_arrow_bytes(df)
 
 
 def arrow_proto_to_dataframe(proto: ArrowTableProto) -> DataFrame:
@@ -130,9 +130,9 @@ def arrow_proto_to_dataframe(proto: ArrowTableProto) -> DataFrame:
 
     import pandas as pd
 
-    data = dataframe_util.bytes_to_data_frame(proto.data)
-    index = dataframe_util.bytes_to_data_frame(proto.index)
-    columns = dataframe_util.bytes_to_data_frame(proto.columns)
+    data = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.data)
+    index = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.index)
+    columns = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.columns)
 
     return pd.DataFrame(
         data.values, index=index.values.T.tolist(), columns=columns.values.T.tolist()

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -115,6 +115,11 @@ class DataFormat(Enum):
 
 
 def is_dataframe_like(obj: object) -> bool:
+    """True if the object is a dataframe-like object.
+
+    This does not include basic collection types like list, dict, tuple, etc.
+    """
+
     return determine_data_format(obj) in [
         DataFormat.PANDAS_DATAFRAME,
         DataFormat.PANDAS_SERIES,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -120,6 +120,11 @@ def is_dataframe_like(obj: object) -> bool:
     This does not include basic collection types like list, dict, tuple, etc.
     """
 
+    if isinstance(obj, (list, tuple, set, dict, str, bytes, int, float, bool)):
+        # Basic types are not considered dataframe-like, so we can
+        # return False early to avoid unnecessary checks.
+        return False
+
     return determine_data_format(obj) in [
         DataFormat.PANDAS_DATAFRAME,
         DataFormat.PANDAS_SERIES,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -118,10 +118,6 @@ class DataFormat(Enum):
     KEY_VALUE_DICT = auto()  # {index: value}
 
 
-def is_dataframe(obj: object) -> TypeGuard[DataFrame]:
-    return is_type(obj, _PANDAS_DF_TYPE_STR)
-
-
 def is_dataframe_like(obj: object) -> bool:
     return determine_data_format(obj) in [
         DataFormat.PANDAS_DATAFRAME,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -27,7 +27,6 @@ from typing import (
     Iterable,
     Protocol,
     Sequence,
-    Tuple,
     TypeVar,
     Union,
     cast,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -223,7 +223,7 @@ def convert_anything_to_pandas_df(
     """
     import pandas as pd
 
-    if is_type(data, _PANDAS_DF_TYPE_STR):
+    if isinstance(data, pd.DataFrame):
         return data.copy() if ensure_copy else cast(pd.DataFrame, data)
 
     if is_pandas_styler(data):

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -120,7 +120,9 @@ def is_dataframe_like(obj: object) -> bool:
     This does not include basic collection types like list, dict, tuple, etc.
     """
 
-    if isinstance(obj, (list, tuple, set, dict, str, bytes, int, float, bool)):
+    if obj is None or isinstance(
+        obj, (list, tuple, set, dict, str, bytes, int, float, bool)
+    ):
         # Basic types are not considered dataframe-like, so we can
         # return False early to avoid unnecessary checks.
         return False

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -431,14 +431,18 @@ def _maybe_truncate_table(
     return table
 
 
-def serialize_arrow_table_to_bytes(table: pa.Table) -> bytes:
-    """Serialize pyarrow.Table to bytes using Apache Arrow.
+def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
+    """Serialize pyarrow.Table to Arrow IPC bytes.
 
     Parameters
     ----------
     table : pyarrow.Table
         A table to convert.
 
+    Returns
+    -------
+    bytes
+        The serialized Arrow IPC bytes.
     """
     try:
         table = _maybe_truncate_table(table)
@@ -589,12 +593,13 @@ def convert_pandas_df_to_arrow_bytes(df: DataFrame) -> bytes:
     except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
         _LOGGER.info(
             "Serialization of dataframe to Arrow table was unsuccessful due to: %s. "
-            "Applying automatic fixes for column types to make the dataframe Arrow-compatible.",
+            "Applying automatic fixes for column types to make the dataframe "
+            "Arrow-compatible.",
             ex,
         )
         df = fix_arrow_incompatible_column_types(df)
         table = pa.Table.from_pandas(df)
-    return serialize_arrow_table_to_bytes(table)
+    return convert_arrow_table_to_arrow_bytes(table)
 
 
 def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
@@ -609,6 +614,10 @@ def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
     source : bytes
         A bytes object to convert.
 
+    Returns
+    -------
+    pandas.DataFrame
+        The converted dataframe.
     """
     import pyarrow as pa
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -511,7 +511,7 @@ class ArrowMixin:
 
         if isinstance(data, pa.Table):
             # For pyarrow tables, we can just serialize the table directly
-            proto.data = dataframe_util.pyarrow_table_to_bytes(data)
+            proto.data = dataframe_util.serialize_arrow_table_to_bytes(data)
         else:
             # For all other data formats, we need to convert them to a pandas.DataFrame
             # thereby, we also apply some data specific configs
@@ -538,7 +538,7 @@ class ArrowMixin:
                 check_arrow_compatibility=False,
             )
             # Serialize the data to bytes:
-            proto.data = dataframe_util.data_frame_to_bytes(data_df)
+            proto.data = dataframe_util.convert_pandas_df_to_arrow_bytes(data_df)
 
         if hide_index is not None:
             update_column_config(
@@ -720,7 +720,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
         marshall_styler(proto, data, default_uuid)
 
     if isinstance(data, pa.Table):
-        proto.data = dataframe_util.pyarrow_table_to_bytes(data)
+        proto.data = dataframe_util.serialize_arrow_table_to_bytes(data)
     else:
         df = dataframe_util.convert_anything_to_pandas_df(data)
-        proto.data = dataframe_util.data_frame_to_bytes(df)
+        proto.data = dataframe_util.convert_pandas_df_to_arrow_bytes(df)

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -511,7 +511,7 @@ class ArrowMixin:
 
         if isinstance(data, pa.Table):
             # For pyarrow tables, we can just serialize the table directly
-            proto.data = dataframe_util.serialize_arrow_table_to_bytes(data)
+            proto.data = dataframe_util.convert_arrow_table_to_arrow_bytes(data)
         else:
             # For all other data formats, we need to convert them to a pandas.DataFrame
             # thereby, we also apply some data specific configs
@@ -720,7 +720,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
         marshall_styler(proto, data, default_uuid)
 
     if isinstance(data, pa.Table):
-        proto.data = dataframe_util.serialize_arrow_table_to_bytes(data)
+        proto.data = dataframe_util.convert_arrow_table_to_arrow_bytes(data)
     else:
         df = dataframe_util.convert_anything_to_pandas_df(data)
         proto.data = dataframe_util.convert_pandas_df_to_arrow_bytes(df)

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
     import altair as alt
     import pandas as pd
 
-    from streamlit.dataframe_util import DataFrameCompatible
     from streamlit.elements.arrow import Data
 
 VegaLiteType: TypeAlias = Literal["quantitative", "ordinal", "temporal", "nominal"]
@@ -391,15 +390,9 @@ def _prep_data(
 
 
 def _last_index_for_melted_dataframes(
-    data: DataFrameCompatible | Any,
+    data: pd.DataFrame,
 ) -> Hashable | None:
-    if dataframe_util.is_dataframe_compatible(data):
-        data = dataframe_util.convert_anything_to_pandas_df(data)
-
-        if data.index.size > 0:
-            return cast(Hashable, data.index[-1])
-
-    return None
+    return cast(Hashable, data.index[-1]) if data.index.size > 0 else None
 
 
 def _is_date_column(df: pd.DataFrame, name: str | None) -> bool:

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -236,7 +236,9 @@ def _marshall_display_values(
 
     """
     new_df = _use_display_values(df, styles)
-    proto.styler.display_values = dataframe_util.data_frame_to_bytes(new_df)
+    proto.styler.display_values = dataframe_util.convert_pandas_df_to_arrow_bytes(
+        new_df
+    )
 
 
 def _use_display_values(df: DataFrame, styles: Mapping[str, Any]) -> DataFrame:

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -280,7 +280,7 @@ def _serialize_data(data: Any) -> bytes:
     import pyarrow as pa
 
     if isinstance(data, pa.Table):
-        return dataframe_util.serialize_arrow_table_to_bytes(data)
+        return dataframe_util.convert_arrow_table_to_arrow_bytes(data)
 
     df = dataframe_util.convert_anything_to_pandas_df(data)
     return dataframe_util.convert_pandas_df_to_arrow_bytes(df)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -280,10 +280,10 @@ def _serialize_data(data: Any) -> bytes:
     import pyarrow as pa
 
     if isinstance(data, pa.Table):
-        return dataframe_util.pyarrow_table_to_bytes(data)
+        return dataframe_util.serialize_arrow_table_to_bytes(data)
 
     df = dataframe_util.convert_anything_to_pandas_df(data)
-    return dataframe_util.data_frame_to_bytes(df)
+    return dataframe_util.convert_pandas_df_to_arrow_bytes(df)
 
 
 def _marshall_chart_data(

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -856,7 +856,7 @@ class DataEditorMixin:
         # Throws an exception if any of the configured types are incompatible.
         _check_type_compatibilities(data_df, column_config_mapping, dataframe_schema)
 
-        arrow_bytes = dataframe_util.serialize_arrow_table_to_bytes(arrow_table)
+        arrow_bytes = dataframe_util.convert_arrow_table_to_arrow_bytes(arrow_table)
 
         # We want to do this as early as possible to avoid introducing nondeterminism,
         # but it isn't clear how much processing is needed to have the data in a

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -856,7 +856,7 @@ class DataEditorMixin:
         # Throws an exception if any of the configured types are incompatible.
         _check_type_compatibilities(data_df, column_config_mapping, dataframe_schema)
 
-        arrow_bytes = dataframe_util.pyarrow_table_to_bytes(arrow_table)
+        arrow_bytes = dataframe_util.serialize_arrow_table_to_bytes(arrow_table)
 
         # We want to do this as early as possible to avoid introducing nondeterminism,
         # but it isn't clear how much processing is needed to have the data in a
@@ -937,7 +937,7 @@ class DataEditorMixin:
 
         _apply_dataframe_edits(data_df, widget_state.value, dataframe_schema)
         self.dg._enqueue("arrow_data_frame", proto)
-        return dataframe_util.convert_df_to_data_format(data_df, data_format)
+        return dataframe_util.convert_pandas_df_to_data_format(data_df, data_format)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -401,22 +401,14 @@ class WriteMixin:
                         item()
                     else:
                         self.write(item, unsafe_allow_html=unsafe_allow_html)
-            elif dataframe_util.is_unevaluated_data_object(
+            elif isinstance(arg, Exception):
+                flush_buffer()
+                self.dg.exception(arg)
+            elif dataframe_util.is_dataframe_like(
                 arg
             ) or dataframe_util.is_snowpark_row_list(arg):
                 flush_buffer()
                 self.dg.dataframe(arg)
-            elif dataframe_util.is_dataframe_like(arg):
-                import numpy as np
-
-                flush_buffer()
-                if len(np.shape(arg)) > 2:
-                    self.dg.text(arg)
-                else:
-                    self.dg.dataframe(arg)
-            elif isinstance(arg, Exception):
-                flush_buffer()
-                self.dg.exception(arg)
             elif type_util.is_altair_chart(arg):
                 flush_buffer()
                 self.dg.altair_chart(arg)

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Final
 
 from streamlit import type_util
-from streamlit.dataframe_util import UNEVALUATED_DATAFRAME_TYPES
+from streamlit.dataframe_util import is_unevaluated_data_object
 from streamlit.elements.spinner import spinner
 from streamlit.logger import get_logger
 from streamlit.runtime.caching.cache_errors import (
@@ -289,10 +289,7 @@ class CachedFunc:
                 # An exception was thrown while we tried to write to the cache. Report it to the user.
                 # (We catch `RuntimeError` here because it will be raised by Apache Spark if we do not
                 # collect dataframe before using `st.cache_data`.)
-                if True in [
-                    type_util.is_type(computed_value, type_name)
-                    for type_name in UNEVALUATED_DATAFRAME_TYPES
-                ]:
+                if is_unevaluated_data_object(computed_value):
                     # If the returned value is an unevaluated dataframe, raise an error.
                     # Unevaluated dataframes are not yet in the local memory, which also
                     # means they cannot be properly cached (serialized).

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -506,7 +506,7 @@ class Dataframe(Element):
 
     @property
     def value(self) -> PandasDataframe:
-        return dataframe_util.bytes_to_data_frame(self.proto.data)
+        return dataframe_util.convert_arrow_bytes_to_pandas_df(self.proto.data)
 
 
 SingleDateValue: TypeAlias = Union[date, datetime]
@@ -1107,7 +1107,7 @@ class Table(Element):
 
     @property
     def value(self) -> PandasDataframe:
-        return dataframe_util.bytes_to_data_frame(self.proto.data)
+        return dataframe_util.convert_arrow_bytes_to_pandas_df(self.proto.data)
 
 
 @dataclass(repr=False)

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -57,7 +57,7 @@ class DataframeUtilTest(unittest.TestCase):
         df2 = pd.DataFrame(df1.dtypes)
 
         try:
-            dataframe_util.data_frame_to_bytes(df2)
+            dataframe_util.convert_pandas_df_to_arrow_bytes(df2)
         except Exception as ex:
             self.fail(f"Converting dtype dataframes to Arrow should not fail: {ex}")
 
@@ -342,7 +342,7 @@ class DataframeUtilTest(unittest.TestCase):
         )
 
         try:
-            dataframe_util.data_frame_to_bytes(df)
+            dataframe_util.convert_pandas_df_to_arrow_bytes(df)
         except Exception as ex:
             self.fail(
                 "No exception should have been thrown here. "
@@ -472,12 +472,12 @@ class DataframeUtilTest(unittest.TestCase):
 
         if metadata.expected_data_format == dataframe_util.DataFormat.UNKNOWN:
             with self.assertRaises(ValueError):
-                dataframe_util.convert_df_to_data_format(
+                dataframe_util.convert_pandas_df_to_data_format(
                     converted_df, metadata.expected_data_format
                 )
             # We don't have to do any other tests for unknown data formats.
         else:
-            converted_data = dataframe_util.convert_df_to_data_format(
+            converted_data = dataframe_util.convert_pandas_df_to_data_format(
                 converted_df, metadata.expected_data_format
             )
 
@@ -513,7 +513,7 @@ class DataframeUtilTest(unittest.TestCase):
         passed an unknown data format.
         """
         with self.assertRaises(ValueError):
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 pd.DataFrame({"a": [1, 2, 3]}), dataframe_util.DataFormat.UNKNOWN
             )
 
@@ -530,25 +530,25 @@ class DataframeUtilTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.LIST_OF_VALUES
             ),
             [None, None, None, None],
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.TUPLE_OF_VALUES
             ),
             (None, None, None, None),
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.SET_OF_VALUES
             ),
             {None},
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.LIST_OF_ROWS
             ),
             [
@@ -559,7 +559,7 @@ class DataframeUtilTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.LIST_OF_RECORDS
             ),
             [
@@ -570,7 +570,7 @@ class DataframeUtilTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.COLUMN_VALUE_MAPPING
             ),
             {
@@ -578,13 +578,13 @@ class DataframeUtilTest(unittest.TestCase):
             },
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.COLUMN_INDEX_MAPPING
             ),
             {"missing": {0: None, 1: None, 2: None, 3: None}},
         )
         self.assertEqual(
-            dataframe_util.convert_df_to_data_format(
+            dataframe_util.convert_pandas_df_to_data_format(
                 df, dataframe_util.DataFormat.KEY_VALUE_DICT
             ),
             {0: None, 1: None, 2: None, 3: None},

--- a/lib/tests/streamlit/elements/arrow_add_rows_test.py
+++ b/lib/tests/streamlit/elements/arrow_add_rows_test.py
@@ -18,7 +18,7 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.dataframe_util import bytes_to_data_frame
+from streamlit.dataframe_util import convert_arrow_bytes_to_pandas_df
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 DATAFRAME = pd.DataFrame({"a": [10], "b": [20], "c": [30]})
@@ -63,7 +63,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME)
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -82,7 +82,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, x="b", y="c")
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -100,7 +100,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, y="b")
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -119,7 +119,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, x="b")
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -138,7 +138,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, x="b", y=["a", "c"])
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -159,7 +159,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, x="b", y=["a", "c"], color=["#f00", "#0f0"])
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -178,7 +178,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = st.scatter_chart(DATAFRAME2, x="b", y=["a", "c"], size="d")
         element.add_rows(NEW_ROWS2)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 
@@ -197,7 +197,7 @@ class DeltaGeneratorAddRowsTest(DeltaGeneratorTestCase):
         element = chart_command(DATAFRAME, x="b", y="a")
         element.add_rows(NEW_ROWS)
 
-        proto = bytes_to_data_frame(
+        proto = convert_arrow_bytes_to_pandas_df(
             self.get_delta_from_queue().arrow_add_rows.data.data
         )
 

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -27,7 +27,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.dataframe_util import (
     convert_arrow_bytes_to_pandas_df,
-    serialize_arrow_table_to_bytes,
+    convert_arrow_table_to_arrow_bytes,
 )
 from streamlit.elements.lib.column_config_utils import INDEX_IDENTIFIER
 from streamlit.errors import StreamlitAPIException
@@ -73,7 +73,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         st.dataframe(table)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        self.assertEqual(proto.data, serialize_arrow_table_to_bytes(table))
+        self.assertEqual(proto.data, convert_arrow_table_to_arrow_bytes(table))
 
     def test_hide_index_true(self):
         """Test that it can be called with hide_index=True param."""

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -25,7 +25,10 @@ from pandas.io.formats.style_render import StylerRenderer as Styler
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.dataframe_util import bytes_to_data_frame, pyarrow_table_to_bytes
+from streamlit.dataframe_util import (
+    convert_arrow_bytes_to_pandas_df,
+    serialize_arrow_table_to_bytes,
+)
 from streamlit.elements.lib.column_config_utils import INDEX_IDENTIFIER
 from streamlit.errors import StreamlitAPIException
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -48,7 +51,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         st.dataframe(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), df)
+        pd.testing.assert_frame_equal(convert_arrow_bytes_to_pandas_df(proto.data), df)
 
     def test_column_order_parameter(self):
         """Test that it can be called with column_order."""
@@ -70,7 +73,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         st.dataframe(table)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        self.assertEqual(proto.data, pyarrow_table_to_bytes(table))
+        self.assertEqual(proto.data, serialize_arrow_table_to_bytes(table))
 
     def test_hide_index_true(self):
         """Test that it can be called with hide_index=True param."""
@@ -150,7 +153,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.styler.display_values), expected
+            convert_arrow_bytes_to_pandas_df(proto.styler.display_values), expected
         )
 
     def test_throw_exception_if_data_exceeds_styler_config(self):
@@ -196,7 +199,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
             st.dataframe(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        self.assertEqual(bytes_to_data_frame(proto.data).iat[0, 0], 42)
+        self.assertEqual(convert_arrow_bytes_to_pandas_df(proto.data).iat[0, 0], 42)
 
     @pytest.mark.require_snowflake
     def test_snowpark_collected(self):
@@ -207,7 +210,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
             st.dataframe(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        self.assertEqual(bytes_to_data_frame(proto.data).iat[0, 0], 42)
+        self.assertEqual(convert_arrow_bytes_to_pandas_df(proto.data).iat[0, 0], 42)
 
     def test_dataframe_on_select_initial_returns(self):
         """Test st.dataframe returns an empty selection as initial result."""
@@ -353,11 +356,11 @@ class StArrowTableAPITest(DeltaGeneratorTestCase):
 
     def test_table(self):
         """Test st.table."""
-        from streamlit.dataframe_util import bytes_to_data_frame
+        from streamlit.dataframe_util import convert_arrow_bytes_to_pandas_df
 
         df = pd.DataFrame([[1, 2], [3, 4]], columns=["col1", "col2"])
 
         st.table(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_table
-        pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), df)
+        pd.testing.assert_frame_equal(convert_arrow_bytes_to_pandas_df(proto.data), df)

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -22,7 +22,10 @@ import pyarrow as pa
 from pandas.io.formats.style_render import StylerRenderer as Styler
 
 import streamlit as st
-from streamlit.dataframe_util import bytes_to_data_frame, pyarrow_table_to_bytes
+from streamlit.dataframe_util import (
+    convert_arrow_bytes_to_pandas_df,
+    serialize_arrow_table_to_bytes,
+)
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -42,7 +45,7 @@ class ArrowTest(DeltaGeneratorTestCase):
         st.table(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_table
-        pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), df)
+        pd.testing.assert_frame_equal(convert_arrow_bytes_to_pandas_df(proto.data), df)
 
     def test_pyarrow_table_data(self):
         df = mock_data_frame()
@@ -50,7 +53,7 @@ class ArrowTest(DeltaGeneratorTestCase):
         st.table(table)
 
         proto = self.get_delta_from_queue().new_element.arrow_table
-        self.assertEqual(proto.data, pyarrow_table_to_bytes(table))
+        self.assertEqual(proto.data, serialize_arrow_table_to_bytes(table))
 
     def test_uuid(self):
         df = mock_data_frame()
@@ -111,7 +114,7 @@ class ArrowTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_table
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.styler.display_values), expected
+            convert_arrow_bytes_to_pandas_df(proto.styler.display_values), expected
         )
 
     def test_table_uses_convert_anything_to_df(self):

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -24,7 +24,7 @@ from pandas.io.formats.style_render import StylerRenderer as Styler
 import streamlit as st
 from streamlit.dataframe_util import (
     convert_arrow_bytes_to_pandas_df,
-    serialize_arrow_table_to_bytes,
+    convert_arrow_table_to_arrow_bytes,
 )
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -53,7 +53,7 @@ class ArrowTest(DeltaGeneratorTestCase):
         st.table(table)
 
         proto = self.get_delta_from_queue().new_element.arrow_table
-        self.assertEqual(proto.data, serialize_arrow_table_to_bytes(table))
+        self.assertEqual(proto.data, convert_arrow_table_to_arrow_bytes(table))
 
     def test_uuid(self):
         df = mock_data_frame()

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -29,10 +29,7 @@ import pyarrow as pa
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.dataframe_util import (
-    DataFormat,
-    bytes_to_data_frame,
-)
+from streamlit.dataframe_util import DataFormat, convert_arrow_bytes_to_pandas_df
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ColumnDataKind,
@@ -407,7 +404,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         return_df = st.data_editor(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), df)
+        pd.testing.assert_frame_equal(convert_arrow_bytes_to_pandas_df(proto.data), df)
         pd.testing.assert_frame_equal(return_df, df)
 
     @parameterized.expand(SHARED_TEST_CASES)
@@ -420,7 +417,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         return_data = st.data_editor(input_data)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        reconstructed_df = bytes_to_data_frame(proto.data)
+        reconstructed_df = convert_arrow_bytes_to_pandas_df(proto.data)
         self.assertEqual(reconstructed_df.shape[0], metadata.expected_rows)
         self.assertEqual(reconstructed_df.shape[1], metadata.expected_cols)
 
@@ -583,7 +580,9 @@ class DataEditorTest(DeltaGeneratorTestCase):
         return_df = st.data_editor(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), return_df)
+        pd.testing.assert_frame_equal(
+            convert_arrow_bytes_to_pandas_df(proto.data), return_df
+        )
         self.assertEqual(return_df.columns.to_list(), ["2_c1", "3_c2", "4_c3"])
 
     def test_pandas_styler_support(self):

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -30,7 +30,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.dataframe_util import (
     convert_arrow_bytes_to_pandas_df,
-    serialize_arrow_table_to_bytes,
+    convert_arrow_table_to_arrow_bytes,
 )
 from streamlit.elements.vega_charts import (
     _extract_selection_parameters,
@@ -629,7 +629,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
 
         self.assertEqual(proto.HasField("data"), True)
-        self.assertEqual(proto.data.data, serialize_arrow_table_to_bytes(table))
+        self.assertEqual(proto.data.data, convert_arrow_table_to_arrow_bytes(table))
 
     def test_add_rows(self):
         """Test that you can call add_rows on arrow_vega_lite_chart (with data)."""

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -28,7 +28,10 @@ from packaging import version
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.dataframe_util import bytes_to_data_frame, pyarrow_table_to_bytes
+from streamlit.dataframe_util import (
+    convert_arrow_bytes_to_pandas_df,
+    serialize_arrow_table_to_bytes,
+)
 from streamlit.elements.vega_charts import (
     _extract_selection_parameters,
     _parse_selection_mode,
@@ -37,9 +40,7 @@ from streamlit.elements.vega_charts import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cached_message_replay
-from streamlit.type_util import (
-    is_altair_version_less_than,
-)
+from streamlit.type_util import is_altair_version_less_than
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 df1 = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
@@ -104,7 +105,8 @@ class AltairChartTest(DeltaGeneratorTestCase):
         self.assertFalse(proto.HasField("data"))
         self.assertEqual(len(proto.datasets), 1)
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.datasets[0].data.data), EXPECTED_DATAFRAME
+            convert_arrow_bytes_to_pandas_df(proto.datasets[0].data.data),
+            EXPECTED_DATAFRAME,
         )
 
         spec_dict = json.loads(proto.spec)
@@ -546,7 +548,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.data.data), df1, check_dtype=False
+            convert_arrow_bytes_to_pandas_df(proto.data.data), df1, check_dtype=False
         )
         self.assertDictEqual(
             json.loads(proto.spec), merge_dicts(autosize_spec, {"mark": "rect"})
@@ -569,7 +571,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.data.data), df1, check_dtype=False
+            convert_arrow_bytes_to_pandas_df(proto.data.data), df1, check_dtype=False
         )
         self.assertDictEqual(
             json.loads(proto.spec),
@@ -605,7 +607,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.data.data), df1, check_dtype=False
+            convert_arrow_bytes_to_pandas_df(proto.data.data), df1, check_dtype=False
         )
         self.assertDictEqual(
             json.loads(proto.spec),
@@ -627,7 +629,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
 
         self.assertEqual(proto.HasField("data"), True)
-        self.assertEqual(proto.data.data, pyarrow_table_to_bytes(table))
+        self.assertEqual(proto.data.data, serialize_arrow_table_to_bytes(table))
 
     def test_add_rows(self):
         """Test that you can call add_rows on arrow_vega_lite_chart (with data)."""
@@ -640,7 +642,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().arrow_add_rows
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.data.data), df2, check_dtype=False
+            convert_arrow_bytes_to_pandas_df(proto.data.data), df2, check_dtype=False
         )
 
     def test_no_args_add_rows(self):
@@ -654,7 +656,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().arrow_add_rows
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.data.data), df1, check_dtype=False
+            convert_arrow_bytes_to_pandas_df(proto.data.data), df1, check_dtype=False
         )
 
     def test_use_container_width(self):
@@ -856,7 +858,7 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
         self.assertIn(chart_spec["mark"], [altair_type, {"type": altair_type}])
 
         pd.testing.assert_frame_equal(
-            bytes_to_data_frame(proto.datasets[0].data.data),
+            convert_arrow_bytes_to_pandas_df(proto.datasets[0].data.data),
             EXPECTED_DATAFRAME,
         )
 
@@ -1120,7 +1122,7 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
             # Manually-specified colors are set via the color scale's range property.
             self.assertTrue(chart_spec["encoding"]["color"]["scale"]["range"])
 
-            proto_df = bytes_to_data_frame(proto.datasets[0].data.data)
+            proto_df = convert_arrow_bytes_to_pandas_df(proto.datasets[0].data.data)
 
             pd.testing.assert_series_equal(
                 proto_df[color_column],
@@ -1362,7 +1364,7 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
         self, orig_df, expected_df, chart_proto
     ):
         """Test that when we modify the outgoing DF we don't mutate the input DF."""
-        output_df = bytes_to_data_frame(chart_proto.datasets[0].data.data)
+        output_df = convert_arrow_bytes_to_pandas_df(chart_proto.datasets[0].data.data)
 
         self.assertNotEqual(id(orig_df), id(output_df))
         self.assertNotEqual(id(orig_df), id(expected_df))


### PR DESCRIPTION
## Describe your changes

Another clean-up and refactoring mainly focused on the dataframe-related type-checks:

- Cleans up several types and methods used to check for dataframe-like objects. 
- Removes redundant methods and checks.
- Added additional docstring comments.
- Unifies the naming of the conversion methods

## Testing Plan

- The existing tests should cover all changes.
- Mostly refactoring, not big logical changes. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
