### PR TITLE
Add `convert_anything_to_arrow_bytes` method

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -425,6 +425,10 @@ def convert_anything_to_arrow_bytes(
 ) -> bytes:
     """Try to convert different formats to Arrow IPC format (bytes).
 
+    This method tries to directly convert the input data to Arrow bytes
+    for some supported formats, but falls back to conversion to a Pandas
+    DataFrame and then to Arrow bytes.
+
     Parameters
     ----------
     data : any

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -235,7 +235,7 @@ def convert_anything_to_pandas_df(
 
     max_unevaluated_rows: int
         If unevaluated data is detected this func will evaluate it,
-        taking max_unevaluated_rows, defaults to 10k and 100 for st.table
+        taking max_unevaluated_rows, defaults to 10k.
 
     ensure_copy: bool
         If True, make sure to always return a copy of the data. If False, it depends on
@@ -329,6 +329,126 @@ Offending object:
 {data}
 ```"""
         ) from ex
+
+
+def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
+    """Serialize pyarrow.Table to Arrow IPC bytes.
+
+    Parameters
+    ----------
+    table : pyarrow.Table
+        A table to convert.
+
+    Returns
+    -------
+    bytes
+        The serialized Arrow IPC bytes.
+    """
+    try:
+        table = _maybe_truncate_table(table)
+    except RecursionError as err:
+        # This is a very unlikely edge case, but we want to make sure that
+        # it doesn't lead to unexpected behavior.
+        # If there is a recursion error, we just return the table as-is
+        # which will lead to the normal message limit exceed error.
+        _LOGGER.warning(
+            "Recursion error while truncating Arrow table. This is not "
+            "supposed to happen.",
+            exc_info=err,
+        )
+
+    import pyarrow as pa
+
+    # Convert table to bytes
+    sink = pa.BufferOutputStream()
+    writer = pa.RecordBatchStreamWriter(sink, table.schema)
+    writer.write_table(table)
+    writer.close()
+    return cast(bytes, sink.getvalue().to_pybytes())
+
+
+def convert_pandas_df_to_arrow_bytes(df: DataFrame) -> bytes:
+    """Serialize pandas.DataFrame to Arrow IPC bytes.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A dataframe to convert.
+
+    Returns
+    -------
+    bytes
+        The serialized Arrow IPC bytes.
+    """
+    import pyarrow as pa
+
+    try:
+        table = pa.Table.from_pandas(df)
+    except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
+        _LOGGER.info(
+            "Serialization of dataframe to Arrow table was unsuccessful due to: %s. "
+            "Applying automatic fixes for column types to make the dataframe "
+            "Arrow-compatible.",
+            ex,
+        )
+        df = fix_arrow_incompatible_column_types(df)
+        table = pa.Table.from_pandas(df)
+    return convert_arrow_table_to_arrow_bytes(table)
+
+
+def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
+    """Convert Arrow bytes (IPC format) to pandas.DataFrame.
+
+    Using this function in production needs to make sure that
+    the pyarrow version >= 14.0.1, because of a critical
+    security vulnerability in pyarrow < 14.0.1.
+
+    Parameters
+    ----------
+    source : bytes
+        A bytes object to convert.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The converted dataframe.
+    """
+    import pyarrow as pa
+
+    reader = pa.RecordBatchStreamReader(source)
+    return reader.read_pandas()
+
+
+def convert_anything_to_arrow_bytes(
+    data: Any,
+    max_unevaluated_rows: int = _MAX_UNEVALUATED_DF_ROWS,
+) -> bytes:
+    """Try to convert different formats to Arrow IPC format (bytes).
+
+    Parameters
+    ----------
+    data : any
+        The data to convert to Arrow bytes.
+
+    max_unevaluated_rows: int
+        If unevaluated data is detected this func will evaluate it,
+        taking max_unevaluated_rows, defaults to 10k.
+
+    Returns
+    -------
+    bytes
+        The serialized Arrow IPC bytes.
+    """
+
+    import pyarrow as pa
+
+    if isinstance(data, pa.Table):
+        return convert_arrow_table_to_arrow_bytes(data)
+
+    # Fallback: try to convert to pandas DataFrame
+    # and then to Arrow bytes
+    df = convert_anything_to_pandas_df(data, max_unevaluated_rows)
+    return convert_pandas_df_to_arrow_bytes(df)
 
 
 def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> Sequence[V_co]:
