### PR TITLE
Clear queue also for fragment-runs to prevent vanishing elements

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1213,6 +1213,8 @@ export class App extends PureComponent<Props, State> {
         // leftover elements will be cleared after finished successfully.
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
+        // (We don't do this if our script had a compilation error and didn't
+        // finish successfully.)
         this.setState(
           ({ scriptRunId, fragmentIdsThisRun }) => ({
             // Apply any pending elements that haven't been applied.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1213,8 +1213,6 @@ export class App extends PureComponent<Props, State> {
         // leftover elements will be cleared after finished successfully.
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
-        // (We don't do this if our script had a compilation error and didn't
-        // finish successfully.)
         this.setState(
           ({ scriptRunId, fragmentIdsThisRun }) => ({
             // Apply any pending elements that haven't been applied.

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -468,8 +468,10 @@ class AppSession:
         if self._local_sources_watcher is not None:
             self._local_sources_watcher.update_watched_pages()
 
-    def _clear_queue(self) -> None:
-        self._browser_queue.clear(retain_lifecycle_msgs=True)
+    def _clear_queue(self, fragment_ids_this_run: list[str] | None = None) -> None:
+        self._browser_queue.clear(
+            retain_lifecycle_msgs=True, fragment_ids_this_run=fragment_ids_this_run
+        )
 
     def _on_scriptrunner_event(
         self,
@@ -481,7 +483,6 @@ class AppSession:
         page_script_hash: str | None = None,
         fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
-        clear_forward_msg_queue: bool = True,
     ) -> None:
         """Called when our ScriptRunner emits an event.
 
@@ -499,7 +500,6 @@ class AppSession:
                 page_script_hash,
                 fragment_ids_this_run,
                 pages,
-                clear_forward_msg_queue,
             )
         )
 
@@ -513,7 +513,6 @@ class AppSession:
         page_script_hash: str | None = None,
         fragment_ids_this_run: list[str] | None = None,
         pages: dict[PageHash, PageInfo] | None = None,
-        clear_forward_msg_queue: bool = True,
     ) -> None:
         """Handle a ScriptRunner event.
 
@@ -585,8 +584,7 @@ class AppSession:
             if page_script_hash != self._client_state.page_script_hash:
                 self._client_state.page_script_hash = page_script_hash
 
-            if clear_forward_msg_queue:
-                self._clear_queue()
+            self._clear_queue(fragment_ids_this_run)
 
             self._enqueue_forward_msg(
                 self._create_new_session_message(

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -113,11 +113,21 @@ class ForwardMsgQueue:
                     "parent_message",
                 }
                 or (
-                    msg.delta is not None
-                    and fragment_ids_this_run is not None
+                    # preserve all messages if this is a fragment rerun and...
+                    fragment_ids_this_run is not None
                     and (
-                        msg.delta.fragment_id is None
-                        or msg.delta.fragment_id not in fragment_ids_this_run
+                        # the message is not a delta message
+                        # (not associated with a fragment) or...
+                        msg.delta is None
+                        or (
+                            # it is a delta but not associated with any of the passed
+                            # fragments
+                            msg.delta is not None
+                            and (
+                                msg.delta.fragment_id is None
+                                or msg.delta.fragment_id not in fragment_ids_this_run
+                            )
+                        )
                     )
                 )
             ]

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -48,9 +48,6 @@ class ForwardMsgQueue:
 
     def enqueue(self, msg: ForwardMsg) -> None:
         """Add message into queue, possibly composing it with another message."""
-        if not _is_composable_message(msg):
-            self._queue.append(msg)
-            return
         self._queue.append(msg)
 
     def clear(self, retain_lifecycle_msgs: bool = False) -> None:
@@ -87,19 +84,6 @@ class ForwardMsgQueue:
 
     def __len__(self) -> int:
         return len(self._queue)
-
-
-def _is_composable_message(msg: ForwardMsg) -> bool:
-    """True if the ForwardMsg is potentially composable with other ForwardMsgs."""
-    if not msg.HasField("delta"):
-        # Non-delta messages are never composable.
-        return False
-
-    # We never compose add_rows messages in Python, because the add_rows
-    # operation can raise errors, and we don't have a good way of handling
-    # those errors in the message queue.
-    delta_type = msg.delta.WhichOneof("type")
-    return delta_type != "add_rows" and delta_type != "arrow_add_rows"
 
 
 def _maybe_compose_deltas(old_delta: Delta, new_delta: Delta) -> Delta | None:

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -81,7 +81,11 @@ class ForwardMsgQueue:
         self._delta_index_map[delta_key] = len(self._queue)
         self._queue.append(msg)
 
-    def clear(self, retain_lifecycle_msgs: bool = False) -> None:
+    def clear(
+        self,
+        retain_lifecycle_msgs: bool = False,
+        fragment_ids_this_run: list[str] | None = None,
+    ) -> None:
         """Clear the queue, potentially retaining lifecycle messages.
 
         The retain_lifecycle_msgs argument exists because in some cases (in particular
@@ -89,6 +93,10 @@ class ForwardMsgQueue:
         to remove certain messages from the queue as doing so may cause the client to
         not hear about important script lifecycle events (such as the script being
         stopped early in order to be rerun).
+
+        If fragment_ids_this_run is provided, delta messages not belonging to any
+        fragment or belonging to a fragment not in fragment_ids_this_run will be
+        preserved to prevent clearing messages unrelated to the running fragments.
         """
         if not retain_lifecycle_msgs:
             self._queue = []
@@ -103,6 +111,14 @@ class ForwardMsgQueue:
                     "session_status_changed",
                     "parent_message",
                 }
+                or (
+                    msg.delta is not None
+                    and fragment_ids_this_run is not None
+                    and (
+                        msg.delta.fragment_id is None
+                        or (msg.delta.fragment_id not in fragment_ids_this_run)
+                    )
+                )
             ]
 
         self._delta_index_map = {}

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -98,6 +98,7 @@ class ForwardMsgQueue:
         fragment or belonging to a fragment not in fragment_ids_this_run will be
         preserved to prevent clearing messages unrelated to the running fragments.
         """
+
         if not retain_lifecycle_msgs:
             self._queue = []
         else:
@@ -116,7 +117,7 @@ class ForwardMsgQueue:
                     and fragment_ids_this_run is not None
                     and (
                         msg.delta.fragment_id is None
-                        or (msg.delta.fragment_id not in fragment_ids_this_run)
+                        or msg.delta.fragment_id not in fragment_ids_this_run
                     )
                 )
             ]

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -469,22 +469,12 @@ class ScriptRunner:
             )
             self._pages_manager.reset_active_script_hash()
 
-            # We want to clear the forward_msg_queue during full script runs and
-            # fragment-scoped fragment reruns. For normal fragment runs, clearing the
-            # forward_msg_queue may cause us to drop messages either corresponding to
-            # other, unrelated fragments or that this fragment run depends on.
-            fragment_ids_this_run = rerun_data.fragment_id_queue
-            clear_forward_msg_queue = (
-                not fragment_ids_this_run or rerun_data.is_fragment_scoped_rerun
-            )
-
             self.on_event.send(
                 self,
                 event=ScriptRunnerEvent.SCRIPT_STARTED,
                 page_script_hash=page_script_hash,
                 fragment_ids_this_run=fragment_ids_this_run,
                 pages=self._pages_manager.get_pages(),
-                clear_forward_msg_queue=clear_forward_msg_queue,
             )
 
             # Compile the script. Any errors thrown here will be surfaced

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -439,8 +439,6 @@ class ScriptRunner:
                 else main_page_info["page_script_hash"]
             )
 
-            fragment_ids_this_run = list(rerun_data.fragment_id_queue)
-
             ctx = self._get_script_run_ctx()
             # Clear widget state on page change. This normally happens implicitly
             # in the script run cleanup steps, but doing it explicitly ensures
@@ -461,6 +459,8 @@ class ScriptRunner:
                 ):
                     widget_ids = {w.id for w in rerun_data.widget_states.widgets}
                 self._session_state.on_script_finished(widget_ids)
+
+            fragment_ids_this_run = list(rerun_data.fragment_id_queue)
 
             ctx.reset(
                 query_string=rerun_data.query_string,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -320,6 +320,8 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
+        script_started_event_data = scriptrunner.event_data[0]
+        script_started_event_data["fragment_ids_this_run"] = ["my_fragment"]
 
         fragment.assert_called_once()
 
@@ -352,6 +354,12 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
+        script_started_event_data = scriptrunner.event_data[0]
+        script_started_event_data["fragment_ids_this_run"] = [
+            "my_fragment1",
+            "my_fragment2",
+            "my_fragment3",
+        ]
 
         fragment.assert_has_calls([call(), call(), call()])
         Runtime._instance.media_file_mgr.clear_session_refs.assert_not_called()
@@ -1250,7 +1258,7 @@ class TestScriptRunner(ScriptRunner):
             self.script_thread_exceptions.append(e)
 
     def _run_script(self, rerun_data: RerunData) -> None:
-        self.forward_msg_queue.clear()
+        self.clear_forward_msgs()
         super()._run_script(rerun_data)
 
         # Set the _dg_stack here to the one belonging to the thread context

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -730,7 +730,7 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
-        self._assert_text_deltas(scriptrunner, ["loop_forever"])
+        assert "loop_forever" in scriptrunner.text_deltas()
 
     def test_shutdown(self):
         """Test that we can shutdown while a script is running."""
@@ -751,7 +751,7 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
-        self._assert_text_deltas(scriptrunner, ["loop_forever"])
+        assert "loop_forever" in scriptrunner.text_deltas()
 
     def test_widgets(self):
         """Tests that widget values behave as expected."""

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -730,7 +730,7 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
-        assert "loop_forever" in scriptrunner.text_deltas()
+        self._assert_text_deltas(scriptrunner, ["loop_forever"])
 
     def test_shutdown(self):
         """Test that we can shutdown while a script is running."""
@@ -751,7 +751,7 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
-        assert "loop_forever" in scriptrunner.text_deltas()
+        self._assert_text_deltas(scriptrunner, ["loop_forever"])
 
     def test_widgets(self):
         """Tests that widget values behave as expected."""


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/streamlit/streamlit/issues/9372
Another, unrelated fix for the linked https://github.com/streamlit/streamlit/issues/9372 issue is done in https://github.com/streamlit/streamlit/pull/9389

There is a problematic interplay between consolidating delta messages [here](https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/runtime/forward_msg_queue.py#L67-L77) and skipping clearing the `forward_msg_queue` in the case of fragment re-runs. 
For fragment re-runs that are not triggered by an explicit `st.rerun` (aka a user interacts with widgets inside of the fragment), we skip clearing the 
`forward_msg_queue`, which can result in updating delta message in-place in the queue before it is flushed to the browser.

Imagine the following backend activity (all before being flushed to the browser yet):
`[enqueue: new_session(A), enqueue: delta(1), enqueue: delta(2), enqueue: delta(3), RERUN_TRIGGERED,  enqueue: script_finished_with_rerun(A), enqueue: new_session(B), update_in_place: delta(1), update_in_place: delta(2), update_in_place: delta(3), enqueue: delta(4), enqueue: script_finished(B)]`

`delta(1)`, `delta(2)`, and `delta(3)` were updated in_place in the queue because they did not change instead of appended to the queue.

-> so this is what the browser will see:
`[new_session(A), delta(1), delta(2), delta(3), script_finished_with_rerun(A), new_session(B), delta(4), script_finished(B)]`

Only `delta(4)` will show up because `delta(1)`, `delta(2)`, and `delta(3)` are associated with `new_session(A)`. Note that the delta messages do not contain any script run information. Instead, the frontend associates all messages belonging to a specific script run based on `<new session: scriptRunId> ... `<session finished: scriptRunId>` messages, so every messages coming in between the new and finished message are associated with the given script run.

When clearing the queue also for fragment re-runs, the flow looks like the following:
`[enqueue: new_session(A), enqueue: delta(1), enqueue: delta(2), enqueue: delta(3), RERUN_TRIGGERED,  CLEAR_QUEUE, enqueue: script_finished_with_rerun(A), enqueue: new_session(B), enqueue: delta(1), enqueue: delta(2), enqueue: delta(3), enqueue: delta(4), enqueue: script_finished(B)]`

-> so this is what the browser will see:
`[new_session(A), script_finished_with_rerun(A), new_session(B), delta(1), delta(2), delta(3), delta(4), script_finished(B)]`

This issue can only happen in fragment-related reruns via interacting with the app, because for other reruns (full app or via st.rerun), we clear the message queue [here](https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/runtime/scriptrunner/script_runner.py#L477-L479); so no delta messages are updated in-place and the order is preserved.

This PR always triggers a `forward_msg_queue.clear`; in order to honor the existing concern of not interfering with other runs, the logic is moved to the queue function and only delta messages belonging to the running fragment are removed.

One alternative would be to remove the optimization of consolidating delta messages (first version of the PR), but this means that the browser will see more messages than necessary; also the optimization exists for a long time and potential side-effects would need to be investigated.
Another alternative to remove the optimization might be to update session messages also in-place; though this would only work if the new_session message has not been flushed already yet. This does not seem trivial and getting it right might be overly complicated.

---

## Reproduce

- Install `pip install streamlit_antd_components`
- Run following example app:
  <details>
  <summary>Example App</summary>
  
  ```python
  import streamlit as st 
  import streamlit_antd_components as sac
  
  
  columns_test_ = st.columns(2)
  
  @st.fragment
  def demo_callback_wdiget_custom():
      if "component_sel_index" not in st.session_state:
          st.session_state["component_sel_index"] = 0
  
      def onChangeSectionSel():
          options_ = ["early", "mid", "late"]
          st.session_state["component_sel_index"] = options_.index(st.session_state["component_val"])
  
      sac.segmented(
              items=[
              sac.SegmentedItem(label='early'),
              sac.SegmentedItem(label='mid'),
              sac.SegmentedItem(label='late'),
              ], index=st.session_state["component_sel_index"], size="xs", radius="sm", key="component_val", bg_color="transparent", color="black", align="end", on_change=onChangeSectionSel
      )
  
      CODE = (
      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." * 1373)
  
      st.code(CODE, language="sql")
      st.write("Content here")
      st.write("selected", st.session_state["component_val"])
      st.write("CCCContent hereontent herCContent hereontent herCContent hereontent herCContent" * 1000)
      st.write("Content here")
      st.write("selected", st.session_state["component_val"])
  
  with columns_test_[0].container(height=400):
      demo_callback_wdiget_custom()
  
  @st.fragment
  def demo_callback_wdiget_custom_two():
      if "component_sel_index_2" not in st.session_state:
          st.session_state["component_sel_index_2"] = 0
  
      def onChangeSectionSel():
  
          options_ = ["early", "mid", "late"]
          st.session_state["component_sel_index_2"] = options_.index(st.session_state["component_val_2"])
  
      sac.segmented(
              items=[
              sac.SegmentedItem(label='early'),
              sac.SegmentedItem(label='mid'),
              sac.SegmentedItem(label='late'),
              ], index=st.session_state["component_sel_index_2"], size="xs", radius="sm", key="component_val_2", bg_color="transparent", color="black", align="end", on_change=onChangeSectionSel
      )
  
      st.write("Content here")
      st.write("selected", st.session_state["component_val_2"])
  
  with columns_test_[1].container(height=400):
      demo_callback_wdiget_custom_two()
  ```
  
  </details>
- Click repeatedly on the menu items (early, mid, late) of the left fragment:

  https://github.com/user-attachments/assets/20eb58dd-88ec-48c1-b84a-8e44791cf471

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - updated existing tests to ensure that the SCRIPT_STARTED event contains the running fragment ids
  - added new test to ensure that `forward_msg_queue.clear` preserves unrelated delta messages
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
