### PR TITLE
Migrate Active Script hash to ScriptRunContext

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
@@ -70,6 +70,12 @@ def page_14():
     time.sleep(0.5)
     st.number_input("mynum", value=1, key="mynum")
 
+    @st.fragment
+    def fragment_number_input():
+        st.number_input("mynum 2", value=1, key="mynum2")
+
+    fragment_number_input()
+
 
 page7 = st.Page(page_7, default=set_default)
 page8 = st.Page(page_8, url_path="my_url_path")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pathlib
+import time
 
 from PIL import Image
 
@@ -65,6 +66,11 @@ def page_10():
     get_input()
 
 
+def page_14():
+    time.sleep(0.5)
+    st.number_input("mynum", value=1, key="mynum")
+
+
 page7 = st.Page(page_7, default=set_default)
 page8 = st.Page(page_8, url_path="my_url_path")
 page9 = st.Page(page_9)
@@ -72,7 +78,7 @@ page10 = st.Page(page_10)
 page11 = st.Page(page_8, title="page 11", url_path="page_11")
 page12 = st.Page(page_9, title="page 12", url_path="page_12")
 page13 = st.Page(page_8, title="page 13", url_path="page_13")
-page14 = st.Page(page_9, title="page 14", url_path="page_14")
+page14 = st.Page(page_14, title="page 14")
 
 hide_sidebar = st.checkbox("Hide sidebar")
 dynamic_nav = st.checkbox("Change navigation dynamically")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -413,3 +413,19 @@ def test_rapid_fire_interaction(app: Page):
     wait_for_app_run(app)
 
     expect(number_input.locator("input")).to_have_value("31")
+
+
+def test_rapid_fire_interaction_in_fragment(app: Page):
+    """Check that the number input in a fragment can handle rapid fire clicks in an Multipage app."""
+    get_page_link(app, "page 14").click()
+
+    number_input = get_element_by_key(app, "mynum2")
+    step_up_btn = number_input.get_by_test_id("stNumberInputStepUp")
+
+    # we need to have the clicking last a long enough time
+    for _ in range(30):
+        step_up_btn.click()
+
+    wait_for_app_run(app)
+
+    expect(number_input.locator("input")).to_have_value("31")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -20,7 +20,11 @@ from e2e_playwright.conftest import (
     wait_for_app_loaded,
     wait_for_app_run,
 )
-from e2e_playwright.shared.app_utils import click_button, click_checkbox
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    get_element_by_key,
+)
 
 
 def main_heading(app: Page):
@@ -56,6 +60,8 @@ expected_page_order = [
     "page 10",
     "page 11",
     "page 12",
+    "page 13",
+    "page 14",
 ]
 
 
@@ -391,3 +397,19 @@ def test_widget_state_reset_on_page_switch(app: Page):
 
     # Slider reset
     expect(app.get_by_text("x is 1")).to_be_attached()
+
+
+def test_rapid_fire_interaction(app: Page):
+    """Check that the number input can handle rapid fire clicks in an Multipage app."""
+    get_page_link(app, "page 14").click()
+
+    number_input = get_element_by_key(app, "mynum")
+    step_up_btn = number_input.get_by_test_id("stNumberInputStepUp")
+
+    # we need to have the clicking last a long enough time
+    for _ in range(30):
+        step_up_btn.click()
+
+    wait_for_app_run(app)
+
+    expect(number_input.locator("input")).to_have_value("31")

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -256,7 +256,7 @@ def navigation(
     page_to_return._can_be_called = True
     msg.navigation.page_script_hash = page_to_return._script_hash
     # Set the current page script hash to the page that is going to be executed
-    ctx.pages_manager.set_current_page_script_hash(page_to_return._script_hash)
+    ctx.set_mpa_v2_page(page_to_return._script_hash)
 
     # This will either navigation or yield if the page is not found
     ctx.enqueue(msg)

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -578,7 +578,7 @@ class ArrowMixin:
                 selection_mode=selection_mode,
                 is_selection_activated=is_selection_activated,
                 form_id=proto.form_id,
-                page=ctx.page_script_hash if ctx else None,
+                page=ctx.active_script_hash if ctx else None,
             )
 
             serde = DataframeSelectionSerde()

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1901,7 +1901,7 @@ class VegaChartsMixin:
                 use_container_width=use_container_width,
                 selection_mode=parsed_selection_modes,
                 form_id=vega_lite_proto.form_id,
