### PR TITLE
Print deprecation warnings when dialog/fragment functions are called

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -141,3 +141,12 @@ def dialog_with_copy_buttons():
 
 if st.button("Open Dialog with Copy Buttons"):
     dialog_with_copy_buttons()
+
+
+@st.experimental_dialog("Usage of deprecated experimental_dialog")
+def dialog_with_deprecation_warning():
+    pass  # No need to write anything in the dialog body.
+
+
+if st.button("Open Dialog with deprecation warning"):
+    dialog_with_deprecation_warning()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -59,6 +61,12 @@ def open_dialog_with_copy_buttons(app: Page):
     app.get_by_role("button").filter(has_text="Open Dialog with Copy Buttons").click()
 
 
+def open_dialog_with_deprecation_warning(app: Page):
+    app.get_by_role("button").filter(
+        has_text="Open Dialog with deprecation warning"
+    ).click()
+
+
 def click_to_dismiss(app: Page):
     # Click somewhere outside the close popover container:
     app.keyboard.press("Escape")
@@ -70,6 +78,10 @@ def test_displays_dialog_properly(app: Page):
     wait_for_app_run(app)
     main_dialog = app.get_by_test_id(modal_test_id)
     expect(main_dialog).to_have_count(1)
+
+    # Verify that we don't print a deprecation warning for usage of @st.dialog. We check
+    # that a warning is printed for @st.experimental_dialog in a later test.
+    expect(app.get_by_test_id("stAlert")).not_to_be_attached()
 
 
 def test_dialog_closes_properly(app: Page):
@@ -332,3 +344,16 @@ def test_dialog_copy_buttons_work(app: Page):
 
     # we should see the pasted content written to the dialog
     expect(app.get_by_test_id("stMarkdown")).to_have_text("[1,2,3]")
+
+
+def test_experimental_dialog_deprecation_warning(app: Page):
+    """Test that using @st.experimental_dialog instead of @st.dialog results in a
+    deprecation warning being displayed in the dialog.
+    """
+    expect(app.get_by_test_id("stAlert")).not_to_be_attached()
+
+    open_dialog_with_deprecation_warning(app)
+
+    expect(app.get_by_test_id("stAlert")).to_have_text(
+        re.compile("Please replace st.experimental_dialog with st.dialog.\n.*")
+    )

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -246,18 +246,8 @@ dialog = _dialog_decorator
 fragment = _fragment
 
 # Experimental APIs
-experimental_dialog = _deprecate_func_name(
-    _experimental_dialog_decorator,
-    "experimental_dialog",
-    "2025-01-01",
-    name_override="dialog",
-)
-experimental_fragment = _deprecate_func_name(
-    _experimental_fragment,
-    "experimental_fragment",
-    "2025-01-01",
-    name_override="fragment",
-)
+experimental_dialog = _experimental_dialog_decorator
+experimental_fragment = _experimental_fragment
 experimental_user = _UserInfoProxy()
 
 _EXPERIMENTAL_QUERY_PARAMS_DEPRECATE_MSG = "Refer to our [docs page](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.query_params) for more information."

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -22,6 +22,10 @@ from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, overload
 
+from streamlit.deprecation_util import (
+    make_deprecated_name_warning,
+    show_deprecation_warning,
+)
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import FragmentHandledException, FragmentStorageKeyError
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -129,6 +133,7 @@ def _fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     additional_hash_info: str = "",
+    should_show_deprecation_warning: bool = False,
 ) -> Callable[[F], F] | F:
     """Contains the actual fragment logic.
 
@@ -171,6 +176,15 @@ def _fragment(
 
         def wrapped_fragment():
             import streamlit as st
+
+            if should_show_deprecation_warning:
+                show_deprecation_warning(
+                    make_deprecated_name_warning(
+                        "experimental_fragment",
+                        "fragment",
+                        "2025-01-01",
+                    )
+                )
 
             # NOTE: We need to call get_script_run_ctx here again and can't just use the
             # value of ctx from above captured by the closure because subsequent
@@ -462,4 +476,4 @@ def experimental_fragment(
     run_every: int | float | timedelta | str | None = None,
 ) -> Callable[[F], F] | F:
     """Deprecated alias for @st.fragment. See the docstring for the decorator's new name."""
-    return _fragment(func, run_every=run_every)
+    return _fragment(func, run_every=run_every, should_show_deprecation_warning=True)

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -24,7 +24,12 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator, dg_stack
 from streamlit.errors import FragmentHandledException, FragmentStorageKeyError
-from streamlit.runtime.fragment import MemoryFragmentStorage, _fragment, fragment
+from streamlit.runtime.fragment import (
+    MemoryFragmentStorage,
+    _fragment,
+    experimental_fragment,
+    fragment,
+)
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner.exceptions import RerunException
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -415,6 +420,32 @@ class FragmentTest(unittest.TestCase):
         # countercheck
         fragment_id2 = _fragment(my_function, additional_hash_info="")()
         assert fragment_id1 == fragment_id2
+
+    @patch("streamlit.runtime.fragment.get_script_run_ctx", MagicMock())
+    @patch("streamlit.runtime.fragment.show_deprecation_warning")
+    def test_calling_experimental_fragment_shows_warning(
+        self, patched_show_deprecation_warning
+    ):
+        @experimental_fragment
+        def my_fragment():
+            pass
+
+        my_fragment()
+
+        patched_show_deprecation_warning.assert_called_once()
+
+    @patch("streamlit.runtime.fragment.get_script_run_ctx", MagicMock())
+    @patch("streamlit.runtime.fragment.show_deprecation_warning")
+    def test_calling_fragment_does_not_show_warning(
+        self, patched_show_deprecation_warning
+    ):
+        @fragment
+        def my_fragment():
+            pass
+
+        my_fragment()
+
+        patched_show_deprecation_warning.assert_not_called()
 
 
 # TESTS FOR WRITING TO CONTAINERS OUTSIDE AND INSIDE OF FRAGMENT


### PR DESCRIPTION
The cause of the issue we're seeing here is that we print a deprecation warning the moment we detect
a function being decorated with `@st.experimental_dialog` or `@st.experimental_fragment`, which may cause
the warning to be printed by a module import that uses the decorator.

This PR changes things to delay printing the deprecation warning until the dialog or fragment function is actually
called.

Closes #9143