### PR TITLE
Enable a little additional strictness in mypy.ini

### DIFF
--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -25,9 +25,6 @@ show_column_numbers = true
 show_error_codes = true
 pretty = true
 
-[mypy-scripts.add_license_headers]
-ignore_errors = True
-
 [mypy-streamlit.proto.*]
 ignore_errors = True
 

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -5,7 +5,7 @@ cache_dir = .mypy_cache
 # TODO(nate): Additional strictness checks to work towards.
 # disallow_incomplete_defs = true
 # disallow_subclassing_any = true
-# disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 
 allow_redefinition = true
 check_untyped_defs = true

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -4,7 +4,7 @@ cache_dir = .mypy_cache
 
 # TODO(nate): Additional strictness checks to work towards.
 # disallow_incomplete_defs = true
-# disallow_subclassing_any = true
+disallow_subclassing_any = true
 disallow_untyped_decorators = true
 
 allow_redefinition = true


### PR DESCRIPTION
## Describe your changes

In mypy.ini, all of the features of strict mode are listed, apparently being gradually uncommented as the codebase comes into compliance with them. Presumably eventually the body of them will be replaced with strict=true. But this is not that day. This change just enables two of them, because the code already passes those and they don't have to be commented. It also stops ignoring errors in add_license_headers, because that file doesn't even exist anymore.

## Testing

mypy is run in the ci and does not complain about the codebase.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
