### PR TITLE
Refactor integration test setup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -232,4 +232,4 @@ jobs:
       - name: Install integration dependencies
         run: uv pip install --editable ./lib[snowflake]
       - name: Run Python Tests for Snowflake
-        run: make pytest-snowflake
+        run: make pytest-integration

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -230,6 +230,6 @@ jobs:
       - name: Run make develop
         run: make develop
       - name: Install integration dependencies
-        run: uv pip install --editable ./lib[snowflake]
+        run: uv pip install -r lib/integration-requirements.txt --force-reinstall
       - name: Run Python Tests for Snowflake
         run: make pytest-integration

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -189,7 +189,7 @@ jobs:
         env:
           TARGET_BRANCH: constraints-${{ github.ref_name }}
 
-  py-integration-tests:
+  py-snowflake-integration-tests:
     needs:
       - build_info
 
@@ -207,7 +207,7 @@ jobs:
       )
 
     name: >
-      py-integration-tests
+      py-unit-tests (snowflake)
 
     env:
       USE_CONSTRAINTS_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINTS_FILE )}}"
@@ -224,7 +224,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Decrypt Snowflake credentials
+      - name: Decrypt credentials
         run: ./.github/scripts/decrypt_credentials.sh
         env:
           PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
@@ -232,7 +232,7 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
-      - name: Install integration dependencies
-        run: uv pip install -r lib/integration-requirements.txt --force-reinstall
-      - name: Run Python integration tests
-        run: make pytest-integration
+      - name: Install lib with snowflake dependencies
+        run: uv pip install --editable ./lib[snowflake]
+      - name: Run Python Tests for Snowflake
+        run: make pytest-snowflake

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -189,7 +189,7 @@ jobs:
         env:
           TARGET_BRANCH: constraints-${{ github.ref_name }}
 
-  py-snowflake-integration-tests:
+  py-integration-tests:
     needs:
       - build_info
 
@@ -206,9 +206,6 @@ jobs:
       (github.event_name == 'schedule')
       )
 
-    name: >
-      py-unit-tests (snowflake)
-
     env:
       USE_CONSTRAINTS_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINTS_FILE )}}"
       CONSTRAINTS_BRANCH: ${{ inputs.constraints-branch || 'constraints-develop' }}
@@ -224,7 +221,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Decrypt credentials
+      - name: Decrypt Snowflake credentials
         run: ./.github/scripts/decrypt_credentials.sh
         env:
           PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
@@ -232,7 +229,7 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
-      - name: Install lib with snowflake dependencies
+      - name: Install integration dependencies
         run: uv pip install --editable ./lib[snowflake]
       - name: Run Python Tests for Snowflake
         run: make pytest-snowflake

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -189,7 +189,7 @@ jobs:
         env:
           TARGET_BRANCH: constraints-${{ github.ref_name }}
 
-  py-snowflake-integration-tests:
+  py-integration-tests:
     needs:
       - build_info
 
@@ -207,7 +207,7 @@ jobs:
       )
 
     name: >
-      py-unit-tests (snowflake)
+      py-integration-tests
 
     env:
       USE_CONSTRAINTS_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINTS_FILE )}}"
@@ -224,7 +224,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Decrypt credentials
+      - name: Decrypt Snowflake credentials
         run: ./.github/scripts/decrypt_credentials.sh
         env:
           PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
@@ -232,7 +232,7 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
-      - name: Install lib with snowflake dependencies
-        run: uv pip install --editable ./lib[snowflake]
-      - name: Run Python Tests for Snowflake
-        run: make pytest-snowflake
+      - name: Install integration dependencies
+        run: uv pip install -r lib/integration-requirements.txt --force-reinstall
+      - name: Run Python integration tests
+        run: make pytest-integration

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ pytest:
 			-l tests/ \
 			$(PYTHON_MODULES)
 
-# Run Python integration tests for snowflake.
+# Run Python integration tests.
 pytest-snowflake:
 	cd lib; \
 		PYTHONPATH=. \

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ pytest:
 			$(PYTHON_MODULES)
 
 # Run Python integration tests.
-pytest-snowflake:
+# This requires the integration-requirements to be installed.
+pytest-integration:
 	cd lib; \
 		PYTHONPATH=. \
 		pytest -v \

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ pytest-integration:
 		PYTHONPATH=. \
 		pytest -v \
 			--junitxml=test-reports/pytest/junit.xml \
-			--require-snowflake \
+			--require-integration \
 			-l tests/ \
 			$(PYTHON_MODULES)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 # Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -146,13 +147,14 @@ pytest:
 			-l tests/ \
 			$(PYTHON_MODULES)
 
-# Run Python integration tests for snowflake.
-pytest-snowflake:
+# Run Python integration tests
+# This requires the integration-requirements to be installed
+pytest-integration:
 	cd lib; \
 		PYTHONPATH=. \
 		pytest -v \
 			--junitxml=test-reports/pytest/junit.xml \
-			--require-snowflake \
+			--require-integration \
 			-l tests/ \
 			$(PYTHON_MODULES)
 
@@ -427,4 +429,3 @@ frontend-lib-prod:
 streamlit-lib-prod:
 	make mini-init;
 	make frontend-lib-prod;
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,14 +146,13 @@ pytest:
 			-l tests/ \
 			$(PYTHON_MODULES)
 
-# Run Python integration tests
-# This requires the integration-requirements to be installed
-pytest-integration:
+# Run Python integration tests for snowflake.
+pytest-snowflake:
 	cd lib; \
 		PYTHONPATH=. \
 		pytest -v \
 			--junitxml=test-reports/pytest/junit.xml \
-			--require-integration \
+			--require-snowflake \
 			-l tests/ \
 			$(PYTHON_MODULES)
 
@@ -429,3 +427,4 @@ frontend-lib-prod:
 streamlit-lib-prod:
 	make mini-init;
 	make frontend-lib-prod;
+

--- a/lib/integration-requirements.txt
+++ b/lib/integration-requirements.txt
@@ -1,0 +1,23 @@
+# Snowflake dependencies:
+snowflake-snowpark-python[modin]>=1.17.0
+snowflake-connector-python>=2.8.0
+
+# Required for testing the langchain integration
+langchain>=0.2.0
+langchain-community>=0.2.0
+
+# Additional dataframe formats for testing:
+polars
+xarray
+dask
+ray
+
+# Used for testing of st.connection
+sqlalchemy[mypy]>=1.4.25, <2
+
+# Pydantic 1.* fails to initialize validators, we add it to requirements
+# to test the fix. Pydantic 2 should not have that issue.
+pydantic>=1.0, <2.0
+
+# Used by audio test:
+scipy>=1.7.3

--- a/lib/pytest.ini
+++ b/lib/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     slow: marks tests as slow
+    require_integration: marks tests that require integration dependencies
 filterwarnings =
     # PyTest filter syntax cheatsheet -> action:message:category:module:line
     ignore::UserWarning:altair.*:

