### PR TITLE
Use shlex.join in mypy (script) instead of backporting it

### DIFF
--- a/scripts/mypy
+++ b/scripts/mypy
@@ -34,14 +34,6 @@ import mypy.main as mypy_main
 PATHS = ["lib/streamlit/", "scripts/*", "e2e/scripts/*"]
 
 
-def shlex_join(split_command: Iterable[str]):
-    """Return a shell-escaped string from *split_command*.
-
-    This function is backported from Python 3.8 - shlex.join
-    """
-    return " ".join(shlex.quote(arg) for arg in split_command)
-
-
 class Module:
     _COLUMNS = (56, 5, 5, 7)
     _HEADERS = ("Module", "Lines", "Typed", "Percent")
@@ -126,7 +118,7 @@ def main(report: bool = False, verbose: bool = False) -> None:
     args.extend(paths)
 
     if verbose:
-        shell_command = shlex_join(itertools.chain(["mypy"], args))
+        shell_command = shlex.join(itertools.chain(["mypy"], args))
         print("Executing command:", shell_command)
     mypy_main.main(stdout=sys.stdout, stderr=sys.stderr, args=args)
     if report:


### PR DESCRIPTION
shlex.join was added in 3.8, which is the min supported python version, so there's no reason to "backport" it rather than just use it.

If curious, you can also see that in [3.8](https://github.com/python/cpython/blob/v3.8.0/Lib/shlex.py#L313) and [3.12](https://github.com/python/cpython/blob/v3.12.5/Lib/shlex.py#L316) the implementation of shlex.join is the same as our backport.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
