### PR TITLE
Add data handling support for xarray

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -41,6 +41,7 @@ pydantic>=1.0, <2.0
 
 # Additional dataframe formats for testing:
 polars
+xarray
 
 # Required for testing the langchain integration
 langchain>=0.2.0

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -972,3 +972,52 @@ try:
     )
 except ModuleNotFoundError:
     print("Polars not installed. Skipping Polars dataframe integration tests.")  # noqa: T201
+
+###################################
+########### Xarray Types ##########
+###################################
+try:
+    import xarray as xr
+
+    SHARED_TEST_CASES.extend(
+        [
+            (
+                "Xarray Dataset",
+                xr.Dataset.from_dataframe(
+                    pd.DataFrame(
+                        {
+                            "name": ["st.text_area", "st.markdown"],
+                            "type": ["widget", "element"],
+                        }
+                    )
+                ),
+                CaseMetadata(
+                    2,
+                    2,
+                    DataFormat.XARRAY_DATASET,
+                    ["st.text_area", "st.markdown"],
+                    "dataframe",
+                    False,
+                ),
+            ),
+            (
+                "Xarray DataArray",
+                xr.DataArray.from_series(
+                    pd.Series(
+                        ["st.number_input", "st.text_area", "st.text_input"],
+                        name="widgets",
+                    )
+                ),
+                CaseMetadata(
+                    3,
+                    1,
+                    DataFormat.XARRAY_DATA_ARRAY,
+                    ["st.number_input", "st.text_area", "st.text_input"],
+                    "dataframe",
+                    False,
+                ),
+            ),
+        ]
+    )
+except ModuleNotFoundError:
+    print("Xarray not installed. Skipping Xarray dataframe integration tests.")  # noqa: T201


### PR DESCRIPTION
## Describe your changes

Adds official support for Xarray Dataset and Data Array. This adds support for Xarray objects to Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/6197

## Testing Plan

- Added to data_mocks -> This will be used for various tests covering many relevant commands.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