--- a/lib/pytest.ini
+++ b/lib/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 markers =
     slow: marks tests as slow
-    require_integration: marks tests that require integration dependencies
 filterwarnings =
     # PyTest filter syntax cheatsheet -> action:message:category:module:line
     ignore::UserWarning:altair.*:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -282,7 +282,7 @@ class SQLConnection(BaseConnection["Engine"]):
 
         This is equivalent to accessing ``self._instance.driver``.
         """
-        return cast(str, self._instance.driver)
+        return self._instance.driver
 
     @property
     def session(self) -> Session:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: We ignore all mypy import-not-found errors as top-level since
+# this module is optional and the SQLAlchemy dependency is not installed
+# by default.
+# mypy: disable-error-code="import-not-found, redundant-cast"
+
 from __future__ import annotations
 
 from collections import ChainMap

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -282,7 +282,7 @@ class SQLConnection(BaseConnection["Engine"]):
 
         This is equivalent to accessing ``self._instance.driver``.
         """
-        return self._instance.driver
+        return cast(str, self._instance.driver)
 
     @property
     def session(self) -> Session:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1192,7 +1192,7 @@ def convert_pandas_df_to_data_format(
         data_format == DataFormat.POLARS_DATAFRAME
         or data_format == DataFormat.POLARS_LAZYFRAME
     ):
-        import polars as pl
+        import polars as pl  # type: ignore[import-not-found]
 
         return pl.from_pandas(df)
     elif data_format == DataFormat.POLARS_SERIES:
