### PR TITLE
Add data handling support for Pydantic instances

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -22,7 +22,7 @@ import inspect
 import math
 import re
 from collections import ChainMap, UserDict, UserList, deque
-from collections.abc import ItemsView, Mapping
+from collections.abc import ItemsView
 from enum import Enum, EnumMeta, auto
 from types import MappingProxyType
 from typing import (
@@ -31,6 +31,7 @@ from typing import (
     Final,
     Iterable,
     List,
+    Mapping,
     Protocol,
     Sequence,
     TypeVar,
@@ -161,7 +162,7 @@ Data: TypeAlias = Union[
     "pa.Table",
     "np.ndarray[Any, np.dtype[Any]]",
     Iterable[Any],
-    Mapping[Any, Any],
+    "Mapping[Any, Any]",
     DBAPICursor,
     CustomDict,
     None,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -28,7 +28,6 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Final,
     Iterable,
     List,
@@ -44,12 +43,14 @@ from typing_extensions import TypeAlias, TypeGuard
 
 from streamlit import config, errors, logger, string_util
 from streamlit.type_util import (
+    CustomDict,
     NumpyShape,
     has_callable_attr,
     is_custom_dict,
     is_dataclass_instance,
     is_list_like,
     is_namedtuple,
+    is_pydantic_model,
     is_type,
 )
 
@@ -160,8 +161,9 @@ Data: TypeAlias = Union[
     "pa.Table",
     "np.ndarray[Any, np.dtype[Any]]",
     Iterable[Any],
-    Dict[Any, Any],
+    Mapping[Any, Any],
     DBAPICursor,
+    CustomDict,
     None,
 ]
 
@@ -657,7 +659,9 @@ def convert_anything_to_pandas_df(
         return _dict_to_pandas_df(dataclasses.asdict(data))
 
     # Support for dict-like objects
-    if isinstance(data, (ChainMap, MappingProxyType, UserDict)):
+    if isinstance(data, (ChainMap, MappingProxyType, UserDict)) or is_pydantic_model(
+        data
+    ):
         return _dict_to_pandas_df(dict(data))
 
     # Try to convert to pandas.DataFrame. This will raise an error is df is not
@@ -1141,6 +1145,7 @@ def determine_data_format(input_data: Any) -> DataFormat:
         or is_dataclass_instance(input_data)
         or is_namedtuple(input_data)
         or is_custom_dict(input_data)
+        or is_pydantic_model(input_data)
     ):
         return DataFormat.KEY_VALUE_DICT
     elif isinstance(input_data, (ItemsView, enumerate)):

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -21,7 +21,12 @@ from typing import TYPE_CHECKING, Any, cast
 
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.type_util import is_custom_dict, is_namedtuple
+from streamlit.type_util import (
+    is_custom_dict,
+    is_list_like,
+    is_namedtuple,
+    is_pydantic_model,
+)
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -79,6 +84,7 @@ class JsonMixin:
            height: 385px
 
         """
+        import streamlit as st
 
         if is_custom_dict(body):
             body = body.to_dict()
@@ -86,18 +92,20 @@ class JsonMixin:
         if is_namedtuple(body):
             body = body._asdict()
 
-        if isinstance(body, (map, enumerate)):
-            body = list(body)
+        if isinstance(
+            body, (ChainMap, types.MappingProxyType, UserDict)
+        ) or is_pydantic_model(body):
+            body = dict(body)  # type: ignore
 
-        if isinstance(body, (ChainMap, types.MappingProxyType, UserDict)):
-            body = dict(body)
+        if is_list_like(body):
+            body = list(body)
 
         if not isinstance(body, str):
             try:
                 # Serialize body to string and try to interpret sets as lists
                 body = json.dumps(body, default=_ensure_serialization)
             except TypeError as err:
-                self.dg.warning(
+                st.warning(
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"
                 )

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -84,7 +84,6 @@ class JsonMixin:
            height: 385px
 
         """
-        import streamlit as st
 
         if is_custom_dict(body):
             body = body.to_dict()
@@ -105,7 +104,7 @@ class JsonMixin:
                 # Serialize body to string and try to interpret sets as lists
                 body = json.dumps(body, default=_ensure_serialization)
             except TypeError as err:
-                st.warning(
+                self.dg.warning(
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"
                 )

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -18,6 +18,7 @@ import dataclasses
 import inspect
 import types
 from collections import ChainMap, UserDict, UserList
+from collections.abc import ItemsView, KeysView, ValuesView
 from io import StringIO
 from typing import (
     TYPE_CHECKING,
@@ -258,13 +259,13 @@ class WriteMixin:
             - write(string)         : Prints the formatted Markdown string, with
                 support for LaTeX expression, emoji shortcodes, and colored text.
                 See docs for st.markdown for more.
-            - write(data_frame)     : Displays any dataframe-compatible value
-                as read-only table.
+            - write(dataframe)      : Displays any dataframe-like in a table.
+            - write(dict)           : Displays dict-like in an interactive viewer.
+            - write(list)           : Displays list-like in an interactive viewer.
             - write(error)          : Prints an exception specially.
             - write(func)           : Displays information about a function.
             - write(module)         : Displays information about the module.
             - write(class)          : Displays information about a class.
-            - write(dict)           : Displays dict in an interactive widget.
             - write(mpl_fig)        : Displays a Matplotlib figure.
             - write(generator)      : Streams the output of a generator.
             - write(openai.Stream)  : Streams the output of an OpenAI stream.
@@ -276,7 +277,9 @@ class WriteMixin:
             - write(bokeh_fig)      : Displays a Bokeh figure.
             - write(sympy_expr)     : Prints SymPy expression using LaTeX.
             - write(htmlable)       : Prints _repr_html_() for the object if available.
+            - write(db_cursor)      : Displays DB API 2.0 cursor results in a table.
             - write(obj)            : Prints str(obj) if otherwise unknown.
+
 
         unsafe_allow_html : bool
             Whether to render HTML within ``*args``. This only applies to
@@ -457,10 +460,14 @@ class WriteMixin:
                         UserDict,
                         ChainMap,
                         UserList,
+                        ItemsView,
+                        KeysView,
+                        ValuesView,
                     ),
                 )
                 or type_util.is_custom_dict(arg)
                 or type_util.is_namedtuple(arg)
+                or type_util.is_pydantic_model(arg)
             ):
                 flush_buffer()
                 self.dg.json(arg)

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -259,7 +259,7 @@ class WriteMixin:
             - write(string)         : Prints the formatted Markdown string, with
                 support for LaTeX expression, emoji shortcodes, and colored text.
                 See docs for st.markdown for more.
-            - write(dataframe)      : Displays any dataframe-like in a table.
+            - write(dataframe)      : Displays any dataframe-like object in a table.
             - write(dict)           : Displays dict-like in an interactive viewer.
             - write(list)           : Displays list-like in an interactive viewer.
             - write(error)          : Prints an exception specially.

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -296,7 +296,9 @@ def is_pydantic_model(obj) -> bool:
     """True if input looks like a Pydantic model instance."""
 
     if isinstance(obj, type):
-        # Should be an instance, not a class.
+        # The obj is a class, but we
+        # only want to check for instances
+        # of Pydantic models, so we return False.
         return False
 
     return _is_type_instance(obj, "pydantic.main.BaseModel")

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -112,6 +112,11 @@ def is_type(obj: object, fqn_type_pattern: str | re.Pattern[str]) -> bool:
         return fqn_type_pattern.match(fqn_type) is not None
 
 
+def _is_type_instance(obj: object, type_to_check: str) -> bool:
+    """Check if instance of type without importing expensive modules."""
+    return type_to_check in [get_fqn(t) for t in type(obj).__mro__]
+
+
 def get_fqn(the_type: type) -> str:
     """Get module.type_name for a given type."""
     return f"{the_type.__module__}.{the_type.__qualname__}"
@@ -285,6 +290,16 @@ def is_dataclass_instance(obj: object) -> bool:
 def is_pydeck(obj: object) -> TypeGuard[Deck]:
     """True if input looks like a pydeck chart."""
     return is_type(obj, "pydeck.bindings.deck.Deck")
+
+
+def is_pydantic_model(obj) -> bool:
+    """True if input looks like a Pydantic model instance."""
+
+    if isinstance(obj, type):
+        # Should be an instance, not a class.
+        return False
+
+    return _is_type_instance(obj, "pydantic.main.BaseModel")
 
 
 def is_custom_dict(obj: object) -> TypeGuard[CustomDict]:

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -260,7 +260,7 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
             1,
             DataFormat.LIST_OF_VALUES,
             ["st.number_input", "st.text_area", "st.text_input"],
-            "markdown",
+            "json",
             False,
             list,
         ),
@@ -277,7 +277,7 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
             1,
             DataFormat.LIST_OF_VALUES,
             ["number", "text", "text"],
-            "markdown",
+            "json",
             False,
             list,
         ),
