### PR TITLE
Update page script hash on script start if necessary

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -578,6 +578,13 @@ class AppSession:
                 page_script_hash is not None
             ), "page_script_hash must be set for the SCRIPT_STARTED event"
 
+            # Update the client state with the new page_script_hash if
+            # necessary. This handles an edge case where a script is never
+            # finishes (eg. by calling st.rerun()), but the page has changed
+            # via st.navigation()
+            if page_script_hash != self._client_state.page_script_hash:
+                self._client_state.page_script_hash = page_script_hash
+
             if clear_forward_msg_queue:
                 self._clear_queue()
 


### PR DESCRIPTION
## Describe your changes

We use `client_state` in the app session in order to handle when a source file changes. We update the page script hash when a script finished event occurs.

The bug this fixes is a scenario where the page script never finishes successfully (in this case, the page always calls `st.rerun()`). We can improve this flow by updating the page script hash on script start event (which we should know by now).

## GitHub Issue Link (if applicable)
Closes #8975

## Testing Plan

- Added Python unit test
- Tested the scenario manually

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
