### PR TITLE
Don't raise FragmentStorageKeyError for auto_rerun fragments

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1786,6 +1786,31 @@ describe("App", () => {
       expect(clearInterval).toHaveBeenCalledWith(expect.any(Number))
       expect(clearInterval).toHaveBeenCalledWith(expect.any(Number))
     })
+
+    it("triggers rerunScript with is_auto_rerun set to true", () => {
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+      jest.advanceTimersByTime(1000)
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].toJSON()
+      ).toStrictEqual({
+        rerunScript: {
+          fragmentId: "myFragmentId",
+          isAutoRerun: true,
+          pageName: "",
+          pageScriptHash: "",
+          queryString: "",
+          widgetStates: {},
+        },
+      })
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -632,7 +632,7 @@ export class App extends PureComponent<Props, State> {
       //      connection dropping.
       if (!this.sessionInfo.last || lastRunWasInterrupted) {
         logMessage("Requesting a script run.")
-        this.widgetMgr.sendUpdateWidgetsMessage(undefined, undefined)
+        this.widgetMgr.sendUpdateWidgetsMessage(undefined)
         this.setState({ dialog: null })
       }
 
@@ -1417,7 +1417,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     // Trigger a full app rerun:
-    this.widgetMgr.sendUpdateWidgetsMessage(undefined, undefined)
+    this.widgetMgr.sendUpdateWidgetsMessage(undefined)
   }
 
   sendLoadGitInfoBackMsg = (): void => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -632,7 +632,7 @@ export class App extends PureComponent<Props, State> {
       //      connection dropping.
       if (!this.sessionInfo.last || lastRunWasInterrupted) {
         logMessage("Requesting a script run.")
-        this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+        this.widgetMgr.sendUpdateWidgetsMessage(undefined, undefined)
         this.setState({ dialog: null })
       }
 
@@ -845,7 +845,7 @@ export class App extends PureComponent<Props, State> {
 
   handleAutoRerun = (autoRerun: AutoRerun): void => {
     const intervalId = setInterval(() => {
-      this.widgetMgr.sendUpdateWidgetsMessage(autoRerun.fragmentId)
+      this.widgetMgr.sendUpdateWidgetsMessage(autoRerun.fragmentId, true)
     }, autoRerun.interval * 1000)
 
     this.setState((prevState: State) => {
@@ -1417,7 +1417,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     // Trigger a full app rerun:
-    this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+    this.widgetMgr.sendUpdateWidgetsMessage(undefined, undefined)
   }
 
   sendLoadGitInfoBackMsg = (): void => {
@@ -1468,7 +1468,8 @@ export class App extends PureComponent<Props, State> {
   sendRerunBackMsg = (
     widgetStates?: WidgetStates,
     fragmentId?: string,
-    pageScriptHash?: string
+    pageScriptHash?: string,
+    isAutoRerun?: boolean
   ): void => {
     const baseUriParts = this.getBaseUriParts()
     if (!baseUriParts) {
@@ -1522,6 +1523,7 @@ export class App extends PureComponent<Props, State> {
           pageScriptHash,
           pageName,
           fragmentId,
+          isAutoRerun,
         },
       })
     )

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -101,7 +101,9 @@ describe("Widget State Manager", () => {
       expect(sendBackMsg).toHaveBeenCalledTimes(1)
       expect(sendBackMsg).toHaveBeenCalledWith(
         expect.anything(),
-        undefined // fragmentId
+        undefined, // fragmentId
+        undefined,
+        undefined
       )
     }
   }
@@ -394,7 +396,9 @@ describe("Widget State Manager", () => {
       )
       expect(sendBackMsg).toHaveBeenCalledWith(
         expect.anything(),
-        "myFragmentId"
+        "myFragmentId",
+        undefined,
+        undefined
       )
     })
 
@@ -410,7 +414,9 @@ describe("Widget State Manager", () => {
       )
       expect(sendBackMsg).toHaveBeenCalledWith(
         expect.anything(),
-        "myFragmentId"
+        "myFragmentId",
+        undefined,
+        undefined
       )
     })
   })
@@ -556,7 +562,9 @@ describe("Widget State Manager", () => {
             { id: "widget2", stringValue: "bar" },
           ],
         },
-        undefined // fragmentId
+        undefined, // fragmentId
+        undefined,
+        undefined
       )
 
       // We have no more pending form.