@@ -454,42 +574,6 @@ def _maybe_truncate_table(
     return table
 
 
-def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
-    """Serialize pyarrow.Table to Arrow IPC bytes.
-
-    Parameters
-    ----------
-    table : pyarrow.Table
-        A table to convert.
-
-    Returns
-    -------
-    bytes
-        The serialized Arrow IPC bytes.
-    """
-    try:
-        table = _maybe_truncate_table(table)
-    except RecursionError as err:
-        # This is a very unlikely edge case, but we want to make sure that
-        # it doesn't lead to unexpected behavior.
-        # If there is a recursion error, we just return the table as-is
-        # which will lead to the normal message limit exceed error.
-        _LOGGER.warning(
-            "Recursion error while truncating Arrow table. This is not "
-            "supposed to happen.",
-            exc_info=err,
-        )
-
-    import pyarrow as pa
-
-    # Convert table to bytes
-    sink = pa.BufferOutputStream()
-    writer = pa.RecordBatchStreamWriter(sink, table.schema)
-    writer.write_table(table)
-    writer.close()
-    return cast(bytes, sink.getvalue().to_pybytes())
-
-
 def is_colum_type_arrow_incompatible(column: Series[Any] | Index) -> bool:
     """Return True if the column type is known to cause issues during Arrow conversion."""
     from pandas.api.types import infer_dtype, is_dict_like, is_list_like
@@ -594,58 +678,6 @@ def fix_arrow_incompatible_column_types(
             df_copy = df.copy()
         df_copy.index = df.index.astype("string")
     return df_copy if df_copy is not None else df
-
-
-def convert_pandas_df_to_arrow_bytes(df: DataFrame) -> bytes:
-    """Serialize pandas.DataFrame to Arrow IPC bytes.
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        A dataframe to convert.
-
-    Returns
-    -------
-    bytes
-        The serialized Arrow IPC bytes.
-    """
-    import pyarrow as pa
-
-    try:
-        table = pa.Table.from_pandas(df)
-    except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
-        _LOGGER.info(
-            "Serialization of dataframe to Arrow table was unsuccessful due to: %s. "
-            "Applying automatic fixes for column types to make the dataframe "
-            "Arrow-compatible.",
-            ex,
-        )
-        df = fix_arrow_incompatible_column_types(df)
-        table = pa.Table.from_pandas(df)
-    return convert_arrow_table_to_arrow_bytes(table)
-
-
-def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
-    """Convert Arrow bytes (IPC format) to pandas.DataFrame.
-
-    Using this function in production needs to make sure that
-    the pyarrow version >= 14.0.1, because of a critical
-    security vulnerability in pyarrow < 14.0.1.
-
-    Parameters
-    ----------
-    source : bytes
-        A bytes object to convert.
-
-    Returns
-    -------
-    pandas.DataFrame
-        The converted dataframe.
-    """
-    import pyarrow as pa
-
-    reader = pa.RecordBatchStreamReader(source)
-    return reader.read_pandas()
 
 
 def _is_list_of_scalars(data: Iterable[Any]) -> bool:

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -691,7 +691,6 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
         (e.g. charts) can ignore it.
 
     """
-    import pyarrow as pa
 
     if dataframe_util.is_pandas_styler(data):
         # default_uuid is a string only if the data is a `Styler`,
@@ -701,8 +700,4 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
         ), "Default UUID must be a string for Styler data."
         marshall_styler(proto, data, default_uuid)
 
-    if isinstance(data, pa.Table):
-        proto.data = dataframe_util.convert_arrow_table_to_arrow_bytes(data)
-    else:
-        df = dataframe_util.convert_anything_to_pandas_df(data)
-        proto.data = dataframe_util.convert_pandas_df_to_arrow_bytes(df)
+    proto.data = dataframe_util.convert_anything_to_arrow_bytes(data)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -269,17 +269,6 @@ def _prepare_vega_lite_spec(
     return spec
 
 
-def _serialize_data(data: Any) -> bytes:
-    """Serialize the any type of data structure to Arrow IPC format (bytes)."""
-    import pyarrow as pa
-
-    if isinstance(data, pa.Table):
-        return dataframe_util.convert_arrow_table_to_arrow_bytes(data)
-
-    df = dataframe_util.convert_anything_to_pandas_df(data)
-    return dataframe_util.convert_pandas_df_to_arrow_bytes(df)
-
-
 def _marshall_chart_data(
     proto: ArrowVegaLiteChartProto,
     spec: VegaLiteSpec,
@@ -302,11 +291,11 @@ def _marshall_chart_data(
             # We just need to pass the data information into the correct proto fields.
 
             # TODO(lukasmasuch): Are there any other cases where we need to serialize the data
-            #                    or can we remove the _serialize_data here?
+            # or can we remove the convert_anything_to_arrow_bytes here?
             dataset.data.data = (
                 dataset_data
                 if isinstance(dataset_data, bytes)
-                else _serialize_data(dataset_data)
+                else dataframe_util.convert_anything_to_arrow_bytes(dataset_data)
             )
         del spec["datasets"]
 
@@ -327,7 +316,7 @@ def _marshall_chart_data(
             del spec["data"]
 
     if data is not None:
-        proto.data.data = _serialize_data(data)
+        proto.data.data = dataframe_util.convert_anything_to_arrow_bytes(data)
 
 
 def _convert_altair_to_vega_lite_spec(altair_chart: alt.Chart) -> VegaLiteSpec:
@@ -349,7 +338,7 @@ def _convert_altair_to_vega_lite_spec(altair_chart: alt.Chart) -> VegaLiteSpec:
         """
         # Already serialize the data to be able to create a stable
         # dataset name:
-        data_bytes = _serialize_data(data)
+        data_bytes = dataframe_util.convert_anything_to_arrow_bytes(data)
         # Use the md5 hash of the data as the name:
         h = hashlib.new("md5", **HASHLIB_KWARGS)
         h.update(str(data_bytes).encode("utf-8"))


### PR DESCRIPTION
## Describe your changes

This PR adds the `convert_anything_to_arrow_bytes`, which will be used in later PRs to enable a direct conversion form input data to Arrow bytes (IPC) without going through Pandas.  

This PR also moves a couple of methods within the module.
## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
