### PR TITLE
Add config option to set TTL for disconnected sessions

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -747,6 +747,17 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "server.disconnectedSessionTTL",
+    description="""
+        TTL in seconds for sessions whose websockets have been disconnected. The server
+        may choose to clean up session state, uploaded files, etc for a given session
+        with no active websocket connection at any point after this time has passed.
+        """,
+    default_val=120,
+    type_=int,
+)
+
 # Config Section: Browser #
 
 _create_section("browser", "Configuration of non-UI browser options.")

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -33,6 +33,7 @@ from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
 from streamlit.web.cache_storage_manager_config import (
@@ -246,6 +247,9 @@ class Server:
                 uploaded_file_manager=uploaded_file_mgr,
                 cache_storage_manager=create_default_cache_storage_manager(),
                 is_hello=is_hello,
+                session_storage=MemorySessionStorage(
+                    ttl_seconds=config.get_option("server.disconnectedSessionTTL")
+                ),
             ),
         )
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -391,6 +391,7 @@ class ConfigTest(unittest.TestCase):
                 "server.enableArrowTruncation",
                 "server.sslCertFile",
                 "server.sslKeyFile",
+                "server.disconnectedSessionTTL",
                 "ui.hideTopBar",
             ]
         )


### PR DESCRIPTION
We set our TTL for disconnected sessions extremely conservatively (to 2 minutes) to ensure that a transient
websocket disconnect can be recovered from on even the slowest of internet connections. 2 minutes is an
eternity in compute time, though, and on most modern connections it should be safe to assume that a reconnect
will either happen within a few seconds or not at all.

This PR gives people the ability to tweak the TTL value for disconnected sessions via the
`server.disconnectedSessionTTL` config option so that they can make this value less conservative if desired.

Related to #6166

