### PR TITLE
Add support for dataframe interchange protocol

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from streamlit import dataframe_util, type_util
+from streamlit import dataframe_util
 from streamlit.elements.lib import pandas_styler_utils
 
 if TYPE_CHECKING:
@@ -122,7 +122,7 @@ def arrow_proto_to_dataframe(proto: ArrowTableProto) -> DataFrame:
 
     """
 
-    if type_util.is_pyarrow_version_less_than("14.0.1"):
+    if dataframe_util.is_pyarrow_version_less_than("14.0.1"):
         raise RuntimeError(
             "The installed pyarrow version is not compatible with this component. "
             "Please upgrade to 14.0.1 or higher: pip install -U pyarrow"

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -181,7 +181,6 @@ Data: TypeAlias = Union[
     Dict[Any, Any],
     DBAPICursor,
     PandasCompatible,
-    ArrowCompatible,
     DataframeInterchangeCompatible,
     None,
 ]

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -536,7 +536,7 @@ def convert_anything_to_pandas_df(
 
     Parameters
     ----------
-    data : any
+    data : dataframe-, array, or collections-like object
         The data to convert to a Pandas DataFrame.
 
     max_unevaluated_rows: int
@@ -875,7 +875,7 @@ def convert_anything_to_arrow_bytes(
 
     Parameters
     ----------
-    data : any
+    data : dataframe-, array-, or collections-like object
         The data to convert to Arrow bytes.
 
     max_unevaluated_rows: int
@@ -940,7 +940,7 @@ def convert_anything_to_sequence(obj: OptionSequence[V_co]) -> list[V_co]:
     Parameters
     ----------
 
-    obj : OptionSequence
+    obj : dataframe-, array-, or collections-like object
         The object to convert to a list.
 
     Returns

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -884,14 +884,6 @@ def convert_anything_to_arrow_bytes(
     if isinstance(data, pa.Table):
         return convert_arrow_table_to_arrow_bytes(data)
 
-    if is_pandas_data_object(data) or is_unevaluated_data_object(data):
-        # All pandas and unevaluated data objects should be handled via
-        # our pandas conversion logic. We are already calling it here
-        # to ensure that its not handled via the interchange
-        # protocol support below.
-        df = convert_anything_to_pandas_df(data, max_unevaluated_rows)
-        return convert_pandas_df_to_arrow_bytes(df)
-
     # TODO(lukasmasuch): Add direct conversion to Arrow here for supproted formats
 
     # Fallback: try to convert to pandas DataFrame

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -365,11 +365,7 @@ def is_snowpark_row_list(obj: object) -> bool:
 
 def is_pyspark_data_object(obj: object) -> bool:
     """True if obj is of type pyspark.sql.dataframe.DataFrame"""
-    return (
-        is_type(obj, _PYSPARK_DF_TYPE_STR)
-        and hasattr(obj, "toPandas")
-        and callable(obj.toPandas)
-    )
+    return is_type(obj, _PYSPARK_DF_TYPE_STR) and has_callable_attr(obj, "toPandas")
 
 
 def is_dask_object(obj: object) -> bool:
@@ -690,9 +686,6 @@ def convert_anything_to_pandas_df(
     if has_callable_attr(data, "to_pandas"):
         return pd.DataFrame(data.to_pandas())
 
-    if has_callable_attr(data, "toPandas"):
-        return pd.DataFrame(data.toPandas())
-
     # Check for dataframe interchange protocol
     # Only available in pandas >= 1.5.0
     # https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#dataframe-interchange-protocol-implementation
@@ -885,7 +878,7 @@ def convert_anything_to_arrow_bytes(
     if isinstance(data, pa.Table):
         return convert_arrow_table_to_arrow_bytes(data)
 
-    if is_pandas_data_object(data) and is_unevaluated_data_object(data):
+    if is_pandas_data_object(data) or is_unevaluated_data_object(data):
         # All pandas and unevaluated data objects should be handled via
         # our pandas conversion logic. We are already calling it here
         # to ensure that its not handled via the interchange

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -50,8 +50,8 @@ from streamlit.type_util import (
     is_dataclass_instance,
     is_list_like,
     is_namedtuple,
-    is_pandas_version_less_than,
     is_type,
+    is_version_less_than,
 )
 
 if TYPE_CHECKING:
@@ -230,6 +230,53 @@ class DataFormat(Enum):
     KEY_VALUE_DICT = auto()  # {index: value}
     DBAPI_CURSOR = auto()  # DBAPI Cursor (PEP 249)
     DUCKDB_RELATION = auto()  # DuckDB Relation
+
+
+def is_pyarrow_version_less_than(v: str) -> bool:
+    """Return True if the current Pyarrow version is less than the input version.
+
+    Parameters
+    ----------
+    v : str
+        Version string, e.g. "0.25.0"
+
+    Returns
+    -------
+    bool
+
+
+    Raises
+    ------
+    InvalidVersion
+        If the version strings are not valid.
+
+    """
+    import pyarrow as pa
+
+    return is_version_less_than(pa.__version__, v)
+
+
+def is_pandas_version_less_than(v: str) -> bool:
+    """Return True if the current Pandas version is less than the input version.
+
+    Parameters
+    ----------
+    v : str
+        Version string, e.g. "0.25.0"
+
+    Returns
+    -------
+    bool
+
+
+    Raises
+    ------
+    InvalidVersion
+        If the version strings are not valid.
+    """
+    import pandas as pd
+
+    return is_version_less_than(pd.__version__, v)
 
 
 def is_dataframe_like(obj: object) -> bool:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -176,6 +176,7 @@ Data: TypeAlias = Union[
     "Styler",
     "Index",
     "pa.Table",
+    "pa.Array",
     "np.ndarray[Any, np.dtype[Any]]",
     Iterable[Any],
     Dict[Any, Any],

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -884,7 +884,7 @@ def convert_anything_to_arrow_bytes(
     if isinstance(data, pa.Table):
         return convert_arrow_table_to_arrow_bytes(data)
 
-    # TODO(lukasmasuch): Add direct conversion to Arrow here for supproted formats
+    # TODO(lukasmasuch): Add direct conversion to Arrow for supported formats here
 
     # Fallback: try to convert to pandas DataFrame
     # and then to Arrow bytes.

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -885,7 +885,7 @@ def convert_anything_to_arrow_bytes(
     if isinstance(data, pa.Table):
         return convert_arrow_table_to_arrow_bytes(data)
 
-    if is_pandas_data_object(data):
+    if is_pandas_data_object(data) and is_unevaluated_data_object(data):
         # All pandas and unevaluated data objects should be handled via
         # our pandas conversion logic. We are already calling it here
         # to ensure that its not handled via the interchange

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -536,7 +536,7 @@ def convert_anything_to_pandas_df(
 
     Parameters
     ----------
-    data : dataframe-, array, or collections-like object
+    data : dataframe-, array-, or collections-like object
         The data to convert to a Pandas DataFrame.
 
     max_unevaluated_rows: int
@@ -894,8 +894,8 @@ def convert_anything_to_arrow_bytes(
         return convert_arrow_table_to_arrow_bytes(data)
 
     if is_pandas_data_object(data) or is_unevaluated_data_object(data):
-        # All pandas and unevluated objects should be handled via our pandas
-        # conversion logic. We are already calling it here
+        # All pandas and unevaluated data objects should be handled via
+        # our pandas conversion logic. We are already calling it here
         # to ensure that its not handled via the interchange
         # protocol support below.
         df = convert_anything_to_pandas_df(data, max_unevaluated_rows)

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -495,6 +495,16 @@ class WriteMixin:
             ):
                 # We either explicitly allow HTML or infer it's not HTML
                 self.dg.markdown(repr_html, unsafe_allow_html=unsafe_allow_html)
+            elif (
+                type_util.has_callable_attr(arg, "to_pandas")
+                or type_util.has_callable_attr(arg, "to_arrow")
+                or type_util.has_callable_attr(arg, "__dataframe__")
+            ):
+                # This object can very likely be converted to a DataFrame
+                # using the to_pandas, to_arrow, or the dataframe interchange
+                # protocol.
+                flush_buffer()
+                self.dg.dataframe(arg)
             else:
                 stringified_arg = str(arg)
 

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -495,11 +495,9 @@ class WriteMixin:
             ):
                 # We either explicitly allow HTML or infer it's not HTML
                 self.dg.markdown(repr_html, unsafe_allow_html=unsafe_allow_html)
-            elif (
-                type_util.has_callable_attr(arg, "to_pandas")
-                or type_util.has_callable_attr(arg, "to_arrow")
-                or type_util.has_callable_attr(arg, "__dataframe__")
-            ):
+            elif type_util.has_callable_attr(
+                arg, "to_pandas"
+            ) or type_util.has_callable_attr(arg, "__dataframe__"):
                 # This object can very likely be converted to a DataFrame
                 # using the to_pandas, to_arrow, or the dataframe interchange
                 # protocol.

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -364,53 +364,6 @@ def check_python_comparable(seq: Sequence[Any]) -> None:
         )
 
 
-def is_pandas_version_less_than(v: str) -> bool:
-    """Return True if the current Pandas version is less than the input version.
-
-    Parameters
-    ----------
-    v : str
-        Version string, e.g. "0.25.0"
-
-    Returns
-    -------
-    bool
-
-
-    Raises
-    ------
-    InvalidVersion
-        If the version strings are not valid.
-    """
-    import pandas as pd
-
-    return is_version_less_than(pd.__version__, v)
-
-
-def is_pyarrow_version_less_than(v: str) -> bool:
-    """Return True if the current Pyarrow version is less than the input version.
-
-    Parameters
-    ----------
-    v : str
-        Version string, e.g. "0.25.0"
-
-    Returns
-    -------
-    bool
-
-
-    Raises
-    ------
-    InvalidVersion
-        If the version strings are not valid.
-
-    """
-    import pyarrow as pa
-
-    return is_version_less_than(pa.__version__, v)
-
-
 def is_altair_version_less_than(v: str) -> bool:
     """Return True if the current Altair version is less than the input version.
 

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -35,7 +35,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from streamlit.dataframe_util import DataFormat
+from streamlit.dataframe_util import DataFormat, is_pandas_version_less_than
 from tests.streamlit.dask_mocks import DataFrame as DaskDataFrame
 from tests.streamlit.dask_mocks import Index as DaskIndex
 from tests.streamlit.dask_mocks import Series as DaskSeries
