### PR TITLE
Fix: Margin on button icons

### DIFF
--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -124,5 +124,12 @@ describe("LinkButton widget", () => {
 
       expect(screen.getByTestId("stIconMaterial")).toBeVisible()
     })
+
+    it("renders an icon with no margin, if there is no label", () => {
+      const props = getProps({ label: "", icon: "🎈" })
+      render(<LinkButton {...props} />)
+
+      expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+    })
   })
 })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -109,27 +109,4 @@ describe("LinkButton widget", () => {
       expect(linkButton).toHaveStyle("width: 100%")
     })
   })
-
-  describe("icons", () => {
-    it("renders an emoji icon", () => {
-      const props = getProps({ icon: "🎈" })
-      render(<LinkButton {...props} />)
-
-      expect(screen.getByText("🎈")).toBeVisible()
-    })
-
-    it("renders a Material icon", () => {
-      const props = getProps({ icon: ":material/bolt:" })
-      render(<LinkButton {...props} />)
-
-      expect(screen.getByTestId("stIconMaterial")).toBeVisible()
-    })
-
-    it("renders an icon with no margin, if there is no label", () => {
-      const props = getProps({ label: "", icon: "🎈" })
-      render(<LinkButton {...props} />)
-
-      expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
-    })
-  })
 })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -16,17 +16,13 @@
 
 import React, { MouseEvent, ReactElement } from "react"
 
-import { useTheme } from "@emotion/react"
-
 import { LinkButton as LinkButtonProto } from "@streamlit/lib/src/proto"
 import {
   BaseButtonKind,
   BaseButtonSize,
   BaseButtonTooltip,
+  DynamicButtonLabel,
 } from "@streamlit/lib/src/components/shared/BaseButton"
-import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
-import { EmotionTheme } from "@streamlit/lib/src/theme"
-import { DynamicIcon } from "@streamlit/lib/src/components/shared/Icon"
 
 import BaseLinkButton from "./BaseLinkButton"
 
