### PR TITLE
Adding issue template for kudos

### DIFF
--- a/.github/ISSUE_TEMPLATE/thank_streamlit_team.yml
+++ b/.github/ISSUE_TEMPLATE/thank_streamlit_team.yml
@@ -1,0 +1,10 @@
+name: ✨ Thank the Streamlit team!
+description: Have some kind words to share with the Streamlit team? We'd love to hear them!
+labels: ["type:kudos"]
+body:
+  - type: textarea
+    attributes:
+      label: Message
+      description: Type your message to the Streamlit team here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/thank_streamlit_team.yml
+++ b/.github/ISSUE_TEMPLATE/thank_streamlit_team.yml
@@ -1,4 +1,4 @@
-name: ✨ Thank the Streamlit team!
+name: 🙏 Thank the Streamlit team!
 description: Have some kind words to share with the Streamlit team? We'd love to hear them!
 labels: ["type:kudos"]
 body:


### PR DESCRIPTION
## Describe your changes
This PR adds a new issue template that allows people to thank the streamlit team (without filing a normal issue and allowing it to be properly tagged). We'd also like to hook this up via webhook so that it posts in our internal slack channel for visibility and to boost morale.

Here's a couple examples of this in the past:
https://github.com/streamlit/streamlit/issues/8970
https://github.com/streamlit/streamlit/issues/4676

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
