### PR TITLE
[chore] Add VSCode Launch file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,3 @@ frontend/test_results
 frontend/cypress/snapshots/darwin
 frontend/cypress/snapshots/linux/1x
 
-########################################################################
-# VSCode
-########################################################################
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,10 @@ frontend/test_results
 frontend/cypress/snapshots/darwin
 frontend/cypress/snapshots/linux/1x
 
+
+########################################################################
+# VSCode
+########################################################################
+.vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-python.mypy-type-checker",
+    "ms-python.python",
+    "ms-python.debugpy",
+    "charliermarsh.ruff",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Streamlit App",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "streamlit",
+      "args": ["run", "${file}"]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,10 @@
       "request": "launch",
       "module": "streamlit",
       "args": ["run", "${file}"]
+      // allows to set breakpoints in installed packages, such as the Streamlit lib itself or custom component code etc.
+      // "justMyCode": false,
+      // allows to use a different installed version of streamlit in another venv folder, e.g.
+      // "program": "~/Projects/streamlit/lib/venv/bin/pytest"
     }
   ]
 }


### PR DESCRIPTION
## Describe your changes

- This adds a [VSCode Launch file](https://code.visualstudio.com/docs/editor/debugging) to our repro to enable shared run configurations.
- To start, this just adds a simple `Debug Streamlit App` launch config. When triggered on a Streamlit app, it will run it and enable all debugging features of VSCode

<img width="2011" alt="Screenshot 2024-09-18 at 10 39 16 AM" src="https://github.com/user-attachments/assets/fa7ad14d-d837-4380-8cc5-e48e6b97ed39">


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed? ✅ Manually tested in VSCode

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