@@ -1051,27 +1051,36 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
             pd.DataFrame,
         ),
     ),
-    (
-        "Dataframe-interchange compatible",
-        CustomDataframe(
-            pd.DataFrame(
-                [
-                    {"name": "st.text_area", "type": "widget"},
-                    {"name": "st.markdown", "type": "element"},
-                ]
-            )
-        ),
-        CaseMetadata(
-            2,
-            2,
-            DataFormat.UNKNOWN,
-            ["st.text_area", "st.markdown"],
-            "dataframe",
-            False,
-            None,
-        ),
-    ),
 ]
+
+###################################
+###### Dataframe Interchange ######
+###################################
+if is_pandas_version_less_than("1.5.0") is False:
+    SHARED_TEST_CASES.extend(
+        [
+            (
+                "Dataframe-interchange compatible",
+                CustomDataframe(
+                    pd.DataFrame(
+                        [
+                            {"name": "st.text_area", "type": "widget"},
+                            {"name": "st.markdown", "type": "element"},
+                        ]
+                    )
+                ),
+                CaseMetadata(
+                    2,
+                    2,
+                    DataFormat.UNKNOWN,
+                    ["st.text_area", "st.markdown"],
+                    "dataframe",
+                    False,
+                    None,
+                ),
+            ),
+        ]
+    )
 
 ###################################
 ########### Polars Types ##########

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -105,6 +105,18 @@ class TestObject:
         return "TestObject"
 
 
