### PR TITLE
Update runtime.py: change test@test.com to test@example.com

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -560,7 +560,7 @@ class Runtime:
             uploaded_file_manager=self._uploaded_file_mgr,
             script_cache=self._script_cache,
             message_enqueued_callback=self._enqueued_some_message,
-            user_info={"email": "test@test.com"},
+            user_info={"email": "test@example.com"},
         )
 
         try:


### PR DESCRIPTION
My streamlit project has been logging an error in my streamlit.app "Manage app" side panel lately because the email of the user accessing it is not on the approved list of emails (so my app doesn't know how to act). The problematic email accessing it is test@test.com.

This commit addresses the only instance of non-test code that has test@test.com, so the problem must be from this. Presumably due to the script health check https://github.com/streamlit/streamlit/blob/621b802fc07d17a657d9e75bd913303adb335491/lib/streamlit/web/server/server.py#L341

So, anyway, I think we should change this example email to test@example.com for the same reason the regular user email is (see https://github.com/streamlit/streamlit/pull/7219). example.com is a reserved domain for such purposes (https://www.rfc-editor.org/rfc/rfc2606.html#section-3), unlike test.com, which is just a regular domain some random person owns, I guess. If it's somehow useful to distinguish between this "user" and the regular local user, then healthcheck@example.com could perhaps be used instead.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
