### PR TITLE
Allow for colors in material icons in `validate_icon_or_emoji`

### DIFF
--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -64,8 +64,16 @@ def is_material_icon(maybe_icon: str) -> bool:
 
 def validate_icon_or_emoji(icon: str | None) -> str:
     """Validate an icon or emoji and return it in normalized format if valid."""
-    if icon is not None and icon.startswith(":material"):
+    if icon is not None and ":material" in icon:
+        match = re.search(r"^:(?:blue|green|red|violet|orange|gray|rainbow)\[(.+)\]$", icon)
+        # Return the normalized icon with the color if it has a color
+        if match:
+            icon_without_color = match.group(1)
+            return re.sub(icon_without_color, validate_material_icon(icon_without_color), icon or "")
+
+        # Otherwise return the normalized icon
         return validate_material_icon(icon)
+
     return validate_emoji(icon)
 
 


### PR DESCRIPTION
## Describe your changes

Streamlit allows for colors in markdown, including the materials icons. However, when validating an icon or emoji in `validate_icon_or_emoji` colors are not allowed. This leads to the following error when a user tries to use a color in a materials icon in e.g., the navbar:

<img width="843" alt="Screenshot 2024-09-04 at 2 17 50 PM" src="https://github.com/user-attachments/assets/1d77e16b-3daa-4deb-a5c1-c96fa0dca9f6">

As this screenshot shows, the color is properly rendered in the error message, but the materials icon is not recognized as an icon. This PR adds some logic to check if a materials icon is wrapped in a color.

## Testing Plan

This is a small change so this should be covered by the existing unit tests, I think

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
