### PR TITLE
Fix Circular Imports: Move deltagenerator static variable to own file

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -89,6 +89,13 @@ sidebar = _dg_singletons.sidebar_dg
 _event = _dg_singletons.event_dg
 _bottom = _dg_singletons.bottom_dg
 
+
+from streamlit.elements.lib.mutable_status_container import StatusContainer
+from streamlit.elements.lib.dialog import Dialog
+
+_dg_singletons._create_status_container = StatusContainer._create
+_dg_singletons._create_dialog = Dialog._create
+
 from streamlit.elements.dialog_decorator import (
     dialog_decorator as _dialog_decorator,
     experimental_dialog_decorator as _experimental_dialog_decorator,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -65,12 +65,25 @@ from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STR
 # Give the package a version.
 __version__ = _STREAMLIT_VERSION_STRING
 
-from streamlit.delta_generator import (
-    main_dg as _main_dg,
-    sidebar_dg as _sidebar_dg,
-    event_dg as _event_dg,
-    bottom_dg as _bottom_dg,
+from streamlit.delta_generator import DeltaGenerator
+from streamlit.proto.RootContainer_pb2 import RootContainer
+import streamlit.delta_generator_singletons as _dg_singletons
+
+# DeltaGenerator methods:
+_dg_singletons.main_dg = DeltaGenerator(root_container=RootContainer.MAIN)
+_dg_singletons.sidebar_dg = DeltaGenerator(
+    root_container=RootContainer.SIDEBAR, parent=_dg_singletons.main_dg
 )
+_dg_singletons.event_dg = DeltaGenerator(
+    root_container=RootContainer.EVENT, parent=_dg_singletons.main_dg
+)
+_dg_singletons.bottom_dg = DeltaGenerator(
+    root_container=RootContainer.BOTTOM, parent=_dg_singletons.main_dg
+)
+_main = _dg_singletons.main_dg
+sidebar = _dg_singletons.sidebar_dg
+_event = _dg_singletons.event_dg
+_bottom = _dg_singletons.bottom_dg
 
 from streamlit.elements.dialog_decorator import (
     dialog_decorator as _dialog_decorator,
@@ -103,9 +116,13 @@ from streamlit.commands.experimental_query_params import (
 
 import streamlit.column_config as _column_config
 
-# Modules that the user should have access to. These are imported with the "as" syntax and the same name; note that renaming the import with "as" does not make it an explicit export.
-# In this case, you should import it with an underscore to make clear that it is internal and then assign it to a variable with the new intended name.
-# You can check the export behavior by running 'mypy --strict example_app.py', which disables implicit_reexport, where you use the respective command in the example_app.py Streamlit app.
+# Modules that the user should have access to. These are imported with the "as" syntax
+# and the same name; note that renaming the import with "as" does not make it an
+# explicit export. In this case, you should import it with an underscore to make clear
+# that it is internal and then assign it to a variable with the new intended name.
+# You can check the export behavior by running 'mypy --strict example_app.py', which
+# disables implicit_reexport, where you use the respective command in the example_app.py
+# Streamlit app.
 
 from streamlit.echo import echo as echo
 from streamlit.commands.logo import logo as logo
@@ -133,12 +150,6 @@ def _update_logger() -> None:
 _config.on_config_parsed(_update_logger, True)
 
 secrets = _secrets_singleton
-
-# DeltaGenerator methods:
-_main = _main_dg
-sidebar = _sidebar_dg
-_event = _event_dg
-_bottom = _bottom_dg
 
 altair_chart = _main.altair_chart
 area_chart = _main.area_chart
@@ -213,7 +224,8 @@ write_stream = _main.write_stream
 color_picker = _main.color_picker
 status = _main.status
 
-# Events - Note: these methods cannot be called directly on sidebar (ex: st.sidebar.toast)
+# Events - Note: these methods cannot be called directly on sidebar
+# (ex: st.sidebar.toast)
 toast = _event.toast
 
 # Config

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -71,18 +71,18 @@ __version__ = _STREAMLIT_VERSION_STRING
 # imports the different elements but some elements also require DeltaGenerator
 # functions such as the dg_stack.
 import streamlit.delta_generator_singletons as _dg_singletons
-from streamlit.delta_generator import DeltaGenerator
-from streamlit.proto.RootContainer_pb2 import RootContainer
+from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
+from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
 
-_dg_singletons.main_dg = DeltaGenerator(root_container=RootContainer.MAIN)
-_dg_singletons.sidebar_dg = DeltaGenerator(
-    root_container=RootContainer.SIDEBAR, parent=_dg_singletons.main_dg
+_dg_singletons.main_dg = _DeltaGenerator(root_container=_RootContainer.MAIN)
+_dg_singletons.sidebar_dg = _DeltaGenerator(
+    root_container=_RootContainer.SIDEBAR, parent=_dg_singletons.main_dg
 )
-_dg_singletons.event_dg = DeltaGenerator(
-    root_container=RootContainer.EVENT, parent=_dg_singletons.main_dg
+_dg_singletons.event_dg = _DeltaGenerator(
+    root_container=_RootContainer.EVENT, parent=_dg_singletons.main_dg
 )
-_dg_singletons.bottom_dg = DeltaGenerator(
-    root_container=RootContainer.BOTTOM, parent=_dg_singletons.main_dg
+_dg_singletons.bottom_dg = _DeltaGenerator(
+    root_container=_RootContainer.BOTTOM, parent=_dg_singletons.main_dg
 )
 _main = _dg_singletons.main_dg
 sidebar = _dg_singletons.sidebar_dg

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -95,8 +95,8 @@ from streamlit.elements.lib.mutable_status_container import (
 )
 from streamlit.elements.lib.dialog import Dialog as _Dialog
 
-_dg_singletons._create_status_container = _StatusContainer._create
-_dg_singletons._create_dialog = _Dialog._create
+_dg_singletons.create_status_container = _StatusContainer._create
+_dg_singletons.create_dialog = _Dialog._create
 
 from streamlit.elements.dialog_decorator import (
     dialog_decorator as _dialog_decorator,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -69,7 +69,8 @@ __version__ = _STREAMLIT_VERSION_STRING
 # We initialize them here so that it is clear where they are instantiated.
 # Further, it helps us to break circular imports because the DeltaGenerator
 # imports the different elements but some elements also require DeltaGenerator
-# functions such as the dg_stack.
+# functions such as the dg_stack. Now, elements that require DeltaGenerator functions
+# can import the singleton module.
 import streamlit.delta_generator_singletons as _dg_singletons
 from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
 from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -90,11 +90,13 @@ _event = _dg_singletons.event_dg
 _bottom = _dg_singletons.bottom_dg
 
 
-from streamlit.elements.lib.mutable_status_container import StatusContainer
-from streamlit.elements.lib.dialog import Dialog
+from streamlit.elements.lib.mutable_status_container import (
+    StatusContainer as _StatusContainer,
+)
+from streamlit.elements.lib.dialog import Dialog as _Dialog
 
-_dg_singletons._create_status_container = StatusContainer._create
-_dg_singletons._create_dialog = Dialog._create
+_dg_singletons._create_status_container = _StatusContainer._create
+_dg_singletons._create_dialog = _Dialog._create
 
 from streamlit.elements.dialog_decorator import (
     dialog_decorator as _dialog_decorator,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -75,20 +75,20 @@ import streamlit.delta_generator_singletons as _dg_singletons
 from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
 from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
 
-_dg_singletons.main_dg = _DeltaGenerator(root_container=_RootContainer.MAIN)
-_dg_singletons.sidebar_dg = _DeltaGenerator(
-    root_container=_RootContainer.SIDEBAR, parent=_dg_singletons.main_dg
+_dg_singletons._main_dg = _DeltaGenerator(root_container=_RootContainer.MAIN)
+_dg_singletons._sidebar_dg = _DeltaGenerator(
+    root_container=_RootContainer.SIDEBAR, parent=_dg_singletons._main_dg
 )
-_dg_singletons.event_dg = _DeltaGenerator(
-    root_container=_RootContainer.EVENT, parent=_dg_singletons.main_dg
+_dg_singletons._event_dg = _DeltaGenerator(
+    root_container=_RootContainer.EVENT, parent=_dg_singletons._main_dg
 )
-_dg_singletons.bottom_dg = _DeltaGenerator(
-    root_container=_RootContainer.BOTTOM, parent=_dg_singletons.main_dg
+_dg_singletons._bottom_dg = _DeltaGenerator(
+    root_container=_RootContainer.BOTTOM, parent=_dg_singletons._main_dg
 )
-_main = _dg_singletons.main_dg
-sidebar = _dg_singletons.sidebar_dg
-_event = _dg_singletons.event_dg
-_bottom = _dg_singletons.bottom_dg
+_main = _dg_singletons._main_dg
+sidebar = _dg_singletons._sidebar_dg
+_event = _dg_singletons._event_dg
+_bottom = _dg_singletons._bottom_dg
 
 
 from streamlit.elements.lib.mutable_status_container import (

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -65,11 +65,15 @@ from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STR
 # Give the package a version.
 __version__ = _STREAMLIT_VERSION_STRING
 
+# DeltaGenerator methods:
+# We initialize them here so that it is clear where they are instantiated.
+# Further, it helps us to break circular imports because the DeltaGenerator
+# imports the different elements but some elements also require DeltaGenerator
+# functions such as the dg_stack.
+import streamlit.delta_generator_singletons as _dg_singletons
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.proto.RootContainer_pb2 import RootContainer
-import streamlit.delta_generator_singletons as _dg_singletons
 
-# DeltaGenerator methods:
 _dg_singletons.main_dg = DeltaGenerator(root_container=RootContainer.MAIN)
 _dg_singletons.sidebar_dg = DeltaGenerator(
     root_container=RootContainer.SIDEBAR, parent=_dg_singletons.main_dg

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -71,33 +71,26 @@ __version__ = _STREAMLIT_VERSION_STRING
 # imports the different elements but some elements also require DeltaGenerator
 # functions such as the dg_stack. Now, elements that require DeltaGenerator functions
 # can import the singleton module.
-import streamlit.delta_generator_singletons as _dg_singletons
+from streamlit.delta_generator_singletons import (
+    DeltaGeneratorSingleton as _DeltaGeneratorSingleton,
+)
 from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
-from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
-
-_dg_singletons._main_dg = _DeltaGenerator(root_container=_RootContainer.MAIN)
-_dg_singletons._sidebar_dg = _DeltaGenerator(
-    root_container=_RootContainer.SIDEBAR, parent=_dg_singletons._main_dg
-)
-_dg_singletons._event_dg = _DeltaGenerator(
-    root_container=_RootContainer.EVENT, parent=_dg_singletons._main_dg
-)
-_dg_singletons._bottom_dg = _DeltaGenerator(
-    root_container=_RootContainer.BOTTOM, parent=_dg_singletons._main_dg
-)
-_main = _dg_singletons._main_dg
-sidebar = _dg_singletons._sidebar_dg
-_event = _dg_singletons._event_dg
-_bottom = _dg_singletons._bottom_dg
-
-
 from streamlit.elements.lib.mutable_status_container import (
     StatusContainer as _StatusContainer,
 )
 from streamlit.elements.lib.dialog import Dialog as _Dialog
 
-_dg_singletons.create_status_container = _StatusContainer._create
-_dg_singletons.create_dialog = _Dialog._create
+# instantiate the DeltaGeneratorSingleton
+_dg_singleton = _DeltaGeneratorSingleton(
+    delta_generator_cls=_DeltaGenerator,
+    status_container_cls=_StatusContainer,
+    dialog_container_cls=_Dialog,
+)
+_main = _dg_singleton._main_dg
+sidebar = _dg_singleton._sidebar_dg
+_event = _dg_singleton._event_dg
+_bottom = _dg_singleton._bottom_dg
+
 
 from streamlit.elements.dialog_decorator import (
     dialog_decorator as _dialog_decorator,

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 from streamlit.components.types.base_custom_component import BaseCustomComponent
 from streamlit.dataframe_util import is_dataframe_like
 from streamlit.delta_generator_singletons import get_main_dg
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import check_cache_replay_rules
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Components_pb2 import ArrowTable as ArrowTableProto

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from streamlit.components.types.base_custom_component import BaseCustomComponent
 from streamlit.dataframe_util import is_dataframe_like
-from streamlit.delta_generator_singletons import get_main_dg
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import check_cache_replay_rules
 from streamlit.errors import StreamlitAPIException
@@ -222,7 +222,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
 
         # We currently only support writing to st._main, but this will change
         # when we settle on an improved API in a post-layout world.
-        dg = get_main_dg()
+        dg = get_dg_singleton_instance().main_dg
 
         element = Element()
         return_value = marshall_component(dg, element)

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from streamlit.components.types.base_custom_component import BaseCustomComponent
 from streamlit.dataframe_util import is_dataframe_like
-from streamlit.delta_generator import main_dg
+from streamlit.delta_generator_singletons import get_main_dg
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.policies import check_cache_replay_rules
 from streamlit.errors import StreamlitAPIException
@@ -222,7 +222,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
 
         # We currently only support writing to st._main, but this will change
         # when we settle on an improved API in a post-layout world.
-        dg = main_dg
+        dg = get_main_dg()
 
         element = Element()
         return_value = marshall_component(dg, element)
@@ -243,7 +243,8 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
     def __ne__(self, other) -> bool:
         """Inequality operator."""
 
-        # we have to use "not X == Y"" here because if we use "X != Y" we call __ne__ again and end up in recursion
+        # we have to use "not X == Y"" here because if we use "X != Y"
+        # we call __ne__ again and end up in recursion
         return not self == other
 
     def __str__(self) -> str:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -686,9 +686,9 @@ def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
 def _show_data_information(msg: str) -> None:
     """Show a message to the user with important information
     about the processed dataset."""
-    from streamlit.delta_generator_singletons import get_main_dg
+    from streamlit.delta_generator_singletons import get_dg_singleton_instance
 
-    get_main_dg().caption(msg)
+    get_dg_singleton_instance().main_dg.caption(msg)
 
 
 def convert_anything_to_arrow_bytes(

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -686,9 +686,9 @@ def convert_arrow_bytes_to_pandas_df(source: bytes) -> DataFrame:
 def _show_data_information(msg: str) -> None:
     """Show a message to the user with important information
     about the processed dataset."""
-    from streamlit.delta_generator import main_dg
+    from streamlit.delta_generator_singletons import get_main_dg
 
-    main_dg.caption(msg)
+    get_main_dg().caption(msg)
 
 
 def convert_anything_to_arrow_bytes(

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -42,7 +42,7 @@ from streamlit import (
     util,
 )
 from streamlit.delta_generator_singletons import (
-    dg_stack,
+    context_dg_stack,
     get_dg_stack_or_default,
     get_last_dg_added_to_context_stack,
 )
@@ -279,7 +279,7 @@ class DeltaGenerator(
 
     def __enter__(self) -> None:
         # with block started
-        dg_stack.set(get_dg_stack_or_default() + (self,))
+        context_dg_stack.set(get_dg_stack_or_default() + (self,))
 
     def __exit__(
         self,
@@ -289,7 +289,7 @@ class DeltaGenerator(
     ) -> Literal[False]:
         # with block ended
 
-        dg_stack.set(get_dg_stack_or_default()[:-1])
+        context_dg_stack.set(get_dg_stack_or_default()[:-1])
 
         # Re-raise any exceptions
         return False

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -43,7 +43,6 @@ from streamlit import (
 )
 from streamlit.delta_generator_singletons import (
     context_dg_stack,
-    get_dg_stack_or_default,
     get_last_dg_added_to_context_stack,
 )
 from streamlit.elements.alert import AlertMixin
@@ -279,7 +278,7 @@ class DeltaGenerator(
 
     def __enter__(self) -> None:
         # with block started
-        context_dg_stack.set(get_dg_stack_or_default() + (self,))
+        context_dg_stack.set(context_dg_stack.get() + (self,))
 
     def __exit__(
         self,
@@ -289,7 +288,7 @@ class DeltaGenerator(
     ) -> Literal[False]:
         # with block ended
 
-        context_dg_stack.set(get_dg_stack_or_default()[:-1])
+        context_dg_stack.set(context_dg_stack.get()[:-1])
 
         # Re-raise any exceptions
         return False

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -103,7 +103,6 @@ if TYPE_CHECKING:
     from streamlit.cursor import Cursor
     from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
 
-
 MAX_DELTA_BYTES: Final[int] = 14 * 1024 * 1024  # 14MB
 
 Value = TypeVar("Value")

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -54,7 +54,8 @@ from streamlit.elements.deck_gl_json_chart import PydeckMixin
 from streamlit.elements.doc_string import HelpMixin
 from streamlit.elements.empty import EmptyMixin
 from streamlit.elements.exception import ExceptionMixin
-from streamlit.elements.form import FormData, FormMixin, current_form_id
+from streamlit.elements.form import FormMixin
+from streamlit.elements.form_utils import FormData, current_form_id
 from streamlit.elements.graphviz_chart import GraphvizMixin
 from streamlit.elements.heading import HeadingMixin
 from streamlit.elements.html import HtmlMixin

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -60,13 +60,18 @@ def get_default_dg_stack() -> tuple[DeltaGenerator, ...]:
     return (main_dg,)
 
 
-dg_stack: ContextVar[tuple[DeltaGenerator, ...]] = ContextVar("dg_stack", default=())
+# we don't use the default factory here because `main_dg` is not initialized when this
+# module is imported. This is why we have the `get_dg_stack_or_default` helper function.
+context_dg_stack: ContextVar[tuple[DeltaGenerator, ...]] = ContextVar(
+    "context_dg_stack", default=()
+)
 
 
 def get_dg_stack_or_default() -> tuple[DeltaGenerator, ...]:
-    if dg_stack.get() is None:
-        dg_stack.set(get_default_dg_stack())
-    return dg_stack.get()
+    """Get the DeltaGenerator stack for the current context."""
+    if len(context_dg_stack.get()) == 0:
+        context_dg_stack.set(get_default_dg_stack())
+    return context_dg_stack.get()
 
 
 def get_last_dg_added_to_context_stack() -> DeltaGenerator | None:

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -1,0 +1,86 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+"""
+The main purpose of this module (right now at least) is to avoid a dependency
+cycle between streamlit.delta_generator and some elements.
+"""
+
+
+main_dg: DeltaGenerator | None = None
+sidebar_dg: DeltaGenerator | None = None
+event_dg: DeltaGenerator | None = None
+bottom_dg: DeltaGenerator | None = None
+
+
+def get_main_dg() -> DeltaGenerator:
+    if main_dg is None:
+        raise RuntimeError("main_dg is not initialized")
+    return main_dg
+
+
+def get_event_dg() -> DeltaGenerator:
+    if event_dg is None:
+        raise RuntimeError("event_dg is not initialized")
+    return event_dg
+
+
+def get_bottom_dg() -> DeltaGenerator:
+    if bottom_dg is None:
+        raise RuntimeError("bottom_dg is not initialized")
+    return bottom_dg
+
+
+# The dg_stack tracks the currently active DeltaGenerator, and is pushed to when
+# a DeltaGenerator is entered via a `with` block. This is implemented as a ContextVar
+# so that different threads or async tasks can have their own stacks.
+def get_default_dg_stack() -> tuple[DeltaGenerator, ...]:
+    if main_dg is None:
+        raise RuntimeError("main_dg is not set")
+
+    return (main_dg,)
+
+
+dg_stack: ContextVar[tuple[DeltaGenerator, ...]] = ContextVar("dg_stack", default=None)
+
+
+def get_dg_stack_or_default() -> tuple[DeltaGenerator, ...]:
+    if dg_stack.get() is None:
+        dg_stack.set(get_default_dg_stack())
+    return dg_stack.get()
+
+
+def get_last_dg_added_to_context_stack() -> DeltaGenerator | None:
+    """Get the last added DeltaGenerator of the stack in the current context.
+
+    Returns None if the stack has only one element or is empty for whatever reason.
+    """
+    current_stack = get_dg_stack_or_default()
+    # If set to "> 0" and thus return the only delta generator in the stack -
+    # which logically makes more sense -, some unit tests fail.
+    # It looks like the reason is that they create their own main delta generator
+    # but do not populate the dg_stack correctly. However, to be on the safe-side,
+    # we keep the logic but leave the comment as shared knowledge for whoever will look
+    # into this in the future.
+    if len(current_stack) > 1:
+        return current_stack[-1]
+    return None

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -15,10 +15,12 @@
 from __future__ import annotations
 
 from contextvars import ContextVar, Token
-from typing import TYPE_CHECKING, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, Literal, TypeVar
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.lib.dialog import Dialog
+    from streamlit.elements.lib.mutable_status_container import StatusContainer
 
 """
 The main purpose of this module (right now at least) is to avoid a dependency
@@ -121,3 +123,30 @@ def get_last_dg_added_to_context_stack() -> DeltaGenerator | None:
     if len(current_stack) > 1:
         return current_stack[-1]
     return None
+
+
+_create_status_container: Callable | None = None
+_create_dialog: Callable | None = None
+
+
+def create_status_container(
+    parent: DeltaGenerator,
+    label: str,
+    expanded: bool = False,
+    state: Literal["running", "complete", "error"] = "running",
+) -> StatusContainer:
+    if _create_status_container is None:
+        raise RuntimeError("Function 'create_status_container' is not initialized.")
+    return _create_status_container(parent, label, expanded, state)
+
+
+def create_dialog(
+    parent: DeltaGenerator,
+    title: str,
+    *,
+    dismissible: bool = True,
+    width: Literal["small", "large"] = "small",
+) -> Dialog:
+    if _create_dialog is None:
+        raise RuntimeError("Function 'create_dialog' is not initialized.")
+    return _create_dialog(parent, title, dismissible=dismissible, width=width)

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -60,7 +60,7 @@ def get_default_dg_stack() -> tuple[DeltaGenerator, ...]:
     return (main_dg,)
 
 
-dg_stack: ContextVar[tuple[DeltaGenerator, ...]] = ContextVar("dg_stack", default=None)
+dg_stack: ContextVar[tuple[DeltaGenerator, ...]] = ContextVar("dg_stack", default=())
 
 
 def get_dg_stack_or_default() -> tuple[DeltaGenerator, ...]:

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -31,6 +31,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from streamlit import dataframe_util
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ColumnConfigMappingInput,
@@ -534,9 +535,6 @@ class ArrowMixin:
         marshall_column_config(proto, column_config_mapping)
 
         if is_selection_activated:
-            # Import here to avoid circular imports
-            from streamlit.elements.form import current_form_id
-
             # If selection events are activated, we need to register the dataframe
             # element as a widget.
             proto.selection_mode.extend(parse_selection_mode(selection_mode))

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -18,7 +18,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
 
 from streamlit.delta_generator_singletons import (
-    get_event_dg,
+    get_dg_singleton_instance,
     get_last_dg_added_to_context_stack,
 )
 from streamlit.deprecation_util import (
@@ -79,7 +79,9 @@ def _dialog_decorator(
         # Call the Dialog on the event_dg because it lives outside of the normal
         # Streamlit UI flow. For example, if it is called from the sidebar, it should
         # not inherit the sidebar theming.
-        dialog = get_event_dg()._dialog(title=title, dismissible=True, width=width)
+        dialog = get_dg_singleton_instance().event_dg._dialog(
+            title=title, dismissible=True, width=width
+        )
         dialog.open()
 
         def dialog_content() -> None:

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
 
-from streamlit.delta_generator import event_dg, get_last_dg_added_to_context_stack
+from streamlit.delta_generator_singletons import (
+    get_event_dg,
+    get_last_dg_added_to_context_stack,
+)
 from streamlit.deprecation_util import (
     make_deprecated_name_warning,
     show_deprecation_warning,
@@ -76,7 +79,7 @@ def _dialog_decorator(
         # Call the Dialog on the event_dg because it lives outside of the normal
         # Streamlit UI flow. For example, if it is called from the sidebar, it should
         # not inherit the sidebar theming.
-        dialog = event_dg._dialog(title=title, dismissible=True, width=width)
+        dialog = get_event_dg()._dialog(title=title, dismissible=True, width=width)
         dialog.open()
 
         def dialog_content() -> None:
@@ -239,7 +242,9 @@ def experimental_dialog_decorator(title: F, *, width: DialogWidth = "small") -> 
 def experimental_dialog_decorator(
     title: F | str, *, width: DialogWidth = "small"
 ) -> F | Callable[[F], F]:
-    """Deprecated alias for @st.dialog. See the docstring for the decorator's new name."""
+    """Deprecated alias for @st.dialog.
+    See the docstring for the decorator's new name.
+    """
     func_or_title = title
     if isinstance(func_or_title, str):
         # Support passing the params via function decorator

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -14,10 +14,13 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, Literal, NamedTuple, cast
+from typing import TYPE_CHECKING, Literal, cast
 
-from streamlit import runtime
-from streamlit.delta_generator_singletons import get_dg_stack_or_default
+from streamlit.elements.form_utils import FormData, current_form_id, is_in_form
+from streamlit.elements.lib.policies import (
+    check_cache_replay_rules,
+    check_session_state_rules,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
@@ -26,60 +29,6 @@ from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
-
-
-class FormData(NamedTuple):
-    """Form data stored on a DeltaGenerator."""
-
-    # The form's unique ID.
-    form_id: str
-
-
-def _current_form(this_dg: DeltaGenerator) -> FormData | None:
-    """Find the FormData for the given DeltaGenerator.
-
-    Forms are blocks, and can have other blocks nested inside them.
-    To find the current form, we walk up the dg_stack until we find
-    a DeltaGenerator that has FormData.
-    """
-    if not runtime.exists():
-        return None
-
-    if this_dg._form_data is not None:
-        return this_dg._form_data
-
-    if this_dg == this_dg._main_dg:
-        # We were created via an `st.foo` call.
-        # Walk up the dg_stack to see if we're nested inside a `with st.form` statement.
-        for dg in reversed(get_dg_stack_or_default()):
-            if dg._form_data is not None:
-                return dg._form_data
-    else:
-        # We were created via an `dg.foo` call.
-        # Take a look at our parent's form data to see if we're nested inside a form.
-        parent = this_dg._parent
-        if parent is not None and parent._form_data is not None:
-            return parent._form_data
-
-    return None
-
-
-def current_form_id(dg: DeltaGenerator) -> str:
-    """Return the form_id for the current form, or the empty string if we're
-    not inside an `st.form` block.
-
-    (We return the empty string, instead of None, because this value is
-    assigned to protobuf message fields, and None is not valid.)
-    """
-    form_data = _current_form(dg)
-    if form_data is None:
-        return ""
-    return form_data.form_id
-
-
-def is_in_form(dg: DeltaGenerator) -> bool:
-    """True if the DeltaGenerator is inside an st.form block."""
-    return current_form_id(dg) != ""
 
 
 def _build_duplicate_form_message(user_key: str | None = None) -> str:
@@ -190,12 +139,6 @@ class FormMixin:
            height: 375px
 
         """
-        # Import this here to avoid circular imports.
-        from streamlit.elements.lib.policies import (
-            check_cache_replay_rules,
-            check_session_state_rules,
-        )
-
         if is_in_form(self.dg):
             raise StreamlitAPIException("Forms cannot be nested in other forms.")
 

--- a/lib/streamlit/elements/form_utils.py
+++ b/lib/streamlit/elements/form_utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+from streamlit import runtime
+from streamlit.delta_generator_singletons import get_dg_stack_or_default
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+class FormData(NamedTuple):
+    """Form data stored on a DeltaGenerator."""
+
+    # The form's unique ID.
+    form_id: str
+
+
+def _current_form(this_dg: DeltaGenerator) -> FormData | None:
+    """Find the FormData for the given DeltaGenerator.
+
+    Forms are blocks, and can have other blocks nested inside them.
+    To find the current form, we walk up the dg_stack until we find
+    a DeltaGenerator that has FormData.
+    """
+    if not runtime.exists():
+        return None
+
+    if this_dg._form_data is not None:
+        return this_dg._form_data
+
+    if this_dg == this_dg._main_dg:
+        # We were created via an `st.foo` call.
+        # Walk up the dg_stack to see if we're nested inside a `with st.form` statement.
+        for dg in reversed(get_dg_stack_or_default()):
+            if dg._form_data is not None:
+                return dg._form_data
+    else:
+        # We were created via an `dg.foo` call.
+        # Take a look at our parent's form data to see if we're nested inside a form.
+        parent = this_dg._parent
+        if parent is not None and parent._form_data is not None:
+            return parent._form_data
+
+    return None
+
+
+def current_form_id(dg: DeltaGenerator) -> str:
+    """Return the form_id for the current form, or the empty string if we're
+    not inside an `st.form` block.
+
+    (We return the empty string, instead of None, because this value is
+    assigned to protobuf message fields, and None is not valid.)
+    """
+    form_data = _current_form(dg)
+    if form_data is None:
+        return ""
+    return form_data.form_id
+
+
+def is_in_form(dg: DeltaGenerator) -> bool:
+    """True if the DeltaGenerator is inside an st.form block."""
+    return current_form_id(dg) != ""

--- a/lib/streamlit/elements/form_utils.py
+++ b/lib/streamlit/elements/form_utils.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from streamlit import runtime
-from streamlit.delta_generator_singletons import get_dg_stack_or_default
+from streamlit.delta_generator_singletons import context_dg_stack
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -46,7 +46,7 @@ def _current_form(this_dg: DeltaGenerator) -> FormData | None:
     if this_dg == this_dg._main_dg:
         # We were created via an `st.foo` call.
         # Walk up the dg_stack to see if we're nested inside a `with st.form` statement.
-        for dg in reversed(get_dg_stack_or_default()):
+        for dg in reversed(context_dg_stack.get()):
             if dg._form_data is not None:
                 return dg._form_data
     else:

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
-from streamlit.delta_generator_singletons import create_dialog, create_status_container
+import streamlit.delta_generator_singletons as delta_generator_singletons
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -770,7 +770,9 @@ class LayoutsMixin:
             height: 300px
 
         """
-        return create_status_container(self.dg, label, expanded=expanded, state=state)
+        return delta_generator_singletons.create_status_container(
+            self.dg, label, expanded=expanded, state=state
+        )
 
     def _dialog(
         self,
@@ -784,7 +786,9 @@ class LayoutsMixin:
         Marked as internal because it is used by the dialog_decorator and is not supposed to be used directly.
         The dialog_decorator also has a more descriptive docstring since it is user-facing.
         """
-        return create_dialog(self.dg, title, dismissible=dismissible, width=width)
+        return delta_generator_singletons.create_dialog(
+            self.dg, title, dismissible=dismissible, width=width
+        )
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
+from streamlit.delta_generator_singletons import create_dialog, create_status_container
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -769,12 +770,7 @@ class LayoutsMixin:
             height: 300px
 
         """
-        # We need to import StatusContainer here to avoid a circular import
-        from streamlit.elements.lib.mutable_status_container import StatusContainer
-
-        return StatusContainer._create(
-            self.dg, label=label, expanded=expanded, state=state
-        )
+        return create_status_container(self.dg, label, expanded=expanded, state=state)
 
     def _dialog(
         self,
@@ -788,11 +784,7 @@ class LayoutsMixin:
         Marked as internal because it is used by the dialog_decorator and is not supposed to be used directly.
         The dialog_decorator also has a more descriptive docstring since it is user-facing.
         """
-
-        # We need to import Dialog here to avoid a circular import
-        from streamlit.elements.lib.dialog import Dialog
-
-        return Dialog._create(self.dg, title, dismissible=dismissible, width=width)
+        return create_dialog(self.dg, title, dismissible=dismissible, width=width)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
-import streamlit.delta_generator_singletons as delta_generator_singletons
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -770,7 +770,7 @@ class LayoutsMixin:
             height: 300px
 
         """
-        return delta_generator_singletons.create_status_container(
+        return get_dg_singleton_instance().status_container_cls._create(
             self.dg, label, expanded=expanded, state=state
         )
 
@@ -786,7 +786,7 @@ class LayoutsMixin:
         Marked as internal because it is used by the dialog_decorator and is not supposed to be used directly.
         The dialog_decorator also has a more descriptive docstring since it is user-facing.
         """
-        return delta_generator_singletons.create_dialog(
+        return get_dg_singleton_instance().dialog_container_cls._create(
             self.dg, title, dismissible=dismissible, width=width
         )
 

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Final, Sequence
 
 from streamlit import config, errors, logger, runtime
-from streamlit.elements.form import is_in_form
+from streamlit.elements.form_utils import is_in_form
 from streamlit.errors import StreamlitAPIException, StreamlitAPIWarning
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import WidgetCallback, get_session_state

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -36,7 +36,7 @@ from typing_extensions import TypeAlias
 
 from streamlit import type_util
 from streamlit.deprecation_util import show_deprecation_warning
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.event_utils import AttributeDictionary
 from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.streamlit_plotly_theme import (

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -37,6 +37,7 @@ from typing_extensions import TypeAlias
 
 import streamlit.elements.lib.dicttools as dicttools
 from streamlit import dataframe_util, type_util
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.built_in_chart_utils import (
     AddRowsMetadata,
     ChartStackType,
@@ -1882,9 +1883,6 @@ class VegaChartsMixin:
         vega_lite_proto.theme = theme or ""
 
         if is_selection_activated:
-            # Import here to avoid circular imports
-            from streamlit.elements.form import current_form_id
-
             # Load the stabilized spec again as a dict:
             final_spec = json.loads(vega_lite_proto.spec)
             # Temporary limitation to disallow multi-view charts (compositions) with selections.

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -31,7 +31,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from streamlit import runtime
-from streamlit.elements.form import current_form_id, is_in_form
+from streamlit.elements.form_utils import current_form_id, is_in_form
 from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
 from streamlit.errors import StreamlitAPIException

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -28,7 +28,7 @@ from typing import (
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.options_selector_utils import (
     convert_to_sequence_and_check_comparable,
     get_default_indices,

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Union, cast
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit import runtime
-from streamlit.delta_generator_singletons import get_bottom_dg
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.elements.form_utils import is_in_form
 from streamlit.elements.image import AtomicImage, WidthBehaviour, image_to_url
 from streamlit.elements.lib.policies import check_widget_policies
@@ -387,7 +387,9 @@ class ChatMixin:
         if position == "bottom":
             # We need to enqueue the chat input into the bottom container
             # instead of the currently active dg.
-            get_bottom_dg()._enqueue("chat_input", chat_input_proto)
+            get_dg_singleton_instance().bottom_dg._enqueue(
+                "chat_input", chat_input_proto
+            )
         else:
             self.dg._enqueue("chat_input", chat_input_proto)
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -19,7 +19,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit import runtime
-from streamlit.elements.form import is_in_form
+from streamlit.delta_generator_singletons import get_bottom_dg
+from streamlit.elements.form_utils import is_in_form
 from streamlit.elements.image import AtomicImage, WidthBehaviour, image_to_url
 from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, to_key
@@ -384,12 +385,9 @@ class ChatMixin:
         if ctx:
             save_for_app_testing(ctx, id, widget_state.value)
         if position == "bottom":
-            # We import it here to avoid circular imports.
-            from streamlit import _bottom
-
             # We need to enqueue the chat input into the bottom container
             # instead of the currently active dg.
-            _bottom._enqueue("chat_input", chat_input_proto)
+            get_bottom_dg()._enqueue("chat_input", chat_input_proto)
         else:
             self.dg._enqueue("chat_input", chat_input_proto)
 

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -39,7 +39,7 @@ from typing_extensions import TypeAlias
 
 from streamlit import dataframe_util
 from streamlit import logger as _logger
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ColumnConfigMapping,

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, List, Literal, Sequence, Union, cast, overload
 from typing_extensions import TypeAlias
 
 from streamlit import config
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 
 from streamlit.dataframe_util import OptionSequence
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.options_selector_utils import (
     check_and_convert_to_indices,
     convert_to_sequence_and_check_comparable,

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Literal, TypeVar, Union, cast, overload
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, Tuple, cast
 from typing_extensions import TypeGuard
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -18,7 +18,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast, overload
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_sequence
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -33,7 +33,7 @@ from typing import (
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Literal, cast, overload
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -32,7 +32,7 @@ from typing import (
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.form import current_form_id
+from streamlit.elements.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -30,8 +30,8 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import FragmentHandledException, FragmentStorageKeyError
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
+from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -156,14 +156,14 @@ def _fragment(
 
     @wraps(non_optional_func)
     def wrap(*args, **kwargs):
-        from streamlit.delta_generator import dg_stack
+        from streamlit.delta_generator_singletons import context_dg_stack
 
         ctx = get_script_run_ctx()
         if ctx is None:
             return
 
         cursors_snapshot = deepcopy(ctx.cursors)
-        dg_stack_snapshot = deepcopy(dg_stack.get())
+        dg_stack_snapshot = deepcopy(context_dg_stack.get())
         h = hashlib.new("md5")
         h.update(
             f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}".encode()
@@ -198,7 +198,7 @@ def _fragment(
                 # state of ctx.cursors and dg_stack to the snapshots we took when this
                 # fragment was declared.
                 ctx.cursors = deepcopy(cursors_snapshot)
-                dg_stack.set(deepcopy(dg_stack_snapshot))
+                context_dg_stack.set(deepcopy(dg_stack_snapshot))
 
             # Always add the fragment id to new_fragment_ids. For full app runs
             # we need to add them anyways and for fragment runs we add them
@@ -236,7 +236,7 @@ def _fragment(
                             # because thats the prefix of the fragment,
                             # e.g. [0, 3, 0] -> [0, 3].
                             # All fragment elements start with [0, 3].
-                            active_dg = dg_stack.get()[-1]
+                            active_dg = context_dg_stack.get()[-1]
                             ctx.current_fragment_delta_path = (
                                 active_dg._cursor.delta_path
                                 if active_dg._cursor

--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
+from streamlit.delta_generator_singletons import dg_stack, get_default_dg_stack
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import FragmentHandledException
 from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
@@ -61,10 +62,6 @@ def exec_func_with_error_handling(
             RerunExceptions, True for all other exceptions).
         - The uncaught exception if one occurred, None otherwise
     """
-
-    # Avoid circular imports
-    from streamlit.delta_generator import dg_stack, get_default_dg_stack
-
     run_without_errors = True
 
     # This will be set to a RerunData instance if our execution

--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-from streamlit.delta_generator_singletons import dg_stack, get_default_dg_stack
+from streamlit.delta_generator_singletons import context_dg_stack, get_default_dg_stack
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import FragmentHandledException
 from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
@@ -90,7 +90,7 @@ def exec_func_with_error_handling(
         # it doesn't matter either way since the fragment resets these values from its
         # snapshot before execution.
         ctx.cursors.clear()
-        dg_stack.set(get_default_dg_stack())
+        context_dg_stack.set(get_default_dg_stack())
 
         # Interruption due to a rerun is usually from `st.rerun()`, which
         # we want to count as a script completion so triggers reset.

--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-from streamlit.delta_generator_singletons import context_dg_stack, get_default_dg_stack
+from streamlit.delta_generator_singletons import (
+    context_dg_stack,
+    get_default_dg_stack_value,
+)
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import FragmentHandledException
 from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
@@ -90,7 +93,7 @@ def exec_func_with_error_handling(
         # it doesn't matter either way since the fragment resets these values from its
         # snapshot before execution.
         ctx.cursors.clear()
-        context_dg_stack.set(get_default_dg_stack())
+        context_dg_stack.set(get_default_dg_stack_value())
 
         # Interruption due to a rerun is usually from `st.rerun()`, which
         # we want to count as a script completion so triggers reset.

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (
+    bottom_dg,
     context_dg_stack,
+    create_dialog,
+    create_status_container,
+    event_dg,
     get_default_dg_stack,
     get_last_dg_added_to_context_stack,
     main_dg,
+    sidebar_dg,
 )
 from streamlit.proto.RootContainer_pb2 import RootContainer
-from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
-class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
+class DeltaGeneratorSingletonsTest(unittest.TestCase):
     def test_get_last_dg_added_to_context_stack(self):
         last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
         self.assertIsNone(last_dg_added_to_context_stack)
@@ -36,14 +42,13 @@ class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
         last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
         self.assertNotEqual(sidebar, last_dg_added_to_context_stack)
 
-    def test_get_dg_stack_or_default(self):
+    def test_context_dg_stack(self):
         dg_stack = context_dg_stack.get()
         self.assertEqual(get_default_dg_stack(), dg_stack)
-        self.assertEqual(context_dg_stack.get(), dg_stack)
         self.assertEqual(len(dg_stack), 1)
 
         new_dg = DeltaGenerator(root_container=RootContainer.MAIN, parent=main_dg)
-        token = context_dg_stack.set(get_default_dg_stack() + (new_dg,))
+        token = context_dg_stack.set(context_dg_stack.get() + (new_dg,))
 
         # get the updated dg_stack for current context
         dg_stack = context_dg_stack.get()
@@ -51,3 +56,27 @@ class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
 
         # reset for the other tests
         context_dg_stack.reset(token)
+        dg_stack = context_dg_stack.get()
+        self.assertEqual(len(dg_stack), 1)
+
+
+class DeltaGeneratorSingletonsVariablesAreInitializedTest(unittest.TestCase):
+    """dg variables are initialized by Streamlit.__init__.py"""
+
+    def test_main_dg_is_initialized(self):
+        self.assertIsNotNone(main_dg)
+
+    def test_sidebar_dg_is_initialized(self):
+        self.assertIsNotNone(sidebar_dg)
+
+    def test_event_dg_is_initialized(self):
+        self.assertIsNotNone(event_dg)
+
+    def test_bottom_dg_is_initialized(self):
+        self.assertIsNotNone(bottom_dg)
+
+    def test_create_status_container_is_initialized(self):
+        self.assertIsNotNone(create_status_container)
+
+    def test_create_dialog_is_initialized(self):
+        self.assertIsNotNone(create_dialog)

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -17,7 +17,6 @@ from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (
     context_dg_stack,
     get_default_dg_stack,
-    get_dg_stack_or_default,
     get_last_dg_added_to_context_stack,
     main_dg,
 )
@@ -38,7 +37,7 @@ class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
         self.assertNotEqual(sidebar, last_dg_added_to_context_stack)
 
     def test_get_dg_stack_or_default(self):
-        dg_stack = get_dg_stack_or_default()
+        dg_stack = context_dg_stack.get()
         self.assertEqual(get_default_dg_stack(), dg_stack)
         self.assertEqual(context_dg_stack.get(), dg_stack)
         self.assertEqual(len(dg_stack), 1)
@@ -47,7 +46,7 @@ class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
         token = context_dg_stack.set(get_default_dg_stack() + (new_dg,))
 
         # get the updated dg_stack for current context
-        dg_stack = get_dg_stack_or_default()
+        dg_stack = context_dg_stack.get()
         self.assertEqual(len(dg_stack), 2)
 
         # reset for the other tests

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -17,15 +17,15 @@ import unittest
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (
-    bottom_dg,
+    _bottom_dg,
+    _event_dg,
+    _main_dg,
+    _sidebar_dg,
     context_dg_stack,
     create_dialog,
     create_status_container,
-    event_dg,
-    get_default_dg_stack,
+    get_default_dg_stack_value,
     get_last_dg_added_to_context_stack,
-    main_dg,
-    sidebar_dg,
 )
 from streamlit.proto.RootContainer_pb2 import RootContainer
 
@@ -33,50 +33,50 @@ from streamlit.proto.RootContainer_pb2 import RootContainer
 class DeltaGeneratorSingletonsTest(unittest.TestCase):
     def test_get_last_dg_added_to_context_stack(self):
         last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-        self.assertIsNone(last_dg_added_to_context_stack)
+        assert last_dg_added_to_context_stack is None
 
         sidebar = st.sidebar
         with sidebar:
             last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-            self.assertEqual(sidebar, last_dg_added_to_context_stack)
+            assert sidebar == last_dg_added_to_context_stack
         last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-        self.assertNotEqual(sidebar, last_dg_added_to_context_stack)
+        assert sidebar != last_dg_added_to_context_stack
 
     def test_context_dg_stack(self):
         dg_stack = context_dg_stack.get()
-        self.assertEqual(get_default_dg_stack(), dg_stack)
-        self.assertEqual(len(dg_stack), 1)
+        assert get_default_dg_stack_value() == dg_stack
+        assert len(dg_stack) == 1
 
-        new_dg = DeltaGenerator(root_container=RootContainer.MAIN, parent=main_dg)
+        new_dg = DeltaGenerator(root_container=RootContainer.MAIN, parent=_main_dg)
         token = context_dg_stack.set(context_dg_stack.get() + (new_dg,))
 
         # get the updated dg_stack for current context
         dg_stack = context_dg_stack.get()
-        self.assertEqual(len(dg_stack), 2)
+        assert len(dg_stack) == 2
 
         # reset for the other tests
         context_dg_stack.reset(token)
         dg_stack = context_dg_stack.get()
-        self.assertEqual(len(dg_stack), 1)
+        assert len(dg_stack) == 1
 
 
 class DeltaGeneratorSingletonsVariablesAreInitializedTest(unittest.TestCase):
     """dg variables are initialized by Streamlit.__init__.py"""
 
     def test_main_dg_is_initialized(self):
-        self.assertIsNotNone(main_dg)
+        assert _main_dg is not None
 
     def test_sidebar_dg_is_initialized(self):
-        self.assertIsNotNone(sidebar_dg)
+        assert _sidebar_dg is not None
 
     def test_event_dg_is_initialized(self):
-        self.assertIsNotNone(event_dg)
+        assert _event_dg is not None
 
     def test_bottom_dg_is_initialized(self):
-        self.assertIsNotNone(bottom_dg)
+        assert _bottom_dg is not None
 
     def test_create_status_container_is_initialized(self):
-        self.assertIsNotNone(create_status_container)
+        assert create_status_container is not None
 
     def test_create_dialog_is_initialized(self):
-        self.assertIsNotNone(create_dialog)
+        assert create_dialog is not None

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+from streamlit.delta_generator_singletons import (
+    context_dg_stack,
+    get_default_dg_stack,
+    get_dg_stack_or_default,
+    get_last_dg_added_to_context_stack,
+    main_dg,
+)
+from streamlit.proto.RootContainer_pb2 import RootContainer
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+class DeltaGeneratorSingletonsTest(DeltaGeneratorTestCase):
+    def test_get_last_dg_added_to_context_stack(self):
+        last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
+        self.assertIsNone(last_dg_added_to_context_stack)
+
+        sidebar = st.sidebar
+        with sidebar:
+            last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
+            self.assertEqual(sidebar, last_dg_added_to_context_stack)
+        last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
+        self.assertNotEqual(sidebar, last_dg_added_to_context_stack)
+
+    def test_get_dg_stack_or_default(self):
+        dg_stack = get_dg_stack_or_default()
+        self.assertEqual(get_default_dg_stack(), dg_stack)
+        self.assertEqual(context_dg_stack.get(), dg_stack)
+        self.assertEqual(len(dg_stack), 1)
+
+        new_dg = DeltaGenerator(root_container=RootContainer.MAIN, parent=main_dg)
+        token = context_dg_stack.set(get_default_dg_stack() + (new_dg,))
+
+        # get the updated dg_stack for current context
+        dg_stack = get_dg_stack_or_default()
+        self.assertEqual(len(dg_stack), 2)
+
+        # reset for the other tests
+        context_dg_stack.reset(token)

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -17,14 +17,9 @@ import unittest
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (
-    _bottom_dg,
-    _event_dg,
-    _main_dg,
-    _sidebar_dg,
     context_dg_stack,
-    create_dialog,
-    create_status_container,
     get_default_dg_stack_value,
+    get_dg_singleton_instance,
     get_last_dg_added_to_context_stack,
 )
 from streamlit.proto.RootContainer_pb2 import RootContainer
@@ -47,7 +42,10 @@ class DeltaGeneratorSingletonsTest(unittest.TestCase):
         assert get_default_dg_stack_value() == dg_stack
         assert len(dg_stack) == 1
 
-        new_dg = DeltaGenerator(root_container=RootContainer.MAIN, parent=_main_dg)
+        new_dg = DeltaGenerator(
+            root_container=RootContainer.MAIN,
+            parent=get_dg_singleton_instance().main_dg,
+        )
         token = context_dg_stack.set(context_dg_stack.get() + (new_dg,))
 
         # get the updated dg_stack for current context
@@ -64,19 +62,19 @@ class DeltaGeneratorSingletonsVariablesAreInitializedTest(unittest.TestCase):
     """dg variables are initialized by Streamlit.__init__.py"""
 
     def test_main_dg_is_initialized(self):
-        assert _main_dg is not None
+        assert get_dg_singleton_instance().main_dg is not None
 
     def test_sidebar_dg_is_initialized(self):
-        assert _sidebar_dg is not None
+        assert get_dg_singleton_instance().sidebar_dg is not None
 
     def test_event_dg_is_initialized(self):
-        assert _event_dg is not None
+        assert get_dg_singleton_instance().event_dg is not None
 
     def test_bottom_dg_is_initialized(self):
-        assert _bottom_dg is not None
+        assert get_dg_singleton_instance().bottom_dg is not None
 
     def test_create_status_container_is_initialized(self):
-        assert create_status_container is not None
+        assert get_dg_singleton_instance().status_container_cls is not None
 
     def test_create_dialog_is_initialized(self):
-        assert create_dialog is not None
+        assert get_dg_singleton_instance().dialog_container_cls is not None

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -34,7 +34,7 @@ import streamlit as st
 import streamlit.delta_generator as delta_generator
 import streamlit.runtime.state.widgets as w
 from streamlit.cursor import LockedCursor, make_delta_path
-from streamlit.delta_generator import DeltaGenerator, get_last_dg_added_to_context_stack
+from streamlit.delta_generator import DeltaGenerator
 from streamlit.errors import DuplicateWidgetID, StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
@@ -289,17 +289,6 @@ class DeltaGeneratorTest(DeltaGeneratorTestCase):
                 ),
                 str(ctx.exception),
             )
-
-    def test_get_last_dg_added_to_context_stack(self):
-        last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-        self.assertIsNone(last_dg_added_to_context_stack)
-
-        sidebar = st.sidebar
-        with sidebar:
-            last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-            self.assertEqual(sidebar, last_dg_added_to_context_stack)
-        last_dg_added_to_context_stack = get_last_dg_added_to_context_stack()
-        self.assertNotEqual(sidebar, last_dg_added_to_context_stack)
 
 
 class DeltaGeneratorClassTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -35,6 +35,7 @@ import streamlit.delta_generator as delta_generator
 import streamlit.runtime.state.widgets as w
 from streamlit.cursor import LockedCursor, make_delta_path
 from streamlit.delta_generator import DeltaGenerator
+from streamlit.delta_generator_singletons import get_sidebar_dg
 from streamlit.errors import DuplicateWidgetID, StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
@@ -390,14 +391,14 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
 
         exc = "is not supported"
         with pytest.raises(StreamlitAPIException, match=exc):
-            delta_generator.sidebar_dg._enqueue("text", TextProto())
+            get_sidebar_dg()._enqueue("text", TextProto())
 
     def test_enqueue_can_write_to_container_in_sidebar(self):
         ctx = get_script_run_ctx()
         ctx.current_fragment_id = "my_fragment_id"
         ctx.fragment_ids_this_run = ["my_fragment_id"]
 
-        delta_generator.sidebar_dg.container().write("Hello world")
+        get_sidebar_dg().container().write("Hello world")
 
         deltas = self.get_all_deltas_from_queue()
         assert [d.fragment_id for d in deltas] == ["my_fragment_id", "my_fragment_id"]

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -35,7 +35,7 @@ import streamlit.delta_generator as delta_generator
 import streamlit.runtime.state.widgets as w
 from streamlit.cursor import LockedCursor, make_delta_path
 from streamlit.delta_generator import DeltaGenerator
-from streamlit.delta_generator_singletons import get_sidebar_dg
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.errors import DuplicateWidgetID, StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
@@ -391,14 +391,14 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
 
         exc = "is not supported"
         with pytest.raises(StreamlitAPIException, match=exc):
-            get_sidebar_dg()._enqueue("text", TextProto())
+            get_dg_singleton_instance().sidebar_dg._enqueue("text", TextProto())
 
     def test_enqueue_can_write_to_container_in_sidebar(self):
         ctx = get_script_run_ctx()
         ctx.current_fragment_id = "my_fragment_id"
         ctx.fragment_ids_this_run = ["my_fragment_id"]
 
-        get_sidebar_dg().container().write("Hello world")
+        get_dg_singleton_instance().sidebar_dg.container().write("Hello world")
 
         deltas = self.get_all_deltas_from_queue()
         assert [d.fragment_id for d in deltas] == ["my_fragment_id", "my_fragment_id"]

--- a/lib/tests/streamlit/form_utils_test.py
+++ b/lib/tests/streamlit/form_utils_test.py
@@ -1,0 +1,85 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from streamlit.delta_generator import DeltaGenerator
+from streamlit.delta_generator_singletons import context_dg_stack, get_default_dg_stack
+from streamlit.elements.form_utils import FormData, is_in_form
+from streamlit.runtime import Runtime, RuntimeConfig
+
+
+class FormUtilsTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        super().tearDown()
+
+        # reset context_dg_stack to clean state for other tests
+        # that are executed in the same thread
+        context_dg_stack.set(get_default_dg_stack())
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        config = RuntimeConfig(
+            script_path="",
+            command_line=None,
+            media_file_storage=None,
+            uploaded_file_manager=None,
+        )
+        # init runtime
+        Runtime(config)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        Runtime._instance = None
+
+    def test_is_in_form_true_when_dg_has_formdata(self):
+        dg = DeltaGenerator()
+        dg._form_data = FormData("form_id")
+
+        self.assertTrue(is_in_form(dg))
+
+    def test_is_in_form_false_when_dg_has_no_formdata(self):
+        dg = DeltaGenerator()
+
+        self.assertFalse(is_in_form(dg))
+
+    def test_is_in_form_true_when_dg_stack_has_form(self):
+        form_dg = DeltaGenerator()
+        form_dg._form_data = FormData("form_id")
+        dg = DeltaGenerator()
+        context_dg_stack.set((form_dg, dg))
+
+        self.assertTrue(is_in_form(dg))
+
+    def test_is_in_form_false_when_dg_stack_has_no_form(self):
+        form_dg = DeltaGenerator()
+        dg = DeltaGenerator()
+        context_dg_stack.set((form_dg, dg))
+
+        self.assertFalse(is_in_form(dg))
+
+    def test_is_in_form_true_when_dg_has_form_parent(self):
+        parent_dg = DeltaGenerator()
+        parent_dg._form_data = FormData("form_id")
+        dg = DeltaGenerator(parent=parent_dg)
+
+        self.assertTrue(is_in_form(dg))
+
+    def test_is_in_form_false_when_dg_has_no_form_parent(self):
+        parent_dg = DeltaGenerator()
+        dg = DeltaGenerator(parent=parent_dg)
+
+        self.assertFalse(is_in_form(dg))

--- a/lib/tests/streamlit/form_utils_test.py
+++ b/lib/tests/streamlit/form_utils_test.py
@@ -15,7 +15,10 @@
 import unittest
 
 from streamlit.delta_generator import DeltaGenerator
-from streamlit.delta_generator_singletons import context_dg_stack, get_default_dg_stack
+from streamlit.delta_generator_singletons import (
+    context_dg_stack,
+    get_default_dg_stack_value,
+)
 from streamlit.elements.form_utils import FormData, is_in_form
 from streamlit.runtime import Runtime, RuntimeConfig
 
@@ -26,7 +29,7 @@ class FormUtilsTest(unittest.TestCase):
 
         # reset context_dg_stack to clean state for other tests
         # that are executed in the same thread
-        context_dg_stack.set(get_default_dg_stack())
+        context_dg_stack.set(get_default_dg_stack_value())
 
     @classmethod
     def setUpClass(cls):
@@ -49,12 +52,12 @@ class FormUtilsTest(unittest.TestCase):
         dg = DeltaGenerator()
         dg._form_data = FormData("form_id")
 
-        self.assertTrue(is_in_form(dg))
+        assert is_in_form(dg) is True
 
     def test_is_in_form_false_when_dg_has_no_formdata(self):
         dg = DeltaGenerator()
 
-        self.assertFalse(is_in_form(dg))
+        assert is_in_form(dg) is False
 
     def test_is_in_form_true_when_dg_stack_has_form(self):
         form_dg = DeltaGenerator()
@@ -62,24 +65,24 @@ class FormUtilsTest(unittest.TestCase):
         dg = DeltaGenerator()
         context_dg_stack.set((form_dg, dg))
 
-        self.assertTrue(is_in_form(dg))
+        assert is_in_form(dg) is True
 
     def test_is_in_form_false_when_dg_stack_has_no_form(self):
         form_dg = DeltaGenerator()
         dg = DeltaGenerator()
         context_dg_stack.set((form_dg, dg))
 
-        self.assertFalse(is_in_form(dg))
+        assert is_in_form(dg) is False
 
     def test_is_in_form_true_when_dg_has_form_parent(self):
         parent_dg = DeltaGenerator()
         parent_dg._form_data = FormData("form_id")
         dg = DeltaGenerator(parent=parent_dg)
 
-        self.assertTrue(is_in_form(dg))
+        assert is_in_form(dg) is True
 
     def test_is_in_form_false_when_dg_has_no_form_parent(self):
         parent_dg = DeltaGenerator()
         dg = DeltaGenerator(parent=parent_dg)
 
-        self.assertFalse(is_in_form(dg))
+        assert is_in_form(dg) is False

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -22,7 +22,8 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.delta_generator import DeltaGenerator, dg_stack
+from streamlit.delta_generator import DeltaGenerator
+from streamlit.delta_generator_singletons import context_dg_stack
 from streamlit.errors import FragmentHandledException, FragmentStorageKeyError
 from streamlit.runtime.fragment import (
     MemoryFragmentStorage,
@@ -96,9 +97,9 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
 class FragmentTest(unittest.TestCase):
     def setUp(self):
-        self.original_dg_stack = dg_stack.get()
+        self.original_dg_stack = context_dg_stack.get()
         root_container = MagicMock()
-        dg_stack.set(
+        context_dg_stack.set(
             (
                 DeltaGenerator(
                     root_container=root_container,
@@ -108,13 +109,13 @@ class FragmentTest(unittest.TestCase):
         )
 
     def tearDown(self):
-        dg_stack.set(self.original_dg_stack)
+        context_dg_stack.set(self.original_dg_stack)
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx", MagicMock())
     def test_wrapped_fragment_calls_original_function(self):
         called = False
 
-        dg_stack_len = len(dg_stack.get())
+        dg_stack_len = len(context_dg_stack.get())
 
         @fragment
         def my_fragment():
@@ -123,7 +124,7 @@ class FragmentTest(unittest.TestCase):
 
             # Verify that a new container gets created for the contents of this
             # fragment to be written to.
-            assert len(dg_stack.get()) == dg_stack_len + 1
+            assert len(context_dg_stack.get()) == dg_stack_len + 1
 
         my_fragment()
         assert called
@@ -192,7 +193,7 @@ class FragmentTest(unittest.TestCase):
 
         dg = MagicMock()
         dg.my_random_field = 7
-        dg_stack.set((dg,))
+        context_dg_stack.set((dg,))
         ctx.cursors = MagicMock()
         ctx.cursors.my_other_random_field = 8
 
@@ -204,7 +205,7 @@ class FragmentTest(unittest.TestCase):
 
             assert ctx.current_fragment_id is not None
 
-            curr_dg_stack = dg_stack.get()
+            curr_dg_stack = context_dg_stack.get()
             # Verify that mutations made in previous runs of my_fragment aren't
             # persisted.
             assert curr_dg_stack[0].my_random_field == 7
@@ -245,13 +246,13 @@ class FragmentTest(unittest.TestCase):
 
         dg = MagicMock()
         dg.my_random_field = 0
-        dg_stack.set((dg,))
+        context_dg_stack.set((dg,))
 
         @fragment
         def my_fragment():
             assert ctx.current_fragment_id is not None
 
-            curr_dg_stack = dg_stack.get()
+            curr_dg_stack = context_dg_stack.get()
             curr_dg_stack[0].my_random_field += 1
 
         assert len(ctx.new_fragment_ids) == 0

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -1251,8 +1251,9 @@ class TestScriptRunner(ScriptRunner):
 
     def _run_script(self, rerun_data: RerunData) -> None:
         self.forward_msg_queue.clear()
-        # Set the _dg_stack here to the one belonging to the thread context
         super()._run_script(rerun_data)
+
+        # Set the _dg_stack here to the one belonging to the thread context
         self._dg_stack = context_dg_stack.get()
 
     def join(self) -> None:

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -26,7 +26,8 @@ import pytest
 from parameterized import parameterized
 from tornado.testing import AsyncTestCase
 
-from streamlit.delta_generator import DeltaGenerator, dg_stack
+from streamlit.delta_generator import DeltaGenerator
+from streamlit.delta_generator_singletons import context_dg_stack
 from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
 from streamlit.errors import FragmentStorageKeyError
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
@@ -897,7 +898,7 @@ class ScriptRunnerTest(AsyncTestCase):
         )
         scriptrunner._fragment_storage.set(
             "my_fragment1",
-            lambda: dg_stack.set(dg_stack_set_by_fragment),
+            lambda: context_dg_stack.set(dg_stack_set_by_fragment),
         )
 
         # trigger a run with fragment_id to avoid clearing the fragment_storage in the script runner
@@ -935,7 +936,7 @@ class ScriptRunnerTest(AsyncTestCase):
         )
         scriptrunner._fragment_storage.set(
             "my_fragment1",
-            lambda: dg_stack.set(dg_stack_set_by_fragment),
+            lambda: context_dg_stack.set(dg_stack_set_by_fragment),
         )
 
         # trigger a run with fragment_id to avoid clearing the fragment_storage in the script runner
@@ -1253,7 +1254,7 @@ class TestScriptRunner(ScriptRunner):
         super()._run_script(rerun_data)
 
         # Set the _dg_stack here to the one belonging to the thread context
-        self._dg_stack = dg_stack.get()
+        self._dg_stack = context_dg_stack.get()
 
     def join(self) -> None:
         """Join the script_thread if it's running."""

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -356,7 +356,7 @@ class ScriptRunnerTest(AsyncTestCase):
         fragment.assert_has_calls([call(), call(), call()])
         Runtime._instance.media_file_mgr.clear_session_refs.assert_not_called()
 
-    def test_run_multiple_foo_fragments_even_if_one_raised_an_exception(self):
+    def test_run_multiple_fragments_even_if_one_raised_an_exception(self):
         """Tests that fragments continue to run when previous fragment raised an error."""
         fragment = MagicMock()
         scriptrunner = TestScriptRunner("good_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -356,7 +356,7 @@ class ScriptRunnerTest(AsyncTestCase):
         fragment.assert_has_calls([call(), call(), call()])
         Runtime._instance.media_file_mgr.clear_session_refs.assert_not_called()
 
-    def test_run_multiple_fragments_even_if_one_raised_an_exception(self):
+    def test_run_multiple_foo_fragments_even_if_one_raised_an_exception(self):
         """Tests that fragments continue to run when previous fragment raised an error."""
         fragment = MagicMock()
         scriptrunner = TestScriptRunner("good_script.py")
@@ -430,7 +430,7 @@ class ScriptRunnerTest(AsyncTestCase):
 
         assert patched_handle_exception.call_args is None
 
-    @patch("streamlit.runtime.fragment.get_script_run_ctx")
+    @patch("streamlit.runtime.scriptrunner.script_runner.get_script_run_ctx")
     @patch("streamlit.runtime.fragment.handle_uncaught_app_exception")
     def test_regular_KeyError_is_rethrown(
         self, patched_handle_exception, patched_get_script_run_ctx
@@ -1251,9 +1251,8 @@ class TestScriptRunner(ScriptRunner):
 
     def _run_script(self, rerun_data: RerunData) -> None:
         self.forward_msg_queue.clear()
-        super()._run_script(rerun_data)
-
         # Set the _dg_stack here to the one belonging to the thread context
+        super()._run_script(rerun_data)
         self._dg_stack = context_dg_stack.get()
 
     def join(self) -> None:


### PR DESCRIPTION
## Describe your changes

Second PR to address circular imports in our code base (see also https://github.com/streamlit/streamlit/pull/9255)

TLDR: get rid of 6 occurrences of `avoid circular imports` comments 🙌 

Right now, there are some circular imports because `DeltaGenerator` is importing the different element mixins, but some of the mixins require the `DeltaGenerator` module. In this PR, we move the shared variables to its own file, `delta_generator_singletons.py` and explicitly initialize them in the `streamlit/__init__.py`. This changes the import structure from (on the example of `form.py`)

```text
delta_generator.py <-> form.py
```

to
```text
    delta_generator_singletons.py
        /                 \
delta_generator.py       form.py
```

Furthermore, form util functions used by many elements are moved to a utils-module to have a clearer separation between the form element code and form-related utils code.

Since during `TYPE_CHECKING` we still use the "real" DeltaGenerator, all docstings and autocompletions are preserved - nothing changes!

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add unit tests for form_utils functions, which were no directly covered so far
  - Add unit tests for new delta_generator_singletons module
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
