### PR TITLE
Fix accidentally watching parent folder for changes

### DIFF
--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -59,7 +59,7 @@ class PagesStrategyV1:
                 source_util.invalidate_pages_cache()
 
             main_script_path = Path(pages_manager.main_script_path)
-            pages_dir = main_script_path.parent / "pages"
+            pages_dir = main_script_path.parent / "pages" / ""
             watch_dir(
                 str(pages_dir),
                 _handle_page_changed,

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -59,7 +59,7 @@ class PagesStrategyV1:
                 source_util.invalidate_pages_cache()
 
             main_script_path = Path(pages_manager.main_script_path)
-            pages_dir = main_script_path.parent / "pages" / ""
+            pages_dir = main_script_path.parent / "pages"
             watch_dir(
                 str(pages_dir),
                 _handle_page_changed,

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -56,6 +56,15 @@ if TYPE_CHECKING:
 _LOGGER: Final = get_logger(__name__)
 
 
+def _get_abs_folder_path(path: str) -> str:
+    """Get the absolute folder path for a given path.
+
+    If the path is a directory, return the absolute path.
+    Otherwise, return the absolute path of the parent directory.
+    """
+    return os.path.abspath(path if os.path.isdir(path) else os.path.dirname(path))
+
+
 class EventBasedPathWatcher:
     """Watches a single path on disk using watchdog"""
 
@@ -164,9 +173,7 @@ class _MultiPathWatcher:
         allow_nonexistent: bool = False,
     ) -> None:
         """Start watching a path."""
-        folder_path = os.path.abspath(
-            path if os.path.isdir(path) else os.path.dirname(path)
-        )
+        folder_path = _get_abs_folder_path(path)
 
         with self._lock:
             folder_handler = self._folder_handlers.get(folder_path)
@@ -188,9 +195,7 @@ class _MultiPathWatcher:
 
     def stop_watching_path(self, path: str, callback: Callable[[str], None]) -> None:
         """Stop watching a path."""
-        folder_path = os.path.abspath(
-            path if os.path.isdir(path) else os.path.dirname(path)
-        )
+        folder_path = _get_abs_folder_path(path)
 
         with self._lock:
             folder_handler = self._folder_handlers.get(folder_path)

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -164,7 +164,9 @@ class _MultiPathWatcher:
         allow_nonexistent: bool = False,
     ) -> None:
         """Start watching a path."""
-        folder_path = os.path.abspath(os.path.dirname(path))
+        folder_path = os.path.abspath(
+            path if os.path.isdir(path) else os.path.dirname(path)
+        )
 
         with self._lock:
             folder_handler = self._folder_handlers.get(folder_path)
@@ -186,7 +188,9 @@ class _MultiPathWatcher:
 
     def stop_watching_path(self, path: str, callback: Callable[[str], None]) -> None:
         """Stop watching a path."""
-        folder_path = os.path.abspath(os.path.dirname(path))
+        folder_path = os.path.abspath(
+            path if os.path.isdir(path) else os.path.dirname(path)
+        )
 
         with self._lock:
             folder_handler = self._folder_handlers.get(folder_path)

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -59,10 +59,10 @@ _LOGGER: Final = get_logger(__name__)
 def _get_abs_folder_path(path: str) -> str:
     """Get the absolute folder path for a given path.
 
-    If the path is a file, return the file directory.
-    Otherwise, return the absolute path of the path.
+    If the path is a directory, return the absolute path.
+    Otherwise, return the absolute path of the parent directory.
     """
-    return os.path.abspath(os.path.dirname(path) if os.path.isfile(path) else path)
+    return os.path.abspath(path if os.path.isdir(path) else os.path.dirname(path))
 
 
 class EventBasedPathWatcher:

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -59,10 +59,10 @@ _LOGGER: Final = get_logger(__name__)
 def _get_abs_folder_path(path: str) -> str:
     """Get the absolute folder path for a given path.
 
-    If the path is a directory, return the absolute path.
-    Otherwise, return the absolute path of the parent directory.
+    If the path is a file, return the file directory.
+    Otherwise, return the absolute path of the path.
     """
