### PR TITLE
Fix uncaught exception metrics tracking

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -27,7 +27,13 @@ if TYPE_CHECKING:
 
 def exec_func_with_error_handling(
     func: Callable[[], None], ctx: ScriptRunContext
-) -> tuple[Any | None, bool, RerunData | None, bool]:
+) -> tuple[
+    Any | None,
+    bool,
+    RerunData | None,
+    bool,
+    Exception | None,
+]:
     """Execute the passed function wrapped in a try/except block.
 
     This function is called by the script runner to execute the user's script or
@@ -53,6 +59,7 @@ def exec_func_with_error_handling(
             interrupted by a RerunException.
         - A boolean indicating whether the script was stopped prematurely (False for
             RerunExceptions, True for all other exceptions).
+        - The uncaught exception if one occurred, None otherwise
     """
 
     # Avoid circular imports
@@ -70,6 +77,9 @@ def exec_func_with_error_handling(
 
     # The result of the passed function
     result: Any | None = None
+
+    # The uncaught exception if one occurred, None otherwise
+    uncaught_exception: Exception | None = None
 
     try:
         result = func()
@@ -102,5 +112,12 @@ def exec_func_with_error_handling(
         run_without_errors = False
         premature_stop = True
         handle_uncaught_app_exception(ex)
+        uncaught_exception = ex
 
-    return result, run_without_errors, rerun_exception_data, premature_stop
+    return (
+        result,
+        run_without_errors,
+        rerun_exception_data,
+        premature_stop,
+        uncaught_exception,
+    )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -425,7 +425,6 @@ class ScriptRunner:
                 rerun_data.page_script_hash, rerun_data.page_name
             )
             main_page_info = self._pages_manager.get_main_page()
-            uncaught_exception = None
 
             page_script_hash = (
                 active_script["page_script_hash"]
@@ -596,6 +595,7 @@ class ScriptRunner:
                 run_without_errors,
                 rerun_exception_data,
                 premature_stop,
+                uncaught_exception,
             ) = exec_func_with_error_handling(code_to_exec, ctx)
             # setting the session state here triggers a yield-callback call
             # which reads self._requests and checks for rerun data

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -621,7 +621,7 @@ class ScriptRunner:
                     # Create and send page profile information
                     ctx.enqueue(
                         create_page_profile_message(
-                            ctx.tracked_commands,
+                            commands=ctx.tracked_commands,
                             exec_time=to_microseconds(timer() - start_time),
                             prep_time=to_microseconds(prep_time),
                             uncaught_exception=(

--- a/lib/tests/streamlit/runtime/scriptrunner/code_exec_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/code_exec_test.py
@@ -47,14 +47,19 @@ class TestWrapInTryAndExec(unittest.TestCase):
             """Test function that does nothing and, thus, succeeds."""
             return 42
 
-        result, run_without_errors, rerun_exception_data, premature_stop = (
-            exec_func_with_error_handling(test_func, self.ctx)
-        )
+        (
+            result,
+            run_without_errors,
+            rerun_exception_data,
+            premature_stop,
+            uncaught_exception,
+        ) = exec_func_with_error_handling(test_func, self.ctx)
 
         assert result == 42
         assert run_without_errors is True
         assert rerun_exception_data is None
         assert premature_stop is False
+        assert uncaught_exception is None
 
     def test_func_throws_rerun_exception(self):
         rerun_data = RerunData(query_string="foo")
@@ -63,37 +68,52 @@ class TestWrapInTryAndExec(unittest.TestCase):
             """Test function that raises a RerunException."""
             raise RerunException(rerun_data)
 
-        _, run_without_errors, rerun_exception_data, premature_stop = (
-            exec_func_with_error_handling(test_func, self.ctx)
-        )
+        (
+            _,
+            run_without_errors,
+            rerun_exception_data,
+            premature_stop,
+            uncaught_exception,
+        ) = exec_func_with_error_handling(test_func, self.ctx)
 
         assert run_without_errors is True
         assert rerun_exception_data == rerun_data
         assert premature_stop is False
+        assert uncaught_exception is None
 
     def test_func_throws_stop_exception(self):
         def test_func():
             """Test function that raises a StopException."""
             raise StopException()
 
-        _, run_without_errors, rerun_exception_data, premature_stop = (
-            exec_func_with_error_handling(test_func, self.ctx)
-        )
+        (
+            _,
+            run_without_errors,
+            rerun_exception_data,
+            premature_stop,
+            uncaught_exception,
+        ) = exec_func_with_error_handling(test_func, self.ctx)
 
         assert run_without_errors is True
         assert rerun_exception_data is None
         assert premature_stop is True
+        assert uncaught_exception is None
 
     @parameterized.expand([(ValueError), (TypeError), (RuntimeError), (Exception)])
-    def test_func_throws_generic_exception(self, exception_type: Exception):
+    def test_func_throws_generic_exception(self, exception_type: type):
         def test_func():
             """Test function that raises a generic Exception."""
             raise exception_type()
 
-        _, run_without_errors, rerun_exception_data, premature_stop = (
-            exec_func_with_error_handling(test_func, self.ctx)
-        )
+        (
+            _,
+            run_without_errors,
+            rerun_exception_data,
+            premature_stop,
+            uncaught_exception,
+        ) = exec_func_with_error_handling(test_func, self.ctx)
 
         assert run_without_errors is False
         assert rerun_exception_data is None
         assert premature_stop is True
+        assert isinstance(uncaught_exception, exception_type)

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -636,6 +636,24 @@ class ScriptRunnerTest(AsyncTestCase):
         )
         self._assert_text_deltas(scriptrunner, [])
 
+    @patch("streamlit.runtime.metrics_util.create_page_profile_message")
+    def test_uncaught_exception_gets_tracked(self, patched_create_page_profile_message):
+        """Tests that we track uncaught exceptions."""
+        with testutil.patch_config_options({"browser.gatherUsageStats": True}):
+            scriptrunner = TestScriptRunner("runtime_error.py")
+            scriptrunner.request_rerun(RerunData())
+            scriptrunner.start()
+            scriptrunner.join()
+
+            patched_create_page_profile_message.assert_called_once()
+            call_kwargs = patched_create_page_profile_message.call_args_list[0].kwargs
+
+            # Check the
+            assert len(call_kwargs["commands"]) == 2  # text & exception command
+            assert call_kwargs["exec_time"] > 0
+            assert call_kwargs["prep_time"] > 0
+            assert call_kwargs["uncaught_exception"] == "AttributeError"
+
     @parameterized.expand([(True,), (False,)])
     def test_runtime_error(self, show_error_details: bool):
         """Tests that we correctly handle scripts with runtime errors."""


### PR DESCRIPTION
## Describe your changes

The metrics tracking for uncaught exceptions broke in 1.37. This PR fixes it so that uncaught exceptions are properly tracked via page profiling. 

## Testing Plan

- Added a unit test to verify that the metrics gathering works correctly when exception is thrown.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
