### PR TITLE
Add .pdf to the list of safe static files

### DIFF
--- a/lib/streamlit/web/server/app_static_file_handler.py
+++ b/lib/streamlit/web/server/app_static_file_handler.py
@@ -31,7 +31,7 @@ _LOGGER: Final = get_logger(__name__)
 MAX_APP_STATIC_FILE_SIZE = 200 * 1024 * 1024  # 200 MB
 # The list of file extensions that we serve with the corresponding Content-Type header.
 # All files with other extensions will be served with Content-Type: text/plain
-SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".webp")
+SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".pdf", ".gif", ".webp")
 
 
 class AppStaticFileHandler(tornado.web.StaticFileHandler):

--- a/lib/tests/streamlit/web/server/app_static_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/app_static_file_handler_test.py
@@ -45,6 +45,9 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmp_png_image_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="image.png", delete=False
         )
+        self._tmp_pdf_document_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="document.pdf", delete=False
+        )
         self._tmp_webp_image_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="image.webp", delete=False
         )
@@ -66,6 +69,7 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._filename = os.path.basename(self._tmpfile.name)
         self._js_filename = os.path.basename(self._tmp_js_file.name)
         self._png_image_filename = os.path.basename(self._tmp_png_image_file.name)
+        self._pdf_document_filename = os.path.basename(self._tmp_pdf_document_file.name)
         self._webp_image_filename = os.path.basename(self._tmp_webp_image_file.name)
 
         super().setUp()
@@ -124,6 +128,17 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 200
         assert response.headers["Content-Type"] == "image/webp"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    def test_static_pdf_document_200(self):
+        """Files with extensions listed in app_static_file_handler.py
+        `SAFE_APP_STATIC_FILE_EXTENSIONS` (e.g. pdf) should have the
+        `Content-Type` header based on their extension.
+        """
+        response = self.fetch(f"/app/static/{self._pdf_document_filename}")
+
+        assert response.code == 200
+        assert response.headers["Content-Type"] == "application/pdf"
         assert response.headers["X-Content-Type-Options"] == "nosniff"
 
     @patch("os.path.getsize", MagicMock(return_value=MAX_APP_STATIC_FILE_SIZE + 1))


### PR DESCRIPTION
## Describe your changes
Add .pdf to the list of safe static files

## GitHub Issue Link (if applicable)
Closes #9425 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Added
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
