### PR TITLE
Fix: Disable form submission & instructions

### DIFF
--- a/e2e_playwright/st_form.py
+++ b/e2e_playwright/st_form.py
@@ -86,3 +86,33 @@ with st.form("form_5"):
         use_container_width=True,
         icon=":material/key:",
     )
+
+with st.form("form_6"):
+    st.write("Inside form 6 - Submit on Enter")
+    text_input = st.text_input("Form 6 - Text Input")
+    submitted_6 = st.form_submit_button(
+        "Form 6 - First Submit",
+        use_container_width=True,
+    )
+    submitted_6b = st.form_submit_button(
+        "Form 6 - Second Submit",
+        disabled=True,
+        use_container_width=True,
+    )
+    if submitted_6 or submitted_6b:
+        st.write("Form submitted")
+
+with st.form("form_7"):
+    st.write("Inside form 7")
+    text_input = st.text_input("Form 7 - Text Input")
+    submitted_7 = st.form_submit_button(
+        "Form 7 - Disables Submit on Enter",
+        use_container_width=True,
+        disabled=True,
+    )
+    submitted_7b = st.form_submit_button(
+        "Form 7 - Second Submit",
+        use_container_width=True,
+    )
+    if submitted_7 or submitted_7b:
+        st.write("Form submitted")

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -136,18 +136,87 @@ def test_form_with_stretched_button(
 
 def test_form_submit_with_emoji_icon(app: Page, assert_snapshot: ImageCompareFunction):
     """Tests if the form submit button with emoji icon renders correctly."""
-    form_2 = app.get_by_test_id("stForm").nth(3)
+    form_4 = app.get_by_test_id("stForm").nth(3)
 
-    assert_snapshot(form_2, name="st_form_submit-emoji_icon")
+    assert_snapshot(form_4, name="st_form_submit-emoji_icon")
 
 
 def test_form_submit_with_material_icon(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Tests if the form submit button with material icon renders correctly."""
-    form_2 = app.get_by_test_id("stForm").nth(4)
+    form_5 = app.get_by_test_id("stForm").nth(4)
 
-    assert_snapshot(form_2, name="st_form_submit-material_icon")
+    assert_snapshot(form_5, name="st_form_submit-material_icon")
+
+
+def test_form_submits_on_enter(app: Page):
+    """Tests that submit on enter works when 1st submit button enabled."""
+    form_6 = app.get_by_test_id("stForm").nth(5)
+    text_input = form_6.get_by_test_id("stTextInput").locator("input")
+    text_input.type("Test")
+    expect(form_6.get_by_test_id("InputInstructions")).to_have_text(
+        "Press Enter to submit form"
+    )
+
+    # Submit the form by pressing Enter, check if submitted.
+    text_input.press("Enter")
+    wait_for_app_run(app)
+    expect(form_6.get_by_test_id("stMarkdown").last).to_have_text("Form submitted")
+
+
+def test_form_disabled_submit_on_enter(app: Page):
+    """Tests that submit on enter does not work when 1st submit button disabled."""
+    form_7 = app.get_by_test_id("stForm").nth(6)
+    text_input = form_7.get_by_test_id("stTextInput").locator("input")
+    text_input.fill("Test")
+    expect(form_7.get_by_test_id("InputInstructions")).to_have_text("")
+
+    # Try to submit the form by pressing Enter, check not submitted.
+    text_input.press("Enter")
+    wait_for_app_run(app)
+    expect(form_7.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
+
+
+def test_form_submits_on_click(app: Page):
+    """Tests that submit via enabled form submit button works."""
+    form_6 = app.get_by_test_id("stForm").nth(5)
+    text_input = form_6.get_by_test_id("stTextInput").locator("input")
+    text_input.fill("Test")
+    expect(form_6.get_by_test_id("InputInstructions")).to_have_text(
+        "Press Enter to submit form"
+    )
+
+    # Submit form with enabled submit button, check submitted
+    form_6.get_by_test_id("stFormSubmitButton").first.click()
+    wait_for_app_run(app)
+    expect(form_6.get_by_test_id("stMarkdown").last).to_have_text("Form submitted")
+
+
+def test_form_disabled_submit_on_click(app: Page):
+    """Tests that submit via disabled form submit button does not work."""
+    form_7 = app.get_by_test_id("stForm").nth(6)
+    text_input = form_7.get_by_test_id("stTextInput").locator("input")
+    text_input.fill("Test")
+    expect(form_7.get_by_test_id("InputInstructions")).to_have_text("")
+
+    # Try submit with disabled submit button, check not submitted
+    form_7.get_by_test_id("stFormSubmitButton").first.click()
+    wait_for_app_run(app)
+    expect(form_7.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
+
+
+def test_secondary_submit_buttons_enabled(app: Page):
+    """Tests that secondary submit buttons work when enabled."""
+    form_7 = app.get_by_test_id("stForm").nth(6)
+    text_input = form_7.get_by_test_id("stTextInput").locator("input")
+    text_input.fill("Test")
+    expect(form_7.get_by_test_id("InputInstructions")).to_have_text("")
+
+    # Submit form with secondary submit button, check submitted
+    form_7.get_by_test_id("stFormSubmitButton").last.click()
+    wait_for_app_run(app)
+    expect(form_7.get_by_test_id("stMarkdown").last).to_have_text("Form submitted")
 
 
 def test_borderless_form(app: Page, assert_snapshot: ImageCompareFunction):

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -678,19 +678,20 @@ export class WidgetStateManager {
   }
 
   /**
-   * Helper function to determine whether to allow enter to submit a form
+   * Helper function to determine whether a form allows enter to submit
+   * for input elements (st.number_input, st.text_input, etc.)
+   * Must be in a form & have 1st submit button enabled to allow
    */
   public allowFormSubmitOnEnter(formId: string): boolean {
     const submitButtons = this.formsData.submitButtons.get(formId)
     const firstSubmitButton = submitButtons?.[0]
 
-    // If there are no submit buttons for the given formId,
-    // it is either an invalid form or not a form
+    // If no submit buttons for the formId, either not in form or invalid form
     if (!firstSubmitButton) {
       return false
     }
 
-    // If first submit button is disabled, disable enter to submit
+    // Allow form submit on enter as long as 1st submit button is not disabled
     return !firstSubmitButton.disabled
   }
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -234,12 +234,6 @@ export class WidgetStateManager {
     const form = this.getOrCreateFormState(formId)
 
     const submitButtons = this.formsData.submitButtons.get(formId)
-    const disableForm = submitButtons?.some(
-      submitButton => submitButton.disabled
-    )
-    if (disableForm) {
-      return
-    }
 
     let selectedSubmitButton
 
@@ -681,6 +675,23 @@ export class WidgetStateManager {
     this.updateFormsData(draft => {
       draft.formsWithUploads = formsWithUploads
     })
+  }
+
+  /**
+   * Helper function to determine whether to allow enter to submit a form
+   */
+  public allowFormSubmitOnEnter(formId: string): boolean {
+    const submitButtons = this.formsData.submitButtons.get(formId)
+    const firstSubmitButton = submitButtons?.[0]
+
+    // If there are no submit buttons for the given formId,
+    // it is either an invalid form or not a form
+    if (!firstSubmitButton) {
+      return false
+    }
+
+    // If first submit button is disabled, disable enter to submit
+    return !firstSubmitButton.disabled
   }
 
   /**

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -39,7 +39,7 @@ describe("InputInstructions", () => {
     expect(screen.getByTestId("InputInstructions").textContent).toBeDefined()
   })
 
-  it("should show Enter instructions", () => {
+  it("should show Enter instructions by default", () => {
     render(<InputInstructions {...props} />)
 
     expect(screen.getByTestId("InputInstructions").textContent).toBe(
@@ -132,17 +132,27 @@ describe("InputInstructions", () => {
         "Press Enter to submit form"
       )
     })
-  })
 
-  it("should show correct instructions to submit form with multiline input", () => {
-    const props = getProps({
-      inForm: true,
-      type: "multiline",
+    it("should show correct instructions to submit form with multiline input", () => {
+      const props = getProps({
+        inForm: true,
+        type: "multiline",
+      })
+      render(<InputInstructions {...props} />)
+
+      expect(screen.getByTestId("InputInstructions").textContent).toBe(
+        "Press ⌘+Enter to submit form"
+      )
     })
-    render(<InputInstructions {...props} />)
 
-    expect(screen.getByTestId("InputInstructions").textContent).toBe(
-      "Press ⌘+Enter to submit form"
-    )
+    it("should not show enter instructions if allowSubmitOnEnter is false", () => {
+      const props = getProps({
+        inForm: true,
+        allowSubmitOnEnter: false,
+      })
+      render(<InputInstructions {...props} />)
+
+      expect(screen.getByTestId("InputInstructions")).toHaveTextContent("")
+    })
   })
 })

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -38,7 +38,7 @@ const InputInstructions = ({
   maxLength,
   className,
   type = "single",
-  allowSubmitOnEnter = false,
+  allowSubmitOnEnter = true,
 }: Props): ReactElement => {
   const messages: ReactElement[] = []
   const addMessage = (text: string, shouldBlink = false): void => {

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -24,19 +24,21 @@ import { StyledMessage } from "./styled-components"
 export interface Props {
   dirty: boolean
   value: string
+  inForm: boolean
   maxLength?: number
   className?: string
   type?: "multiline" | "single" | "chat"
-  inForm: boolean
+  allowSubmitOnEnter?: boolean
 }
 
 const InputInstructions = ({
   dirty,
   value,
+  inForm,
   maxLength,
   className,
   type = "single",
-  inForm,
+  allowSubmitOnEnter = false,
 }: Props): ReactElement => {
   const messages: ReactElement[] = []
   const addMessage = (text: string, shouldBlink = false): void => {
@@ -51,7 +53,10 @@ const InputInstructions = ({
     )
   }
 
-  if (dirty) {
+  // Show enter instruction if not a form or form allows submit on Enter
+  const showEnterInstruction = allowSubmitOnEnter || !inForm
+
+  if (dirty && showEnterInstruction) {
     const toSubmitFormOrApplyText = inForm ? "submit form" : "apply"
     if (type === "multiline") {
       const commandKey = isFromMac() ? "⌘" : "Ctrl"

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -54,9 +54,7 @@ const InputInstructions = ({
   }
 
   // Show enter instruction if not a form or form allows submit on Enter
-  const showEnterInstruction = allowSubmitOnEnter || !inForm
-
-  if (dirty && showEnterInstruction) {
+  if (dirty && allowSubmitOnEnter) {
     const toSubmitFormOrApplyText = inForm ? "submit form" : "apply"
     if (type === "multiline") {
       const commandKey = isFromMac() ? "⌘" : "Ctrl"

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -198,6 +198,9 @@ export const NumberInput: React.FC<Props> = ({
   const canDec = canDecrement(value, step, min)
   const canInc = canIncrement(value, step, max)
 
+  // Allows form submission on Enter & displays Enter instructions
+  const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(elementFormId)
+
   // update the step if the props change
   React.useEffect(() => {
     setStep(getStep({ step: element.step, dataType: element.dataType }))
@@ -375,12 +378,20 @@ export const NumberInput: React.FC<Props> = ({
         if (dirty) {
           commitValue({ value, source: { fromUi: true } })
         }
-        if (isInForm({ formId: elementFormId })) {
+        if (allowSubmitOnEnter) {
           widgetMgr.submitForm(elementFormId, fragmentId)
         }
       }
     },
-    [dirty, value, commitValue, widgetMgr, elementFormId, fragmentId]
+    [
+      dirty,
+      value,
+      commitValue,
+      widgetMgr,
+      elementFormId,
+      fragmentId,
+      allowSubmitOnEnter,
+    ]
   )
 
   return (
@@ -517,7 +528,8 @@ export const NumberInput: React.FC<Props> = ({
           <InputInstructions
             dirty={dirty}
             value={formattedValue ?? ""}
-            inForm={isInForm({ formId: element.formId })}
+            inForm={isInForm({ formId: elementFormId })}
+            allowSubmitOnEnter={allowSubmitOnEnter}
           />
         </StyledInstructionsContainer>
       )}

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -198,8 +198,10 @@ export const NumberInput: React.FC<Props> = ({
   const canDec = canDecrement(value, step, min)
   const canInc = canIncrement(value, step, max)
 
+  const inForm = isInForm({ formId: elementFormId })
   // Allows form submission on Enter & displays Enter instructions
-  const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(elementFormId)
+  const allowFormSubmitOnEnter =
+    widgetMgr.allowFormSubmitOnEnter(elementFormId)
 
   // update the step if the props change
   React.useEffect(() => {
@@ -378,7 +380,7 @@ export const NumberInput: React.FC<Props> = ({
         if (dirty) {
           commitValue({ value, source: { fromUi: true } })
         }
-        if (allowSubmitOnEnter) {
+        if (allowFormSubmitOnEnter) {
           widgetMgr.submitForm(elementFormId, fragmentId)
         }
       }
@@ -390,7 +392,7 @@ export const NumberInput: React.FC<Props> = ({
       widgetMgr,
       elementFormId,
       fragmentId,
-      allowSubmitOnEnter,
+      allowFormSubmitOnEnter,
     ]
   )
 
@@ -528,8 +530,8 @@ export const NumberInput: React.FC<Props> = ({
           <InputInstructions
             dirty={dirty}
             value={formattedValue ?? ""}
-            inForm={isInForm({ formId: elementFormId })}
-            allowSubmitOnEnter={allowSubmitOnEnter}
+            inForm={inForm}
+            allowSubmitOnEnter={allowFormSubmitOnEnter || !inForm}
           />
         </StyledInstructionsContainer>
       )}

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -265,6 +265,55 @@ describe("TextArea widget", () => {
     )
   })
 
+  it("shows Input Instructions on dirty state when not in form (by default)", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(<TextArea {...props} />)
+
+    // Trigger dirty state
+    const textArea = screen.getByRole("textbox")
+    await user.click(textArea)
+    await user.keyboard("TEST")
+
+    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
+      "Press ⌘+Enter to apply"
+    )
+  })
+
+  it("shows Input Instructions if in form that allows submit on enter", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ formId: "form" })
+    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+
+    render(<TextArea {...props} />)
+
+    // Trigger dirty state
+    const textArea = screen.getByRole("textbox")
+    await user.click(textArea)
+    await user.keyboard("TEST")
+
+    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
+      "Press ⌘+Enter to submit form"
+    )
+  })
+
+  it("hides Input Instructions if in form that doesn't allow submit on enter", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ formId: "form" })
+    jest
+      .spyOn(props.widgetMgr, "allowFormSubmitOnEnter")
+      .mockReturnValue(false)
+
+    render(<TextArea {...props} />)
+
+    // Trigger dirty state
+    const textArea = screen.getByRole("textbox")
+    await user.click(textArea)
+    await user.keyboard("TEST")
+
+    expect(screen.queryByTestId("InputInstructions")).toHaveTextContent("")
+  })
+
   it("focuses input when clicking label", async () => {
     const props = getProps()
     render(<TextArea {...props} />)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -171,17 +171,16 @@ class TextArea extends React.PureComponent<Props, State> {
   private onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     const { metaKey, ctrlKey } = e
     const { dirty } = this.state
+    const { element, widgetMgr, fragmentId } = this.props
+    const { formId } = element
+    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
 
     if (this.isEnterKeyPressed(e) && (ctrlKey || metaKey) && dirty) {
       e.preventDefault()
 
       this.commitWidgetValue({ fromUi: true })
-      const { formId } = this.props.element
-      if (isInForm({ formId })) {
-        this.props.widgetMgr.submitForm(
-          this.props.element.formId,
-          this.props.fragmentId
-        )
+      if (allowSubmitOnEnter) {
+        widgetMgr.submitForm(element.formId, fragmentId)
       }
     }
   }
@@ -190,12 +189,14 @@ class TextArea extends React.PureComponent<Props, State> {
     const { element, disabled, width, widgetMgr, theme } = this.props
     const { value, dirty } = this.state
     const style = { width }
-    const { height, placeholder } = element
+    const { height, placeholder, formId } = element
+    // Show "Please enter" instructions only if in a form & allowed
+    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
       widgetMgr,
-      element.formId,
+      formId,
       this.onFormCleared
     )
 
@@ -265,7 +266,8 @@ class TextArea extends React.PureComponent<Props, State> {
             value={value ?? ""}
             maxLength={element.maxChars}
             type={"multiline"}
-            inForm={isInForm({ formId: element.formId })}
+            inForm={isInForm({ formId })}
+            allowSubmitOnEnter={allowSubmitOnEnter}
           />
         )}
       </div>

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -173,14 +173,14 @@ class TextArea extends React.PureComponent<Props, State> {
     const { dirty } = this.state
     const { element, widgetMgr, fragmentId } = this.props
     const { formId } = element
-    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    const allowFormSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
 
     if (this.isEnterKeyPressed(e) && (ctrlKey || metaKey) && dirty) {
       e.preventDefault()
 
       this.commitWidgetValue({ fromUi: true })
-      if (allowSubmitOnEnter) {
-        widgetMgr.submitForm(element.formId, fragmentId)
+      if (allowFormSubmitOnEnter) {
+        widgetMgr.submitForm(formId, fragmentId)
       }
     }
   }
@@ -190,8 +190,9 @@ class TextArea extends React.PureComponent<Props, State> {
     const { value, dirty } = this.state
     const style = { width }
     const { height, placeholder, formId } = element
-    // Show "Please enter" instructions only if in a form & allowed
-    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    // Show "Please enter" instructions if in a form & allowed, or not in form
+    const allowSubmitOnEnter =
+      widgetMgr.allowFormSubmitOnEnter(formId) || !isInForm({ formId })
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -250,6 +250,7 @@ describe("TextInput widget", () => {
   it("does update widget value on text changes when inside of a form", async () => {
     const props = getProps({ formId: "formId" })
     const setStringValueSpy = jest.spyOn(props.widgetMgr, "setStringValue")
+    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
 
     render(<TextInput {...props} />)
 
@@ -318,6 +319,55 @@ describe("TextInput widget", () => {
       },
       undefined
     )
+  })
+
+  it("shows Input Instructions on dirty state by default", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(<TextInput {...props} />)
+
+    // Trigger dirty state
+    const textInput = screen.getByRole("textbox")
+    await user.click(textInput)
+    await user.keyboard("TEST")
+
+    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
+      "Press Enter to apply"
+    )
+  })
+
+  it("shows Input Instructions if in form that allows submit on enter", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ formId: "form" })
+    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+
+    render(<TextInput {...props} />)
+
+    // Trigger dirty state
+    const textInput = screen.getByRole("textbox")
+    await user.click(textInput)
+    await user.keyboard("TEST")
+
+    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
+      "Press Enter to submit form"
+    )
+  })
+
+  it("hides Input Instructions if in form that doesn't allow submit on enter", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ formId: "form" })
+    jest
+      .spyOn(props.widgetMgr, "allowFormSubmitOnEnter")
+      .mockReturnValue(false)
+
+    render(<TextInput {...props} />)
+
+    // Trigger dirty state
+    const textInput = screen.getByRole("textbox")
+    await user.click(textInput)
+    await user.keyboard("TEST")
+
+    expect(screen.queryByTestId("InputInstructions")).toHaveTextContent("")
   })
 
   it("hides Please enter to apply text when width is smaller than 180px", () => {

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -184,15 +184,16 @@ class TextInput extends React.PureComponent<Props, State> {
   private onKeyPress = (
     e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
   ): void => {
+    const { element, widgetMgr, fragmentId } = this.props
+    const { formId } = element
+    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+
     if (e.key === "Enter") {
       if (this.state.dirty) {
         this.commitWidgetValue({ fromUi: true })
       }
-      if (isInForm(this.props.element)) {
-        this.props.widgetMgr.submitForm(
-          this.props.element.formId,
-          this.props.fragmentId
-        )
+      if (allowSubmitOnEnter) {
+        widgetMgr.submitForm(formId, fragmentId)
       }
     }
   }
@@ -206,12 +207,14 @@ class TextInput extends React.PureComponent<Props, State> {
   public render(): React.ReactNode {
     const { dirty, value } = this.state
     const { element, width, disabled, widgetMgr, theme } = this.props
-    const { placeholder } = element
+    const { placeholder, formId } = element
+    // Show "Please enter" instructions only if in a form & allowed
+    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
       widgetMgr,
-      element.formId,
+      formId,
       this.onFormCleared
     )
 
@@ -289,7 +292,8 @@ class TextInput extends React.PureComponent<Props, State> {
             dirty={dirty}
             value={value ?? ""}
             maxLength={element.maxChars}
-            inForm={isInForm({ formId: element.formId })}
+            inForm={isInForm({ formId })}
+            allowSubmitOnEnter={allowSubmitOnEnter}
           />
         )}
       </StyledTextInput>

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -186,13 +186,13 @@ class TextInput extends React.PureComponent<Props, State> {
   ): void => {
     const { element, widgetMgr, fragmentId } = this.props
     const { formId } = element
-    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    const allowFormSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
 
     if (e.key === "Enter") {
       if (this.state.dirty) {
         this.commitWidgetValue({ fromUi: true })
       }
-      if (allowSubmitOnEnter) {
+      if (allowFormSubmitOnEnter) {
         widgetMgr.submitForm(formId, fragmentId)
       }
     }
@@ -208,8 +208,9 @@ class TextInput extends React.PureComponent<Props, State> {
     const { dirty, value } = this.state
     const { element, width, disabled, widgetMgr, theme } = this.props
     const { placeholder, formId } = element
-    // Show "Please enter" instructions only if in a form & allowed
-    const allowSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    // Show "Please enter" instructions if in a form & allowed, or not in form
+    const allowSubmitOnEnter =
+      widgetMgr.allowFormSubmitOnEnter(formId) || !isInForm({ formId })
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(


### PR DESCRIPTION
## Describe your changes
Update logic for form submission and the "Press enter to submit" instruction display:
- if first submit button is disabled, disable enter to submit and hide the “Press enter to submit” text from the field
- if the 2nd, 3rd, etc submit button is disabled (1st enabled), allow enter to submit (show text)
- always allow form submission via enabled submit buttons

## GitHub Issue Link
Closes #8042 

## Testing Plan
- Unit Tests: ✅  Updated existing & added
- E2E Tests: ✅  Added
- Manual Testing: ✅ 