-    return os.path.abspath(path if os.path.isdir(path) else os.path.dirname(path))
+    return os.path.abspath(os.path.dirname(path) if os.path.isfile(path) else path)
 
 
 class EventBasedPathWatcher:

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Callable, Type, Union
 
 import streamlit.watcher
@@ -147,6 +148,10 @@ def watch_dir(
     glob_pattern: str | None = None,
     allow_nonexistent: bool = False,
 ) -> bool:
+    # Add a trailing slash to the path to ensure
+    # that its interpreted as a directory.
+    path = os.path.join(path, "")
+
     return _watch_path(
         path,
         on_dir_changed,

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -132,9 +132,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    @mock.patch("os.path.isfile")
-    def test_correctly_resolves_watched_folder_path(self, mock_is_file):
-        mock_is_file.return_value = True
+    @mock.patch("os.path.isdir")
+    def test_correctly_resolves_watched_folder_path(self, mock_is_dir):
+        mock_is_dir.return_value = True
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
@@ -150,9 +150,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    @mock.patch("os.path.isfile")
-    def test_correctly_resolves_watched_file_path(self, mock_is_file):
-        mock_is_file.return_value = False
+    @mock.patch("os.path.isdir")
+    def test_correctly_resolves_watched_file_path(self, mock_is_dir):
+        mock_is_dir.return_value = False
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -132,9 +132,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    @mock.patch("os.path.isdir")
-    def test_correctly_resolves_watched_folder_path(self, mock_is_dir):
-        mock_is_dir.return_value = True
+    @mock.patch("os.path.isfile")
+    def test_correctly_resolves_watched_folder_path(self, mock_is_file):
+        mock_is_file.return_value = True
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
@@ -150,9 +150,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    @mock.patch("os.path.isdir")
-    def test_correctly_resolves_watched_file_path(self, mock_is_dir):
-        mock_is_dir.return_value = False
+    @mock.patch("os.path.isfile")
+    def test_correctly_resolves_watched_file_path(self, mock_is_file):
+        mock_is_file.return_value = False
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -132,6 +132,40 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
+    @mock.patch("os.path.isdir")
+    def test_correctly_resolves_watched_folder_path(self, mock_is_dir):
+        mock_is_dir.return_value = True
+        cb = mock.Mock()
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+
+        ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/dir", cb)
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        fo._observer.schedule.assert_called_once()
+
+        folder_path = fo._observer.schedule.call_args[0][1]
+        assert folder_path == "/this/is/my/dir"
+
+    @mock.patch("os.path.isdir")
+    def test_correctly_resolves_watched_file_path(self, mock_is_dir):
+        mock_is_dir.return_value = False
+        cb = mock.Mock()
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            "/this/is/my/dir/file.txt", cb
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        fo._observer.schedule.assert_called_once()
+
+        folder_path = fo._observer.schedule.call_args[0][1]
+        assert folder_path == "/this/is/my/dir"
+
     def test_changed_modification_time_0_0(self):
         """Test that when a directory is modified, but modification time is 0.0,
         the callback is called anyway."""

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -148,6 +148,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_path = fo._observer.schedule.call_args[0][1]
         assert folder_path == "/this/is/my/dir"
 
+        ro.close()
+
     @mock.patch("os.path.isdir")
     def test_correctly_resolves_watched_file_path(self, mock_is_dir):
         mock_is_dir.return_value = False
@@ -165,6 +167,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         folder_path = fo._observer.schedule.call_args[0][1]
         assert folder_path == "/this/is/my/dir"
+
+        ro.close()
 
     def test_changed_modification_time_0_0(self):
         """Test that when a directory is modified, but modification time is 0.0,

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -168,7 +168,7 @@ class FileWatcherTest(unittest.TestCase):
 
         self.assertTrue(watching_dir)
         mock_event_watcher.assert_called_with(
-            "some/dir/path",
+            "some/dir/path/",
             on_file_changed,
             glob_pattern="*.py",
             allow_nonexistent=True,


### PR DESCRIPTION
## Describe your changes

Streamlit accidentally watches the parent directory of the directory it is supposed to watch. This can get quite problematic since the parent directory can contain lots of files. This PR fixes it by correctly resolving the path. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/7467

## Testing Plan

- Added unit test to make sure paths are correctly resolved.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
