### PR TITLE
Allow array parameters in CLI

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -188,7 +188,6 @@ def _create_option(
     replaced_by: str | None = None,
     type_: type = str,
     sensitive: bool = False,
-    multiple: bool = False,
 ) -> ConfigOption:
     '''Create a ConfigOption and store it globally in this module.
 
@@ -237,7 +236,6 @@ def _create_option(
         replaced_by=replaced_by,
         type_=type_,
         sensitive=sensitive,
-        multiple=multiple,
     )
     assert (
         option.section in _section_descriptions
@@ -569,7 +567,6 @@ _create_option(
         Example: ['/home/user1/env', 'relative/path/to/folder']
     """,
     default_val=[],
-    multiple=True,
 )
 
 _create_option(
@@ -980,7 +977,6 @@ _create_option(
         file_util.get_streamlit_file_path("secrets.toml"),
         file_util.get_project_streamlit_file_path("secrets.toml"),
     ],
-    multiple=True,
 )
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -188,6 +188,7 @@ def _create_option(
     replaced_by: str | None = None,
     type_: type = str,
     sensitive: bool = False,
+    multiple: bool = False,
 ) -> ConfigOption:
     '''Create a ConfigOption and store it globally in this module.
 
@@ -236,6 +237,7 @@ def _create_option(
         replaced_by=replaced_by,
         type_=type_,
         sensitive=sensitive,
+        multiple=multiple,
     )
     assert (
         option.section in _section_descriptions
@@ -567,6 +569,7 @@ _create_option(
         Example: ['/home/user1/env', 'relative/path/to/folder']
     """,
     default_val=[],
+    multiple=True,
 )
 
 _create_option(
@@ -977,6 +980,7 @@ _create_option(
         file_util.get_streamlit_file_path("secrets.toml"),
         file_util.get_project_streamlit_file_path("secrets.toml"),
     ],
+    multiple=True,
 )
 
 

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -108,7 +108,6 @@ class ConfigOption:
         replaced_by: str | None = None,
         type_: type = str,
         sensitive: bool = False,
-        multiple: bool = False,
     ):
         """Create a ConfigOption with the given name.
 
@@ -180,7 +179,8 @@ class ConfigOption:
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
         self.sensitive = sensitive
-        self.multiple = multiple
+        # infer multiple values if the default value is a list or tuple
+        self.multiple = isinstance(default_val, (list, tuple))
 
         if self.replaced_by:
             self.deprecated = True

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -108,6 +108,7 @@ class ConfigOption:
         replaced_by: str | None = None,
         type_: type = str,
         sensitive: bool = False,
+        multiple: bool = False,
     ):
         """Create a ConfigOption with the given name.
 
@@ -179,6 +180,7 @@ class ConfigOption:
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
         self.sensitive = sensitive
+        self.multiple = multiple
 
         if self.replaced_by:
             self.deprecated = True

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -59,6 +59,7 @@ def _convert_config_option_to_click_option(
         "type": config_option.type,
         "option": option,
         "envvar": config_option.env_var,
+        "multiple": config_option.multiple,
     }
 
 
@@ -101,6 +102,7 @@ def configurator_options(func: F) -> F:
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
+            multiple=parsed_parameter["multiple"],
             **click_option_kwargs,
         )
         func = config_option(func)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -98,8 +98,7 @@ class ConfigTest(unittest.TestCase):
         config_option = ConfigOption(
             "_test.simpleParam",
             description="Simple config option.",
-            default_val=12345,
-            multiple=True,
+            default_val=[12345],
         )
 
         assert config_option.key == "_test.simpleParam"
@@ -107,7 +106,7 @@ class ConfigTest(unittest.TestCase):
         assert config_option.name == "simpleParam"
         assert config_option.description == "Simple config option."
         assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
-        assert config_option.value == 12345
+        assert config_option.value == [12345]
         assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
         assert config_option.multiple
 
@@ -339,7 +338,6 @@ class ConfigTest(unittest.TestCase):
             "_test.testMultipleValueOption",
             description="This option tests multiple values for an option",
             default_val=["Option 1", "Option 2"],
-            multiple=True,
         )
 
         assert option.multiple

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -84,13 +84,32 @@ class ConfigTest(unittest.TestCase):
         )
 
         # Test that it works.
-        self.assertEqual(config_option.key, "_test.simpleParam")
-        self.assertEqual(config_option.section, "_test")
-        self.assertEqual(config_option.name, "simpleParam")
-        self.assertEqual(config_option.description, "Simple config option.")
-        self.assertEqual(config_option.where_defined, ConfigOption.DEFAULT_DEFINITION)
-        self.assertEqual(config_option.value, 12345)
-        self.assertEqual(config_option.env_var, "STREAMLIT__TEST_SIMPLE_PARAM")
+        assert config_option.key == "_test.simpleParam"
+        assert config_option.section == "_test"
+        assert config_option.name == "simpleParam"
+        assert config_option.description == "Simple config option."
+        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
+        assert config_option.value == 12345
+        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
+        assert not config_option.multiple
+
+    def test_multiple_config_option(self):
+        """Test creating a multiple value config option."""
+        config_option = ConfigOption(
+            "_test.simpleParam",
+            description="Simple config option.",
+            default_val=12345,
+            multiple=True,
+        )
+
+        assert config_option.key == "_test.simpleParam"
+        assert config_option.section == "_test"
+        assert config_option.name == "simpleParam"
+        assert config_option.description == "Simple config option."
+        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
+        assert config_option.value == 12345
+        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
+        assert config_option.multiple
 
     def test_complex_config_option(self):
         """Test setting a complex (functional) config option."""
@@ -314,6 +333,21 @@ class ConfigTest(unittest.TestCase):
         )
 
         config._delete_option("_test.testDeleteOption")
+
+    def test_multiple_value_option(self):
+        option = config._create_option(
+            "_test.testMultipleValueOption",
+            description="This option tests multiple values for an option",
+            default_val=["Option 1", "Option 2"],
+            multiple=True,
+        )
+
+        assert option.multiple
+        config.get_config_options(force_reparse=True)
+        assert config.get_option("_test.testMultipleValueOption") == [
+            "Option 1",
+            "Option 2",
+        ]
 
     def test_sections_order(self):
         sections = sorted(

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -175,6 +175,41 @@ class CliTest(unittest.TestCase):
         self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
         self.assertEqual(0, result.exit_code)
 
+    def test_run_command_with_multiple_secrets_path_single_value(self):
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
+            "streamlit.web.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+            result = self.runner.invoke(
+                cli, ["run", "file_name.py", "--secrets.files=secrets1.toml"]
+            )
+
+        streamlit.web.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
+        assert kwargs["flag_options"]["secrets_files"] == ("secrets1.toml",)
+        assert result.exit_code == 0
+
+    def test_run_command_with_multiple_secrets_path_multiple_value(self):
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
+            "streamlit.web.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+            result = self.runner.invoke(
+                cli,
+                [
+                    "run",
+                    "file_name.py",
+                    "--secrets.files=secrets1.toml",
+                    "--secrets.files=secrets2.toml",
+                ],
+            )
+
+        streamlit.web.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
+        assert kwargs["flag_options"]["secrets_files"] == (
+            "secrets1.toml",
+            "secrets2.toml",
+        )
+        assert result.exit_code == 0
+
     @parameterized.expand(["mapbox.token", "server.cookieSecret"])
     def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
         with patch("streamlit.url_util.is_url", return_value=False), patch(


### PR DESCRIPTION
## Describe your changes

Streamlit has two config options that support multiple values. It works with `config.toml`, but it does not work with the CLI arguments. This is because we are not leveraging Click's [multiple](https://click.palletsprojects.com/en/8.1.x/options/#multiple-options) parameter. This change allows us to specify it. We infer the multiple value if the default val is a list or tuple.

## Testing Plan

- Python Unit Tests updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
