### PR TITLE
Fix issue with empty Azure OpenAI chunk

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -165,7 +165,7 @@ class WriteMixin:
             if type_util.is_openai_chunk(chunk):
                 # Try to convert OpenAI chat completion chunk to a string:
                 try:
-                    if len(chunk.choices) == 0:
+                    if len(chunk.choices) == 0 or chunk.choices[0].delta is None:
                         # The choices list can be empty. E.g. when using the
                         # AzureOpenAI client, the first chunk will always be empty.
                         chunk = ""


### PR DESCRIPTION
## Describe your changes

Don't error out on message chunks in `st.write_stream` if the delta property is None. Based on https://github.com/streamlit/streamlit/issues/9227, this can sometimes happen in the Azure OpenAI client. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9227

## Testing Plan

- We are not yet integration testing usage of the Azure OpenAI client since this would require an active connection.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
