### PR TITLE
Add warning for nested paths in url path

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -212,14 +212,18 @@ class StreamlitPage:
                 "The title of the page cannot be empty or consist of underscores/spaces only"
             )
 
-        if url_path is not None and url_path.strip() == "" and not default:
-            raise StreamlitAPIException(
-                "The URL path cannot be an empty string unless the page is the default page."
-            )
-
         self._url_path: str = inferred_name
         if url_path is not None:
-            self._url_path = url_path.lstrip("/")
+            if url_path.strip() == "" and not default:
+                raise StreamlitAPIException(
+                    "The URL path cannot be an empty string unless the page is the default page."
+                )
+
+            self._url_path = url_path.strip("/")
+            if "/" in self._url_path:
+                raise StreamlitAPIException(
+                    "The URL path cannot contain a nested path (e.g. foo/bar)."
+                )
 
         if self._icon:
             validate_icon_or_emoji(self._icon)

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -99,6 +99,11 @@ class StPagesTest(DeltaGeneratorTestCase):
         page = st.Page("page_8.py", url_path="/my_url_path")
         assert page.url_path == "my_url_path"
 
+    def test_url_path_strips_trailing_slash(self):
+        """Tests that url path strips leading slash if provided"""
+        page = st.Page("page_8.py", url_path="my_url_path/")
+        assert page.url_path == "my_url_path"
+
     def test_url_path_is_empty_string_if_default(self):
         """Tests that url path is "" if the page is the default page"""
 
@@ -116,6 +121,15 @@ class StPagesTest(DeltaGeneratorTestCase):
 
         with pytest.raises(StreamlitAPIException):
             st.Page(page_9, url_path="")
+
+    def test_non_default_pages_cannot_have_nested_url_path(self):
+        """Tests that an error is raised if the url path contains a nested path"""
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, url_path="foo/bar")
 
     def test_page_with_no_title_raises_api_exception(self):
         """Tests that an error is raised if the title is empty or inferred to be empty"""


### PR DESCRIPTION
## Describe your changes

From #8971 having a nested path in the url path causes issues in identifying the exact location of assets. Such a solution requires passing down the exact path to the frontend on load, but there are many possible consequences and behavior changes. For now, we will inform the user that it is currently not allowed.

## Testing Plan

- Python unit tests are updated.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
