### PR TITLE
Fix duplicate dialog fragment id

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 import streamlit as st
+from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 
 
 @st.experimental_dialog("Test Dialog with Images")
@@ -90,6 +91,19 @@ with st.sidebar:
         dialog_in_sidebar()
 
 
+@st.experimental_dialog("Submit-button Dialog")
+def submit_button_dialog():
+    st.write("This dialog has a submit button.")
+    st.write(f"Fragment Id: {get_script_run_ctx().current_fragment_id}")
+
+    if st.button("Submit", key="dialog6-btn"):
+        st.rerun()
+
+
+if st.button("Open submit-button Dialog"):
+    submit_button_dialog()
+
+
 @st.experimental_dialog("Level2 Dialog")
 def level2_dialog():
     st.write("Second level dialog")
@@ -98,6 +112,7 @@ def level2_dialog():
 @st.experimental_dialog("Level1 Dialog")
 def level1_dialog():
     st.write("First level dialog")
+    st.write(f"Fragment Id: {get_script_run_ctx().current_fragment_id}")
     level2_dialog()
 
 

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -83,7 +83,7 @@ def test_dialog_closes_properly(app: Page):
 
 
 def test_dialog_dismisses_properly(app: Page):
-    """Test that dialog is dismissed properly after clicking on modal close (= dismiss)."""
+    """Test that dialog is dismissed properly after clicking on close (= dismiss)."""
     open_dialog_with_images(app)
     wait_for_app_run(app)
     main_dialog = app.get_by_test_id(modal_test_id)
@@ -95,7 +95,8 @@ def test_dialog_dismisses_properly(app: Page):
     expect(main_dialog).to_have_count(0)
 
 
-# on webkit this test was flaky and manually reproducing the flaky error did not work, so we skip it for now
+# on webkit this test was flaky and manually reproducing the flaky error did not work,
+# so we skip it for now
 @pytest.mark.skip_browser("webkit")
 def test_dialog_reopens_properly_after_dismiss(app: Page):
     """Test that dialog reopens after dismiss."""
@@ -107,8 +108,8 @@ def test_dialog_reopens_properly_after_dismiss(app: Page):
 
         main_dialog = app.get_by_test_id(modal_test_id)
 
-        # sometimes the dialog does not seem to open in the test, so retry opening it by clicking on it.
-        # if it does not open after the second attempt, fail the test.
+        # sometimes the dialog does not seem to open in the test, so retry opening it by
+        # clicking on it. if it does not open after the second attempt, fail the test.
         if main_dialog.count() == 0:
             app.wait_for_timeout(100)
             open_dialog_without_images(app)
@@ -173,7 +174,7 @@ def test_fullscreen_is_disabled_for_dialog_elements(app: Page):
 
 
 def test_actions_for_dialog_headings(app: Page):
-    """Test that headings within the dialog show the tooltip icon but not the link icon."""
+    """Test that dialog headings show the tooltip icon but not the link icon."""
     open_headings_dialogs(app)
     wait_for_app_run(app)
     main_dialog = app.get_by_test_id(modal_test_id)
