### PR TITLE
Add support for Kubernetes / directory with mounted file style secrets

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -923,6 +923,21 @@ _create_option(
     """,
 )
 
+# Config Section: Secrets #
+
+_create_section("secrets", "Secrets configuration.")
+
+_create_option(
+    "secrets.files",
+    description="""List of locations where secrets are searched. Entries can be a path to toml file or directory path where Kubernetes style secrets will be scanned. Order is important, import is first to last, so secrets in later files will take precedence over earlier ones.""",
+    default_val=[
+        # NOTE: The order here is important! Project-level secrets should overwrite global
+        # secrets.
+        file_util.get_streamlit_file_path("secrets.toml"),
+        file_util.get_project_streamlit_file_path("secrets.toml"),
+    ],
+)
+
 
 def get_where_defined(key: str) -> str:
     """Indicate where (e.g. in which file) this option was defined.

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -19,6 +19,7 @@ import threading
 from copy import deepcopy
 from typing import (
     Any,
+    Callable,
     Final,
     ItemsView,
     Iterator,
@@ -32,16 +33,98 @@ from blinker import Signal
 
 import streamlit as st
 import streamlit.watcher.path_watcher
-from streamlit import file_util, runtime
+from streamlit import runtime
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
-SECRETS_FILE_LOCS: Final[list[str]] = [
-    file_util.get_streamlit_file_path("secrets.toml"),
-    # NOTE: The order here is important! Project-level secrets should overwrite global
-    # secrets.
-    file_util.get_project_streamlit_file_path("secrets.toml"),
-]
+
+
+class SecretErrorMessages:
+    """SecretErrorMessages stores all error messages we use for secrets to allow customization for different environments.
+    For example Streamlit Cloud can customize the message to be different than the open source.
+
+    For internal use, may change in future releases without notice.
+    """
+
+    def __init__(self):
+        self.missing_attr_message = lambda attr_name: (
+            f'st.secrets has no attribute "{attr_name}". '
+            f"Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings on Streamlit Cloud? "
+            f"More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
+        )
+        self.missing_key_message = lambda key: (
+            f'st.secrets has no key "{key}". '
+            f"Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings on Streamlit Cloud? "
+            f"More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
+        )
+        self.no_secrets_found = lambda file_paths: (
+            f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(file_paths)}"
+        )
+        self.error_parsing_file_at_path = (
+            lambda path, ex: f"Error parsing secrets file at {path}: {ex}"
+        )
+        self.subfolder_path_is_not_a_folder = lambda sub_folder_path: (
+            f"{sub_folder_path} is not a folder. "
+            "To use directory based secrets, mount every secret in a subfolder under the secret directory"
+        )
+        self.invalid_secret_path = lambda path: (
+            f"Invalid secrets path: {path}: path is not a .toml file or a directory"
+        )
+
+    def set_missing_attr_message(self, message: Callable[[str], str]) -> None:
+        """Set the missing attribute error message."""
+        self.missing_attr_message = message
+
+    def set_missing_key_message(self, message: Callable[[str], str]) -> None:
+        """Set the missing key error message."""
+        self.missing_key_message = message
+
+    def set_no_secrets_found_message(self, message: Callable[[list[str]], str]) -> None:
+        """Set the no secrets found error message."""
+        self.no_secrets_found = message
+
+    def set_error_parsing_file_at_path_message(
+        self, message: Callable[[str, Exception], str]
+    ) -> None:
+        """Set the error parsing file at path error message."""
+        self.error_parsing_file_at_path = message
+
+    def set_subfolder_path_is_not_a_folder_message(
+        self, message: Callable[[str], str]
+    ) -> None:
+        """Set the subfolder path is not a folder error message."""
+        self.subfolder_path_is_not_a_folder = message
+
+    def set_invalid_secret_path_message(self, message: Callable[[str], str]) -> None:
+        """Set the invalid secret path error message."""
+        self.invalid_secret_path = message
+
+    def get_missing_attr_message(self, attr_name: str) -> str:
+        """Get the missing attribute error message."""
+        return self.missing_attr_message(attr_name)
+
+    def get_missing_key_message(self, key: str) -> str:
+        """Get the missing key error message."""
+        return self.missing_key_message(key)
+
+    def get_no_secrets_found_message(self, file_paths: list[str]) -> str:
+        """Get the no secrets found error message."""
+        return self.no_secrets_found(file_paths)
+
+    def get_error_parsing_file_at_path_message(self, path: str, ex: Exception) -> str:
+        """Get the error parsing file at path error message."""
+        return self.error_parsing_file_at_path(path, ex)
+
+    def get_subfolder_path_is_not_a_folder_message(self, sub_folder_path: str) -> str:
+        """Get the subfolder path is not a folder error message."""
+        return self.subfolder_path_is_not_a_folder(sub_folder_path)
+
+    def get_invalid_secret_path_message(self, path: str) -> str:
+        """Get the invalid secret path error message."""
+        return self.invalid_secret_path(path)
+
+
+secret_error_messages_singleton: Final = SecretErrorMessages()
 
 
 def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
@@ -52,24 +135,15 @@ def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
 
 
 def _missing_attr_error_message(attr_name: str) -> str:
-    return (
-        f'st.secrets has no attribute "{attr_name}". '
-        f"Did you forget to add it to secrets.toml or the app settings on Streamlit Cloud? "
-        f"More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
-    )
+    return secret_error_messages_singleton.get_missing_attr_message(attr_name)
 
 
 def _missing_key_error_message(key: str) -> str:
-    return (
-        f'st.secrets has no key "{key}". '
-        f"Did you forget to add it to secrets.toml or the app settings on Streamlit Cloud? "
-        f"More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
-    )
+    return secret_error_messages_singleton.get_missing_key_message(key)
 
 
 class AttrDict(Mapping[str, Any]):
-    """
-    We use AttrDict to wrap up dictionary values from secrets
+    """We use AttrDict to wrap up dictionary values from secrets
     to provide dot access to nested secrets
     """
 
@@ -123,12 +197,12 @@ class Secrets(Mapping[str, Any]):
     Safe to use from multiple threads.
     """
 
-    def __init__(self, file_paths: list[str]):
+    def __init__(self):
         # Our secrets dict.
         self._secrets: Mapping[str, Any] | None = None
         self._lock = threading.RLock()
         self._file_watchers_installed = False
-        self._file_paths = file_paths
+        self._suppress_print_error_on_exception = False
 
         self.file_change_listener = Signal(
             doc="Emitted when a `secrets.toml` file has been changed."
@@ -143,12 +217,34 @@ class Secrets(Mapping[str, Any]):
 
         Thread-safe.
         """
+        prev_suppress_print_error_on_exception = self._suppress_print_error_on_exception
         try:
-            self._parse(print_exceptions=False)
+            # temporarily suppress printing errors on exceptions, we don't want to print errors
+            # in this method since it only loads secrets if they exist
+
+            self._suppress_print_error_on_exception = True
+            self._parse()
+
             return True
         except FileNotFoundError:
             # No secrets.toml files exist. That's fine.
             return False
+        finally:
+            self._suppress_print_error_on_exception = (
+                prev_suppress_print_error_on_exception
+            )
+
+    def set_suppress_print_error_on_exception(
+        self, suppress_print_error_on_exception: bool
+    ) -> None:
+        """Set whether exceptions should be printed when accessing secrets.
+        For internal use, may change in future releases without notice."""
+        self._suppress_print_error_on_exception = suppress_print_error_on_exception
+
+    def _print_exception_if_not_suppressed(self, error_msg: str) -> None:
+        """Print the given error message if exceptions are not suppressed."""
+        if not self._suppress_print_error_on_exception:
+            st.error(str(error_msg))
 
     def _reset(self) -> None:
         """Clear the secrets dictionary and remove any secrets that were
@@ -164,7 +260,95 @@ class Secrets(Mapping[str, Any]):
                 self._maybe_delete_environment_variable(k, v)
             self._secrets = None
 
-    def _parse(self, print_exceptions: bool) -> Mapping[str, Any]:
+    def _parse_toml_file(self, path: str) -> tuple[Mapping[str, Any], bool]:
+        """Parse a TOML file and return the secrets as a dictionary."""
+        secrets = {}
+        found_secrets_file = False
+
+        try:
+            with open(path, encoding="utf-8") as f:
+                secrets_file_str = f.read()
+
+            found_secrets_file = True
+        except FileNotFoundError:
+            # the default config for secrets contains two paths. It's likely one of will not have secrets file.
+            return {}, False
+
+        try:
+            import toml
+
+            secrets.update(toml.loads(secrets_file_str))
+        except (TypeError, toml.TomlDecodeError) as ex:
+            error_msg = (
+                secret_error_messages_singleton.get_error_parsing_file_at_path_message(
+                    path, ex
+                )
+            )
+            self._print_exception_if_not_suppressed(error_msg)
+            raise
+
+        return secrets, found_secrets_file
+
+    def _parse_directory(self, path: str) -> tuple[Mapping[str, Any], bool]:
+        """Parse a directory for secrets. Directory style can be used to support Kubernetes secrets that are mounted to folders.
+
+        Example structure:
+        - top_level_secret_folder
+            - user_pass_secret (folder)
+                - username (file), content: myuser
+                - password (file), content: mypassword
+            - my_plain_secret (folder)
+                - regular_secret (file), content: mysecret
+
+        See: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume
+        And: https://docs.snowflake.com/en/developer-guide/snowpark-container-services/additional-considerations-services-jobs#passing-secrets-in-local-container-files
+        """
+        secrets: dict[str, Any] = {}
+        found_secrets_file = False
+
+        for dirname in os.listdir(path):
+            sub_folder_path = os.path.join(path, dirname)
+            if not os.path.isdir(sub_folder_path):
+                error_msg = secret_error_messages_singleton.get_subfolder_path_is_not_a_folder_message(
+                    sub_folder_path
+                )
+                self._print_exception_if_not_suppressed(error_msg)
+                raise ValueError(error_msg)
+            sub_secrets = {}
+
+            for filename in os.listdir(sub_folder_path):
+                file_path = os.path.join(sub_folder_path, filename)
+
+                # ignore folders
+                if os.path.isdir(file_path):
+                    continue
+
+                with open(file_path) as f:
+                    sub_secrets[filename] = f.read().strip()
+                    found_secrets_file = True
+
+            if len(sub_secrets) == 1:
+                # if there's just one file, collapse it so it's directly under `dirname`
+                secrets[dirname] = sub_secrets[list(sub_secrets.keys())[0]]
+            else:
+                secrets[dirname] = sub_secrets
+
+        return secrets, found_secrets_file
+
+    def _parse_file_path(self, path: str) -> tuple[Mapping[str, Any], bool]:
+        if path.endswith(".toml"):
+            return self._parse_toml_file(path)
+
+        if os.path.isdir(path):
+            return self._parse_directory(path)
+
+        error_msg = secret_error_messages_singleton.get_invalid_secret_path_message(
+            path
+        )
+        self._print_exception_if_not_suppressed(error_msg)
+        raise ValueError(error_msg)
+
+    def _parse(self) -> Mapping[str, Any]:
         """Parse our secrets.toml files if they're not already parsed.
         This function is safe to call from multiple threads.
 
@@ -190,41 +374,23 @@ class Secrets(Mapping[str, Any]):
             if self._secrets is not None:
                 return self._secrets
 
-            # It's fine for a user to only have one secrets.toml file defined, so
-            # we ignore individual FileNotFoundErrors when attempting to read files
-            # below and only raise an exception if we weren't able read *any* secrets
-            # file.
-            found_secrets_file = False
             secrets = {}
 
-            for path in self._file_paths:
-                try:
-                    with open(path, encoding="utf-8") as f:
-                        secrets_file_str = f.read()
-                    found_secrets_file = True
-                except FileNotFoundError:
-                    continue
-
-                try:
-                    import toml
-
-                    secrets.update(toml.loads(secrets_file_str))
-                except:
-                    if print_exceptions:
-                        st.error(f"Error parsing secrets file at {path}")
-                    raise
+            file_paths = st.config.get_option("secrets.files")
+            found_secrets_file = False
+            for path in file_paths:
+                path_secrets, found_secrets_file_in_path = self._parse_file_path(path)
+                found_secrets_file = found_secrets_file or found_secrets_file_in_path
+                secrets.update(path_secrets)
 
             if not found_secrets_file:
-                err_msg = f"No secrets files found. Valid paths for a secrets.toml file are: {', '.join(self._file_paths)}"
-                if print_exceptions:
-                    st.error(err_msg)
-                raise FileNotFoundError(err_msg)
-
-            if len([p for p in self._file_paths if os.path.exists(p)]) > 1:
-                _LOGGER.info(
-                    f"Secrets found in multiple locations: {', '.join(self._file_paths)}. "
-                    "When multiple secret.toml files exist, local secrets will take precedence over global secrets."
+                error_msg = (
+                    secret_error_messages_singleton.get_no_secrets_found_message(
+                        file_paths
+                    )
                 )
+                self._print_exception_if_not_suppressed(error_msg)
+                raise FileNotFoundError(error_msg)
 
             for k, v in secrets.items():
                 self._maybe_set_environment_variable(k, v)
@@ -236,7 +402,7 @@ class Secrets(Mapping[str, Any]):
 
     def to_dict(self) -> dict[str, Any]:
         """Converts the secrets store into a nested dictionary, where nested AttrDict objects are also converted into dictionaries."""
-        secrets = self._parse(True)
+        secrets = self._parse()
         return _convert_to_dict(secrets)
 
     @staticmethod
@@ -262,13 +428,21 @@ class Secrets(Mapping[str, Any]):
             if self._file_watchers_installed:
                 return
 
-            for path in self._file_paths:
+            file_paths = st.config.get_option("secrets.files")
+            for path in file_paths:
                 try:
-                    streamlit.watcher.path_watcher.watch_file(
-                        path,
-                        self._on_secrets_file_changed,
-                        watcher_type="poll",
-                    )
+                    if path.endswith(".toml"):
+                        streamlit.watcher.path_watcher.watch_file(
+                            path,
+                            self._on_secrets_changed,
+                            watcher_type="poll",
+                        )
+                    else:
+                        streamlit.watcher.path_watcher.watch_dir(
+                            path,
+                            self._on_secrets_changed,
+                            watcher_type="poll",
+                        )
                 except FileNotFoundError:
                     # A user may only have one secrets.toml file defined, so we'd expect
                     # FileNotFoundErrors to be raised when attempting to install a
@@ -279,11 +453,11 @@ class Secrets(Mapping[str, Any]):
             # failed to avoid repeatedly trying to install it.
             self._file_watchers_installed = True
 
-    def _on_secrets_file_changed(self, changed_file_path) -> None:
+    def _on_secrets_changed(self, changed_file_path) -> None:
         with self._lock:
-            _LOGGER.debug("Secrets file %s changed, reloading", changed_file_path)
+            _LOGGER.debug("Secret path %s changed, reloading", changed_file_path)
             self._reset()
-            self._parse(print_exceptions=True)
+            self._parse()
 
         # Emit a signal to notify receivers that the `secrets.toml` file
         # has been changed.
@@ -296,7 +470,7 @@ class Secrets(Mapping[str, Any]):
         Thread-safe.
         """
         try:
-            value = self._parse(True)[key]
+            value = self._parse()[key]
             if not isinstance(value, Mapping):
                 return value
             else:
@@ -314,7 +488,7 @@ class Secrets(Mapping[str, Any]):
         Thread-safe.
         """
         try:
-            value = self._parse(True)[key]
+            value = self._parse()[key]
             if not isinstance(value, Mapping):
                 return value
             else:
@@ -329,36 +503,36 @@ class Secrets(Mapping[str, Any]):
         # the file must already exist.
         """A string representation of the contents of the dict. Thread-safe."""
         if not runtime.exists():
-            return f"{self.__class__.__name__}(file_paths={self._file_paths!r})"
-        return repr(self._parse(True))
+            return f"{self.__class__.__name__}"
+        return repr(self._parse())
 
     def __len__(self) -> int:
         """The number of entries in the dict. Thread-safe."""
-        return len(self._parse(True))
+        return len(self._parse())
 
     def has_key(self, k: str) -> bool:
         """True if the given key is in the dict. Thread-safe."""
-        return k in self._parse(True)
+        return k in self._parse()
 
     def keys(self) -> KeysView[str]:
         """A view of the keys in the dict. Thread-safe."""
-        return self._parse(True).keys()
+        return self._parse().keys()
 
     def values(self) -> ValuesView[Any]:
         """A view of the values in the dict. Thread-safe."""
-        return self._parse(True).values()
+        return self._parse().values()
 
     def items(self) -> ItemsView[str, Any]:
         """A view of the key-value items in the dict. Thread-safe."""
-        return self._parse(True).items()
+        return self._parse().items()
 
     def __contains__(self, key: Any) -> bool:
         """True if the given key is in the dict. Thread-safe."""
-        return key in self._parse(True)
+        return key in self._parse()
 
     def __iter__(self) -> Iterator[str]:
         """An iterator over the keys in the dict. Thread-safe."""
-        return iter(self._parse(True))
+        return iter(self._parse())
 
 
-secrets_singleton: Final = Secrets(SECRETS_FILE_LOCS)
+secrets_singleton: Final = Secrets()

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -333,7 +333,7 @@ class AppTest:
         saved_secrets: Secrets = st.secrets
         # Only modify global secrets stuff if we have been given secrets
         if self.secrets:
-            new_secrets = Secrets([])
+            new_secrets = Secrets()
             new_secrets._secrets = self.secrets
             st.secrets = new_secrets
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import copy
 import os
+import sys
 import textwrap
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
@@ -326,6 +327,7 @@ class ConfigTest(unittest.TestCase):
                 "magic",
                 "mapbox",
                 "runner",
+                "secrets",
                 "server",
                 "ui",
             ]
@@ -369,6 +371,7 @@ class ConfigTest(unittest.TestCase):
                 "magic.displayRootDocString",
                 "magic.displayLastExprIfNoSemicolon",
                 "mapbox.token",
+                "secrets.files",
                 "server.baseUrlPath",
                 "server.enableCORS",
                 "server.cookieSecret",
@@ -575,6 +578,24 @@ class ConfigTest(unittest.TestCase):
 
             disconnect_callback()
             patched_disconnect.assert_called_once()
+
+    def test_secret_files_default_values(self):
+        """Verify that we're looking for secrets.toml in the right place."""
+        if "win32" not in sys.platform:
+            # conftest.py sets the HOME envvar to "/mock/home/folder".
+            expected_global_path = "/mock/home/folder/.streamlit/secrets.toml"
+        else:
+            # On windows systems, HOME does not work so we look in the user's directory instead.
+            expected_global_path = os.path.join(
+                os.path.expanduser("~"), ".streamlit", "secrets.toml"
+            )
+        self.assertEqual(
+            [
+                expected_global_path,
+                os.path.abspath("./.streamlit/secrets.toml"),
+            ],
+            config.get_option("secrets.files"),
+        )
 
 
 class ConfigLoadingTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -102,7 +102,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         [
             # No type is specified, and there's no config file to find one
             # in.
-            (None, FileNotFoundError, "No secrets files found"),
+            (None, FileNotFoundError, "No secrets found"),
             # Nonexistent module.
             (
                 "nonexistent.module.SomeConnection",

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 import unittest
 from collections.abc import Mapping as MappingABC
@@ -28,7 +27,12 @@ from unittest.mock import MagicMock, mock_open, patch
 from parameterized import parameterized
 from toml import TomlDecodeError
 
-from streamlit.runtime.secrets import SECRETS_FILE_LOCS, AttrDict, Secrets
+from streamlit.runtime.secrets import (
+    AttrDict,
+    SecretErrorMessages,
+    Secrets,
+)
+from tests import testutil
 from tests.exception_capturing_thread import call_on_threads
 
 MOCK_TOML = """
@@ -44,6 +48,24 @@ email="eng@streamlit.io"
 MOCK_SECRETS_FILE_LOC = "/mock/secrets.toml"
 
 
+class TestSecretErrorMessages(unittest.TestCase):
+    def test_changing_message(self):
+        messages = SecretErrorMessages()
+        self.assertEqual(
+            messages.get_missing_attr_message("attr"),
+            'st.secrets has no attribute "attr". Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings on Streamlit Cloud? More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management',
+        )
+
+        messages.set_missing_attr_message(
+            lambda attr: "Missing attribute message",
+        )
+
+        self.assertEqual(
+            messages.get_missing_attr_message([""]),
+            "Missing attribute message",
+        )
+
+
 class SecretsTest(unittest.TestCase):
     """Tests for st.secrets with a single secrets.toml file"""
 
@@ -53,7 +75,7 @@ class SecretsTest(unittest.TestCase):
         self._prev_environ = dict(os.environ)
         # Run tests on our own Secrets instance to reduce global state
         # mutations.
-        self.secrets = Secrets([MOCK_SECRETS_FILE_LOC])
+        self.secrets = Secrets()
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -61,6 +83,7 @@ class SecretsTest(unittest.TestCase):
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
     def test_access_secrets(self, *mocks):
         self.assertEqual(self.secrets["db_username"], "Jane")
         self.assertEqual(self.secrets["subsection"]["email"], "eng@streamlit.io")
@@ -70,7 +93,7 @@ class SecretsTest(unittest.TestCase):
         [
             [
                 False,
-                "Secrets(file_paths=['/mock/secrets.toml'])",
+                "Secrets",
             ],
             [
                 True,
@@ -83,34 +106,18 @@ class SecretsTest(unittest.TestCase):
     )
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
     def test_repr_secrets(self, runtime_exists, secrets_repr, *mocks):
         with patch("streamlit.runtime.exists", return_value=runtime_exists):
             self.assertEqual(repr(self.secrets), secrets_repr)
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
     def test_access_secrets_via_attribute(self, *mocks):
         self.assertEqual(self.secrets.db_username, "Jane")
         self.assertEqual(self.secrets.subsection["email"], "eng@streamlit.io")
         self.assertEqual(self.secrets.subsection.email, "eng@streamlit.io")
-
-    def test_secrets_file_location(self):
-        """Verify that we're looking for secrets.toml in the right place."""
-        if "win32" not in sys.platform:
-            # conftest.py sets the HOME envvar to "/mock/home/folder".
-            expected_global_path = "/mock/home/folder/.streamlit/secrets.toml"
-        else:
-            # On windows systems, HOME does not work so we look in the user's directory instead.
-            expected_global_path = os.path.join(
-                os.path.expanduser("~"), ".streamlit", "secrets.toml"
-            )
-        self.assertEqual(
-            [
-                expected_global_path,
-                os.path.abspath("./.streamlit/secrets.toml"),
-            ],
-            SECRETS_FILE_LOCS,
-        )
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_os_environ(self, _):
@@ -133,7 +140,8 @@ class SecretsTest(unittest.TestCase):
         self.assertFalse(self.secrets.load_if_toml_exists())
 
     @patch("streamlit.error")
-    def test_missing_toml_error(self, mock_st_error):
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_missing_toml_error(self, _, mock_st_error):
         """Secrets access raises an error, and calls st.error, if
         secrets.toml is missing.
         """
@@ -144,12 +152,30 @@ class SecretsTest(unittest.TestCase):
                 self.secrets.get("no_such_secret", None)
 
         mock_st_error.assert_called_once_with(
-            f"No secrets files found. Valid paths for a secrets.toml file are: {MOCK_SECRETS_FILE_LOC}"
+            f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {MOCK_SECRETS_FILE_LOC}"
         )
+
+    @patch("streamlit.error")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_missing_toml_error_with_suppressed_error(self, _, mock_st_error):
+        """Secrets access raises an error, and does not calls st.error, if
+        secrets.toml is missing because printing errors have been suppressed.
+        """
+
+        self.secrets.set_suppress_print_error_on_exception(True)
+
+        with patch("builtins.open", mock_open()) as mock_file:
+            mock_file.side_effect = FileNotFoundError()
+
+            with self.assertRaises(FileNotFoundError):
+                self.secrets.get("no_such_secret", None)
+
+        mock_st_error.assert_not_called()
 
     @patch("builtins.open", new_callable=mock_open, read_data="invalid_toml")
     @patch("streamlit.error")
-    def test_malformed_toml_error(self, mock_st_error, _):
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_malformed_toml_error(self, mock_get_option, mock_st_error, _):
         """Secrets access raises an error, and calls st.error, if
         secrets.toml is malformed.
         """
@@ -157,7 +183,7 @@ class SecretsTest(unittest.TestCase):
             self.secrets.get("no_such_secret", None)
 
         mock_st_error.assert_called_once_with(
-            "Error parsing secrets file at /mock/secrets.toml"
+            "Error parsing secrets file at /mock/secrets.toml: Key name found without value. Reached end of file. (line 1 column 13 char 12)"
         )
 
     @patch("streamlit.watcher.path_watcher.watch_file")
@@ -191,7 +217,8 @@ class SecretsTest(unittest.TestCase):
             self.secrets["subsection"]["nonexistent_secret"]
 
     @patch("streamlit.watcher.path_watcher.watch_file")
-    def test_reload_secrets_when_file_changes(self, mock_watch_file):
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_reload_secrets_when_file_changes(self, mock_get_option, mock_watch_file):
         """When secrets.toml is loaded, the secrets file gets watched."""
         with patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML):
             self.assertEqual("Jane", self.secrets["db_username"])
@@ -205,7 +232,7 @@ class SecretsTest(unittest.TestCase):
         # a virtual filesystem that watchdog is unable to fire events for.)
         mock_watch_file.assert_called_once_with(
             MOCK_SECRETS_FILE_LOC,
-            self.secrets._on_secrets_file_changed,
+            self.secrets._on_secrets_changed,
             watcher_type="poll",
         )
 
@@ -218,7 +245,7 @@ class SecretsTest(unittest.TestCase):
             # Trigger a secrets file reload, ensure the secrets dict
             # gets repopulated as expected, and ensure that os.environ is
             # also updated properly.
-            self.secrets._on_secrets_file_changed(MOCK_SECRETS_FILE_LOC)
+            self.secrets._on_secrets_changed(MOCK_SECRETS_FILE_LOC)
 
             # A change in `secrets.toml` should emit a signal.
             self.secrets.file_change_listener.send.assert_called_once()
@@ -233,8 +260,8 @@ class MultipleSecretsFilesTest(unittest.TestCase):
     """Tests for st.secrets with multiple secrets.toml files."""
 
     def setUp(self) -> None:
-        self._fd1, self._path1 = tempfile.mkstemp()
-        self._fd2, self._path2 = tempfile.mkstemp()
+        self._fd1, self._path1 = tempfile.mkstemp(".toml")
+        self._fd2, self._path2 = tempfile.mkstemp(".toml")
 
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
@@ -262,14 +289,19 @@ class MultipleSecretsFilesTest(unittest.TestCase):
             "/mock1/secrets.toml",
             "/mock2/secrets.toml",
         ]
-        secrets = Secrets(secrets_file_locations)
-
-        with self.assertRaises(FileNotFoundError):
-            secrets.get("no_such_secret", None)
-
-        mock_st_error.assert_called_once_with(
-            "No secrets files found. Valid paths for a secrets.toml file are: /mock1/secrets.toml, /mock2/secrets.toml"
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"secrets.files": secrets_file_locations}
         )
+
+        with patch("streamlit.config.get_option", new=mock_get_option):
+            secrets = Secrets()
+
+            with self.assertRaises(FileNotFoundError):
+                secrets.get("no_such_secret", None)
+
+            mock_st_error.assert_called_once_with(
+                "No secrets found. Valid paths for a secrets.toml file or secret directories are: /mock1/secrets.toml, /mock2/secrets.toml"
+            )
 
     @patch("streamlit.runtime.secrets._LOGGER")
     def test_only_one_secrets_file_fine(self, patched_logger):
@@ -280,10 +312,15 @@ class MultipleSecretsFilesTest(unittest.TestCase):
             self._path1,
             "/mock2/secrets.toml",
         ]
