### PR TITLE
Remove usage of `stHidden` class

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -325,7 +325,7 @@ const RawElementNodeRenderer = (
       )
 
     case "empty":
-      return <div className="stHidden" data-testid="stEmpty" />
+      return <div className="stEmpty" data-testid="stEmpty" />
 
     case "exception":
       return (
@@ -748,10 +748,6 @@ const ElementNodeRenderer = (
     props.scriptRunId,
     fragmentIdsThisRun
   )
-
-  // TODO: If would be great if we could return an empty fragment if isHidden is true, to keep the
-  // DOM clean. But this would require the keys passed to ElementNodeRenderer at Block.tsx to be a
-  // stable hash of some sort.
 
   return (
     <Maybe enable={enable}>

--- a/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
@@ -51,11 +51,11 @@ describe("Balloons element", () => {
     })
   })
 
-  it("renders as hidden element", () => {
+  it("uses correct top-level class", () => {
     const props = getProps()
     render(<Balloons {...props} />)
 
     const balloonElement = screen.getByTestId("stBalloons")
-    expect(balloonElement).toHaveClass("stHidden")
+    expect(balloonElement).toHaveClass("stBalloons")
   })
 })

--- a/frontend/lib/src/components/elements/Particles/Particles.test.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.test.tsx
@@ -28,7 +28,7 @@ const DummyParticle: FC<React.PropsWithChildren<ParticleProps>> = () => (
 )
 
 const getProps = (): Props => ({
-  className: "particles",
+  className: "c",
   numParticles: 10,
   numParticleTypes: 5,
   ParticleComponent: DummyParticle,
@@ -54,13 +54,5 @@ describe("Particles element", () => {
     // eslint-disable-next-line testing-library/no-node-access
     const particleComponents = particleElement.children
     expect(particleComponents.length).toBe(10)
-  })
-
-  it("renders as hidden element", () => {
-    const props = getProps()
-    render(<Particles {...props} />)
-
-    const particleElement = screen.getByTestId("particles")
-    expect(particleElement).toHaveClass("stHidden")
   })
 })

--- a/frontend/lib/src/components/elements/Particles/Particles.test.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.test.tsx
@@ -28,7 +28,7 @@ const DummyParticle: FC<React.PropsWithChildren<ParticleProps>> = () => (
 )
 
 const getProps = (): Props => ({
-  className: "c",
+  className: "particles",
   numParticles: 10,
   numParticleTypes: 5,
   ParticleComponent: DummyParticle,

--- a/frontend/lib/src/components/elements/Particles/Particles.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.tsx
@@ -17,7 +17,6 @@
 import React, { FC, memo } from "react"
 
 import range from "lodash/range"
-import classNames from "classnames"
 
 import { StyledParticles } from "./styled-components"
 

--- a/frontend/lib/src/components/elements/Particles/Particles.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.tsx
@@ -42,10 +42,7 @@ const Particles: FC<React.PropsWithChildren<Props>> = ({
 }: Props) => (
   // Keys should be unique each time, so React replaces the images in the DOM and their animations
   // actually rerun.
-  <StyledParticles
-    className={classNames(className, "stHidden")}
-    data-testid={`${className}`}
-  >
+  <StyledParticles className={className} data-testid={className}>
     {range(numParticles).map(i => {
       const randNum = Math.floor(Math.random() * numParticleTypes)
 

--- a/frontend/lib/src/components/elements/Snow/Snow.test.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.test.tsx
@@ -52,11 +52,11 @@ describe("Snow element", () => {
     })
   })
 
-  it("renders as hidden element", () => {
+  it("uses correct top-level class", () => {
     const props = getProps()
     render(<Snow {...props} />)
 
     const snowElement = screen.getByTestId("stSnow")
-    expect(snowElement).toHaveClass("stHidden")
+    expect(snowElement).toHaveClass("stSnow")
   })
 })


### PR DESCRIPTION
## Describe your changes

Cleans up an unused `stHidden` class name from some elements (`stEmpty`, `stBalloons`, `stSnow`). The `stHidden` class name was used long ago to hide certain elements. But in the current version, this class name is unused. It also appears that there aren't any significant CSS hacks that require this class. 

## Testing Plan

- Only removal of unused class name.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
