### PR TITLE
Fix issue with button clicks for enqueued fragments being dropped

### DIFF
--- a/e2e_playwright/st_fragment_queue.py
+++ b/e2e_playwright/st_fragment_queue.py
@@ -1,0 +1,45 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import streamlit as st
+
+
+@st.fragment
+def my_fragment1():
+    st.button("rerun fragment 1")
+    time.sleep(3)
+    st.write("fragment 1 done!")
+
+
+@st.fragment
+def my_fragment2():
+    if st.button("rerun fragment 2"):
+        st.write("ran fragment 2")
+    st.write("fragment 2 done!")
+
+
+@st.fragment
+def my_fragment3():
+    st.button("rerun fragment 3")
+    st.write("fragment 3 done!")
+
+
+with st.container(border=True):
+    my_fragment1()
+with st.container(border=True):
+    my_fragment2()
+with st.container(border=True):
+    my_fragment3()

--- a/e2e_playwright/st_fragment_queue_test.py
+++ b/e2e_playwright/st_fragment_queue_test.py
@@ -1,0 +1,44 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import get_button, get_markdown
+
+
+def test_fragment_queue(app: Page):
+    # Sanity check:
+    expect(app.get_by_test_id("stMarkdown")).to_have_count(3)
+    get_markdown(app, "fragment 1 done!")
+    get_markdown(app, "fragment 2 done!")
+    get_markdown(app, "fragment 3 done!")
+
+    # Quickly click all 3 buttons on the page without waiting for the app to finish
+    # between each click.
+    for b in [
+        get_button(app, "rerun fragment 1"),
+        get_button(app, "rerun fragment 2"),
+        get_button(app, "rerun fragment 3"),
+    ]:
+        b.click()
+    wait_for_app_run(app)
+
+    # Verify that the second button click wasn't dropped by checking that
+    # "ran fragment 2" was indeed printed.
+    expect(app.get_by_test_id("stMarkdown")).to_have_count(4)
+    get_markdown(app, "fragment 1 done!")
+    get_markdown(app, "ran fragment 2")
+    get_markdown(app, "fragment 2 done!")
+    get_markdown(app, "fragment 3 done!")

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Final, Mapping
 from typing_extensions import TypeAlias
 
 from streamlit.errors import DuplicateWidgetID
+from streamlit.proto.Common_pb2 import StringTriggerValue as StringTriggerValueProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.state.common import (
     RegisterWidgetResult,
@@ -243,20 +244,31 @@ def coalesce_widget_states(
         wstate.id: wstate for wstate in new_states.widgets
     }
 
-    trigger_value_types = [("trigger_value", False), ("string_trigger_value", None)]
+    trigger_value_types = [
+        ("trigger_value", False),
+        ("string_trigger_value", StringTriggerValueProto(data=None)),
+    ]
     for old_state in old_states.widgets:
         for trigger_value_type, unset_value in trigger_value_types:
             if (
                 old_state.WhichOneof("value") == trigger_value_type
-                and old_state.trigger_value != unset_value
+                and getattr(old_state, trigger_value_type) != unset_value
             ):
-                # Ensure the corresponding new_state is also a trigger;
-                # otherwise, a widget that was previously a button but no longer is
-                # could get a bad value.
                 new_trigger_val = states_by_id.get(old_state.id)
-                if (
-                    new_trigger_val
-                    and new_trigger_val.WhichOneof("value") == trigger_value_type
+                # It should nearly always be the case that new_trigger_val is None
+                # here as trigger values are deleted from the client's WidgetStateManager
+                # as soon as a rerun_script BackMsg is sent to the server. Since it's
+                # impossible to test that the client sends us state in the expected
+                # format in a unit test, we test for this behavior in
+                # e2e_playwright/test_fragment_queue_test.py
+                if not new_trigger_val or (
+                    # Ensure the corresponding new_state is also a trigger;
+                    # otherwise, a widget that was previously a button/chat_input but no
+                    # longer is could get a bad value.
+                    new_trigger_val.WhichOneof("value") == trigger_value_type
+                    # We only want to take the value of old_state if new_trigger_val is
+                    # unset as the old value may be stale if a newer one was entered.
+                    and getattr(new_trigger_val, trigger_value_type) == unset_value
                 ):
                     states_by_id[old_state.id] = old_state
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -27,8 +27,8 @@ from parameterized import parameterized
 from tornado.testing import AsyncTestCase
 
 from streamlit.delta_generator import DeltaGenerator, dg_stack
-from streamlit.errors import FragmentStorageKeyError
 from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
+from streamlit.errors import FragmentStorageKeyError
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -228,6 +228,9 @@ class WidgetManagerTests(unittest.TestCase):
         ).string_trigger_value.CopyFrom(StringTriggerValueProto(data=None))
         _create_widget("missing_in_new", old_states).int_value = 123
         _create_widget("shape_changing_trigger", old_states).trigger_value = True
+        _create_widget(
+            "overwritten_string_trigger", old_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data="old string"))
 
         session_state._set_widget_metadata(
             create_metadata("old_set_trigger", "trigger_value")
@@ -250,6 +253,9 @@ class WidgetManagerTests(unittest.TestCase):
         session_state._set_widget_metadata(
             create_metadata("shape changing trigger", "trigger_value")
         )
+        session_state._set_widget_metadata(
+            create_metadata("overwritten_string_trigger", "string_trigger_value")
+        )
 
         new_states = WidgetStates()
 
@@ -268,6 +274,12 @@ class WidgetManagerTests(unittest.TestCase):
         )
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
+        _create_widget(
+            "overwritten_string_trigger", new_states
+        ).string_trigger_value.CopyFrom(
+            StringTriggerValueProto(data="Overwritten string")
+        )
+
         session_state._set_widget_metadata(
             create_metadata("new_set_trigger", "trigger_value")
         )
@@ -294,6 +306,9 @@ class WidgetManagerTests(unittest.TestCase):
         self.assertEqual("", session_state["old_set_empty_string_trigger"].data)
         self.assertEqual(
             "Some other string", session_state["new_set_string_trigger"].data
+        )
+        self.assertEqual(
+            "Overwritten string", session_state["overwritten_string_trigger"].data
         )
 
         # Widgets that were triggers before, but no longer are, will *not*


### PR DESCRIPTION
The reason we end up dropping trigger values in this case is that `coalesce_widget_states` fails
to take into account that the `WidgetStateManager` on the frontend immediately clears trigger
values after sending the `BackMsg` informing the server that widget values have changed.

This fixes the incorrect assumption in the function so that we still keep the old trigger value if we
can't find a widget with the same ID in `new_state` (which will essentially always be the case).