-                page=ctx.page_script_hash if ctx else None,
+                page=ctx.active_script_hash if ctx else None,
             )
 
             serde = VegaLiteStateSerde(parsed_selection_modes)

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -282,7 +282,7 @@ class StreamlitPage:
         if not ctx:
             return
 
-        with ctx.pages_manager.run_with_active_hash(self._script_hash):
+        with ctx.run_with_active_hash(self._script_hash):
             if callable(self._page):
                 self._page()
                 return

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -222,9 +222,7 @@ def _fragment(
                 # This ensures that elements (especially widgets) are tied
                 # to a consistent active script hash
                 active_hash_context = (
-                    ctx.pages_manager.run_with_active_hash(
-                        initialized_active_script_hash
-                    )
+                    ctx.run_with_active_hash(initialized_active_script_hash)
                     if initialized_active_script_hash != ctx.active_script_hash
                     else contextlib.nullcontext()
                 )

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -73,6 +73,10 @@ class PagesStrategyV1:
         if setup_watcher:
             PagesStrategyV1.watch_pages_dir(pages_manager)
 
+    @property
+    def initial_active_script_hash(self) -> PageHash:
+        return self.pages_manager.current_page_script_hash
+
     def get_initial_active_script(
         self, page_script_hash: PageHash, page_name: PageName
     ) -> PageInfo | None:
@@ -147,6 +151,10 @@ class PagesStrategyV2:
             "page_script_hash": page_script_hash
             or self.pages_manager.main_script_hash,  # Default Hash
         }
+
+    @property
+    def initial_active_script_hash(self) -> PageHash:
+        return self.pages_manager.main_script_hash
 
     def get_page_script(self, fallback_page_hash: PageHash) -> PageInfo | None:
         if self._pages is None:
@@ -250,6 +258,10 @@ class PagesManager:
     @property
     def intended_page_script_hash(self) -> PageHash | None:
         return self._intended_page_script_hash
+
+    @property
+    def initial_active_script_hash(self) -> PageHash:
+        return self.pages_strategy.initial_active_script_hash
 
     @property
     def mpa_version(self) -> int:

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -229,6 +229,7 @@ class PagesManager:
         self._script_cache = script_cache
         self._intended_page_script_hash: PageHash | None = None
         self._intended_page_name: PageName | None = None
+        self._current_page_script_hash: PageHash = ""
 
     @property
     def main_script_path(self) -> ScriptPath:
@@ -237,6 +238,10 @@ class PagesManager:
     @property
     def main_script_hash(self) -> PageHash:
         return self._main_script_hash
+
+    @property
+    def current_page_script_hash(self) -> PageHash | None:
+        return self._current_page_script_hash
 
     @property
     def intended_page_name(self) -> PageName | None:
@@ -249,6 +254,9 @@ class PagesManager:
     @property
     def mpa_version(self) -> int:
         return 2 if isinstance(self.pages_strategy, PagesStrategyV2) else 1
+
+    def set_current_page_script_hash(self, page_script_hash: PageHash) -> None:
+        self._current_page_script_hash = page_script_hash
 
     def get_main_page(self) -> PageInfo:
         return {

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -248,7 +248,7 @@ class PagesManager:
         return self._main_script_hash
 
     @property
-    def current_page_script_hash(self) -> PageHash | None:
+    def current_page_script_hash(self) -> PageHash:
         return self._current_page_script_hash
 
     @property

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Final, Literal
+from typing import TYPE_CHECKING, Any, Callable, Final
 
 from streamlit import source_util
 from streamlit.logger import get_logger
@@ -309,7 +309,3 @@ class PagesManager:
             return ""
 
         return self._script_cache.get_bytecode(script_path)
-
-    @property
-    def mpa_version(self) -> Literal["v1", "v2"]:
-        return "v1" if isinstance(self.pages_strategy, PagesStrategyV1) else "v2"

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -467,7 +467,6 @@ class ScriptRunner:
                 page_script_hash=page_script_hash,
                 fragment_ids_this_run=fragment_ids_this_run,
             )
-            self._pages_manager.reset_active_script_hash()
 
             # We want to clear the forward_msg_queue during full script runs and
             # fragment-scoped fragment reruns. For normal fragment runs, clearing the

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -15,10 +15,18 @@
 from __future__ import annotations
 
 import collections
