### PR TITLE
[chore] Fix typedefs for deck.gl

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -755,18 +755,6 @@ SOFTWARE.
 
 The following software may be included in this product: @mapbox/tiny-sdf. A copy of the source code may be downloaded from git+https://github.com/mapbox/tiny-sdf.git. This software contains the following license and notice below:
 
-Copyright © 2016-2021 Mapbox, Inc.
-This code available under the terms of the BSD 2-Clause license.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-The following software may be included in this product: @mapbox/tiny-sdf. A copy of the source code may be downloaded from git+https://github.com/mapbox/tiny-sdf.git. This software contains the following license and notice below:
-
 BSD-2-Clause
 Copyright (c) 2016-2022 Mapbox, Inc.
 
@@ -775,6 +763,18 @@ Redistribution and use in source and binary forms, with or without modification,
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+The following software may be included in this product: @mapbox/tiny-sdf. A copy of the source code may be downloaded from git+https://github.com/mapbox/tiny-sdf.git. This software contains the following license and notice below:
+
+Copyright © 2016-2021 Mapbox, Inc.
+This code available under the terms of the BSD 2-Clause license.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -27,9 +27,14 @@
     "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx --max-warnings 0 src"
   },
   "dependencies": {
+    "@deck.gl/aggregation-layers": "^8.9.36",
     "@deck.gl/carto": "^8.9.36",
     "@deck.gl/core": "^8.9.36",
+    "@deck.gl/geo-layers": "^8.9.36",
     "@deck.gl/json": "^8.9.36",
+    "@deck.gl/layers": "^8.9.36",
+    "@deck.gl/mesh-layers": "^8.9.36",
+    "@deck.gl/react": "^8.9.36",
     "@emotion-icons/emotion-icon": "^4.1.0",
     "@emotion-icons/material-outlined": "^3.14.0",
     "@emotion-icons/material-rounded": "^3.14.0",

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -124,17 +124,17 @@ describe("DeckGlJsonChart element", () => {
 
     it("should return false if info is undefined", () => {
       const result = deckGlInstance.createTooltip(undefined)
-      expect(result).toBe(false)
+      expect(result).toBe(null)
     })
 
     it("should return false if info.object is undefined", () => {
       const result = deckGlInstance.createTooltip({})
-      expect(result).toBe(false)
+      expect(result).toBe(null)
     })
 
     it("should return false if element.tooltip is undefined", () => {
       const result = deckGlInstance.createTooltip({ object: {} })
-      expect(result).toBe(false)
+      expect(result).toBe(null)
     })
 
     it("should interpolate the html with the correct object", () => {
@@ -178,7 +178,7 @@ describe("DeckGlJsonChart element", () => {
         object: { elevationValue: 10 },
       })
 
-      expect(result.html).toBe(undefined)
+      expect(result?.html).toBe(undefined)
     })
   })
 

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -16,25 +16,24 @@
 
 import React, { PureComponent, ReactNode } from "react"
 
-import { DeckGL } from "deck.gl"
+import { DeckGL } from "@deck.gl/react/typed"
 import JSON5 from "json5"
 import isEqual from "lodash/isEqual"
 import { MapContext, NavigationControl, StaticMap } from "react-map-gl"
 import { withTheme } from "@emotion/react"
-// We don't have Typescript defs for these imports, which makes ESLint unhappy
-/* eslint-disable import/no-extraneous-dependencies */
 import {
   CartoLayer,
   colorBins,
   colorCategories,
   colorContinuous,
-} from "@deck.gl/carto"
-import * as layers from "@deck.gl/layers"
-import { JSONConverter } from "@deck.gl/json"
-import * as geoLayers from "@deck.gl/geo-layers"
-import * as aggregationLayers from "@deck.gl/aggregation-layers"
-import * as meshLayers from "@deck.gl/mesh-layers"
-/* eslint-enable */
+} from "@deck.gl/carto/typed"
+import * as layers from "@deck.gl/layers/typed"
+import { JSONConverter } from "@deck.gl/json/typed"
+import * as geoLayers from "@deck.gl/geo-layers/typed"
+import * as aggregationLayers from "@deck.gl/aggregation-layers/typed"
+import * as meshLayers from "@deck.gl/mesh-layers/typed"
+import { DeckProps, PickingInfo } from "@deck.gl/core/typed"
+import { TooltipContent } from "@deck.gl/core/typed/lib/tooltip"
 import { CSVLoader } from "@loaders.gl/csv"
 import { GLTFLoader } from "@loaders.gl/gltf"
 import { registerLoaders } from "@loaders.gl/core"
@@ -54,18 +53,12 @@ import {
 
 import "mapbox-gl/dist/mapbox-gl.css"
 
-interface PickingInfo {
-  object: {
-    [key: string]: any
-  }
-}
-
 interface DeckObject {
   initialViewState: {
     height: number
     width: number
   }
-  layers: Record<string, unknown>[]
+  layers: DeckProps["layers"]
   mapStyle?: string | Array<string>
 }
 
@@ -215,11 +208,11 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
     return jsonConverter.convert(state.pydeckJson)
   }
 