@@ -38,11 +34,6 @@ export interface Props {
 
 function LinkButton(props: Readonly<Props>): ReactElement {
   const { disabled, element, width } = props
-  const { colors }: EmotionTheme = useTheme()
-  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
-  const isMaterialIcon = element.icon.startsWith(":material")
-  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
-
   const style = { width }
 
   const kind =
@@ -77,21 +68,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           rel="noreferrer"
           aria-disabled={disabled}
         >
-          {element.icon && (
-            <DynamicIcon
-              iconValue={element.icon}
-              color={colors.bodyText}
-              size={isMaterialIcon ? "lg" : "base"}
-              margin={element.label ? iconMargin : "0"}
-            />
-          )}
-          <StreamlitMarkdown
-            source={element.label}
-            allowHTML={false}
-            isLabel
-            largerLabel
-            disableLinks
-          />
+          <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseLinkButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -41,6 +41,8 @@ function LinkButton(props: Readonly<Props>): ReactElement {
   const { colors }: EmotionTheme = useTheme()
   // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
   const isMaterialIcon = element.icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
+
   const style = { width }
 
   const kind =
@@ -80,7 +82,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
               iconValue={element.icon}
               color={colors.bodyText}
               size={isMaterialIcon ? "lg" : "base"}
-              margin={isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"}
+              margin={element.label ? iconMargin : "0"}
             />
           )}
           <StreamlitMarkdown

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -53,14 +53,18 @@ describe("Popover container", () => {
     expect(popoverButton).toHaveClass("stPopover")
   })
 
-  it("renders label as expected", () => {
+  it("renders label on the popover", () => {
     const props = getProps()
     render(
       <Popover {...props}>
         <div>test</div>
       </Popover>
     )
-    expect(screen.getByText(props.element.label)).toBeInTheDocument()
+
+    const popover = screen.getByRole("button", {
+      name: `${props.element.label}`,
+    })
+    expect(popover).toBeInTheDocument()
   })
 
   it("should render the text when opened", () => {
@@ -74,25 +78,5 @@ describe("Popover container", () => {
     fireEvent.click(screen.getByText("label"))
     // Text should be visible now
     expect(screen.queryByText("test")).toBeVisible()
-  })
-
-  it("renders an emoji icon if provided", () => {
-    render(<Popover {...getProps({ icon: "🦄" })} />)
-
-    const icon = screen.getByTestId("stIconEmoji")
-    expect(icon).toHaveTextContent("🦄")
-  })
-
-  it("renders a material icon if provided", () => {
-    render(<Popover {...getProps({ icon: ":material/thumb_up:" })} />)
-
-    const icon = screen.getByTestId("stIconMaterial")
-    expect(icon).toHaveTextContent("thumb_up")
-  })
-
-  it("renders an icon with no margin, if there is no label", () => {
-    render(<Popover {...getProps({ label: "", icon: "🦄" })} />)
-
-    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -89,4 +89,10 @@ describe("Popover container", () => {
     const icon = screen.getByTestId("stIconMaterial")
     expect(icon).toHaveTextContent("thumb_up")
   })
+
+  it("renders an icon with no margin, if there is no label", () => {
+    render(<Popover {...getProps({ label: "", icon: "🦄" })} />)
+
+    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+  })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -21,17 +21,14 @@ import { ExpandLess, ExpandMore } from "@emotion-icons/material-outlined"
 import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
 
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
-import {
-  DynamicIcon,
-  StyledIcon,
-} from "@streamlit/lib/src/components/shared/Icon"
+import { StyledIcon } from "@streamlit/lib/src/components/shared/Icon"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
 import BaseButton, {
   BaseButtonKind,
   BaseButtonSize,
   BaseButtonTooltip,
+  DynamicButtonLabel,
 } from "@streamlit/lib/src/components/shared/BaseButton"
-import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
 import IsSidebarContext from "@streamlit/lib/src/components/core/IsSidebarContext"
 
 import { StyledPopoverButtonIcon } from "./styled-components"
@@ -57,10 +54,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // When useContainerWidth true & has help tooltip,
   // we need to pass the container width down to the button
   const fluidButtonWidth = element.help ? width : true
-
-  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
-  const isMaterialIcon = element.icon.startsWith(":material")
-  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div data-testid="stPopover" className="stPopover">
@@ -144,21 +137,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               fluidWidth={element.useContainerWidth ? fluidButtonWidth : false}
               onClick={() => setOpen(!open)}
             >
-              {element.icon && (
-                <DynamicIcon
-                  size={isMaterialIcon ? "lg" : "base"}
-                  margin={element.label ? iconMargin : "0"}
-                  color={theme.colors.bodyText}
-                  iconValue={element.icon}
-                />
-              )}
-              <StreamlitMarkdown
-                source={element.label}
-                allowHTML={false}
-                isLabel
-                largerLabel
-                disableLinks
-              />
+              <DynamicButtonLabel icon={element.icon} label={element.label} />
               <StyledPopoverButtonIcon>
                 <StyledIcon
                   as={open ? ExpandLess : ExpandMore}

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -60,6 +60,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
 
   // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
   const isMaterialIcon = element.icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div data-testid="stPopover" className="stPopover">
@@ -146,7 +147,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               {element.icon && (
                 <DynamicIcon
                   size={isMaterialIcon ? "lg" : "base"}
-                  margin={isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"}
+                  margin={element.label ? iconMargin : "0"}
                   color={theme.colors.bodyText}
                   iconValue={element.icon}
                 />

--- a/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+import { render } from "@streamlit/lib/src/test_util"
+
+import {
+  DynamicButtonLabel,
+  DynamicButtonLabelProps,
+} from "./DynamicButtonLabel"
+
+const getProps = (
+  propOverrides: Partial<DynamicButtonLabelProps> = {}
+): DynamicButtonLabelProps => ({
+  icon: "😀",
+  label: "Button Label",
+  ...propOverrides,
+})
+
+describe("DynamicButtonLabel", () => {
+  it("renders without crashing", () => {
+    render(<DynamicButtonLabel {...getProps()} />)
+    const buttonLabel = screen.getByText("Button Label")
+    expect(buttonLabel).toBeInTheDocument()
+  })
+
+  it("renders label with no icon", () => {
+    render(<DynamicButtonLabel {...getProps({ icon: "" })} />)
+    expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
+      "Button Label"
+    )
+    expect(screen.queryByTestId("stIconEmoji")).toBeNull()
+  })
+
+  it("renders icon with no label", () => {
+    render(<DynamicButtonLabel {...getProps({ label: "" })} />)
+    expect(screen.getByTestId("stIconEmoji")).toHaveTextContent("😀")
+    expect(screen.queryByTestId("stMarkdownContainer")).toBeNull()
+  })
+
+  it("renders an emoji icon", () => {
+    render(<DynamicButtonLabel {...getProps()} />)
+
+    const icon = screen.getByTestId("stIconEmoji")
+    expect(icon).toHaveTextContent("😀")
+  })
+
+  it("renders a material icon", () => {
+    render(
+      <DynamicButtonLabel {...getProps({ icon: ":material/thumb_up:" })} />
+    )
+
+    const icon = screen.getByTestId("stIconMaterial")
+    expect(icon).toHaveTextContent("thumb_up")
+  })
+
+  it("renders icon with no margin, if there is no label", () => {
+    render(<DynamicButtonLabel {...getProps({ label: "" })} />)
+
+    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+  })
+})

--- a/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { useTheme } from "@emotion/react"
+
+import { EmotionTheme } from "@streamlit/lib/src/theme"
+import { DynamicIcon } from "@streamlit/lib/src/components/shared/Icon"
+import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
+
+export interface DynamicButtonLabelProps {
+  icon: string
+  label: string
+}
+
+export const DynamicButtonLabel = ({
+  icon,
+  label,
+}: DynamicButtonLabelProps): React.ReactElement | null => {
+  const { colors }: EmotionTheme = useTheme()
+
+  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
+  const isMaterialIcon = icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
+
+  return (
+    <>
+      {icon && (
+        <DynamicIcon
+          size={isMaterialIcon ? "lg" : "base"}
+          margin={label ? iconMargin : "0"}
+          color={colors.bodyText}
+          iconValue={icon}
+        />
+      )}
+      {label && (
+        <StreamlitMarkdown
+          source={label}
+          allowHTML={false}
+          isLabel
+          largerLabel
+          disableLinks
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/lib/src/components/shared/BaseButton/index.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/index.tsx
@@ -16,6 +16,7 @@
 
 import { BaseButtonProps as BaseButtonPropsT } from "./BaseButton"
 
+export { DynamicButtonLabel } from "./DynamicButtonLabel"
 export { default, BaseButtonKind, BaseButtonSize } from "./BaseButton"
 export { BaseButtonTooltip as BaseButtonTooltip } from "./BaseButtonTooltip"
 export type BaseButtonProps = BaseButtonPropsT

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -154,4 +154,10 @@ describe("Button widget", () => {
     const icon = screen.getByTestId("stIconMaterial")
     expect(icon).toHaveTextContent("thumb_up")
   })
+
+  it("renders an icon with no margin, if there is no label", () => {
+    render(<Button {...getProps({ label: "", icon: "😀" })} />)
+
+    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+  })
 })

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -140,24 +140,4 @@ describe("Button widget", () => {
     const buttonWidget = screen.getByRole("button")
     expect(buttonWidget).toHaveStyle(`width: ${250}px`)
   })
-
-  it("renders an emoji icon if provided", () => {
-    render(<Button {...getProps({ icon: "😀" })} />)
-
-    const icon = screen.getByTestId("stIconEmoji")
-    expect(icon).toHaveTextContent("😀")
-  })
-
-  it("renders a material icon if provided", () => {
-    render(<Button {...getProps({ icon: ":material/thumb_up:" })} />)
-
-    const icon = screen.getByTestId("stIconMaterial")
-    expect(icon).toHaveTextContent("thumb_up")
-  })
-
-  it("renders an icon with no margin, if there is no label", () => {
-    render(<Button {...getProps({ label: "", icon: "😀" })} />)
-
-    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
-  })
 })

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -16,18 +16,14 @@
 
 import React, { ReactElement } from "react"
 
-import { useTheme } from "@emotion/react"
-
 import { Button as ButtonProto } from "@streamlit/lib/src/proto"
 import BaseButton, {
   BaseButtonKind,
   BaseButtonSize,
   BaseButtonTooltip,
+  DynamicButtonLabel,
 } from "@streamlit/lib/src/components/shared/BaseButton"
-import { DynamicIcon } from "@streamlit/lib/src/components/shared/Icon"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
-import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
-import { EmotionTheme } from "@streamlit/lib/src/theme"
 
 export interface Props {
   disabled: boolean
@@ -38,7 +34,6 @@ export interface Props {
 }
 
 function Button(props: Props): ReactElement {
-  const { colors }: EmotionTheme = useTheme()
   const { disabled, element, widgetMgr, width, fragmentId } = props
   const style = { width }
 
@@ -50,10 +45,6 @@ function Button(props: Props): ReactElement {
   // When useContainerWidth true & has help tooltip,
   // we need to pass the container width down to the button
   const fluidWidth = element.help ? width : true
-
-  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
-  const isMaterialIcon = element.icon.startsWith(":material")
-  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div className="stButton" data-testid="stButton" style={style}>
@@ -67,21 +58,7 @@ function Button(props: Props): ReactElement {
             widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
           }
         >
-          {element.icon && (
-            <DynamicIcon
-              size={isMaterialIcon ? "lg" : "base"}
-              margin={element.label ? iconMargin : "0"}
-              color={colors.bodyText}
-              iconValue={element.icon}
-            />
-          )}
-          <StreamlitMarkdown
-            source={element.label}
-            allowHTML={false}
-            isLabel
-            largerLabel
-            disableLinks
-          />
+          <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -53,6 +53,7 @@ function Button(props: Props): ReactElement {
 
   // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
   const isMaterialIcon = element.icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div className="stButton" data-testid="stButton" style={style}>
@@ -69,7 +70,7 @@ function Button(props: Props): ReactElement {
           {element.icon && (
             <DynamicIcon
               size={isMaterialIcon ? "lg" : "base"}
-              margin={isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"}
+              margin={element.label ? iconMargin : "0"}
               color={colors.bodyText}
               iconValue={element.icon}
             />

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -170,24 +170,4 @@ describe("DownloadButton widget", () => {
       expect(downloadButton).toHaveStyle("width: 100%")
     })
   })
-
-  it("renders an emoji icon if provided", () => {
-    render(<DownloadButton {...getProps({ icon: "😀" })} />)
-
-    const icon = screen.getByTestId("stIconEmoji")
-    expect(icon).toHaveTextContent("😀")
-  })
-
-  it("renders a material icon if provided", () => {
-    render(<DownloadButton {...getProps({ icon: ":material/thumb_up:" })} />)
-
-    const icon = screen.getByTestId("stIconMaterial")
-    expect(icon).toHaveTextContent("thumb_up")
-  })
-
-  it("renders an icon with no margin, if there is no label", () => {
-    render(<DownloadButton {...getProps({ label: "", icon: "😀" })} />)
-
-    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
-  })
 })

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -184,4 +184,10 @@ describe("DownloadButton widget", () => {
     const icon = screen.getByTestId("stIconMaterial")
     expect(icon).toHaveTextContent("thumb_up")
   })
+
+  it("renders an icon with no margin, if there is no label", () => {
+    render(<DownloadButton {...getProps({ label: "", icon: "😀" })} />)
+
+    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+  })
 })

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -88,6 +88,7 @@ function DownloadButton(props: Props): ReactElement {
 
   // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
   const isMaterialIcon = element.icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div
@@ -106,7 +107,7 @@ function DownloadButton(props: Props): ReactElement {
           {element.icon && (
             <DynamicIcon
               size={isMaterialIcon ? "lg" : "base"}
-              margin={isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"}
+              margin={element.label ? iconMargin : "0"}
               color={colors.bodyText}
               iconValue={element.icon}
             />

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -16,20 +16,16 @@
 
 import React, { ReactElement } from "react"
 
-import { useTheme } from "@emotion/react"
-
 import { DownloadButton as DownloadButtonProto } from "@streamlit/lib/src/proto"
 import BaseButton, {
   BaseButtonKind,
   BaseButtonSize,
   BaseButtonTooltip,
+  DynamicButtonLabel,
 } from "@streamlit/lib/src/components/shared/BaseButton"
-import { DynamicIcon } from "@streamlit/lib/src/components/shared/Icon"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
-import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
 import { StreamlitEndpoints } from "@streamlit/lib/src/StreamlitEndpoints"
 import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
-import { EmotionTheme } from "@streamlit/lib/src/theme"
 
 export interface Props {
   endpoints: StreamlitEndpoints
@@ -58,7 +54,6 @@ export function createDownloadLink(
 }
 
 function DownloadButton(props: Props): ReactElement {
-  const { colors }: EmotionTheme = useTheme()
   const { disabled, element, widgetMgr, width, endpoints, fragmentId } = props
   const style = { width }
   const {
@@ -86,10 +81,6 @@ function DownloadButton(props: Props): ReactElement {
   // we need to pass the container width down to the button
   const fluidWidth = element.help ? width : true
 
-  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
-  const isMaterialIcon = element.icon.startsWith(":material")
-  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
-
   return (
     <div
       className="stDownloadButton"
@@ -104,21 +95,7 @@ function DownloadButton(props: Props): ReactElement {
           onClick={handleDownloadClick}
           fluidWidth={element.useContainerWidth ? fluidWidth : false}
         >
-          {element.icon && (
-            <DynamicIcon
-              size={isMaterialIcon ? "lg" : "base"}
-              margin={element.label ? iconMargin : "0"}
-              color={colors.bodyText}
-              iconValue={element.icon}
-            />
-          )}
-          <StreamlitMarkdown
-            source={element.label}
-            allowHTML={false}
-            isLabel
-            largerLabel
-            disableLinks
-          />
+          <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -213,4 +213,14 @@ describe("FormSubmitButton", () => {
     const icon = screen.getByTestId("stIconMaterial")
     expect(icon).toHaveTextContent("thumb_up")
   })
+
+  it("renders an icon with no margin, if there is no label", () => {
+    render(
+      <FormSubmitButton
+        {...getProps({}, { label: "", icon: "😀", help: "" })}
+      />
+    )
+
+    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
+  })
 })

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -82,7 +82,7 @@ describe("FormSubmitButton", () => {
     expect(formSubmitButton).toHaveStyle(`width: ${props.width}px`)
   })
 
-  it("renders a label", () => {
+  it("renders a label within the button", () => {
     const props = getProps()
     render(<FormSubmitButton {...props} />)
 
@@ -194,33 +194,5 @@ describe("FormSubmitButton", () => {
 
     const formSubmitButton = screen.getByRole("button")
     expect(formSubmitButton).toHaveStyle("width: 100%")
-  })
-
-  it("renders an emoji icon", () => {
-    render(<FormSubmitButton {...getProps({}, { icon: "😀", help: "" })} />)
-
-    const icon = screen.getByTestId("stIconEmoji")
-    expect(icon).toHaveTextContent("😀")
-  })
-
-  it("renders a material icon", () => {
-    render(
-      <FormSubmitButton
-        {...getProps({}, { icon: ":material/thumb_up:", help: "" })}
-      />
-    )
-
-    const icon = screen.getByTestId("stIconMaterial")
-    expect(icon).toHaveTextContent("thumb_up")
-  })
-
-  it("renders an icon with no margin, if there is no label", () => {
-    render(
-      <FormSubmitButton
-        {...getProps({}, { label: "", icon: "😀", help: "" })}
-      />
-    )
-
-    expect(screen.getByTestId("stIconEmoji")).toHaveStyle("margin: 0")
   })
 })

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -16,18 +16,14 @@
 
 import React, { ReactElement, useEffect } from "react"
 
-import { useTheme } from "@emotion/react"
-
 import { Button as ButtonProto } from "@streamlit/lib/src/proto"
 import BaseButton, {
   BaseButtonKind,
   BaseButtonSize,
   BaseButtonTooltip,
+  DynamicButtonLabel,
 } from "@streamlit/lib/src/components/shared/BaseButton"
-import { DynamicIcon } from "@streamlit/lib/src/components/shared/Icon"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
-import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
-import { EmotionTheme } from "@streamlit/lib/src/theme"
 
 export interface Props {
   disabled: boolean
@@ -39,7 +35,6 @@ export interface Props {
 }
 
 export function FormSubmitButton(props: Props): ReactElement {
-  const { colors }: EmotionTheme = useTheme()
   const {
     disabled,
     element,
@@ -64,10 +59,6 @@ export function FormSubmitButton(props: Props): ReactElement {
   // we need to pass the container width down to the button
   const fluidWidth = element.help ? width : true
 
-  // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
-  const isMaterialIcon = element.icon.startsWith(":material")
-  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
-
   return (
     <div
       className="stFormSubmitButton"
@@ -84,21 +75,7 @@ export function FormSubmitButton(props: Props): ReactElement {
             widgetMgr.submitForm(element.formId, fragmentId, element)
           }}
         >
-          {element.icon && (
-            <DynamicIcon
-              size={isMaterialIcon ? "lg" : "base"}
-              margin={element.label ? iconMargin : "0"}
-              color={colors.bodyText}
-              iconValue={element.icon}
-            />
-          )}
-          <StreamlitMarkdown
-            source={element.label}
-            allowHTML={false}
-            isLabel
-            largerLabel
-            disableLinks
-          />
+          <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -66,6 +66,7 @@ export function FormSubmitButton(props: Props): ReactElement {
 
   // Material icons need to be larger to render similar size of emojis, emojis need addtl margin
   const isMaterialIcon = element.icon.startsWith(":material")
+  const iconMargin = isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"
 
   return (
     <div
@@ -86,7 +87,7 @@ export function FormSubmitButton(props: Props): ReactElement {
           {element.icon && (
             <DynamicIcon
               size={isMaterialIcon ? "lg" : "base"}
-              margin={isMaterialIcon ? "0 sm 0 0" : "0 md 0 0"}
+              margin={element.label ? iconMargin : "0"}
               color={colors.bodyText}
               iconValue={element.icon}
             />


### PR DESCRIPTION
## Describe your changes
Make `margin: 0` on button icons when there is no button label to allow for icon-only buttons.
Also refactor to abstract shared button label code to new component `DynamicButtonLabel`

## Testing Plan
- Unit Tests (JS and/or Python): ✅ 