### PR TITLE
Fix CI issue with `bash --login`

### DIFF
--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash --login -eo pipefail {0}
+      shell: bash

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash --login -v -eo pipefail {0}
+      shell: bash

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash --login -v -o pipefail {0}
+      shell: bash --login -v -eo pipefail {0}

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash
+      shell: bash --login -eo pipefail

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash --login -eo pipefail
+      shell: bash -eo pipefail {0}

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash -eo pipefail {0}
+      shell: bash --login {0}

--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -35,4 +35,4 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_INPUTS: ${{ toJson(inputs) }}
-      shell: bash --login {0}
+      shell: bash --login -v -o pipefail {0}

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         pip install pre-commit
         pre-commit install-hooks
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -33,7 +33,7 @@ runs:
         # Create the cache directory if it does not exist.
         mkdir -p $(yarn cache dir)
         make react-init
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     # We require protoc >= 3.20, but Ubuntu 22.04 - the OS that these Github
     # Actions are running as of 2024.06.04 - doesn't have recent versions
     # of protoc in its package repository. To work around this, we
@@ -47,7 +47,7 @@ runs:
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
         # Print out your System's protoc version:
         protoc --version
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     # Combine hashes of the Python interpreter, Pipfile, and today's
     # date into a file whose hash will key the Python virtualenv.
     #
@@ -67,7 +67,7 @@ runs:
         md5sum lib/setup.py >> $GITHUB_WORKSPACE/python_cache_key.md5
         md5sum Makefile >> $GITHUB_WORKSPACE/python_cache_key.md5
         date +%F >> $GITHUB_WORKSPACE/python_cache_key.md5
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     - if: inputs.use_cached_venv == 'true'
       name: Restore virtualenv from cache
       id: cache-virtualenv
@@ -84,10 +84,10 @@ runs:
         pip install uv
         make python-init
         deactivate
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     - name: Activate virtualenv
       run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     - name: Show environment info
       run: |
         echo "Show environment info"
@@ -95,7 +95,7 @@ runs:
         python --version
         echo "Installed dependencies:"
         python -m pip list
-      shell: bash --login -eo pipefail {0}
+      shell: bash
     - name: Generate Protobufs
       run: make protobuf
-      shell: bash --login -eo pipefail {0}
+      shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -45,6 +45,7 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local bin/protoc
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
+        echo "/usr/local/bin" >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -46,7 +46,6 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
         echo "/usr/local/bin" >> $GITHUB_PATH
-        echo "/usr/bin" >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash
@@ -85,6 +84,10 @@ runs:
         pip install --upgrade pip
         pip install uv
         make python-init
+        deactivate
+      shell: bash
+    - name: Activate virtualenv
+      run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
       shell: bash
     - name: Show environment info
       run: |
@@ -95,5 +98,7 @@ runs:
         python -m pip list
       shell: bash
     - name: Generate Protobufs
-      run: make protobuf
+      run: |
+        source venv/bin/activate
+        make protobuf
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -45,7 +45,6 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local bin/protoc
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
-        echo "/usr/local/bin" >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash
@@ -84,9 +83,7 @@ runs:
         pip install --upgrade pip
         pip install uv
         make python-init
-      shell: bash
-    - name: Activate virtualenv
-      run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
+        echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
       shell: bash
     - name: Show environment info
       run: |
@@ -97,6 +94,5 @@ runs:
         python -m pip list
       shell: bash
     - name: Generate Protobufs
-      run: |
-        make protobuf
+      run: make protobuf
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -80,11 +80,9 @@ runs:
       name: Create Virtual Env
       run: |
         python -m venv venv
-        source venv/bin/activate
-        pip install --upgrade pip
         pip install uv
         uv venv
-        VIRTUAL_ENV=./.venv
+        source .venv/bin/activate
         echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
         echo "$PWD/.venv/bin" >> $GITHUB_PATH
         make python-init
@@ -99,6 +97,5 @@ runs:
       shell: bash
     - name: Generate Protobufs
       run: |
-        source venv/bin/activate
         make protobuf
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -46,7 +46,7 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
         echo "/usr/local/bin" >> $GITHUB_PATH
-        echo "/usr/bin >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -83,11 +83,11 @@ runs:
         source venv/bin/activate
         pip install --upgrade pip
         pip install uv
