### PR TITLE
move disallow_cached_widget_usage out of ScriptRunContext and into a contextvar for thread-safety

### DIFF
--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -21,6 +21,7 @@ from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException, StreamlitAPIWarning
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import WidgetCallback, get_session_state
+from streamlit.runtime.scriptrunner.script_run_context import disallow_cached_widget_usage
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -115,8 +116,7 @@ def check_cache_replay_rules() -> None:
     function to check for those as well. And rename it to check_widget_usage_rules.
     """
     if runtime.exists():
-        ctx = get_script_run_ctx()
-        if ctx and ctx.disallow_cached_widget_usage:
+        if disallow_cached_widget_usage.get():
             from streamlit import exception
 
             # We use an exception here to show a proper stack trace

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -28,6 +28,7 @@ from streamlit.runtime.caching.hashing import update_hash
 from streamlit.runtime.scriptrunner.script_run_context import (
     ScriptRunContext,
     get_script_run_ctx,
+    disallow_cached_widget_usage
 )
 from streamlit.util import HASHLIB_KWARGS
 
@@ -247,7 +248,7 @@ class CachedMessageReplayContext(threading.local):
         nested_call = False
         ctx = get_script_run_ctx()
         if ctx:
-            if ctx.disallow_cached_widget_usage:
+            if disallow_cached_widget_usage.get():
                 # The disallow_cached_widget_usage is already set to true.
                 # This indicates that this cached function run is called from another
                 # cached function that disallows widget usage.
@@ -260,7 +261,7 @@ class CachedMessageReplayContext(threading.local):
                 # If we're in a cached function that disallows widget usage, we need to set
                 # the disallow_cached_widget_usage to true for this cached function run
                 # to prevent widget usage (triggers a warning).
-                ctx.disallow_cached_widget_usage = True
+                disallow_cached_widget_usage.set(True)
         try:
             yield
         finally:
@@ -269,7 +270,7 @@ class CachedMessageReplayContext(threading.local):
             if ctx and not nested_call:
                 # Reset the disallow_cached_widget_usage flag. But only if this
                 # is not nested inside a cached function that disallows widget usage.
-                ctx.disallow_cached_widget_usage = False
+                disallow_cached_widget_usage.set(False)
 
     def save_element_message(
         self,

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import collections
+import contextvars
 import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Counter, Dict, Final, Union
@@ -38,6 +39,11 @@ if TYPE_CHECKING:
 _LOGGER: Final = get_logger(__name__)
 
 UserInfo: TypeAlias = Dict[str, Union[str, None]]
+
+
+# If true, it indicates that we are in a cached function that disallows the usage of widgets.
+# Using contextvars to be thread-safe.
+disallow_cached_widget_usage: contextvars.ContextVar[bool] = contextvars.ContextVar("disallow_cached_widget_usage", default=False)
 
 
 @dataclass
@@ -81,9 +87,6 @@ class ScriptRunContext:
     new_fragment_ids: set[str] = field(default_factory=set)
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
-    # If true, it indicates that we are in a cached function that disallows
-    # the usage of widgets.
-    disallow_cached_widget_usage: bool = False
 
     # TODO(willhuang1997): Remove this variable when experimental query params are removed
     _experimental_query_params_used = False
@@ -120,7 +123,6 @@ class ScriptRunContext:
         self.fragment_ids_this_run = fragment_ids_this_run
         self.new_fragment_ids = set()
         self.has_dialog_opened = False
-        self.disallow_cached_widget_usage = False
 
         parsed_query_params = parse.parse_qs(query_string, keep_blank_values=True)
         with self.session_state.query_params() as qp:

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -176,7 +176,7 @@ class CheckCacheReplayTest(ElementPoliciesTest):
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch(
         "streamlit.elements.lib.policies.get_script_run_ctx",
-        MagicMock(return_value=MagicMock(disallow_cached_widget_usage=False)),
+        MagicMock(return_value=MagicMock()),
     )
     @patch("streamlit.exception")
     def test_cache_replay_rules_succeeds(self, patched_st_exception):
@@ -186,7 +186,7 @@ class CheckCacheReplayTest(ElementPoliciesTest):
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch(
         "streamlit.elements.lib.policies.get_script_run_ctx",
-        MagicMock(return_value=MagicMock(disallow_cached_widget_usage=True)),
+        MagicMock(return_value=MagicMock()),
     )
     @patch("streamlit.exception")
     def test_cache_replay_rules_fails(self, patched_st_exception):


### PR DESCRIPTION
## Describe your changes

Moves `disallow_cached_widget_usage` from a member of `ScriptRunContext` to a contextvar. This prevents spurious `CachedWidgetWarning` when using async to render multiple things. This takes inspiration from https://github.com/streamlit/streamlit/pull/7715 which conceptually did the same thing.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9260

## Testing Plan

I have only tested this locally with my app. It seems reasonable to have a unittest for this, but I'm not too familiar with the setup for this. For now, I'm making the PR mostly as a template/suggestion for how it might be fixed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