@@ -591,7 +599,9 @@ describe("Widget State Manager", () => {
             { id: "widget1", stringValue: "foo" },
           ],
         },
-        "myFragmentId"
+        "myFragmentId",
+        undefined,
+        undefined
       )
 
       // We have no more pending form.
@@ -620,6 +630,8 @@ describe("Widget State Manager", () => {
         {
           widgets: [{ id: "firstSubmitButton", triggerValue: true }],
         },
+        undefined,
+        undefined,
         undefined
       )
     })
@@ -711,6 +723,8 @@ describe("Widget State Manager", () => {
             { id: FORM_1.id, stringValue: "foo" },
           ],
         },
+        undefined,
+        undefined,
         undefined
       )
     })
@@ -741,6 +755,8 @@ describe("Widget State Manager", () => {
             { id: FORM_2.id, stringValue: "bar" },
           ],
         },
+        undefined,
+        undefined,
         undefined
       )
     })
@@ -775,6 +791,8 @@ describe("Widget State Manager", () => {
             { id: FORM_2.id, stringValue: "bar" },
           ],
         },
+        undefined,
+        undefined,
         undefined
       )
     })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -259,7 +259,7 @@ export class WidgetStateManager {
     this.widgetStates.copyFrom(form.widgetStates)
     form.widgetStates.clear()
 
-    this.sendUpdateWidgetsMessage(fragmentId, undefined)
+    this.sendUpdateWidgetsMessage(fragmentId)
     this.syncFormsWithPendingChanges()
 
     if (selectedSubmitButton) {
@@ -560,7 +560,7 @@ export class WidgetStateManager {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
     } else if (source.fromUi) {
-      this.sendUpdateWidgetsMessage(fragmentId, undefined)
+      this.sendUpdateWidgetsMessage(fragmentId)
     }
   }
 
@@ -583,7 +583,7 @@ export class WidgetStateManager {
 
   public sendUpdateWidgetsMessage(
     fragmentId: string | undefined,
-    isAutoRerun: boolean | undefined
+    isAutoRerun: boolean | undefined = undefined
   ): void {
     this.props.sendRerunBackMsg(
       this.widgetStates.createWidgetStatesMsg(),

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -156,7 +156,9 @@ interface Props {
   /** Callback to deliver a message to the server */
   sendRerunBackMsg: (
     widgetStates: WidgetStates,
-    fragmentId: string | undefined
+    fragmentId: string | undefined,
+    pageScriptHash: string | undefined,
+    isAutoRerun: boolean | undefined
   ) => void
 
   /**
@@ -257,7 +259,7 @@ export class WidgetStateManager {
     this.widgetStates.copyFrom(form.widgetStates)
     form.widgetStates.clear()
 
-    this.sendUpdateWidgetsMessage(fragmentId)
+    this.sendUpdateWidgetsMessage(fragmentId, undefined)
     this.syncFormsWithPendingChanges()
 
     if (selectedSubmitButton) {
@@ -558,7 +560,7 @@ export class WidgetStateManager {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
     } else if (source.fromUi) {
-      this.sendUpdateWidgetsMessage(fragmentId)
+      this.sendUpdateWidgetsMessage(fragmentId, undefined)
     }
   }
 
@@ -579,10 +581,15 @@ export class WidgetStateManager {
     })
   }
 
-  public sendUpdateWidgetsMessage(fragmentId: string | undefined): void {
+  public sendUpdateWidgetsMessage(
+    fragmentId: string | undefined,
+    isAutoRerun: boolean | undefined
+  ): void {
     this.props.sendRerunBackMsg(
       this.widgetStates.createWidgetStatesMsg(),
-      fragmentId
+      fragmentId,
+      undefined,
+      isAutoRerun
     )
   }
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -363,6 +363,7 @@ class AppSession:
                 client_state.page_script_hash,
                 client_state.page_name,
                 fragment_id=fragment_id if fragment_id else None,
+                is_auto_rerun=client_state.is_auto_rerun,
             )
         else:
             rerun_data = RerunData()

--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -54,6 +54,7 @@ class RerunData:
     # The queue of fragment_ids waiting to be run.
     fragment_id_queue: list[str] = field(default_factory=list)
     is_fragment_scoped_rerun: bool = False
+    is_auto_rerun: bool = False
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -180,6 +181,7 @@ class ScriptRequests:
                     page_name=new_data.page_name,
                     fragment_id_queue=fragment_id_queue,
                     is_fragment_scoped_rerun=new_data.is_fragment_scoped_rerun,
+                    is_auto_rerun=new_data.is_auto_rerun,
                 )
 
                 return True

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -555,9 +555,16 @@ class ScriptRunner:
                                 wrapped_fragment()
 
                             except FragmentStorageKeyError:
-                                raise RuntimeError(
-                                    f"Could not find fragment with id {fragment_id}"
-                                )
+                                # Only raise an error if the fragment is not an
+                                # auto_rerun. If it is an auto_rerun, we might have a
+                                # race condition where the fragment_id is removed
+                                # but the webapp sends a rerun request before the
+                                # removal information has reached the web app
+                                # (see https://github.com/streamlit/streamlit/issues/9080).
+                                if not rerun_data.is_auto_rerun:
+                                    raise RuntimeError(
+                                        f"Could not find fragment with id {fragment_id}"
+                                    )
                             except (RerunException, StopException) as e:
                                 # The wrapped_fragment function is executed
                                 # inside of a exec_func_with_error_handling call, so

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -411,6 +411,24 @@ class ScriptRunnerTest(AsyncTestCase):
         ex = patched_handle_exception.call_args[0][0]
         assert isinstance(ex, RuntimeError)
 
+    @patch("streamlit.runtime.scriptrunner.exec_code.handle_uncaught_app_exception")
+    def test_FragmentStorageKeyError_for_autoRerun_is_not_raised(
+        self, patched_handle_exception
+    ):
+        fragment = MagicMock()
+        fragment.side_effect = FragmentStorageKeyError("kaboom")
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.set("my_fragment", fragment)
+
+        scriptrunner.request_rerun(
+            RerunData(fragment_id_queue=["my_fragment"], is_auto_rerun=True)
+        )
+        scriptrunner.start()
+        scriptrunner.join()
+
+        assert patched_handle_exception.call_args is None
+
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     @patch("streamlit.runtime.fragment.handle_uncaught_app_exception")
     def test_regular_KeyError_is_rethrown(

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -28,4 +28,5 @@ message ClientState {
   string page_script_hash = 3;
   string page_name = 4;
   string fragment_id = 5;
+  bool is_auto_rerun = 6;
 }


### PR DESCRIPTION
## Describe your changes

Closes #9080 

When a fragment is scheduled via `rerun_every` with a small interval, we might run into a race condition when the fragment is removed from the app, e.g. by de-selecting a checkbox. This happens because the `script_runner` on the Python backend might remove the fragment and a `NewSession` message is sent to the web app which informs about the scheduled fragments, ;but before the message reaches the web app, the scheduled interval-runner sends another re-run message. The following flow diagram depicts this: 

![Fragment rerun_every Race Condition - Page 1 (1)](https://github.com/user-attachments/assets/2b09c898-f054-4883-adcf-2f05a4fc31d1)



## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - [JS] Add a unit test to ensure that the RerunScript sent via the `handleAutoRerun` function contains the `is_auto_rerun` flag
  - [Python] Add a unit test to ensure that the `FragmentStorageKeyError` is not raised when the `is_auto_rerun` flag is set on `RerunData`
- E2E Tests
  - Since this relies on an interval and frequent user action (e.g. selecting & deselecting a checkbox as described in #9080) before it happens and, thus, is not completely deterministic, I figure a better approach is to rely on the unit tests.
- Any manual testing needed?
 - I tested the user app described in #9080 manually

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
