### PR TITLE
Add customizable link target option to LinkColumn

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -34,7 +34,7 @@ export interface LinkColumnParams {
   // a value to display in the link cell. Can be a regex to parse out a specific substring of the url to be displayed
   readonly display_text?: string
   // A target to open link in (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)
-  readonly target?: "_self" | "_blank" | "_parent" | "_top"
+  readonly target?: "_blank" | "_top"
 }
 
 /**

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -33,6 +33,8 @@ export interface LinkColumnParams {
   readonly validate?: string
   // a value to display in the link cell. Can be a regex to parse out a specific substring of the url to be displayed
   readonly display_text?: string
+  // A target to open link in (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)
+  readonly target?: "_self" | "_blank" | "_parent" | "_top"
 }
 
 /**
@@ -162,7 +164,7 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
         onClickUri: a => {
           window.open(
             href.startsWith("www.") ? `https://${href}` : href,
-            "_blank",
+            parameters.target ?? "_blank",
             "noopener,noreferrer"
           )
           a.preventDefault()

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -43,6 +43,8 @@ ColumnType: TypeAlias = Literal[
     "progress",
 ]
 
+LinkTargetType: TypeAlias = Literal["_self", "_blank", "_parent", "_top"]
+
 
 class NumberColumnConfig(TypedDict):
     type: Literal["number"]
@@ -72,6 +74,7 @@ class LinkColumnConfig(TypedDict):
     max_chars: NotRequired[int | None]
     validate: NotRequired[str | None]
     display_text: NotRequired[str | None]
+    target: NotRequired[LinkTargetType | None]
 
 
 class BarChartColumnConfig(TypedDict):
@@ -484,6 +487,7 @@ def LinkColumn(
     max_chars: int | None = None,
     validate: str | None = None,
     display_text: str | None = None,
+    target: LinkTargetType | None = None,
 ) -> ColumnConfig:
     """Configure a link column in ``st.dataframe`` or ``st.data_editor``.
 
@@ -541,6 +545,21 @@ def LinkColumn(
         <https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.format.html>`_
         function on the underlying dataframe. Note that this makes the app slow,
         doesn't work with editable columns, and might be removed in the future.
+    target: ``"_blank"``, ``"_parent"``, ``"_self"``, ``"_top"`` or ``None``
+        The target to open link in. Can be one of:
+
+        * ``"_blank"``	URL is loaded into a new window, or tab. This is the default
+
+        * ``"_parent"``	URL is loaded into the parent frame
+
+        * ``"_self"``	URL replaces the current page
+
+        * ``"_top"``	URL replaces any framesets that may be loaded
+
+        * ``None``      Is default value and interpreted as ``"_blank"``
+
+        For more info please read here: https://developer.mozilla.org/en-US/docs/Web/API/Window/open#target
+
 
     Examples
     --------
@@ -599,6 +618,7 @@ def LinkColumn(
             max_chars=max_chars,
             validate=validate,
             display_text=display_text,
+            target=target,
         ),
     )
 

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -43,7 +43,7 @@ ColumnType: TypeAlias = Literal[
     "progress",
 ]
 
-LinkTargetType: TypeAlias = Literal["_self", "_blank", "_parent", "_top"]
+LinkTargetType: TypeAlias = Literal["_blank", "_top"]
 
 
 class NumberColumnConfig(TypedDict):
@@ -545,14 +545,10 @@ def LinkColumn(
         <https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.format.html>`_
         function on the underlying dataframe. Note that this makes the app slow,
         doesn't work with editable columns, and might be removed in the future.
-    target: ``"_blank"``, ``"_parent"``, ``"_self"``, ``"_top"`` or ``None``
+    target: ``"_blank"``, ``"_top"`` or ``None``
         The target to open link in. Can be one of:
 
         * ``"_blank"``	URL is loaded into a new window, or tab. This is the default
-
-        * ``"_parent"``	URL is loaded into the parent frame
-
-        * ``"_self"``	URL replaces the current page
 
         * ``"_top"``	URL replaces any framesets that may be loaded
 


### PR DESCRIPTION
Allow specifying a target attribute for link opening behavior in LinkColumn. This enables more flexibility in how links are opened, defaulting to "_blank" if no target is provided.
