### PR TITLE
Fix #8638

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -157,27 +157,41 @@ def make_cached_func_wrapper(info: CachedFuncInfo) -> Callable[..., Any]:
     some or all of the wrapper's cached values.
     """
     cached_func = CachedFunc(info)
+    return functools.update_wrapper(cached_func, info.func)
 
-    # We'd like to simply return `cached_func`, which is already a Callable.
-    # But using `functools.update_wrapper` on the CachedFunc instance
-    # itself results in errors when our caching decorators are used to decorate
-    # member functions. (See https://github.com/streamlit/streamlit/issues/6109)
 
-    @functools.wraps(info.func)
-    def wrapper(*args, **kwargs):
-        return cached_func(*args, **kwargs)
+class BoundCachedFunc:
+    """A wrapper around a CachedFunc that binds it to a specific instance in case of
+    decorated function is a class method."""
 
-    # Give our wrapper its `clear` function.
-    # (This results in a spurious mypy error that we suppress.)
-    wrapper.clear = cached_func.clear  # type: ignore
+    def __init__(self, cached_func: CachedFunc, instance: Any):
+        self._cached_func = cached_func
+        self._instance = instance
 
-    return wrapper
+    def __call__(self, *args, **kwargs) -> Any:
+        return self._cached_func(self._instance, *args, **kwargs)
+
+    def __repr__(self):
+        return f"<BoundCachedFunc: {self._cached_func._info.func} of {self._instance}>"
+
+    def clear(self, *args, **kwargs):
+        self._cached_func.clear(self._instance, *args, **kwargs)
 
 
 class CachedFunc:
     def __init__(self, info: CachedFuncInfo):
         self._info = info
         self._function_key = _make_function_key(info.cache_type, info.func)
+
+    def __repr__(self):
+        return f"<CachedFunc: {self._info.func}>"
+
+    def __get__(self, instance, owner=None):
+        """CachedFunc implements descriptor protocol to support cache methods."""
+        if instance is None:
+            return self
+
+        return functools.update_wrapper(BoundCachedFunc(self, instance), self)
 
     def __call__(self, *args, **kwargs) -> Any:
         """The wrapper. We'll only call our underlying function on a cache miss."""

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -244,10 +244,18 @@ If you think this is actually a Streamlit bug, please
                 return self.x
 
         example_instance = ExampleClass()
+        # Calling method foo produces the side effect of incrementing self.x
+        # and returning it as the result.
 
+        # calling foo(1) should return 1
         assert example_instance.foo(1) == 1
+        # calling foo.clear(2) should clear the cache for the argument 2,
+        # and keep the cache for the argument 1, therefore calling foo(1) should return
+        # cached value 1
         example_instance.foo.clear(2)
         assert example_instance.foo(1) == 1
+        # calling foo.clear(1) should clear the cache for the argument 1,
+        # therefore calling foo(1) should return the new value 2
         example_instance.foo.clear(1)
         assert example_instance.foo(1) == 2
 

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -234,6 +234,23 @@ If you think this is actually a Streamlit bug, please
         foo.clear(1)
         assert foo(1) == 2
 
+    def test_cached_st_method_clear_args(self):
+        self.x = 0
+
+        class ExampleClass:
+            @st.cache_data
+            def foo(_self, y):
+                self.x += y
+                return self.x
+
+        example_instance = ExampleClass()
+
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear(2)
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear(1)
+        assert example_instance.foo(1) == 2
+
 
 class CacheDataPersistTest(DeltaGeneratorTestCase):
     """st.cache_data disk persistence tests"""

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -194,6 +194,23 @@ If you think this is actually a Streamlit bug, please
         foo.clear(1)
         assert foo(1) == 2
 
+    def test_cached_st_method_clear_args(self):
+        self.x = 0
+
+        class ExampleClass:
+            @st.cache_resource()
+            def foo(_self, y):
+                self.x += y
+                return self.x
+
+        example_instance = ExampleClass()
+
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear(2)
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear(1)
+        assert example_instance.foo(1) == 2
+
 
 class CacheResourceValidateTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -204,10 +204,18 @@ If you think this is actually a Streamlit bug, please
                 return self.x
 
         example_instance = ExampleClass()
+        # Calling method foo produces the side effect of incrementing self.x
+        # and returning it as the result.
 
+        # calling foo(1) should return 1
         assert example_instance.foo(1) == 1
+        # calling foo.clear(2) should clear the cache for the argument 2,
+        # and keep the cache for the argument 1, therefore calling foo(1) should return
+        # cached value 1
         example_instance.foo.clear(2)
         assert example_instance.foo(1) == 1
+        # calling foo.clear(1) should clear the cache for the argument 1,
+        # therefore calling foo(1) should return the new value 2
         example_instance.foo.clear(1)
         assert example_instance.foo(1) == 2
 


### PR DESCRIPTION
## Describe your changes
Make `CachedFunc` a descriptor, add `BoundCachedFunc` to handle clear for cached methods correctly

With this change, we do not lose the context of execution for cached methods, so `.clear` with specific arguments for cached methods works as expected.   

## GitHub Issue Link (if applicable)
Closes: #8638

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE!
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
