### PR TITLE
Remove EXCLUDE_FILES from scripts/mypy

### DIFF
--- a/scripts/mypy
+++ b/scripts/mypy
@@ -32,11 +32,6 @@ import click
 import mypy.main as mypy_main
 
 PATHS = ["lib/streamlit/", "scripts/*", "e2e/scripts/*"]
-EXCLUDE_FILES = {
-    os.path.join("scripts", "add_license_headers.py"),
-    os.path.join("e2e", "scripts", "st_reuse_label.py"),
-    os.path.join("scripts", "license-template.txt"),
-}
 
 
 def shlex_join(split_command: Iterable[str]):

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -113,7 +113,7 @@ def main(report: bool = False, verbose: bool = False) -> None:
     for path in PATHS:
         if "*" in path:
             for filename in glob.glob(path):
-                if not (filename in EXCLUDE_FILES or filename.endswith(".sh")):
+                if not filename.endswith(".sh"): #TODO: should this also exclude .txt?
                     paths.append(filename)
         else:
             paths.append(path)

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -113,7 +113,7 @@ def main(report: bool = False, verbose: bool = False) -> None:
     for path in PATHS:
         if "*" in path:
             for filename in glob.glob(path):
-                if not filename.endswith(".sh"): #TODO: should this also exclude .txt?
+                if not (filename.endswith(".sh") or filename.endswith(".txt")):
                     paths.append(filename)
         else:
             paths.append(path)


### PR DESCRIPTION
## Describe your changes

It turns out two of the excluded files no longer exist. And the third is a txt, and therefore can be excluded by the same means that .sh files are excluded. So, the EXCLUDE_FILES mechanism is now completely unnecessary.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
