### PR TITLE
[fix] `st.{balloons|snow}` fixes when rendered in `st.dialog`

### DIFF
--- a/frontend/app/src/ThemedApp.tsx
+++ b/frontend/app/src/ThemedApp.tsx
@@ -18,7 +18,7 @@ import React from "react"
 
 import { CUSTOM_THEME_NAME, RootStyleProvider } from "@streamlit/lib"
 import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclaration"
-import { StyledDataFrameOverlay } from "@streamlit/app/src/styled-components"
+import { PortalProvider } from "@streamlit/lib/src/components/core/Portal/PortalProvider"
 
 import AppWithScreencast from "./App"
 import { useThemeManager } from "./util/useThemeManager"
@@ -31,10 +31,11 @@ const ThemedApp = (): JSX.Element => {
 
   return (
     <RootStyleProvider theme={activeTheme}>
-      {hasCustomFonts && <FontFaceDeclaration fontFaces={fontFaces} />}
-      <AppWithScreencast theme={themeManager} />
       {/* The data grid requires one root level portal element for rendering cell overlays */}
-      <StyledDataFrameOverlay id="portal" data-testid="portal" />
+      <PortalProvider>
+        {hasCustomFonts && <FontFaceDeclaration fontFaces={fontFaces} />}
+        <AppWithScreencast theme={themeManager} />
+      </PortalProvider>
     </RootStyleProvider>
   )
 }

--- a/frontend/app/src/styled-components.ts
+++ b/frontend/app/src/styled-components.ts
@@ -39,16 +39,3 @@ export const StyledApp = styled.div(({ theme }) => {
     },
   }
 })
-
-/**
- * The glide-data-grid requires one root level portal element for rendering the cell overlays:
- * https://github.com/glideapps/glide-data-grid/blob/main/packages/core/API.md#htmlcss-prerequisites
- * This is added to the body in ThemedApp.
- */
-export const StyledDataFrameOverlay = styled.div(({ theme }) => ({
-  position: "fixed",
-  top: 0,
-  left: 0,
-  zIndex: theme.zIndices.tablePortal,
-  lineHeight: "100%",
-}))

--- a/frontend/lib/src/components/core/Portal/PortalContext.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalContext.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react"
+
+export const PortalContext = React.createContext<
+  (() => HTMLElement | null) | null
+>(null)

--- a/frontend/lib/src/components/core/Portal/PortalProvider.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalProvider.tsx
@@ -29,12 +29,7 @@ export const PortalProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <PortalContext.Provider value={getRefElement}>
       {children}
-      <StyledDataFrameOverlay
-        data-testid="portal"
-        id="portal"
-        ref={ref}
-        tabIndex={-1}
-      />
+      <StyledDataFrameOverlay data-testid="portal" id="portal" ref={ref} />
     </PortalContext.Provider>
   )
 }

--- a/frontend/lib/src/components/core/Portal/PortalProvider.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalProvider.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { FC, PropsWithChildren, useCallback, useRef } from "react"
+
+import { StyledDataFrameOverlay } from "@streamlit/lib/src/styled-components"
+
+import { PortalContext } from "./PortalContext"
+
+export const PortalProvider: FC<PropsWithChildren> = ({ children }) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  const getRefElement = useCallback(() => {
+    return ref.current
+  }, [])
+
+  return (
+    <PortalContext.Provider value={getRefElement}>
+      {children}
+      <StyledDataFrameOverlay
+        data-testid="portal"
+        id="portal"
+        ref={ref}
+        tabIndex={-1}
+      />
+    </PortalContext.Provider>
+  )
+}

--- a/frontend/lib/src/components/core/Portal/RenderInPortalIfExists.tsx
+++ b/frontend/lib/src/components/core/Portal/RenderInPortalIfExists.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, PropsWithChildren, useContext } from "react"
+
+import { createPortal } from "react-dom"
+
+import { PortalContext } from "./PortalContext"
+
+export const RenderInPortalIfExists: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const portalElement = useContext(PortalContext)?.()
+
+  return portalElement ? (
+    createPortal(children, portalElement)
+  ) : (
+    <>{children}</>
+  )
+}

