### PR TITLE
Reset ctx.current_fragment_id to last ID instead of None

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -193,7 +193,10 @@ def _fragment(
             ctx.new_fragment_ids.add(fragment_id)
             # Set ctx.current_fragment_id so that elements corresponding to this
             # fragment get tagged with the appropriate ID. ctx.current_fragment_id gets
-            # reset after the fragment function finishes running.
+            # reset after the fragment function finishes running to either return to the
+            # script (outside of any fragments) or to the outer fragment this one is
+            # nested in.
+            prev_fragment_id = ctx.current_fragment_id
             ctx.current_fragment_id = fragment_id
 
             try:
@@ -245,7 +248,7 @@ def _fragment(
                             raise FragmentHandledException(e)
                     return result
             finally:
-                ctx.current_fragment_id = None
+                ctx.current_fragment_id = prev_fragment_id
                 ctx.current_fragment_delta_path = []
 
         if not ctx.fragment_storage.contains(fragment_id):

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -130,11 +130,11 @@ class FragmentTest(unittest.TestCase):
 
         @fragment
         def my_fragment():
-            pass
+            assert ctx.current_fragment_id != "my_fragment_id"
 
         ctx.current_fragment_id = "my_fragment_id"
         my_fragment()
-        assert ctx.current_fragment_id is None
+        assert ctx.current_fragment_id == "my_fragment_id"
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     def test_resets_current_fragment_id_on_exception(self, patched_get_script_run_ctx):
@@ -145,6 +145,7 @@ class FragmentTest(unittest.TestCase):
 
         @fragment
         def my_exploding_fragment():
+            assert ctx.current_fragment_id != "my_fragment_id"
             raise Exception(exception_message)
 
         ctx.current_fragment_id = "my_fragment_id"
@@ -153,7 +154,7 @@ class FragmentTest(unittest.TestCase):
 
         assert str(ex.value) == exception_message
 
-        assert ctx.current_fragment_id is None
+        assert ctx.current_fragment_id == "my_fragment_id"
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     def test_wrapped_fragment_saved_in_FragmentStorage(


### PR DESCRIPTION
@sfc-gh-dmatthews caught a bug with nested fragments where the order of fragments being run
relative to widgets being created within a fragment can break things: inner fragments being called
after all widgets are written to works correctly, but inner fragments being called beforehand causes
each widget created by an outer fragment to trigger a full script rerun.

This is caused by a somewhat silly bug on my part where we're always resetting the fragment ID to
`None` rather than whatever it was before we ran the fragment.