### PR TITLE
Fix grey-out for selectbox index columns

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -19,8 +19,8 @@ import { DropdownCellType } from "@glideapps/glide-data-grid-cells"
 
 import { Type as ArrowType } from "@streamlit/lib/src/dataframes/Quiver"
 
-import { BaseColumnProps, isErrorCell, isMissingValueCell } from "./utils"
 import SelectboxColumn, { SelectboxColumnParams } from "./SelectboxColumn"
+import { BaseColumnProps, isErrorCell, isMissingValueCell } from "./utils"
 
 const MOCK_CATEGORICAL_TYPE: ArrowType = {
   pandas_type: "int8",
@@ -130,6 +130,21 @@ describe("SelectboxColumn", () => {
 
     const errorCell = mockColumn.getCell(null, true)
     expect(isErrorCell(errorCell)).toEqual(true)
+  })
+
+  it("uses faded style for index columns", () => {
+    const mockColumn = getSelectboxColumn(
+      MOCK_CATEGORICAL_TYPE,
+      {
+        options: ["foo", "bar"],
+      },
+      {
+        isIndex: true,
+      }
+    )
+
+    const mockCell = mockColumn.getCell("foo")
+    expect(mockCell.style).toEqual("faded")
   })
 
   it("creates error cell if value is not in options", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
@@ -75,6 +75,7 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
     copyData: "",
     contentAlign: props.contentAlignment,
     readonly: !props.isEditable,
+    style: props.isIndex ? "faded" : "normal",
     data: {
       kind: "dropdown-cell",
       allowedValues: [
@@ -85,7 +86,6 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
           .map(opt => toSafeString(opt)), // convert everything to string
       ],
       value: "",
-      readonly: !props.isEditable,
     },
   } as DropdownCellType
 


### PR DESCRIPTION
## Describe your changes

Adds the style=faded property to the selectbox column implementation to properly fade the content if it is used as an index.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/8772

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
