### PR TITLE
Fix nested fragment stale elements

### DIFF
--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -16,9 +16,13 @@ from uuid import uuid4
 
 import streamlit as st
 
+if "counter" not in st.session_state:
+    st.session_state.counter = -1
+
 
 @st.fragment
 def outer_fragment():
+    st.session_state.counter += 1
     with st.container(border=True):
         st.write(f"outer fragment: {uuid4()}")
         st.button("rerun outer fragment")
@@ -30,6 +34,10 @@ def inner_fragment():
     with st.container(border=True):
         st.write(f"inner fragment: {uuid4()}")
         st.button("rerun inner fragment")
+
+        # show inner-fragment counter message only if counter is between 1 and 3
+        if 1 <= st.session_state.counter < 3:
+            st.write(f"Counter has value {st.session_state.counter}")
 
 
 st.write(f"outside all fragments: {uuid4()}")

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -50,10 +50,22 @@ def outer_fragment2():
     @st.fragment
     def inner_fragment2():
         with st.container(border=True):
+            st.write(c._active_dg._cursor.delta_path)
             c.write(f"inner fragment2: {uuid4()}")
+            # st.write("foo")
             st.button("rerun inner fragment2")
 
     inner_fragment2()
+
+    @st.fragment
+    def inner_fragment3():
+        with st.container(border=True):
+            st.write(c._active_dg._cursor.delta_path)
+            c.write(f"inner fragment3: {uuid4()}")
+            # st.write("foo")
+            st.button("rerun inner fragment3")
+
+    inner_fragment3()
 
 
 st.write(f"outside all fragments: {uuid4()}")

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -16,16 +16,10 @@ from uuid import uuid4
 
 import streamlit as st
 
-if "counter" not in st.session_state:
-    st.session_state.counter = 0
-
-c = st.empty()
-
 
 @st.fragment
 def outer_fragment():
     with st.container(border=True):
-        st.session_state.counter += 1
         st.write(f"outer fragment: {uuid4()}")
         st.button("rerun outer fragment")
         inner_fragment()
@@ -37,39 +31,7 @@ def inner_fragment():
         st.write(f"inner fragment: {uuid4()}")
         st.button("rerun inner fragment")
 
-        if 5 < st.session_state.counter < 10:
-            st.write("FOO!")
-            c.write("BAR!")
-
-
-@st.fragment
-def outer_fragment2():
-    c = st.container(border=True)
-    c.button("rerun outer fragment2")
-
-    @st.fragment
-    def inner_fragment2():
-        with st.container(border=True):
-            st.write(c._active_dg._cursor.delta_path)
-            c.write(f"inner fragment2: {uuid4()}")
-            # st.write("foo")
-            st.button("rerun inner fragment2")
-
-    inner_fragment2()
-
-    @st.fragment
-    def inner_fragment3():
-        with st.container(border=True):
-            st.write(c._active_dg._cursor.delta_path)
-            c.write(f"inner fragment3: {uuid4()}")
-            # st.write("foo")
-            st.button("rerun inner fragment3")
-
-    inner_fragment3()
-
 
 st.write(f"outside all fragments: {uuid4()}")
 st.button("rerun whole app")
 outer_fragment()
-
-outer_fragment2()

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -42,6 +42,22 @@ def inner_fragment():
             c.write("BAR!")
 
 
+@st.fragment
+def outer_fragment2():
+    c = st.container(border=True)
+    c.button("rerun outer fragment2")
+
+    @st.fragment
+    def inner_fragment2():
+        with st.container(border=True):
+            c.write(f"inner fragment2: {uuid4()}")
+            st.button("rerun inner fragment2")
+
+    inner_fragment2()
+
+
 st.write(f"outside all fragments: {uuid4()}")
 st.button("rerun whole app")
 outer_fragment()
+
+outer_fragment2()

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -16,10 +16,16 @@ from uuid import uuid4
 
 import streamlit as st
 
+if "counter" not in st.session_state:
+    st.session_state.counter = 0
+
+c = st.container()
+
 
 @st.fragment
 def outer_fragment():
     with st.container(border=True):
+        st.session_state.counter += 1
         st.write(f"outer fragment: {uuid4()}")
         st.button("rerun outer fragment")
         inner_fragment()
@@ -30,6 +36,10 @@ def inner_fragment():
     with st.container(border=True):
         st.write(f"inner fragment: {uuid4()}")
         st.button("rerun inner fragment")