+class CustomDataframe:
+    """A dummy dataframe-like class that supports the dataframe interchange protocol
+    (__dataframe__ method).
+    """
+
+    def __init__(self, data: pd.DataFrame):
+        self._data: pd.DataFrame = data
+
+    def __dataframe__(self, allow_copy: bool = True):
+        return self._data.__dataframe__(allow_copy=allow_copy)
+
+
 class StrTestEnum(str, enum.Enum):
     NUMBER_INPUT = "st.number_input"
     TEXT_AREA = "st.text_area"
@@ -1037,6 +1049,26 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
             "dataframe",
             True,
             pd.DataFrame,
+        ),
+    ),
+    (
+        "Dataframe-interchange compatible",
+        CustomDataframe(
+            pd.DataFrame(
+                [
+                    {"name": "st.text_area", "type": "widget"},
+                    {"name": "st.markdown", "type": "element"},
+                ]
+            )
+        ),
+        CaseMetadata(
+            2,
+            2,
+            DataFormat.UNKNOWN,
+            ["st.text_area", "st.markdown"],
+            "dataframe",
+            False,
+            None,
         ),
     ),
 ]

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -170,13 +170,9 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
             st.dataframe(df.style.format("{:03d}"))
         pd.reset_option("styler.render.max_elements")
 
