### PR TITLE
Do not preserve children of a block if the block type changes

### DIFF
--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -860,11 +860,16 @@ export class AppRoot {
   ): AppRoot {
     const existingNode = this.root.getIn(deltaPath)
 
-    // If we're replacing an existing Block, this new Block inherits
-    // the existing Block's children. This prevents existing widgets from
-    // having their values reset.
-    const children: AppNode[] =
-      existingNode instanceof BlockNode ? existingNode.children : []
+    // If we're replacing an existing Block of the same type, this new Block
+    // inherits the existing Block's children. This prevents existing widgets
+    // from having their values reset.
+    let children: AppNode[] = []
+    if (
+      existingNode instanceof BlockNode &&
+      existingNode.deltaBlock.type === block.type
+    ) {
+      children = existingNode.children
+    }
 
     const blockNode = new BlockNode(
       activeScriptHash,

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -861,8 +861,9 @@ export class AppRoot {
     const existingNode = this.root.getIn(deltaPath)
 
     // If we're replacing an existing Block of the same type, this new Block
-    // inherits the existing Block's children. This prevents existing widgets
-    // from having their values reset.
+    // inherits the existing Block's children. This preserves two things:
+    //  1. Widget State
+    //  2. React state of all elements
     let children: AppNode[] = []
     if (
       existingNode instanceof BlockNode &&


### PR DESCRIPTION
## Describe your changes

We have this convenience that preserves the children of a block even if a block changes. This was likely because we want to keep the same block and children and we don't want to make random elements disappear (and preserve widget state). This change keeps the existing behavior, but it _will_ reset the children if the _type_ of the block changes as well. 

## GitHub Issue Link (if applicable)
Closes #9259
Closes #8676

## Testing Plan

- Added a unit test to define the behavior accurately

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
