### PR TITLE
Support theming in embed better

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -30,7 +30,7 @@ import {
   mockWindowLocation,
   ScriptRunState,
   SessionInfo,
-  createAutoTheme,
+  getHostSpecifiedTheme,
   CUSTOM_THEME_NAME,
   lightTheme,
   toExportedTheme,
@@ -621,7 +621,9 @@ describe("App", () => {
 
       expect(props.theme.setTheme).toHaveBeenCalledTimes(2)
       // @ts-expect-error
-      expect(props.theme.setTheme.mock.calls[1][0]).toEqual(createAutoTheme())
+      expect(props.theme.setTheme.mock.calls[1][0]).toEqual(
+        getHostSpecifiedTheme()
+      )
     })
 
     it("updates the custom theme if the one received from server has different hash", () => {

--- a/frontend/app/src/util/useThemeManager.ts
+++ b/frontend/app/src/util/useThemeManager.ts
@@ -28,6 +28,7 @@ import {
   createTheme,
   CustomThemeConfig,
   ICustomThemeConfig,
+  getHostSpecifiedTheme,
 } from "@streamlit/lib"
 
 export interface ThemeManager {
@@ -70,7 +71,7 @@ export function useThemeManager(): [ThemeManager, object[]] {
 
   const updateAutoTheme = useCallback((): void => {
     if (theme.name === AUTO_THEME_NAME) {
-      updateTheme(createAutoTheme())
+      updateTheme(getHostSpecifiedTheme())
     }
     const constantThemes = availableThemes.filter(
       theme => theme.name !== AUTO_THEME_NAME

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -433,7 +433,45 @@ describe("HostCommunicationManager messaging", () => {
     expect(
       // @ts-expect-error - props are private
       hostCommunicationMgr.props.themeChanged
-    ).toHaveBeenCalledWith(mockCustomThemeConfig)
+    ).toHaveBeenCalledWith(undefined, mockCustomThemeConfig)
+  })
+
+  it("can process a received SET_CUSTOM_THEME_CONFIG message with a dark theme name", async () => {
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_CUSTOM_THEME_CONFIG",
+          themeName: "Dark",
+        },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    expect(
+      // @ts-expect-error - props are private
+      hostCommunicationMgr.props.themeChanged
+    ).toHaveBeenCalledWith("Dark", undefined)
+  })
+
+  it("can process a received SET_CUSTOM_THEME_CONFIG message with a light theme name", async () => {
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_CUSTOM_THEME_CONFIG",
+          themeName: "Light",
+        },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    expect(
+      // @ts-expect-error - props are private
+      hostCommunicationMgr.props.themeChanged
+    ).toHaveBeenCalledWith("Light", undefined)
   })
 
   it("can process a received SET_AUTH_TOKEN message with JWT pair", () => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -27,7 +27,7 @@ import {
 } from "./types"
 
 import { isValidOrigin } from "@streamlit/lib/src/util/UriUtil"
-
+import { PresetThemeName } from "@streamlit/lib/src/theme/types"
 import Resolver from "@streamlit/lib/src/util/Resolver"
 
 export const HOST_COMM_VERSION = 1
@@ -43,7 +43,10 @@ export interface HostCommunicationProps {
   readonly clearCache: () => void
   readonly sendAppHeartbeat: () => void
   readonly setInputsDisabled: (inputsDisabled: boolean) => void
-  readonly themeChanged: (themeInfo: ICustomThemeConfig) => void
+  readonly themeChanged: (
+    themeName?: PresetThemeName,
+    themeInfo?: ICustomThemeConfig
+  ) => void
   readonly pageChanged: (pageScriptHash: string) => void
   readonly isOwnerChanged: (isOwner: boolean) => void
   readonly jwtHeaderChanged: (jwtPayload: {
@@ -248,7 +251,7 @@ export default class HostCommunicationManager {
     }
 
     if (message.type === "SET_CUSTOM_THEME_CONFIG") {
-      this.props.themeChanged(message.themeInfo)
+      this.props.themeChanged(message.themeName, message.themeInfo)
     }
 
     if (message.type === "RESTART_WEBSOCKET_CONNECTION") {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -115,7 +115,7 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_CUSTOM_THEME_CONFIG"
       themeName?: PresetThemeName
-      // TODO: Consider removing this once stakeholders no longer use it
+      // TODO: Consider removing themeInfo once stakeholders no longer use it
       themeInfo?: ICustomThemeConfig
     }
   | {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -18,6 +18,7 @@ import { ICustomThemeConfig, IAppPage } from "@streamlit/lib/src/proto"
 import { ExportedTheme } from "@streamlit/lib/src/theme"
 import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
 import { LibConfig } from "@streamlit/lib/src/components/core/LibContext"
+import { PresetThemeName } from "@streamlit/lib/src/theme/types"
 
 export type DeployedAppMetadata = {
   hostedAt?: string
@@ -113,7 +114,9 @@ export type IHostToGuestMessage = {
     }
   | {
       type: "SET_CUSTOM_THEME_CONFIG"
-      themeInfo: ICustomThemeConfig
+      themeName?: PresetThemeName
+      // TODO: Consider removing this once stakeholders no longer use it
+      themeInfo?: ICustomThemeConfig
     }
   | {
       type: "SEND_APP_HEARTBEAT"

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -52,6 +52,7 @@ export { default as ThemeProvider } from "./components/core/ThemeProvider"
 export { LocalStore, localStorageAvailable } from "./util/storageUtils"
 export {
   createAutoTheme,
+  getHostSpecifiedTheme,
   createPresetThemes,
   CUSTOM_THEME_NAME,
   getCachedTheme,
@@ -70,7 +71,7 @@ export {
   hasLightBackgroundColor,
 } from "./theme"
 export { default as emotionLightTheme } from "./theme/emotionLightTheme"
-export type { ThemeConfig, EmotionTheme } from "./theme"
+export type { ThemeConfig, EmotionTheme, PresetThemeName } from "./theme"
 export { mockWindowLocation, render } from "./test_util"
 export { logError, logMessage, logWarning, logAlways } from "./util/log"
 export { getPossibleBaseUris, buildHttpUri, buildWsUri } from "./util/UriUtil"
@@ -98,10 +99,10 @@ export {
   getEmbeddingIdClassName,
   getIFrameEnclosingApp,
   isColoredLineDisplayed,
-  isDarkTheme,
+  isDarkThemeInQueryParams,
   isEmbed,
   isInChildFrame,
-  isLightTheme,
+  isLightThemeInQueryParams,
   isPaddingDisplayed,
   isScrollingHidden,
   isToolbarDisplayed,

--- a/frontend/lib/src/theme/types.ts
+++ b/frontend/lib/src/theme/types.ts
@@ -46,3 +46,4 @@ type ThemeColors = typeof emotionBaseTheme.colors
 export type IconSize = keyof IconSizes
 export type ThemeColor = Extract<keyof ThemeColors, string>
 export type ThemeSpacing = keyof ThemeSpacings
+export type PresetThemeName = "Light" | "Dark"

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -44,6 +44,7 @@ import {
   removeCachedTheme,
   setCachedTheme,
   hasLightBackgroundColor,
+  getHostSpecifiedTheme,
 } from "./utils"
 
 const matchMediaFillers = {
@@ -405,6 +406,67 @@ describe("getSystemTheme", () => {
     windowSpy = mockWindow(windowMatchMedia("dark"))
 
     expect(getSystemTheme().name).toBe("Dark")
+  })
+})
+
+describe("getHostSpecifiedTheme", () => {
+  let windowSpy: jest.SpyInstance
+
+  afterEach(() => {
+    windowSpy.mockRestore()
+    window.localStorage.clear()
+  })
+
+  it("sets default to the auto theme when there is no theme preference", () => {
+    windowSpy = mockWindow()
+    const defaultTheme = getHostSpecifiedTheme()
+
+    expect(defaultTheme.name).toBe(AUTO_THEME_NAME)
+    // Also verify that the theme is our lightTheme.
+    expect(defaultTheme.emotion.colors).toEqual(lightTheme.emotion.colors)
+  })
+
+  it("sets the auto theme correctly when the OS preference is dark", () => {
+    mockWindow(windowSpy, windowMatchMedia("dark"))
+
+    const defaultTheme = getHostSpecifiedTheme()
+
+    expect(defaultTheme.name).toBe(AUTO_THEME_NAME)
+    expect(defaultTheme.emotion.colors).toEqual(darkTheme.emotion.colors)
+  })
+
+  it("sets default to the light theme when an embed query parameter is set", () => {
+    windowSpy = mockWindow(
+      windowLocationSearch("?embed=true&embed_options=light_theme")
+    )
+    const defaultTheme = getHostSpecifiedTheme()
+
+    expect(defaultTheme.name).toBe("Light")
+    // Also verify that the theme is our lightTheme.
+    expect(defaultTheme.emotion.colors).toEqual(lightTheme.emotion.colors)
+  })
+
+  it("sets default to the dark theme when an embed query parameter is set", () => {
+    windowSpy = mockWindow(
+      windowLocationSearch("?embed=true&embed_options=dark_theme")
+    )
+    const defaultTheme = getHostSpecifiedTheme()
+
+    expect(defaultTheme.name).toBe("Dark")
+    // Also verify that the theme is our darkTheme.
+    expect(defaultTheme.emotion.colors).toEqual(darkTheme.emotion.colors)
+  })
+
+  it("respects embed query parameter is set over system theme", () => {
+    windowSpy = mockWindow(
+      windowMatchMedia("dark"),
+      windowLocationSearch("?embed=true&embed_options=light_theme")
+    )
+    const defaultTheme = getHostSpecifiedTheme()
+
+    expect(defaultTheme.name).toBe("Light")
+    // Also verify that the theme is our lightTheme.
+    expect(defaultTheme.emotion.colors).toEqual(lightTheme.emotion.colors)
   })
 })
 

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -28,8 +28,8 @@ import {
   isToolbarDisplayed,
   isPaddingDisplayed,
   isScrollingHidden,
-  isLightTheme,
-  isDarkTheme,
+  isLightThemeInQueryParams,
+  isDarkThemeInQueryParams,
   keysToSnakeCase,
 } from "./utils"
 
@@ -252,8 +252,8 @@ describe("isEmbed", () => {
     expect(isToolbarDisplayed()).toBe(false)
     expect(isPaddingDisplayed()).toBe(false)
     expect(isScrollingHidden()).toBe(false)
-    expect(isLightTheme()).toBe(false)
-    expect(isDarkTheme()).toBe(false)
+    expect(isLightThemeInQueryParams()).toBe(false)
+    expect(isDarkThemeInQueryParams()).toBe(false)
   })
 
   it("embed Options should return false even if ?embed=false", () => {
@@ -291,7 +291,7 @@ describe("isEmbed", () => {
       },
     }))
 
-    expect(isLightTheme()).toBe(true)
+    expect(isLightThemeInQueryParams()).toBe(true)
   })
 
   it("should specify dark theme if in embed options", () => {
@@ -301,7 +301,7 @@ describe("isEmbed", () => {
       },
     }))
 
-    expect(isDarkTheme()).toBe(true)
+    expect(isDarkThemeInQueryParams()).toBe(true)
   })
 
   it("should disable scrolling if in embed options", () => {
@@ -315,8 +315,8 @@ describe("isEmbed", () => {
     expect(isToolbarDisplayed()).toBe(false)
     expect(isPaddingDisplayed()).toBe(false)
     expect(isScrollingHidden()).toBe(true)
-    expect(isLightTheme()).toBe(false)
-    expect(isDarkTheme()).toBe(false)
+    expect(isLightThemeInQueryParams()).toBe(false)
+    expect(isDarkThemeInQueryParams()).toBe(false)
   })
 
   it("should show padding if in embed options", () => {
@@ -330,8 +330,8 @@ describe("isEmbed", () => {
     expect(isToolbarDisplayed()).toBe(false)
     expect(isPaddingDisplayed()).toBe(true)
     expect(isScrollingHidden()).toBe(false)
-    expect(isLightTheme()).toBe(false)
-    expect(isDarkTheme()).toBe(false)
+    expect(isLightThemeInQueryParams()).toBe(false)
+    expect(isDarkThemeInQueryParams()).toBe(false)
   })
 
   it("should show the toolbar if in embed options", () => {
@@ -345,8 +345,8 @@ describe("isEmbed", () => {
     expect(isToolbarDisplayed()).toBe(true)
     expect(isPaddingDisplayed()).toBe(false)
     expect(isScrollingHidden()).toBe(false)
-    expect(isLightTheme()).toBe(false)
-    expect(isDarkTheme()).toBe(false)
+    expect(isLightThemeInQueryParams()).toBe(false)
+    expect(isDarkThemeInQueryParams()).toBe(false)
   })
 
   it("should show the colored line if in embed options", () => {
@@ -360,8 +360,8 @@ describe("isEmbed", () => {
     expect(isToolbarDisplayed()).toBe(false)
     expect(isPaddingDisplayed()).toBe(false)
     expect(isScrollingHidden()).toBe(false)
-    expect(isLightTheme()).toBe(false)
-    expect(isDarkTheme()).toBe(false)
+    expect(isLightThemeInQueryParams()).toBe(false)
+    expect(isDarkThemeInQueryParams()).toBe(false)
   })
 
   it("isEmbed is case insensitive, so should return true when ?embed=TrUe", () => {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -179,7 +179,7 @@ export function isPaddingDisplayed(): boolean {
 /**
  * Returns true if the URL parameters contain ?embed_options=light_theme (case insensitive).
  */
-export function isLightTheme(): boolean {
+export function isLightThemeInQueryParams(): boolean {
   // NOTE: We don't check for ?embed=true here, because we want to allow display without any
   // other embed options (for example in our e2e tests).
   return getEmbedUrlParams(EMBED_OPTIONS_QUERY_PARAM_KEY).has(
@@ -190,7 +190,7 @@ export function isLightTheme(): boolean {
 /**
  * Returns true if the URL parameters contain ?embed_options=dark_theme (case insensitive).
  */
-export function isDarkTheme(): boolean {
+export function isDarkThemeInQueryParams(): boolean {
   // NOTE: We don't check for ?embed=true here, because we want to allow display without any
   // other embed options (for example in our e2e tests).
   return getEmbedUrlParams(EMBED_OPTIONS_QUERY_PARAM_KEY).has(EMBED_DARK_THEME)


### PR DESCRIPTION
## Describe your changes

This change resolves three challenges:

1. The "Auto Theme" respects embed params first before using a system theme. We use the AutoTheme as an "undo" of any theme. We can perhaps consider calling it a "Default Theme"
2. For post message, we will allow setting Light or Dark theme and not make it interpreted as a custom theme. We do that by specifying the theme name or a custom theme.
3. Theme specified embedded apps disables cached theming. Cached theming essentially occurs when the developer defines a custom theme or when the user specifies a theme preference in the settings dialog. Lots of confusion from how the embedder wishes apps to look causes issues, so it's best to not cache any theme when there's a preference from the embedder. The tradeoff is that custom themes will not be cached for the next rerun, but it feels like the right set of controls to ensure proper functionality.

## Testing Plan

- JS Unit Tests are updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