-        secrets = Secrets(secrets_file_locations)
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"secrets.files": secrets_file_locations}
+        )
 
-        self.assertEqual(secrets.db_username, "Jane")
-        patched_logger.info.assert_not_called()
+        with patch("streamlit.config.get_option", new=mock_get_option):
+            secrets = Secrets()
+
+            self.assertEqual(secrets.db_username, "Jane")
+            patched_logger.info.assert_not_called()
 
     @patch("streamlit.runtime.secrets._LOGGER")
     def test_secret_overwriting(self, patched_logger):
@@ -309,26 +346,26 @@ email2="eng2@streamlit.io"
             self._path1,
             self._path2,
         ]
-        secrets = Secrets(secrets_file_locations)
-
-        # secrets.db_username is only defined in the first secrets.toml file, so it
-        # remains unchanged.
-        self.assertEqual(secrets.db_username, "Jane")
-
-        # secrets.db_password should be overwritten because it's set to a different
-        # value in our second secrets.toml file.
-        self.assertEqual(secrets.db_password, "54321dvorak")
-
-        # secrets.hi only appears in our second secrets.toml file.
-        self.assertEqual(secrets.hi, "I'm new")
-
-        # Secrets subsections are overwritten entirely rather than being merged.
-        self.assertEqual(secrets.subsection, {"email2": "eng2@streamlit.io"})
-
-        patched_logger.info.assert_called_once_with(
-            f"Secrets found in multiple locations: {self._path1}, {self._path2}. "
-            "When multiple secret.toml files exist, local secrets will take precedence over global secrets."
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"secrets.files": secrets_file_locations}
         )
