### PR TITLE
Fix logo + sidebar sizing interaction

### DIFF
--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -307,5 +307,15 @@ describe("Sidebar Component", () => {
       )
       expect(screen.getByTestId("stLogo")).toBeInTheDocument()
     })
+
+    it("sets maxWidth of logo based on sidebar width", () => {
+      renderSidebar({ appLogo: imageWithLink })
+      const sidebarWidth = window.getComputedStyle(
+        screen.getByTestId("stSidebar")
+      ).width
+      expect(screen.getByTestId("stLogo")).toHaveStyle(
+        `max-width: calc(${sidebarWidth} - 5.75rem)`
+      )
+    })
   })
 })

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -247,6 +247,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
         src={source}
         sidebarWidth={sidebarWidth}
         alt="Logo"
+        className="stLogo"
         data-testid="stLogo"
       />
     )

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -241,6 +241,16 @@ class Sidebar extends PureComponent<SidebarProps, State> {
     const displayImage =
       collapsed && appLogo.iconImage ? appLogo.iconImage : appLogo.image
     const source = endpoints.buildMediaURL(displayImage)
+
+    const logo = (
+      <StyledLogo
+        src={source}
+        sidebarWidth={sidebarWidth}
+        alt="Logo"
+        data-testid="stLogo"
+      />
+    )
+
     if (appLogo.link) {
       return (
         <StyledLogoLink
@@ -249,23 +259,11 @@ class Sidebar extends PureComponent<SidebarProps, State> {
           rel="noreferrer"
           data-testid="stLogoLink"
         >
-          <StyledLogo
-            sidebarWidth={sidebarWidth}
-            src={source}
-            alt="Logo"
-            data-testid="stLogo"
-          />
+          {logo}
         </StyledLogoLink>
       )
     }
-    return (
-      <StyledLogo
-        sidebarWidth={sidebarWidth}
-        src={source}
-        alt="Logo"
-        data-testid="stLogo"
-      />
-    )
+    return logo
   }
 
   public render(): ReactNode {

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -231,7 +231,8 @@ class Sidebar extends PureComponent<SidebarProps, State> {
   }
 
   renderLogo(collapsed: boolean): ReactElement {
-    const { appLogo } = this.props
+    const { appLogo, endpoints } = this.props
+    const { sidebarWidth } = this.state
 
     if (!appLogo) {
       return <StyledNoLogoSpacer data-testid="stLogoSpacer" />
@@ -239,7 +240,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
     const displayImage =
       collapsed && appLogo.iconImage ? appLogo.iconImage : appLogo.image
-    const source = this.props.endpoints.buildMediaURL(displayImage)
+    const source = endpoints.buildMediaURL(displayImage)
     if (appLogo.link) {
       return (
         <StyledLogoLink
@@ -248,11 +249,23 @@ class Sidebar extends PureComponent<SidebarProps, State> {
           rel="noreferrer"
           data-testid="stLogoLink"
         >
-          <StyledLogo src={source} alt="Logo" data-testid="stLogo" />
+          <StyledLogo
+            sidebarWidth={sidebarWidth}
+            src={source}
+            alt="Logo"
+            data-testid="stLogo"
+          />
         </StyledLogoLink>
       )
     }
-    return <StyledLogo src={source} alt="Logo" data-testid="stLogo" />
+    return (
+      <StyledLogo
+        sidebarWidth={sidebarWidth}
+        src={source}
+        alt="Logo"
+        data-testid="stLogo"
+      />
+    )
   }
 
   public render(): ReactNode {

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -259,8 +259,11 @@ export interface StyledLogoProps {
 
 export const StyledLogo = styled.img<StyledLogoProps>(
   ({ theme, sidebarWidth }) => ({
-    height: "1.5rem",
-    margin: "0.25rem 0.5rem 0.25rem 0",
+    height: theme.sizes.logoHeight,
+    marginTop: theme.spacing.twoXS,
+    marginRight: theme.spacing.sm,
+    marginBottom: theme.spacing.twoXS,
+    marginLeft: theme.spacing.none,
     zIndex: theme.zIndices.header,
 
     ...(sidebarWidth && {

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -264,9 +264,8 @@ export const StyledLogo = styled.img<StyledLogoProps>(
     zIndex: theme.zIndices.header,
 
     ...(sidebarWidth && {
-      // Control max width of logo so doesn't hide sidebar collapse button (issue #8707)
-      // L & R padding (3rem) + R margin (0.5rem)
-      // + sidebar collapse button (2.25rem) = 5.75rem
+      // Control max width of logo so sidebar collapse button always shows (issue #8707)
+      // L & R padding (3rem) + R margin (.5rem) + collapse button (2.25rem) = 5.75rem
       maxWidth: `calc(${sidebarWidth}px - 5.75rem)`,
     }),
   })

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -253,12 +253,24 @@ export const StyledLogoLink = styled.a(({}) => ({
   },
 }))
 
-export const StyledLogo = styled.img(({ theme }) => ({
-  height: "1.5rem",
-  maxWidth: "15rem",
-  margin: "0.25rem 0.5rem 0.25rem 0",
-  zIndex: theme.zIndices.header,
-}))
+export interface StyledLogoProps {
+  sidebarWidth?: string
+}
+
+export const StyledLogo = styled.img<StyledLogoProps>(
+  ({ theme, sidebarWidth }) => ({
+    height: "1.5rem",
+    margin: "0.25rem 0.5rem 0.25rem 0",
+    zIndex: theme.zIndices.header,
+
+    ...(sidebarWidth && {
+      // Control max width of logo so doesn't hide sidebar collapse button (issue #8707)
+      // L & R padding (3rem) + R margin (0.5rem)
+      // + sidebar collapse button (2.25rem) = 5.75rem
+      maxWidth: `calc(${sidebarWidth}px - 5.75rem)`,
+    }),
+  })
+)
 
 export const StyledNoLogoSpacer = styled.div(({}) => ({
   height: "2.0rem",

--- a/frontend/lib/src/theme/primitives/sizes.ts
+++ b/frontend/lib/src/theme/primitives/sizes.ts
@@ -22,4 +22,5 @@ export const sizes = {
   contentMaxWidth: "46rem",
   borderWidth: "1px",
   minElementHeight: "2.5rem",
+  logoHeight: "1.5rem",
 }


### PR DESCRIPTION
## Describe your changes
Update styling logo `max-width` based on the sidebar's width (dynamic/resizeable) so the logo never hides the collapse sidebar button

## GitHub Issue Link (if applicable)
Closes #8707

## Testing Plan
- Unit Tests - JS Unit test added ✅ 
- Manual Testing - ✅ 