### PR TITLE
Add data handling support for Polars

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/arrowUtils.ts
@@ -145,7 +145,7 @@ export function getColumnTypeFromArrow(arrowType: ArrowType): ColumnCreator {
 
   typeName = typeName.toLowerCase().trim()
   // Match based on arrow types
-  if (["unicode", "empty"].includes(typeName)) {
+  if (["unicode", "empty", "large_string[pyarrow]"].includes(typeName)) {
     return TextColumn
   }
 

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -39,6 +39,8 @@ sqlalchemy[mypy]>=1.4.25, <2
 # to test the fix. Pydantic 2 should not have that issue.
 pydantic>=1.0, <2.0
 
+# Additional dataframe formats for testing:
+polars
 
 # Required for testing the langchain integration
 langchain>=0.2.0

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -912,3 +912,63 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
         ),
     ),
 ]
+
+###################################
+########### Polars Types ##########
+###################################
+try:
+    import polars as pl
+
+    SHARED_TEST_CASES.extend(
+        [
+            (
+                "Polars DataFrame",
+                pl.DataFrame(
+                    [
+                        {"name": "st.text_area", "type": "widget"},
+                        {"name": "st.markdown", "type": "element"},
+                    ]
+                ),
+                CaseMetadata(
+                    2,
+                    2,
+                    DataFormat.POLARS_DATAFRAME,
+                    ["st.text_area", "st.markdown"],
+                    "dataframe",
+                    False,
+                ),
+            ),
+            (
+                "Polars Series",
+                pl.Series(["st.number_input", "st.text_area", "st.text_input"]),
+                CaseMetadata(
+                    3,
+                    1,
+                    DataFormat.POLARS_SERIES,
+                    ["st.number_input", "st.text_area", "st.text_input"],
+                    "dataframe",
+                    False,
+                ),
+            ),
+            (
+                "Polars LazyFrame",
+                pl.LazyFrame(
+                    {
+                        "name": ["st.text_area", "st.markdown"],
+                        "type": ["widget", "element"],
+                    }
+                ),
+                CaseMetadata(
+                    2,
+                    2,
+                    DataFormat.POLARS_LAZYFRAME,
+                    ["st.text_area", "st.markdown"],
+                    "dataframe",
+                    True,
+                    pl.DataFrame,
+                ),
+            ),
+        ]
+    )
+except ModuleNotFoundError:
+    print("Polars not installed. Skipping Polars dataframe integration tests.")  # noqa: T201


### PR DESCRIPTION
## Describe your changes

Adds official support for Polars Dataframe, Series and Lazyframe to our data handling. This adds support for Polars to  Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/5088
- Closes https://github.com/streamlit/streamlit/issues/8273
- Closes https://github.com/streamlit/streamlit/issues/8007
- Closes https://github.com/streamlit/streamlit/issues/6334

## Testing Plan

- Added to data_mocks -> This will be used for various tests covering many relevant commands.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
