### PR TITLE
Add data handling support for Dask

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -455,6 +455,8 @@ def convert_anything_to_pandas_df(
     if is_dask_object(data):
         data = data.head(max_unevaluated_rows, compute=True)
 
+        # Dask returns a Pandas object (DataFrame, Series, Index) when
+        # executing operations like `head`.
         if isinstance(data, (pd.Series, pd.Index)):
             data = data.to_frame()
 

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -42,6 +42,7 @@ pydantic>=1.0, <2.0
 # Additional dataframe formats for testing:
 polars
 xarray
+dask
 
 # Required for testing the langchain integration
 langchain>=0.2.0

--- a/lib/tests/streamlit/dask_mocks.py
+++ b/lib/tests/streamlit/dask_mocks.py
@@ -1,0 +1,80 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class DataFrame:
+    """This is dummy DataFrame class, which imitates dask.dataframe.core.DataFrame class
+    for testing purposes. We use this to make sure that our code does a special handling
+    if it detects a Dask DataFrame.
+
+    This allows testing of the functionality without having the library installed,
+    but it won't capture changes in the API of the library. This requires
+    integration tests.
+    """
+
+    __module__ = "dask.dataframe.core"
+
+    def __init__(self, data: pd.DataFrame):
+        self._data: pd.DataFrame = data
+
+    def head(self, n: int, compute: bool) -> pd.DataFrame:
+        """Returns the top n element of a mock version of Dask DataFrame."""
+        return self._data.head(n)
+
+
+class Series:
+    """This is dummy Series class, which imitates dask.dataframe.core.Series class
+    for testing purposes. We use this to make sure that our code does a special handling
+    if it detects a Dask Series.
+
+    This allows testing of the functionality without having the library installed,
+    but it won't capture changes in the API of the library. This requires
+    integration tests.
+    """
+
+    __module__ = "dask.dataframe.core"
+
+    def __init__(self, data: pd.Series):
+        self._data: pd.Series = data
+
+    def head(self, n: int, compute: bool) -> pd.Series:
+        """Returns the top n element of a mock version of Dask Series."""
+        return self._data.head(n)
+
+
+class Index:
+    """This is dummy Index class, which imitates dask.dataframe.core.Index class
+    for testing purposes. We use this to make sure that our code does a special handling
+    if it detects a Dask Index.
+
+    This allows testing of the functionality without having the library installed,
+    but it won't capture changes in the API of the library. This requires
+    integration tests.
+    """
+
+    __module__ = "dask.dataframe.core"
+
+    def __init__(self, data: pd.Index):
+        self._data: pd.Index = data
+
+    def head(self, n: int, compute: bool) -> pd.Index:
+        """Returns the top n element of a mock version of Dask Index."""
+        return self._data[:n]

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -28,6 +28,9 @@ import pandas as pd
 import pyarrow as pa
 
 from streamlit.dataframe_util import DataFormat
+from tests.streamlit.dask_mocks import DataFrame as DaskDataFrame
+from tests.streamlit.dask_mocks import Index as DaskIndex
+from tests.streamlit.dask_mocks import Series as DaskSeries
 from tests.streamlit.modin_mocks import DataFrame as ModinDataFrame
 from tests.streamlit.modin_mocks import Series as ModinSeries
 from tests.streamlit.pyspark_mocks import DataFrame as PySparkDataFrame
@@ -905,6 +908,54 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
             2,
             2,
             DataFormat.PYSPARK_OBJECT,
+            ["st.text_area", "st.markdown"],
+            "dataframe",
+            True,
+            pd.DataFrame,
+        ),
+    ),
+    (
+        "Dask DataFrame",
+        DaskDataFrame(
+            pd.DataFrame(
+                [
+                    {"name": "st.text_area", "type": "widget"},
+                    {"name": "st.markdown", "type": "element"},
+                ]
+            )
+        ),
+        CaseMetadata(
+            2,
+            2,
+            DataFormat.DASK_OBJECT,
+            ["st.text_area", "st.markdown"],
+            "dataframe",
+            True,
+            pd.DataFrame,
+        ),
+    ),
+    (
+        "Dask Series",
+        DaskSeries(pd.Series(["st.text_area", "st.markdown"])),
+        CaseMetadata(
+            2,
+            1,
+            DataFormat.DASK_OBJECT,
+            ["st.text_area", "st.markdown"],
+            "dataframe",
+            True,
+            pd.DataFrame,
+        ),
+    ),
+    (
+        "Dask Index",
+        DaskIndex(
+            pd.Index(["st.text_area", "st.markdown"]),
+        ),
+        CaseMetadata(
+            2,
+            1,
+            DataFormat.DASK_OBJECT,
             ["st.text_area", "st.markdown"],
             "dataframe",
             True,

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -516,6 +516,11 @@ class DataframeUtilTest(unittest.TestCase):
             )
 
     def test_verify_dask_integration(self):
+        """Integration test dask object handling.
+
+        This is in addition to the tests using the mocks to verify that
+        the latest version of the library is still supported.
+        """
         dask = pytest.importorskip("dask")
 
         dask_df = dask.datasets.timeseries()

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -515,6 +515,31 @@ class DataframeUtilTest(unittest.TestCase):
                 pd.DataFrame,
             )
 
+    def test_verify_dask_integration(self):
+        dask = pytest.importorskip("dask")
+
+        dask_df = dask.datasets.timeseries()
+
+        assert dataframe_util.is_dask_object(dask_df) is True
+        assert isinstance(
+            dataframe_util.convert_anything_to_pandas_df(dask_df),
+            pd.DataFrame,
+        )
+
+        dask_series = dask_df["x"]
+        assert dataframe_util.is_dask_object(dask_series) is True
+        assert isinstance(
+            dataframe_util.convert_anything_to_pandas_df(dask_series),
+            pd.DataFrame,
+        )
+
+        dask_index = dask_df.index
+        assert dataframe_util.is_dask_object(dask_index) is True
+        assert isinstance(
+            dataframe_util.convert_anything_to_pandas_df(dask_index),
+            pd.DataFrame,
+        )
+
     @parameterized.expand(
         SHARED_TEST_CASES,
     )


### PR DESCRIPTION
## Describe your changes

Adds official support for Dask DataFrame, Series, and Index. This adds support for Dask objects as input for Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more.

## Testing Plan

- Added to `data_mocks` -> This will be used for various tests covering many relevant commands.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
