### PR TITLE
Remove static element to value_type map & take id in register_widget instead of proto

### DIFF
--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -194,12 +194,12 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                 return ui_value
 
             component_state = register_widget(
-                element_type="component_instance",
                 element_proto=element.component_instance,
                 deserializer=deserialize_component,
                 serializer=lambda x: x,
                 ctx=ctx,
                 on_change_handler=on_change,
+                value_type="json_value",
             )
             widget_value = component_state.value
 

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -194,7 +194,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                 return ui_value
 
             component_state = register_widget(
-                element_proto=element.component_instance,
+                element.component_instance.id,
                 deserializer=deserialize_component,
                 serializer=lambda x: x,
                 ctx=ctx,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -581,7 +581,7 @@ class ArrowMixin:
 
             serde = DataframeSelectionSerde()
             widget_state = register_widget(
-                proto,
+                proto.id,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -581,12 +581,12 @@ class ArrowMixin:
 
             serde = DataframeSelectionSerde()
             widget_state = register_widget(
-                "dataframe",
                 proto,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,
                 ctx=ctx,
+                value_type="string_value",
             )
             self.dg._enqueue("arrow_data_frame", proto)
             return cast(DataframeState, widget_state.value)

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -399,12 +399,12 @@ class PydeckMixin:
             serde = PydeckSelectionSerde()
 
             widget_state = register_widget(
-                "deck_gl_json_chart",
                 pydeck_proto,
                 ctx=ctx,
                 deserializer=serde.deserialize,
                 on_change_handler=on_select if callable(on_select) else None,
                 serializer=serde.serialize,
+                value_type="string_value",
             )
 
             self.dg._enqueue("deck_gl_json_chart", pydeck_proto)

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -399,7 +399,7 @@ class PydeckMixin:
             serde = PydeckSelectionSerde()
 
             widget_state = register_widget(
-                pydeck_proto,
+                pydeck_proto.id,
                 ctx=ctx,
                 deserializer=serde.deserialize,
                 on_change_handler=on_select if callable(on_select) else None,

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -524,7 +524,7 @@ class PlotlyMixin:
             serde = PlotlyChartSelectionSerde()
 
             widget_state = register_widget(
-                plotly_chart_proto,
+                plotly_chart_proto.id,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -524,12 +524,12 @@ class PlotlyMixin:
             serde = PlotlyChartSelectionSerde()
 
             widget_state = register_widget(
-                "plotly_chart",
                 plotly_chart_proto,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,
                 ctx=ctx,
+                value_type="string_value",
             )
 
             self.dg._enqueue("plotly_chart", plotly_chart_proto)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1910,12 +1910,12 @@ class VegaChartsMixin:
             serde = VegaLiteStateSerde(parsed_selection_modes)
 
             widget_state = register_widget(
-                "vega_lite_chart",
                 vega_lite_proto,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,
                 ctx=ctx,
+                value_type="string_value",
             )
 
             self.dg._enqueue(

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1910,7 +1910,7 @@ class VegaChartsMixin:
             serde = VegaLiteStateSerde(parsed_selection_modes)
 
             widget_state = register_widget(
-                vega_lite_proto,
+                vega_lite_proto.id,
                 on_change_handler=on_select if callable(on_select) else None,
                 deserializer=serde.deserialize,
                 serializer=serde.serialize,

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -226,7 +226,7 @@ class AudioInputMixin:
         serde = AudioInputSerde()
 
         audio_input_state = register_widget(
-            audio_input_proto,
+            audio_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -226,7 +226,6 @@ class AudioInputMixin:
         serde = AudioInputSerde()
 
         audio_input_state = register_widget(
-            "audio_input",
             audio_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -234,6 +233,7 @@ class AudioInputMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="file_uploader_state_value",
         )
 
         self.dg._enqueue("audio_input", audio_input_proto)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -709,7 +709,7 @@ class ButtonMixin:
         serde = ButtonSerde()
 
         button_state = register_widget(
-            download_button_proto,
+            download_button_proto.id,
             on_change_handler=on_click,
             args=args,
             kwargs=kwargs,
@@ -902,7 +902,7 @@ class ButtonMixin:
         serde = ButtonSerde()
 
         button_state = register_widget(
-            button_proto,
+            button_proto.id,
             on_change_handler=on_click,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -709,7 +709,6 @@ class ButtonMixin:
         serde = ButtonSerde()
 
         button_state = register_widget(
-            "download_button",
             download_button_proto,
             on_change_handler=on_click,
             args=args,
@@ -717,6 +716,7 @@ class ButtonMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="trigger_value",
         )
 
         self.dg._enqueue("download_button", download_button_proto)
@@ -902,7 +902,6 @@ class ButtonMixin:
         serde = ButtonSerde()
 
         button_state = register_widget(
-            "button",
             button_proto,
             on_change_handler=on_click,
             args=args,
@@ -910,6 +909,7 @@ class ButtonMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="trigger_value",
         )
 
         if ctx:

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -620,7 +620,7 @@ class ButtonGroupMixin:
         )
 
         widget_state = register_widget(
-            proto,
+            proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -620,7 +620,6 @@ class ButtonGroupMixin:
         )
 
         widget_state = register_widget(
-            widget_name,
             proto,
             on_change_handler=on_change,
             args=args,
@@ -628,6 +627,7 @@ class ButtonGroupMixin:
             deserializer=deserializer,
             serializer=serializer,
             ctx=ctx,
+            value_type="int_array_value",
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -226,7 +226,6 @@ class CameraInputMixin:
         serde = CameraInputSerde()
 
         camera_input_state = register_widget(
-            "camera_input",
             camera_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -234,6 +233,7 @@ class CameraInputMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="file_uploader_state_value",
         )
 
         self.dg._enqueue("camera_input", camera_input_proto)

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -226,7 +226,7 @@ class CameraInputMixin:
         serde = CameraInputSerde()
 
         camera_input_state = register_widget(
-            camera_input_proto,
+            camera_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -370,7 +370,7 @@ class ChatMixin:
 
         serde = ChatInputSerde()
         widget_state = register_widget(
-            chat_input_proto,
+            chat_input_proto.id,
             on_change_handler=on_submit,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -370,7 +370,6 @@ class ChatMixin:
 
         serde = ChatInputSerde()
         widget_state = register_widget(
-            "chat_input",
             chat_input_proto,
             on_change_handler=on_submit,
             args=args,
@@ -378,6 +377,7 @@ class ChatMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_trigger_value",
         )
 
         chat_input_proto.disabled = disabled

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -317,7 +317,7 @@ class CheckboxMixin:
         serde = CheckboxSerde(value)
 
         checkbox_state = register_widget(
-            checkbox_proto,
+            checkbox_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -317,7 +317,6 @@ class CheckboxMixin:
         serde = CheckboxSerde(value)
 
         checkbox_state = register_widget(
-            "checkbox",
             checkbox_proto,
             on_change_handler=on_change,
             args=args,
@@ -325,6 +324,7 @@ class CheckboxMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="bool_value",
         )
 
         if checkbox_state.value_changed:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -237,7 +237,6 @@ class ColorPickerMixin:
         serde = ColorPickerSerde(value)
 
         widget_state = register_widget(
-            "color_picker",
             color_picker_proto,
             on_change_handler=on_change,
             args=args,
@@ -245,6 +244,7 @@ class ColorPickerMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_value",
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -237,7 +237,7 @@ class ColorPickerMixin:
         serde = ColorPickerSerde(value)
 
         widget_state = register_widget(
-            color_picker_proto,
+            color_picker_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -943,7 +943,6 @@ class DataEditorMixin:
         serde = DataEditorSerde()
 
         widget_state = register_widget(
-            "data_editor",
             proto,
             on_change_handler=on_change,
             args=args,
@@ -951,6 +950,7 @@ class DataEditorMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_value",
         )
 
         _apply_dataframe_edits(data_df, widget_state.value, dataframe_schema)

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -943,7 +943,7 @@ class DataEditorMixin:
         serde = DataEditorSerde()
 
         widget_state = register_widget(
-            proto,
+            proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -457,7 +457,7 @@ class FileUploaderMixin:
         # representing the current set of files that this uploader should
         # know about.
         widget_state = register_widget(
-            file_uploader_proto,
+            file_uploader_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -457,7 +457,6 @@ class FileUploaderMixin:
         # representing the current set of files that this uploader should
         # know about.
         widget_state = register_widget(
-            "file_uploader",
             file_uploader_proto,
             on_change_handler=on_change,
             args=args,
@@ -465,6 +464,7 @@ class FileUploaderMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="file_uploader_state_value",
         )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -300,7 +300,7 @@ class MultiSelectMixin:
 
         serde = MultiSelectSerde(indexable_options, default_values)
         widget_state = register_widget(
-            proto,
+            proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -300,7 +300,6 @@ class MultiSelectMixin:
 
         serde = MultiSelectSerde(indexable_options, default_values)
         widget_state = register_widget(
-            "multiselect",
             proto,
             on_change_handler=on_change,
             args=args,
@@ -308,6 +307,7 @@ class MultiSelectMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="int_array_value",
         )
 
         _check_max_selections(widget_state.value, max_selections)

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -507,7 +507,7 @@ class NumberInputMixin:
 
         serde = NumberInputSerde(value, data_type)
         widget_state = register_widget(
-            number_input_proto,
+            number_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -507,7 +507,6 @@ class NumberInputMixin:
 
         serde = NumberInputSerde(value, data_type)
         widget_state = register_widget(
-            "number_input",
             number_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -515,6 +514,7 @@ class NumberInputMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="double_value"
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -370,7 +370,6 @@ class RadioMixin:
         serde = RadioSerde(opt, index)
 
         widget_state = register_widget(
-            "radio",
             radio_proto,
             on_change_handler=on_change,
             args=args,
@@ -378,6 +377,7 @@ class RadioMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="int_value",
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -370,7 +370,7 @@ class RadioMixin:
         serde = RadioSerde(opt, index)
 
         widget_state = register_widget(
-            radio_proto,
+            radio_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -399,7 +399,7 @@ class SelectSliderMixin:
         serde = SelectSliderSerde(opt, slider_value, _is_range_value(value))
 
         widget_state = register_widget(
-            slider_proto,
+            slider_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -399,7 +399,6 @@ class SelectSliderMixin:
         serde = SelectSliderSerde(opt, slider_value, _is_range_value(value))
 
         widget_state = register_widget(
-            "slider",
             slider_proto,
             on_change_handler=on_change,
             args=args,
@@ -407,6 +406,7 @@ class SelectSliderMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="double_array_value",
         )
         if isinstance(widget_state.value, tuple):
             widget_state = maybe_coerce_enum_sequence(

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -328,7 +328,7 @@ class SelectboxMixin:
         serde = SelectboxSerde(opt, index)
 
         widget_state = register_widget(
-            selectbox_proto,
+            selectbox_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -328,7 +328,6 @@ class SelectboxMixin:
         serde = SelectboxSerde(opt, index)
 
         widget_state = register_widget(
-            "selectbox",
             selectbox_proto,
             on_change_handler=on_change,
             args=args,
@@ -336,6 +335,7 @@ class SelectboxMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="int_value",
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -822,7 +822,6 @@ class SliderMixin:
         serde = SliderSerde(value, data_type, single_value, orig_tz)
 
         widget_state = register_widget(
-            "slider",
             slider_proto,
             on_change_handler=on_change,
             args=args,
@@ -830,6 +829,7 @@ class SliderMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="double_array_value",
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -822,7 +822,7 @@ class SliderMixin:
         serde = SliderSerde(value, data_type, single_value, orig_tz)
 
         widget_state = register_widget(
-            slider_proto,
+            slider_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -331,7 +331,7 @@ class TextWidgetsMixin:
         serde = TextInputSerde(value)
 
         widget_state = register_widget(
-            text_input_proto,
+            text_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
@@ -586,7 +586,7 @@ class TextWidgetsMixin:
 
         serde = TextAreaSerde(value)
         widget_state = register_widget(
-            text_area_proto,
+            text_area_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -331,7 +331,6 @@ class TextWidgetsMixin:
         serde = TextInputSerde(value)
 
         widget_state = register_widget(
-            "text_input",
             text_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -339,6 +338,7 @@ class TextWidgetsMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_value",
         )
 
         if widget_state.value_changed:
@@ -586,7 +586,6 @@ class TextWidgetsMixin:
 
         serde = TextAreaSerde(value)
         widget_state = register_widget(
-            "text_area",
             text_area_proto,
             on_change_handler=on_change,
             args=args,
@@ -594,6 +593,7 @@ class TextWidgetsMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_value",
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -496,7 +496,6 @@ class TimeWidgetsMixin:
 
         serde = TimeInputSerde(parsed_time)
         widget_state = register_widget(
-            "time_input",
             time_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -504,6 +503,7 @@ class TimeWidgetsMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_value",
         )
 
         if widget_state.value_changed:
@@ -797,7 +797,6 @@ class TimeWidgetsMixin:
         serde = DateInputSerde(parsed_values)
 
         widget_state = register_widget(
-            "date_input",
             date_input_proto,
             on_change_handler=on_change,
             args=args,
@@ -805,6 +804,7 @@ class TimeWidgetsMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
+            value_type="string_array_value",
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -496,7 +496,7 @@ class TimeWidgetsMixin:
 
         serde = TimeInputSerde(parsed_time)
         widget_state = register_widget(
-            time_input_proto,
+            time_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
@@ -797,7 +797,7 @@ class TimeWidgetsMixin:
         serde = DateInputSerde(parsed_values)
 
         widget_state = register_widget(
-            date_input_proto,
+            date_input_proto.id,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -26,7 +26,6 @@ from typing import (
     Literal,
     Tuple,
     TypeVar,
-    Union,
     cast,
     get_args,
 )
@@ -37,56 +36,6 @@ from streamlit import util
 from streamlit.errors import (
     StreamlitAPIException,
 )
-from streamlit.proto.Arrow_pb2 import Arrow
-from streamlit.proto.ArrowVegaLiteChart_pb2 import ArrowVegaLiteChart
-from streamlit.proto.AudioInput_pb2 import AudioInput
-from streamlit.proto.Button_pb2 import Button
-from streamlit.proto.ButtonGroup_pb2 import ButtonGroup
-from streamlit.proto.CameraInput_pb2 import CameraInput
-from streamlit.proto.ChatInput_pb2 import ChatInput
-from streamlit.proto.Checkbox_pb2 import Checkbox
-from streamlit.proto.ColorPicker_pb2 import ColorPicker
-from streamlit.proto.Components_pb2 import ComponentInstance
-from streamlit.proto.DateInput_pb2 import DateInput
-from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart
-from streamlit.proto.DownloadButton_pb2 import DownloadButton
-from streamlit.proto.FileUploader_pb2 import FileUploader
-from streamlit.proto.MultiSelect_pb2 import MultiSelect
-from streamlit.proto.NumberInput_pb2 import NumberInput
-from streamlit.proto.PlotlyChart_pb2 import PlotlyChart
-from streamlit.proto.Radio_pb2 import Radio
-from streamlit.proto.Selectbox_pb2 import Selectbox
-from streamlit.proto.Slider_pb2 import Slider
-from streamlit.proto.TextArea_pb2 import TextArea
-from streamlit.proto.TextInput_pb2 import TextInput
-from streamlit.proto.TimeInput_pb2 import TimeInput
-
-# Protobuf types for all widgets.
-WidgetProto: TypeAlias = Union[
-    Arrow,
-    ArrowVegaLiteChart,
-    AudioInput,
-    Button,
-    ButtonGroup,
-    CameraInput,
-    ChatInput,
-    Checkbox,
-    ColorPicker,
-    ComponentInstance,
-    DateInput,
-    DeckGlJsonChart,
-    DownloadButton,
-    FileUploader,
-    MultiSelect,
-    NumberInput,
-    PlotlyChart,
-    Radio,
-    Selectbox,
-    Slider,
-    TextArea,
-    TextInput,
-    TimeInput,
-]
 
 GENERATED_ELEMENT_ID_PREFIX: Final = "$$ID"
 TESTING_KEY = "$$STREAMLIT_INTERNAL_KEY_TESTING"

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -36,13 +36,13 @@ if TYPE_CHECKING:
 
 def register_widget(
     element_proto: WidgetProto,
+    *,
     deserializer: WidgetDeserializer[T],
     serializer: WidgetSerializer[T],
     ctx: ScriptRunContext | None,
     on_change_handler: WidgetCallback | None = None,
     args: WidgetArgs | None = None,
     kwargs: WidgetKwargs | None = None,
-    *,
     value_type: ValueFieldName,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -14,10 +14,7 @@
 
 from __future__ import annotations
 
-from types import MappingProxyType
-from typing import TYPE_CHECKING, Final, Mapping
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING
 
 from streamlit.runtime.state.common import (
     RegisterWidgetResult,
@@ -37,48 +34,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner import ScriptRunContext
 
 
-ElementType: TypeAlias = str
-
-# NOTE: We use this table to start with a best-effort guess for the value_type
-# of each widget. Once we actually receive a proto for a widget from the
-# frontend, the guess is updated to be the correct type. Unfortunately, we're
-# not able to always rely on the proto as the type may be needed earlier.
-# Thankfully, in these cases (when value_type == "trigger_value"), the static
-# table here being slightly inaccurate should never pose a problem.
-ELEMENT_TYPE_TO_VALUE_TYPE: Final[Mapping[ElementType, ValueFieldName]] = (
-    MappingProxyType(
-        {
-            "audio_input": "file_uploader_state_value",
-            "button": "trigger_value",
-            "button_group": "int_array_value",
-            "camera_input": "file_uploader_state_value",
-            "chat_input": "string_trigger_value",
-            "checkbox": "bool_value",
-            "color_picker": "string_value",
-            "component_instance": "json_value",
-            "data_editor": "string_value",
-            "dataframe": "string_value",
-            "date_input": "string_array_value",
-            "deck_gl_json_chart": "string_value",
-            "download_button": "trigger_value",
-            "file_uploader": "file_uploader_state_value",
-            "multiselect": "int_array_value",
-            "number_input": "double_value",
-            "plotly_chart": "string_value",
-            "radio": "int_value",
-            "selectbox": "int_value",
-            "slider": "double_array_value",
-            "text_area": "string_value",
-            "text_input": "string_value",
-            "time_input": "string_value",
-            "vega_lite_chart": "string_value",
-        }
-    )
-)
-
-
 def register_widget(
-    element_type: ElementType,
     element_proto: WidgetProto,
     deserializer: WidgetDeserializer[T],
     serializer: WidgetSerializer[T],
@@ -86,14 +42,14 @@ def register_widget(
     on_change_handler: WidgetCallback | None = None,
     args: WidgetArgs | None = None,
     kwargs: WidgetKwargs | None = None,
+    *,
+    value_type: ValueFieldName,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
 
     Parameters
     ----------
-    element_type : ElementType
-        The type of the element as stored in proto.
     element_proto : WidgetProto
         The proto of the specified type (e.g. Button/Multiselect/Slider proto)
     deserializer : WidgetDeserializer[T]
@@ -109,6 +65,15 @@ def register_widget(
         args to pass to on_change_handler when invoked
     kwargs : WidgetKwargs or None
         kwargs to pass to on_change_handler when invoked
+    value_type: ValueType
+        The value_type the widget is going to use.
+        We use this information to start with a best-effort guess for the value_type
+        of each widget. Once we actually receive a proto for a widget from the
+        frontend, the guess is updated to be the correct type. Unfortunately, we're
+        not able to always rely on the proto as the type may be needed earlier.
+        Thankfully, in these cases (when value_type == "trigger_value"), the static
+        table here being slightly inaccurate should never pose a problem.
+
 
     Returns
     -------
@@ -139,7 +104,7 @@ def register_widget(
         element_proto.id,
         deserializer,
         serializer,
-        value_type=ELEMENT_TYPE_TO_VALUE_TYPE[element_type],
+        value_type=value_type,
         callback=on_change_handler,
         callback_args=args,
         callback_kwargs=kwargs,

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -25,7 +25,6 @@ from streamlit.runtime.state.common import (
     WidgetDeserializer,
     WidgetKwargs,
     WidgetMetadata,
-    WidgetProto,
     WidgetSerializer,
     user_key_from_element_id,
 )
@@ -35,7 +34,7 @@ if TYPE_CHECKING:
 
 
 def register_widget(
-    element_proto: WidgetProto,
+    element_id: str,
     *,
     deserializer: WidgetDeserializer[T],
     serializer: WidgetSerializer[T],
@@ -50,8 +49,8 @@ def register_widget(
 
     Parameters
     ----------
-    element_proto : WidgetProto
-        The proto of the specified type (e.g. Button/Multiselect/Slider proto)
+    element_id : str
+        The id of the element. Must be unique.
     deserializer : WidgetDeserializer[T]
         Called to convert a widget's protobuf value to the value returned by
         its st.<widget_name> function.
@@ -101,7 +100,7 @@ def register_widget(
     """
     # Create the widget's updated metadata, and register it with session_state.
     metadata = WidgetMetadata(
-        element_proto.id,
+        element_id,
         deserializer,
         serializer,
         value_type=value_type,


### PR DESCRIPTION
## Describe your changes

So far, the `register_widget` function used a static dict to map elements to value types. With the button_group widget we may get the first widget that can either by an `int_array` value or a `trigger_value`. But even without that, we want to switch to a dynamic registration to make widgets more self-contained and open the possibility also for custom components in the future. This reduces the places we have to touch when we add a new element 🙌 
So this PR changes the `register_widget` function so that not the proto but an id has to be passed and the `value_type` is passed directly from the widgets.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Added a new Python unit test to ensure that `register_widget` is called for all widgets and that a valid `value_type` is passed.
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
