### PR TITLE
[WIP] Fix z-index related to Modals

### DIFF
--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -45,10 +45,7 @@ export function RootStyleProvider(
 ): ReactElement {
   const { children, theme } = props
   return (
-    <BaseProvider
-      theme={theme.basewebTheme}
-      zIndex={theme.emotion.zIndices.popupMenu}
-    >
+    <BaseProvider theme={theme.basewebTheme}>
       <CacheProvider value={cache}>
         <EmotionThemeProvider theme={theme.emotion}>
           <Global styles={globalStyles} />


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9349

The global zIndex sets the z-index for all baseui layers, which effects the `UIModal`'s layer z-index.
This PR is WIP; a safer solution might be to override the z-index for modals in our app. Although setting the z-index globally doesn't seem to be the best approach; especially since the value does not seem to be used by AppView elements by default (presumably because baseweb layers are not used). The `zIndex` instead should be set fine-granular where needed. Let's see whether all our tests pass now.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
