### PR TITLE
Make ScriptControlException inherit from BaseException again

### DIFF
--- a/e2e_playwright/st_rerun.py
+++ b/e2e_playwright/st_rerun.py
@@ -32,6 +32,15 @@ def my_fragment():
         st.rerun(scope="fragment")
 
 
+@st.fragment
+def fragment_with_rerun_in_try_block():
+    try:
+        if st.button("rerun try_fragment"):
+            st.rerun()
+    except Exception as e:
+        st.write(f"Caught exception: {e}")
+
+
 st.session_state.count += 1
 
 if st.session_state.count < 4:
@@ -41,4 +50,5 @@ if st.session_state.count >= 4:
     st.text("Being able to rerun a session is awesome!")
 
 my_fragment()
+fragment_with_rerun_in_try_block()
 st.write(f"app run count: {st.session_state.count}")

--- a/lib/streamlit/runtime/scriptrunner/exceptions.py
+++ b/lib/streamlit/runtime/scriptrunner/exceptions.py
@@ -16,7 +16,10 @@ from streamlit.runtime.scriptrunner.script_requests import RerunData
 from streamlit.util import repr_
 
 
-class ScriptControlException(Exception):
+# We inherit from BaseException to avoid being caught by user code.
+# For example, having it inherit from Exception might make st.rerun not
+# work in a try/except block.
+class ScriptControlException(BaseException):  # NOSONAR
     """Base exception for ScriptRunner."""
 
     pass


### PR DESCRIPTION
## Describe your changes

Closes #9155, #9182

Unfortunately, I changed the base class of `ScriptControlException` in https://github.com/streamlit/streamlit/commit/485ec8d64a1b2c6b6662ad140d99447a185d3bb2 from `BaseException` to `Exception`. This broke a bunch of user apps because `st.rerun` started to not work in `try-except` blocks anymore when `Exception` was caught. We use `BaseException` again after some discussion to avoid the exception being caught in the accidentally.

## GitHub Issue Link (if applicable)

## Testing Plan

- E2E Tests
  - Add a test to ensure that the base class won't be changed unnoticeably again in the future

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
