### PR TITLE
Only clear up fragment-related stale widgets

### DIFF
--- a/e2e_playwright/st_rerun.py
+++ b/e2e_playwright/st_rerun.py
@@ -62,4 +62,7 @@ st.write(f"selectbox selection: {s}")
 
 my_fragment()
 fragment_with_rerun_in_try_block()
+
+# have elements in the main app after fragments to ensure that the main app elements are
+#  not cleared when rerunning fragments
 st.write(f"app run count: {st.session_state.count}")

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -37,18 +37,15 @@ def test_fragment_scoped_st_rerun(app: Page):
         "Being able to rerun a session is awesome!"
     )
 
-    click_button(app, "rerun fragment")
-    expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(
-        "fragment run count: 5"
-    )
-    _expect_initial_reruns_count_text(app)
+    # perform multiple clicks to make sure that the fragment rerun works as expected
+    # and the main app content is still rendered
+    for i in range(1, 10):
+        click_button(app, "rerun fragment")
+        expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(
+            f"fragment run count: {i * 5}"
+        )
+        _expect_initial_reruns_count_text(app)
 
-    click_button(app, "rerun fragment")
-    expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(
-        "fragment run count: 10"
-    )
-    # wait for app run to make sure that we do not check a stale state of the app
-    wait_for_app_run(app)
     # the main apps rerun count should not have been incremented
     _expect_initial_reruns_count_text(app)
 

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -47,6 +47,8 @@ def test_fragment_scoped_st_rerun(app: Page):
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(
         "fragment run count: 10"
     )
+    # wait for app run to make sure that we do not check a stale state of the app
+    wait_for_app_run(app)
     # the main apps rerun count should not have been incremented
     _expect_initial_reruns_count_text(app)
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -508,7 +508,10 @@ export class BlockNode implements AppNode {
 
         // This blocks belong to our fragment, but it was modified in a previous script run.
         // This means it is stale now!
-        if (this.scriptRunId !== currentScriptRunId) {
+        if (
+          this.fragmentId === fragmentIdOfBlock &&
+          this.scriptRunId !== currentScriptRunId
+        ) {
           return undefined
         }
 


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/streamlit/streamlit/pull/9186

I have realized that the e2e_test for st_rerun (https://github.com/streamlit/streamlit/blob/develop/e2e_playwright/st_rerun.py) became flaky after merging https://github.com/streamlit/streamlit/pull/9186. The reason is that the
current logic seems to sometimes remove main app nodes that are rendered after a fragment. This PR adds a check to compare the fragment id with the current block's fragment id. The PR also hardens the e2e test to ensure that we would catch a regression without flakiness (the test passed when for the PR to merge 🙄)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
  - harden the e2e test
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
