### PR TITLE
Unstale just updated fragments

### DIFF
--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -41,10 +41,17 @@ describe("isElementStale", () => {
   })
 
   // When running in a fragment, the only elements that should be set to stale
-  // are those belonging to the fragment that's currently running.
-  it("if running and currentFragmentId is set, compares with node's fragmentId", () => {
+  // are those belonging to the fragment that's currently running and only if the script run id is different.
+  // If the script run id is the same, the element has just been updated and is not stale.
+  it("if running and currentFragmentId is set, compares with node's fragmentId and scriptrunId", () => {
     expect(
       isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
+        "myFragmentId",
+      ])
+    ).toBe(false)
+
+    expect(
+      isElementStale(node, ScriptRunState.RUNNING, "otherScriptRunId", [
         "myFragmentId",
       ])
     ).toBe(true)

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -47,8 +47,13 @@ export function isElementStale(
 
   if (scriptRunState === ScriptRunState.RUNNING) {
     if (fragmentIdsThisRun && fragmentIdsThisRun.length) {
+      // if the fragmentId is set, we only want to mark elements as stale
+      // that belong to the same fragmentId and have a different scriptRunId.
+      // If they have the same scriptRunId, they were just updated.
       return Boolean(
-        node.fragmentId && fragmentIdsThisRun.includes(node.fragmentId)
+        node.fragmentId &&
+          fragmentIdsThisRun.includes(node.fragmentId) &&
+          node.scriptRunId !== scriptRunId
       )
     }
     return node.scriptRunId !== scriptRunId


### PR DESCRIPTION
## Describe your changes

During a full app rerun, elements that are updated (have the same scriptRunId as the current scriptRunId) are immediately shown as un-stale. For fragment runs, the elements are shown as stale until the end and then all at once are un-staled. 
In this PR, we show elements as non-stale during the scriptrun also for fragments.

Before:

https://github.com/user-attachments/assets/75cd2b61-1c2e-42be-bc47-1b9dfb19e7d8

After:

https://github.com/user-attachments/assets/b12d66fd-2e8b-46fd-b328-4eade3513a38




## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - update JS unit test to cover the updated behavior
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