+
+        if 5 < st.session_state.counter < 10:
+            st.write("FOO!")
+            c.write("BAR!")
 
 
 st.write(f"outside all fragments: {uuid4()}")

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -33,11 +33,20 @@ def outer_fragment():
 def inner_fragment():
     with st.container(border=True):
         st.write(f"inner fragment: {uuid4()}")
-        st.button("rerun inner fragment")
+        st.button("rerun inner fragment1")
 
         # show inner-fragment counter message only if counter is between 1 and 3
         if 1 <= st.session_state.counter < 3:
             st.write(f"Counter has value {st.session_state.counter}")
+
+        inner_fragment2()
+
+
+@st.fragment
+def inner_fragment2():
+    with st.container(border=True):
+        st.write(f"inner fragment2: {uuid4()}")
+        st.button("rerun inner fragment2")
 
 
 st.write(f"outside all fragments: {uuid4()}")

--- a/e2e_playwright/st_fragments_nested.py
+++ b/e2e_playwright/st_fragments_nested.py
@@ -19,7 +19,7 @@ import streamlit as st
 if "counter" not in st.session_state:
     st.session_state.counter = 0
 
-c = st.container()
+c = st.empty()
 
 
 @st.fragment

--- a/e2e_playwright/st_fragments_nested_test.py
+++ b/e2e_playwright/st_fragments_nested_test.py
@@ -21,31 +21,45 @@ from playwright.sync_api import Locator, Page, expect
 from e2e_playwright.shared.app_utils import click_button
 
 COUNTER_TEXT_START: Final = "Counter has value"
+DEFAULT_NUMBER_MARKDOWN_ELEMENTS: Final = 4
 
 
-def _get_uuids(app: Page, markdown_count: int = 3) -> tuple[str, str, str]:
+def _get_uuids(
+    app: Page, markdown_count: int = DEFAULT_NUMBER_MARKDOWN_ELEMENTS
+) -> tuple[str, str, str, str]:
     expect(app.get_by_test_id("stMarkdown")).to_have_count(markdown_count)
 
     outside_fragment_text = (
         app.get_by_test_id("stMarkdown")
-        .filter(has_text="outside all fragments")
+        .filter(has_text="outside all fragments:")
         .text_content()
         or ""
     )
     outer_fragment_text = (
         app.get_by_test_id("stMarkdown")
-        .filter(has_text="outer fragment")
+        .filter(has_text="outer fragment:")
         .text_content()
         or ""
     )
     inner_fragment_text = (
         app.get_by_test_id("stMarkdown")
-        .filter(has_text="inner fragment")
+        .filter(has_text="inner fragment:")
+        .text_content()
+        or ""
+    )
+    inner_fragment2_text = (
+        app.get_by_test_id("stMarkdown")
+        .filter(has_text="inner fragment2:")
         .text_content()
         or ""
     )
 
-    return outside_fragment_text, outer_fragment_text, inner_fragment_text
+    return (
+        outside_fragment_text,
+        outer_fragment_text,
+        inner_fragment_text,
+        inner_fragment2_text,
+    )
 
 
 def _rerun_outer_fragment(app: Page):
@@ -53,7 +67,11 @@ def _rerun_outer_fragment(app: Page):
 
 
 def _rerun_inner_fragment(app: Page):
-    click_button(app, "rerun inner fragment")
+    click_button(app, "rerun inner fragment1")
+
+
+def _rerun_inner_fragment2(app: Page):
+    click_button(app, "rerun inner fragment2")
 
 
 def _get_inner_fragment_counter_text(app: Page) -> Locator:
@@ -61,7 +79,12 @@ def _get_inner_fragment_counter_text(app: Page) -> Locator:
 
 
 def test_full_app_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
+    (
+        outside_fragment_text,
+        outer_fragment_text,
+        inner_fragment_text,
+        inner_fragment2_text,
+    ) = _get_uuids(app)
 
     click_button(app, "rerun whole app")
 
@@ -72,11 +95,19 @@ def test_full_app_rerun(app: Page):
     expect(app.get_by_test_id("stMarkdown").nth(1)).not_to_have_text(
         outer_fragment_text
     )
-    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").nth(2)).not_to_have_text(
+        inner_fragment_text
+    )
+    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment2_text)
 
 
 def test_outer_fragment_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
