### PR TITLE
Add explicit return to fragment wrap function

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -216,6 +216,7 @@ def _fragment(
             prev_fragment_id = ctx.current_fragment_id
             ctx.current_fragment_id = fragment_id
 
+            result = None
             try:
                 # Make sure we set the active script hash to the same value
                 # for the fragment run as when defined upon initialization
@@ -228,7 +229,6 @@ def _fragment(
                     if initialized_active_script_hash != ctx.active_script_hash
                     else contextlib.nullcontext()
                 )
-                result = None
                 with active_hash_context:
                     with st.container():
                         try:
@@ -263,10 +263,11 @@ def _fragment(
                             # raise here again in case we are in full app execution
                             # and some flags have to be set
                             raise FragmentHandledException(e)
-                    return result
             finally:
                 ctx.current_fragment_id = prev_fragment_id
                 ctx.current_fragment_delta_path = []
+
+            return result
 
         if not ctx.fragment_storage.contains(fragment_id):
             ctx.fragment_storage.set(fragment_id, wrapped_fragment)


### PR DESCRIPTION
## Describe your changes

Closes the code scanner finding: https://github.com/streamlit/streamlit/security/code-scanning/9343
by adding an explicit return to the end of the function.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