@@ -298,7 +298,7 @@ SHARED_TEST_CASES: list[tuple[str, Any, CaseMetadata]] = [
                 ("st.text_area", "text"),
                 ("st.text_input", "text"),
             ],
-            "markdown",
+            "json",
             False,
             list,
         ),
@@ -1149,3 +1149,36 @@ try:
     )
 except ModuleNotFoundError:
     print("Xarray not installed. Skipping Xarray dataframe integration tests.")  # noqa: T201
+
+###################################
+########## Pydantic Types #########
+###################################
+try:
+    from pydantic import BaseModel
+
+    class ElementPydanticModel(BaseModel):
+        name: str
+        is_widget: bool
+        usage: float
+
+    SHARED_TEST_CASES.extend(
+        [
+            (
+                "Pydantic Model",
+                ElementPydanticModel(
+                    name="st.number_input", is_widget=True, usage=0.32
+                ),
+                CaseMetadata(
+                    3,
+                    1,
+                    DataFormat.KEY_VALUE_DICT,
+                    ["st.number_input", True, 0.32],
+                    "json",
+                    False,
+                    dict,
+                ),
+            ),
+        ]
+    )
+except ModuleNotFoundError:
+    print("Pydantic not installed. Skipping Pydantic dataframe tests.")  # noqa: T201

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -86,6 +86,21 @@ class TypeUtilTest(unittest.TestCase):
         res = type_util.is_namedtuple(John)
         self.assertTrue(res)
 
