### PR TITLE
Improvements to NumberInput formatting

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -299,6 +299,18 @@ describe("NumberInput widget", () => {
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
       expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.00)
     })
+
+    it('does not automatically format when the step size is integer', () => {
+      const props = getFloatProps({
+        default: 1.0,
+        step: 1,
+      })
+
+      render(<NumberInput {...props} />)
+    
+      expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.00)
+    })
   })
 
   describe("IntData", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -249,6 +249,56 @@ describe("NumberInput widget", () => {
 
       expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(15.0)
     })
+
+    describe("Formatting", () => {
+      it("allows explicit formatting string", () => {
+        const props = getFloatProps({
+          default: 1.11111,
+          format: "%0.4f",
+        })
+        render(<NumberInput {...props} />)
+    
+        expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
+        expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.1111)
+      })
+    })
+
+    it("allows formatting a float as an integer", () => {
+      const props = getFloatProps({
+        default: 1.11111,
+        format: "%d",
+      })
+
+      render(<NumberInput {...props} />)
+    
+      expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1)
+    })
+
+    it("automatically sets formatting when none provided based on step", () => {
+      const props = getFloatProps({
+        default: 1.0,
+        step: 0.005,
+      })
+
+      render(<NumberInput {...props} />)
+    
+      expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.000)
+    })
+
+    it('does not automatically format when a format is explicitly provided', () => {
+      const props = getFloatProps({
+        default: 1.0,
+        step: 0.1,
+        format: '%0.2f',
+      })
+
+      render(<NumberInput {...props} />)
+    
+      expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.00)
+    })
   })
 
   describe("IntData", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -257,7 +257,7 @@ describe("NumberInput widget", () => {
           format: "%0.4f",
         })
         render(<NumberInput {...props} />)
-    
+
         expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
         expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.1111)
       })
@@ -270,7 +270,7 @@ describe("NumberInput widget", () => {
       })
 
       render(<NumberInput {...props} />)
-    
+
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
       expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1)
     })
@@ -282,34 +282,34 @@ describe("NumberInput widget", () => {
       })
 
       render(<NumberInput {...props} />)
-    
+
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.000)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
     })
 
-    it('does not automatically format when a format is explicitly provided', () => {
+    it("does not automatically format when a format is explicitly provided", () => {
       const props = getFloatProps({
         default: 1.0,
         step: 0.1,
-        format: '%0.2f',
+        format: "%0.2f",
       })
 
       render(<NumberInput {...props} />)
-    
+
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.00)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
     })
 
-    it('does not automatically format when the step size is integer', () => {
+    it("does not automatically format when the step size is integer", () => {
       const props = getFloatProps({
         default: 1.0,
         step: 1,
       })
 
       render(<NumberInput {...props} />)
-    
+
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.00)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
     })
   })
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -259,7 +259,9 @@ describe("NumberInput widget", () => {
         render(<NumberInput {...props} />)
 
         expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-        expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.1111)
+        expect(screen.getByTestId("stNumberInput-Input")).toHaveDisplayValue(
+          "1.1111"
+        )
       })
     })
 
@@ -272,7 +274,7 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveDisplayValue("1")
     })
 
     it("automatically sets formatting when none provided based on step", () => {
@@ -284,7 +286,9 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveDisplayValue(
+        "1.000"
+      )
     })
 
     it("does not automatically format when a format is explicitly provided", () => {
@@ -297,7 +301,9 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveDisplayValue(
+        "1.00"
+      )
     })
 
     it("does not automatically format when the step size is integer", () => {
@@ -309,7 +315,7 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       expect(screen.getByTestId("stNumberInput")).toBeInTheDocument()
-      expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(1.0)
+      expect(screen.getByTestId("stNumberInput-Input")).toHaveDisplayValue("1")
     })
   })
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -156,31 +156,31 @@ export class NumberInput extends React.PureComponent<Props, State> {
       return null
     }
 
-    let format = getNonEmptyString(this.props.element.format)
+    const { format, step } = this.props.element
+    let formatString = getNonEmptyString(format)
 
     /**
      * In the instance where a step is specified for a float,
      * and a format is not explicitly provided, we will use the
      * precision of the step to format the result.
      */
