### PR TITLE
Update watchdog so Streamlit can use version 5.X

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -52,7 +52,7 @@ INSTALL_REQUIRES = [
     "typing-extensions>=4.3.0, <5",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
-    "watchdog>=2.1.5, <5; platform_system != 'Darwin'",
+    "watchdog>=2.1.5, <6; platform_system != 'Darwin'",
 ]
 
 # We want to exclude some dependencies in our internal Snowpark conda distribution of

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -342,11 +342,12 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             _LOGGER.debug("Don't care about event type %s", event.event_type)
             return
 
-        # changed_path can be a bytes object, convert it to a string when this is the case
+        # If the path is a bytes object, convert it to a string before getting
+        # the absolute path, otherwise get the absolute path directly.
         if isinstance(changed_path, bytes):
-            changed_path = changed_path.decode("utf-8")
-
-        abs_changed_path = os.path.abspath(changed_path)
+            abs_changed_path = os.path.abspath(changed_path.decode("utf-8"))
+        else:
+            abs_changed_path = os.path.abspath(changed_path)
 
         changed_path_info = self._watched_paths.get(abs_changed_path, None)
         if changed_path_info is None:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -346,7 +346,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
         # In Watchdog 5.X, the path can be bytes or str, but in Watchdog 4.X, the path is always str,
         # that's why we convert the path to str, but we need to ignore the unreachable code warning for Python 3.8.
         if isinstance(changed_path, bytes):  # type: ignore[unreachable]
-            changed_path = changed_path.decode("utf-8") # type: ignore[unreachable]
+            changed_path = changed_path.decode("utf-8")  # type: ignore[unreachable]
 
         abs_changed_path = os.path.abspath(changed_path)
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -323,7 +323,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
         # Check for both modified and moved files, because many programs write
         # to a backup file then rename (i.e. move) it.
         if event.event_type == events.EVENT_TYPE_MODIFIED:
-            changed_path = event.src_path
+            changed_path = os.path.abspath(event.src_path)
         elif event.event_type == events.EVENT_TYPE_MOVED:
             # Teach mypy that this event has a dest_path, because it can't infer
             # the desired subtype from the event_type check
@@ -332,18 +332,15 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             _LOGGER.debug(
                 "Move event: src %s; dest %s", event.src_path, event.dest_path
             )
-            changed_path = event.dest_path
+            changed_path = os.path.abspath(event.dest_path)
         # On OSX with VI, on save, the file is deleted, the swap file is
         # modified and then the original file is created hence why we
         # capture EVENT_TYPE_CREATED
         elif event.event_type == events.EVENT_TYPE_CREATED:
-            changed_path = event.src_path
+            changed_path = os.path.abspath(event.src_path)
         else:
             _LOGGER.debug("Don't care about event type %s", event.event_type)
             return
-
-        changed_path = os.path.abspath(changed_path)
-        assert isinstance(changed_path, str)
 
         changed_path_info = self._watched_paths.get(changed_path, None)
         if changed_path_info is None:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -201,7 +201,7 @@ class _MultiPathWatcher:
 
             folder_handler.remove_path_change_listener(path, callback)
 
-            if not folder_handler.is_watching_paths():
+            if not folder_handler.is_watching_paths() and folder_handler.watch is not None:
                 self._observer.unschedule(folder_handler.watch)
                 del self._folder_handlers[folder_path]
 
@@ -340,6 +340,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             return
 
         changed_path = os.path.abspath(changed_path)
+        assert isinstance(changed_path, str)
 
         changed_path_info = self._watched_paths.get(changed_path, None)
         if changed_path_info is None:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -342,12 +342,13 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             _LOGGER.debug("Don't care about event type %s", event.event_type)
             return
 
