### PR TITLE
Add data handling support for DB API 2.0

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -231,5 +231,5 @@ jobs:
         run: make develop
       - name: Install integration dependencies
         run: uv pip install -r lib/integration-requirements.txt --force-reinstall
-      - name: Run Python Tests for Snowflake
+      - name: Run Python integration tests
         run: make pytest-integration

--- a/lib/integration-requirements.txt
+++ b/lib/integration-requirements.txt
@@ -11,6 +11,7 @@ polars
 xarray
 dask
 ray
+duckdb
 
 # Used for testing of st.connection
 sqlalchemy[mypy]>=1.4.25, <2

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1124,6 +1124,8 @@ def determine_data_format(input_data: Any) -> DataFormat:
         return DataFormat.DASK_OBJECT
     elif is_snowpark_data_object(input_data) or is_snowpark_row_list(input_data):
         return DataFormat.SNOWPARK_OBJECT
+    elif is_duckdb_relation(input_data):
+        return DataFormat.DUCKDB_RELATION
     elif is_dbapi_cursor(input_data):
         return DataFormat.DBAPI_CURSOR
     elif (

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -975,6 +975,7 @@ def is_colum_type_arrow_incompatible(column: Series[Any] | Index) -> bool:
         "period[ns]",
         "period[U]",
         "period[us]",
+        "geometry",
     }:
         return True
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -600,7 +600,11 @@ def convert_anything_to_pandas_df(
         return data
 
     if is_dbapi_cursor(data):
-        columns = [d[0] for d in data.description] if data.description else None
+        # Based on the specification, the first item in the description is the
+        # column name (if available)
+        columns = (
+            [d[0] if d else "" for d in data.description] if data.description else None
+        )
         data = pd.DataFrame(data.fetchmany(max_unevaluated_rows), columns=columns)
         if data.shape[0] == max_unevaluated_rows:
             _show_data_information(

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -100,7 +100,11 @@ V_co = TypeVar(
 @runtime_checkable
 class DBAPICursor(Protocol):
     """Protocol for DBAPI 2.0 Cursor objects (PEP 249).
-    This is a simplified version of the DBAPI Cursor protocol.
+
+    This is a simplified version of the DBAPI Cursor protocol
+    that only contains the methods that are relevant or used for
+    our DB API Integration.
+
     Specification: https://peps.python.org/pep-0249/
     Inspired by: https://github.com/python/typeshed/blob/main/stdlib/_typeshed/dbapi.pyi
     """

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -477,7 +477,11 @@ class DataframeUtilTest(unittest.TestCase):
         con.close()
 
     @pytest.mark.require_integration
-    def test_verify_duckdb_integration(self):
+    def test_verify_duckdb_db_api_integration(self):
+        """Test that duckdb cursor can be used as a data source.
+
+        https://duckdb.org/docs/api/python/dbapi
+        """
         import duckdb
 
         con = duckdb.connect(database=":memory:")

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -506,7 +506,7 @@ class DataframeUtilTest(unittest.TestCase):
 
     @pytest.mark.require_integration
     def test_verify_duckdb_relational_api_integration(self):
-        """Test that duckdb cursor can be used as a data source.
+        """Test that duckdb relational API can be used as a data source.
 
         https://duckdb.org/docs/api/python/relational_api
         """

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -505,6 +505,28 @@ class DataframeUtilTest(unittest.TestCase):
         con.close()
 
     @pytest.mark.require_integration
+    def test_verify_duckdb_relational_api_integration(self):
+        """Test that duckdb cursor can be used as a data source.
+
+        https://duckdb.org/docs/api/python/relational_api
+        """
+        import duckdb
+
+        items = pd.DataFrame([["foo", 1], ["bar", 2]], columns=["name", "value"])
+        db_relation = duckdb.sql("SELECT * from items")
+        assert dataframe_util.is_duckdb_relation(db_relation) is True
+        assert (
+            dataframe_util.determine_data_format(db_relation)
+            is dataframe_util.DataFormat.DUCKDB_RELATION
+        )
+        converted_df = dataframe_util.convert_anything_to_pandas_df(db_relation)
+        assert isinstance(
+            converted_df,
+            pd.DataFrame,
+        )
+        assert converted_df.shape == items.shape
+
+    @pytest.mark.require_integration
     def test_verify_snowpark_integration(self):
         """Integration test snowpark object handling.
         This is in addition to the tests using the mocks to verify that


### PR DESCRIPTION
## Describe your changes

Adds official support for Database Cursors that conform with the [DB API 2.0 Spec](https://peps.python.org/pep-0249/) (PEP 249). This adds support for DB cursor objects as input for Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more.

This implementation is expected to support a large number of database clients such as:
- sqlite3
- duckdb
- psycopg2
- sqlalchemy

## Testing Plan

- Added unit tests to verify that the integration works.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
