### PR TITLE
`st.switch_page` clears non-embed query params 

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics.py
+++ b/e2e_playwright/multipage_apps/mpa_basics.py
@@ -17,6 +17,8 @@ import streamlit as st
 st.header("Main Page")
 st.slider("x")
 
+st.write("Query Params:", st.query_params)
+
 if st.button("`pages/02_page2.py`"):
     st.switch_page("pages/02_page2.py")
 

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -157,6 +157,25 @@ def test_switch_page(app: Page):
     expect(app.get_by_test_id("stHeading")).to_contain_text("Main Page")
 
 
+def test_switch_page_preserves_embed_params(page: Page, app_port: int):
+    """Test that st.switch_page only preserves embed params."""
+
+    # Start at main page with embed & other query params
+    page.goto(
+        f"http://localhost:{app_port}/?embed=true&embed_options=light_theme&bar=foo"
+    )
+    wait_for_app_loaded(page)
+
+    # Trigger st.switch_page
+    page.get_by_test_id("stButton").nth(0).locator("button").first.click()
+    wait_for_app_loaded(page)
+
+    # Check that only embed query params persist
+    expect(page).to_have_url(
+        f"http://localhost:{app_port}/page2?embed=true&embed_options=light_theme"
+    )
+
+
 def test_switch_page_removes_query_params(page: Page, app_port: int):
     """Test that query params are removed when navigating via st.switch_page"""
 

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -164,11 +164,11 @@ def test_switch_page_preserves_embed_params(page: Page, app_port: int):
     page.goto(
         f"http://localhost:{app_port}/?embed=true&embed_options=light_theme&bar=foo"
     )
-    wait_for_app_loaded(page)
+    wait_for_app_loaded(page, embedded=True)
 
     # Trigger st.switch_page
     page.get_by_test_id("stButton").nth(0).locator("button").first.click()
-    wait_for_app_loaded(page)
+    wait_for_app_loaded(page, embedded=True)
 
     # Check that only embed query params persist
     expect(page).to_have_url(

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -165,6 +165,7 @@ def test_switch_page_preserves_embed_params(page: Page, app_port: int):
         f"http://localhost:{app_port}/?embed=true&embed_options=light_theme&bar=foo"
     )
     wait_for_app_loaded(page, embedded=True)
+    expect(page.get_by_test_id("stJson")).to_contain_text('{"bar":"foo"}')
 
     # Trigger st.switch_page
     page.get_by_test_id("stButton").nth(0).locator("button").first.click()
@@ -174,6 +175,7 @@ def test_switch_page_preserves_embed_params(page: Page, app_port: int):
     expect(page).to_have_url(
         f"http://localhost:{app_port}/page2?embed=true&embed_options=light_theme"
     )
+    expect(page.get_by_test_id("stJson")).not_to_contain_text('{"bar":"foo"}')
 
 
 def test_switch_page_removes_query_params(page: Page, app_port: int):

--- a/e2e_playwright/multipage_apps/pages/02_page2.py
+++ b/e2e_playwright/multipage_apps/pages/02_page2.py
@@ -16,6 +16,8 @@ import streamlit as st
 
 st.header("Page 2")
 
+st.write("Query Params:", st.query_params)
+
 page_6 = st.button("`pages/06_page_6.py`")
 if page_6:
     st.switch_page("pages/06_page_6.py")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -151,6 +151,10 @@ def switch_page(page: str | StreamlitPage) -> NoReturn:  # type: ignore[misc]
 
         page_script_hash = matched_pages[0]["page_script_hash"]
 
+    # We want to reset query params (with exception of embed) when switching pages
+    with ctx.session_state.query_params() as qp:
+        qp.clear()
+
     ctx.script_requests.request_rerun(
         RerunData(
             query_string=ctx.query_string,


### PR DESCRIPTION
## Describe your changes
Add logic to `st.switch_page` to clear non-embed related query params 

## GitHub Issue Link (if applicable)
Closes #9050 

## Testing Plan
- E2E Test: ✅ 
- Manual Testing: ✅ 
