### PR TITLE
Remove unused metric events

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2120,42 +2120,6 @@ describe("App", () => {
         expect(screen.getByText("Here is some text")).toBeInTheDocument()
       })
     })
-
-    it("calls MetricsManager handleDeltaMessage", () => {
-      renderApp(getProps())
-
-      const metricsManager = getStoredValue<SegmentMetricsManager>(
-        SegmentMetricsManager
-      )
-      const handleDeltaMessageSpy = jest.spyOn(
-        metricsManager,
-        "handleDeltaMessage"
-      )
-
-      // Need to set up a Script ID
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
-      // Need to set the script to running
-      sendForwardMessage("sessionStatusChanged", {
-        runOnSave: false,
-        scriptIsRunning: true,
-      })
-      sendForwardMessage(
-        "delta",
-        {
-          type: "newElement",
-          newElement: {
-            type: "text",
-            text: {
-              body: "Here is some text",
-              help: "",
-            },
-          },
-        },
-        { deltaPath: [0, 0] }
-      )
-
-      expect(handleDeltaMessageSpy).toHaveBeenCalledTimes(1)
-    })
   })
 
   describe("App.handleAutoRerun and autoRerun interval handling", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -900,15 +900,6 @@ export class App extends PureComponent<Props, State> {
         // if we don't have a pending rerun request, and we don't have
         // a script compilation failure
         scriptRunState = ScriptRunState.NOT_RUNNING
-
-        const customComponentCounter =
-          this.metricsMgr.getAndResetCustomComponentCounter()
-        Object.entries(customComponentCounter).forEach(([name, count]) => {
-          this.metricsMgr.enqueue("customComponentStats", {
-            name,
-            count,
-          })
-        })
       }
 
       return {
@@ -1337,9 +1328,6 @@ export class App extends PureComponent<Props, State> {
       metadataMsg
     )
 
-    // Update metrics
-    this.metricsMgr.handleDeltaMessage(deltaMsg)
-
     if (!this.pendingElementsTimerRunning) {
       this.pendingElementsTimerRunning = true
 
@@ -1416,8 +1404,6 @@ export class App extends PureComponent<Props, State> {
       // Don't queue up multiple rerunScript requests
       return
     }
-
-    this.metricsMgr.enqueue("rerunScript")
 
     this.setState({ scriptRunState: ScriptRunState.RERUN_REQUESTED })
 
@@ -1617,7 +1603,6 @@ export class App extends PureComponent<Props, State> {
   clearCache = (): void => {
     this.closeDialog()
     if (this.isServerConnected()) {
-      this.metricsMgr.enqueue("clearCache")
       const backMsg = new BackMsg({ clearCache: true })
       backMsg.type = "clearCache"
       this.sendBackMsg(backMsg)

--- a/frontend/app/src/SegmentMetricsManager.test.ts
+++ b/frontend/app/src/SegmentMetricsManager.test.ts
@@ -18,8 +18,6 @@
 // @ts-nocheck
 
 import {
-  Delta,
-  Element,
   mockSessionInfo,
   mockSessionInfoProps,
   SessionInfo,
@@ -167,25 +165,5 @@ test("ip address is overwritten", () => {
     context: {
       ip: "0.0.0.0",
     },
-  })
-})
-
-describe("handleDeltaMessage", () => {
-  it("handles componentInstance Delta messages", () => {
-    const mm = getSegmentMetricsManager()
-
-    const delta = Delta.create({
-      newElement: Element.create({
-        componentInstance: {
-          id: "mockId",
-          componentName: "mockComponentName",
-        },
-      }),
-    })
-
-    mm.handleDeltaMessage(delta)
-    expect(mm.getAndResetCustomComponentCounter()).toEqual({
-      mockComponentName: 1,
-    })
   })
 })

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
@@ -178,13 +178,11 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
   }
 
   private handleThemeChange = (index: number | null): void => {
-    const { activeTheme: oldTheme, availableThemes }: LibContextProps =
-      this.context
+    const { availableThemes }: LibContextProps = this.context
     const newTheme = availableThemes[index ?? 0]
 
-    this.props.metricsMgr.enqueue("themeChanged", {
-      oldThemeName: oldTheme.name,
-      newThemeName: newTheme.name,
+    this.props.metricsMgr.enqueue("menuClick", {
+      label: "changeTheme",
     })
 
     this.context.setTheme(newTheme)


### PR DESCRIPTION
## Describe your changes

Cleans up some outdated and unused metric events: 
- `customComponentStats`: covered by page profile
- `themeChanged`: adds a menuClick: changeTheme instead. Also, theme info is covered by page profile
- `clearCache`: covered by `menuClick`
- `rerunScript`: covered by `menuClick`

## Testing Plan

- Only removes logic -> no new tests required. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
