### PR TITLE
Remove `st.logo` if stale

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1704,7 +1704,7 @@ describe("App", () => {
       })
 
       // Since the logo was added with a different activeScriptHash, it should be removed
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.queryByTestId("stLogo")).not.toBeInTheDocument()
       })
     })
@@ -1725,14 +1725,18 @@ describe("App", () => {
 
       expect(screen.getByTestId("stLogo")).toBeInTheDocument()
 
-      // Trigger a rerun for new scriptRunId
-      const widgetStateManager =
-        getStoredValue<WidgetStateManager>(WidgetStateManager)
-      widgetStateManager.sendUpdateWidgetsMessage(undefined)
+      // Trigger a new scriptRunId via new session
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Trigger cleanup in script finished handler
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+      )
 
       // Since no logo is sent in this script run, logo must not be present in the script anymore
       // Stale logo should be removed
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.queryByTestId("stLogo")).not.toBeInTheDocument()
       })
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1663,6 +1663,81 @@ describe("App", () => {
     })
   })
 
+  describe("Logo handling", () => {
+    it("adds logo on receipt of logo ForwardMsg", () => {
+      renderApp(getProps())
+
+      sendForwardMessage(
+        "logo",
+        {
+          image:
+            "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",
+        },
+        {
+          activeScriptHash: "page_script_hash",
+        }
+      )
+
+      expect(screen.getByTestId("stLogo")).toBeInTheDocument()
+    })
+
+    it("will remove logo if activeScriptHash does not match", async () => {
+      renderApp(getProps())
+
+      sendForwardMessage(
+        "logo",
+        {
+          image:
+            "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",
+        },
+        {
+          activeScriptHash: "page_script_hash",
+        }
+      )
+
+      expect(screen.getByTestId("stLogo")).toBeInTheDocument()
+
+      // Trigger a new session with a different pageScriptHash
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        pageScriptHash: "different_page_script_hash",
+      })
+
+      // Since the logo was added with a different activeScriptHash, it should be removed
+      waitFor(() => {
+        expect(screen.queryByTestId("stLogo")).not.toBeInTheDocument()
+      })
+    })
+
+    it("will remove logo if scriptRunId does not match", async () => {
+      renderApp(getProps())
+
+      sendForwardMessage(
+        "logo",
+        {
+          image:
+            "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",
+        },
+        {
+          activeScriptHash: "page_script_hash",
+        }
+      )
+
+      expect(screen.getByTestId("stLogo")).toBeInTheDocument()
+
+      // Trigger a rerun for new scriptRunId
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      widgetStateManager.sendUpdateWidgetsMessage(undefined)
+
+      // Since no logo is sent in this script run, logo must not be present in the script anymore
+      // Stale logo should be removed
+      waitFor(() => {
+        expect(screen.queryByTestId("stLogo")).not.toBeInTheDocument()
+      })
+    })
+  })
+
   //   * handlePageNotFound has branching error messages depending on pageName
   describe("App.handlePageNotFound", () => {
     it("includes the missing page name in error modal message if available", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -739,9 +739,16 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleLogo = (logo: Logo, metadata: ForwardMsgMetadata): void => {
+    const { scriptRunId } = this.state
+    const { activeScriptHash } = metadata
+
     this.setState(
       {
-        elements: this.pendingElementsBuffer.appRootWithLogo(logo, metadata),
+        elements: this.pendingElementsBuffer.appRootWithLogo(
+          logo,
+          activeScriptHash,
+          scriptRunId
+        ),
       },
       () => {
         this.pendingElementsBuffer = this.state.elements

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -740,15 +740,16 @@ export class App extends PureComponent<Props, State> {
 
   handleLogo = (logo: Logo, metadata: ForwardMsgMetadata): void => {
     // Pass the current page & run ID for cleanup
-    const { scriptRunId } = this.state
-    const { activeScriptHash } = metadata
+    const logoMetadata = {
+      activeScriptHash: metadata.activeScriptHash,
+      scriptRunId: this.state.scriptRunId,
+    }
 
     this.setState(
       {
         elements: this.pendingElementsBuffer.appRootWithLogo(
           logo,
-          activeScriptHash,
-          scriptRunId
+          logoMetadata
         ),
       },
       () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -739,6 +739,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleLogo = (logo: Logo, metadata: ForwardMsgMetadata): void => {
+    // Pass the current page & run ID for cleanup
     const { scriptRunId } = this.state
     const { activeScriptHash } = metadata
 

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -23,10 +23,10 @@ import {
   ArrowNamedDataSet,
   Block as BlockProto,
   Delta as DeltaProto,
-  Logo as LogoProto,
   Element,
   ForwardMsgMetadata,
   IArrowVegaLiteChart,
+  Logo as LogoProto,
 } from "./proto"
 import { AppNode, AppRoot, BlockNode, ElementNode } from "./AppNode"
 import { IndexTypeName } from "./dataframes/Quiver"

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -23,6 +23,7 @@ import {
   ArrowNamedDataSet,
   Block as BlockProto,
   Delta as DeltaProto,
+  Logo as LogoProto,
   Element,
   ForwardMsgMetadata,
   IArrowVegaLiteChart,
@@ -1149,6 +1150,21 @@ describe("AppRoot.clearStaleNodes", () => {
     // We should now only have a single element, inside a single block
     expect(newRoot.main.getIn([0, 0])).toBeTextNode("newElement!")
     expect(newRoot.getElements().size).toBe(1)
+  })
+
+  it("clears a stale logo", () => {
+    const logo = LogoProto.create({
+      image:
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",
+    })
+    const newRoot = ROOT.appRootWithLogo(logo, {
+      activeScriptHash: "hash",
+      scriptRunId: "script_run_id",
+    })
+    expect(newRoot.logo).not.toBeNull()
+
+    const newNewRoot = newRoot.clearStaleNodes("new_script_run_id", [])
+    expect(newNewRoot.logo).toBeNull()
   })
 
   it("handles currentFragmentId correctly", () => {

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -51,7 +51,7 @@ interface AppLogo {
   // Associated scriptHash that created the logo
   activeScriptHash: string
 
-  // Script run id when the logo was created
+  // Associated scriptRunId that created the logo
   scriptRunId: string
 }
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -46,13 +46,16 @@ import { Quiver } from "./dataframes/Quiver"
 import { ensureError } from "./util/ErrorHandling"
 
 const NO_SCRIPT_RUN_ID = "NO_SCRIPT_RUN_ID"
-interface AppLogo {
-  logo: Logo
+
+interface LogoMetadata {
   // Associated scriptHash that created the logo
   activeScriptHash: string
 
   // Associated scriptRunId that created the logo
   scriptRunId: string
+}
+interface AppLogo extends LogoMetadata {
+  logo: Logo
 }
 
 /**
@@ -679,15 +682,10 @@ export class AppRoot {
     return this.appLogo?.logo ?? null
   }
 
-  public appRootWithLogo(
-    logo: Logo,
-    activeScriptHash: string,
-    scriptRunId: string
-  ): AppRoot {
+  public appRootWithLogo(logo: Logo, metadata: LogoMetadata): AppRoot {
     return new AppRoot(this.mainScriptHash, this.root, {
       logo,
-      activeScriptHash,
-      scriptRunId,
+      ...metadata,
     })
   }
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -50,6 +50,9 @@ interface AppLogo {
   logo: Logo
   // Associated scriptHash that created the logo
   activeScriptHash: string
+
+  // Script run id when the logo was created
+  scriptRunId: string
 }
 
 /**
@@ -676,11 +679,15 @@ export class AppRoot {
     return this.appLogo?.logo ?? null
   }
 
-  public appRootWithLogo(logo: Logo, metadata: ForwardMsgMetadata): AppRoot {
-    const { activeScriptHash } = metadata
+  public appRootWithLogo(
+    logo: Logo,
+    activeScriptHash: string,
+    scriptRunId: string
+  ): AppRoot {
     return new AppRoot(this.mainScriptHash, this.root, {
       logo,
       activeScriptHash,
+      scriptRunId,
     })
   }
 
@@ -791,6 +798,9 @@ export class AppRoot {
       this.bottom.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
       new BlockNode(this.mainScriptHash)
 
+    const appLogo =
+      this.appLogo?.scriptRunId === currentScriptRunId ? this.appLogo : null
+
     return new AppRoot(
       this.mainScriptHash,
       new BlockNode(
@@ -799,7 +809,7 @@ export class AppRoot {
         new BlockProto({ allowEmpty: true }),
         currentScriptRunId
       ),
-      this.appLogo
+      appLogo
     )
   }
 


### PR DESCRIPTION
## Describe your changes
Currently, a stale logo persists between re-runs for a SPA, MPA v1, & MPA v2. This PR attaches the `scriptRunId` to the `st.logo` call so that a stale logo is cleaned up on script finish (when `clearStaleNodes` is called).

## GitHub Issue Link (if applicable)
Closes #9336 

## Testing Plan
- Unit/Integration Tests: Added ✅ 
- Manual Testing: ✅ 