+import contextlib
 import contextvars
 import threading
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Counter, Dict, Final, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Counter,
+    Dict,
+    Final,
+    Union,
+)
 from urllib import parse
 
 from typing_extensions import TypeAlias
@@ -90,6 +98,8 @@ class ScriptRunContext:
     current_fragment_id: str | None = None
     fragment_ids_this_run: list[str] | None = None
     new_fragment_ids: set[str] = field(default_factory=set)
+    _active_script_hash: str = ""
+    _page_script_hash: str = ""
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
 
@@ -99,11 +109,28 @@ class ScriptRunContext:
 
     @property
     def page_script_hash(self):
-        return self.pages_manager.get_current_page_script_hash()
+        return self._page_script_hash
 
     @property
     def active_script_hash(self):
-        return self.pages_manager.get_active_script_hash()
+        if self.pages_manager.mpa_version == "v1":
+            return self._page_script_hash
+
+        return self._active_script_hash
+
+    @contextlib.contextmanager
+    def run_with_active_hash(self, page_hash: str):
+        original_page_hash = self._active_script_hash
+        self._active_script_hash = page_hash
+        try:
+            yield
+        finally:
+            # in the event of any exception, ensure we set the active hash back
+            self._active_script_hash = original_page_hash
+
+    def set_mpa_v2_page(self, page_script_hash: str):
+        self._active_script_hash = self.pages_manager.main_script_hash
+        self._page_script_hash = page_script_hash
 
     def reset(
         self,
@@ -116,7 +143,9 @@ class ScriptRunContext:
         self.widget_user_keys_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
-        self.pages_manager.set_current_page_script_hash(page_script_hash)
+        self._page_script_hash = page_script_hash
+        if self.pages_manager.mpa_version == "v2":
+            self._active_script_hash = self.pages_manager.main_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -113,7 +113,7 @@ class ScriptRunContext:
 
     @property
     def active_script_hash(self):
-        if self.pages_manager.mpa_version == "v1":
+        if self.pages_manager.mpa_version == 1:
             return self._page_script_hash
 
         return self._active_script_hash
@@ -144,7 +144,7 @@ class ScriptRunContext:
         self.form_ids_this_run = set()
         self.query_string = query_string
         self._page_script_hash = page_script_hash
-        if self.pages_manager.mpa_version == "v2":
+        if self.pages_manager.mpa_version == 2:
             self._active_script_hash = self.pages_manager.main_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -112,9 +112,6 @@ class ScriptRunContext:
 
     @property
     def active_script_hash(self):
-        if self.pages_manager.mpa_version == 1:
-            return self.page_script_hash
-
         return self._active_script_hash
 
     @contextlib.contextmanager
@@ -143,8 +140,7 @@ class ScriptRunContext:
         self.form_ids_this_run = set()
         self.query_string = query_string
         self.pages_manager.set_current_page_script_hash(page_script_hash)
-        if self.pages_manager.mpa_version == 2:
-            self._active_script_hash = self.pages_manager.main_script_hash
+        self._active_script_hash = self.pages_manager.initial_active_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -99,7 +99,6 @@ class ScriptRunContext:
     fragment_ids_this_run: list[str] | None = None
     new_fragment_ids: set[str] = field(default_factory=set)
     _active_script_hash: str = ""
-    _page_script_hash: str = ""
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
 
@@ -109,12 +108,12 @@ class ScriptRunContext:
 
     @property
     def page_script_hash(self):
-        return self._page_script_hash
+        return self.pages_manager.current_page_script_hash
 
     @property
     def active_script_hash(self):
         if self.pages_manager.mpa_version == 1:
-            return self._page_script_hash
+            return self.page_script_hash
 
         return self._active_script_hash
 
@@ -130,7 +129,7 @@ class ScriptRunContext:
 
     def set_mpa_v2_page(self, page_script_hash: str):
         self._active_script_hash = self.pages_manager.main_script_hash
-        self._page_script_hash = page_script_hash
+        self.pages_manager.set_current_page_script_hash(page_script_hash)
 
     def reset(
         self,
@@ -143,7 +142,7 @@ class ScriptRunContext:
         self.widget_user_keys_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
-        self._page_script_hash = page_script_hash
+        self.pages_manager.set_current_page_script_hash(page_script_hash)
         if self.pages_manager.mpa_version == 2:
             self._active_script_hash = self.pages_manager.main_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -323,6 +323,8 @@ class NumberInputTest(DeltaGeneratorTestCase):
         )
 
     def test_should_keep_type_of_return_value_after_rerun(self):
+        # set the initial page script hash
+        self.script_run_ctx.reset(page_script_hash=self.script_run_ctx.page_script_hash)
         # Generate widget id and reset context
         st.number_input("a number", min_value=1, max_value=100, key="number")
         widget_id = self.script_run_ctx.session_state.get_widget_states()[0].id

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -321,37 +321,33 @@ class FragmentTest(unittest.TestCase):
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     def test_sets_active_script_hash_if_needed(self, patched_get_script_run_ctx):
         ctx = MagicMock()
+        patched_run_with_active_hash = MagicMock()
+        ctx.run_with_active_hash = patched_run_with_active_hash
         ctx.fragment_storage = MemoryFragmentStorage()
         ctx.pages_manager = PagesManager("")
         ctx.pages_manager.set_pages({})  # Migrate to MPAv2
-        ctx.pages_manager.set_active_script_hash("some_hash")
-        ctx.active_script_hash = ctx.pages_manager.get_active_script_hash()
+        ctx.active_script_hash = "some_hash"
         patched_get_script_run_ctx.return_value = ctx
 
-        with patch.object(
-            ctx.pages_manager, "run_with_active_hash"
-        ) as patched_run_with_active_hash:
+        @fragment
+        def my_fragment():
+            pass
 
-            @fragment
-            def my_fragment():
-                pass
+        my_fragment()
 
-            my_fragment()
+        # Reach inside our MemoryFragmentStorage internals to pull out our saved
+        # fragment.
+        saved_fragment = list(ctx.fragment_storage._fragments.values())[0]
 
-            # Reach inside our MemoryFragmentStorage internals to pull out our saved
-            # fragment.
-            saved_fragment = list(ctx.fragment_storage._fragments.values())[0]
+        # set the hash to something different for subsequent calls
+        ctx.active_script_hash = "a_different_hash"
 
-            # set the hash to something different for subsequent calls
-            ctx.pages_manager.set_active_script_hash("a_different_hash")
-            ctx.active_script_hash = ctx.pages_manager.get_active_script_hash()
-
-            # Verify subsequent calls will run with the original active script hash
-            saved_fragment()
-            patched_run_with_active_hash.assert_called_with("some_hash")
-            patched_run_with_active_hash.reset_mock()
-            saved_fragment()
-            patched_run_with_active_hash.assert_called_with("some_hash")
+        # Verify subsequent calls will run with the original active script hash
+        saved_fragment()
+        patched_run_with_active_hash.assert_called_with("some_hash")
+        patched_run_with_active_hash.reset_mock()
+        saved_fragment()
+        patched_run_with_active_hash.assert_called_with("some_hash")
 
     @patch("streamlit.runtime.fragment.get_script_run_ctx")
     def test_fragment_code_returns_value(

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -78,26 +78,6 @@ class PagesManagerV2Test(unittest.TestCase):
         # This signifies the change to V2
         self.pages_manager.set_pages({})
 
-    def test_run_with_active_hash(self):
-        """Ensure the active script is set correctly"""
-        main_script_hash = self.pages_manager.main_script_hash
-        assert self.pages_manager.get_active_script_hash() == main_script_hash
-
-        with self.pages_manager.run_with_active_hash("new_hash"):
-            assert self.pages_manager.get_active_script_hash() == "new_hash"
-
-        assert self.pages_manager.get_active_script_hash() == main_script_hash
-
-    def test_reset_active_script_hash(self):
-        """Ensure the active script hash is reset correctly"""
-        main_script_hash = self.pages_manager.main_script_hash
-        assert self.pages_manager.get_active_script_hash() == main_script_hash
-
-        self.pages_manager.set_active_script_hash("new_hash")
-        self.pages_manager.reset_active_script_hash()
-
-        assert self.pages_manager.get_active_script_hash() == main_script_hash
-
     def test_get_page_script_valid_hash(self):
         """Ensure the page script is provided with valid page hash specified"""
 


### PR DESCRIPTION
## Describe your changes

Before, the PagesManager preserves the script hash across threads which led to race conditions with widgets resetting (See issue). The ScriptRunContext should manage the script hashes in a thread-safe way (because they only make sense in the context of a script run and do not need to be preserved between script runs).

## GitHub Issue Link (if applicable)
closes #9100

## Testing Plan

- Python Unit tests are updated
- E2E test for this rapid fire implementation

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