+    def test_is_pydantic_model(self):
+        from pydantic import BaseModel
+
+        class OtherObject:
+            foo: int
+            bar: str
+
+        class BarModel(BaseModel):
+            foo: int
+            bar: str
+
+        self.assertTrue(type_util.is_pydantic_model(BarModel(foo=1, bar="test")))
+        self.assertFalse(type_util.is_pydantic_model(BarModel))
+        self.assertFalse(type_util.is_pydantic_model(OtherObject))
+
     def test_to_bytes(self):
         bytes_obj = b"some bytes"
         self.assertTrue(type_util.is_bytes_like(bytes_obj))

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -86,6 +86,7 @@ class TypeUtilTest(unittest.TestCase):
         res = type_util.is_namedtuple(John)
         self.assertTrue(res)
 
+    @pytest.mark.require_integration
     def test_is_pydantic_model(self):
         from pydantic import BaseModel
 


### PR DESCRIPTION
## Describe your changes

This adds support for correctly handling pydantic model instances as input for Streamlit commands, such as `st.dataframe`, `st.data_editor`, charts, `st.map`, `st.write`, `st.selectbox`, and many more.

This also applies a small refactoring for st.json handling. Dict values, keys, and item instances will be visualized via `st.json` when used in `st.write` and not printed out as string.

## Testing Plan

- Added to `data_mocks` -> This will be used for various tests covering many relevant commands.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
