### PR TITLE
[RFC] Only rerun script on reconnect if a script run was interrupted

### DIFF
--- a/e2e_playwright/websocket_reconnects.py
+++ b/e2e_playwright/websocket_reconnects.py
@@ -12,16 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import streamlit as st
 
 # st.session_state can only be accessed while running with streamlit
 if "counter" not in st.session_state:
     st.session_state.counter = 0
+    st.session_state.slow_operations_attempted = 0
 
 if st.button("click me!"):
     st.session_state.counter += 1
 
+if st.checkbox("do something slow"):
+    st.session_state.slow_operations_attempted += 1
+    time.sleep(5)
+
 st.write(f"count: {st.session_state.counter}")
+st.write(f"slow operations attempted: {st.session_state.slow_operations_attempted}")
 
 if f := st.file_uploader("Upload a file"):
     st.text(f.read())

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -623,10 +623,22 @@ export class App extends PureComponent<Props, State> {
     )
 
     if (newState === ConnectionState.CONNECTED) {
-      logMessage("Reconnected to server; requesting a script run")
-      // Trigger a full app rerun:
-      this.widgetMgr.sendUpdateWidgetsMessage(undefined)
-      this.setState({ dialog: null })
+      logMessage("Reconnected to server.")
+
+      const lastRunWasInterrupted =
+        this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED ||
+        this.state.scriptRunState === ScriptRunState.RUNNING
+
+      // We request a script rerun if:
+      //   1. this is the first time we establish a websocket connection to the
+      //      server, or
+      //   2. our last script run attempt was interrupted by the websocket
+      //      connection dropping.
+      if (!this.sessionInfo.last || lastRunWasInterrupted) {
+        logMessage("Requesting a script run.")
+        this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+        this.setState({ dialog: null })
+      }
 
       this.hostCommunicationMgr.sendMessageToHost({
         type: "WEBSOCKET_CONNECTED",


### PR DESCRIPTION
Currently, our websocket reconnect behavior is too aggressive with when it decides to rerun an app:
it always requests that the app is rerun regardless of the app state at the time of the websocket
disconnect/reconnect.

For the most part, this behavior hasn't been problematic in practice (at least few to no people seem to
complain about it despite the possible weirdness it can cause), but having to think about it due to work
being done with websocket reconnects in SiS made us realize that there's not much reason to force an
app rerun if the websocket disconnect didn't interrupt a user's script run.

This PR changes our websocket reconnect behavior so that we only send a script rerun request on
reconnect if a script run request was interrupted by the disconnect.