@@ -197,7 +198,8 @@ def test_dialog_displays_correctly(app: Page, assert_snapshot: ImageCompareFunct
     open_dialog_without_images(app)
     wait_for_app_run(app)
     dialog = app.get_by_role("dialog")
-    # click on the dialog title to take away focus of all elements and make the screenshot stable. Then hover over the button for visual effect.
+    # click on the dialog title to take away focus of all elements and make the
+    # screenshot stable. Then hover over the button for visual effect.
     dialog.locator("div", has_text="Simple Dialog").click()
     submit_button = dialog.get_by_test_id("stButton")
     expect(submit_button).to_be_visible()
@@ -211,7 +213,8 @@ def test_largewidth_dialog_displays_correctly(
     open_largewidth_dialog(app)
     wait_for_app_run(app)
     dialog = app.get_by_role("dialog")
-    # click on the dialog title to take away focus of all elements and make the screenshot stable. Then hover over the button for visual effect.
+    # click on the dialog title to take away focus of all elements and make the
+    # screenshot stable. Then hover over the button for visual effect.
     dialog.locator("div", has_text="Large-width Dialog").click()
     submit_button = dialog.get_by_test_id("stButton")
     expect(submit_button).to_be_visible()
@@ -219,14 +222,17 @@ def test_largewidth_dialog_displays_correctly(
     assert_snapshot(dialog, name="st_dialog-with_large_width")
 
 
-# its enough to test this on one browser as showing the error inline is more a backend functionality than a frontend one
+# its enough to test this on one browser as showing the error inline is more a backend
+# functionality than a frontend one
 @pytest.mark.only_browser("chromium")
 def test_dialog_shows_error_inline(app: Page, assert_snapshot: ImageCompareFunction):
-    """Additional check to the unittests we have to ensure errors thrown during the main script execution (not a fragment-only rerun) are rendered within the dialog."""
+    """Additional check to the unittests we have to ensure errors thrown during the main
+    script execution (not a fragment-only rerun) are rendered within the dialog."""
     open_dialog_with_internal_error(app)
     wait_for_app_run(app)
     dialog = app.get_by_role("dialog")
-    # click on the dialog title to take away focus of all elements and make the screenshot stable. Then hover over the button for visual effect.
+    # click on the dialog title to take away focus of all elements and make the
+    # screenshot stable. Then hover over the button for visual effect.
     dialog.locator("div", has_text="Dialog with error").click()
     expect(dialog.get_by_text("TypeError")).to_be_visible()
     assert_snapshot(dialog, name="st_dialog-with_inline_error")
@@ -240,7 +246,8 @@ def test_sidebar_dialog_displays_correctly(
     dialog = app.get_by_role("dialog")
     submit_button = dialog.get_by_test_id("stButton")
     expect(submit_button).to_be_visible()
-    # ensure focus of the button to avoid flakiness where sometimes snapshots are made when the button is not in focus
+    # ensure focus of the button to avoid flakiness where sometimes snapshots are made
+    # when the button is not in focus
     submit_button.get_by_test_id("baseButton-secondary").hover()
     assert_snapshot(dialog, name="st_dialog-in_sidebar")
 
@@ -256,6 +263,9 @@ def test_nested_dialogs(app: Page):
     )
 
 
+# on webkit this test was flaky and manually reproducing the flaky error did not work,
+# so we skip it for now
+@pytest.mark.skip_browser("webkit")
 def test_dialogs_have_different_fragment_ids(app: Page):
     """Test that st.dialog may not be nested inside other dialogs."""
     open_submit_button_dialog(app)

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -16,6 +16,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.shared.app_utils import get_markdown
 
 modal_test_id = "stModal"
 
@@ -44,6 +45,14 @@ def open_sidebar_dialog(app: Page):
 
 def open_dialog_with_internal_error(app: Page):
     app.get_by_role("button").filter(has_text="Open Dialog with Key Error").click()
+
+
+def open_nested_dialogs(app: Page):
+    app.get_by_role("button").filter(has_text="Open Nested Dialogs").click()
+
+
+def open_submit_button_dialog(app: Page):
+    app.get_by_role("button").filter(has_text="Open submit-button Dialog").click()
 
 
 def click_to_dismiss(app: Page):
@@ -238,10 +247,46 @@ def test_sidebar_dialog_displays_correctly(
 
 def test_nested_dialogs(app: Page):
     """Test that st.dialog may not be nested inside other dialogs."""
-    app.get_by_text("Open Nested Dialogs").click()
+    open_nested_dialogs(app)
     wait_for_app_run(app)
     exception_message = app.get_by_test_id("stException")
 
     expect(exception_message).to_contain_text(
         "StreamlitAPIException: Dialogs may not be nested inside other dialogs."
     )
+
+
+def test_dialogs_have_different_fragment_ids(app: Page):
+    """Test that st.dialog may not be nested inside other dialogs."""
+    open_submit_button_dialog(app)
+    wait_for_app_run(app)
+    large_width_dialog_fragment_id = get_markdown(app, "Fragment Id:").text_content()
+    dialog = app.get_by_role("dialog")
+    submit_button = dialog.get_by_test_id("stButton")
+    expect(submit_button).to_be_visible()
+    submit_button.get_by_test_id("baseButton-secondary").click()
+    wait_for_app_run(app)
+
+    open_nested_dialogs(app)
+    wait_for_app_run(app)
+    nested_dialog_fragment_id = get_markdown(app, "Fragment Id:").text_content()
+    exception_message = app.get_by_test_id("stException")
+    expect(exception_message).to_contain_text(
+        "StreamlitAPIException: Dialogs may not be nested inside other dialogs."
+    )
+    click_to_dismiss(app)
+    # wait after dismiss so that we can open the next dialog
+    app.wait_for_timeout(200)
+    expect(app.get_by_test_id(modal_test_id)).not_to_be_attached()
+    open_submit_button_dialog(app)
+    wait_for_app_run(app)
+    dialog = app.get_by_role("dialog")
+    submit_button = dialog.get_by_test_id("stButton")
+    expect(submit_button).to_be_visible()
+    submit_button.get_by_test_id("baseButton-secondary").click()
+    wait_for_app_run(app)
+
+    exception_message = app.get_by_test_id("stException")
+    expect(exception_message).not_to_be_attached()
+
+    assert large_width_dialog_fragment_id != nested_dialog_fragment_id

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -72,7 +72,12 @@ def _dialog_decorator(
             return None
 
         # the fragment decorator has multiple return types so that you can pass arguments to it. Here we know the return type, so we cast
-        fragmented_dialog_content = cast(Callable[[], None], _fragment(dialog_content))
+        fragmented_dialog_content = cast(
+            Callable[[], None],
+            _fragment(
+                dialog_content, additional_hash_info=non_optional_func.__qualname__
+            ),
+        )
         with dialog:
             fragmented_dialog_content()
             return None

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -123,7 +123,10 @@ class MemoryFragmentStorage(FragmentStorage):
 
 
 def _fragment(
-    func: F | None = None, *, run_every: int | float | timedelta | str | None = None
+    func: F | None = None,
+    *,
+    run_every: int | float | timedelta | str | None = None,
+    additional_hash_info: str = "",
 ) -> Callable[[F], F] | F:
     """Contains the actual fragment logic.
 
@@ -156,7 +159,7 @@ def _fragment(
         dg_stack_snapshot = deepcopy(dg_stack.get())
         h = hashlib.new("md5")
         h.update(
-            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}".encode()
+            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}".encode()
         )
         fragment_id = h.hexdigest()
 

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -395,21 +395,21 @@ class FragmentTest(unittest.TestCase):
     def test_fragment_additional_hash_info_param_used_for_generating_id(
         self, patched_get_script_run_ctx
     ):
-        ctx = MagicMock()
-        patched_get_script_run_ctx.return_value = ctx
         """Test that the internal function can be called with an
         additional hash info parameter."""
+        ctx = MagicMock()
+        patched_get_script_run_ctx.return_value = ctx
 
         def my_function():
             return ctx.current_fragment_id
 
         fragment_id1 = _fragment(my_function)()
         fragment_id2 = _fragment(my_function, additional_hash_info="some_hash_info")()
-        self.assertNotEqual(fragment_id1, fragment_id2)
+        assert fragment_id1 != fragment_id2
 
         # countercheck
         fragment_id2 = _fragment(my_function, additional_hash_info="")()
-        self.assertEqual(fragment_id1, fragment_id2)
+        assert fragment_id1 == fragment_id2
 
 
 # TESTS FOR WRITING TO CONTAINERS OUTSIDE AND INSIDE OF FRAGMENT

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator, dg_stack
 from streamlit.errors import FragmentStorageKeyError
-from streamlit.runtime.fragment import MemoryFragmentStorage, fragment
+from streamlit.runtime.fragment import MemoryFragmentStorage, _fragment, fragment
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner.exceptions import RerunException
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -390,6 +390,26 @@ class FragmentTest(unittest.TestCase):
                 raise exception_type()
 
             my_fragment()
+
+    @patch("streamlit.runtime.fragment.get_script_run_ctx")
+    def test_fragment_additional_hash_info_param_used_for_generating_id(
+        self, patched_get_script_run_ctx
+    ):
+        ctx = MagicMock()
+        patched_get_script_run_ctx.return_value = ctx
+        """Test that the internal function can be called with an
+        additional hash info parameter."""
+
+        def my_function():
+            return ctx.current_fragment_id
+
+        fragment_id1 = _fragment(my_function)()
+        fragment_id2 = _fragment(my_function, additional_hash_info="some_hash_info")()
+        self.assertNotEqual(fragment_id1, fragment_id2)
+
+        # countercheck
+        fragment_id2 = _fragment(my_function, additional_hash_info="")()
+        self.assertEqual(fragment_id1, fragment_id2)
 
 
 # TESTS FOR WRITING TO CONTAINERS OUTSIDE AND INSIDE OF FRAGMENT


### PR DESCRIPTION
## Describe your changes

Right now, dialogs within an app always generate the same fragment id. This is problematic and can lead to mixing contents of different dialogs. Add a new parameter that is used by the dialog decorator to pass the actually wrapped function name to the fragment in order to generate the hash.
This behavior started to surface with [these changed lines](https://github.com/streamlit/streamlit/pull/9019/files#diff-1a48dd69fdc75dd4d8575a0a890d1b90fd18b4a8124ecc132357460b025435edR218-R219) in the `feature/st.fragment` branch; prior to that we overwrote fragments with the same id in the storage and since we only allow a single dialog at any given time, this issue stayed unrecognized.

<details>
<summary>Before</summary>

https://github.com/streamlit/streamlit/assets/3775781/7bc47033-df0e-4695-9a05-2975968758ee

</details>

<details>
<summary>After</summary>

https://github.com/streamlit/streamlit/assets/3775781/91f4e5c8-b1b8-48e6-bfc5-e949fbfecb65

</details>

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
  - Unit tests seem difficult to add for this because if we use the `DeltaGeneratorTestCase`, the dialogs have different delta paths when opened simultaneously versus the same delta path in a real app after a rerun happened. Hence, I figured the e2e test resembles the chain of sequence best.
- E2E Tests
  - Add an e2e test that triggers the sequence of action that leads to the bug

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