-        # If the path is a bytes object, convert it to a string before getting
-        # the absolute path, otherwise get the absolute path directly.
-        if isinstance(changed_path, bytes):
-            abs_changed_path = os.path.abspath(changed_path.decode("utf-8"))
-        else:
-            abs_changed_path = os.path.abspath(changed_path)
+        # Watchdog 5.X is supports Python >=3.9, so watchdog 4.X is used for Python 3.8.
+        # In Watchdog 5.X, the path can be bytes or str, but in Watchdog 4.X, the path is always str,
+        # that's why we convert the path to str, but we need to ignore the unreachable code warning for Python 3.8.
+        if isinstance(changed_path, bytes):  # type: ignore[unreachable]
+            changed_path = changed_path.decode("utf-8") # type: ignore[unreachable]
+
+        abs_changed_path = os.path.abspath(changed_path)
 
         changed_path_info = self._watched_paths.get(abs_changed_path, None)
         if changed_path_info is None:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -201,7 +201,10 @@ class _MultiPathWatcher:
 
             folder_handler.remove_path_change_listener(path, callback)
 
-            if not folder_handler.is_watching_paths() and folder_handler.watch is not None:
+            if (
+                not folder_handler.is_watching_paths()
+                and folder_handler.watch is not None
+            ):
                 self._observer.unschedule(folder_handler.watch)
                 del self._folder_handlers[folder_path]
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -342,7 +342,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             _LOGGER.debug("Don't care about event type %s", event.event_type)
             return
 
-        # Watchdog 5.X is supports Python >=3.9, so watchdog 4.X is used for Python 3.8.
+        # Watchdog 5.X is supported Python >=3.9, so watchdog 4.X is used for Python 3.8.
         # In Watchdog 5.X, the path can be bytes or str, but in Watchdog 4.X, the path is always str,
         # that's why we convert the path to str, but we need to ignore the unreachable code warning for Python 3.8.
         if isinstance(changed_path, bytes):  # type: ignore[unreachable]

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -345,8 +345,8 @@ class _FolderEventHandler(events.FileSystemEventHandler):
         # Watchdog 5.X is supported Python >=3.9, so watchdog 4.X is used for Python 3.8.
         # In Watchdog 5.X, the path can be bytes or str, but in Watchdog 4.X, the path is always str,
         # that's why we convert the path to str, but we need to ignore the unreachable code warning for Python 3.8.
-        if isinstance(changed_path, bytes):  # type: ignore[unreachable]
-            changed_path = changed_path.decode("utf-8")  # type: ignore[unreachable]
+        if isinstance(changed_path, bytes):  # type: ignore[unreachable, unused-ignore]
+            changed_path = changed_path.decode("utf-8")  # type: ignore[unreachable, unused-ignore]
 
         abs_changed_path = os.path.abspath(changed_path)
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -342,9 +342,10 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             _LOGGER.debug("Don't care about event type %s", event.event_type)
             return
 
-        # changed_path can technically be a bytes object, but this is
-        # never the case in Streamlit.
-        assert isinstance(changed_path, str)
+        # changed_path can be a bytes object, convert it to a string when this is the case
+        if isinstance(changed_path, bytes):
+            changed_path = changed_path.decode("utf-8")
+
         abs_changed_path = os.path.abspath(changed_path)
 
         changed_path_info = self._watched_paths.get(abs_changed_path, None)

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -77,7 +77,6 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-
     def test_works_with_bytes_path(self):
         """Test that when a file path in bytes, the callback is called."""
         cb = mock.Mock()

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -77,6 +77,34 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
+
+    def test_works_with_bytes_path(self):
+        """Test that when a file path in bytes, the callback is called."""
+        cb = mock.Mock()
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+
+        ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        fo._observer.schedule.assert_called_once()
+
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        cb.assert_not_called()
+
+        self.mock_util.path_modification_time = lambda *args: 102.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+
+        ev = events.FileSystemEvent(b"/this/is/my/file.py")
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        cb.assert_called_once()
+
+        ro.close()
+
     def test_works_with_directories(self):
         """Test that when a directory is modified, the callback is called."""
         cb = mock.Mock()


### PR DESCRIPTION
## Describe your changes
This week watchdog released a new major version. However, Streamlit limited watchdog to `<5` last year (before the watchdog release). This PR ensures that Streamlit now also uses the most recent Watchdog version.

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed? _I haven't tested this change on Windows yet, it would be awesome if someone could do this!_

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