+
+        with patch("streamlit.config.get_option", new=mock_get_option):
+            secrets = Secrets()
+
+            # secrets.db_username is only defined in the first secrets.toml file, so it
+            # remains unchanged.
+            self.assertEqual(secrets.db_username, "Jane")
+
+            # secrets.db_password should be overwritten because it's set to a different
+            # value in our second secrets.toml file.
+            self.assertEqual(secrets.db_password, "54321dvorak")
+
+            # secrets.hi only appears in our second secrets.toml file.
+            self.assertEqual(secrets.hi, "I'm new")
+
+            # Secrets subsections are overwritten entirely rather than being merged.
+            self.assertEqual(secrets.subsection, {"email2": "eng2@streamlit.io"})
 
 
 class SecretsThreadingTests(unittest.TestCase):
@@ -339,7 +376,7 @@ class SecretsThreadingTests(unittest.TestCase):
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
         self._prev_environ = dict(os.environ)
-        self.secrets = Secrets(MOCK_SECRETS_FILE_LOC)
+        self.secrets = Secrets()
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -368,6 +405,71 @@ class SecretsThreadingTests(unittest.TestCase):
             self.assertEqual(self.secrets["db_username"], "Jane")
 
         call_on_threads(reload_secrets, num_threads=self.NUM_THREADS)
