### PR TITLE
Fix edge case where title can be empty string

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -206,6 +206,12 @@ class StreamlitPage:
         self._page: Path | Callable[[], None] = page
         self._title: str = title or inferred_name.replace("_", " ")
         self._icon: str = icon or inferred_icon
+
+        if self._title.strip() == "":
+            raise StreamlitAPIException(
+                "The title of the page cannot be an empty string. Please provide a title."
+            )
+
         if url_path is not None and url_path.strip() == "" and not default:
             raise StreamlitAPIException(
                 "The URL path cannot be an empty string unless the page is the default page."

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -209,7 +209,7 @@ class StreamlitPage:
 
         if self._title.strip() == "":
             raise StreamlitAPIException(
-                "The title of the page cannot be an empty string. Please provide a title."
+                "The title of the page cannot be empty or consist of underscores/spaces only"
             )
 
         if url_path is not None and url_path.strip() == "" and not default:

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -51,8 +51,8 @@ class StPagesTest(DeltaGeneratorTestCase):
 
         try:
             st.Page(Foo(), title="Hello")
-        except Exception:
-            pytest.fail("Should not raise exception")
+        except Exception as e:
+            pytest.fail("Should not raise exception: " + str(e))
 
     def test_invalid_icon_raises_exception(self):
         """Test that passing an invalid icon raises an exception."""
@@ -116,6 +116,18 @@ class StPagesTest(DeltaGeneratorTestCase):
 
         with pytest.raises(StreamlitAPIException):
             st.Page(page_9, url_path="")
+
+    def test_page_with_no_title_raises_api_exception(self):
+        """Tests that an error is raised if the title is empty or inferred to be empty"""
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page("_.py")
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, title="    ")
 
     def test_page_run_cannot_run_standalone(self):
         """Test that a page cannot run standalone."""


### PR DESCRIPTION
## Describe your changes

Depending on file naming schemes, the inferred title can be empty string (or a set of spaces. This is insufficient for MPA, so we will disallow it if anything leads to the title being an empty string.

## GitHub Issue Link (if applicable)
Closes #8892

## Testing Plan

- Unit tests updated with the changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
