### PR TITLE
Redirect pages with removed trailing slashes

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -93,6 +93,12 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             super().write_error(status_code, **kwargs)
 
 
+class AddSlashHandler(tornado.web.RequestHandler):
+    @tornado.web.addslash
+    def get(self):
+        pass
+
+
 class RemoveSlashHandler(tornado.web.RequestHandler):
     @tornado.web.removeslash
     def get(self):

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -93,8 +93,8 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             super().write_error(status_code, **kwargs)
 
 
-class AddSlashHandler(tornado.web.RequestHandler):
-    @tornado.web.addslash
+class RemoveSlashHandler(tornado.web.RequestHandler):
+    @tornado.web.removeslash
     def get(self):
         pass
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -44,10 +44,10 @@ from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandl
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
 from streamlit.web.server.routes import (
-    AddSlashHandler,
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
+    RemoveSlashHandler,
     StaticFileHandler,
 )
 from streamlit.web.server.server_util import DEVELOPMENT_PORT, make_url_path_regex
@@ -368,6 +368,10 @@ class Server:
             routes.extend(
                 [
                     (
+                        make_url_path_regex(base, "(.*)", trailing_slash="required"),
+                        RemoveSlashHandler,
+                    ),
+                    (
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
                         {
@@ -381,7 +385,6 @@ class Server:
                             ],
                         },
                     ),
-                    (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
                 ]
             )
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -44,6 +44,7 @@ from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandl
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
 from streamlit.web.server.routes import (
+    AddSlashHandler,
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
@@ -385,6 +386,7 @@ class Server:
                             ],
                         },
                     ),
+                    (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
                 ]
             )
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -386,7 +386,10 @@ class Server:
                             ],
                         },
                     ),
-                    (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
+                    (
+                        make_url_path_regex(base, trailing_slash="prohibited"),
+                        AddSlashHandler,
+                    ),
                 ]
             )
 

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -79,7 +79,13 @@ def _get_server_address_if_manually_set() -> str | None:
 def make_url_path_regex(*path, **kwargs) -> str:
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x.strip("/") for x in path if x]  # Filter out falsely components.
-    path_format = r"^/%s/?$" if kwargs.get("trailing_slash", True) else r"^/%s$"
+    path_format = r"^/%s$"
+    trailing_slash = kwargs.get("trailing_slash", "optional")
+    if trailing_slash == "optional":
+        path_format = r"^/%s/?$"
+    elif trailing_slash == "required":
+        path_format = r"^/%s/$"
+
     return path_format % "/".join(path)
 
 

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal
 from urllib.parse import urljoin
 
 from streamlit import config, net_util, url_util
@@ -76,11 +76,12 @@ def _get_server_address_if_manually_set() -> str | None:
     return None
 
 
-def make_url_path_regex(*path, **kwargs) -> str:
+def make_url_path_regex(
+    *path, trailing_slash: Literal["optional", "required", "prohibited"] = "optional"
+) -> str:
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x.strip("/") for x in path if x]  # Filter out falsely components.
     path_format = r"^/%s$"
-    trailing_slash = kwargs.get("trailing_slash", "optional")
     if trailing_slash == "optional":
         path_format = r"^/%s/?$"
     elif trailing_slash == "required":

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -32,6 +32,7 @@ from streamlit.web.server.server import (
     HOST_CONFIG_ENDPOINT,
     MESSAGE_ENDPOINT,
     NEW_HEALTH_ENDPOINT,
+    AddSlashHandler,
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
@@ -208,6 +209,26 @@ class RemoveSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):
         for idx, r in enumerate(responses):
             assert r.code == 301
             assert r.headers["Location"] == paths[idx].rstrip("/")
+
+
+class AddSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/(.*)",
+                    AddSlashHandler,
+                )
+            ]
+        )
+
+    def test_parse_url_path_301(self):
+        paths = ["/page1"]
+        responses = [self.fetch(path, follow_redirects=False) for path in paths]
+
+        for idx, r in enumerate(responses):
+            assert r.code == 301
+            assert r.headers["Location"] == paths[idx] + "/"
 
 
 class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -35,6 +35,7 @@ from streamlit.web.server.server import (
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
+    RemoveSlashHandler,
     StaticFileHandler,
 )
 from tests.streamlit.message_mocks import create_dataframe_msg
@@ -187,6 +188,26 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         for r in responses:
             assert r.code == 404
+
+
+class RemoveSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/(.*)/",
+                    RemoveSlashHandler,
+                )
+            ]
+        )
+
+    def test_parse_url_path_301(self):
+        paths = ["/page1/", "/page2/page3/"]
+        responses = [self.fetch(path, follow_redirects=False) for path in paths]
+
+        for idx, r in enumerate(responses):
+            assert r.code == 301
+            assert r.headers["Location"] == paths[idx].rstrip("/")
 
 
 class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -74,3 +74,20 @@ class ServerUtilTest(unittest.TestCase):
             actual_url = server_util.get_url("the_ip_address")
 
         self.assertEqual(expected_url, actual_url)
+
+    def test_make_url_path_regex(self):
+        assert (
+            server_util.make_url_path_regex("foo") == r"^/foo/?$"
+        )  # defaults to optional
+        assert (
+            server_util.make_url_path_regex("foo", trailing_slash="optional")
+            == r"^/foo/?$"
+        )
+        assert (
+            server_util.make_url_path_regex("foo", trailing_slash="required")
+            == r"^/foo/$"
+        )
+        assert (
+            server_util.make_url_path_regex("foo", trailing_slash="prohibited")
+            == r"^/foo$"
+        )


### PR DESCRIPTION
## Describe your changes

Adding a trailing slash to the url causes confusion on the assets location in Streamlit frontend, so we will filter through a request handler that will redirect to the url without a trailing slash.

## GitHub Issue Link (if applicable)

closes #9127

## Testing Plan

- Python unit tests are updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