+
+
+class SecretsDirectoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir_path = self.temp_dir.name
+        os.makedirs(os.path.join(self.temp_dir_path, "example_login"))
+        with open(
+            os.path.join(self.temp_dir_path, "example_login", "username"), "w"
+        ) as f:
+            f.write("example_username")
+        with open(
+            os.path.join(self.temp_dir_path, "example_login", "password"), "w"
+        ) as f:
+            f.write("example_password")
+        os.makedirs(os.path.join(self.temp_dir_path, "example_token"))
+        with open(os.path.join(self.temp_dir_path, "example_token", "token"), "w") as f:
+            f.write("token123")
+
+        self.secrets = Secrets()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @patch("streamlit.watcher.path_watcher.watch_dir")
+    def test_access_secrets(self, mock_watch_dir):
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"secrets.files": [self.temp_dir_path]}
+        )
+
+        with patch("streamlit.config.get_option", new=mock_get_option):
+            self.assertEqual(
+                self.secrets["example_login"]["username"], "example_username"
+            )
+            self.assertEqual(
+                self.secrets["example_login"]["password"], "example_password"
+            )
+            self.assertEqual(self.secrets["example_token"], "token123")
+
+            mock_watch_dir.assert_called_once_with(
+                self.temp_dir_path,
+                self.secrets._on_secrets_changed,
+                watcher_type="poll",
+            )
+
+    @patch("streamlit.watcher.path_watcher.watch_dir", MagicMock())
+    def test_secrets_reload(self):
+        with open(
+            os.path.join(self.temp_dir_path, "example_login", "password"), "w"
+        ) as f:
+            f.write("example_password2")
+
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"secrets.files": [self.temp_dir_path]}
+        )
+
+        with patch("streamlit.config.get_option", new=mock_get_option):
+            self.secrets._on_secrets_changed(self.temp_dir_path)
+            self.assertEqual(
+                self.secrets["example_login"]["username"], "example_username"
+            )
+            self.assertEqual(
+                self.secrets["example_login"]["password"], "example_password2"
+            )
+            self.assertEqual(self.secrets["example_token"], "token123")
 
 
 class AttrDictTest(unittest.TestCase):


### PR DESCRIPTION
## Describe your changes
Add Kubernetes/directory style secret support that will allow Streamlit secrets to be used with [Snowpark Container Services secret format](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/additional-considerations-services-jobs#using-snowflake-secrets-to-pass-credentials-to-a-container) which is based on [Kubernetes Secret](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume)

In this format the secrets are expected to be placed under a directory (such as `/.streamlit/.secrets`) in the following ways:
- user_pass_secret (folder)
   - username (file), content: myuser
   - password (file), content: mypassword
- my_plain_secret (folder)
   - regular_secret (file), content: mysecret

If there are multiple files in a folder they will be available as:
```
> st.secrets['user_pass_secret']['username']
myuser
```

if there's a single file in a folder it will be folded into the folder name such as:
```
> st.secrets['my_plain_secrets']
mysecret
```

Another feature added is the ability to customize the error messages by environment to have different messages when running inside Snowflake environment

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
