### PR TITLE
Feature: Add `enter_to_submit` param to `st.form`

### DIFF
--- a/e2e_playwright/st_form.py
+++ b/e2e_playwright/st_form.py
@@ -116,3 +116,13 @@ with st.form("form_7"):
     )
     if submitted_7 or submitted_7b:
         st.write("Form submitted")
+
+with st.form("form_8", enter_to_submit=False):
+    st.write("Inside form 8")
+    number_input = st.number_input("Form 8 - Number Input", 0, 100, step=1)
+    submitted_8 = st.form_submit_button(
+        "Form 8 - Submit",
+        use_container_width=True,
+    )
+    if submitted_8:
+        st.write("Form submitted")

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -178,6 +178,19 @@ def test_form_disabled_submit_on_enter(app: Page):
     expect(form_7.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
 
 
+def test_submit_on_enter_false(app: Page):
+    """Tests that submit on enter does not work when enter_to_submit=False."""
+    form_8 = app.get_by_test_id("stForm").nth(7)
+    number_input = form_8.get_by_test_id("stNumberInput").locator("input")
+    number_input.fill("42")
+    expect(form_8.get_by_test_id("InputInstructions")).to_have_text("")
+
+    # Try to submit the form by pressing Enter, check not submitted.
+    number_input.press("Enter")
+    wait_for_app_run(app)
+    expect(form_8.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
+
+
 def test_form_submits_on_click(app: Page):
     """Tests that submit via enabled form submit button works."""
     form_6 = app.get_by_test_id("stForm").nth(5)

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -178,8 +178,8 @@ def test_form_disabled_submit_on_enter(app: Page):
     expect(form_7.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
 
 
-def test_submit_on_enter_false(app: Page):
-    """Tests that submit on enter does not work when enter_to_submit=False."""
+def test_enter_to_submit_false(app: Page):
+    """Tests that pressing Enter does not submit form when enter_to_submit=False."""
     form_8 = app.get_by_test_id("stForm").nth(7)
     number_input = form_8.get_by_test_id("stNumberInput").locator("input")
     number_input.fill("42")

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -780,7 +780,7 @@ describe("Widget State Manager", () => {
       const formId = "mockFormId"
 
       // Create form with enter_to_submit=False
-      widgetMgr.setFormClearAndEnterSubmit(formId, false, false)
+      widgetMgr.setFormSubmitBehaviors(formId, false, false)
 
       widgetMgr.addSubmitButton(
         formId,

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -774,6 +774,31 @@ describe("Widget State Manager", () => {
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
       expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(true)
     })
+
+    it("returns false if form created with enter_to_submit=False", () => {
+      // Create form with a submit button
+      const formId = "mockFormId"
+
+      // Create form with enter_to_submit=False
+      widgetMgr.setFormClearAndEnterSubmit(formId, false, false)
+
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "submitButton" })
+      )
+      widgetMgr.setStringValue(
+        { id: "widget1", formId },
+        "foo",
+        {
+          fromUi: true,
+        },
+        undefined
+      )
+
+      // @ts-expect-error - Created form should exist, but no allow submit on Enter
+      expect(widgetMgr.forms.get(formId)).toBeTruthy()
+      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(false)
+    })
   })
 
   describe("Forms don't interfere with each other", () => {

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -660,7 +660,7 @@ describe("Widget State Manager", () => {
     })
   })
 
-  describe("allowFormSubmitOnEnter", () => {
+  describe("allowFormEnterToSubmit", () => {
     it("returns true for a valid formId with 1st submit button enabled", () => {
       // Create form with a submit button
       const formId = "mockFormId"
@@ -681,7 +681,7 @@ describe("Widget State Manager", () => {
       // Form should exist & allow submission on Enter
       // @ts-expect-error - checking that form exists via internal state
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
-      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(true)
+      expect(widgetMgr.allowFormEnterToSubmit(formId)).toBe(true)
     })
 
     it("returns false for an invalid formId", () => {
@@ -706,7 +706,7 @@ describe("Widget State Manager", () => {
 
       // @ts-expect-error - Other form should NOT exist & should not allow submit on Enter
       expect(widgetMgr.forms.get("INVALID_FORM_ID")).toBeFalsy()
-      expect(widgetMgr.allowFormSubmitOnEnter("INVALID_FORM_ID")).toBe(false)
+      expect(widgetMgr.allowFormEnterToSubmit("INVALID_FORM_ID")).toBe(false)
     })
 
     it("returns false for a valid formId with no submit buttons", () => {
@@ -724,7 +724,7 @@ describe("Widget State Manager", () => {
 
       // @ts-expect-error - Created form should exist, but no allow submit on Enter
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
-      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(false)
+      expect(widgetMgr.allowFormEnterToSubmit(formId)).toBe(false)
     })
 
     it("returns false if the 1st submit button disabled", () => {
@@ -746,7 +746,7 @@ describe("Widget State Manager", () => {
 
       // @ts-expect-error - Created form should exist, but no allow submit on Enter
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
-      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(false)
+      expect(widgetMgr.allowFormEnterToSubmit(formId)).toBe(false)
     })
 
     it("returns true if the 1st submit button enabled, others disabled", () => {
@@ -772,7 +772,7 @@ describe("Widget State Manager", () => {
 
       // @ts-expect-error - Created form should exist and allow submit on Enter
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
-      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(true)
+      expect(widgetMgr.allowFormEnterToSubmit(formId)).toBe(true)
     })
 
     it("returns false if form created with enter_to_submit=False", () => {
@@ -797,7 +797,7 @@ describe("Widget State Manager", () => {
 
       // @ts-expect-error - Created form should exist, but no allow submit on Enter
       expect(widgetMgr.forms.get(formId)).toBeTruthy()
-      expect(widgetMgr.allowFormSubmitOnEnter(formId)).toBe(false)
+      expect(widgetMgr.allowFormEnterToSubmit(formId)).toBe(false)
     })
   })
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -147,6 +147,9 @@ class FormState {
   /** True if the form was created with the clear_on_submit flag. */
   public clearOnSubmit = false
 
+  /** True if the form was created with the enter_to_submit flag. */
+  public enterToSubmit = true
+
   /** Signal emitted when the form is cleared. */
   public readonly formCleared = new Signal()
 
@@ -209,11 +212,17 @@ export class WidgetStateManager {
   }
 
   /**
-   * Register a Form, and assign its clearOnSubmit value.
+   * Register a Form, and assign its clearOnSubmit & enterToSubmit values.
    * The `Form` element calls this when it's first mounted.
    */
-  public setFormClearOnSubmit(formId: string, clearOnSubmit: boolean): void {
-    this.getOrCreateFormState(formId).clearOnSubmit = clearOnSubmit
+  public setFormClearAndEnterSubmit(
+    formId: string,
+    clearOnSubmit: boolean,
+    enterToSubmit = true
+  ): void {
+    const form = this.getOrCreateFormState(formId)
+    form.clearOnSubmit = clearOnSubmit
+    form.enterToSubmit = enterToSubmit
   }
 
   /**
@@ -680,9 +689,18 @@ export class WidgetStateManager {
   /**
    * Helper function to determine whether a form allows enter to submit
    * for input elements (st.number_input, st.text_input, etc.)
+   * First checks form's enterToSubmit param, otherwise default behavior:
    * Must be in a form & have 1st submit button enabled to allow
    */
   public allowFormSubmitOnEnter(formId: string): boolean {
+    // Check user-set enterToSubmit param first (in FormState)
+    // Don't allow if false
+    const form = this.forms.get(formId)
+    if (notNullOrUndefined(form) && !form.enterToSubmit) {
+      return false
+    }
+
+    // Otherwise, use default behavior
     const submitButtons = this.formsData.submitButtons.get(formId)
     const firstSubmitButton = submitButtons?.[0]
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -215,10 +215,10 @@ export class WidgetStateManager {
    * Register a Form, and assign its clearOnSubmit & enterToSubmit values.
    * The `Form` element calls this when it's first mounted.
    */
-  public setFormClearAndEnterSubmit(
+  public setFormSubmitBehaviors(
     formId: string,
     clearOnSubmit: boolean,
-    enterToSubmit = true
+    enterToSubmit: boolean = true
   ): void {
     const form = this.getOrCreateFormState(formId)
     form.clearOnSubmit = clearOnSubmit

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -689,25 +689,23 @@ export class WidgetStateManager {
   /**
    * Helper function to determine whether a form allows enter to submit
    * for input elements (st.number_input, st.text_input, etc.)
-   * First checks form's enterToSubmit param, otherwise default behavior:
-   * Must be in a form & have 1st submit button enabled to allow
+   * If in form, checks form's enterToSubmit paramf first, otherwise default
+   * behavior: Must have 1st submit button enabled to allow
    */
   public allowFormEnterToSubmit(formId: string): boolean {
-    // Check user-set enterToSubmit param first (in FormState)
-    // Don't allow if false
+    // Don't allow if not in form
+    if (!isValidFormId(formId)) return false
+
+    // Check if user-set enterToSubmit param is false (in FormState)
     const form = this.forms.get(formId)
-    if (notNullOrUndefined(form) && !form.enterToSubmit) {
-      return false
-    }
+    if (form && !form.enterToSubmit) return false
 
     // Otherwise, use default behavior
     const submitButtons = this.formsData.submitButtons.get(formId)
     const firstSubmitButton = submitButtons?.[0]
 
-    // If no submit buttons for the formId, either not in form or invalid form
-    if (!firstSubmitButton) {
-      return false
-    }
+    // If no submit buttons for the formId, invalid form
+    if (!firstSubmitButton) return false
 
     // Allow form submit on enter as long as 1st submit button is not disabled
     return !firstSubmitButton.disabled

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -218,7 +218,7 @@ export class WidgetStateManager {
   public setFormSubmitBehaviors(
     formId: string,
     clearOnSubmit: boolean,
-    enterToSubmit: boolean = true
+    enterToSubmit = true
   ): void {
     const form = this.getOrCreateFormState(formId)
     form.clearOnSubmit = clearOnSubmit
@@ -692,7 +692,7 @@ export class WidgetStateManager {
    * First checks form's enterToSubmit param, otherwise default behavior:
    * Must be in a form & have 1st submit button enabled to allow
    */
-  public allowFormSubmitOnEnter(formId: string): boolean {
+  public allowFormEnterToSubmit(formId: string): boolean {
     // Check user-set enterToSubmit param first (in FormState)
     // Don't allow if false
     const form = this.forms.get(formId)

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -136,7 +136,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   }
 
   if (node.deltaBlock.type === "form") {
-    const { formId, clearOnSubmit, border } = node.deltaBlock
+    const { formId, clearOnSubmit, enterToSubmit, border } = node.deltaBlock
       .form as BlockProto.Form
     const submitButtons = props.formsData.submitButtons.get(formId)
     const hasSubmitButton =
@@ -145,6 +145,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
       <Form
         formId={formId}
         clearOnSubmit={clearOnSubmit}
+        enterToSubmit={enterToSubmit}
         width={props.width}
         hasSubmitButton={hasSubmitButton}
         scriptRunState={props.scriptRunState}

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -145,10 +145,10 @@ describe("InputInstructions", () => {
       )
     })
 
-    it("should not show enter instructions if allowSubmitOnEnter is false", () => {
+    it("should not show enter instructions if allowEnterToSubmit is false", () => {
       const props = getProps({
         inForm: true,
-        allowSubmitOnEnter: false,
+        allowEnterToSubmit: false,
       })
       render(<InputInstructions {...props} />)
 

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -28,7 +28,7 @@ export interface Props {
   maxLength?: number
   className?: string
   type?: "multiline" | "single" | "chat"
-  allowSubmitOnEnter?: boolean
+  allowEnterToSubmit?: boolean
 }
 
 const InputInstructions = ({
@@ -38,7 +38,7 @@ const InputInstructions = ({
   maxLength,
   className,
   type = "single",
-  allowSubmitOnEnter = true,
+  allowEnterToSubmit = true,
 }: Props): ReactElement => {
   const messages: ReactElement[] = []
   const addMessage = (text: string, shouldBlink = false): void => {
@@ -53,8 +53,8 @@ const InputInstructions = ({
     )
   }
 
-  // Show enter instruction if not a form or form allows submit on Enter
-  if (dirty && allowSubmitOnEnter) {
+  // Show enter instruction if not a form or form allows Enter to submit
+  if (dirty && allowEnterToSubmit) {
     const toSubmitFormOrApplyText = inForm ? "submit form" : "apply"
     if (type === "multiline") {
       const commandKey = isFromMac() ? "⌘" : "Ctrl"

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -335,7 +335,7 @@ describe("ButtonGroup widget", () => {
       formId: "form",
       clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
     })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntArrayValue")
 

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -335,7 +335,7 @@ describe("ButtonGroup widget", () => {
       formId: "form",
       clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
     })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntArrayValue")
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -160,7 +160,7 @@ describe("Checkbox widget", () => {
   it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setBoolValue")
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -160,7 +160,7 @@ describe("Checkbox widget", () => {
   it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setBoolValue")
 

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -122,7 +122,7 @@ describe("ColorPicker widget", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     jest.spyOn(props.widgetMgr, "setStringValue")
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     render(<ColorPicker {...props} />)
 

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -122,7 +122,7 @@ describe("ColorPicker widget", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     jest.spyOn(props.widgetMgr, "setStringValue")
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     render(<ColorPicker {...props} />)
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -234,7 +234,7 @@ describe("DateInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringArrayValue")
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -234,7 +234,7 @@ describe("DateInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringArrayValue")
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -638,7 +638,7 @@ describe("FileUploader widget tests", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     jest.spyOn(props.widgetMgr, "setFileUploaderStateValue")
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -638,7 +638,7 @@ describe("FileUploader widget tests", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     jest.spyOn(props.widgetMgr, "setFileUploaderStateValue")
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
 

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -33,6 +33,7 @@ describe("Form", () => {
       hasSubmitButton: false,
       scriptRunState: ScriptRunState.RUNNING,
       clearOnSubmit: false,
+      enterToSubmit: true,
       widgetMgr: new WidgetStateManager({
         sendRerunBackMsg: jest.fn(),
         formsDataChanged: jest.fn(),

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -56,10 +56,9 @@ export function Form(props: Props): ReactElement {
     border,
   } = props
 
-  // Tell WidgetStateManager if this form is `clearOnSubmit` so that it can
-  // do the right thing when the form is submitted.
+  // Tell WidgetStateManager if this form is `clearOnSubmit` and `enterToSubmit`
   useEffect(() => {
-    widgetMgr.setFormClearAndEnterSubmit(formId, clearOnSubmit, enterToSubmit)
+    widgetMgr.setFormSubmitBehaviors(formId, clearOnSubmit, enterToSubmit)
   }, [widgetMgr, formId, clearOnSubmit, enterToSubmit])
 
   // Determine if we need to show the "missing submit button" warning.

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -26,6 +26,7 @@ import { StyledErrorContainer, StyledForm } from "./styled-components"
 export interface Props {
   formId: string
   clearOnSubmit: boolean
+  enterToSubmit: boolean
   width: number
   hasSubmitButton: boolean
   scriptRunState: ScriptRunState
@@ -51,14 +52,15 @@ export function Form(props: Props): ReactElement {
     width,
     scriptRunState,
     clearOnSubmit,
+    enterToSubmit,
     border,
   } = props
 
   // Tell WidgetStateManager if this form is `clearOnSubmit` so that it can
   // do the right thing when the form is submitted.
   useEffect(() => {
-    widgetMgr.setFormClearOnSubmit(formId, clearOnSubmit)
-  }, [widgetMgr, formId, clearOnSubmit])
+    widgetMgr.setFormClearAndEnterSubmit(formId, clearOnSubmit, enterToSubmit)
+  }, [widgetMgr, formId, clearOnSubmit, enterToSubmit])
 
   // Determine if we need to show the "missing submit button" warning.
   // If we have a submit button, we don't show the warning, of course.

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -237,7 +237,7 @@ describe("Multiselect widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntArrayValue")
 

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -237,7 +237,7 @@ describe("Multiselect widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntArrayValue")
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -176,7 +176,7 @@ describe("NumberInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getIntProps({ formId: "form", default: 10 })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
     render(<NumberInput {...props} />)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -222,7 +222,7 @@ describe("NumberInput widget", () => {
   it("shows Input Instructions if in form that allows submit on enter", async () => {
     const user = userEvent.setup()
     const props = getIntProps({ formId: "form" })
-    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+    jest.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
 
     render(<NumberInput {...props} />)
     const numberInput = screen.getByTestId("stNumberInputField")
@@ -240,7 +240,7 @@ describe("NumberInput widget", () => {
     const user = userEvent.setup()
     const props = getIntProps({ formId: "form" })
     jest
-      .spyOn(props.widgetMgr, "allowFormSubmitOnEnter")
+      .spyOn(props.widgetMgr, "allowFormEnterToSubmit")
       .mockReturnValue(false)
 
     render(<NumberInput {...props} />)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -176,7 +176,7 @@ describe("NumberInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getIntProps({ formId: "form", default: 10 })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
     render(<NumberInput {...props} />)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -200,8 +200,8 @@ export const NumberInput: React.FC<Props> = ({
 
   const inForm = isInForm({ formId: elementFormId })
   // Allows form submission on Enter & displays Enter instructions
-  const allowFormSubmitOnEnter =
-    widgetMgr.allowFormSubmitOnEnter(elementFormId)
+  const allowFormEnterToSubmit =
+    widgetMgr.allowFormEnterToSubmit(elementFormId)
 
   // update the step if the props change
   React.useEffect(() => {
@@ -380,7 +380,7 @@ export const NumberInput: React.FC<Props> = ({
         if (dirty) {
           commitValue({ value, source: { fromUi: true } })
         }
-        if (allowFormSubmitOnEnter) {
+        if (allowFormEnterToSubmit) {
           widgetMgr.submitForm(elementFormId, fragmentId)
         }
       }
@@ -392,7 +392,7 @@ export const NumberInput: React.FC<Props> = ({
       widgetMgr,
       elementFormId,
       fragmentId,
-      allowFormSubmitOnEnter,
+      allowFormEnterToSubmit,
     ]
   )
 
@@ -531,7 +531,7 @@ export const NumberInput: React.FC<Props> = ({
             dirty={dirty}
             value={formattedValue ?? ""}
             inForm={inForm}
-            allowSubmitOnEnter={allowFormSubmitOnEnter || !inForm}
+            allowEnterToSubmit={allowFormEnterToSubmit || !inForm}
           />
         </StyledInstructionsContainer>
       )}

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -187,7 +187,7 @@ describe("Radio widget", () => {
   it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
     render(<Radio {...props} />)

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -187,7 +187,7 @@ describe("Radio widget", () => {
   it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
     render(<Radio {...props} />)

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -110,7 +110,7 @@ describe("Selectbox widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
 

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -110,7 +110,7 @@ describe("Selectbox widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setIntValue")
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -200,7 +200,7 @@ describe("Slider widget", () => {
     it("resets its value when form is cleared", async () => {
       // Create a widget in a clearOnSubmit form
       const props = getProps({ formId: "form" })
-      props.widgetMgr.setFormClearOnSubmit("form", true)
+      props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
       render(<Slider {...props} />)
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -200,7 +200,7 @@ describe("Slider widget", () => {
     it("resets its value when form is cleared", async () => {
       // Create a widget in a clearOnSubmit form
       const props = getProps({ formId: "form" })
-      props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
 
       render(<Slider {...props} />)
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -239,7 +239,7 @@ describe("TextArea widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -283,7 +283,7 @@ describe("TextArea widget", () => {
   it("shows Input Instructions if in form that allows submit on enter", async () => {
     const user = userEvent.setup()
     const props = getProps({ formId: "form" })
-    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+    jest.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
 
     render(<TextArea {...props} />)
 
@@ -301,7 +301,7 @@ describe("TextArea widget", () => {
     const user = userEvent.setup()
     const props = getProps({ formId: "form" })
     jest
-      .spyOn(props.widgetMgr, "allowFormSubmitOnEnter")
+      .spyOn(props.widgetMgr, "allowFormEnterToSubmit")
       .mockReturnValue(false)
 
     render(<TextArea {...props} />)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -239,7 +239,7 @@ describe("TextArea widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -173,13 +173,13 @@ class TextArea extends React.PureComponent<Props, State> {
     const { dirty } = this.state
     const { element, widgetMgr, fragmentId } = this.props
     const { formId } = element
-    const allowFormSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    const allowFormEnterToSubmit = widgetMgr.allowFormEnterToSubmit(formId)
 
     if (this.isEnterKeyPressed(e) && (ctrlKey || metaKey) && dirty) {
       e.preventDefault()
 
       this.commitWidgetValue({ fromUi: true })
-      if (allowFormSubmitOnEnter) {
+      if (allowFormEnterToSubmit) {
         widgetMgr.submitForm(formId, fragmentId)
       }
     }
@@ -191,8 +191,8 @@ class TextArea extends React.PureComponent<Props, State> {
     const style = { width }
     const { height, placeholder, formId } = element
     // Show "Please enter" instructions if in a form & allowed, or not in form
-    const allowSubmitOnEnter =
-      widgetMgr.allowFormSubmitOnEnter(formId) || !isInForm({ formId })
+    const allowEnterToSubmit =
+      widgetMgr.allowFormEnterToSubmit(formId) || !isInForm({ formId })
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -268,7 +268,7 @@ class TextArea extends React.PureComponent<Props, State> {
             maxLength={element.maxChars}
             type={"multiline"}
             inForm={isInForm({ formId })}
-            allowSubmitOnEnter={allowSubmitOnEnter}
+            allowEnterToSubmit={allowEnterToSubmit}
           />
         )}
       </div>

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -297,7 +297,7 @@ describe("TextInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -297,7 +297,7 @@ describe("TextInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -250,7 +250,7 @@ describe("TextInput widget", () => {
   it("does update widget value on text changes when inside of a form", async () => {
     const props = getProps({ formId: "formId" })
     const setStringValueSpy = jest.spyOn(props.widgetMgr, "setStringValue")
-    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+    jest.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
 
     render(<TextInput {...props} />)
 
@@ -339,7 +339,7 @@ describe("TextInput widget", () => {
   it("shows Input Instructions if in form that allows submit on enter", async () => {
     const user = userEvent.setup()
     const props = getProps({ formId: "form" })
-    jest.spyOn(props.widgetMgr, "allowFormSubmitOnEnter").mockReturnValue(true)
+    jest.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
 
     render(<TextInput {...props} />)
 
@@ -357,7 +357,7 @@ describe("TextInput widget", () => {
     const user = userEvent.setup()
     const props = getProps({ formId: "form" })
     jest
-      .spyOn(props.widgetMgr, "allowFormSubmitOnEnter")
+      .spyOn(props.widgetMgr, "allowFormEnterToSubmit")
       .mockReturnValue(false)
 
     render(<TextInput {...props} />)

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -186,13 +186,13 @@ class TextInput extends React.PureComponent<Props, State> {
   ): void => {
     const { element, widgetMgr, fragmentId } = this.props
     const { formId } = element
-    const allowFormSubmitOnEnter = widgetMgr.allowFormSubmitOnEnter(formId)
+    const allowFormEnterToSubmit = widgetMgr.allowFormEnterToSubmit(formId)
 
     if (e.key === "Enter") {
       if (this.state.dirty) {
         this.commitWidgetValue({ fromUi: true })
       }
-      if (allowFormSubmitOnEnter) {
+      if (allowFormEnterToSubmit) {
         widgetMgr.submitForm(formId, fragmentId)
       }
     }
@@ -209,8 +209,8 @@ class TextInput extends React.PureComponent<Props, State> {
     const { element, width, disabled, widgetMgr, theme } = this.props
     const { placeholder, formId } = element
     // Show "Please enter" instructions if in a form & allowed, or not in form
-    const allowSubmitOnEnter =
-      widgetMgr.allowFormSubmitOnEnter(formId) || !isInForm({ formId })
+    const allowEnterToSubmit =
+      widgetMgr.allowFormEnterToSubmit(formId) || !isInForm({ formId })
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -294,7 +294,7 @@ class TextInput extends React.PureComponent<Props, State> {
             value={value ?? ""}
             maxLength={element.maxChars}
             inForm={isInForm({ formId })}
-            allowSubmitOnEnter={allowSubmitOnEnter}
+            allowEnterToSubmit={allowEnterToSubmit}
           />
         )}
       </StyledTextInput>

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -188,7 +188,7 @@ describe("TimeInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -188,7 +188,7 @@ describe("TimeInput widget", () => {
   it("resets its value when form is cleared", () => {
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
-    props.widgetMgr.setFormClearOnSubmit("form", true)
+    props.widgetMgr.setFormClearAndEnterSubmit("form", true)
 
     jest.spyOn(props.widgetMgr, "setStringValue")
 

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -61,7 +61,12 @@ def _build_duplicate_form_message(user_key: str | None = None) -> str:
 class FormMixin:
     @gather_metrics("form")
     def form(
-        self, key: str, clear_on_submit: bool = False, *, border: bool = True
+        self,
+        key: str,
+        clear_on_submit: bool = False,
+        *,
+        enter_to_submit: bool = True,
+        border: bool = True,
     ) -> DeltaGenerator:
         """Create a form that batches elements together with a "Submit" button.
 
@@ -93,6 +98,9 @@ class FormMixin:
             values after the user presses the Submit button. Defaults to False.
             (Note that Custom Components are unaffected by this flag, and
             will not be reset to their defaults on form submission.)
+        enter_to_submit : bool
+            Whether to submit the form when a user presses Enter while
+            interacting with a widget inside the form. Defaults to True.
         border : bool
             Whether to show a border around the form. Defaults to True.
 
@@ -159,6 +167,7 @@ class FormMixin:
         block_proto = Block_pb2.Block()
         block_proto.form.form_id = form_id
         block_proto.form.clear_on_submit = clear_on_submit
+        block_proto.form.enter_to_submit = enter_to_submit
         block_proto.form.border = border
         block_dg = self.dg._block(block_proto)
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -181,6 +181,7 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block
         self.assertEqual("foo", form_proto.form.form_id)
         self.assertEqual(True, form_proto.form.clear_on_submit)
+        self.assertEqual(True, form_proto.form.enter_to_submit)
         self.assertEqual(True, form_proto.form.border)
         self.clear_queue()
 
@@ -192,6 +193,17 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block
         self.assertEqual("bar", form_proto.form.form_id)
         self.assertEqual(False, form_proto.form.clear_on_submit)
+
+    def test_form_enter_to_submit(self):
+        """Test that a form can be created with enter_to_submit=False."""
+
+        # Test with enter_to_submit=False
+        with st.form(key="foo", enter_to_submit=False):
+            pass
+
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 1)
+        form_proto = self.get_delta_from_queue(0).add_block
+        self.assertEqual(False, form_proto.form.enter_to_submit)
 
     def test_form_without_border(self):
         """Test that a form can be created without a border."""

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -80,6 +80,7 @@ message Block {
     string form_id = 1;
     bool clear_on_submit = 2;
     bool border = 3;
+    bool enter_to_submit = 4;
   }
 
   message TabContainer {


### PR DESCRIPTION
## Describe your changes
Adds a parameter to `st.form` that allows you to disable/enable “Enter to submit” functionality/instruction display. 
Also consolidates naming convention from `SubmitOnEnter` to `EnterToSubmit`

## GitHub Issue Link (if applicable)
Closes #7538 

## Testing Plan
- Unit Tests: Python & JS Added ✅ 
- E2E Tests: Added ✅ 
- Manual Testing: ✅ 