### PR TITLE
Replace ad-hoc computation of reversed session_state map with in-memory version

### DIFF
--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -281,6 +281,50 @@ def _missing_key_error_message(key: str) -> str:
 
 
 @dataclass
+class KeyIdMapper:
+    """A mapping of user-provided keys to widget IDs.
+    It also maps widget IDs to user-provided keys so that this reverse mapping
+    does not have to be computed ad-hoc. All operations should happen via the key.
+    """
+
+    _key_id_mapping: dict[str, str] = field(default_factory=dict)
+    _id_key_mapping: dict[str, str] = field(default_factory=dict)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._key_id_mapping
+
+    def __setitem__(self, key: str, widget_id: Any) -> None:
+        self._key_id_mapping[key] = widget_id
+        self._id_key_mapping[widget_id] = key
+
+    def __delitem__(self, key: str) -> None:
+        self.delete(key)
+
+    def set_key_id_mapping(self, key_id_mapping: dict[str, str]) -> None:
+        self._key_id_mapping = key_id_mapping
+        self._id_key_mapping = {v: k for k, v in key_id_mapping.items()}
+
+    def get_id_from_key(self, key: str, default: Any = None) -> str:
+        return self._key_id_mapping.get(key, default)
+
+    def get_key_from_id(self, widget_id: str) -> str:
+        return self._id_key_mapping[widget_id]
+
+    def update(self, other: KeyIdMapper) -> None:
+        self._key_id_mapping.update(other._key_id_mapping)
+        self._id_key_mapping.update(other._id_key_mapping)
+
+    def clear(self):
+        self._key_id_mapping.clear()
+        self._id_key_mapping.clear()
+
+    def delete(self, key: str):
+        widget_id = self._key_id_mapping[key]
+        del self._key_id_mapping[key]
+        del self._id_key_mapping[widget_id]
+
+
+@dataclass
 class SessionState:
     """SessionState allows users to store values that persist between app
     reruns.
@@ -309,9 +353,10 @@ class SessionState:
     _new_widget_state: WStates = field(default_factory=WStates)
 
     # Keys used for widgets will be eagerly converted to the matching widget id
-    _key_id_mapping: dict[str, str] = field(default_factory=dict)
+    _key_id_mapper: KeyIdMapper = field(default_factory=KeyIdMapper)
 
-    # query params are stored in session state because query params will be tied with widget state at one point.
+    # query params are stored in session state because query params will be tied with
+    # widget state at one point.
     query_params: QueryParams = field(default_factory=QueryParams)
 
     def __repr__(self):
@@ -338,7 +383,7 @@ class SessionState:
         self._old_state.clear()
         self._new_session_state.clear()
         self._new_widget_state.clear()
-        self._key_id_mapping.clear()
+        self._key_id_mapper.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -369,8 +414,7 @@ class SessionState:
     @property
     def _reverse_key_wid_map(self) -> dict[str, str]:
         """Return a mapping of widget_id : widget_key."""
-        wid_key_map = {v: k for k, v in self._key_id_mapping.items()}
-        return wid_key_map
+        return self._key_id_mapper._id_key_mapping
 
     def _keys(self) -> set[str]:
         """All keys active in Session State, with widget keys converted
@@ -463,7 +507,7 @@ class SessionState:
         ctx = get_script_run_ctx()
 
         if ctx is not None:
-            widget_id = self._key_id_mapping.get(user_key, None)
+            widget_id = self._key_id_mapper.get_id_from_key(user_key, None)
             widget_ids = ctx.widget_ids_this_run
             form_ids = ctx.form_ids_this_run
 
@@ -487,8 +531,8 @@ class SessionState:
         if key in self._old_state:
             del self._old_state[key]
 
-        if key in self._key_id_mapping:
-            del self._key_id_mapping[key]
+        if key in self._key_id_mapper:
+            self._key_id_mapper.delete(key)
 
         if widget_id in self._new_widget_state:
             del self._new_widget_state[widget_id]
@@ -608,10 +652,10 @@ class SessionState:
         """Turns a value that might be a widget id or a user provided key into
         an appropriate widget id.
         """
-        return self._key_id_mapping.get(k, k)
+        return self._key_id_mapper.get_id_from_key(k, k)
 
     def _set_key_widget_mapping(self, widget_id: str, user_key: str) -> None:
-        self._key_id_mapping[user_key] = widget_id
+        self._key_id_mapper[user_key] = widget_id
 
     def register_widget(
         self, metadata: WidgetMetadata[T], user_key: str | None

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -888,13 +888,17 @@ class SessionStateStatProviderTests(DeltaGeneratorTestCase):
         stat = state.get_stats()[0]
         assert stat.category_name == "st_session_state"
 
+        # The expected size of the session state in bytes.
+        # It composes of the session_state's fields.
+        expected_session_state_size_bytes = 3000
+
         init_size = stat.byte_length
-        assert init_size < 2500
+        assert init_size < expected_session_state_size_bytes
 
         state["foo"] = 2
         new_size = state.get_stats()[0].byte_length
         assert new_size > init_size
-        assert new_size < 2500
+        assert new_size < expected_session_state_size_bytes
 
         state["foo"] = 1
         new_size_2 = state.get_stats()[0].byte_length
@@ -903,7 +907,7 @@ class SessionStateStatProviderTests(DeltaGeneratorTestCase):
         st.checkbox("checkbox", key="checkbox")
         new_size_3 = state.get_stats()[0].byte_length
         assert new_size_3 > new_size_2
-        assert new_size_3 - new_size_2 < 2500
+        assert new_size_3 - new_size_2 < expected_session_state_size_bytes
 
         state._compact_state()
         new_size_4 = state.get_stats()[0].byte_length

--- a/lib/tests/streamlit/runtime/state/strategies.py
+++ b/lib/tests/streamlit/runtime/state/strategies.py
@@ -82,7 +82,7 @@ def _merge_states(a: SessionState, b: SessionState) -> None:
     a._new_session_state.update(b._new_session_state)
     a._new_widget_state.update(b._new_widget_state)
     a._old_state.update(b._old_state)
-    a._key_id_mapping.update(b._key_id_mapping)
+    a._key_id_mapper.update(b._key_id_mapper)
 
 
 # TODO: don't generate states where there is a k-wid mapping where the key exists but the widget doesn't


### PR DESCRIPTION
## Describe your changes

Closes #9415 

In #9415, we have discovered that the current implementation of Streamlit's `session_state.filtered_state` property / function is kind of slow, because the reverse-map is computed on-the-fly every time the property is accessed. This PR introduces a wrapper-dict that keeps the original dict as well as the reversed version in sync.

The example app of #9415 takes ~300ms to run on the current `develop` version and ~130ms to run with this PR's version:
![Screenshot 2024-09-16 at 11 18 17](https://github.com/user-attachments/assets/7636e660-3a03-4210-8de3-b79da94682bb)
![Screenshot 2024-09-16 at 11 18 00](https://github.com/user-attachments/assets/841ace1c-139d-4ecc-bfa3-f3c9fd28e90a)

With the following check added to the test app:

```python
import sys

st.write(f"Session state map size: {sys.getsizeof(ctx.session_state.filtered_state)}")
```
the size of the newly added map is ~9kb (same as the existing map `_key_id_map`; so we double the map's memory footprint, but it seems to be very small in general).

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add unit tests for the new wrapper dict
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
