### PR TITLE
Fix dataframe maximum update depth error 

### DIFF
--- a/e2e_playwright/st_dataframe_stable_rendering.py
+++ b/e2e_playwright/st_dataframe_stable_rendering.py
@@ -1,0 +1,45 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This test checks that the dataframe component renders without crashing
+when used in different containers.
+
+This mainly addresses this issue: https://github.com/streamlit/streamlit/issues/7949
+"""
+
+import numpy as np
+import pandas as pd
+
+import streamlit as st
+
+np.random.seed(0)
+df = pd.DataFrame(np.random.randn(20, 5), columns=["a", "b", "c", "d", "e"])
+
+use_container_width = st.toggle("use_container_width", True)
+
+with st.popover("popover"):
+    st.dataframe(df, use_container_width=use_container_width)
+
+with st.sidebar:
+    st.dataframe(df, use_container_width=use_container_width)
+
+tab1, tab2 = st.tabs(["Tab 1", "Tab 2"])
+
+col1, col2, col3 = tab1.columns([1, 2, 3])
+col1.dataframe(df, use_container_width=use_container_width, height=100)
+col2.dataframe(df, use_container_width=use_container_width, height=100)
+col3.dataframe(df, use_container_width=use_container_width, height=100)
+
+tab1.dataframe(df, use_container_width=use_container_width, height=100)
+tab2.dataframe(df, use_container_width=use_container_width, height=100)

--- a/e2e_playwright/st_dataframe_stable_rendering.py
+++ b/e2e_playwright/st_dataframe_stable_rendering.py
@@ -30,7 +30,7 @@ use_container_width = st.toggle("use_container_width", True)
 
 with st.popover("popover 4 (with dataframe)", help="help text"):
     st.markdown("Popover with dataframe")
-    st.dataframe(df, use_container_width=False)
+    st.dataframe(df, use_container_width=True)
     st.image(np.repeat(0, 100).reshape(10, 10))
 
 with st.sidebar:

--- a/e2e_playwright/st_dataframe_stable_rendering.py
+++ b/e2e_playwright/st_dataframe_stable_rendering.py
@@ -28,10 +28,8 @@ df = pd.DataFrame(np.random.randn(20, 5), columns=["a", "b", "c", "d", "e"])
 
 use_container_width = st.toggle("use_container_width", True)
 
-with st.popover("popover 4 (with dataframe)", help="help text"):
-    st.markdown("Popover with dataframe")
+with st.popover("popover"):
     st.dataframe(df, use_container_width=True)
-    st.image(np.repeat(0, 100).reshape(10, 10))
 
 with st.sidebar:
     st.dataframe(df, use_container_width=use_container_width)

--- a/e2e_playwright/st_dataframe_stable_rendering.py
+++ b/e2e_playwright/st_dataframe_stable_rendering.py
@@ -28,8 +28,10 @@ df = pd.DataFrame(np.random.randn(20, 5), columns=["a", "b", "c", "d", "e"])
 
 use_container_width = st.toggle("use_container_width", True)
 
-with st.popover("popover"):
-    st.dataframe(df, use_container_width=use_container_width)
+with st.popover("popover 4 (with dataframe)", help="help text"):
+    st.markdown("Popover with dataframe")
+    st.dataframe(df, use_container_width=False)
+    st.image(np.repeat(0, 100).reshape(10, 10))
 
 with st.sidebar:
     st.dataframe(df, use_container_width=use_container_width)

--- a/e2e_playwright/st_dataframe_stable_rendering.py
+++ b/e2e_playwright/st_dataframe_stable_rendering.py
@@ -29,7 +29,7 @@ df = pd.DataFrame(np.random.randn(20, 5), columns=["a", "b", "c", "d", "e"])
 use_container_width = st.toggle("use_container_width", True)
 
 with st.popover("popover"):
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, use_container_width=use_container_width)
 
 with st.sidebar:
     st.dataframe(df, use_container_width=use_container_width)

--- a/e2e_playwright/st_dataframe_stable_rendering_test.py
+++ b/e2e_playwright/st_dataframe_stable_rendering_test.py
@@ -18,16 +18,16 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.shared.app_utils import click_toggle
 
 
-def test_dataframe_renders_without_crashing_with_use_container_width_true(app: Page):
-    """Test that st.dataframe renders without crashing if use_container_width is True."""
+def test_dataframe_renders_without_crashing_with_use_container_width_false(app: Page):
+    """Test that st.dataframe renders without crashing if use_container_width is False."""
+    click_toggle(app, "use_container_width")
     dataframe_elements = app.get_by_test_id("stDataFrame")
     expect(dataframe_elements).to_have_count(7)
     expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
 
 
-def test_dataframe_renders_without_crashing_with_use_container_width_false(app: Page):
-    """Test that st.dataframe renders without crashing if use_container_width is False."""
-    click_toggle(app, "use_container_width")
+def test_dataframe_renders_without_crashing_with_use_container_width_true(app: Page):
+    """Test that st.dataframe renders without crashing if use_container_width is True."""
     dataframe_elements = app.get_by_test_id("stDataFrame")
     expect(dataframe_elements).to_have_count(7)
     expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()

--- a/e2e_playwright/st_dataframe_stable_rendering_test.py
+++ b/e2e_playwright/st_dataframe_stable_rendering_test.py
@@ -15,19 +15,27 @@
 
 from playwright.sync_api import Page, expect
 
+from e2e_playwright.conftest import wait_for_app_loaded
 from e2e_playwright.shared.app_utils import click_toggle
 
 
-def test_dataframe_renders_without_crashing_with_use_container_width_false(app: Page):
-    """Test that st.dataframe renders without crashing if use_container_width is False."""
-    click_toggle(app, "use_container_width")
-    dataframe_elements = app.get_by_test_id("stDataFrame")
-    expect(dataframe_elements).to_have_count(7)
-    expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
+def test_dataframe_renders_without_crashing(app: Page):
+    """Test that st.dataframe renders without crashing."""
 
+    # Reload the page a couple of times to make sure that the dataframe
+    # crash doesn't appear.
+    # More info here: https://github.com/streamlit/streamlit/issues/7949
+    for _ in range(5):
+        dataframe_elements = app.get_by_test_id("stDataFrame")
+        expect(dataframe_elements).to_have_count(7)
+        expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
 
-def test_dataframe_renders_without_crashing_with_use_container_width_true(app: Page):
-    """Test that st.dataframe renders without crashing if use_container_width is True."""
-    dataframe_elements = app.get_by_test_id("stDataFrame")
-    expect(dataframe_elements).to_have_count(7)
-    expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
+        # Set use_container_width to False:
+        click_toggle(app, "use_container_width")
+        dataframe_elements = app.get_by_test_id("stDataFrame")
+        expect(dataframe_elements).to_have_count(7)
+        expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
+
+        # Reload the page:
+        app.reload()
+        wait_for_app_loaded(app)

--- a/e2e_playwright/st_dataframe_stable_rendering_test.py
+++ b/e2e_playwright/st_dataframe_stable_rendering_test.py
@@ -24,7 +24,12 @@ def test_dataframe_renders_without_crashing(app: Page):
 
     # Reload the page a couple of times to make sure that the dataframe
     # crash doesn't appear.
-    # More info here: https://github.com/streamlit/streamlit/issues/7949
+    # This test is safeguarding against potential regressions that
+    # cause crashes as report in: https://github.com/streamlit/streamlit/issues/7949
+    # But these crashes are usually more random, thats why we run
+    # it for a couple of page reloads.
+    # Also, even if there are crashes, its not gurunteed that they will
+    # happen in our CI environment.
     for _ in range(5):
         dataframe_elements = app.get_by_test_id("stDataFrame")
         expect(dataframe_elements).to_have_count(7)

--- a/e2e_playwright/st_dataframe_stable_rendering_test.py
+++ b/e2e_playwright/st_dataframe_stable_rendering_test.py
@@ -22,6 +22,7 @@ def test_dataframe_renders_without_crashing_with_use_container_width_true(app: P
     """Test that st.dataframe renders without crashing if use_container_width is True."""
     dataframe_elements = app.get_by_test_id("stDataFrame")
     expect(dataframe_elements).to_have_count(7)
+    expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()
 
 
 def test_dataframe_renders_without_crashing_with_use_container_width_false(app: Page):
@@ -29,3 +30,4 @@ def test_dataframe_renders_without_crashing_with_use_container_width_false(app: 
     click_toggle(app, "use_container_width")
     dataframe_elements = app.get_by_test_id("stDataFrame")
     expect(dataframe_elements).to_have_count(7)
+    expect(app.get_by_test_id("stAlertContainer")).not_to_be_attached()

--- a/e2e_playwright/st_dataframe_stable_rendering_test.py
+++ b/e2e_playwright/st_dataframe_stable_rendering_test.py
@@ -1,0 +1,31 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.shared.app_utils import click_toggle
+
+
+def test_dataframe_renders_without_crashing_with_use_container_width_true(app: Page):
+    """Test that st.dataframe renders without crashing if use_container_width is True."""
+    dataframe_elements = app.get_by_test_id("stDataFrame")
+    expect(dataframe_elements).to_have_count(7)
+
+
+def test_dataframe_renders_without_crashing_with_use_container_width_false(app: Page):
+    """Test that st.dataframe renders without crashing if use_container_width is False."""
+    click_toggle(app, "use_container_width")
+    dataframe_elements = app.get_by_test_id("stDataFrame")
+    expect(dataframe_elements).to_have_count(7)

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -40,7 +40,7 @@ with st.popover(
 
 with st.popover("popover 4 (with dataframe)", help="help text"):
     st.markdown("Popover with dataframe")
-    st.dataframe(df, use_container_width=False)
+    st.dataframe(df, use_container_width=True)
     st.image(np.repeat(0, 100).reshape(10, 10))
 
 with st.sidebar.popover("popover 5 (in sidebar)"):

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
@@ -37,7 +37,7 @@ export const BORDER_THRESHOLD = 2
 export const ROW_HEIGHT = 35
 // Min width for the resizable table container:
 // Based on one column at minimum width + borders
-const MIN_TABLE_WIDTH = MIN_COLUMN_WIDTH + BORDER_THRESHOLD
+export const MIN_TABLE_WIDTH = MIN_COLUMN_WIDTH + BORDER_THRESHOLD
 // Min height for the resizable table container:
 // Based on header + one column, and border threshold
 const MIN_TABLE_HEIGHT = 2 * ROW_HEIGHT + BORDER_THRESHOLD
@@ -81,6 +81,13 @@ function useTableSizer(
   )
 
   let initialHeight = Math.min(maxHeight, DEFAULT_TABLE_HEIGHT)
+  // The available width should be at least the minimum table width
+  // to prevent "maximum update depth exceeded" error. The reason
+  // is that the container width can be -1 in some edge cases
+  // caused by the resize observer in the Block component.
+  // This can trigger the "maximum update depth exceeded" error
+  // within the grid component.
+  const availableWidth = Math.max(containerWidth, MIN_TABLE_WIDTH)
 
   if (element.height) {
     // User has explicitly configured a height
@@ -100,19 +107,20 @@ function useTableSizer(
     }
   }
 
-  let initialWidth: number | undefined // If container width is undefined, auto set based on column widths
-  let maxWidth = containerWidth
+  let initialWidth: number | undefined
+  let maxWidth = availableWidth
 
   if (element.useContainerWidth) {
-    // Always use the full container width
-    initialWidth = containerWidth
+    // If user has set use_container_width,
+    // use the full container width.
+    initialWidth = availableWidth
   } else if (element.width) {
     // User has explicitly configured a width
     initialWidth = Math.min(
       Math.max(element.width, MIN_TABLE_WIDTH),
-      containerWidth
+      availableWidth
     )
-    maxWidth = Math.min(Math.max(element.width, maxWidth), containerWidth)
+    maxWidth = Math.min(Math.max(element.width, maxWidth), availableWidth)
   }
 
   const [resizableSize, setResizableSize] = React.useState<ResizableSize>({
@@ -125,11 +133,11 @@ function useTableSizer(
     // changes and the table uses the full container width.
     if (element.useContainerWidth && resizableSize.width === "100%") {
       setResizableSize({
-        width: containerWidth,
+        width: availableWidth,
         height: resizableSize.height,
       })
     }
-  }, [containerWidth])
+  }, [availableWidth])
 
   // Reset the height if the number of rows changes (e.g. via add_rows):
   React.useLayoutEffect(() => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
@@ -45,11 +45,17 @@ const MIN_TABLE_HEIGHT = 2 * ROW_HEIGHT + BORDER_THRESHOLD
 const DEFAULT_TABLE_HEIGHT = 400
 
 export type AutoSizerReturn = {
+  // The minimum height that the data grid can be resized to
   minHeight: number
+  // The maximum height of the data grid can be resized to
   maxHeight: number
+  // The minimum width of the data grid can be resized to
   minWidth: number
+  // The maximum width of the data grid can be resized to
   maxWidth: number
+  // The current (or initial) size of the data grid
   resizableSize: ResizableSize
+  // A callback function to change the size of the data grid.
   setResizableSize: React.Dispatch<React.SetStateAction<ResizableSize>>
 }
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
@@ -120,7 +120,13 @@ function useTableSizer(
   // within the grid component.
   const availableWidth = Math.max(containerWidth, MIN_TABLE_WIDTH)
 
+  // The initial width of the data grid.
+  // If not set, the data grid will be auto adapted to its content.
+  // The reason why we have initial width is that the data grid itself
+  // is resizable by the user. It starts with initial width but can be
+  // resized between min and max width.
   let initialWidth: number | undefined
+  // The maximum width of the data grid can be resized to.
   let maxWidth = availableWidth
 
   if (element.useContainerWidth) {


### PR DESCRIPTION
## Describe your changes

Fixes an issue with the dataframe component that causes random crashes:

![image](https://github.com/user-attachments/assets/da32e051-95ac-4562-aee6-bdb82a2fbd27)

The crash can happen on low-resolution monitors if dataframes are rendered with `use_container_width=True` are used in some of our containers (popover, tabs, sidebar, columns). It appears that our width calculation in the Block component causes this. If the width can't be determined yet by the resize observer, it can be -1 for some time. This seems to be a trigger for the maximum update depth. Unfortunately, I don't have a validated explanation of why it actually leads to the error :(

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/7949

## Testing Plan

- Add e2e test to discover similar breakage. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