+    (
+        outside_fragment_text,
+        outer_fragment_text,
+        inner_fragment_text,
+        inner_fragment2_text,
+    ) = _get_uuids(app)
 
     _rerun_outer_fragment(app)
 
@@ -86,18 +117,46 @@ def test_outer_fragment_rerun(app: Page):
     expect(app.get_by_test_id("stMarkdown").nth(1)).not_to_have_text(
         outer_fragment_text
     )
-    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").nth(2)).not_to_have_text(
+        inner_fragment_text
+    )
+    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment2_text)
 
 
 def test_inner_fragment_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
+    (
+        outside_fragment_text,
+        outer_fragment_text,
+        inner_fragment_text,
+        inner_fragment2_text,
+    ) = _get_uuids(app)
 
     _rerun_inner_fragment(app)
 
     # We reran the inner fragment. Only that corresponding UUID should have changed.
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(outer_fragment_text)
-    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").nth(2)).not_to_have_text(
+        inner_fragment_text
+    )
+    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment2_text)
+
+
+def test_inner_fragment2_rerun(app: Page):
+    (
+        outside_fragment_text,
+        outer_fragment_text,
+        inner_fragment_text,
+        inner_fragment2_text,
+    ) = _get_uuids(app)
+
+    _rerun_inner_fragment2(app)
+
+    # We reran the inner fragment. Only that corresponding UUID should have changed.
+    expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(outer_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").nth(2)).to_have_text(inner_fragment_text)
+    expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment2_text)
 
 
 def test_outer_fragment_rerun_clears_stale_widgets_in_inner_fragment(app: Page):
@@ -112,11 +171,12 @@ def test_outer_fragment_rerun_clears_stale_widgets_in_inner_fragment(app: Page):
         expect(counter_text).to_have_text(f"{COUNTER_TEXT_START} {i + 1}")
 
     # rerunning inner fragment should not change the inner fragment text
-    _, _, previous_inner_fragment_text = _get_uuids(app, 4)
+    number_markdown_elements: Final = DEFAULT_NUMBER_MARKDOWN_ELEMENTS + 1
+    _, _, previous_inner_fragment_text, _ = _get_uuids(app, number_markdown_elements)
     for _ in range(0, 10):
         _rerun_inner_fragment(app)
         # ensure that the inner fragment indeed runs
-        _, _, inner_fragment_text = _get_uuids(app, 4)
+        _, _, inner_fragment_text, _ = _get_uuids(app, number_markdown_elements)
         assert previous_inner_fragment_text != inner_fragment_text
         # the inner text stays the same
         counter_text = _get_inner_fragment_counter_text(app)

--- a/e2e_playwright/st_fragments_nested_test.py
+++ b/e2e_playwright/st_fragments_nested_test.py
@@ -112,7 +112,7 @@ def test_outer_fragment_rerun(app: Page):
     _rerun_outer_fragment(app)
 
     # We reran the outer fragment, so the UUID outside of the fragments should stay
