### PR TITLE
Remove a type ignore

### DIFF
--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -533,7 +533,7 @@ class SliderMixin:
         timelike_args = (
             data_type in TIMELIKE_TYPES
             and isinstance(step, timedelta)
-            and type(min_value) == type(max_value)
+            and type(min_value) is type(max_value)
         )
 
         if not int_args and not float_args and not timelike_args:

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -521,7 +521,9 @@ class TimeWidgetsMixin:
     def date_input(
         self,
         label: str,
-        value: DateValue | Literal["today"] | Literal["default_value_today"] = "default_value_today",
+        value: DateValue
+        | Literal["today"]
+        | Literal["default_value_today"] = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -522,7 +522,8 @@ class TimeWidgetsMixin:
         self,
         label: str,
         value: DateValue
-        | Literal["today", "default_value_today"] | None = "default_value_today",
+        | Literal["today", "default_value_today"]
+        | None = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -522,8 +522,7 @@ class TimeWidgetsMixin:
         self,
         label: str,
         value: DateValue
-        | Literal["today"]
-        | Literal["default_value_today"] = "default_value_today",
+        | Literal["today", "default_value_today"] = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -522,7 +522,7 @@ class TimeWidgetsMixin:
         self,
         label: str,
         value: DateValue
-        | Literal["today", "default_value_today"] = "default_value_today",
+        | Literal["today", "default_value_today"] | None = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -521,7 +521,7 @@ class TimeWidgetsMixin:
     def date_input(
         self,
         label: str,
-        value: DateValue | Literal["today"] = "default_value_today",  # type: ignore[assignment]
+        value: DateValue | Literal["today"] | Literal["default_value_today"] = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,


### PR DESCRIPTION
## Describe your changes

Slight improvements: removed a `# type: ignore[assignment]` statement by adding the right type, added a `None` to the type union where it should be, and handled an unrelated ruff error.

It is always better to do the right thing than compromise the typechecker, if such a route is possible.

I suspect the previous author of the code didn't add "default_value_today" to the type signature because it's not intended for users of the function to pass that value in. However, since it's the default argument, the information is already not hidden. Instead, in both versions of the code, the documentation must be relied upon to tell what should be passed to the function. Which, incidentally, reminds me, that I've added `None` as a possible value as well, because the docstring says so, and the function seems to handle it (I manually tested that it works, as well).

Along the way, I fixed another ruff error, an E721.

## Testing Plan

The typechecker (and ruff) is already run over this code, so there need be no change in testing plan. Since this widens the allowed type, I'm not worried about accidentally ruling out something valid.

Ideally, I think mypy would be run over a suite of usage code, too, such as the tests folder, but that's a story for another day.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
