### PR TITLE
Determine common mime types by extension

### DIFF
--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -29,16 +29,16 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
-_common_mime_types = {
-    '.html' : 'text/html',
-    '.js' : 'application/javascript',
-    '.css' : 'text/css',
-}
-
 
 class ComponentRequestHandler(tornado.web.RequestHandler):
     def initialize(self, registry: BaseComponentRegistry):
         self._registry = registry
+
+        # This ensures that common mime-types are robust against
+        # system misconfiguration.
+        mimetypes.add_type('text/html', '.html')
+        mimetypes.add_type('application/javascript', '.js')
+        mimetypes.add_type('text/css', '.css')
 
     def get(self, path: str) -> None:
         parts = path.split("/")
@@ -102,13 +102,6 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         """Returns the ``Content-Type`` header to be used for this request.
         From tornado.web.StaticFileHandler.
         """
-        # Common mime types can be detected using the extension.
-        # This is more robust than mimetypes.guess_type() as it is immune 
-        # against system misconfiguration.
-        _, ext = posixpath.splitext(abspath)
-        if ext in _common_mime_types:
-            return _common_mime_types[ext]
-
         mime_type, encoding = mimetypes.guess_type(abspath)
         # per RFC 6713, use the appropriate type for a gzip compressed file
         if encoding == "gzip":

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -35,9 +35,9 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
 
         # This ensures that common mime-types are robust against
         # system misconfiguration.
-        mimetypes.add_type('text/html', '.html')
-        mimetypes.add_type('application/javascript', '.js')
-        mimetypes.add_type('text/css', '.css')
+        mimetypes.add_type("text/html", ".html")
+        mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("text/css", ".css")
 
     def get(self, path: str) -> None:
         parts = path.split("/")

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import mimetypes
-import posixpath
 import os
 from typing import TYPE_CHECKING, Final
 


### PR DESCRIPTION
## Describe your changes

The mime-type of a file is important for the browser to determine how to render content. For custom components in Streamlit, the mime-type is determined by `mimetypes.guess_type()`, which (skipping over some details) determines the mime type by file extension and a predefined mapping of `file-extension->mime-type`. Furthermore, the configuration of the operating system (for windows that is the registry) is taken into account and given precedent over the predefined mapping in Python.

The registry can in principle be changed by any program and [some programs](https://github.com/golang/go/issues/32350) seem to change the mime-type of javascript files to `text/plain` during installation. This causes an issue for custom components as web browsers refuse to execute javascript files with the mime-type `text/plain` causing custom components not to be rendered. This was the root cause of #9365.

This issue was also discussed by the [Python community](https://bugs.python.org/issue32462). They opted not to fix it as the mime type returned is correct for the given system configuration. Any side effects would be system misconfiguration from their point of view.

For Streamlit, the argument whether it is system misconfiguration or not is not really applicable. The consequence is that custom components are not rendered and thus this is clearly unintended behavior. The changes in this PR determine the mime-type for the three most common web-related file formats (`html`, `js`, and `css`) by file extension alone using a lookup table. For all other formats the mime-type is determined using the previous implementation.

Notable repos with similar approaches:
- the [tensorboard project](https://github.com/tensorflow/tensorboard/blob/b9ab24224405d0d7cbbeed4ee2da842f645c364d/tensorboard/program.py#L378-L397) solves the same issue in the same way
- the [azure-cli project](https://github.com/Azure/azure-cli/blob/6322e5868aa50dbc9a71c45b1dc82bdd2e58f9c2/src/azure-cli/azure/cli/command_modules/storage/util.py#L305) also hard-codes the javascript mimetype

## GitHub Issue Link (if applicable)

Fixes #9365 

## Testing Plan

It is hard to come up with a simplistic test case for the cause of the issue as this would require changing the system configuration of the test image.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
