### PR TITLE
When clearing forward queue add a stopped for rerun message

### DIFF
--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -210,7 +210,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         script_finished_msg = ForwardMsg()
         script_finished_msg.script_finished = (
-            ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+            ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
         )
 
         session_status_changed_msg = ForwardMsg()
@@ -225,13 +225,22 @@ class ForwardMsgQueueTest(unittest.TestCase):
         fmq.enqueue(session_status_changed_msg)
         fmq.enqueue(parent_msg)
 
+        expected_new_finished_message = ForwardMsg()
+        expected_new_finished_message.script_finished = (
+            ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+        )
+
         fmq.clear(retain_lifecycle_msgs=True)
-        assert fmq._queue == [
+        expected_retained_messages = [
             NEW_SESSION_MSG,
-            script_finished_msg,
+            expected_new_finished_message,
             session_status_changed_msg,
             parent_msg,
         ]
+        assert fmq._queue == expected_retained_messages
+
+        fmq.clear(retain_lifecycle_msgs=True)
+        assert fmq._queue == expected_retained_messages
 
         fmq.clear()
         assert fmq._queue == []


### PR DESCRIPTION
## Describe your changes
At the moment, some delta messages may not be sent to the frontend but the script_finished_successfully message may still be sent to the front end, at which point the front end will remove stale elements.

From the perspective of the frontend there is no difference between a scriptRunner finishing execution but some of the later messages being dropped and the scriptRunner being stopped prematurely for a rerun.

In the case of the issue #9163, the number input element is considered stale, so removed. It is then added back by the rerun, but has lost its state, so the value is nulled out.

This PR instead modifies the preserved script_finished messages by setting FINISHED_EARLY_FOR_RERUN as the value when the browser queue was not flushed before a new script run started.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9163

## Testing Plan

The bug this aims to fix is related to concurrency and seems quite difficult to test in an automated fashion. The bug cannot be reliably reproduced so e2e testing doesnt seem too useful either. 

I have verified these changes resolve the issue shared above. 

Updated the existing tests and added some new tests for the different return values of the _clear_queue function.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