--- a/frontend/lib/src/components/elements/Balloons/Balloons.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useContext } from "react"
-
-import { createPortal } from "react-dom"
+import React, { FC, memo } from "react"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is
@@ -30,7 +28,7 @@ import Balloon4 from "@streamlit/lib/src/assets/img/balloons/balloon-4.png"
 import Balloon5 from "@streamlit/lib/src/assets/img/balloons/balloon-5.png"
 import Particles from "@streamlit/lib/src/components/elements/Particles"
 import { ParticleProps } from "@streamlit/lib/src/components/elements/Particles/Particles"
-import { PortalContext } from "@streamlit/lib/src/components/core/Portal/PortalContext"
+import { RenderInPortalIfExists } from "@streamlit/lib/src/components/core/Portal/RenderInPortalIfExists"
 
 import { StyledBalloon } from "./styled-components"
 
@@ -55,12 +53,10 @@ const Balloon: FC<React.PropsWithChildren<ParticleProps>> = ({
   particleType,
 }) => <StyledBalloon src={BALLOON_IMAGES[particleType]} />
 
-const Balloons: FC<React.PropsWithChildren<Props>> = ({ scriptRunId }) => {
-  const portalElement = useContext(PortalContext)?.()
-
+const Balloons: FC<React.PropsWithChildren<Props>> = ({ scriptRunId }) => (
   // Keys should be unique each time, so React replaces the images in the DOM and their animations
   // actually rerun.
-  const content = (
+  <RenderInPortalIfExists>
     <Particles
       className="stBalloons"
       data-testid="stBalloons"
@@ -69,9 +65,7 @@ const Balloons: FC<React.PropsWithChildren<Props>> = ({ scriptRunId }) => {
       numParticles={NUM_BALLOONS}
       ParticleComponent={Balloon}
     />
-  )
-
-  return portalElement ? createPortal(content, portalElement) : content
-}
+  </RenderInPortalIfExists>
+)
 
 export default memo(Balloons)

--- a/frontend/lib/src/components/elements/Balloons/Balloons.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import React, { FC, memo } from "react"
+import React, { FC, memo, useContext } from "react"
+
+import { createPortal } from "react-dom"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is
@@ -28,6 +30,7 @@ import Balloon4 from "@streamlit/lib/src/assets/img/balloons/balloon-4.png"
 import Balloon5 from "@streamlit/lib/src/assets/img/balloons/balloon-5.png"
 import Particles from "@streamlit/lib/src/components/elements/Particles"
 import { ParticleProps } from "@streamlit/lib/src/components/elements/Particles/Particles"
+import { PortalContext } from "@streamlit/lib/src/components/core/Portal/PortalContext"
 
 import { StyledBalloon } from "./styled-components"
 
@@ -52,17 +55,23 @@ const Balloon: FC<React.PropsWithChildren<ParticleProps>> = ({
   particleType,
 }) => <StyledBalloon src={BALLOON_IMAGES[particleType]} />
 
-const Balloons: FC<React.PropsWithChildren<Props>> = ({ scriptRunId }) => (
+const Balloons: FC<React.PropsWithChildren<Props>> = ({ scriptRunId }) => {
+  const portalElement = useContext(PortalContext)?.()
+
   // Keys should be unique each time, so React replaces the images in the DOM and their animations
   // actually rerun.
-  <Particles
-    className="stBalloons"
-    data-testid="stBalloons"
-    scriptRunId={scriptRunId}
-    numParticleTypes={NUM_BALLOON_TYPES}
-    numParticles={NUM_BALLOONS}
-    ParticleComponent={Balloon}
-  />
-)
+  const content = (
+    <Particles
+      className="stBalloons"
+      data-testid="stBalloons"
+      scriptRunId={scriptRunId}
+      numParticleTypes={NUM_BALLOON_TYPES}
+      numParticles={NUM_BALLOONS}
+      ParticleComponent={Balloon}
+    />
+  )
+
+  return portalElement ? createPortal(content, portalElement) : content
+}
 
 export default memo(Balloons)

--- a/frontend/lib/src/components/elements/Snow/Snow.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useContext } from "react"
-
-import { createPortal } from "react-dom"
+import React, { FC, memo } from "react"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is
@@ -27,7 +25,7 @@ import Flake1 from "@streamlit/lib/src/assets/img/snow/flake-1.png"
 import Flake2 from "@streamlit/lib/src/assets/img/snow/flake-2.png"
 import Particles from "@streamlit/lib/src/components/elements/Particles"
 import { ParticleProps } from "@streamlit/lib/src/components/elements/Particles/Particles"
