### PR TITLE
Do not clear nodes for fragment-finished-via-rerun messages

### DIFF
--- a/e2e_playwright/st_rerun.py
+++ b/e2e_playwright/st_rerun.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import streamlit as st
 
 if "count" not in st.session_state:
@@ -66,3 +68,14 @@ fragment_with_rerun_in_try_block()
 # have elements in the main app after fragments to ensure that the main app elements are
 #  not cleared when rerunning fragments
 st.write(f"app run count: {st.session_state.count}")
+
+if "foo" not in st.session_state:
+    st.write("Setting state")
+    st.session_state["foo"] = "bar"
+
+if st.button("#8599 - Bug"):
+    # Allow for forward message queue to flush button element
+    time.sleep(1)
+
+    del st.session_state["foo"]
+    st.rerun()

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -25,7 +25,7 @@ def _expect_initial_reruns_finished(app: Page):
 
 
 def _expect_initial_reruns_count_text(app: Page):
-    expect(app.get_by_test_id("stMarkdown").last).to_have_text("app run count: 4")
+    expect_markdown(app, "app run count: 4")
 
 
 def test_st_rerun_restarts_the_session_when_invoked(app: Page):
@@ -57,7 +57,7 @@ def test_rerun_works_in_try_except_block(app: Page):
     click_button(app, "rerun try_fragment")
     # the rerun in the try-block worked as expected, so the session_state count
     # incremented
-    expect(app.get_by_test_id("stMarkdown").last).to_have_text("app run count: 5")
+    expect_markdown(app, "app run count: 5")
 
 
 def test_state_retained_on_app_scoped_rerun(app: Page):
@@ -76,3 +76,10 @@ def test_state_retained_on_app_scoped_rerun(app: Page):
     # Rerun the fragment and verify that the selectbox kept its state
     click_button(app, "rerun whole app (from fragment)")
     expect_markdown(app, "selectbox selection: a")
