### PR TITLE
Deactivate cached venv usage for integration test

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -226,6 +226,8 @@ jobs:
           python-version: "3.11"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
+        with:
+          use_cached_venv: false
       - name: Run make develop
         run: make develop
       - name: Install integration dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
         with:
+          # Deactivate usage of cached venv to avoid inferring with the Python 3.11
+          # unit test job. The key generation for the cache resolves to the same key,
+          # which might cause some unexpected issues with dependencies.
           use_cached_venv: false
       - name: Run make develop
         run: make develop


### PR DESCRIPTION
## Describe your changes

Deactivates usage of a cached environment in the integration test to prevent interfering with the cached environment in the normal Python 3.11 integration test. This doesn't change the usage of cached environment for our Python unit tests.

## Testing Plan

- Only CI changes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
