### PR TITLE
Centralize data type alias

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -89,12 +89,12 @@ OptionSequence: TypeAlias = Union[
 
 # Various data types supported by our dataframe processing:
 Data: TypeAlias = Union[
-    DataFrame,
-    Series,
-    Styler,
-    Index,
-    pa.Table,
-    np.ndarray,
+    "DataFrame",
+    "Series",
+    "Styler",
+    "Index",
+    "pa.Table",
+    "np.ndarray",
     Iterable[Any],
     Dict[Any, Any],
     None,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -22,6 +22,7 @@ from enum import Enum, EnumMeta, auto
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Final,
     Iterable,
     Protocol,
@@ -84,6 +85,19 @@ class DataFrameGenericAlias(Protocol[V_co]):
 OptionSequence: TypeAlias = Union[
     Iterable[V_co],
     DataFrameGenericAlias[V_co],
+]
+
+# Various data types supported by our dataframe processing:
+Data: TypeAlias = Union[
+    DataFrame,
+    Series,
+    Styler,
+    Index,
+    pa.Table,
+    np.ndarray,
+    Iterable[Any],
+    Dict[Any, Any],
+    None,
 ]
 
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -87,7 +87,9 @@ OptionSequence: TypeAlias = Union[
     DataFrameGenericAlias[V_co],
 ]
 
-# Various data types supported by our dataframe processing:
+# Various data types supported by our dataframe processing
+# used for commands like `st.dataframe`, `st.table`, `st.map`,
+# st.line_chart`...
 Data: TypeAlias = Union[
     "DataFrame",
     "Series",

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -100,7 +100,7 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
     from streamlit.cursor import Cursor
-    from streamlit.elements.arrow import Data
+    from streamlit.dataframe_util import Data
     from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
 
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -18,14 +18,10 @@ import json
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
-    Any,
-    Dict,
     Final,
     Iterable,
-    List,
     Literal,
     TypedDict,
-    Union,
     cast,
     overload,
 )
@@ -53,24 +49,9 @@ from streamlit.runtime.state import WidgetCallback, register_widget
 from streamlit.runtime.state.common import compute_widget_id
 
 if TYPE_CHECKING:
-    import pyarrow as pa
-    from numpy import ndarray
-    from pandas import DataFrame, Index, Series
-    from pandas.io.formats.style import Styler
-
+    from streamlit.dataframe_util import Data
     from streamlit.delta_generator import DeltaGenerator
 
-Data: TypeAlias = Union[
-    "DataFrame",
-    "Series",
-    "Styler",
-    "Index",
-    "pa.Table",
-    "ndarray",
-    Iterable,
-    Dict[str, List[Any]],
-    None,
-]
 
 SelectionMode: TypeAlias = Literal[
     "single-row", "multi-row", "single-column", "multi-column"

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     import altair as alt
     import pandas as pd
 
-    from streamlit.elements.arrow import Data
+    from streamlit.dataframe_util import Data
 
 VegaLiteType: TypeAlias = Literal["quantitative", "ordinal", "temporal", "nominal"]
 ChartStackType: TypeAlias = Literal["normalize", "center", "layered"]

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Collection, Dict, Final, Iterable, Union, cast
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Collection, Final, cast
 
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit import config, dataframe_util
@@ -33,18 +31,9 @@ from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
     from pandas import DataFrame
-    from pandas.io.formats.style import Styler
 
+    from streamlit.dataframe_util import Data
     from streamlit.delta_generator import DeltaGenerator
-
-
-Data: TypeAlias = Union[
-    "DataFrame",
-    "Styler",
-    Iterable[Any],
-    Dict[Any, Any],
-    None,
-]
 
 # Map used as the basis for st.map.
 _DEFAULT_MAP: Final[dict[str, Any]] = dict(deck_gl_json_chart.EMPTY_MAP)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -60,8 +60,8 @@ if TYPE_CHECKING:
     import altair as alt
 
     from streamlit.color_util import Color
+    from streamlit.dataframe_util import Data
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.elements.arrow import Data
 
 # See https://vega.github.io/vega-lite/docs/encoding.html
 _CHANNELS: Final = {


### PR DESCRIPTION
## Describe your changes

Centralize the data type alias we use for a couple of commands into the `dataframe_utils` module.

## Testing Plan

- No logical changes -> no tests required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
