### PR TITLE
Add OpenTelemetry context propagation to script runner

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -73,7 +73,12 @@ EXTRA_REQUIRES = {
     "snowflake": [
         "snowflake-snowpark-python>=0.9.0; python_version<'3.12'",
         "snowflake-connector-python>=2.8.0; python_version<'3.12'",
-    ]
+    ],
+    "opentelemetry": [
+        "opentelemetry-api>=1.1.0",
+        "opentelemetry-sdk>=1.1.0",
+        "opentelemetry-instrumentation-tornado>=0.47b0",
+    ],
 }
 
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -314,6 +314,15 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
         if os.path.exists(filename):
             watch_file(filename, on_config_changed)
 
+def _instrument_tornado():
+    try:
+        from opentelemetry.instrumentation.tornado import TornadoInstrumentor  # type: ignore
+
+        TornadoInstrumentor().instrument()
+
+    except ImportError:
+        _LOGGER.debug("opentelemetry is not installed, skipping Tornado instrumentation")
+
 
 def run(
     main_script_path: str,
@@ -331,6 +340,7 @@ def run(
     _fix_pydeck_mapbox_api_warning()
     _fix_pydantic_duplicate_validators_error()
     _install_config_watchers(flag_options)
+    _instrument_tornado()
 
     # Create the server. It won't start running yet.
     server = Server(main_script_path, is_hello)


### PR DESCRIPTION
## Describe your changes

This PR adds Tornado instrumentation if OpenTelemetry is installed and propagates the context from the webserver to the script runner.

## GitHub Issue Link (if applicable)

Fixes: #9159

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