+        uv venv
+        VIRTUAL_ENV=./.venv
+        echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+        echo "$PWD/.venv/bin" >> $GITHUB_PATH
         make python-init
-        deactivate
-      shell: bash
-    - name: Activate virtualenv
-      run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
       shell: bash
     - name: Show environment info
       run: |

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -80,12 +80,13 @@ runs:
       name: Create Virtual Env
       run: |
         python -m venv venv
+        source venv/bin/activate
+        pip install --upgrade pip
         pip install uv
-        uv venv
-        source .venv/bin/activate
-        echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
-        echo "$PWD/.venv/bin" >> $GITHUB_PATH
         make python-init
+      shell: bash
+    - name: Activate virtualenv
+      run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
       shell: bash
     - name: Show environment info
       run: |

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -46,6 +46,7 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
         echo "/usr/local/bin" >> $GITHUB_PATH
+        echo "/usr/bin >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -85,10 +85,6 @@ runs:
         pip install --upgrade pip
         pip install uv
         make python-init
-        deactivate
-      shell: bash
-    - name: Activate virtualenv
-      run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
       shell: bash
     - name: Show environment info
       run: |

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -45,7 +45,6 @@ runs:
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local bin/protoc
         sudo unzip -o protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local 'include/*'
         sudo ln -s /usr/local/bin/protoc /usr/bin/protoc
-        echo "/usr/local/bin" >> $GITHUB_PATH
         # Print out your System's protoc version:
         protoc --version
       shell: bash
@@ -84,7 +83,9 @@ runs:
         pip install --upgrade pip
         pip install uv
         make python-init
-        echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Activate virtualenv
+      run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
       shell: bash
     - name: Show environment info
       run: |

--- a/.github/actions/preview_branch/action.yml
+++ b/.github/actions/preview_branch/action.yml
@@ -38,4 +38,4 @@ runs:
           fi
         )" >> $GITHUB_ENV
         echo "BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-      shell: bash --login -eo pipefail {0}
+      shell: bash

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -18,7 +18,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -18,7 +18,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/cypress-update-snapshots.yml
+++ b/.github/workflows/cypress-update-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -24,7 +24,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -136,7 +136,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Check Cypress test matrix status

--- a/.github/workflows/ensure-relative-imports.yml
+++ b/.github/workflows/ensure-relative-imports.yml
@@ -24,7 +24,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -24,8 +24,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
-
+        shell: bash
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v4
@@ -80,7 +79,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     permissions:
       # Additional permission needed to generate tag
@@ -142,7 +142,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     outputs:
       enable-setup: ${{ steps.exports.outputs.enable-setup }}
@@ -227,7 +227,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Core Previews Repo

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -15,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/playwright-custom-components.yml
+++ b/.github/workflows/playwright-custom-components.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -22,7 +22,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     outputs:
       enable-setup: ${{ steps.exports.outputs.enable-setup }}
@@ -121,7 +121,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Core Previews Repo

--- a/.github/workflows/python-bare-executions.yml
+++ b/.github/workflows/python-bare-executions.yml
@@ -24,7 +24,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -20,7 +20,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --login -eo pipefail {0}
+    shell: bash
 
 env:
   FORCE_COLOR: "1"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --login -eo pipefail {0}
+    shell: bash
 
 env:
   FORCE_COLOR: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash
 
     permissions:
       # Additional permission needed to generate release


### PR DESCRIPTION
## Describe your changes

The `--login` flag seems to cause our CI to crash with the latest Github ubuntu runner image `20240804.1.0` which is currently rolled out ([example](https://github.com/streamlit/streamlit/actions/runs/10265321950/job/28401273688)). Most likely this is caused by something that gets loaded in the bash profile that returns error code 3. Based on the [bash manual](https://www.man7.org/linux/man-pages/man1/bash.1.html), The `--login` flag will cause `bash` to source some profile files, which won't happen anymore after this PR. 
This PR changes all the bash uses to use the default Github action settings: `bash`, which resolves to `bash --noprofile --norc -eo pipefail {0}` (see [GitHub docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)).

It seems that originally this behavior was used in our workflows to make the Python virtual env available by writing `source venv/bin` to the `bash_profile` file which then was sourced. Now, we don't source it from the `bash_profile` anymore but set the environment explicitly in the `GITHUB_PATH` to make it available. This not only resolves the issue, but is also way leaner.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
