### PR TITLE
[Fix] Embedded app spacing

### DIFF
--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -317,6 +317,103 @@ describe("AppView element", () => {
     expect(style.maxWidth).toEqual("initial")
   })
 
+  describe("handles padding an embedded app", () => {
+    it("embedded triggers default padding", () => {
+      const realUseContext = React.useContext
+      jest.spyOn(React, "useContext").mockImplementation(input => {
+        if (input === AppContext) {
+          return getContextOutput({ embedded: true })
+        }
+
+        return realUseContext(input)
+      })
+      render(<AppView {...getProps()} />)
+      const style = window.getComputedStyle(
+        screen.getByTestId("stMainBlockContainer")
+      )
+      expect(style.paddingTop).toEqual("2.1rem")
+      expect(style.paddingBottom).toEqual("1rem")
+    })
+
+    it("showPadding triggers expected padding", () => {
+      const realUseContext = React.useContext
+      jest.spyOn(React, "useContext").mockImplementation(input => {
+        if (input === AppContext) {
+          return getContextOutput({ showPadding: true })
+        }
+
+        return realUseContext(input)
+      })
+      render(<AppView {...getProps()} />)
+      const style = window.getComputedStyle(
+        screen.getByTestId("stMainBlockContainer")
+      )
+      expect(style.paddingTop).toEqual("6rem")
+      expect(style.paddingBottom).toEqual("10rem")
+    })
+
+    it("showToolbar triggers expected top padding", () => {
+      const realUseContext = React.useContext
+      jest.spyOn(React, "useContext").mockImplementation(input => {
+        if (input === AppContext) {
+          return getContextOutput({ showToolbar: true })
+        }
+
+        return realUseContext(input)
+      })
+      render(<AppView {...getProps()} />)
+      const style = window.getComputedStyle(
+        screen.getByTestId("stMainBlockContainer")
+      )
+      expect(style.paddingTop).toEqual("4.5rem")
+      expect(style.paddingBottom).toEqual("1rem")
+    })
+
+    it("hasSidebar triggers expected top padding", () => {
+      const realUseContext = React.useContext
+      jest.spyOn(React, "useContext").mockImplementation(input => {
+        if (input === AppContext) {
+          return getContextOutput({ embedded: true })
+        }
+
+        return realUseContext(input)
+      })
+
+      const sidebarElement = new ElementNode(
+        makeElementWithInfoText("sidebar!"),
+        ForwardMsgMetadata.create({}),
+        "no script run id",
+        FAKE_SCRIPT_HASH
+      )
+
+      const sidebar = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [sidebarElement],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const empty = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const props = getProps({
+        elements: new AppRoot(
+          FAKE_SCRIPT_HASH,
+          new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+        ),
+      })
+
+      render(<AppView {...props} />)
+      const style = window.getComputedStyle(
+        screen.getByTestId("stMainBlockContainer")
+      )
+      expect(style.paddingTop).toEqual("4.5rem")
+      expect(style.paddingBottom).toEqual("1rem")
+    })
+  })
+
   describe("handles logo rendering with no sidebar", () => {
     const imageOnly = LogoProto.create({
       image:

--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -124,7 +124,7 @@ export const StyledAppViewBlockContainer =
         (addPaddingForHeader && !showPadding) ||
         (isEmbedded && hasSidebar)
       ) {
-        topEmbedPadding = "3rem"
+        topEmbedPadding = `calc(${theme.sizes.headerHeight} + ${theme.spacing.md})`
       }
       const bottomEmbedPadding =
         showPadding && !hasBottom ? "10rem" : theme.spacing.lg

--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -124,7 +124,10 @@ export const StyledAppViewBlockContainer =
         (addPaddingForHeader && !showPadding) ||
         (isEmbedded && hasSidebar)
       ) {
-        topEmbedPadding = `calc(${theme.sizes.headerHeight} + ${theme.spacing.md})`
+        // Use parseFloat vs. calc to allow for JS unit test
+        topEmbedPadding = `${
+          parseFloat(theme.sizes.headerHeight) + parseFloat(theme.spacing.md)
+        }rem`
       }
       const bottomEmbedPadding =
         showPadding && !hasBottom ? "10rem" : theme.spacing.lg


### PR DESCRIPTION
Adjust the hardcoded embed spacing value with theme's `headerHeight` so embedded apps with sidebar content and those displaying toolbar don't hide app content 

### Current:
* **`embed=true` with sidebar content**
<img width="600" alt="develop-embed" src="https://github.com/user-attachments/assets/2808dbb5-d083-49e8-a29e-7729cdf34b78">

* **`embed=true&embed_options=show_toolbar`** 
<img width="600" alt="develop-embed-toolbar" src="https://github.com/user-attachments/assets/30b500a0-abb1-4fb8-aa1e-479bb24c56ec">


### Updated:
* **`embed=true` with sidebar content**
<img width="600" alt="new-embed" src="https://github.com/user-attachments/assets/cbd70e48-02d4-456d-9af4-8669e1ae40a1">

* **`embed=true&embed_options=show_toolbar`**
<img width="600" alt="new-embed-toolbar" src="https://github.com/user-attachments/assets/b1055240-7ba2-4f07-8793-0d36da103290">


## GitHub Issue Link
Closes #9341

## Testing Plan
- Unit Tests: ✅ 
- Manual Testing: ✅ 