-import { PortalContext } from "@streamlit/lib/src/components/core/Portal/PortalContext"
+import { RenderInPortalIfExists } from "@streamlit/lib/src/components/core/Portal/RenderInPortalIfExists"
 
 import { StyledFlake } from "./styled-components"
 
@@ -48,22 +46,20 @@ const Flake: FC<React.PropsWithChildren<ParticleProps>> = ({
 const Snow: FC<React.PropsWithChildren<Props>> = function Snow({
   scriptRunId,
 }) {
-  const portalElement = useContext(PortalContext)?.()
-
   // Keys should be unique each time, so React replaces the images in the DOM and their animations
   // actually rerun.
-  const content = (
-    <Particles
-      className="stSnow"
-      data-testid="stSnow"
-      scriptRunId={scriptRunId}
-      numParticleTypes={NUM_FLAKE_TYPES}
-      numParticles={NUM_FLAKES}
-      ParticleComponent={Flake}
-    />
+  return (
+    <RenderInPortalIfExists>
+      <Particles
+        className="stSnow"
+        data-testid="stSnow"
+        scriptRunId={scriptRunId}
+        numParticleTypes={NUM_FLAKE_TYPES}
+        numParticles={NUM_FLAKES}
+        ParticleComponent={Flake}
+      />
+    </RenderInPortalIfExists>
   )
-
-  return portalElement ? createPortal(content, portalElement) : content
 }
 
 export default memo(Snow)

--- a/frontend/lib/src/components/elements/Snow/Snow.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import React, { FC, memo } from "react"
+import React, { FC, memo, useContext } from "react"
+
+import { createPortal } from "react-dom"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is
@@ -25,6 +27,7 @@ import Flake1 from "@streamlit/lib/src/assets/img/snow/flake-1.png"
 import Flake2 from "@streamlit/lib/src/assets/img/snow/flake-2.png"
 import Particles from "@streamlit/lib/src/components/elements/Particles"
 import { ParticleProps } from "@streamlit/lib/src/components/elements/Particles/Particles"
+import { PortalContext } from "@streamlit/lib/src/components/core/Portal/PortalContext"
 
 import { StyledFlake } from "./styled-components"
 
@@ -45,9 +48,11 @@ const Flake: FC<React.PropsWithChildren<ParticleProps>> = ({
 const Snow: FC<React.PropsWithChildren<Props>> = function Snow({
   scriptRunId,
 }) {
+  const portalElement = useContext(PortalContext)?.()
+
   // Keys should be unique each time, so React replaces the images in the DOM and their animations
   // actually rerun.
-  return (
+  const content = (
     <Particles
       className="stSnow"
       data-testid="stSnow"
@@ -57,6 +62,8 @@ const Snow: FC<React.PropsWithChildren<Props>> = function Snow({
       ParticleComponent={Flake}
     />
   )
+
+  return portalElement ? createPortal(content, portalElement) : content
 }
 
 export default memo(Snow)


### PR DESCRIPTION
## Describe your changes

This change renders `st.balloons` and `st.snow` in a [React Portal](https://react.dev/reference/react-dom/createPortal) to fix a number of visual glitches.

This reuses the `StyledDataFrameOverlay`, and exposes it via `PortalContext` so that other elements (such as `st.balloons` and `st.snow`) can access it and render into it via [React Portal](https://react.dev/reference/react-dom/createPortal)

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/9236

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed ✅
  - Manually tested the balloons/snow interaction when in `st.dialog` and in standalone
    - I also manually tested that while in Dialog, keyboard focus stays on the Dialog so that things like `esc` key still close the Dialog
  - I manually tested some data frame interactions, since they render into the existing portaled DOM element that is being reused here.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
