### PR TITLE
Print bottom container always at the end of the app content

### DIFF
--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -76,6 +76,12 @@ export const StyledStickyBottomContainer = styled.div(() => ({
   left: 0,
   bottom: 0,
   width: "100%",
+
+  // move the bottom container to the end of pages in print-mode so that nothing
+  // (e.g. a floating chat-input) overlays the actual app content
+  "@media print": {
+    position: "static",
+  },
 }))
 
 export const StyledInnerBottomContainer = styled.div(({ theme }) => ({


### PR DESCRIPTION
## Describe your changes

In print-mode, the bottom container can overlay the actual app. For example, a floating chat input might hide the app content. For this reason, we want to move the bottom container to the very end when printing.

<details>
<summary>Before in printing-mode:</summary>

![Screenshot 2024-07-23 at 13 35 05](https://github.com/user-attachments/assets/bac1ebac-523e-4640-bf2f-a8ee01f71ee2)

</details>

<details>
<summary>After in printing-mode:</summary>

![Screenshot 2024-07-23 at 13 35 58](https://github.com/user-attachments/assets/848cee96-cee4-4e2c-afff-092f58e2aed6)

</details>


## GitHub Issue Link (if applicable)

## Testing Plan

- We have some printing e2e tests, but this one here relies on multi-page content etc. This seems to be niche-enough to not have an extra printing test just for this. I have left a comment at the respective place to let future fellow devs know what the CSS-line was added for.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