+
+
+# From GitHub issue #8599
+def test_clears_stale_elements_correctly(app: Page):
+    click_button(app, "#8599 - Bug")
+
+    expect(app.get_by_text("#8599 - Bug")).to_have_count(1)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1207,8 +1207,12 @@ export class App extends PureComponent<Props, State> {
           ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
       ) {
         // Clear any stale elements left over from the previous run.
-        // (We don't do this if our script had a compilation error and didn't
-        // finish successfully.)
+        // We only do that for completed runs, not for runs that were finished early
+        // due to reruns; this is to avoid flickering of elements where they disappear for
+        // a moment and then are readded by a new session. After the new session finished,
+        // leftover elements will be cleared after finished successfully.
+        // We also don't do this if our script had a compilation error and didn't
+        // finish successfully.
         this.setState(
           ({ scriptRunId, fragmentIdsThisRun }) => ({
             // Apply any pending elements that haven't been applied.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1201,27 +1201,27 @@ export class App extends PureComponent<Props, State> {
         this.state.scriptFinishedHandlers.map(handler => handler())
       }, 0)
 
-      // Clear any stale elements left over from the previous run.
-      // (We don't do this if our script had a compilation error and didn't
-      // finish successfully.)
-      this.setState(
-        ({ scriptRunId, fragmentIdsThisRun }) => ({
-          // Apply any pending elements that haven't been applied.
-          elements: this.pendingElementsBuffer.clearStaleNodes(
-            scriptRunId,
-            fragmentIdsThisRun
-          ),
-        }),
-        () => {
-          this.pendingElementsBuffer = this.state.elements
-        }
-      )
-
       if (
         status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
         status ===
           ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
       ) {
+        // Clear any stale elements left over from the previous run.
+        // (We don't do this if our script had a compilation error and didn't
+        // finish successfully.)
+        this.setState(
+          ({ scriptRunId, fragmentIdsThisRun }) => ({
+            // Apply any pending elements that haven't been applied.
+            elements: this.pendingElementsBuffer.clearStaleNodes(
+              scriptRunId,
+              fragmentIdsThisRun
+            ),
+          }),
+          () => {
+            this.pendingElementsBuffer = this.state.elements
+          }
+        )
+
         // Tell the WidgetManager which widgets still exist. It will remove
         // widget state for widgets that have been removed.
         const activeWidgetIds = new Set(

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -204,46 +204,56 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
   // Handle cycling of colors for dividers:
   assignDividerColor(props.node, useTheme())
 
+  // Capture all the element ids to avoid rendering the same element twice
+  const elementKeySet = new Set<string>()
+
   return (
     <>
       {props.node.children &&
-        props.node.children.map(
-          (node: AppNode, index: number): ReactElement => {
-            const disableFullscreenMode =
-              libConfig.disableFullscreenMode || props.disableFullscreenMode
+        props.node.children.map((node: AppNode, index: number): ReactNode => {
+          const disableFullscreenMode =
+            libConfig.disableFullscreenMode || props.disableFullscreenMode
 
-            // Base case: render a leaf node.
-            if (node instanceof ElementNode) {
-              // Put node in childProps instead of passing as a node={node} prop in React to
-              // guarantee it doesn't get overwritten by {...childProps}.
-              const childProps = {
-                ...props,
-                disableFullscreenMode,
-                node: node as ElementNode,
-              }
-
-              const key = getElementId(node.element) || index
-              return <ElementNodeRenderer key={key} {...childProps} />
+          // Base case: render a leaf node.
+          if (node instanceof ElementNode) {
+            // Put node in childProps instead of passing as a node={node} prop in React to
+            // guarantee it doesn't get overwritten by {...childProps}.
+            const childProps = {
+              ...props,
+              disableFullscreenMode,
+              node: node as ElementNode,
             }
 
-            // Recursive case: render a block, which can contain other blocks
-            // and elements.
-            if (node instanceof BlockNode) {
-              // Put node in childProps instead of passing as a node={node} prop in React to
-              // guarantee it doesn't get overwritten by {...childProps}.
-              const childProps = {
-                ...props,
-                disableFullscreenMode,
-                node: node as BlockNode,
-              }
-
-              return <BlockNodeRenderer key={index} {...childProps} />
+            const key = getElementId(node.element) || index.toString()
+            // Avoid rendering the same element twice. We assume the first one is the one we want
+            // because the page is rendered top to bottom, so a valid widget would be rendered
+            // correctly and we assume the second one is therefore stale (or throw an error).
+            if (elementKeySet.has(key)) {
+              return null
             }
 
-            // We don't have any other node types!
-            throw new Error(`Unrecognized AppNode: ${node}`)
+            elementKeySet.add(key)
+
+            return <ElementNodeRenderer key={key} {...childProps} />
           }
-        )}
+
+          // Recursive case: render a block, which can contain other blocks
+          // and elements.
+          if (node instanceof BlockNode) {
+            // Put node in childProps instead of passing as a node={node} prop in React to
+            // guarantee it doesn't get overwritten by {...childProps}.
+            const childProps = {
+              ...props,
+              disableFullscreenMode,
+              node: node as BlockNode,
+            }
+
+            return <BlockNodeRenderer key={index} {...childProps} />
+          }
+
+          // We don't have any other node types!
+          throw new Error(`Unrecognized AppNode: ${node}`)
+        })}
     </>
   )
 }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -228,6 +228,8 @@ const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
             // Avoid rendering the same element twice. We assume the first one is the one we want
             // because the page is rendered top to bottom, so a valid widget would be rendered
             // correctly and we assume the second one is therefore stale (or throw an error).
+            // Also, our setIn logic pushes stale widgets down in the list of elements, so the
+            // most recent one should always come first.
             if (elementKeySet.has(key)) {
               return null
             }


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/streamlit/streamlit/issues/9372 and PR https://github.com/streamlit/streamlit/pull/9381 

### Changes

Two changes we make here:
1. Right now, we trigger a stale-node clearing also for fragment runs that were interrupted by a rerun message. This leads to a situation where elements can disappear for a moment (see [this user comment with video](https://github.com/streamlit/streamlit/issues/9372#issuecomment-2324932864)).
This PR moves the clearing into the if-block that is only executed for finished complete runs.
2. We capture all element ids we rendered and if we encounter the same id twice, we ignore it (prevents regressing on #8360) 

### Analysis

For the example app:

<details>
<summary>Example App</summary>

```python
import streamlit as st
import time

if 'count' not in st.session_state:
  st.session_state.count = 0

if 'foo' not in st.session_state:
    st.write(f'Setting state ({st.session_state.count})')
    st.session_state['foo'] = 'bar'

if st.button('Run'):
    # Allow for forward message queue to flush button element
    time.sleep(1)

    st.session_state.count += 1
    del st.session_state['foo']
    st.rerun()
```

</details>

the flow is as following (ever step triggers a new session message with a new `scriptRunId`):
<table>
<tr>
  <th>Step</th>
  <th>Phase / Action</th>
  <th>Messages the Frontend receives</th>
  <th>Comment</th>
</tr>
<tr>
 <td>1</td>
  <td>First App Run</td>
  <td>[Markdown, Button]</td>
  <td></td>
</tr>
<tr>
 <td>2</td>
  <td>Rerun by Button Click</td>
  <td>[Button]</td>
  <td>The button click itself triggers an app rerun. <code>foo</code> is in the session state (not deleted yet), so the <code>if</code> block is <i>not</i> executed.</td>
</tr>
<tr>
 <td>3</td>
  <td>Rerun by <code>st.rerun</code> in the button's if-block</td>
  <td>[Markdown, Button]</td>
  <td>The <code>st.rerun</code> line executes a rerun. <code>foo</code> is deleted from the session state, so the <code>if</code> block is executed again. <b>No stale-nodes cleaning happened</b> because its an early interrupt by a rerun.</td>
</tr>
<tr>
 <td>4</td>
  <td>App Run is Complete</td>
  <td>Session Finished</td>
  <td>The stale-nodes are cleaned because this is a full app finished run.</td>
</tr>
</table>

With fix 1 (move cleaning of stale nodes to finished successfully runs), what happens is that the `Button` element of step 3 is sent to the frontend, but the `Button` element of step 2 is still in the `elements` list, because it was not cleaned up (after the fix 1 change). Both elements have the same React key, which throws an error and leads to the stale React element being shown.
With fix 2, this is addressed because the `Button` element is sent to the frontend, now the list of elements still contain two `Button` elements with the same id (remember no cleaning happened). But now, only one element with the same ket is rendered and the second is ignored. Our `applyDelta`'s `setIn` logic leads to the fact that the _new_ `Button` element appears in the `elements` list _before_ the old one, which means that the newer element is rendered and the older one is ignored.
In step 4, the script finishes successfully completely (a full top to bottom run), and. thus. a `cleanStaleNodes` execution is triggered which establishes the final, cleaned state. Now, the frontend again has just two elements in its list: `[Markdown, Button]`.

## Reproduction

In this comment I have linked a video and an example app: https://github.com/streamlit/streamlit/pull/9389#issuecomment-234295933

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add JS unit tests for cleaning node behavior (also enhance our typing)
- E2E Tests
  - Add e2e test to test app that would have been regressed with first version of the PR
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