-  createTooltip = (info: PickingInfo): Record<string, unknown> | boolean => {
+  createTooltip = (info: PickingInfo): TooltipContent => {
     const { element } = this.props
 
     if (!info || !info.object || !element.tooltip) {
-      return false
+      return null
     }
 
     const tooltip = JSON5.parse(element.tooltip)
@@ -253,7 +246,7 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
     return body
   }
 
-  onViewStateChange = ({ viewState }: State): void => {
+  onViewStateChange: DeckProps["onViewStateChange"] = ({ viewState }) => {
     this.setState({ viewState })
   }
 
@@ -276,6 +269,7 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
           width={width}
           layers={this.state.initialized ? deck.layers : []}
           getTooltip={this.createTooltip}
+          // @ts-expect-error There is a type mismatch due to our versions of the libraries
           ContextProvider={MapContext.Provider}
           controller
         >

--- a/frontend/lib/src/declarations.d.ts
+++ b/frontend/lib/src/declarations.d.ts
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-// We don't have typings for deck.gl, so let's make it untyped.
-declare module "deck.gl"
-
-declare module "@deck.gl/aggregation-layers"
-
-declare module "@deck.gl/carto"
-
-declare module "@deck.gl/geo-layers"
-
-declare module "@deck.gl/json"
-
-declare module "@deck.gl/layers"
-
-declare module "@deck.gl/mesh-layers"
-
 declare module "@loaders.gl/core"
 
 declare module "@loaders.gl/csv"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1300,7 +1300,7 @@
   dependencies:
     "@date-io/core" "^2.10.6"
 
-"@deck.gl/aggregation-layers@8.9.36":
+"@deck.gl/aggregation-layers@8.9.36", "@deck.gl/aggregation-layers@^8.9.36":
   version "8.9.36"
   resolved "https://registry.yarnpkg.com/@deck.gl/aggregation-layers/-/aggregation-layers-8.9.36.tgz#a4cfd03b2cb8245076310b702138627b538f72e5"
   integrity sha512-EwUJ1bwhhAG6LF9hAdZDaIAwIFDUGC8XpQgHmitTLohciVrIp70p9zpgHNNU6oPy+iQvccmWctLcSC9TpgjsIg==
@@ -1362,7 +1362,7 @@
     "@babel/runtime" "^7.0.0"
     "@luma.gl/shadertools" "^8.5.21"
 
-"@deck.gl/geo-layers@8.9.36":
+"@deck.gl/geo-layers@8.9.36", "@deck.gl/geo-layers@^8.9.36":
   version "8.9.36"
   resolved "https://registry.yarnpkg.com/@deck.gl/geo-layers/-/geo-layers-8.9.36.tgz#ae376405bd5b926067aa3b46748bd244743a933f"
   integrity sha512-OmJhbRpNK2MPVfEWqWR45Q1e8Sz90fGuFOkcl8Ecl6HZJV7IWcAlnybtaAeJNWO2OohN2TI53UdRKUNGFYS4AQ==
@@ -1401,7 +1401,7 @@
     d3-dsv "^1.0.8"
     expression-eval "^2.0.0"
 
-"@deck.gl/layers@8.9.36":
+"@deck.gl/layers@8.9.36", "@deck.gl/layers@^8.9.36":
   version "8.9.36"
   resolved "https://registry.yarnpkg.com/@deck.gl/layers/-/layers-8.9.36.tgz#1f8a224fba4568d6fa3a4afec2f9a0b2f9ecdbf6"
   integrity sha512-sr/QKELXZ4W0ZHb12QC2+EV1bZJOM6cU6kAfOJD5jOVixOcyccr+FnPPGn39VK9cl/VFY0S339ZPs9reyhDFVg==
@@ -1424,7 +1424,7 @@
     "@babel/runtime" "^7.0.0"
     "@types/mapbox-gl" "^2.6.3"
 
-"@deck.gl/mesh-layers@8.9.36":
+"@deck.gl/mesh-layers@8.9.36", "@deck.gl/mesh-layers@^8.9.36":
   version "8.9.36"
   resolved "https://registry.yarnpkg.com/@deck.gl/mesh-layers/-/mesh-layers-8.9.36.tgz#d1d3005f0403f441f25cf9abef7fdb94a217beb3"
   integrity sha512-xQ+OSdU3z3HIgaHJfxbcNIxmWYPUBMJZAM+fAbynojGVzGYLJo2MUjUJLtCsw0Ejs3YtnocyuFRM+zObB0I3jw==
@@ -1435,7 +1435,7 @@
     "@luma.gl/experimental" "^8.5.21"
     "@luma.gl/shadertools" "^8.5.21"
 
-"@deck.gl/react@8.9.36":
+"@deck.gl/react@8.9.36", "@deck.gl/react@^8.9.36":
   version "8.9.36"
   resolved "https://registry.yarnpkg.com/@deck.gl/react/-/react-8.9.36.tgz#6fb0daef9b3f7c146aab082107875d90e969a985"
   integrity sha512-/WIvHK0aJwppLnpA6GZrOhfanx5WVWihx/o6U88kX53VsyJQMZU10+EXKc1FkI3nd5/jsLbLc8fC0dUtiXiSVw==


### PR DESCRIPTION
## Describe your changes

- This uses TypeScript types for `deck.gl` on the frontend for better type checking
- Previously, all `deck.gl` libraries were explicitly untyped. Since `deck.gl` v8.8, the library ships [an opt-in typed version](https://deck.gl/docs/get-started/using-with-typescript#deckgl-v8). We are already on v8.9, so this utilizes the typed version and makes some local changes to ensure types are working as expected.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
  - This is purely a type change, so TypeScript compiler will do the heavy lifting of verification here.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
