### PR TITLE
Fix dialogs not re-opening in some cases after dismiss

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -150,3 +150,12 @@ def dialog_with_deprecation_warning():
 
 if st.button("Open Dialog with deprecation warning"):
     dialog_with_deprecation_warning()
+
+
+@st.fragment()
+def fragment():
+    if st.button("Fragment Button"):
+        st.write("Fragment Button clicked")
+
+
+fragment()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -156,7 +156,7 @@ def test_dialog_reopens_properly_after_close(app: Page):
 
 def test_dialog_stays_dismissed_when_interacting_with_different_fragment(app: Page):
     """Dismissing a dialog is a UI-only interaction as of today (the Python backend does
-    not know about this). We use a deltaMessageId to differentiate React renders
+    not know about this). We use a deltaMsgReceivedAt to differentiate React renders
     for dialogs triggered via a new backend message which changes the id vs. other
     interactions. This test ensures that the dialog stays dismissed when interacting
     with a different fragment.

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -128,25 +128,13 @@ def test_dialog_reopens_properly_after_dismiss(app: Page):
         wait_for_app_run(app)
 
         main_dialog = app.get_by_test_id(modal_test_id)
-
-        # sometimes the dialog does not seem to open in the test, so retry opening it by
-        # clicking on it. if it does not open after the second attempt, fail the test.
-        if main_dialog.count() == 0:
-            # app.wait_for_timeout(100)
-            open_dialog_without_images(app)
-            wait_for_app_run(app)
-
         expect(main_dialog).to_have_count(1)
-        # app.wait_for_timeout(1000)
 
         click_to_dismiss(app)
         expect(main_dialog).not_to_be_attached()
 
         main_dialog = app.get_by_test_id(modal_test_id)
         expect(main_dialog).to_have_count(0)
-
-        # don't click indefinitely fast to give the dialog time to set the state
-        # app.wait_for_timeout(500)
 
 
 def test_dialog_reopens_properly_after_close(app: Page):

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -123,21 +123,21 @@ def test_dialog_reopens_properly_after_dismiss(app: Page):
     """Test that dialog reopens after dismiss."""
 
     # open and close the dialog multiple times
-    for _ in range(0, 3):
+    for _ in range(0, 10):
         open_dialog_without_images(app)
-        wait_for_app_run(app, wait_delay=250)
+        wait_for_app_run(app)
 
         main_dialog = app.get_by_test_id(modal_test_id)
 
         # sometimes the dialog does not seem to open in the test, so retry opening it by
         # clicking on it. if it does not open after the second attempt, fail the test.
         if main_dialog.count() == 0:
-            app.wait_for_timeout(100)
+            # app.wait_for_timeout(100)
             open_dialog_without_images(app)
             wait_for_app_run(app)
 
         expect(main_dialog).to_have_count(1)
-        app.wait_for_timeout(1000)
+        # app.wait_for_timeout(1000)
 
         click_to_dismiss(app)
         expect(main_dialog).not_to_be_attached()
@@ -146,7 +146,7 @@ def test_dialog_reopens_properly_after_dismiss(app: Page):
         expect(main_dialog).to_have_count(0)
 
         # don't click indefinitely fast to give the dialog time to set the state
-        app.wait_for_timeout(500)
+        # app.wait_for_timeout(500)
 
 
 def test_dialog_reopens_properly_after_close(app: Page):

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -965,6 +965,7 @@ describe("AppRoot.applyDelta", () => {
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.fragmentId).toBe(undefined)
+    expect(newRoot.main.deltaMessageId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -987,6 +988,7 @@ describe("AppRoot.applyDelta", () => {
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.fragmentId).toBe(undefined)
+    expect(newRoot.main.deltaMessageId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -1147,6 +1149,22 @@ describe("AppRoot.applyDelta", () => {
 
     const newNode = newRoot.main.getIn([1, 1]) as BlockNode
     expect(newNode.fragmentId).toBe("myFragmentId")
+  })
+
+  it("timestamp is set on BlockNode as message id", () => {
+    const timestamp = new Date(Date.UTC(2017, 1, 14)).valueOf()
+    Date.now = jest.fn(() => timestamp)
+    const delta = makeProto(DeltaProto, {
+      addBlock: {},
+    })
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1])
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+    expect(newNode.deltaMessageId).toBe(timestamp)
   })
 })
 

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -965,7 +965,7 @@ describe("AppRoot.applyDelta", () => {
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.fragmentId).toBe(undefined)
-    expect(newRoot.main.deltaMessageId).toBe(undefined)
+    expect(newRoot.main.deltaMsgReceivedAt).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -988,7 +988,7 @@ describe("AppRoot.applyDelta", () => {
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.fragmentId).toBe(undefined)
-    expect(newRoot.main.deltaMessageId).toBe(undefined)
+    expect(newRoot.main.deltaMsgReceivedAt).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -1164,7 +1164,7 @@ describe("AppRoot.applyDelta", () => {
     )
 
     const newNode = newRoot.main.getIn([1, 1]) as BlockNode
-    expect(newNode.deltaMessageId).toBe(timestamp)
+    expect(newNode.deltaMsgReceivedAt).toBe(timestamp)
   })
 })
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -116,11 +116,11 @@ export interface AppNode {
    */
   readonly activeScriptHash?: string
 
-  // An id indicating based on which delta message the node was created.
+  // A timestamp indicating based on which delta message the node was created.
   // If the node was created without a delta message, this field is undefined.
   // This helps us to update React components based on a new backend message even though other
   // props have not changed; this can happen for UI-only interactions such as dimissing a dialog.
-  readonly deltaMessageId?: number
+  readonly deltaMsgReceivedAt?: number
 
   /**
    * Return the AppNode for the given index path, or undefined if the path
@@ -398,7 +398,7 @@ export class BlockNode implements AppNode {
 
   public readonly fragmentId?: string
 
-  public readonly deltaMessageId?: number
+  public readonly deltaMsgReceivedAt?: number
 
   // The hash of the script that created this block.
   public readonly activeScriptHash: string
@@ -409,14 +409,14 @@ export class BlockNode implements AppNode {
     deltaBlock?: BlockProto,
     scriptRunId?: string,
     fragmentId?: string,
-    deltaMessageId?: number
+    deltaMsgReceivedAt?: number
   ) {
     this.activeScriptHash = activeScriptHash
     this.children = children ?? []
     this.deltaBlock = deltaBlock ?? new BlockProto({})
     this.scriptRunId = scriptRunId ?? NO_SCRIPT_RUN_ID
     this.fragmentId = fragmentId
-    this.deltaMessageId = deltaMessageId
+    this.deltaMsgReceivedAt = deltaMsgReceivedAt
   }
 
   /** True if this Block has no children. */
@@ -472,7 +472,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       scriptRunId,
       this.fragmentId,
-      this.deltaMessageId
+      this.deltaMsgReceivedAt
     )
   }
 
@@ -492,7 +492,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       this.scriptRunId,
       this.fragmentId,
-      this.deltaMessageId
+      this.deltaMsgReceivedAt
     )
   }
 
@@ -544,7 +544,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       currentScriptRunId,
       this.fragmentId,
-      this.deltaMessageId
+      this.deltaMsgReceivedAt
     )
   }
 
@@ -734,14 +734,14 @@ export class AppRoot {
       }
 
       case "addBlock": {
-        const deltaMessageId = Date.now()
+        const deltaMsgReceivedAt = Date.now()
         return this.addBlock(
           deltaPath,
           delta.addBlock as BlockProto,
           scriptRunId,
           activeScriptHash,
           delta.fragmentId,
-          deltaMessageId
+          deltaMsgReceivedAt
         )
       }
 
@@ -873,7 +873,7 @@ export class AppRoot {
     scriptRunId: string,
     activeScriptHash: string,
     fragmentId?: string,
-    deltaMessageId?: number
+    deltaMsgReceivedAt?: number
   ): AppRoot {
     const existingNode = this.root.getIn(deltaPath)
 
@@ -895,7 +895,7 @@ export class AppRoot {
       block,
       scriptRunId,
       fragmentId,
-      deltaMessageId
+      deltaMsgReceivedAt
     )
     return new AppRoot(
       this.mainScriptHash,

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -119,7 +119,7 @@ export interface AppNode {
   // An id indicating based on which delta message the node was created.
   // If the node was created without a delta message, this field is undefined.
   // This helps us to update React components based on a new backend message even though other
-  // props have not chnged.
+  // props have not changed; this can happen for UI-only interactions such as dimissing a dialog.
   readonly deltaMessageId?: number
 
   /**

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -116,6 +116,12 @@ export interface AppNode {
    */
   readonly activeScriptHash?: string
 
+  // An id indicating based on which delta message the node was created.
+  // If the node was created without a delta message, this field is undefined.
+  // This helps us to update React components based on a new backend message even though other
+  // props have not chnged.
+  readonly deltaMessageId?: number
+
   /**
    * Return the AppNode for the given index path, or undefined if the path
    * is invalid.
@@ -392,14 +398,10 @@ export class BlockNode implements AppNode {
 
   public readonly fragmentId?: string
 
+  public readonly deltaMessageId?: number
+
   // The hash of the script that created this block.
   public readonly activeScriptHash: string
-
-  // A timestamp indicating when this node was created based on an incoming delta
-  // message. If the node was created without a delta message, this field is undefined.
-  // This helps us to update React components based on a new backend message even though other
-  // props have not chnged.
-  public readonly appliedAt?: number
 
   public constructor(
     activeScriptHash: string,
@@ -407,14 +409,14 @@ export class BlockNode implements AppNode {
     deltaBlock?: BlockProto,
     scriptRunId?: string,
     fragmentId?: string,
-    appliedAt?: number
+    deltaMessageId?: number
   ) {
     this.activeScriptHash = activeScriptHash
     this.children = children ?? []
     this.deltaBlock = deltaBlock ?? new BlockProto({})
     this.scriptRunId = scriptRunId ?? NO_SCRIPT_RUN_ID
     this.fragmentId = fragmentId
-    this.appliedAt = appliedAt
+    this.deltaMessageId = deltaMessageId
   }
 
   /** True if this Block has no children. */
@@ -470,7 +472,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       scriptRunId,
       this.fragmentId,
-      this.appliedAt
+      this.deltaMessageId
     )
   }
 
@@ -490,7 +492,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       this.scriptRunId,
       this.fragmentId,
-      this.appliedAt
+      this.deltaMessageId
     )
   }
 
@@ -542,7 +544,7 @@ export class BlockNode implements AppNode {
       this.deltaBlock,
       currentScriptRunId,
       this.fragmentId,
-      this.appliedAt
+      this.deltaMessageId
     )
   }
 
@@ -732,14 +734,14 @@ export class AppRoot {
       }
 
       case "addBlock": {
-        const appliedAt = Date.now()
+        const deltaMessageId = Date.now()
         return this.addBlock(
           deltaPath,
           delta.addBlock as BlockProto,
           scriptRunId,
           activeScriptHash,
           delta.fragmentId,
-          appliedAt
+          deltaMessageId
         )
       }
 
@@ -871,7 +873,7 @@ export class AppRoot {
     scriptRunId: string,
     activeScriptHash: string,
     fragmentId?: string,
-    appliedAt?: number
+    deltaMessageId?: number
   ): AppRoot {
     const existingNode = this.root.getIn(deltaPath)
 
@@ -893,7 +895,7 @@ export class AppRoot {
       block,
       scriptRunId,
       fragmentId,
-      appliedAt
+      deltaMessageId
     )
     return new AppRoot(
       this.mainScriptHash,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -104,7 +104,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     return (
       <Dialog
         element={node.deltaBlock.dialog as BlockProto.Dialog}
-        appliedAt={node.appliedAt}
+        deltaMessageId={node.deltaMessageId}
       >
         {child}
       </Dialog>

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -102,7 +102,10 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
 
   if (node.deltaBlock.dialog) {
     return (
-      <Dialog element={node.deltaBlock.dialog as BlockProto.Dialog}>
+      <Dialog
+        element={node.deltaBlock.dialog as BlockProto.Dialog}
+        appliedAt={node.appliedAt}
+      >
         {child}
       </Dialog>
     )

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -104,7 +104,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     return (
       <Dialog
         element={node.deltaBlock.dialog as BlockProto.Dialog}
-        deltaMessageId={node.deltaMessageId}
+        deltaMsgReceivedAt={node.deltaMsgReceivedAt}
       >
         {child}
       </Dialog>

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -32,6 +32,7 @@ import { StyledDialogContent } from "./styled-components"
 
 export interface Props {
   element: BlockProto.Dialog
+  appliedAt?: number
 }
 
 function parseWidthConfig(
@@ -52,15 +53,10 @@ function parseWidthConfig(
 
 const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
   element,
+  appliedAt,
   children,
 }): ReactElement => {
-  const {
-    title,
-    dismissible,
-    width,
-    isOpen: initialIsOpen,
-    updateId,
-  } = element
+  const { title, dismissible, width, isOpen: initialIsOpen } = element
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   useEffect(() => {
@@ -68,7 +64,7 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     if (notNullOrUndefined(initialIsOpen)) {
       setIsOpen(initialIsOpen)
     }
-  }, [initialIsOpen, updateId])
+  }, [initialIsOpen, appliedAt])
 
   const theme = useTheme()
   const size: string = useMemo(

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -65,7 +65,9 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
       setIsOpen(initialIsOpen)
     }
 
-    // when the deltaMessageId changes, we might want to open the dialog again
+    // when the deltaMessageId changes, we might want to open the dialog again.
+    // since dismissing is a UI-only action, the initialIsOpen prop might not have
+    // changed which would lead to the dialog not opening again.
   }, [initialIsOpen, deltaMessageId])
 
   const theme = useTheme()

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -54,7 +54,13 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
   element,
   children,
 }): ReactElement => {
-  const { title, dismissible, width, isOpen: initialIsOpen } = element
+  const {
+    title,
+    dismissible,
+    width,
+    isOpen: initialIsOpen,
+    updateId,
+  } = element
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   useEffect(() => {
@@ -62,7 +68,7 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     if (notNullOrUndefined(initialIsOpen)) {
       setIsOpen(initialIsOpen)
     }
-  }, [initialIsOpen])
+  }, [initialIsOpen, updateId])
 
   const theme = useTheme()
   const size: string = useMemo(

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -32,7 +32,7 @@ import { StyledDialogContent } from "./styled-components"
 
 export interface Props {
   element: BlockProto.Dialog
-  appliedAt?: number
+  deltaMessageId?: number
 }
 
 function parseWidthConfig(
@@ -53,7 +53,7 @@ function parseWidthConfig(
 
 const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
   element,
-  appliedAt,
+  deltaMessageId,
   children,
 }): ReactElement => {
   const { title, dismissible, width, isOpen: initialIsOpen } = element
@@ -64,7 +64,7 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     if (notNullOrUndefined(initialIsOpen)) {
       setIsOpen(initialIsOpen)
     }
-  }, [initialIsOpen, appliedAt])
+  }, [initialIsOpen, deltaMessageId])
 
   const theme = useTheme()
   const size: string = useMemo(

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -64,6 +64,8 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     if (notNullOrUndefined(initialIsOpen)) {
       setIsOpen(initialIsOpen)
     }
+
+    // when the deltaMessageId changes, we might want to open the dialog again
   }, [initialIsOpen, deltaMessageId])
 
   const theme = useTheme()

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -32,7 +32,7 @@ import { StyledDialogContent } from "./styled-components"
 
 export interface Props {
   element: BlockProto.Dialog
-  deltaMessageId?: number
+  deltaMsgReceivedAt?: number
 }
 
 function parseWidthConfig(
@@ -53,7 +53,7 @@ function parseWidthConfig(
 
 const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
   element,
-  deltaMessageId,
+  deltaMsgReceivedAt,
   children,
 }): ReactElement => {
   const { title, dismissible, width, isOpen: initialIsOpen } = element
@@ -65,10 +65,10 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
       setIsOpen(initialIsOpen)
     }
 
-    // when the deltaMessageId changes, we might want to open the dialog again.
+    // when the deltaMsgReceivedAt changes, we might want to open the dialog again.
     // since dismissing is a UI-only action, the initialIsOpen prop might not have
     // changed which would lead to the dialog not opening again.
-  }, [initialIsOpen, deltaMessageId])
+  }, [initialIsOpen, deltaMsgReceivedAt])
 
   const theme = useTheme()
   const size: string = useMemo(

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-import time
+import uuid
 from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
@@ -96,9 +96,6 @@ class Dialog(DeltaGenerator):
 
         dialog._delta_path = delta_path
         dialog._current_proto = block_proto
-        # We add a sleep here to give the web app time to react to the update. Otherwise,
-        #  we might run into issues where the dialog cannot be opened again after closing
-        time.sleep(0.05)
         return dialog
 
     def __init__(
@@ -124,12 +121,9 @@ class Dialog(DeltaGenerator):
         msg.metadata.delta_path[:] = self._delta_path
         msg.delta.add_block.CopyFrom(self._current_proto)
         msg.delta.add_block.dialog.is_open = should_open
-
+        msg.delta.add_block.dialog.update_id = str(uuid.uuid4())
         self._current_proto = msg.delta.add_block
 
-        # We add a sleep here to give the web app time to react to the update. Otherwise,
-        #  we might run into issues where the dialog cannot be opened again after closing
-        time.sleep(0.05)
         enqueue_message(msg)
 
     def open(self) -> None:

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import uuid
 from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self, TypeAlias
@@ -87,8 +86,9 @@ class Dialog(DeltaGenerator):
         block_proto.dialog.dismissible = dismissible
         block_proto.dialog.width = _process_dialog_width_input(width)
 
-        # We store the delta path here, because in _update we enqueue a new proto message to update the
-        # open status. Without this, the dialog content is gone when the _update message is sent
+        # We store the delta path here, because in _update we enqueue a new proto
+        # message to update the open status. Without this, the dialog content is gone
+        # when the _update message is sent
         delta_path: list[int] = (
             parent._active_dg._cursor.delta_path if parent._active_dg._cursor else []
         )
@@ -121,7 +121,6 @@ class Dialog(DeltaGenerator):
         msg.metadata.delta_path[:] = self._delta_path
         msg.delta.add_block.CopyFrom(self._current_proto)
         msg.delta.add_block.dialog.is_open = should_open
-        msg.delta.add_block.dialog.update_id = str(uuid.uuid4())
         self._current_proto = msg.delta.add_block
 
         enqueue_message(msg)

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -74,6 +74,7 @@ message Block {
     bool dismissible = 2;
     DialogWidth width = 3;
     optional bool is_open = 4;
+    optional string update_id = 5;
   }
 
   message Form {

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -74,7 +74,6 @@ message Block {
     bool dismissible = 2;
     DialogWidth width = 3;
     optional bool is_open = 4;
-    optional string update_id = 5;
   }
 
   message Form {


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9323

The issue in https://github.com/streamlit/streamlit/issues/9323 seems to come from the fact that sometimes the web app ignores the initial dialog message and just uses the message where `is_open=true` - potentially because React merges state updates. This is problematic because from React point's of view, the Dialog props didn't change in this case (`isOpen` stays `true`) and the component's state is not updated.

The following screenshot shows that in the case where the dialog did not open properly after a dismiss, the message where `isOpen=false` (or equivalently the `isOpen` field does not exist), is not handled:
![Screenshot 2024-08-26 at 14 20 46](https://github.com/user-attachments/assets/92fa3ffd-c019-44aa-997b-e49ec0fcd194)


This PR suggests to add a new proto field `update_id` to the `Dialog` message, which updates randomly whenever the backend's `update` function is called. This enables the frontend to differentiate between `is_open` delta messages from previous runs vs. "freshly" triggered ones (to stress again: the `is_open` property of the message does not change after a dismiss because the backend does not know about it). This helps us to remove the `time.sleep` on the Python side as well, which was problematic code we did not like anyway 😅 
We cannot use the `scriptRunId` on the web app side, because in case of the dialog, the dialog block is always updated with each script run independent of whether its open or not; for full app runs this is not problematic but when you interact with other fragments, we cannot use the scriptRunId to determine whether the Dialog's `isOpen` message is a new one coming from an interaction or an old one.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - add a JS test to make sure that the timestamp is set on the `BlockNode`
- E2E Tests
  - the existing dialog tests for reopening after dismissing should catch any potential regression
  - added a new test where a dialog is dismissed and then a different fragment is interacted with to ensure that the dialog stays closed. This will make sure our `deltaMessageId` stays stable

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