-    @patch(
-        "streamlit.type_util.is_pandas_version_less_than",
-        MagicMock(return_value=False),
-    )
     @patch.object(Styler, "_translate")
-    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):
-        """Tests that `styler._translate` is called with correct arguments in Pandas >= 1.3.0"""
+    def test_styler_translate_gets_called(self, mock_styler_translate):
+        """Tests that `styler._translate` is called with correct arguments."""
         df = mock_data_frame()
         styler = df.style.set_uuid("FAKE_UUID")
 

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -14,12 +14,11 @@
 
 """Arrow marshalling unit tests."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from pandas.io.formats.style_render import StylerRenderer as Styler
 
 import streamlit as st
 from streamlit.dataframe_util import (
@@ -128,16 +127,3 @@ class ArrowTest(DeltaGeneratorTestCase):
 
             st.table(df)
             convert_anything_to_df.assert_called_once()
-
-    @patch(
-        "streamlit.type_util.is_pandas_version_less_than",
-        MagicMock(return_value=False),
-    )
-    @patch.object(Styler, "_translate")
-    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):
-        """Tests that `styler._translate` is called with correct arguments in Pandas >= 1.3.0"""
-        df = mock_data_frame()
-        styler = df.style.set_uuid("FAKE_UUID")
-
-        st.table(styler)
-        mock_styler_translate.assert_called_once_with(False, False)

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -29,7 +29,11 @@ import pyarrow as pa
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.dataframe_util import DataFormat, convert_arrow_bytes_to_pandas_df
+from streamlit.dataframe_util import (
+    DataFormat,
+    convert_arrow_bytes_to_pandas_df,
+    is_pandas_version_less_than,
+)
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ColumnDataKind,
@@ -46,7 +50,6 @@ from streamlit.elements.widgets.data_editor import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
-from streamlit.type_util import is_pandas_version_less_than
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_mocks import SHARED_TEST_CASES, CaseMetadata
 

--- a/lib/tests/streamlit/snowpandas_mocks.py
+++ b/lib/tests/streamlit/snowpandas_mocks.py
@@ -81,6 +81,7 @@ class Index:
     snowflake.snowpark.modin.plugin.extensions.index.Index class for testing purposes.
     We use this to make sure that our code does a special handling
     if it detects a Snowpark Pandas Index.
+
     This allows testing of the functionality without having the library installed,
     but it won't capture changes in the API of the library. This requires
     integration tests.


### PR DESCRIPTION
## Describe your changes

Adds official support for the [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/). Objects supporting this protocol can be used as input for Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more.

This PR also moves the pandas and pyarrow version checks into the dataframe_util.

## Testing Plan

- Added to a mock class to `data_mocks` -> This will be used for various tests covering many relevant commands.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