-    # constant, but the other two should have changed.
+    # constant, but the nested fragments' UUIDs should have changed.
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(1)).not_to_have_text(
         outer_fragment_text
@@ -133,7 +133,8 @@ def test_inner_fragment_rerun(app: Page):
 
     _rerun_inner_fragment(app)
 
-    # We reran the inner fragment. Only that corresponding UUID should have changed.
+    # We reran the inner fragment directly nested in the outer fragment. This UUID and
+    # UUID of the inner fragment's nested fragment (inner_fragment2) should've changed.
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(outer_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(2)).not_to_have_text(
@@ -152,7 +153,8 @@ def test_inner_fragment2_rerun(app: Page):
 
     _rerun_inner_fragment2(app)
 
-    # We reran the inner fragment. Only that corresponding UUID should have changed.
+    # We reran the inner-most nested fragment. Only that corresponding UUID should have
+    # changed.
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(outer_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(2)).to_have_text(inner_fragment_text)

--- a/e2e_playwright/st_fragments_nested_test.py
+++ b/e2e_playwright/st_fragments_nested_test.py
@@ -12,23 +12,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import Page, expect
+from __future__ import annotations
+
+from typing import Final
+
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.shared.app_utils import click_button
 
+COUNTER_TEXT_START: Final = "Counter has value"
 
-def get_uuids(app: Page):
-    expect(app.get_by_test_id("stMarkdown")).to_have_count(3)
 
-    outside_fragment_text = app.get_by_test_id("stMarkdown").first.text_content()
-    outer_fragment_text = app.get_by_test_id("stMarkdown").nth(1).text_content()
-    inner_fragment_text = app.get_by_test_id("stMarkdown").last.text_content()
+def _get_uuids(app: Page, markdown_count: int = 3) -> tuple[str, str, str]:
+    expect(app.get_by_test_id("stMarkdown")).to_have_count(markdown_count)
+
+    outside_fragment_text = (
+        app.get_by_test_id("stMarkdown")
+        .filter(has_text="outside all fragments")
+        .text_content()
+        or ""
+    )
+    outer_fragment_text = (
+        app.get_by_test_id("stMarkdown")
+        .filter(has_text="outer fragment")
+        .text_content()
+        or ""
+    )
+    inner_fragment_text = (
+        app.get_by_test_id("stMarkdown")
+        .filter(has_text="inner fragment")
+        .text_content()
+        or ""
+    )
 
     return outside_fragment_text, outer_fragment_text, inner_fragment_text
 
 
+def _rerun_outer_fragment(app: Page):
+    click_button(app, "rerun outer fragment")
+
+
+def _rerun_inner_fragment(app: Page):
+    click_button(app, "rerun inner fragment")
+
+
+def _get_inner_fragment_counter_text(app: Page) -> Locator:
+    return app.get_by_test_id("stMarkdown").filter(has_text=COUNTER_TEXT_START)
+
+
 def test_full_app_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = get_uuids(app)
+    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
 
     click_button(app, "rerun whole app")
 
@@ -43,9 +76,9 @@ def test_full_app_rerun(app: Page):
 
 
 def test_outer_fragment_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = get_uuids(app)
+    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
 
-    click_button(app, "rerun outer fragment")
+    _rerun_outer_fragment(app)
 
     # We reran the outer fragment, so the UUID outside of the fragments should stay
     # constant, but the other two should have changed.
@@ -57,11 +90,41 @@ def test_outer_fragment_rerun(app: Page):
 
 
 def test_inner_fragment_rerun(app: Page):
-    outside_fragment_text, outer_fragment_text, inner_fragment_text = get_uuids(app)
+    outside_fragment_text, outer_fragment_text, inner_fragment_text = _get_uuids(app)
 
-    click_button(app, "rerun inner fragment")
+    _rerun_inner_fragment(app)
 
     # We reran the inner fragment. Only that corresponding UUID should have changed.
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(outside_fragment_text)
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(outer_fragment_text)
     expect(app.get_by_test_id("stMarkdown").last).not_to_have_text(inner_fragment_text)
+
+
+def test_outer_fragment_rerun_clears_stale_widgets_in_inner_fragment(app: Page):
+    expect(_get_inner_fragment_counter_text(app)).to_have_count(0)
+
+    max_bound: Final = 2
+    for i in range(0, max_bound):
+        _rerun_outer_fragment(app)
+        # the inner text is rendered now
+        counter_text = _get_inner_fragment_counter_text(app)
+        expect(counter_text).to_have_count(1)
+        expect(counter_text).to_have_text(f"{COUNTER_TEXT_START} {i + 1}")
+
+    # rerunning inner fragment should not change the inner fragment text
+    _, _, previous_inner_fragment_text = _get_uuids(app, 4)
+    for _ in range(0, 10):
+        _rerun_inner_fragment(app)
+        # ensure that the inner fragment indeed runs
+        _, _, inner_fragment_text = _get_uuids(app, 4)
+        assert previous_inner_fragment_text != inner_fragment_text
+        # the inner text stays the same
+        counter_text = _get_inner_fragment_counter_text(app)
+        expect(counter_text).to_have_count(1)
+        expect(counter_text).to_have_text(f"{COUNTER_TEXT_START} {max_bound}")
+        previous_inner_fragment_text = inner_fragment_text
+
+    # rerunning outer fragment should increase the counter above the max_bound value
+    # and clear the inner fragment text
+    _rerun_outer_fragment(app)
+    expect(_get_inner_fragment_counter_text(app)).to_have_count(0)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1321,7 +1321,6 @@ export class App extends PureComponent<Props, State> {
     deltaMsg: Delta,
     metadataMsg: ForwardMsgMetadata
   ): void => {
-    console.log("DeltaMsg", deltaMsg, metadataMsg.deltaPath)
     this.pendingElementsBuffer = this.pendingElementsBuffer.applyDelta(
       this.state.scriptRunId,
       deltaMsg,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1321,6 +1321,7 @@ export class App extends PureComponent<Props, State> {
     deltaMsg: Delta,
     metadataMsg: ForwardMsgMetadata
   ): void => {
+    console.log("DeltaMsg", deltaMsg, metadataMsg.deltaPath)
     this.pendingElementsBuffer = this.pendingElementsBuffer.applyDelta(
       this.state.scriptRunId,
       deltaMsg,

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -1261,6 +1261,66 @@ describe("AppRoot.clearStaleNodes", () => {
       (pruned.main.getIn([2, 0]) as BlockNode).deltaBlock.tab?.label
     ).toContain("tab1")
   })
+
+  it("clear childNodes of a block node in fragment run", () => {
+    // Add a new element and clear stale nodes
+    const delta = makeProto(DeltaProto, {
+      newElement: { text: { body: "newElement!" } },
+      fragmentId: "my_fragment_id",
+    })
+    const newRoot = AppRoot.empty(FAKE_SCRIPT_HASH)
+      // Block corresponding to my_fragment_id
+      .applyDelta(
+        "new_session_id",
+        makeProto(DeltaProto, {
+          addBlock: { vertical: {}, allowEmpty: false },
+          fragmentId: "my_fragment_id",
+        }),
+        forwardMsgMetadata([0, 0])
+      )
+      .applyDelta("new_session_id", delta, forwardMsgMetadata([0, 0, 0]))
+      // Block with child where scriptRunId is different
+      .applyDelta(
+        "new_session_id",
+        makeProto(DeltaProto, {
+          addBlock: { vertical: {}, allowEmpty: false },
+          fragmentId: "my_fragment_id",
+        }),
+        forwardMsgMetadata([0, 1])
+      )
+      .applyDelta("new_session_id", delta, forwardMsgMetadata([0, 1, 0]))
+      .applyDelta("new_session_id", delta, forwardMsgMetadata([0, 1, 1]))
+      // this child is a nested fragment_id from an old run and should be pruned
+      .applyDelta(
+        "old_session_id",
+        makeProto(DeltaProto, {
+          newElement: { text: { body: "oldElement!" } },
+          fragmentId: "my_nested_fragment_id",
+        }),
+        forwardMsgMetadata([0, 1, 2])
+      )
+      // this child is a nested fragment_id from the same run and should be preserved
+      .applyDelta(
+        "new_session_id",
+        makeProto(DeltaProto, {
+          newElement: { text: { body: "newElement!" } },
+          fragmentId: "my_nested_fragment_id",
+        }),
+        forwardMsgMetadata([0, 1, 3])
+      )
+
+    expect((newRoot.main.getIn([1]) as BlockNode).children).toHaveLength(4)
+
+    const pruned = newRoot.clearStaleNodes("new_session_id", [
+      "my_fragment_id",
+    ])
+
+    expect(pruned.main.getIn([0])).toBeInstanceOf(BlockNode)
+    expect((pruned.main.getIn([0]) as BlockNode).children).toHaveLength(1)
+    expect(pruned.main.getIn([1])).toBeInstanceOf(BlockNode)
+    // the stale nested fragment child should have been pruned
+    expect((pruned.main.getIn([1]) as BlockNode).children).toHaveLength(3)
+  })
 })
 
 describe("AppRoot.getElements", () => {

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -135,7 +135,7 @@ export interface AppNode {
   clearStaleNodes(
     currentScriptRunId: string,
     fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: Set<string>
+    fragmentIdOfBlock?: string
   ): AppNode | undefined
 
   /**
@@ -254,46 +254,9 @@ export class ElementNode implements AppNode {
   public clearStaleNodes(
     currentScriptRunId: string,
     fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: Set<string>
+    fragmentIdOfBlock?: string
   ): ElementNode | undefined {
     if (fragmentIdsThisRun && fragmentIdsThisRun.length) {
-      // if (fragmentIdOfBlock?.size) {
-      //   return undefined
-      // }
-
-      // If we're currently running a fragment, and this element is nested inside of
-      // another fragment that was run, but this element wasn't run in this scriptRun,
-      // we consider it to be stale
-      // console.log(
-      //   "ElementNode.clearStaleNodes",
-      //   this,
-      //   "fragmentIdOfBlock",
-      //   fragmentIdOfBlock,
-      //   "fragmentIdsThisRun",
-      //   fragmentIdsThisRun,
-      //   "currentScriptRunId",
-      //   currentScriptRunId
-      // )
-      // if (
-      //   this.fragmentId &&
-      //   fragmentIdsThisRun?.some(id => fragmentIdOfBlock?.has(id)) &&
-      //   // fragmentIdOfBlock?.has(this.fragmentId) &&
-      //   !fragmentIdsThisRun?.includes(this.fragmentId) &&
-      //   this.scriptRunId !== currentScriptRunId
-      // ) {
-      //   console.log(
-      //     "ElementNode.clearStaleNodes: returning undefined",
-      //     this,
-      //     "fragmentIdOfBlock",
-      //     fragmentIdOfBlock,
-      //     "fragmentIdsThisRun",
-      //     fragmentIdsThisRun,
-      //     "currentScriptRunId",
-      //     currentScriptRunId
-      //   )
-      //   return undefined
-      // }
-
       // If we're currently running a fragment, nodes unrelated to the fragment
       // shouldn't be cleared. This can happen when,
       //   1. This element doesn't correspond to a fragment at all.
@@ -307,10 +270,8 @@ export class ElementNode implements AppNode {
       //      defined containers.
       if (
         !this.fragmentId ||
-        !fragmentIdOfBlock?.size ||
-        // !fragmentIdsThisRun.includes(this.fragmentId) ||
-        // !fragmentIdOfBlock?.has(this.fragmentId)
-        (fragmentIdOfBlock?.size && this.scriptRunId === currentScriptRunId)
+        !fragmentIdOfBlock ||
+        (fragmentIdOfBlock && this.scriptRunId === currentScriptRunId)
       ) {
         return this
       }
@@ -526,7 +487,7 @@ export class BlockNode implements AppNode {
   public clearStaleNodes(
     currentScriptRunId: string,
     fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: Set<string>
+    fragmentIdOfBlock?: string
   ): BlockNode | undefined {
     if (!fragmentIdsThisRun || !fragmentIdsThisRun.length) {
       // If we're not currently running a fragment, then we can remove any blocks
@@ -537,48 +498,7 @@ export class BlockNode implements AppNode {
     } else {
       // Otherwise, we are currently running a fragment, and our behavior
       // depends on the fragmentId of this BlockNode.
-
-      // if (this.fragmentId) {
-      //   // This blocks belong to our fragment, but it was modified in a previous script run.
-      //   // This means it is stale now!
-      //   if (
-      //     (fragmentIdOfBlock?.has(this.fragmentId) ||
-      //       fragmentIdsThisRun?.some(id => fragmentIdOfBlock?.has(id))) &&
-      //     this.scriptRunId !== currentScriptRunId
-      //   ) {
-      //     return undefined
-      //   }
-
-      //   // if (
-      //   //   !fragmentIdsThisRun.includes(this.fragmentId) &&
-      //   //   currentScriptRunId === this.scriptRunId
-      //   // )
-      //   //   return this
-
-      //   if (
-      //     this.fragmentId &&
-      //     fragmentIdsThisRun?.some(id => fragmentIdOfBlock?.has(id)) &&
-      //     // fragmentIdOfBlock?.has(this.fragmentId) &&
-      //     !fragmentIdsThisRun?.includes(this.fragmentId) &&
-      //     this.scriptRunId !== currentScriptRunId
-      //   )
-      //     return this
-
-      //   // If this BlockNode *does* correspond to a currently running fragment,
-      //   // we recurse into it below and set the fragmentIdOfBlock parameter to
-      //   // keep track of which fragment this BlockNode belongs to.
-      //   if (!fragmentIdOfBlock) {
-      //     fragmentIdOfBlock = new Set()
-      //   }
-      //   // if (fragmentIdsThisRun?.includes(this.fragmentId)) {
-      //   fragmentIdOfBlock?.add(this.fragmentId)
-      //   // }
-      // }
-
-      // If this BlockNode doesn't correspond to a fragment at all, we recurse
-      // into it below as one of its children might.
-
-      if (fragmentIdOfBlock?.size && this.scriptRunId !== currentScriptRunId) {
+      if (fragmentIdOfBlock && this.scriptRunId !== currentScriptRunId) {
         return undefined
       }
 
@@ -587,9 +507,7 @@ export class BlockNode implements AppNode {
         fragmentIdsThisRun.includes(this.fragmentId) &&
         this.scriptRunId === currentScriptRunId
       ) {
-        fragmentIdOfBlock = new Set()
-        fragmentIdOfBlock.add(this.fragmentId)
-        // return undefined
+        fragmentIdOfBlock = this.fragmentId
       }
     }
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -499,7 +499,7 @@ export class BlockNode implements AppNode {
       }
 
       // This block is modified by the current run, so we indicate this to our children in case
-      // there were not modified by the current run, which means they are stale.
+      // they were not modified by the current run, which means they are stale.
       if (
         this.fragmentId &&
         fragmentIdsThisRun.includes(this.fragmentId) &&

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -265,7 +265,7 @@ export class ElementNode implements AppNode {
       if (
         !this.fragmentId ||
         !fragmentIdOfBlock ||
-        (fragmentIdOfBlock && this.scriptRunId === currentScriptRunId)
+        this.scriptRunId === currentScriptRunId
       ) {
         return this
       }

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -268,8 +268,7 @@ def _fragment(
                 ctx.current_fragment_id = prev_fragment_id
                 ctx.current_fragment_delta_path = []
 
-        if not ctx.fragment_storage.contains(fragment_id):
-            ctx.fragment_storage.set(fragment_id, wrapped_fragment)
+        ctx.fragment_storage.set(fragment_id, wrapped_fragment)
 
         if run_every:
             msg = ForwardMsg()

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -180,7 +180,7 @@ class FragmentTest(unittest.TestCase):
         # fragment a single time.
         my_fragment()
         my_fragment()
-        ctx.fragment_storage.set.assert_called_once()
+        assert ctx.fragment_storage.set.call_count == 2
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     def test_sets_dg_stack_and_cursor_to_snapshots_if_fragment_ids_this_run(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -163,7 +163,7 @@ class FragmentTest(unittest.TestCase):
         assert ctx.current_fragment_id == "my_fragment_id"
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
-    def test_wrapped_fragment_saved_in_FragmentStorage(
+    def test_wrapped_fragment_not_saved_in_FragmentStorage(
         self, patched_get_script_run_ctx
     ):
         ctx = MagicMock()


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9233
Closes https://github.com/streamlit/streamlit/issues/9267

This PR changes the way how we deprecate child nodes in fragment runs. 
Right now, we have the issue that child fragment elements can be stale even if the parent changed (related to issue https://github.com/streamlit/streamlit/issues/9233 but not unique to Dialogs). 

For the following videos, this app is used: 
```python
from uuid import uuid4

import streamlit as st

if "counter" not in st.session_state:
    st.session_state.counter = 0

@st.fragment
def outer_fragment():
    with st.container(border=True):
        st.session_state.counter += 1
        st.write(f"outer fragment: {uuid4()}")
        st.button("rerun outer fragment")
        inner_fragment()


@st.fragment
def inner_fragment():
    with st.container(border=True):
        st.write(f"inner fragment: {uuid4()}")
        st.button("rerun inner fragment")

        if 5 < st.session_state.counter < 10:
            st.write("FOO!")

st.write(f"outside all fragments: {uuid4()}")
st.button("rerun whole app")
outer_fragment()
```

Where the inner fragment writes an element when `session_state.count` is between 5 and 10. The count is incremented when the outer fragment is re-run. You can see that right now, even if the outer fragment is clicked more than 10 times, the `FOO!` does not disappear!

Before

https://github.com/user-attachments/assets/6ff73dcb-14bd-4a5f-ab8b-9078e6f94de4


After

https://github.com/user-attachments/assets/a319be75-0b56-4bba-90d5-d04083071e0b


---

The PR changes the behavior now as following:
- when the parent fragment was changed during a run, we consider all _nested_ fragment elements as stale as well unless they were also modified during the same run (the scriptRunId is correct).

---

An alternative approach to closing https://github.com/streamlit/streamlit/issues/923 would be to create a new function `cleanFragments` which is passed to the `Dialog` component and called in the `onClose` callback. But this would be a pure dialog-solution and wouldn't fix the general stale-element issue in fragments demonstrated in the videos.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add new frontend test to ensure that stale nested fragments are removed
- E2E Tests
  - Update the existing `st_fragments_nested` test.
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
