### PR TITLE
Always add fragment_ids to set

### DIFF
--- a/e2e_playwright/st_fragment_mixed_execution_flow.py
+++ b/e2e_playwright/st_fragment_mixed_execution_flow.py
@@ -1,0 +1,41 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from uuid import uuid4
+
+import streamlit as st
+
+if "sleep_time" not in st.session_state:
+    st.session_state["sleep_time"] = 0
+sleep_time = st.session_state["sleep_time"]
+
+
+@st.fragment
+def my_fragment(n):
+    with st.container(border=True):
+        st.button("rerun this fragment", key=n)
+        st.write(f"uuid in fragment {n}: {uuid4()}")
+    # sleep here so that we have time to react to the flow
+    # and trigger buttons etc. before the fragment is finished
+    # and the next starts to render
+    time.sleep(sleep_time)
+
+
+my_fragment(1)
+my_fragment(2)
+my_fragment(3)
+
+st.session_state["sleep_time"] = 3
+st.button("Full app rerun")

--- a/e2e_playwright/st_fragment_mixed_execution_flow_test.py
+++ b/e2e_playwright/st_fragment_mixed_execution_flow_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+
+
+def get_uuids(app: Page):
+    expect(app.get_by_test_id("stMarkdown")).to_have_count(2)
+
+    fragment_1_text = app.get_by_test_id("stMarkdown").first.text_content()
+    fragment_2_text = app.get_by_test_id("stMarkdown").last.text_content()
+
+    return fragment_1_text, fragment_2_text
+
+
+def test_fragments_rerun_correctly_during_full_app_run(app: Page):
+    # Click the first button and verify that only the uuid in the first fragment
+    # changed.
+
+    app.get_by_test_id("stButton").locator("button").filter(
+        has_text="Full app rerun"
+    ).click()
+    app.get_by_test_id("stButton").locator("button").nth(1).click()
+    wait_for_app_run(app)
+
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="uuid in fragment 1").first
+    ).to_be_attached()
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="uuid in fragment 2").first
+    ).to_be_attached()
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="uuid in fragment 3").first
+    ).to_be_attached()

--- a/e2e_playwright/st_fragment_mixed_execution_flow_test.py
+++ b/e2e_playwright/st_fragment_mixed_execution_flow_test.py
@@ -27,12 +27,23 @@ def get_uuids(app: Page):
 
 
 def test_fragments_rerun_correctly_during_full_app_run(app: Page):
-    # Click the first button and verify that only the uuid in the first fragment
-    # changed.
+    """Test that fragments can send fragment-bound reruns during full app runs.
+
+    Click on the full app rerun button and immediately click on the second
+    fragment button. This will send a rerun message bound to the fragment while
+    the full app run is still executing. The expectation is that the full app
+    run is still continuing and the following fragments are also registered
+    and executing correctly.
+    """
 
     app.get_by_test_id("stButton").locator("button").filter(
         has_text="Full app rerun"
     ).click()
+
+    # wait until first fragment is finished
+    sleep_time_of_fragment = 3500
+    app.wait_for_timeout(sleep_time_of_fragment)
+
     app.get_by_test_id("stButton").locator("button").nth(1).click()
     wait_for_app_run(app)
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -154,10 +154,9 @@ def _fragment(
 
         cursors_snapshot = deepcopy(ctx.cursors)
         dg_stack_snapshot = deepcopy(dg_stack.get())
-        active_dg = dg_stack_snapshot[-1]
         h = hashlib.new("md5")
         h.update(
-            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{active_dg._get_delta_path_str()}".encode()
+            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}".encode()
         )
         fragment_id = h.hexdigest()
 


### PR DESCRIPTION
## Describe your changes

Fix two issues:
- the `current_fragment_delta_path` could have been taken from the wrong snapshot
- always add the `current_fragment_id` to the set of new fragment ids. This prevents an issue where a fragment rerun is triggered during full app execution. 

<details>
<summary>Current Fragment Id not found error video</summary>

https://github.com/streamlit/streamlit/assets/3775781/804f2d1c-563f-4e11-a319-c003516d387d

</details>

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
 - Add e2e test to ensure that the `current_fragment_id` error does not happen
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
