### PR TITLE
Fix copy-buttons in dialogs

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -14,12 +14,16 @@
 
 from __future__ import annotations
 
+import platform
 import re
 from typing import Pattern
 
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
+
+# Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
+COMMAND_KEY = "Meta" if platform.system() == "Darwin" else "Control"
 
 
 def get_checkbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator:

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -12,22 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import platform
 
 import pytest
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
-from e2e_playwright.shared.app_utils import expect_prefixed_markdown
+from e2e_playwright.shared.app_utils import COMMAND_KEY, expect_prefixed_markdown
 from e2e_playwright.shared.dataframe_utils import (
     calc_middle_cell_position,
     select_column,
     select_row,
     sort_column,
 )
-
-# Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
-_COMMAND_KEY = "Meta" if platform.system() == "Darwin" else "Control"
 
 
 def _get_single_row_select_df(app: Page) -> Locator:
@@ -205,10 +201,10 @@ def test_multi_column_select(app: Page):
     canvas = _get_multi_column_select_df(app)
 
     select_column(canvas, 1)
-    app.keyboard.down(_COMMAND_KEY)
+    app.keyboard.down(COMMAND_KEY)
     select_column(canvas, 3)
     select_column(canvas, 4)
-    app.keyboard.up(_COMMAND_KEY)
+    app.keyboard.up(COMMAND_KEY)
     wait_for_app_run(app)
 
     expect_prefixed_markdown(
@@ -223,10 +219,10 @@ def _select_some_rows_and_columns(app: Page, canvas: Locator):
     select_row(canvas, 1)
     # Column 0 is the row marker column
     select_column(canvas, 2, has_row_marker_col=True)
-    app.keyboard.down(_COMMAND_KEY)
+    app.keyboard.down(COMMAND_KEY)
     select_column(canvas, 4, has_row_marker_col=True)
     select_column(canvas, 5, has_row_marker_col=True)
-    app.keyboard.up(_COMMAND_KEY)
+    app.keyboard.up(COMMAND_KEY)
     select_row(canvas, 3)
     wait_for_app_run(app)
 

--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -129,3 +129,15 @@ def dialog_with_error():
 
 if st.button("Open Dialog with Key Error"):
     dialog_with_error()
+
+
+@st.dialog("Dialog with copy buttons")
+def dialog_with_copy_buttons():
+    st.json([1, 2, 3])
+
+    copied_text = st.text_input("Enter copied text")
+    st.write(copied_text)
+
+
+if st.button("Open Dialog with Copy Buttons"):
+    dialog_with_copy_buttons()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -326,10 +326,9 @@ def test_dialog_copy_buttons_work(app: Page):
     json_element.locator(".copy-icon").first.click()
 
     # paste the copied content into the input field
-    app.get_by_test_id("stTextInput").locator("input").focus()
+    app.get_by_test_id("stTextInput").locator("input").click()
     app.keyboard.press(f"{COMMAND_KEY}+V")
     app.keyboard.press("Enter")
 
     # we should see the pasted content written to the dialog
-    expected_copied_text = "[\n  1,\n  2,\n  3\n]"
-    expect(app.get_by_test_id("stMarkdown")).to_have_text(expected_copied_text)
+    expect(app.get_by_test_id("stMarkdown")).to_have_text("[1,2,3]")

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -33,7 +33,11 @@ class CopyButton extends PureComponent<Props> {
     const node = this.button.current
 
     if (node !== null) {
-      this.clipboard = new Clipboard(node)
+      this.clipboard = new Clipboard(node, {
+        // we set the container here so that copying also works in dialogs.
+        // otherwise, the copy event is swallowed somehow.
+        container: node.parentElement ?? undefined,
+      })
     }
   }
 

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -81,6 +81,7 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
       closeable={dismissible}
       onClose={() => setIsOpen(false)}
       size={size}
+      focusLock={false}
     >
       <ModalHeader>{title}</ModalHeader>
       <ModalBody>

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -81,7 +81,6 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
       closeable={dismissible}
       onClose={() => setIsOpen(false)}
       size={size}
-      focusLock={false}
     >
       <ModalHeader>{title}</ModalHeader>
       <ModalBody>

--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { ReactElement, useRef } from "react"
 import { useTheme } from "@emotion/react"
 import JSON5 from "json5"
 import ReactJson from "react-json-view"
 import ErrorElement from "@streamlit/lib/src/components/shared/ErrorElement"
+import Clipboard from "clipboard"
 
 import { Json as JsonProto } from "@streamlit/lib/src/proto"
 import {
@@ -38,6 +39,8 @@ export interface JsonProps {
 export default function Json({ width, element }: JsonProps): ReactElement {
   const styleProp = { width }
   const theme: EmotionTheme = useTheme()
+
+  const elementRef = useRef<HTMLDivElement>(null)
 
   let bodyObject
   try {
@@ -59,8 +62,17 @@ export default function Json({ width, element }: JsonProps): ReactElement {
   // theme's background is light or dark.
   const jsonTheme = hasLightBackgroundColor(theme) ? "rjv-default" : "monokai"
 
+  const handleCopy = (copy: any): void => {
+    // we use ClipboardJS to do the copying, because it allows
+    // us to specify a container element. This is necessary because
+    // otherwise copying doesn't work in dialogs.
+    Clipboard.copy(JSON.stringify(copy.src), {
+      container: elementRef.current ?? undefined,
+    })
+  }
+
   return (
-    <div data-testid="stJson" style={styleProp}>
+    <div data-testid="stJson" style={styleProp} ref={elementRef}>
       <ReactJson
         src={bodyObject}
         collapsed={!element.expanded}
@@ -68,6 +80,7 @@ export default function Json({ width, element }: JsonProps): ReactElement {
         displayObjectSize={false}
         name={false}
         theme={jsonTheme}
+        enableClipboard={handleCopy}
         style={{
           fontFamily: theme.genericFonts.codeFont,
           fontSize: theme.fontSizes.sm,


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9112

Right now, copy buttons in dialogs don't work. This seems to be because the Modal swallows the focus events. This PR fixes this by using the `container` property from `ClipboardJS` (inspiration from [here](https://github.com/mac-s-g/react-json-view/issues/131#issuecomment-444095616)). This is now also used in our `ReactJSON` element.

In the first iteration we set `focusLock={false}` on the Dialog which also solved this issue. However, that came with an accessibility drawback where you would be able to select elements outside of the container via the `Tab` key.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
  - Add an e2e test to ensure that copying works
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
