### PR TITLE
Remove Snowpark Pandas integration test

### DIFF
--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -560,39 +560,6 @@ class DataframeUtilTest(unittest.TestCase):
             )
 
     @pytest.mark.require_integration
-    def test_verify_snowpandas_integration(self):
-        """Integration test snowpark pandas object handling.
-        This is in addition to the tests using the mocks to verify that
-        the latest version of the library is still supported.
-        """
-        import modin.pandas as modin_pd
-
-        # Import the Snowpark pandas plugin for modin.
-        import snowflake.snowpark.modin.plugin  # noqa: F401
-
-        with create_snowpark_session():
-            snowpandas_df = modin_pd.DataFrame([1, 2, 3], columns=["col1"])
-            assert dataframe_util.is_snowpandas_data_object(snowpandas_df) is True
-            assert isinstance(
-                dataframe_util.convert_anything_to_pandas_df(snowpandas_df),
-                pd.DataFrame,
-            )
-
-            snowpandas_series = snowpandas_df["col1"]
-            assert dataframe_util.is_snowpandas_data_object(snowpandas_series) is True
-            assert isinstance(
-                dataframe_util.convert_anything_to_pandas_df(snowpandas_series),
-                pd.DataFrame,
-            )
-
-            snowpandas_index = snowpandas_df.index
-            assert dataframe_util.is_snowpandas_data_object(snowpandas_index) is True
-            assert isinstance(
-                dataframe_util.convert_anything_to_pandas_df(snowpandas_index),
-                pd.DataFrame,
-            )
-
-    @pytest.mark.require_integration
     def test_verify_dask_integration(self):
         """Integration test dask object handling.
 


### PR DESCRIPTION
## Describe your changes

Snowpark removed their implementation of Pandas Series and replaced it with the `modin.Series` (see [PR](https://github.com/snowflakedb/snowpark-python/pull/2205)). This broke our integration tests. I fully removed the Snowpark Pandas integration test since it seems that Snowpark also plans to replace all of the Pandas objects with the versions from Modin. Different tests are already covering Modin objects.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