-    if (format == null) {
-      const { step } = this.props.element
+    if (formatString == null) {
       const strStep = step.toString()
       if (this.isFloatData() && step !== 0 && strStep.includes(".")) {
         const decimalPlaces = strStep.split(".")[1].length
-        format = `%0.${decimalPlaces}f`
+        formatString = `%0.${decimalPlaces}f`
       }
     }
 
-    if (format == null) {
+    if (formatString == null) {
       return value.toString()
     }
 
     try {
-      return sprintf(format, value)
+      return sprintf(formatString, value)
     } catch (e) {
-      // Don't explode if we have a malformed format string.
-      logWarning(`Error in sprintf(${format}, ${value}): ${e}`)
+      // Don't explode if we have a malformed formatString.
+      logWarning(`Error in sprintf(${formatString}, ${value}): ${e}`)
       return String(value)
     }
   }

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -156,7 +156,22 @@ export class NumberInput extends React.PureComponent<Props, State> {
       return null
     }
 
-    const format = getNonEmptyString(this.props.element.format)
+    let format = getNonEmptyString(this.props.element.format)
+
+    /**
+     * In the instance where a step is specified for a float,
+     * and a format is not explicitly provided, we will use the
+     * precision of the step to format the result.
+     */
+    if (format == null) {
+      const { step } = this.props.element
+      const strStep = step.toString()
+      if (this.isFloatData() && step !== 0 && strStep.includes(".")) {
+        const decimalPlaces = strStep.split(".")[1].length
+        format = `%.${decimalPlaces}f`
+      }
+    }
+
     if (format == null) {
       return value.toString()
     }
@@ -172,6 +187,10 @@ export class NumberInput extends React.PureComponent<Props, State> {
 
   private isIntData = (): boolean => {
     return this.props.element.dataType === NumberInputProto.DataType.INT
+  }
+
+  private isFloatData = (): boolean => {
+    return this.props.element.dataType === NumberInputProto.DataType.FLOAT
   }
 
   private getMin = (): number => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -168,7 +168,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
       const strStep = step.toString()
       if (this.isFloatData() && step !== 0 && strStep.includes(".")) {
         const decimalPlaces = strStep.split(".")[1].length
-        format = `%.${decimalPlaces}f`
+        format = `%0.${decimalPlaces}f`
       }
     }
 

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -196,7 +196,7 @@ class NumberInputMixin:
             display numbers. Output must be purely numeric. This does not impact
             the return value. Formatting is handled by [sprintf.js](https://github.com/alexei/sprintf.js).
             This can be used to adjust decimal precision in the displayed result. For example,
-            ``'%.1f'`` to only show 1 digit after the decimal.
+            ``'%0.1f'`` to only show 1 digit after the decimal.
         key : str or int
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -194,7 +194,9 @@ class NumberInputMixin:
         format : str or None
             A printf-style format string controlling how the interface should
             display numbers. Output must be purely numeric. This does not impact
-            the return value. Valid formatters: %d %e %f %g %i %u
+            the return value. Formatting is handled by [sprintf.js](https://github.com/alexei/sprintf.js).
+            This can be used to adjust decimal precision in the displayed result. For example,
+            ``'%.1f'`` to only show 1 digit after the decimal.
         key : str or int
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget


### PR DESCRIPTION
## Describe your changes

This PR changes a few things related to the formatting of the `<NumberInput />` component:
1. The docs were updated to provide more information about the `format` parameter and how to use it.
2. If the number is a float, a `step` is specified (and is a float), and a `format` is not specified, we format the result with the same number of decimal places as the `step`.
3. Unit tests to cover newly added functionality.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/7163

## Testing Plan

These changes have been tested via jest unit tests. Specifically, it adds tests for:
- normal case of using a formatting string to set decimal places
- using a formatting string to format a float as an integer
- automatically formatting when the condition above is met (float + float `step` + no `format` provided)
- not automatically formatting when explicit `format` is provided
- not automatically formatting when the `step` is an integer

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
