### PR TITLE
Fix mypy errors

### DIFF
--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,7 +1,7 @@
 pre-commit
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.5
-mypy>=1.4, <1.7
+mypy>=1.4, <1.12
 mypy-protobuf>=3.2
 # semver 3 renames VersionInfo so temporarily pin until we deal with it
 semver<3

--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,7 +1,9 @@
 pre-commit
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.5
-mypy>=1.4, <1.12
+# as soon as the error reported in https://github.com/python/mypy/issues/17604
+# is released for mypy, we can update to version 1.11
+mypy>=1.4, <1.11
 mypy-protobuf>=3.2
 # semver 3 renames VersionInfo so temporarily pin until we deal with it
 semver<3

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -986,7 +986,7 @@ def determine_data_format(input_data: Any) -> DataFormat:
         if len(input_data.shape) == 1:
             # For technical reasons, we need to distinguish one
             # one-dimensional numpy array from multidimensional ones.
-            return DataFormat.NUMPY_LIST
+            return DataFormat.NUMPY_LIST  # type: ignore[unreachable]
         return DataFormat.NUMPY_MATRIX
     elif isinstance(input_data, pa.Table):
         return DataFormat.PYARROW_TABLE

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -42,6 +42,7 @@ from typing_extensions import TypeAlias, TypeGuard
 
 from streamlit import config, errors, logger, string_util
 from streamlit.type_util import (
+    NumpyShape,
     has_callable_attr,
     is_custom_dict,
     is_dataclass_instance,
@@ -983,10 +984,10 @@ def determine_data_format(input_data: Any) -> DataFormat:
     elif isinstance(input_data, pd.DataFrame):
         return DataFormat.PANDAS_DATAFRAME
     elif isinstance(input_data, np.ndarray):
-        if len(input_data.shape) == 1:
+        if len(cast(NumpyShape, input_data.shape)) == 1:
             # For technical reasons, we need to distinguish one
             # one-dimensional numpy array from multidimensional ones.
-            return DataFormat.NUMPY_LIST  # type: ignore[unreachable]
+            return DataFormat.NUMPY_LIST
         return DataFormat.NUMPY_MATRIX
     elif isinstance(input_data, pa.Table):
         return DataFormat.PYARROW_TABLE

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -119,7 +119,7 @@ Data: TypeAlias = Union[
     "Styler",
     "Index",
     "pa.Table",
-    "np.ndarray",
+    "np.ndarray[Any, np.dtype[Any]]",
     Iterable[Any],
     Dict[Any, Any],
     None,

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Final, Mapping, cast
+from typing import TYPE_CHECKING, Any, Dict, Final, Mapping, cast
 
 from streamlit import config
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
@@ -158,7 +158,7 @@ def _get_pydeck_tooltip(pydeck_obj: Deck | None) -> dict[str, str] | None:
     # For details, see: https://github.com/visgl/deck.gl/pull/7125/files
     tooltip = getattr(pydeck_obj, "_tooltip", None)
     if tooltip is not None and isinstance(tooltip, dict):
-        return cast(dict[str, str], tooltip)
+        return cast(Dict[str, str], tooltip)
 
     return None
 

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -158,7 +158,7 @@ def _get_pydeck_tooltip(pydeck_obj: Deck | None) -> dict[str, str] | None:
     # For details, see: https://github.com/visgl/deck.gl/pull/7125/files
     tooltip = getattr(pydeck_obj, "_tooltip", None)
     if tooltip is not None and isinstance(tooltip, dict):
-        return tooltip
+        return cast(dict[str, str], tooltip)
 
     return None
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -261,15 +261,15 @@ def _4d_to_list_3d(array: npt.NDArray[Any]) -> list[npt.NDArray[Any]]:
 def _verify_np_shape(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
     if len(array.shape) not in (2, 3):
         raise StreamlitAPIException("Numpy shape has to be of length 2 or 3.")
-    if len(array.shape) == 3 and array.shape[-1] not in (1, 3, 4):
+    if len(array.shape) == 3 and array.shape[-1] not in (1, 3, 4):  # type: ignore[unreachable]
         raise StreamlitAPIException(
             "Channel can only be 1, 3, or 4 got %d. Shape is %s"
             % (array.shape[-1], str(array.shape))
         )
 
     # If there's only one channel, convert is to x, y
-    if len(array.shape) == 3 and array.shape[-1] == 1:
-        array = array[:, :, 0]
+    if len(array.shape) == 3 and array.shape[-1] == 1:  # type: ignore[unreachable]
+        array = array[:, :, 0]  # type: ignore[unreachable]
 
     return array
 
@@ -419,7 +419,7 @@ def image_to_url(
 
         if channels == "BGR":
             if len(image.shape) == 3:
-                image = image[:, :, [2, 1, 0]]
+                image = image[:, :, [2, 1, 0]]  # type: ignore[unreachable]
             else:
                 raise StreamlitAPIException(
                     'When using `channels="BGR"`, the input image should '
@@ -510,7 +510,7 @@ def marshall_images(
     if isinstance(image, list):
         images = image
     elif isinstance(image, np.ndarray) and len(image.shape) == 4:
-        images = _4d_to_list_3d(image)
+        images = _4d_to_list_3d(image)  # type: ignore[unreachable]
     else:
         images = [image]
 
@@ -521,7 +521,7 @@ def marshall_images(
             captions = [caption]
         # You can pass in a 1-D Numpy array as captions.
         elif isinstance(caption, np.ndarray) and len(caption.shape) == 1:
-            captions = caption.tolist()
+            captions = caption.tolist()  # type: ignore[unreachable]
         # If there are no captions then make the captions list the same size
         # as the images list.
         elif caption is None:

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -667,10 +667,12 @@ def _get_offset_encoding(
     x_offset = alt.XOffset()
     y_offset = alt.YOffset()
 
+    _color_column = color_column if color_column is not None else alt.utils.Undefined
+
     if chart_type is ChartType.VERTICAL_BAR:
-        x_offset = alt.XOffset(field=color_column)
+        x_offset = alt.XOffset(field=_color_column)
     elif chart_type is ChartType.HORIZONTAL_BAR:
-        y_offset = alt.YOffset(field=color_column)
+        y_offset = alt.YOffset(field=_color_column)
 
     return x_offset, y_offset
 
@@ -912,11 +914,13 @@ def _get_color_encoding(
             if len(color_values) != len(y_column_list):
                 raise StreamlitColorLengthError(color_values, y_column_list)
 
-            if len(color_value) == 1:
+            if len(color_values) == 1:
                 return alt.ColorValue(to_css_color(cast(Any, color_value[0])))
             else:
                 return alt.Color(
-                    field=color_column,
+                    field=color_column
+                    if color_column is not None
+                    else alt.utils.Undefined,
                     scale=alt.Scale(range=[to_css_color(c) for c in color_values]),
                     legend=_COLOR_LEGEND_SETTINGS,
                     type="nominal",
@@ -926,7 +930,7 @@ def _get_color_encoding(
         raise StreamlitInvalidColorError(df, color_from_user)
 
     elif color_column is not None:
-        column_type: str | tuple[str, list[Any]]
+        column_type: VegaLiteType
 
         if color_column == _MELTED_COLOR_COLUMN_NAME:
             column_type = "nominal"

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -667,7 +667,10 @@ def _get_offset_encoding(
     x_offset = alt.XOffset()
     y_offset = alt.YOffset()
 
-    _color_column = color_column if color_column is not None else alt.utils.Undefined
+    # our merge gate does not find the alt.UndefinedType type for some reason
+    _color_column: str | alt.UndefinedType = (  # type: ignore[name-defined]
+        color_column if color_column is not None else alt.utils.Undefined
+    )
 
     if chart_type is ChartType.VERTICAL_BAR:
         x_offset = alt.XOffset(field=_color_column)

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -33,6 +33,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state.common import compute_widget_id
 from streamlit.time_util import time_to_seconds
+from streamlit.type_util import NumpyShape
 
 if TYPE_CHECKING:
     from typing import Any
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from numpy import typing as npt
 
     from streamlit.delta_generator import DeltaGenerator
+
 
 MediaData: TypeAlias = Union[
     str, bytes, io.BytesIO, io.RawIOBase, io.BufferedReader, "npt.NDArray[Any]", None
@@ -635,8 +637,8 @@ def _validate_and_normalize(data: npt.NDArray[Any]) -> tuple[bytes, int]:
 
     transformed_data: npt.NDArray[Any] = np.array(data, dtype=float)
 
-    if len(transformed_data.shape) == 1:
-        nchan = 1  # type: ignore[unreachable]
+    if len(cast(NumpyShape, transformed_data.shape)) == 1:
+        nchan = 1
     elif len(transformed_data.shape) == 2:
         # In wave files,channels are interleaved. E.g.,
         # "L1R1L2R2..." for stereo. See

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -633,29 +633,29 @@ def _validate_and_normalize(data: npt.NDArray[Any]) -> tuple[bytes, int]:
     # to st.audio data)
     import numpy as np
 
-    data: npt.NDArray[Any] = np.array(data, dtype=float)
+    transformed_data: npt.NDArray[Any] = np.array(data, dtype=float)
 
-    if len(data.shape) == 1:
-        nchan = 1
-    elif len(data.shape) == 2:
+    if len(transformed_data.shape) == 1:
+        nchan = 1  # type: ignore[unreachable]
+    elif len(transformed_data.shape) == 2:
         # In wave files,channels are interleaved. E.g.,
         # "L1R1L2R2..." for stereo. See
         # http://msdn.microsoft.com/en-us/library/windows/hardware/dn653308(v=vs.85).aspx
         # for channel ordering
-        nchan = data.shape[0]
-        data = data.T.ravel()
+        nchan = transformed_data.shape[0]
+        transformed_data = transformed_data.T.ravel()
     else:
         raise StreamlitAPIException("Numpy array audio input must be a 1D or 2D array.")
 
-    if data.size == 0:
-        return data.astype(np.int16).tobytes(), nchan
+    if transformed_data.size == 0:
+        return transformed_data.astype(np.int16).tobytes(), nchan
 
-    max_abs_value = np.max(np.abs(data))
+    max_abs_value = np.max(np.abs(transformed_data))
     # 16-bit samples are stored as 2's-complement signed integers,
     # ranging from -32768 to 32767.
     # scaled_data is PCM 16 bit numpy array, that's why we multiply [-1, 1] float
     # values to 32_767 == 2 ** 15 - 1.
-    np_array = (data / max_abs_value) * 32767
+    np_array = (transformed_data / max_abs_value) * 32767
     scaled_data = np_array.astype(np.int16)
     return scaled_data.tobytes(), nchan
 

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
-Value: TypeAlias = Union["np.integer", "np.floating", float, int, str, None]
+Value: TypeAlias = Union["np.integer[Any]", "np.floating[Any]", float, int, str, None]
 Delta: TypeAlias = Union[float, int, str, None]
 DeltaColor: TypeAlias = Literal["normal", "inverse", "off"]
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -454,7 +454,9 @@ class _CacheFuncHasher:
         elif type_util.is_type(obj, "numpy.ndarray"):
             import numpy as np
 
-            obj = cast(np.ndarray[Any, Any], obj)
+            # write cast type as string to make it work with our Python 3.8 tests
+            # - can be removed once we sunset support for Python 3.8
+            obj = cast("np.ndarray[Any, Any]", obj)
             self.update(h, obj.shape)
             self.update(h, str(obj.dtype))
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -454,7 +454,7 @@ class _CacheFuncHasher:
         elif type_util.is_type(obj, "numpy.ndarray"):
             import numpy as np
 
-            obj = cast(np.ndarray[Any, np.dtype[Any]], obj)
+            obj = cast(np.ndarray[Any, Any], obj)
             self.update(h, obj.shape)
             self.update(h, str(obj.dtype))
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -405,7 +405,7 @@ class _CacheFuncHasher:
         elif obj is False:
             return b"0"
 
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             return self.to_bytes(dataclasses.asdict(obj))
 
         elif isinstance(obj, Enum):

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import collections
+import collections.abc
 import dataclasses
 import datetime
 import functools
@@ -31,7 +32,8 @@ import threading
 import uuid
 import weakref
 from enum import Enum
-from typing import Any, Callable, Dict, Final, Pattern, Type, Union
+from types import MappingProxyType
+from typing import Any, Callable, Dict, Final, Pattern, Type, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -405,15 +407,15 @@ class _CacheFuncHasher:
         elif obj is False:
             return b"0"
 
-        elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        elif not isinstance(obj, type) and dataclasses.is_dataclass(obj):
             return self.to_bytes(dataclasses.asdict(obj))
-
         elif isinstance(obj, Enum):
             return str(obj).encode()
 
         elif type_util.is_type(obj, "pandas.core.series.Series"):
             import pandas as pd
 
+            obj = cast(pd.Series, obj)
             self.update(h, obj.size)
             self.update(h, obj.dtype.name)
 
@@ -431,6 +433,7 @@ class _CacheFuncHasher:
         elif type_util.is_type(obj, "pandas.core.frame.DataFrame"):
             import pandas as pd
 
+            obj = cast(pd.DataFrame, obj)
             self.update(h, obj.shape)
 
             if len(obj) >= _PANDAS_ROWS_LARGE:
@@ -449,6 +452,9 @@ class _CacheFuncHasher:
                 return b"%s" % pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
 
         elif type_util.is_type(obj, "numpy.ndarray"):
+            import numpy as np
+
+            obj = cast(np.ndarray[Any, np.dtype[Any]], obj)
             self.update(h, obj.shape)
             self.update(h, str(obj.dtype))
 
@@ -462,6 +468,9 @@ class _CacheFuncHasher:
             return h.digest()
         elif type_util.is_type(obj, "PIL.Image.Image"):
             import numpy as np
+            from PIL.Image import Image
+
+            obj = cast(Image, obj)
 
             # we don't just hash the results of obj.tobytes() because we want to use
             # the sampling logic for numpy data
@@ -471,8 +480,8 @@ class _CacheFuncHasher:
         elif inspect.isbuiltin(obj):
             return bytes(obj.__name__.encode())
 
-        elif type_util.is_type(obj, "builtins.mappingproxy") or type_util.is_type(
-            obj, "builtins.dict_items"
+        elif isinstance(obj, MappingProxyType) or isinstance(
+            obj, collections.abc.ItemsView
         ):
             return self.to_bytes(dict(obj))
 

--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 def exec_func_with_error_handling(
-    func: Callable[[], None], ctx: ScriptRunContext
+    func: Callable[[], Any], ctx: ScriptRunContext
 ) -> tuple[
     Any | None,
     bool,

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 import threading
 from pathlib import Path
-from typing import Any, Callable, Final, TypedDict, cast
+from typing import Callable, Final, TypedDict
 
 from blinker import Signal
 from typing_extensions import NotRequired, TypeAlias
@@ -88,14 +88,9 @@ def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     URL-encode them. To solve this, we only swap the underscores for spaces
     right before we render page names.
     """
-    extraction = re.search(PAGE_FILENAME_REGEX, script_path.name)
+    extraction: re.Match[str] | None = re.search(PAGE_FILENAME_REGEX, script_path.name)
     if extraction is None:
         return "", ""
-
-    # This cast to Any+type annotation weirdness is done because
-    # cast(re.Match[str], ...) explodes at runtime since Python interprets it
-    # as an attempt to index into re.Match instead of as a type annotation.
-    extraction: re.Match[str] = cast(Any, extraction)
 
     icon_and_name = re.sub(
         r"[_ ]+", "_", extraction.group(2)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -31,6 +31,7 @@ from typing import (
     NamedTuple,
     Protocol,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
     overload,
@@ -48,6 +49,10 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
+
+# we define our own type here because mypy doesn't seem to support the shape type and
+# reports unreachable code. When mypy supports it, we can remove this custom type.
+NumpyShape: TypeAlias = Tuple[int, ...]
 
 
 class SupportsStr(Protocol):


### PR DESCRIPTION
## Describe your changes

Our mypy-checks have started to fail in the merge gates (see [here](https://github.com/streamlit/streamlit/actions/runs/10347072909/job/28639963961)), probably because altair was updated with better typing. This PR updates our max version of mypy and fixes some of the reported errors with `mypy==1.10` (`mypy 1.11.1` has [an issue](https://github.com/python/mypy/issues/17604) with the `NotRequired` type we use at a few places which is why we use 1.10 for now)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
