### PR TITLE
Add assert note to element mock test

### DIFF
--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -241,7 +241,11 @@ class StreamlitTest(unittest.TestCase):
             for element, _ in WIDGET_ELEMENTS + NON_WIDGET_ELEMENTS + CONTAINER_ELEMENTS
         }
         mocked_elements.update(NON_ELEMENT_COMMANDS)
-        assert api == mocked_elements
+        assert api == mocked_elements, (
+            "There are new public commands that might be needed to be added to element "
+            "mocks or NON_ELEMENT_COMMANDS. Please add it to the correct list of "
+            "mocked elements or NON_ELEMENT_COMMANDS."
+        )
 
     def test_pydoc(self):
         """Test that we can run pydoc on the streamlit package"""


### PR DESCRIPTION
## Describe your changes

We have a new test enforcing that elements get added to the element mocks list. This adds additional info as an assert message to make what to do more obvious.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
