### PR TITLE
Reformat some comments so that `make help` works.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard
 .PHONY: help
 help:
 	@# Magic line used to create self-documenting makefiles.
+	@# Note that this means the documenting comment just before the command (but after the .PHONY) must be all one line, and should begin with a capital letter and end with a period.
 	@# See https://stackoverflow.com/a/35730928
 	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' Makefile | column -s: -t
 
@@ -48,14 +49,11 @@ all-devel: init develop pre-commit-install
 	@echo ""
 
 .PHONY: mini-devel
-# Get minimal dependencies for development and install Streamlit into Python
-# environment -- but do not build the frontend.
+# Get minimal dependencies for development and install Streamlit into Python environment -- but do not build the frontend.
 mini-devel: mini-init develop pre-commit-install
 
 .PHONY: build-deps
-# An even smaller installation than mini-devel. Installs the bare minimum
-# necessary to build Streamlit (by leaving out some dependencies necessary for
-# the development process). Does not build the frontend.
+# An even smaller installation than mini-devel. Installs the bare minimum necessary to build Streamlit (by leaving out some dependencies necessary for the development process). Does not build the frontend.
 build-deps: mini-init develop
 
 .PHONY: init
@@ -81,17 +79,17 @@ develop:
 	INSTALL_DEV_REQS=false INSTALL_TEST_REQS=false make python-init
 
 .PHONY: python-init-all
-# Install Streamlit and all (test and dev) requirements
+# Install Streamlit and all (test and dev) requirements.
 python-init-all:
 	INSTALL_DEV_REQS=true INSTALL_TEST_REQS=true make python-init
 
 .PHONY: python-init-dev-only
-# Install Streamlit and dev requirements
+# Install Streamlit and dev requirements.
 python-init-dev-only:
 	INSTALL_DEV_REQS=true INSTALL_TEST_REQS=false make python-init
 
 .PHONY: python-init-test-only
-# Install Streamlit and test requirements
+# Install Streamlit and test requirements.
 python-init-test-only: lib/test-requirements.txt
 	INSTALL_DEV_REQS=false INSTALL_TEST_REQS=true make python-init
 
@@ -119,8 +117,7 @@ python-init:
 	fi;\
 
 .PHONY: pylint
-# Verify that our Python files are properly formatted
-# and that there are no lint errors.
+# Verify that our Python files are properly formatted and that there are no lint errors.
 pylint:
 	# Checks if the formatting is correct:
 	ruff format --check
@@ -129,9 +126,8 @@ pylint:
 
 .PHONY: pyformat
 # Fix Python files that are not properly formatted.
-# https://docs.astral.sh/ruff/formatter/#sorting-imports
 pyformat:
-	# Sort imports:
+	# Sort imports ( see https://docs.astral.sh/ruff/formatter/#sorting-imports )
 	ruff check --select I --fix
 	# Run code formatter
 	ruff format
@@ -168,12 +164,12 @@ bare-execution-tests:
 	python3 scripts/run_bare_execution_tests.py
 
 .PHONY: cli-smoke-tests
-# Verify that CLI boots as expected when called with `python -m streamlit`
+# Verify that CLI boots as expected when called with `python -m streamlit`.
 cli-smoke-tests:
 	python3 scripts/cli_smoke_tests.py
 
 .PHONY: cli-regression-tests
-# Verify that CLI boots as expected when called with `python -m streamlit`
+# Verify that CLI boots as expected when called with `python -m streamlit`.
 cli-regression-tests: install
 	pytest scripts/cli_regression_tests.py
 
@@ -199,7 +195,7 @@ conda-distribution:
 	GIT_HASH=$$(git rev-parse --short HEAD) conda build lib/conda-recipe --output-folder lib/conda-recipe/dist
 
 .PHONY: conda-package
-# Build lib and (maybe) frontend assets, and then run 'conda-distribution'
+# Build lib and (maybe) frontend assets, and then run 'conda-distribution'.
 conda-package: build-deps
 	if [ "${SNOWPARK_CONDA_BUILD}" = "1" ] ; then\
 		echo "Creating Snowpark conda build, so skipping building frontend assets."; \
@@ -279,10 +275,12 @@ protobuf: check-protoc
 	) > ./lib/src/proto.d.ts
 
 .PHONY: react-init
+# React init.
 react-init:
 	cd frontend/ ; yarn install --frozen-lockfile
 
 .PHONY: react-build
+# React build.
 react-build:
 	cd frontend/ ; yarn run build
 	rsync -av --delete --delete-excluded --exclude=reports \
@@ -296,7 +294,7 @@ frontend-fast:
 		frontend/app/build/ lib/streamlit/static/
 
 .PHONY: frontend-lib
-# Build the frontend library
+# Build the frontend library.
 frontend-lib:
 	cd frontend/ ; yarn run buildLib;
 
@@ -306,13 +304,13 @@ frontend-app:
 	cd frontend/ ; yarn run buildApp
 
 .PHONY: jslint
-# Lint the JS code
+# Lint the JS code.
 jslint:
 	cd frontend; \
 		yarn lint;
 
 .PHONY: tstypecheck
-# Type check the JS/TS code
+# Typecheck the JS/TS code.
 tstypecheck:
 	pre-commit run typecheck-lib --all-files --hook-stage manual && pre-commit run typecheck-app --all-files --hook-stage manual
 
@@ -409,22 +407,22 @@ gen-min-dep-constraints:
 	python scripts/get_min_versions.py >lib/min-constraints-gen.txt
 
 .PHONY: pre-commit-install
+# Pre-commit install.
 pre-commit-install:
 	pre-commit install
 
 .PHONY: ensure-relative-imports
-# ensure relative imports exist within the lib/dist folder when doing yarn buildLibProd
+# Ensure relative imports exist within the lib/dist folder when doing yarn buildLibProd.
 ensure-relative-imports:
 	./scripts/ensure_relative_imports.sh
 
 .PHONY frontend-lib-prod:
-# build the production version for @streamlit/lib
+# Build the production version for @streamlit/lib.
 frontend-lib-prod:
 	cd frontend/ ; yarn run buildLibProd;
 
 .PHONY streamlit-lib-prod:
-# build the production version for @streamlit/lib
-# while also doing a make init so it's a single command
+# Build the production version for @streamlit/lib while also doing a make init so it's a single command.
 streamlit-lib-prod:
 	make mini-init;
 	make frontend-lib-prod;


### PR DESCRIPTION
## Describe your changes

Previously, `make help`, which is supposed to give output like

```all                            Get dependencies, build frontend, install Streamlit into Python environment.```

 would emit some lines like

```build-deps                     the development process). Does not build the frontend.```.

Other lines were not formatted in a consistent way, and some commands were not documented at all. This commit changes the source comments to fix all that.

## Testing Plan

Although it's theoretically possible to conceive of a unit test to prevent this situation, such an expenditure of effort strikes me as unwise.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
