### PR TITLE
Add a build option for easier embedding of Streamlit.

### DIFF
--- a/frontend/app/craco.config.js
+++ b/frontend/app/craco.config.js
@@ -112,6 +112,8 @@ module.exports = {
         // Use fixed names for the main JS & CSS files, if asked to.
         webpackConfig.output.filename = "static/js/[name].js"
         webpackConfig.output.cssFilename = "static/css/[name].css"
+        // Use fixed names for font files as well.
+        webpackConfig.output.assetModuleFilename = "static/media/[base]"
       }
 
       tsRule.include = undefined

--- a/frontend/app/craco.config.js
+++ b/frontend/app/craco.config.js
@@ -108,6 +108,12 @@ module.exports = {
         rule.test.toString().includes("ts|tsx")
       )
 
+      if (process.env.OMIT_HASH_FROM_MAIN_FILES) {
+        // Use fixed names for the main JS & CSS files, if asked to.
+        webpackConfig.output.filename = "static/js/[name].js"
+        webpackConfig.output.cssFilename = "static/css/[name].css"
+      }
+
       tsRule.include = undefined
       tsRule.exclude = /node_modules/
 

--- a/frontend/app/craco.config.js
+++ b/frontend/app/craco.config.js
@@ -114,6 +114,21 @@ module.exports = {
         webpackConfig.output.cssFilename = "static/css/[name].css"
         // Use fixed names for font files as well.
         webpackConfig.output.assetModuleFilename = "static/media/[base]"
+
+        // The MiniCssExtractPlugin doesn't honor cssFilename, so recreate the
+        // plugin with better settings if it's present.
+        const cssPluginIndex = webpackConfig.plugins.findIndex(
+          value => value.constructor?.name === "MiniCssExtractPlugin"
+        )
+        if (cssPluginIndex >= 0) {
+          const MiniCssExtractPlugin = require("mini-css-extract-plugin")
+          const cssPlugin = webpackConfig.plugins[cssPluginIndex]
+          const newPlugin = new MiniCssExtractPlugin({
+            filename: webpackConfig.output.cssFilename,
+            chunkFilename: cssPlugin.options.chunkFilename,
+          })
+          webpackConfig.plugins[cssPluginIndex] = newPlugin
+        }
       }
 
       tsRule.include = undefined

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -99,6 +99,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-github-actions-reporter": "^1.0.3",
     "jest-websocket-mock": "^2.4.0",
+    "mini-css-extract-plugin": "^2.4.5",
     "prettier": "^2.8.3",
     "prop-types": "^15.7.2",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
## Describe your changes

Add an environment variable, OMIT_HASH_FROM_MAIN_FILES, which, when set, will use a simple name for the webpack entrypoint files (`main.js` and `main.css`) and for font files.

This makes it easier to host Streamlit in a custom `index.html` file, since you can hard-code a single asset path instead of needing to update with each version.

Note that these files will be generated to the same output directory as before (`/static/{js,css,media}`).

## Testing Plan

Ran build with `OMIT_HASH_FROM_MAIN_FILES=yes` and without it set; confirmed output looked reasonable.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
