### PR TITLE
Do not format title for MPAv2 in Sidebar nav

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_title.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_title.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def a():
+    st.header("Page A")
+    st.write("This is page A")
+
+
+def b():
+    st.header("Page B")
+    st.write("This is page B")
+
+
+page = st.navigation([st.Page(a), st.Page(b, title="1_page__2")])
+page.run()

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_title_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_title_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import (
+    wait_for_app_run,
+)
+
+expected_page_order = ["a", "1_page__2"]
+
+
+def get_page_link(
+    app: Page, page_name: str, page_order: list[str] = expected_page_order
+):
+    return (
+        app.get_by_test_id("stSidebarNav").locator("a").nth(page_order.index(page_name))
+    )
+
+
+def test_can_switch_between_pages_by_clicking_on_sidebar_links(app: Page):
+    """Test that we can switch between pages by clicking on sidebar links."""
+    nav = app.get_by_test_id("stSidebarNav")
+    for i, title in enumerate(expected_page_order):
+        expect(nav.locator("a").nth(i)).to_contain_text(title)
+
+    get_page_link(app, "1_page__2").click()
+    wait_for_app_run(app)
+    expect(app).to_have_title("1_page__2")

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -240,7 +240,11 @@ const NEW_SESSION_JSON: INewSession = {
     isHello: false,
   },
   appPages: [
-    { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+    {
+      pageScriptHash: "page_script_hash",
+      pageName: "streamlit app",
+      urlPathname: "streamlit_app",
+    },
   ],
   pageScriptHash: "page_script_hash",
   mainScriptPath: "path/to/file.py",
@@ -864,8 +868,8 @@ describe("App", () => {
       expect(screen.queryByTestId("stSidebarNav")).not.toBeInTheDocument()
 
       const appPages = [
-        { pageScriptHash: "hash1", pageName: "page1" },
-        { pageScriptHash: "hash2", pageName: "page2" },
+        { pageScriptHash: "hash1", pageName: "page1", urlPathname: "page1" },
+        { pageScriptHash: "hash2", pageName: "page2", urlPathname: "page2" },
       ]
 
       sendForwardMessage("newSession", {
@@ -988,8 +992,16 @@ describe("App", () => {
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
           appPages: [
-            { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
-            { pageScriptHash: "hash2", pageName: "page2" },
+            {
+              pageScriptHash: "page_script_hash",
+              pageName: "streamlit app",
+              urlPathname: "streamlit_app",
+            },
+            {
+              pageScriptHash: "hash2",
+              pageName: "page2",
+              urlPathname: "page2",
+            },
           ],
           pageScriptHash: "hash2",
         })
@@ -1026,8 +1038,16 @@ describe("App", () => {
         )
 
         const appPages = [
-          { pageScriptHash: "toppage_hash", pageName: "streamlit_app" },
-          { pageScriptHash: "subpage_hash", pageName: "page2" },
+          {
+            pageScriptHash: "toppage_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
+          {
+            pageScriptHash: "subpage_hash",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
         ]
 
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
@@ -1069,8 +1089,16 @@ describe("App", () => {
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
           appPages: [
-            { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
-            { pageScriptHash: "hash2", pageName: "page2" },
+            {
+              pageScriptHash: "page_script_hash",
+              pageName: "streamlit app",
+              urlPathname: "streamlit_app",
+            },
+            {
+              pageScriptHash: "hash2",
+              pageName: "page2",
+              urlPathname: "page2",
+            },
           ],
           pageScriptHash: "hash2",
         })
@@ -1087,8 +1115,16 @@ describe("App", () => {
         history.replaceState({}, "", "/") // The URL is set to the main page from the beginning.
 
         const appPages = [
-          { pageScriptHash: "toppage_hash", pageName: "streamlit_app" },
-          { pageScriptHash: "subpage_hash", pageName: "page2" },
+          {
+            pageScriptHash: "toppage_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
+          {
+            pageScriptHash: "subpage_hash",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
         ]
 
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
@@ -1122,8 +1158,16 @@ describe("App", () => {
         history.replaceState({}, "", "/page2") // Starting from a not main page.
 
         const appPages = [
-          { pageScriptHash: "toppage_hash", pageName: "streamlit_app" },
-          { pageScriptHash: "subpage_hash", pageName: "page2" },
+          {
+            pageScriptHash: "toppage_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
+          {
+            pageScriptHash: "subpage_hash",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
         ]
 
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
@@ -1275,8 +1319,16 @@ describe("App", () => {
         isHello: false,
       },
       appPages: [
-        { pageScriptHash: "top_hash", pageName: "streamlit_app" },
-        { pageScriptHash: "sub_hash", pageName: "page2" },
+        {
+          pageScriptHash: "top_hash",
+          pageName: "streamlit app",
+          urlPathname: "",
+        },
+        {
+          pageScriptHash: "sub_hash",
+          pageName: "page2",
+          urlPathname: "page2",
+        },
       ],
       pageScriptHash: "top_hash",
       fragmentIdsThisRun: [],
@@ -1574,8 +1626,16 @@ describe("App", () => {
       )
 
       const appPages = [
-        { pageScriptHash: "toppage_hash", pageName: "streamlit_app" },
-        { pageScriptHash: "subpage_hash", pageName: "page2" },
+        {
+          pageScriptHash: "toppage_hash",
+          pageName: "streamlit app",
+          urlPathname: "streamlit_app",
+        },
+        {
+          pageScriptHash: "subpage_hash",
+          pageName: "page2",
+          urlPathname: "page2",
+        },
       ]
 
       // Because the page URL is already "/" pointing to the main page, no new history is pushed.
@@ -1748,7 +1808,13 @@ describe("App", () => {
       renderApp(getProps())
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
-        appPages: [{ pageScriptHash: "page_hash", pageName: "streamlit_app" }],
+        appPages: [
+          {
+            pageScriptHash: "page_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
+        ],
         pageScriptHash: "page_hash",
       })
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
@@ -1774,7 +1840,13 @@ describe("App", () => {
       renderApp(getProps())
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
-        appPages: [{ pageScriptHash: "page_hash", pageName: "streamlit_app" }],
+        appPages: [
+          {
+            pageScriptHash: "page_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
+        ],
         pageScriptHash: "page_hash",
       })
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
@@ -2500,8 +2572,18 @@ describe("App", () => {
       const hostCommunicationMgr = prepareHostCommunicationManager()
 
       const appPages = [
-        { icon: "", pageName: "bob", scriptPath: "bob.py" },
-        { icon: "", pageName: "carl", scriptPath: "carl.py" },
+        {
+          icon: "",
+          pageName: "bob",
+          scriptPath: "bob.py",
+          urlPathname: "bob",
+        },
+        {
+          icon: "",
+          pageName: "carl",
+          scriptPath: "carl.py",
+          urlPathname: "carl",
+        },
       ]
 
       sendForwardMessage("pagesChanged", {
@@ -2652,8 +2734,8 @@ describe("App", () => {
       expect(screen.queryByTestId("stSidebarNav")).not.toBeInTheDocument()
 
       const appPages = [
-        { pageScriptHash: "hash1", pageName: "page1" },
-        { pageScriptHash: "hash2", pageName: "page2" },
+        { pageScriptHash: "hash1", pageName: "page1", urlPathname: "page1" },
+        { pageScriptHash: "hash2", pageName: "page2", urlPathname: "page2" },
       ]
 
       sendForwardMessage("newSession", {

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -203,8 +203,16 @@ describe("Sidebar Component", () => {
 
   it("renders SidebarNav component", () => {
     const appPages = [
-      { pageName: "first_page", pageScriptHash: "page_hash" },
-      { pageName: "second_page", pageScriptHash: "page_hash2" },
+      {
+        pageName: "first page",
+        pageScriptHash: "page_hash",
+        urlPathname: "first_page",
+      },
+      {
+        pageName: "second page",
+        pageScriptHash: "page_hash2",
+        urlPathname: "second_page",
+      },
     ]
     renderSidebar({ appPages })
 

--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -43,10 +43,15 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   appPages: [
     {
       pageScriptHash: "main_page_hash",
-      pageName: "streamlit_app",
+      pageName: "streamlit app",
+      urlPathname: "streamlit_app",
       isDefault: true,
     },
-    { pageScriptHash: "other_page_hash", pageName: "my_other_page" },
+    {
+      pageScriptHash: "other_page_hash",
+      pageName: "my other page",
+      urlPathname: "my_other_page",
+    },
   ],
   navSections: [],
   collapseSidebar: jest.fn(),
@@ -91,7 +96,7 @@ describe("SidebarNav", () => {
       const buildAppPageURL = jest
         .fn()
         .mockImplementation((pageLinkBaseURL: string, page: IAppPage) => {
-          return `http://mock/app/page/${page.pageName}`
+          return `http://mock/app/page/${page.urlPathname}`
         })
       const props = getProps({ endpoints: mockEndpoints({ buildAppPageURL }) })
 

--- a/frontend/app/src/components/Sidebar/SidebarNav.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.tsx
@@ -72,7 +72,6 @@ const SidebarNav = ({
     (page: IAppPage, index: number) => {
       const pageUrl = endpoints.buildAppPageURL(pageLinkBaseUrl, page)
       const pageName = page.pageName as string
-      const tooltipContent = pageName.replace(/_/g, " ")
       const isActive = page.pageScriptHash === currentPageScriptHash
 
       return (
@@ -89,7 +88,7 @@ const SidebarNav = ({
               }
             }}
           >
-            {tooltipContent}
+            {pageName}
           </SidebarNavLink>
         </li>
       )

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -23,7 +23,6 @@ import { emotionLightTheme, mockEndpoints, render } from "@streamlit/lib"
 
 import { SidebarProps } from "./Sidebar"
 import ThemedSidebar from "./ThemedSidebar"
-import { url } from "inspector"
 
 function getProps(
   props: Partial<SidebarProps> = {}

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -23,6 +23,7 @@ import { emotionLightTheme, mockEndpoints, render } from "@streamlit/lib"
 
 import { SidebarProps } from "./Sidebar"
 import ThemedSidebar from "./ThemedSidebar"
+import { url } from "inspector"
 
 function getProps(
   props: Partial<SidebarProps> = {}
@@ -56,8 +57,16 @@ describe("ThemedSidebar Component", () => {
 
   it("plumbs appPages to main Sidebar component", () => {
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "other_app_page", scriptPath: "other_app_page.py" },
+      {
+        pageName: "streamlit app",
+        scriptPath: "streamlit_app.py",
+        urlPathname: "streamlit_app",
+      },
+      {
+        pageName: "other app page",
+        scriptPath: "other_app_page.py",
+        urlPathname: "other_app_page",
+      },
     ]
     render(<ThemedSidebar {...getProps({ appPages })} />)
 

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
@@ -129,10 +129,15 @@ describe("DefaultStreamlitEndpoints", () => {
     const appPages = [
       {
         pageScriptHash: "main_page_hash",
-        pageName: "streamlit_app",
+        pageName: "streamlit app",
+        urlPathname: "streamlit_app",
         isDefault: true,
       },
-      { pageScriptHash: "other_page_hash", pageName: "my_other_page" },
+      {
+        pageScriptHash: "other_page_hash",
+        pageName: "my other page",
+        urlPathname: "my_other_page",
+      },
     ]
 
     it("uses window.location.port", () => {

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -91,8 +91,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     pageLinkBaseURL: string | undefined,
     page: IAppPage
   ): string {
-    const pageName = page.pageName as string
-    const urlPath = page.urlPathname || pageName
+    const urlPath = page.urlPathname as string
     const navigateTo = page.isDefault ? "" : urlPath
 
     if (notNullOrUndefined(pageLinkBaseURL) && pageLinkBaseURL.length > 0) {

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -82,7 +82,11 @@ function generateNewSession(changes = {}): NewSession {
       isHello: false,
     },
     appPages: [
-      { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+      {
+        pageScriptHash: "page_script_hash",
+        pageName: "streamlit app",
+        urlPathname: "streamlit_app",
+      },
     ],
     pageScriptHash: "page_script_hash",
     mainScriptHash: "main_script_hash",
@@ -139,7 +143,11 @@ describe("AppNavigation", () => {
 
       const [newState] = maybeState!
       expect(newState.appPages).toEqual([
-        { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+        {
+          pageScriptHash: "page_script_hash",
+          pageName: "streamlit app",
+          urlPathname: "streamlit_app",
+        },
       ])
     })
 
@@ -161,7 +169,11 @@ describe("AppNavigation", () => {
       expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
         type: "SET_APP_PAGES",
         appPages: [
-          { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+          },
         ],
       })
 
@@ -185,7 +197,11 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handlePagesChanged(
         new PagesChanged({
           appPages: [
-            { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+            {
+              pageScriptHash: "other_page_script_hash",
+              pageName: "foo bar",
+              urlPathname: "foo_bar",
+            },
           ],
         })
       )
@@ -193,7 +209,11 @@ describe("AppNavigation", () => {
 
       const [newState] = maybeState!
       expect(newState.appPages).toEqual([
-        { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+        {
+          pageScriptHash: "other_page_script_hash",
+          pageName: "foo bar",
+          urlPathname: "foo_bar",
+        },
       ])
     })
 
@@ -201,7 +221,11 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handlePagesChanged(
         new PagesChanged({
           appPages: [
-            { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+            {
+              pageScriptHash: "other_page_script_hash",
+              pageName: "foo bar",
+              urlPathname: "foo_bar",
+            },
           ],
         })
       )
@@ -213,7 +237,11 @@ describe("AppNavigation", () => {
       expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
         type: "SET_APP_PAGES",
         appPages: [
-          { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+          {
+            pageScriptHash: "other_page_script_hash",
+            pageName: "foo bar",
+            urlPathname: "foo_bar",
+          },
         ],
       })
     })
@@ -261,7 +289,7 @@ describe("AppNavigation", () => {
       const page = appNavigation.findPageByUrlPath("/streamlit_app")
 
       expect(page.pageScriptHash).toEqual("page_script_hash")
-      expect(page.pageName).toEqual("streamlit_app")
+      expect(page.pageName).toEqual("streamlit app")
     })
 
     it("returns default url by path when path is invalid", () => {
@@ -270,7 +298,7 @@ describe("AppNavigation", () => {
       const page = appNavigation.findPageByUrlPath("foo")
 
       expect(page.pageScriptHash).toEqual("page_script_hash")
-      expect(page.pageName).toEqual("streamlit_app")
+      expect(page.pageName).toEqual("streamlit app")
     })
   })
 
@@ -313,7 +341,11 @@ describe("AppNavigation", () => {
       const maybeState = appNavigation.handlePagesChanged(
         new PagesChanged({
           appPages: [
-            { pageScriptHash: "other_page_script_hash", pageName: "foo_bar" },
+            {
+              pageScriptHash: "other_page_script_hash",
+              pageName: "foo bar",
+              urlPathname: "foo_bar",
+            },
           ],
         })
       )

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -157,8 +157,6 @@ export class StrategyV1 {
 
     return (
       this.appPages.find(appPage =>
-        // The page name is embedded at the end of the URL path, and if not, we are in the main page.
-        // See https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/App.tsx#L740
         pathname.endsWith("/" + appPage.urlPathname)
       ) ?? this.appPages[0]
     )

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -78,13 +78,13 @@ export class StrategyV1 {
     // Otherwise, we'd either have no main script or a nameless main script,
     // neither of which can happen.
     const mainPage = this.appPages[0] as IAppPage
-    const mainPageName = mainPage.pageName ?? ""
+    const mainPageName = mainPage.urlPathname ?? ""
     // We're similarly guaranteed that newPageName will be found / truthy
     // here.
     const newPageName =
       this.appPages.find(
         page => page.pageScriptHash === this.currentPageScriptHash
-      )?.pageName ?? ""
+      )?.urlPathname ?? ""
 
     const isViewingMainPage =
       mainPage.pageScriptHash === this.currentPageScriptHash
@@ -159,7 +159,7 @@ export class StrategyV1 {
       this.appPages.find(appPage =>
         // The page name is embedded at the end of the URL path, and if not, we are in the main page.
         // See https://github.com/streamlit/streamlit/blob/1.19.0/frontend/src/App.tsx#L740
-        pathname.endsWith("/" + appPage.pageName)
+        pathname.endsWith("/" + appPage.urlPathname)
       ) ?? this.appPages[0]
     )
   }

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -854,7 +854,8 @@ class AppSession:
             page_proto = msg.app_pages.add()
 
             page_proto.page_script_hash = page_script_hash
-            page_proto.page_name = page_info["page_name"]
+            page_proto.page_name = page_info["page_name"].replace("_", " ")
+            page_proto.url_pathname = page_info["page_name"]
             page_proto.icon = page_info["icon"]
 
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -426,8 +426,12 @@ class AppSessionTest(unittest.TestCase):
         "get_pages",
         MagicMock(
             return_value={
-                "hash1": {"page_name": "page1", "icon": "", "script_path": "script1"},
-                "hash2": {"page_name": "page2", "icon": "🎉", "script_path": "script2"},
+                "hash1": {"page_name": "page_1", "icon": "", "script_path": "script1"},
+                "hash2": {
+                    "page_name": "page_2",
+                    "icon": "🎉",
+                    "script_path": "script2",
+                },
             }
         ),
     )
@@ -439,8 +443,18 @@ class AppSessionTest(unittest.TestCase):
         expected_msg = ForwardMsg()
         expected_msg.pages_changed.app_pages.extend(
             [
-                AppPage(page_script_hash="hash1", page_name="page1", icon=""),
-                AppPage(page_script_hash="hash2", page_name="page2", icon="🎉"),
+                AppPage(
+                    page_script_hash="hash1",
+                    page_name="page 1",
+                    icon="",
+                    url_pathname="page_1",
+                ),
+                AppPage(
+                    page_script_hash="hash2",
+                    page_name="page 2",
+                    icon="🎉",
+                    url_pathname="page_2",
+                ),
             ]
         )
 
@@ -658,8 +672,12 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         "get_pages",
         MagicMock(
             return_value={
-                "hash1": {"page_name": "page1", "icon": "", "script_path": "script1"},
-                "hash2": {"page_name": "page2", "icon": "🎉", "script_path": "script2"},
+                "hash1": {"page_name": "page_1", "icon": "", "script_path": "script1"},
+                "hash2": {
+                    "page_name": "page_2",
+                    "icon": "🎉",
+                    "script_path": "script2",
+                },
             }
         ),
     )
@@ -722,8 +740,18 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         assert init_msg.HasField("user_info")
 
         assert list(new_session_msg.app_pages) == [
-            AppPage(page_script_hash="hash1", page_name="page1", icon=""),
-            AppPage(page_script_hash="hash2", page_name="page2", icon="🎉"),
+            AppPage(
+                page_script_hash="hash1",
+                page_name="page 1",
+                icon="",
+                url_pathname="page_1",
+            ),
+            AppPage(
+                page_script_hash="hash2",
+                page_name="page 2",
+                icon="🎉",
+                url_pathname="page_2",
+            ),
         ]
 
         add_script_run_ctx(ctx=orig_ctx)


### PR DESCRIPTION
## Describe your changes

MPAv2 allows more flexibility in the title including adding underscores. We originally formatted on the frontend to remove those _. This change removes that setup. Instead, we do the following:

1. Remove formatting on the sidebarnav (Assume the pageName is valid for the scenario).
2. For MPAv1, supply a `urlPathname` to be the `pageName`, and the page name to be the formatted pageName (replacing _ with spaces). This is done in the NewSession Message (leveraged only in MPAv1).
3. With this change, in generating the app link, just use the `urlPathname` instead of both.


## GitHub Issue Link (if applicable)
Closes #8890 

## Testing Plan

- E2E Test to verify the page title is set correctly. I used a separate script because this test does not require screenshots.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