@@ -1200,7 +1200,7 @@ def convert_pandas_df_to_data_format(
 
         return pl.from_pandas(_pandas_df_to_series(df))
     elif data_format == DataFormat.XARRAY_DATASET:
-        import xarray as xr
+        import xarray as xr  # type: ignore[import-not-found]
 
         return xr.Dataset.from_dataframe(df)
     elif data_format == DataFormat.XARRAY_DATA_ARRAY:

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -31,25 +31,20 @@ the API *from LangChain itself*.
 This module is lazy-loaded.
 """
 
-# NOTE: We ignore all mypy import-not-found errors as top-level since
-# this module is optional and the langchain dependency is not installed
-# by default.
-# mypy: disable-error-code="import-not-found, unused-ignore, misc"
-
 from __future__ import annotations
 
 import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from langchain.callbacks.base import (
+from langchain.callbacks.base import (  # type: ignore[import-not-found, unused-ignore]
     BaseCallbackHandler,
 )
 
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
-    from langchain.schema import (
+    from langchain.schema import (  # type: ignore[import-not-found, unused-ignore]
         AgentAction,
         AgentFinish,
         LLMResult,

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -31,20 +31,25 @@ the API *from LangChain itself*.
 This module is lazy-loaded.
 """
 
+# NOTE: We ignore all mypy import-not-found errors as top-level since
+# this module is optional and the langchain dependency is not installed
+# by default.
+# mypy: disable-error-code="import-not-found, unused-ignore, misc"
+
 from __future__ import annotations
 
 import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from langchain.callbacks.base import (  # type: ignore[import-not-found, unused-ignore]
+from langchain.callbacks.base import (
     BaseCallbackHandler,
 )
 
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
-    from langchain.schema import (  # type: ignore[import-not-found, unused-ignore]
+    from langchain.schema import (
         AgentAction,
         AgentFinish,
         LLMResult,

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -160,9 +160,9 @@ def _fix_pydantic_duplicate_validators_error():
     which should not be critical.
     """
     try:
-        from pydantic import class_validators
+        from pydantic import class_validators  # type: ignore[import-not-found]
 
-        class_validators.in_ipython = lambda: True  # type: ignore[attr-defined]
+        class_validators.in_ipython = lambda: True
     except ImportError:
         pass
 

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -5,11 +5,8 @@ bokeh==2.4.3
 graphviz>=0.17
 matplotlib>=3.3.4
 plotly>=5.3.1
-pydot>=1.4.2
-scipy>=1.7.3
 seaborn>=0.11.2
 watchdog>=2.1.5
-urllib3>=1.9
 # Use by vega-lite / altair e2e tests:
 vega_datasets
 # Testing infrastructure dependencies:
@@ -31,14 +28,5 @@ pixelmatch>=0.3.0
 pytest-xdist
 pytest-rerunfailures
 pytest-github-actions-annotate-failures
-
 # Used for testing of st.connection
 sqlalchemy[mypy]>=1.4.25, <2
-
-# Pydantic 1.* fails to initialize validators, we add it to requirements
-# to test the fix. Pydantic 2 should not have that issue.
-pydantic>=1.0, <2.0
-
-# Required for testing the langchain integration
-langchain>=0.2.0
-langchain-community>=0.2.0

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -31,5 +31,4 @@ pixelmatch>=0.3.0
 pytest-xdist
 pytest-rerunfailures
 pytest-github-actions-annotate-failures
-# Used for testing of st.connection
-sqlalchemy[mypy]>=1.4.25, <2
+

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -39,11 +39,6 @@ sqlalchemy[mypy]>=1.4.25, <2
 # to test the fix. Pydantic 2 should not have that issue.
 pydantic>=1.0, <2.0
 
-# Additional dataframe formats for testing:
-polars
-xarray
-dask
-
 # Required for testing the langchain integration
 langchain>=0.2.0
 langchain-community>=0.2.0

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -7,6 +7,9 @@ matplotlib>=3.3.4
 plotly>=5.3.1
 seaborn>=0.11.2
 watchdog>=2.1.5
+# We still need numpy < 2 for our bokeh tests since
+# bokeh 2.4.3 is incompatible with numpy 2.x:
+numpy<2
 # Use by vega-lite / altair e2e tests:
 vega_datasets
 # Testing infrastructure dependencies:

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -71,21 +71,21 @@ def pytest_addoption(parser: pytest.Parser):
     group = parser.getgroup("streamlit")
 
     group.addoption(
-        "--require-integration",
+        "--require-snowflake",
         action="store_true",
-        help="only run integration tests. ",
+        help="only run tests that requires snowflake. ",
     )
 
 
 def pytest_configure(config: pytest.Config):
     config.addinivalue_line(
         "markers",
-        "require_integration(name): mark test to run only on "
-        "when --require-integration option is passed to pytest",
+        "require_snowflake(name): mark test to run only on "
+        "when --require-snowflake option is passed to pytest",
     )
 
-    is_require_integration = config.getoption("--require-integration", default=False)
-    if is_require_integration:
+    is_require_snowflake = config.getoption("--require-snowflake", default=False)
+    if is_require_snowflake:
         try:
             import snowflake.snowpark  # noqa: F401
         except ImportError:
@@ -104,21 +104,19 @@ def pytest_runtest_setup(item: pytest.Item):
 
     PagesManager.DefaultStrategy = PagesStrategyV1
 
-    is_require_integration = item.config.getoption(
-        "--require-integration", default=False
-    )
-    has_require_integration_marker = bool(
-        list(item.iter_markers(name="require_integration"))
+    is_require_snowflake = item.config.getoption("--require-snowflake", default=False)
+    has_require_snowflake_marker = bool(
+        list(item.iter_markers(name="require_snowflake"))
     )
 
-    if is_require_integration and not has_require_integration_marker:
+    if is_require_snowflake and not has_require_snowflake_marker:
         pytest.skip(
-            f"The test is skipped because it has require_integration marker. "
-            f"This tests are only run when --require-integration flag is passed to pytest. "
+            f"The test is skipped because it has require_snowflake marker. "
+            f"This tests are only run when --require-snowflake flag is passed to pytest. "
             f"{item}"
         )
-    if not is_require_integration and has_require_integration_marker:
+    if not is_require_snowflake and has_require_snowflake_marker:
         pytest.skip(
             f"The test is skipped because it does not have the right marker. "
-            f"Only tests marked with pytest.mark.require_integration() are run. {item}"
+            f"Only tests marked with pytest.mark.require_snowflake() are run. {item}"
         )

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -71,21 +71,21 @@ def pytest_addoption(parser: pytest.Parser):
     group = parser.getgroup("streamlit")
 
     group.addoption(
-        "--require-snowflake",
+        "--require-integration",
         action="store_true",
-        help="only run tests that requires snowflake. ",
+        help="only run integration tests. ",
     )
 
 
 def pytest_configure(config: pytest.Config):
     config.addinivalue_line(
         "markers",
-        "require_snowflake(name): mark test to run only on "
-        "when --require-snowflake option is passed to pytest",
+        "require_integration(name): mark test to run only on "
+        "when --require-integration option is passed to pytest",
     )
 
-    is_require_snowflake = config.getoption("--require-snowflake", default=False)
-    if is_require_snowflake:
+    is_require_integration = config.getoption("--require-integration", default=False)
+    if is_require_integration:
         try:
             import snowflake.snowpark  # noqa: F401
         except ImportError:
@@ -104,19 +104,21 @@ def pytest_runtest_setup(item: pytest.Item):
 
     PagesManager.DefaultStrategy = PagesStrategyV1
 
-    is_require_snowflake = item.config.getoption("--require-snowflake", default=False)
-    has_require_snowflake_marker = bool(
-        list(item.iter_markers(name="require_snowflake"))
+    is_require_integration = item.config.getoption(
+        "--require-integration", default=False
+    )
+    has_require_integration_marker = bool(
+        list(item.iter_markers(name="require_integration"))
     )
 
-    if is_require_snowflake and not has_require_snowflake_marker:
+    if is_require_integration and not has_require_integration_marker:
         pytest.skip(
-            f"The test is skipped because it has require_snowflake marker. "
-            f"This tests are only run when --require-snowflake flag is passed to pytest. "
+            f"The test is skipped because it has require_integration marker. "
+            f"This tests are only run when --require-integration flag is passed to pytest. "
             f"{item}"
         )
-    if not is_require_snowflake and has_require_snowflake_marker:
+    if not is_require_integration and has_require_integration_marker:
         pytest.skip(
             f"The test is skipped because it does not have the right marker. "
-            f"Only tests marked with pytest.mark.require_snowflake() are run. {item}"
+            f"Only tests marked with pytest.mark.require_integration() are run. {item}"
         )

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -42,9 +42,10 @@ from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime, RuntimeConfig
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
-from streamlit.runtime.scriptrunner import ScriptRunContext, add_script_run_ctx
+from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.type_util import to_bytes
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.testutil import create_mock_script_run_ctx
 
 if TYPE_CHECKING:
     from streamlit.components.types.base_custom_component import BaseCustomComponent
@@ -81,8 +82,7 @@ class DeclareComponentTest(unittest.TestCase):
         self.runtime = Runtime(config)
 
         # declare_component needs a script_run_ctx to be set
-        self.script_run_ctx = MagicMock(spec=ScriptRunContext)
-        add_script_run_ctx(threading.current_thread(), self.script_run_ctx)
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
     def tearDown(self) -> None:
         Runtime._instance = None

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -26,7 +26,7 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
-@pytest.mark.require_snowflake
+@pytest.mark.require_integration
 class SnowflakeConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -26,7 +26,7 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
-@pytest.mark.require_integration
+@pytest.mark.require_snowflake
 class SnowflakeConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -26,7 +26,7 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
-@pytest.mark.require_integration
+@pytest.mark.require_snowflake
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -26,7 +26,7 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
-@pytest.mark.require_snowflake
+@pytest.mark.require_integration
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -41,7 +41,6 @@ DB_SECRETS = {
 }
 
 
-@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def setUp(self) -> None:
         # Caching functions rely on an active script run ctx
@@ -55,6 +54,7 @@ class SQLConnectionTest(unittest.TestCase):
 
         st.cache_data.clear()
 
+    @pytest.mark.require_integration
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -66,6 +66,7 @@ class SQLConnectionTest(unittest.TestCase):
 
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -81,6 +82,7 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
         )
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -101,6 +103,7 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
         )
 
+    @pytest.mark.require_integration
     def test_error_if_no_config(self):
         with patch(
             "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -111,6 +114,7 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert "Missing SQL DB connection configuration." in str(e.value)
 
+    @pytest.mark.require_integration
     @parameterized.expand([("dialect",), ("username",), ("host",)])
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)
@@ -125,6 +129,7 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(
@@ -145,6 +150,7 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert kwargs == {"foo": "bar", "baz": "qux"}
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_query_caches_value(self, patched_read_sql):
@@ -158,6 +164,7 @@ class SQLConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
@@ -174,6 +181,7 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert patched_read_sql.call_count == 2
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_scopes_caches_by_connection_name(self, patched_read_sql):
@@ -191,6 +199,7 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert patched_read_sql.call_count == 2
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     def test_repr_html_(self):
         conn = SQLConnection("my_sql_connection")
@@ -204,6 +213,7 @@ class SQLConnectionTest(unittest.TestCase):
         )
         assert "Dialect: `postgres`" in repr_
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -222,6 +232,7 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior(self, patched_read_sql):
@@ -246,6 +257,7 @@ class SQLConnectionTest(unittest.TestCase):
             assert conn._connect.call_count == 3
             conn._connect.reset_mock()
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+import unittest
 from copy import deepcopy
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -20,8 +22,13 @@ from parameterized import parameterized
 
 from streamlit.connections import SQLConnection
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime import Runtime
+from streamlit.runtime.caching.storage.dummy_cache_storage import (
+    MemoryCacheStorageManager,
+)
+from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.secrets import AttrDict
-from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.testutil import create_mock_script_run_ctx
 
 DB_SECRETS = {
     "dialect": "postgres",
@@ -34,8 +41,20 @@ DB_SECRETS = {
 }
 
 
-@pytest.mark.require_integration
-class SQLConnectionTest(DeltaGeneratorTestCase):
+class SQLConnectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        Runtime._instance = mock_runtime
+
+    def tearDown(self):
+        import streamlit as st
+
+        st.cache_data.clear()
+
+    @pytest.mark.require_integration
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -47,6 +66,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
 
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -62,6 +82,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
         )
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -82,6 +103,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
             == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
         )
 
+    @pytest.mark.require_integration
     def test_error_if_no_config(self):
         with patch(
             "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -93,6 +115,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
             assert "Missing SQL DB connection configuration." in str(e.value)
 
     @parameterized.expand([("dialect",), ("username",), ("host",)])
+    @pytest.mark.require_integration
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)
         del secrets[missing_param]
@@ -106,6 +129,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
+    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(
@@ -126,9 +150,12 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
 
         assert kwargs == {"foo": "bar", "baz": "qux"}
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_query_caches_value(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -137,9 +164,12 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -151,9 +181,12 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
 
         assert patched_read_sql.call_count == 2
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_scopes_caches_by_connection_name(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn1 = SQLConnection("my_sql_connection1")
@@ -166,6 +199,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
 
         assert patched_read_sql.call_count == 2
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     def test_repr_html_(self):
         conn = SQLConnection("my_sql_connection")
@@ -179,6 +213,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
         )
         assert "Dialect: `postgres`" in repr_
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -197,6 +232,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior(self, patched_read_sql):
@@ -221,6 +257,7 @@ class SQLConnectionTest(DeltaGeneratorTestCase):
             assert conn._connect.call_count == 3
             conn._connect.reset_mock()
 
+    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -114,8 +114,8 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert "Missing SQL DB connection configuration." in str(e.value)
 
-    @parameterized.expand([("dialect",), ("username",), ("host",)])
     @pytest.mark.require_integration
+    @parameterized.expand([("dialect",), ("username",), ("host",)])
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)
         del secrets[missing_param]

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -22,6 +22,10 @@ from parameterized import parameterized
 
 from streamlit.connections import SQLConnection
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime import Runtime
+from streamlit.runtime.caching.storage.dummy_cache_storage import (
+    MemoryCacheStorageManager,
+)
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
@@ -38,6 +42,13 @@ DB_SECRETS = {
 
 
 class SQLConnectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        Runtime._instance = mock_runtime
+
     def tearDown(self) -> None:
         import streamlit as st
 

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -20,7 +20,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from parameterized import parameterized
 
-import streamlit as st
 from streamlit.connections import SQLConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -38,8 +37,11 @@ DB_SECRETS = {
 }
 
 
+@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
+        import streamlit as st
+
         st.cache_data.clear()
 
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -38,6 +38,7 @@ DB_SECRETS = {
 }
 
 
+@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
-import unittest
 from copy import deepcopy
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -22,13 +20,8 @@ from parameterized import parameterized
 
 from streamlit.connections import SQLConnection
 from streamlit.errors import StreamlitAPIException
-from streamlit.runtime import Runtime
-from streamlit.runtime.caching.storage.dummy_cache_storage import (
-    MemoryCacheStorageManager,
-)
-from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.secrets import AttrDict
-from tests.testutil import create_mock_script_run_ctx
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 DB_SECRETS = {
     "dialect": "postgres",
@@ -41,20 +34,8 @@ DB_SECRETS = {
 }
 
 
-class SQLConnectionTest(unittest.TestCase):
-    def setUp(self) -> None:
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
-        mock_runtime = MagicMock(spec=Runtime)
-        mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
-        Runtime._instance = mock_runtime
-
-    def tearDown(self) -> None:
-        import streamlit as st
-
-        st.cache_data.clear()
-
-    @pytest.mark.require_integration
+@pytest.mark.require_integration
+class SQLConnectionTest(DeltaGeneratorTestCase):
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -66,7 +47,6 @@ class SQLConnectionTest(unittest.TestCase):
 
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
-    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -82,7 +62,6 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
         )
 
-    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(return_value=AttrDict(DB_SECRETS)),
@@ -103,7 +82,6 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
         )
 
-    @pytest.mark.require_integration
     def test_error_if_no_config(self):
         with patch(
             "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -115,7 +93,6 @@ class SQLConnectionTest(unittest.TestCase):
             assert "Missing SQL DB connection configuration." in str(e.value)
 
     @parameterized.expand([("dialect",), ("username",), ("host",)])
-    @pytest.mark.require_integration
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)
         del secrets[missing_param]
@@ -129,7 +106,6 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
-    @pytest.mark.require_integration
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
         PropertyMock(
@@ -150,12 +126,9 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert kwargs == {"foo": "bar", "baz": "qux"}
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_query_caches_value(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -164,12 +137,9 @@ class SQLConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -181,12 +151,9 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert patched_read_sql.call_count == 2
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_scopes_caches_by_connection_name(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn1 = SQLConnection("my_sql_connection1")
@@ -199,7 +166,6 @@ class SQLConnectionTest(unittest.TestCase):
 
         assert patched_read_sql.call_count == 2
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     def test_repr_html_(self):
         conn = SQLConnection("my_sql_connection")
@@ -213,7 +179,6 @@ class SQLConnectionTest(unittest.TestCase):
         )
         assert "Dialect: `postgres`" in repr_
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch(
         "streamlit.connections.sql_connection.SQLConnection._secrets",
@@ -232,7 +197,6 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior(self, patched_read_sql):
@@ -257,7 +221,6 @@ class SQLConnectionTest(unittest.TestCase):
             assert conn._connect.call_count == 3
             conn._connect.reset_mock()
 
-    @pytest.mark.require_integration
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+import unittest
+from copy import deepcopy
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from parameterized import parameterized
+
+import streamlit as st
+from streamlit.connections import SQLConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
+from tests.testutil import create_mock_script_run_ctx
 
 DB_SECRETS = {
     "dialect": "postgres",
@@ -24,230 +38,213 @@ DB_SECRETS = {
 }
 
 
-# class SQLConnectionTest(unittest.TestCase):
-#     def setUp(self) -> None:
-#         # Caching functions rely on an active script run ctx
-#         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
-#         mock_runtime = MagicMock(spec=Runtime)
-#         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
-#         Runtime._instance = mock_runtime
+@pytest.mark.require_integration
+class SQLConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
 
-#     def tearDown(self):
-#         import streamlit as st
+    @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
+    @patch(
+        "streamlit.connections.sql_connection.SQLConnection._secrets",
+        PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_set_explicitly_in_secrets(self, patched_create_engine):
+        SQLConnection("my_sql_connection")
 
-#         st.cache_data.clear()
+        patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
-#     @pytest.mark.require_integration
-#     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
-#     @patch(
-#         "streamlit.connections.sql_connection.SQLConnection._secrets",
-#         PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
-#     )
-#     @patch("sqlalchemy.create_engine")
-#     def test_url_set_explicitly_in_secrets(self, patched_create_engine):
-#         SQLConnection("my_sql_connection")
+    @patch(
+        "streamlit.connections.sql_connection.SQLConnection._secrets",
+        PropertyMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_constructed_from_secrets_params(self, patched_create_engine):
+        SQLConnection("my_sql_connection")
 
-#         patched_create_engine.assert_called_once_with("some_sql_conn_string")
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
+        )
 
-#     @pytest.mark.require_integration
-#     @patch(
-#         "streamlit.connections.sql_connection.SQLConnection._secrets",
-#         PropertyMock(return_value=AttrDict(DB_SECRETS)),
-#     )
-#     @patch("sqlalchemy.create_engine")
-#     def test_url_constructed_from_secrets_params(self, patched_create_engine):
-#         SQLConnection("my_sql_connection")
+    @patch(
+        "streamlit.connections.sql_connection.SQLConnection._secrets",
+        PropertyMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_kwargs_overwrite_secrets_values(self, patched_create_engine):
+        SQLConnection(
+            "my_sql_connection",
+            port=2345,
+            username="DnomaidEruza",
+            query={"charset": "utf8mb4"},
+        )
 
-#         patched_create_engine.assert_called_once()
-#         args, _ = patched_create_engine.call_args_list[0]
-#         assert (
-#             str(args[0])
-#             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
-#         )
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
+        )
 
-#     @pytest.mark.require_integration
-#     @patch(
-#         "streamlit.connections.sql_connection.SQLConnection._secrets",
-#         PropertyMock(return_value=AttrDict(DB_SECRETS)),
-#     )
-#     @patch("sqlalchemy.create_engine")
-#     def test_kwargs_overwrite_secrets_values(self, patched_create_engine):
-#         SQLConnection(
-#             "my_sql_connection",
-#             port=2345,
-#             username="DnomaidEruza",
-#             query={"charset": "utf8mb4"},
-#         )
+    def test_error_if_no_config(self):
+        with patch(
+            "streamlit.connections.sql_connection.SQLConnection._secrets",
+            PropertyMock(return_value=AttrDict({})),
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                SQLConnection("my_sql_connection")
 
-#         patched_create_engine.assert_called_once()
-#         args, _ = patched_create_engine.call_args_list[0]
-#         assert (
-#             str(args[0])
-#             == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres?charset=utf8mb4"
-#         )
+            assert "Missing SQL DB connection configuration." in str(e.value)
 
-#     @pytest.mark.require_integration
-#     def test_error_if_no_config(self):
-#         with patch(
-#             "streamlit.connections.sql_connection.SQLConnection._secrets",
-#             PropertyMock(return_value=AttrDict({})),
-#         ):
-#             with pytest.raises(StreamlitAPIException) as e:
-#                 SQLConnection("my_sql_connection")
+    @parameterized.expand([("dialect",), ("username",), ("host",)])
+    def test_error_if_missing_required_param(self, missing_param):
+        secrets = deepcopy(DB_SECRETS)
+        del secrets[missing_param]
 
-#             assert "Missing SQL DB connection configuration." in str(e.value)
+        with patch(
+            "streamlit.connections.sql_connection.SQLConnection._secrets",
+            PropertyMock(return_value=AttrDict(secrets)),
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                SQLConnection("my_sql_connection")
 
-#     @pytest.mark.require_integration
-#     def test_error_if_missing_required_param(self):
-#         for missing_param in ["dialect", "username", "host"]:
-#             secrets = deepcopy(DB_SECRETS)
-#             del secrets[missing_param]
+            assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
-#             with patch(
-#                 "streamlit.connections.sql_connection.SQLConnection._secrets",
-#                 PropertyMock(return_value=AttrDict(secrets)),
-#             ):
-#                 with pytest.raises(StreamlitAPIException) as e:
-#                     SQLConnection("my_sql_connection")
+    @patch(
+        "streamlit.connections.sql_connection.SQLConnection._secrets",
+        PropertyMock(
+            return_value=AttrDict(
+                {
+                    **DB_SECRETS,
+                    "create_engine_kwargs": {"foo": "bar", "baz": "i get overwritten"},
+                }
+            )
+        ),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_create_engine_kwargs_secrets_section(self, patched_create_engine):
+        SQLConnection("my_sql_connection", baz="qux")
 
-#                 assert (
-#                     str(e.value) == f"Missing SQL DB connection param: {missing_param}"
-#                 )
+        patched_create_engine.assert_called_once()
+        _, kwargs = patched_create_engine.call_args_list[0]
 
-#     @pytest.mark.require_integration
-#     @patch(
-#         "streamlit.connections.sql_connection.SQLConnection._secrets",
-#         PropertyMock(
-#             return_value=AttrDict(
-#                 {
-#                     **DB_SECRETS,
-#                     "create_engine_kwargs": {"foo": "bar", "baz": "i get overwritten"},
-#                 }
-#             )
-#         ),
-#     )
-#     @patch("sqlalchemy.create_engine")
-#     def test_create_engine_kwargs_secrets_section(self, patched_create_engine):
-#         SQLConnection("my_sql_connection", baz="qux")
+        assert kwargs == {"foo": "bar", "baz": "qux"}
 
-#         patched_create_engine.assert_called_once()
-#         _, kwargs = patched_create_engine.call_args_list[0]
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("pandas.read_sql")
+    def test_query_caches_value(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
 
-#         assert kwargs == {"foo": "bar", "baz": "qux"}
+        conn = SQLConnection("my_sql_connection")
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch("pandas.read_sql")
-#     def test_query_caches_value(self, patched_read_sql):
-#         patched_read_sql.return_value = "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        patched_read_sql.assert_called_once()
 
-#         conn = SQLConnection("my_sql_connection")
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("pandas.read_sql")
+    def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
 
-#         assert conn.query("SELECT 1;") == "i am a dataframe"
-#         assert conn.query("SELECT 1;") == "i am a dataframe"
-#         patched_read_sql.assert_called_once()
+        conn = SQLConnection("my_sql_connection")
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch("pandas.read_sql")
-#     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
-#         patched_read_sql.return_value = "i am a dataframe"
+        conn.query("SELECT 1;", ttl=10)
+        conn.query("SELECT 2;", ttl=20)
+        conn.query("SELECT 1;", ttl=10)
+        conn.query("SELECT 2;", ttl=20)
 
-#         conn = SQLConnection("my_sql_connection")
+        assert patched_read_sql.call_count == 2
 
-#         conn.query("SELECT 1;", ttl=10)
-#         conn.query("SELECT 2;", ttl=20)
-#         conn.query("SELECT 1;", ttl=10)
-#         conn.query("SELECT 2;", ttl=20)
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("pandas.read_sql")
+    def test_scopes_caches_by_connection_name(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
 
-#         assert patched_read_sql.call_count == 2
+        conn1 = SQLConnection("my_sql_connection1")
+        conn2 = SQLConnection("my_sql_connection2")
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch("pandas.read_sql")
-#     def test_scopes_caches_by_connection_name(self, patched_read_sql):
-#         patched_read_sql.return_value = "i am a dataframe"
+        conn1.query("SELECT 1;")
+        conn1.query("SELECT 1;")
+        conn2.query("SELECT 1;")
+        conn2.query("SELECT 1;")
 
-#         conn1 = SQLConnection("my_sql_connection1")
-#         conn2 = SQLConnection("my_sql_connection2")
+        assert patched_read_sql.call_count == 2
 
-#         conn1.query("SELECT 1;")
-#         conn1.query("SELECT 1;")
-#         conn2.query("SELECT 1;")
-#         conn2.query("SELECT 1;")
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    def test_repr_html_(self):
+        conn = SQLConnection("my_sql_connection")
+        with conn.session as s:
+            s.bind.dialect.name = "postgres"
+        repr_ = conn._repr_html_()
 
-#         assert patched_read_sql.call_count == 2
+        assert (
+            "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQLConnection`"
+            in repr_
+        )
+        assert "Dialect: `postgres`" in repr_
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     def test_repr_html_(self):
-#         conn = SQLConnection("my_sql_connection")
-#         with conn.session as s:
-#             s.bind.dialect.name = "postgres"
-#         repr_ = conn._repr_html_()
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch(
+        "streamlit.connections.sql_connection.SQLConnection._secrets",
+        PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+    )
+    def test_repr_html_with_secrets(self):
+        conn = SQLConnection("my_sql_connection")
+        with conn.session as s:
+            s.bind.dialect.name = "postgres"
+        repr_ = conn._repr_html_()
 
-#         assert (
-#             "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQLConnection`"
-#             in repr_
-#         )
-#         assert "Dialect: `postgres`" in repr_
+        assert (
+            "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQLConnection`"
+            in repr_
+        )
+        assert "Dialect: `postgres`" in repr_
+        assert "Configured from `[connections.my_sql_connection]`" in repr_
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch(
-#         "streamlit.connections.sql_connection.SQLConnection._secrets",
-#         PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
-#     )
-#     def test_repr_html_with_secrets(self):
-#         conn = SQLConnection("my_sql_connection")
-#         with conn.session as s:
-#             s.bind.dialect.name = "postgres"
-#         repr_ = conn._repr_html_()
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("pandas.read_sql")
+    def test_retry_behavior(self, patched_read_sql):
+        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
-#         assert (
-#             "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQLConnection`"
-#             in repr_
-#         )
-#         assert "Dialect: `postgres`" in repr_
-#         assert "Configured from `[connections.my_sql_connection]`" in repr_
+        for error_class in [DatabaseError, InternalError, OperationalError]:
+            patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch("pandas.read_sql")
-#     def test_retry_behavior(self, patched_read_sql):
-#         from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
+            conn = SQLConnection("my_sql_connection")
 
-#         for error_class in [DatabaseError, InternalError, OperationalError]:
-#             patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
+            with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+                with pytest.raises(error_class):
+                    conn.query("SELECT 1;")
 
-#             conn = SQLConnection("my_sql_connection")
+                # Our connection should have been reset after each failed attempt to call
+                # query.
+                assert wrapped_reset.call_count == 3
 
-#             with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-#                 with pytest.raises(error_class):
-#                     conn.query("SELECT 1;")
+            # conn._connect should have been called three times: once in the initial
+            # connection, then once each after the second and third attempts to call
+            # query.
+            assert conn._connect.call_count == 3
+            conn._connect.reset_mock()
 
-#                 # Our connection should have been reset after each failed attempt to call
-#                 # query.
-#                 assert wrapped_reset.call_count == 3
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("pandas.read_sql")
+    def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):
+        patched_read_sql.side_effect = Exception("kaboom")
 
-#             # conn._connect should have been called three times: once in the initial
-#             # connection, then once each after the second and third attempts to call
-#             # query.
-#             assert conn._connect.call_count == 3
-#             conn._connect.reset_mock()
+        conn = SQLConnection("my_sql_connection")
 
-#     @pytest.mark.require_integration
-#     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-#     @patch("pandas.read_sql")
-#     def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):
-#         patched_read_sql.side_effect = Exception("kaboom")
+        with pytest.raises(Exception):  # noqa: B017
+            conn.query("SELECT 1;")
 
-#         conn = SQLConnection("my_sql_connection")
-
-#         with pytest.raises(Exception):
-#             conn.query("SELECT 1;")
-
-#         # conn._connect should have just been called once when first creating the
-#         # connection.
-#         assert conn._connect.call_count == 1
-#         conn._connect.reset_mock()
+        # conn._connect should have just been called once when first creating the
+        # connection.
+        assert conn._connect.call_count == 1
+        conn._connect.reset_mock()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from parameterized import parameterized
-from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
 import streamlit as st
 from streamlit.connections import SQLConnection
@@ -210,27 +209,29 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
-    @parameterized.expand([(DatabaseError,), (InternalError,), (OperationalError,)])
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
-    def test_retry_behavior(self, error_class, patched_read_sql):
-        patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
+    def test_retry_behavior(self, patched_read_sql):
+        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
-        conn = SQLConnection("my_sql_connection")
+        for error_class in [DatabaseError, InternalError, OperationalError]:
+            patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
 
-        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-            with pytest.raises(error_class):
-                conn.query("SELECT 1;")
+            conn = SQLConnection("my_sql_connection")
 
-            # Our connection should have been reset after each failed attempt to call
+            with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+                with pytest.raises(error_class):
+                    conn.query("SELECT 1;")
+
+                # Our connection should have been reset after each failed attempt to call
+                # query.
+                assert wrapped_reset.call_count == 3
+
+            # conn._connect should have been called three times: once in the initial
+            # connection, then once each after the second and third attempts to call
             # query.
-            assert wrapped_reset.call_count == 3
-
-        # conn._connect should have been called three times: once in the initial
-        # connection, then once each after the second and third attempts to call
-        # query.
-        assert conn._connect.call_count == 3
-        conn._connect.reset_mock()
+            assert conn._connect.call_count == 3
+            conn._connect.reset_mock()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -114,8 +114,8 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert "Missing SQL DB connection configuration." in str(e.value)
 
-    @pytest.mark.require_integration
     @parameterized.expand([("dialect",), ("username",), ("host",)])
+    @pytest.mark.require_integration
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)
         del secrets[missing_param]

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -18,7 +18,6 @@ from copy import deepcopy
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from parameterized import parameterized
 
 from streamlit.connections import SQLConnection
 from streamlit.errors import StreamlitAPIException
@@ -115,19 +114,21 @@ class SQLConnectionTest(unittest.TestCase):
             assert "Missing SQL DB connection configuration." in str(e.value)
 
     @pytest.mark.require_integration
-    @parameterized.expand([("dialect",), ("username",), ("host",)])
-    def test_error_if_missing_required_param(self, missing_param):
-        secrets = deepcopy(DB_SECRETS)
-        del secrets[missing_param]
+    def test_error_if_missing_required_param(self):
+        for missing_param in ["dialect", "username", "host"]:
+            secrets = deepcopy(DB_SECRETS)
+            del secrets[missing_param]
 
-        with patch(
-            "streamlit.connections.sql_connection.SQLConnection._secrets",
-            PropertyMock(return_value=AttrDict(secrets)),
-        ):
-            with pytest.raises(StreamlitAPIException) as e:
-                SQLConnection("my_sql_connection")
+            with patch(
+                "streamlit.connections.sql_connection.SQLConnection._secrets",
+                PropertyMock(return_value=AttrDict(secrets)),
+            ):
+                with pytest.raises(StreamlitAPIException) as e:
+                    SQLConnection("my_sql_connection")
 
-            assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
+                assert (
+                    str(e.value) == f"Missing SQL DB connection param: {missing_param}"
+                )
 
     @pytest.mark.require_integration
     @patch(

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -41,6 +41,7 @@ DB_SECRETS = {
 }
 
 
+@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def setUp(self) -> None:
         # Caching functions rely on an active script run ctx

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -37,7 +37,6 @@ DB_SECRETS = {
 }
 
 
-@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         import streamlit as st

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -154,8 +154,6 @@ class SQLConnectionTest(unittest.TestCase):
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_query_caches_value(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -168,8 +166,6 @@ class SQLConnectionTest(unittest.TestCase):
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQLConnection("my_sql_connection")
@@ -185,8 +181,6 @@ class SQLConnectionTest(unittest.TestCase):
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
     def test_scopes_caches_by_connection_name(self, patched_read_sql):
-        # Caching functions rely on an active script run ctx
-        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn1 = SQLConnection("my_sql_connection1")

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -38,7 +38,6 @@ DB_SECRETS = {
 }
 
 
-@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from parameterized import parameterized
-from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
 import streamlit as st
 from streamlit.connections import SQLConnection
@@ -39,6 +38,7 @@ DB_SECRETS = {
 }
 
 
+@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
@@ -210,27 +210,29 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
-    @parameterized.expand([(DatabaseError,), (InternalError,), (OperationalError,)])
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
-    def test_retry_behavior(self, error_class, patched_read_sql):
-        patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
+    def test_retry_behavior(self, patched_read_sql):
+        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
-        conn = SQLConnection("my_sql_connection")
+        for error_class in [DatabaseError, InternalError, OperationalError]:
+            patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
 
-        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-            with pytest.raises(error_class):
-                conn.query("SELECT 1;")
+            conn = SQLConnection("my_sql_connection")
 
-            # Our connection should have been reset after each failed attempt to call
+            with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+                with pytest.raises(error_class):
+                    conn.query("SELECT 1;")
+
+                # Our connection should have been reset after each failed attempt to call
+                # query.
+                assert wrapped_reset.call_count == 3
+
+            # conn._connect should have been called three times: once in the initial
+            # connection, then once each after the second and third attempts to call
             # query.
-            assert wrapped_reset.call_count == 3
-
-        # conn._connect should have been called three times: once in the initial
-        # connection, then once each after the second and third attempts to call
-        # query.
-        assert conn._connect.call_count == 3
-        conn._connect.reset_mock()
+            assert conn._connect.call_count == 3
+            conn._connect.reset_mock()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from parameterized import parameterized
+from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
 
 import streamlit as st
 from streamlit.connections import SQLConnection
@@ -38,7 +39,6 @@ DB_SECRETS = {
 }
 
 
-@pytest.mark.require_integration
 class SQLConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
@@ -210,29 +210,27 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
+    @parameterized.expand([(DatabaseError,), (InternalError,), (OperationalError,)])
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
-    def test_retry_behavior(self, patched_read_sql):
-        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
+    def test_retry_behavior(self, error_class, patched_read_sql):
+        patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
 
-        for error_class in [DatabaseError, InternalError, OperationalError]:
-            patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
+        conn = SQLConnection("my_sql_connection")
 
-            conn = SQLConnection("my_sql_connection")
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(error_class):
+                conn.query("SELECT 1;")
 
-            with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-                with pytest.raises(error_class):
-                    conn.query("SELECT 1;")
-
-                # Our connection should have been reset after each failed attempt to call
-                # query.
-                assert wrapped_reset.call_count == 3
-
-            # conn._connect should have been called three times: once in the initial
-            # connection, then once each after the second and third attempts to call
+            # Our connection should have been reset after each failed attempt to call
             # query.
-            assert conn._connect.call_count == 3
-            conn._connect.reset_mock()
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # query.
+        assert conn._connect.call_count == 3
+        conn._connect.reset_mock()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -39,7 +39,7 @@ class ConnectionUtilTest(unittest.TestCase):
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 
-    @pytest.mark.require_snowflake
+    @pytest.mark.require_integration
     @patch(
         "snowflake.snowpark._internal.utils.is_in_stored_procedure",
         MagicMock(return_value=True),
@@ -47,7 +47,7 @@ class ConnectionUtilTest(unittest.TestCase):
     def test_running_in_sis(self):
         assert running_in_sis()
 
-    @pytest.mark.require_snowflake
+    @pytest.mark.require_integration
     @patch(
         "snowflake.snowpark._internal.utils.is_in_stored_procedure",
         MagicMock(side_effect=ModuleNotFoundError("oh no")),

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -39,7 +39,7 @@ class ConnectionUtilTest(unittest.TestCase):
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 
-    @pytest.mark.require_integration
+    @pytest.mark.require_snowflake
     @patch(
         "snowflake.snowpark._internal.utils.is_in_stored_procedure",
         MagicMock(return_value=True),
@@ -47,7 +47,7 @@ class ConnectionUtilTest(unittest.TestCase):
     def test_running_in_sis(self):
         assert running_in_sis()
 
-    @pytest.mark.require_integration
+    @pytest.mark.require_snowflake
     @patch(
         "snowflake.snowpark._internal.utils.is_in_stored_procedure",
         MagicMock(side_effect=ModuleNotFoundError("oh no")),

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -522,7 +522,7 @@ class DataframeUtilTest(unittest.TestCase):
         This is in addition to the tests using the mocks to verify that
         the latest version of the library is still supported.
         """
-        dask = pytest.importorskip("dask")
+        import dask
 
         dask_df = dask.datasets.timeseries()
 
@@ -553,7 +553,7 @@ class DataframeUtilTest(unittest.TestCase):
         This is in addition to the tests using the mocks to verify that
         the latest version of the library is still supported.
         """
-        ray = pytest.importorskip("ray")
+        import ray
 
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         ray_dataset = ray.data.from_pandas(df)

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -515,6 +515,7 @@ class DataframeUtilTest(unittest.TestCase):
                 pd.DataFrame,
             )
 
+    @pytest.mark.require_integration
     def test_verify_dask_integration(self):
         """Integration test dask object handling.
 
@@ -545,6 +546,7 @@ class DataframeUtilTest(unittest.TestCase):
             pd.DataFrame,
         )
 
+    @pytest.mark.require_integration
     def test_verify_ray_integration(self):
         """Integration test ray object handling.
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -449,7 +449,7 @@ class DataframeUtilTest(unittest.TestCase):
         # if snowflake.snowpark.dataframe.DataFrame def is_snowpark_data_object should return true
         self.assertTrue(dataframe_util.is_snowpark_data_object(SnowparkDataFrame(df)))
 
-    @pytest.mark.require_snowflake
+    @pytest.mark.require_integration
     def test_verify_snowpark_integration(self):
         """Integration test snowpark object handling.
         This is in addition to the tests using the mocks to verify that
@@ -482,7 +482,7 @@ class DataframeUtilTest(unittest.TestCase):
                 pd.DataFrame,
             )
 
-    @pytest.mark.require_snowflake
+    @pytest.mark.require_integration
     def test_verify_snowpandas_integration(self):
         """Integration test snowpark pandas object handling.
         This is in addition to the tests using the mocks to verify that

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -449,7 +449,7 @@ class DataframeUtilTest(unittest.TestCase):
         # if snowflake.snowpark.dataframe.DataFrame def is_snowpark_data_object should return true
         self.assertTrue(dataframe_util.is_snowpark_data_object(SnowparkDataFrame(df)))
 
-    @pytest.mark.require_integration
+    @pytest.mark.require_snowflake
     def test_verify_snowpark_integration(self):
         """Integration test snowpark object handling.
         This is in addition to the tests using the mocks to verify that
@@ -482,7 +482,7 @@ class DataframeUtilTest(unittest.TestCase):
                 pd.DataFrame,
             )
 
-    @pytest.mark.require_integration
+    @pytest.mark.require_snowflake
     def test_verify_snowpandas_integration(self):
         """Integration test snowpark pandas object handling.
         This is in addition to the tests using the mocks to verify that

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -18,8 +18,8 @@ import os
 from io import BytesIO
 
 import numpy as np
+import pytest
 from parameterized import parameterized
-from scipy.io import wavfile
 
 import streamlit as st
 from streamlit.elements.media import (
@@ -210,8 +210,11 @@ class AudioTest(DeltaGeneratorTestCase):
         computed_bytes = _maybe_convert_to_wav_bytes(np_arr, sample_rate=None)
         self.assertTrue(computed_bytes is np_arr)
 
+    @pytest.mark.require_integration
     def test_st_audio_from_file(self):
         """Test st.audio using generated data in a file-like object."""
+        from scipy.io import wavfile
+
         sample_rate = 44100
         frequency = 440
         length = 5

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import unittest
 
+import pytest
+
 import streamlit as st
 
 
+@pytest.mark.require_integration
 class StreamlitCallbackHandlerAPITest(unittest.TestCase):
     def test_import_path(self):
         """StreamlitCallbackHandler is imported by LangChain itself, and so it

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -30,9 +30,14 @@ from tests import testutil
 from tests.testutil import patch_config_options, should_skip_pydantic_tests
 
 
+@pytest.mark.require_integration
 class BootstrapPydanticFixTest(unittest.TestCase):
     def pydantic_model_definition(self):
-        from pydantic import BaseModel, root_validator, validator
+        from pydantic import (  # type: ignore[import-not-found]
+            BaseModel,
+            root_validator,
+            validator,
+        )
 
         class UserModel(BaseModel):
             name: str
@@ -64,7 +69,7 @@ class BootstrapPydanticFixTest(unittest.TestCase):
     )
     @patch("pydantic.class_validators.in_ipython", Mock(return_value=False))
     def test_fix_pydantic_crash(self):
