### PR TITLE
Allow tenacity version 9.x

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = [
     "pyarrow>=7.0",
     "requests>=2.27, <3",
     "rich>=10.14.0, <14",
-    "tenacity>=8.1.0, <9",
+    "tenacity>=8.1.0, <10",
     "toml>=0.10.1, <2",
     "typing-extensions>=4.3.0, <5",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.


### PR DESCRIPTION
## Describe your changes

Update the major version pin for Tenacity to allow version 9.x, which was released recently. There are no breaking changes with 9.x that impact Streamlit and all tests are succeeding. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9346

## Testing Plan

- No logical changes -> no tests required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
