### PR TITLE
Fix Circular Imports: Move functions out of delta_generator

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -24,7 +24,6 @@ from typing import (
     Any,
     Callable,
     Final,
-    Hashable,
     Iterable,
     Literal,
     NoReturn,
@@ -38,7 +37,6 @@ from streamlit import (
     cli_util,
     config,
     cursor,
-    dataframe_util,
     env_util,
     logger,
     runtime,
@@ -89,26 +87,23 @@ from streamlit.elements.widgets.slider import SliderMixin
 from streamlit.elements.widgets.text_widgets import TextWidgetsMixin
 from streamlit.elements.widgets.time_widgets import TimeWidgetsMixin
 from streamlit.elements.write import WriteMixin
-from streamlit.errors import NoSessionContext, StreamlitAPIException
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2, ForwardMsg_pb2
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime import caching
+from streamlit.runtime.scriptrunner import enqueue_message as _enqueue_message
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 if TYPE_CHECKING:
     from google.protobuf.message import Message
-    from numpy import typing as npt
-    from pandas import DataFrame
 
     from streamlit.cursor import Cursor
-    from streamlit.dataframe_util import Data
     from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
 
 
 MAX_DELTA_BYTES: Final[int] = 14 * 1024 * 1024  # 14MB
 
 Value = TypeVar("Value")
-DG = TypeVar("DG", bound="DeltaGenerator")
 
 # Type aliases for Ancestor Block Types
 BlockType: TypeAlias = str
@@ -554,121 +549,6 @@ class DeltaGenerator(
 
         return block_dg
 
-    def _arrow_add_rows(
-        self: DG,
-        data: Data = None,
-        **kwargs: (
-            DataFrame | npt.NDArray[Any] | Iterable[Any] | dict[Hashable, Any] | None
-        ),
-    ) -> DG | None:
-        """Concatenate a dataframe to the bottom of the current one.
-
-        Parameters
-        ----------
-        data : pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict, or None
-            Table to concat. Optional.
-
-        **kwargs : pandas.DataFrame, numpy.ndarray, Iterable, dict, or None
-            The named dataset to concat. Optional. You can only pass in 1
-            dataset (including the one in the data parameter).
-
-        Example
-        -------
-        >>> import streamlit as st
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>>
-        >>> df1 = pd.DataFrame(
-        ...     np.random.randn(50, 20), columns=("col %d" % i for i in range(20))
-        ... )
-        >>> my_table = st.table(df1)
-        >>>
-        >>> df2 = pd.DataFrame(
-        ...     np.random.randn(50, 20), columns=("col %d" % i for i in range(20))
-        ... )
-        >>> my_table.add_rows(df2)
-        >>> # Now the table shown in the Streamlit app contains the data for
-        >>> # df1 followed by the data for df2.
-
-        You can do the same thing with plots. For example, if you want to add
-        more data to a line chart:
-
-        >>> # Assuming df1 and df2 from the example above still exist...
-        >>> my_chart = st.line_chart(df1)
-        >>> my_chart.add_rows(df2)
-        >>> # Now the chart shown in the Streamlit app contains the data for
-        >>> # df1 followed by the data for df2.
-
-        And for plots whose datasets are named, you can pass the data with a
-        keyword argument where the key is the name:
-
-        >>> my_chart = st.vega_lite_chart(
-        ...     {
-        ...         "mark": "line",
-        ...         "encoding": {"x": "a", "y": "b"},
-        ...         "datasets": {
-        ...             "some_fancy_name": df1,  # <-- named dataset
-        ...         },
-        ...         "data": {"name": "some_fancy_name"},
-        ...     }
-        ... )
-        >>> my_chart.add_rows(some_fancy_name=df2)  # <-- name used as keyword
-
-        """
-        if self._root_container is None or self._cursor is None:
-            return self
-
-        if not self._cursor.is_locked:
-            raise StreamlitAPIException("Only existing elements can `add_rows`.")
-
-        # Accept syntax st._arrow_add_rows(df).
-        if data is not None and len(kwargs) == 0:
-            name = ""
-        # Accept syntax st._arrow_add_rows(foo=df).
-        elif len(kwargs) == 1:
-            name, data = kwargs.popitem()
-        # Raise error otherwise.
-        else:
-            raise StreamlitAPIException(
-                "Wrong number of arguments to add_rows()."
-                "Command requires exactly one dataset"
-            )
-
-        # When doing _arrow_add_rows on an element that does not already have data
-        # (for example, st.line_chart() without any args), call the original
-        # st.foo() element with new data instead of doing a _arrow_add_rows().
-        if (
-            "add_rows_metadata" in self._cursor.props
-            and self._cursor.props["add_rows_metadata"]
-            and self._cursor.props["add_rows_metadata"].last_index is None
-        ):
-            st_method = getattr(
-                self, self._cursor.props["add_rows_metadata"].chart_command
-            )
-            st_method(data, **kwargs)
-            return None
-
-        new_data, self._cursor.props["add_rows_metadata"] = _prep_data_for_add_rows(
-            data,
-            self._cursor.props["add_rows_metadata"],
-        )
-
-        msg = ForwardMsg_pb2.ForwardMsg()
-        msg.metadata.delta_path[:] = self._cursor.delta_path
-
-        import streamlit.elements.arrow as arrow_proto
-
-        default_uuid = str(hash(self._get_delta_path_str()))
-        arrow_proto.marshall(msg.delta.arrow_add_rows.data, new_data, default_uuid)
-
-        if name:
-            msg.delta.arrow_add_rows.name = name
-            msg.delta.arrow_add_rows.has_name = True
-
-        _enqueue_message(msg)
-
-        return self
-
 
 main_dg = DeltaGenerator(root_container=RootContainer.MAIN)
 sidebar_dg = DeltaGenerator(root_container=RootContainer.SIDEBAR, parent=main_dg)
@@ -702,42 +582,7 @@ def get_last_dg_added_to_context_stack() -> DeltaGenerator | None:
     return None
 
 
-def _prep_data_for_add_rows(
-    data: Data,
-    add_rows_metadata: AddRowsMetadata | None,
-) -> tuple[Data, AddRowsMetadata | None]:
-    if not add_rows_metadata:
-        if dataframe_util.is_pandas_styler(data):
-            # When calling add_rows on st.table or st.dataframe we want styles to
-            # pass through.
-            return data, None
-        return dataframe_util.convert_anything_to_pandas_df(data), None
-
-    # If add_rows_metadata is set, it indicates that the add_rows used called
-    # on a chart based on our built-in chart commands.
-
-    # For built-in chart commands we have to reshape the data structure
-    # otherwise the input data and the actual data used
-    # by vega_lite will be different, and it will throw an error.
-    from streamlit.elements.lib.built_in_chart_utils import prep_chart_data_for_add_rows
-
-    return prep_chart_data_for_add_rows(data, add_rows_metadata)
-
-
-def _enqueue_message(msg: ForwardMsg_pb2.ForwardMsg) -> None:
-    """Enqueues a ForwardMsg proto to send to the app."""
-    ctx = get_script_run_ctx()
-
-    if ctx is None:
-        raise NoSessionContext()
-
-    if ctx.current_fragment_id and msg.WhichOneof("type") == "delta":
-        msg.delta.fragment_id = ctx.current_fragment_id
-
-    ctx.enqueue(msg)
-
-
-def _writes_directly_to_sidebar(dg: DG) -> bool:
+def _writes_directly_to_sidebar(dg: DeltaGenerator) -> bool:
     in_sidebar = any(a._root_container == RootContainer.SIDEBAR for a in dg._ancestors)
     has_container = bool(len(list(dg._ancestor_block_types)))
     return in_sidebar and not has_container

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -18,7 +18,9 @@ import json
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Final,
+    Hashable,
     Iterable,
     Literal,
     TypedDict,
@@ -43,14 +45,22 @@ from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.scriptrunner.script_run_context import (
+    enqueue_message,
+    get_script_run_ctx,
+)
 from streamlit.runtime.state import WidgetCallback, register_widget
 from streamlit.runtime.state.common import compute_widget_id
 
 if TYPE_CHECKING:
+    from numpy import typing as npt
+    from pandas import DataFrame
+
     from streamlit.dataframe_util import Data
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
 
 
 SelectionMode: TypeAlias = Literal[
@@ -671,12 +681,148 @@ class ArrowMixin:
         >>> my_chart.add_rows(some_fancy_name=df2)  # <-- name used as keyword
 
         """
-        return self.dg._arrow_add_rows(data, **kwargs)
+        return _arrow_add_rows(self.dg, data, **kwargs)
 
     @property
     def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)
+
+
+def _prep_data_for_add_rows(
+    data: Data,
+    add_rows_metadata: AddRowsMetadata | None,
+) -> tuple[Data, AddRowsMetadata | None]:
+    if not add_rows_metadata:
+        if dataframe_util.is_pandas_styler(data):
+            # When calling add_rows on st.table or st.dataframe we want styles to
+            # pass through.
+            return data, None
+        return dataframe_util.convert_anything_to_pandas_df(data), None
+
+    # If add_rows_metadata is set, it indicates that the add_rows used called
+    # on a chart based on our built-in chart commands.
+
+    # For built-in chart commands we have to reshape the data structure
+    # otherwise the input data and the actual data used
+    # by vega_lite will be different, and it will throw an error.
+    from streamlit.elements.lib.built_in_chart_utils import prep_chart_data_for_add_rows
+
+    return prep_chart_data_for_add_rows(data, add_rows_metadata)
+
+
+def _arrow_add_rows(
+    dg: DeltaGenerator,
+    data: Data = None,
+    **kwargs: (
+        DataFrame | npt.NDArray[Any] | Iterable[Any] | dict[Hashable, Any] | None
+    ),
+) -> DeltaGenerator | None:
+    """Concatenate a dataframe to the bottom of the current one.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict, or None
+        Table to concat. Optional.
+
+    **kwargs : pandas.DataFrame, numpy.ndarray, Iterable, dict, or None
+        The named dataset to concat. Optional. You can only pass in 1
+        dataset (including the one in the data parameter).
+
+    Example
+    -------
+    >>> import streamlit as st
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>>
+    >>> df1 = pd.DataFrame(
+    ...     np.random.randn(50, 20), columns=("col %d" % i for i in range(20))
+    ... )
+    >>> my_table = st.table(df1)
+    >>>
+    >>> df2 = pd.DataFrame(
+    ...     np.random.randn(50, 20), columns=("col %d" % i for i in range(20))
+    ... )
+    >>> my_table.add_rows(df2)
+    >>> # Now the table shown in the Streamlit app contains the data for
+    >>> # df1 followed by the data for df2.
+
+    You can do the same thing with plots. For example, if you want to add
+    more data to a line chart:
+
+    >>> # Assuming df1 and df2 from the example above still exist...
+    >>> my_chart = st.line_chart(df1)
+    >>> my_chart.add_rows(df2)
+    >>> # Now the chart shown in the Streamlit app contains the data for
+    >>> # df1 followed by the data for df2.
+
+    And for plots whose datasets are named, you can pass the data with a
+    keyword argument where the key is the name:
+
+    >>> my_chart = st.vega_lite_chart(
+    ...     {
+    ...         "mark": "line",
+    ...         "encoding": {"x": "a", "y": "b"},
+    ...         "datasets": {
+    ...             "some_fancy_name": df1,  # <-- named dataset
+    ...         },
+    ...         "data": {"name": "some_fancy_name"},
+    ...     }
+    ... )
+    >>> my_chart.add_rows(some_fancy_name=df2)  # <-- name used as keyword
+
+    """
+    if dg._root_container is None or dg._cursor is None:
+        return dg
+
+    if not dg._cursor.is_locked:
+        raise StreamlitAPIException("Only existing elements can `add_rows`.")
+
+    # Accept syntax st._arrow_add_rows(df).
+    if data is not None and len(kwargs) == 0:
+        name = ""
+    # Accept syntax st._arrow_add_rows(foo=df).
+    elif len(kwargs) == 1:
+        name, data = kwargs.popitem()
+    # Raise error otherwise.
+    else:
+        raise StreamlitAPIException(
+            "Wrong number of arguments to add_rows()."
+            "Command requires exactly one dataset"
+        )
+
+    # When doing _arrow_add_rows on an element that does not already have data
+    # (for example, st.line_chart() without any args), call the original
+    # st.foo() element with new data instead of doing a _arrow_add_rows().
+    if (
+        "add_rows_metadata" in dg._cursor.props
+        and dg._cursor.props["add_rows_metadata"]
+        and dg._cursor.props["add_rows_metadata"].last_index is None
+    ):
+        st_method = getattr(dg, dg._cursor.props["add_rows_metadata"].chart_command)
+        st_method(data, **kwargs)
+        return None
+
+    new_data, dg._cursor.props["add_rows_metadata"] = _prep_data_for_add_rows(
+        data,
+        dg._cursor.props["add_rows_metadata"],
+    )
+
+    msg = ForwardMsg()
+    msg.metadata.delta_path[:] = dg._cursor.delta_path
+
+    import streamlit.elements.arrow as arrow_proto
+
+    default_uuid = str(hash(dg._get_delta_path_str()))
+    arrow_proto.marshall(msg.delta.arrow_add_rows.data, new_data, default_uuid)
+
+    if name:
+        msg.delta.arrow_add_rows.name = name
+        msg.delta.arrow_add_rows.has_name = True
+
+    enqueue_message(msg)
+
+    return dg
 
 
 def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> None:

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -811,10 +811,8 @@ def _arrow_add_rows(
     msg = ForwardMsg()
     msg.metadata.delta_path[:] = dg._cursor.delta_path
 
-    import streamlit.elements.arrow as arrow_proto
-
     default_uuid = str(hash(dg._get_delta_path_str()))
-    arrow_proto.marshall(msg.delta.arrow_add_rows.data, new_data, default_uuid)
+    marshall(msg.delta.arrow_add_rows.data, new_data, default_uuid)
 
     if name:
         msg.delta.arrow_add_rows.name = name

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -19,11 +19,14 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
 
-from streamlit.delta_generator import DeltaGenerator, _enqueue_message
+from streamlit.delta_generator import DeltaGenerator
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.scriptrunner.script_run_context import (
+    enqueue_message,
+    get_script_run_ctx,
+)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -127,7 +130,7 @@ class Dialog(DeltaGenerator):
         # We add a sleep here to give the web app time to react to the update. Otherwise,
         #  we might run into issues where the dialog cannot be opened again after closing
         time.sleep(0.05)
-        _enqueue_message(msg)
+        enqueue_message(msg)
 
     def open(self) -> None:
         self._update(True)

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -19,10 +19,11 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
 
-from streamlit.delta_generator import DeltaGenerator, _enqueue_message
+from streamlit.delta_generator import DeltaGenerator
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.scriptrunner.script_run_context import enqueue_message
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -150,7 +151,7 @@ class StatusContainer(DeltaGenerator):
             self._current_state = state
 
         self._current_proto = msg.delta.add_block
-        _enqueue_message(msg)
+        enqueue_message(msg)
 
     def __enter__(self) -> Self:  # type: ignore[override]
         # This is a little dubious: we're returning a different type than

--- a/lib/streamlit/runtime/scriptrunner/__init__.py
+++ b/lib/streamlit/runtime/scriptrunner/__init__.py
@@ -17,6 +17,7 @@ from streamlit.runtime.scriptrunner.script_requests import RerunData
 from streamlit.runtime.scriptrunner.script_run_context import (
     ScriptRunContext,
     add_script_run_ctx,
+    enqueue_message,
     get_script_run_ctx,
 )
 from streamlit.runtime.scriptrunner.script_runner import ScriptRunner, ScriptRunnerEvent
@@ -26,6 +27,7 @@ __all__ = [
     "ScriptRunContext",
     "add_script_run_ctx",
     "get_script_run_ctx",
+    "enqueue_message",
     "RerunException",
     "ScriptRunner",
     "ScriptRunnerEvent",

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -22,8 +22,7 @@ from urllib import parse
 
 from typing_extensions import TypeAlias
 
-from streamlit import runtime
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.logger import get_logger
 
 if TYPE_CHECKING:
@@ -224,15 +223,28 @@ def get_script_run_ctx(suppress_warning: bool = False) -> ScriptRunContext | Non
     """
     thread = threading.current_thread()
     ctx: ScriptRunContext | None = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-    if ctx is None and runtime.exists() and not suppress_warning:
+    if ctx is None and not suppress_warning:
         # Only warn about a missing ScriptRunContext if suppress_warning is False, and
         # we were started via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit
         # bits that are irrelevant when not connected to a session.
-        _LOGGER.warning("Thread '%s': missing ScriptRunContext", thread.name)
+        _LOGGER.warning(
+            "Thread '%s': missing ScriptRunContext! This warning can be ignored when "
+            "running in bare mode.",
+            thread.name,
+        )
 
     return ctx
 
 
-# Needed to avoid circular dependencies while running tests.
-import streamlit  # noqa: E402, F401
+def enqueue_message(msg: ForwardMsg) -> None:
+    """Enqueues a ForwardMsg proto to send to the app."""
+    ctx = get_script_run_ctx()
+
+    if ctx is None:
+        raise NoSessionContext()
+
+    if ctx.current_fragment_id and msg.WhichOneof("type") == "delta":
+        msg.delta.fragment_id = ctx.current_fragment_id
+
+    ctx.enqueue(msg)


### PR DESCRIPTION
## Describe your changes

In context of the codebase cleanup project to resolve circular imports, this is the first PR: move functions that are used in a very narrow domain out of the delta generator. We move:
- `_arrow_add_rows` to `arrow.py` because it is only used in there
- `enqueue_message` to `script_run_ctx` because it is tightly coupled with it

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add unit tests for `enqueue` which seem to have been untested before
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