-        import pydantic
+        import pydantic  # type: ignore[import-not-found]
 
         # Check that without fix it crashes when model with validator
         # defined two times (we emulate Streamlit rerun).

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -31,9 +31,8 @@ import requests
 import requests_mock
 from click.testing import CliRunner
 from parameterized import parameterized
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter, Retry
 from testfixtures import tempdir
-from urllib3 import Retry
 
 import streamlit
 import streamlit.web.bootstrap

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -61,6 +61,7 @@ def create_mock_script_run_ctx() -> ScriptRunContext:
         user_info={"email": "mock@test.com"},
         fragment_storage=MemoryFragmentStorage(),
         pages_manager=PagesManager(""),
+        widget_ids_this_run=set(),
     )
 
 

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -61,7 +61,6 @@ def create_mock_script_run_ctx() -> ScriptRunContext:
         user_info={"email": "mock@test.com"},
         fragment_storage=MemoryFragmentStorage(),
         pages_manager=PagesManager(""),
-        widget_ids_this_run=set(),
     )
 
 

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -56,7 +56,7 @@ IGNORE_PATTERN = re.compile(
     r"|^(\.dockerignore|\.editorconfig|\.gitignore|\.gitmodules)$"
     r"|^frontend/(\.dockerignore|\.eslintrc.js|\.prettierignore)$"
     r"|^lib/(\.coveragerc|\.dockerignore|MANIFEST\.in|mypy\.ini)$"
-    r"|^lib/(test|dev)-requirements\.txt$"
+    r"|^lib/.*-requirements\.txt$"
     r"|^lib/min-constraints-gen\.txt"
     r"|\.isort\.cfg$"
     r"|\.credentials/\.gitignore$"

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -56,7 +56,7 @@ IGNORE_PATTERN = re.compile(
     r"|^(\.dockerignore|\.editorconfig|\.gitignore|\.gitmodules)$"
     r"|^frontend/(\.dockerignore|\.eslintrc.js|\.prettierignore)$"
     r"|^lib/(\.coveragerc|\.dockerignore|MANIFEST\.in|mypy\.ini)$"
-    r"|^lib/.*-requirements\.txt$"
+    r"|^lib/(test|dev)-requirements\.txt$"
     r"|^lib/min-constraints-gen\.txt"
     r"|\.isort\.cfg$"
     r"|\.credentials/\.gitignore$"


### PR DESCRIPTION
## Describe your changes

Refactors the snowflake integration test workflow to a more generic integration test that allows the testing of any optional dependencies/integrations. This also moves a couple of tests from our core unit test workflow to the integration test workflow:

- Snowflake integrations
- SQL-connection (uses SQLalchemy)
- Dataframe libraries Integrations
- Langchain Handler 

This makes it easier for us to add tests for more integrations since it will not interfere with our core tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
