### PR TITLE
Treat @streamlit as an internal import for eslint

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -181,6 +181,11 @@ module.exports = {
             group: "external",
             position: "before",
           },
+          {
+            pattern: "@streamlit/**",
+            group: "internal",
+            position: "after",
+          },
         ],
         pathGroupsExcludedImportTypes: ["react"],
         groups: [

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -184,7 +184,7 @@ module.exports = {
           {
             pattern: "@streamlit/**",
             group: "internal",
-            position: "after",
+            position: "before",
           },
         ],
         pathGroupsExcludedImportTypes: ["react"],

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -26,6 +26,7 @@ import {
 } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import cloneDeep from "lodash/cloneDeep"
+
 import {
   Config,
   CUSTOM_THEME_NAME,
@@ -49,7 +50,6 @@ import {
   toExportedTheme,
   WidgetStateManager,
 } from "@streamlit/lib"
-
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 import { ConnectionManager } from "@streamlit/app/src/connection/ConnectionManager"
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -20,6 +20,8 @@ import moment from "moment"
 import { HotKeys, KeyMap } from "react-hotkeys"
 import { enableAllPlugins as enableImmerPlugins } from "immer"
 import classNames from "classnames"
+import without from "lodash/without"
+
 import {
   AppConfig,
   AppRoot,
@@ -95,13 +97,11 @@ import {
   WidgetStateManager,
   WidgetStates,
 } from "@streamlit/lib"
-import without from "lodash/without"
 import {
   isNullOrUndefined,
   notNullOrUndefined,
   preserveEmbedQueryParams,
 } from "@streamlit/lib/src/util/utils"
-
 import { AppContext } from "@streamlit/app/src/components/AppContext"
 import AppView from "@streamlit/app/src/components/AppView"
 import StatusWidget from "@streamlit/app/src/components/StatusWidget"

--- a/frontend/app/src/SegmentMetricsManager.ts
+++ b/frontend/app/src/SegmentMetricsManager.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import pick from "lodash/pick"
+
 import {
   isNullOrUndefined,
   notNullOrUndefined,
 } from "@streamlit/lib/src/util/utils"
-import pick from "lodash/pick"
 import {
   Delta,
   DeployedAppMetadata,
@@ -27,7 +28,6 @@ import {
   logAlways,
   SessionInfo,
 } from "@streamlit/lib"
-
 import { initializeSegment } from "@streamlit/app/src/vendor/Segment"
 
 /**

--- a/frontend/app/src/SessionEventDispatcher.ts
+++ b/frontend/app/src/SessionEventDispatcher.ts
@@ -15,6 +15,7 @@
  */
 
 import { Signal } from "typed-signals"
+
 import { SessionEvent } from "@streamlit/lib"
 
 /** Redispatches SessionEvent messages received from the server. */

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -20,6 +20,7 @@ import React, { PureComponent, ReactElement } from "react"
 
 import "@testing-library/jest-dom"
 import { screen, waitFor } from "@testing-library/react"
+
 import {
   AppRoot,
   ComponentRegistry,

--- a/frontend/app/src/ThemedApp.tsx
+++ b/frontend/app/src/ThemedApp.tsx
@@ -17,7 +17,6 @@
 import React from "react"
 
 import { CUSTOM_THEME_NAME, RootStyleProvider } from "@streamlit/lib"
-
 import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclaration"
 import { StyledDataFrameOverlay } from "@streamlit/app/src/styled-components"
 

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -18,6 +18,7 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { screen, within } from "@testing-library/react"
+
 import {
   AppRoot,
   BlockNode,
@@ -37,7 +38,6 @@ import {
   ScriptRunState,
   WidgetStateManager,
 } from "@streamlit/lib"
-
 import {
   AppContext,
   Props as AppContextProps,

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -32,7 +32,6 @@ import {
   VerticalBlock,
   WidgetStateManager,
 } from "@streamlit/lib"
-
 import { ThemedSidebar } from "@streamlit/app/src/components/Sidebar"
 import EventContainer from "@streamlit/app/src/components/EventContainer"
 import {

--- a/frontend/app/src/components/Countdown/Countdown.test.tsx
+++ b/frontend/app/src/components/Countdown/Countdown.test.tsx
@@ -16,8 +16,9 @@
 
 import React from "react"
 
-import { render } from "@streamlit/lib"
 import { screen } from "@testing-library/react"
+
+import { render } from "@streamlit/lib"
 import "@testing-library/jest-dom"
 
 import Countdown from "./Countdown"

--- a/frontend/app/src/components/EventContainer/EventContainer.test.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { screen } from "@testing-library/react"
+
 import "@testing-library/jest-dom"
 import { render } from "@streamlit/lib/src/test_util"
 

--- a/frontend/app/src/components/EventContainer/EventContainer.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.tsx
@@ -18,6 +18,7 @@ import React, { ReactElement, ReactNode, useEffect } from "react"
 
 import { PLACEMENT, toaster, ToasterContainer } from "baseui/toast"
 import { useTheme } from "@emotion/react"
+
 import { EmotionTheme } from "@streamlit/lib"
 
 export interface EventContainerProps {

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -18,8 +18,8 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { screen, waitFor, within } from "@testing-library/react"
-import { Config, IMenuItem, mockSessionInfo, render } from "@streamlit/lib"
 
+import { Config, IMenuItem, mockSessionInfo, render } from "@streamlit/lib"
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 import { getMenuStructure, openMenu } from "./mainMenuTestHelpers"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -16,11 +16,12 @@
 
 import React, { forwardRef, memo, MouseEvent, ReactElement } from "react"
 
-import { notNullOrUndefined } from "@streamlit/lib/src/util/utils"
 import { StatefulMenu } from "baseui/menu"
 import { PLACEMENT, StatefulPopover } from "baseui/popover"
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { useTheme } from "@emotion/react"
+
+import { notNullOrUndefined } from "@streamlit/lib/src/util/utils"
 import {
   BaseButton,
   BaseButtonKind,
@@ -31,7 +32,6 @@ import {
   IMenuItem,
   PageConfig,
 } from "@streamlit/lib"
-
 import ScreenCastRecorder from "@streamlit/app/src/util/ScreenCastRecorder"
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -17,8 +17,9 @@
 import styled from "@emotion/styled"
 import { keyframes } from "@emotion/react"
 import { Keyframes } from "@emotion/serialize"
-import { EmotionTheme } from "@streamlit/lib"
 import { transparentize } from "color2k"
+
+import { EmotionTheme } from "@streamlit/lib"
 
 const recordingIndicatorPulse = (theme: EmotionTheme): Keyframes => keyframes`
 0% {

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -23,6 +23,7 @@ import {
   screen,
   within,
 } from "@testing-library/react"
+
 import {
   emotionLightTheme,
   Logo,

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ import React, { PureComponent, ReactElement, ReactNode } from "react"
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 import { withTheme } from "@emotion/react"
 import { Resizable } from "re-resizable"
+
 import {
   BaseButton,
   BaseButtonKind,

--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -19,6 +19,7 @@ import "@testing-library/jest-dom"
 
 import * as reactDeviceDetect from "react-device-detect"
 import { fireEvent, screen } from "@testing-library/react"
+
 import {
   IAppPage,
   mockEndpoints,

--- a/frontend/app/src/components/Sidebar/SidebarNav.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.tsx
@@ -26,8 +26,8 @@ import groupBy from "lodash/groupBy"
 // We import react-device-detect in this way so that tests can mock its
 // isMobile field sanely.
 import * as reactDeviceDetect from "react-device-detect"
-import { IAppPage, StreamlitEndpoints, useIsOverflowing } from "@streamlit/lib"
 
+import { IAppPage, StreamlitEndpoints, useIsOverflowing } from "@streamlit/lib"
 import { AppContext } from "@streamlit/app/src/components/AppContext"
 
 import NavSection from "./NavSection"

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -18,6 +18,7 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { screen } from "@testing-library/react"
+
 import { emotionLightTheme, mockEndpoints, render } from "@streamlit/lib"
 
 import { SidebarProps } from "./Sidebar"

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
@@ -22,7 +22,6 @@ import {
   ThemeConfig,
   ThemeProvider,
 } from "@streamlit/lib"
-
 import { AppContext } from "@streamlit/app/src/components/AppContext"
 
 import Sidebar, { SidebarProps } from "./Sidebar"

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -16,6 +16,7 @@
 
 import { transparentize } from "color2k"
 import styled from "@emotion/styled"
+
 import {
   getWrappedHeadersStyle,
   hasLightBackgroundColor,

--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -18,13 +18,13 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
+
 import {
   mockTheme,
   render,
   ScriptRunState,
   SessionEvent,
 } from "@streamlit/lib"
-
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import { SessionEventDispatcher } from "@streamlit/app/src/SessionEventDispatcher"
 

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -16,13 +16,13 @@
 
 import React, { PureComponent, ReactNode } from "react"
 
-import {
-  isNullOrUndefined,
-  notNullOrUndefined,
-} from "@streamlit/lib/src/util/utils"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 import { Ellipses, Info, Warning } from "@emotion-icons/open-iconic"
 import { withTheme } from "@emotion/react"
+import { HotKeys } from "react-hotkeys"
+import { CSSTransition } from "react-transition-group"
+import { SignalConnection } from "typed-signals"
+
 import {
   BaseButton,
   BaseButtonKind,
@@ -35,10 +35,10 @@ import {
   Timer,
   Tooltip,
 } from "@streamlit/lib"
-import { HotKeys } from "react-hotkeys"
-import { CSSTransition } from "react-transition-group"
-import { SignalConnection } from "typed-signals"
-
+import {
+  isNullOrUndefined,
+  notNullOrUndefined,
+} from "@streamlit/lib/src/util/utils"
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import { SessionEventDispatcher } from "@streamlit/app/src/SessionEventDispatcher"
 /*

--- a/frontend/app/src/components/StatusWidget/styled-components.ts
+++ b/frontend/app/src/components/StatusWidget/styled-components.ts
@@ -15,6 +15,7 @@
  */
 
 import styled, { CSSObject } from "@emotion/styled"
+
 import { EmotionTheme, hasLightBackgroundColor } from "@streamlit/lib"
 
 /*

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
@@ -17,8 +17,9 @@
 import React, { ReactElement } from "react"
 
 import { Card } from "baseui/card"
-import { EmotionTheme } from "@streamlit/lib"
 import { useTheme } from "@emotion/react"
+
+import { EmotionTheme } from "@streamlit/lib"
 
 interface IDeployCardProps {
   children?: React.ReactNode

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -17,8 +17,8 @@
 import React, { ReactElement, ReactNode, useCallback, useContext } from "react"
 
 import { StyledAction, StyledBody } from "baseui/card"
-import { BaseButton, BaseButtonKind, GitInfo, IGitInfo } from "@streamlit/lib"
 
+import { BaseButton, BaseButtonKind, GitInfo, IGitInfo } from "@streamlit/lib"
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 import {
   DialogType,

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployModal.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployModal.tsx
@@ -16,8 +16,9 @@
 
 import React, { ReactElement } from "react"
 
-import { Modal, ModalBody, ModalHeader } from "@streamlit/lib"
 import { CloseSource } from "baseui/modal/types"
+
+import { Modal, ModalBody, ModalHeader } from "@streamlit/lib"
 
 interface IDeployModalProps {
   children: React.ReactNode

--- a/frontend/app/src/components/StreamlitDialog/ScriptChangedDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ScriptChangedDialog.tsx
@@ -17,6 +17,7 @@
 import React, { PureComponent, ReactNode } from "react"
 
 import { HotKeys } from "react-hotkeys"
+
 import {
   BaseButtonKind,
   Modal,

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { fireEvent, screen } from "@testing-library/react"
+
 import "@testing-library/jest-dom"
 import { customRenderLibContext } from "@streamlit/lib/src/test_util"
 import {
@@ -26,7 +27,6 @@ import {
   lightTheme,
   mockSessionInfo,
 } from "@streamlit/lib"
-
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 import { Props, SettingsDialog } from "./SettingsDialog"

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
@@ -32,7 +32,6 @@ import {
   ThemeConfig,
   UISelectbox,
 } from "@streamlit/lib"
-
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 import {

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
@@ -16,8 +16,9 @@
 
 import React, { Fragment } from "react"
 
-import { mockSessionInfo, render, SessionInfo } from "@streamlit/lib"
 import { screen } from "@testing-library/react"
+
+import { mockSessionInfo, render, SessionInfo } from "@streamlit/lib"
 
 import { DialogType, StreamlitDialog } from "./StreamlitDialog"
 import "@testing-library/jest-dom"

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -16,6 +16,8 @@
 
 import React, { CSSProperties, ReactElement, ReactNode } from "react"
 
+import { HotKeys } from "react-hotkeys"
+
 import {
   BaseButtonKind,
   IException,
@@ -27,8 +29,6 @@ import {
   SessionInfo,
   StreamlitMarkdown,
 } from "@streamlit/lib"
-import { HotKeys } from "react-hotkeys"
-
 import {
   ScriptChangedDialog,
   Props as ScriptChangedDialogProps,

--- a/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
@@ -18,6 +18,7 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { fireEvent, screen, within } from "@testing-library/react"
+
 import {
   CustomThemeConfig,
   darkTheme,

--- a/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -20,6 +20,7 @@ import { Check } from "@emotion-icons/material-outlined"
 import { toHex } from "color2k"
 import humanizeString from "humanize-string"
 import mapValues from "lodash/mapValues"
+
 import {
   BaseButton,
   BaseButtonKind,

--- a/frontend/app/src/components/StreamlitDialog/styled-components.ts
+++ b/frontend/app/src/components/StreamlitDialog/styled-components.ts
@@ -17,6 +17,7 @@
 import styled from "@emotion/styled"
 import { ChevronLeft } from "react-feather"
 import { darken } from "color2k"
+
 import { Small } from "@streamlit/lib"
 
 export const StyledRerunHeader = styled.div(({ theme }) => ({

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -18,8 +18,8 @@ import React from "react"
 
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
-import { mockSessionInfo, render } from "@streamlit/lib"
 
+import { mockSessionInfo, render } from "@streamlit/lib"
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 import ToolbarActions, {

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -22,7 +22,6 @@ import {
   IGuestToHostMessage,
   IToolbarItem,
 } from "@streamlit/lib"
-
 import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
 
 import {

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
@@ -16,6 +16,7 @@
 
 import axios from "axios"
 import MockAdapter from "axios-mock-adapter"
+
 import { BaseUriParts, buildHttpUri, ForwardMsg } from "@streamlit/lib"
 
 import { DefaultStreamlitEndpoints } from "./DefaultStreamlitEndpoints"

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { notNullOrUndefined } from "@streamlit/lib/src/util/utils"
 import axios, { AxiosRequestConfig, AxiosResponse, CancelToken } from "axios"
+
+import { notNullOrUndefined } from "@streamlit/lib/src/util/utils"
 import {
   BaseUriParts,
   buildHttpUri,

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -19,13 +19,13 @@ import React, { Fragment } from "react"
 import axios from "axios"
 import { WS } from "jest-websocket-mock"
 import zip from "lodash/zip"
+
 import {
   BackMsg,
   mockEndpoints,
   mockSessionInfoProps,
   SessionInfo,
 } from "@streamlit/lib"
-
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import {
   Args,

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -16,12 +16,13 @@
 
 import React, { Fragment } from "react"
 
+import styled from "@emotion/styled"
+import axios from "axios"
+
 import {
   isNullOrUndefined,
   notNullOrUndefined,
 } from "@streamlit/lib/src/util/utils"
-import styled from "@emotion/styled"
-import axios from "axios"
 import {
   BackMsg,
   BaseUriParts,
@@ -39,7 +40,6 @@ import {
   SessionInfo,
   StreamlitEndpoints,
 } from "@streamlit/lib"
-
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 
 /**

--- a/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
@@ -19,6 +19,7 @@ import React from "react"
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
+
 import { render } from "@streamlit/lib"
 
 import ScreencastDialog, { Props } from "./ScreencastDialog"

--- a/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
@@ -19,6 +19,7 @@ import React from "react"
 import { BaseProvider, LightTheme } from "baseui"
 import "@testing-library/jest-dom"
 import { screen } from "@testing-library/react"
+
 import { render } from "@streamlit/lib"
 
 import UnsupportedBrowserDialog from "./UnsupportedBrowserDialog"

--- a/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -19,6 +19,7 @@ import React from "react"
 import { BaseProvider, LightTheme } from "baseui"
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
+
 import { render } from "@streamlit/lib"
 
 import VideoRecordedDialog, { Props } from "./VideoRecordedDialog"

--- a/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
@@ -18,6 +18,7 @@ import React, { PureComponent, ReactElement } from "react"
 
 import "@testing-library/jest-dom"
 import { screen } from "@testing-library/react"
+
 import { render } from "@streamlit/lib"
 
 import withScreencast, { ScreenCastHOC, Steps } from "./withScreencast"

--- a/frontend/app/src/hocs/withScreencast/withScreencast.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.tsx
@@ -16,10 +16,10 @@
 
 import React, { ComponentType, PureComponent, ReactNode } from "react"
 
-import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
-import { logWarning } from "@streamlit/lib"
 import hoistNonReactStatics from "hoist-non-react-statics"
 
+import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
+import { logWarning } from "@streamlit/lib"
 import ScreenCastRecorder from "@streamlit/app/src/util/ScreenCastRecorder"
 import {
   ScreencastDialog,

--- a/frontend/app/src/styled-components.ts
+++ b/frontend/app/src/styled-components.ts
@@ -15,6 +15,7 @@
  */
 
 import styled from "@emotion/styled"
+
 import { hasLightBackgroundColor } from "@streamlit/lib"
 
 export const StyledApp = styled.div(({ theme }) => {

--- a/frontend/app/src/util/useThemeManager.test.ts
+++ b/frontend/app/src/util/useThemeManager.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { act, renderHook } from "@testing-library/react-hooks"
+
 import {
   AUTO_THEME_NAME,
   createPresetThemes,


### PR DESCRIPTION
## Describe your changes

This PR lets eslint know that `@streamlit` is an internal package and that it should sort it as such. I found it a bit odd that this rule changed ZERO things in lib... but from my manual verification, it seems okay..?

Follow up from this discussion: https://github.com/streamlit/streamlit/pull/9153#discussion_r1695996337


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
