### PR TITLE
Chat input with file uploder UI polish

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -52,6 +52,7 @@ import {
   StyledInputInstructionsContainer,
   StyledSendIconButton,
   StyledSendIconButtonContainer,
+  StyledVerticalDivider,
 } from "./styled-components"
 
 import { FileUploadClient } from "@streamlit/lib/src/FileUploadClient"
@@ -510,9 +511,12 @@ function ChatInput({
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
 
-  console.log(width)
   return (
-    <>
+    <StyledChatInputContainer
+      className="stChatInput"
+      data-testid="stChatInput"
+      width={width}
+    >
       <div style={{ position: "absolute", bottom: "100%" }}>
         {files.length > 0 && (
           <UploadedFiles
@@ -523,105 +527,99 @@ function ChatInput({
           />
         )}
       </div>
-      <StyledChatInputContainer
-        className="stChatInput"
-        data-testid="stChatInput"
-        width={width}
-      >
-        <StyledChatInput>
-          {element.acceptFile !== "false" ? (
-            <>
-              <div {...getRootProps()}>
-                <input {...getInputProps()} />
-                <BaseButton
-                  kind={BaseButtonKind.BORDERLESS_ICON}
-                  onClick={() => {}}
-                  disabled={disabled}
-                >
-                  <Icon content={AttachFile} size="lg" color="inherit" />
-                </BaseButton>
-                {/* <button>+</button> */}
-              </div>
-              <span>|</span>
-            </>
-          ) : null}
-          <UITextArea
-            inputRef={chatInputRef}
-            value={value}
-            placeholder={placeholder}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            aria-label={placeholder}
-            disabled={disabled}
-            rows={1}
-            overrides={{
-              Root: {
-                style: {
-                  minHeight: theme.sizes.minElementHeight,
-                  outline: "none",
-                  backgroundColor: theme.colors.transparent,
-                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                  borderLeftWidth: theme.sizes.borderWidth,
-                  borderRightWidth: theme.sizes.borderWidth,
-                  borderTopWidth: theme.sizes.borderWidth,
-                  borderBottomWidth: theme.sizes.borderWidth,
-                  width: `${width}px`,
-                },
+      <StyledChatInput>
+        {element.acceptFile !== "false" ? (
+          <>
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <BaseButton
+                kind={BaseButtonKind.BORDERLESS_ICON}
+                onClick={() => {}}
+                disabled={disabled}
+              >
+                <Icon content={AttachFile} size="base" color="inherit" />
+              </BaseButton>
+            </div>
+            <StyledVerticalDivider />
+          </>
+        ) : null}
+        <UITextArea
+          inputRef={chatInputRef}
+          value={value}
+          placeholder={placeholder}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          aria-label={placeholder}
+          disabled={disabled}
+          rows={1}
+          overrides={{
+            Root: {
+              style: {
+                minHeight: theme.sizes.minElementHeight,
+                outline: "none",
+                backgroundColor: theme.colors.transparent,
+                // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                border: element.acceptFile ? "none" : theme.sizes.borderWidth,
+                borderLeftWidth: theme.sizes.borderWidth,
+                borderRightWidth: theme.sizes.borderWidth,
+                borderTopWidth: theme.sizes.borderWidth,
+                borderBottomWidth: theme.sizes.borderWidth,
+                // width: `${width}px`,
               },
-              InputContainer: {
-                style: {
-                  backgroundColor: theme.colors.transparent,
-                },
+            },
+            InputContainer: {
+              style: {
+                backgroundColor: theme.colors.transparent,
               },
-              Input: {
-                props: {
-                  "data-testid": "stChatInputTextArea",
-                },
-                style: {
-                  lineHeight: theme.lineHeights.inputWidget,
-                  backgroundColor: theme.colors.transparent,
-                  "::placeholder": {
-                    color: placeholderColor,
-                  },
-                  height: isInputExtended
-                    ? `${scrollHeight + ROUNDING_OFFSET}px`
-                    : "auto",
-                  maxHeight: maxHeight ? `${maxHeight}px` : "none",
-                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                  paddingRight: "3rem",
-                  paddingLeft: theme.spacing.sm,
-                  paddingBottom: theme.spacing.sm,
-                  paddingTop: theme.spacing.sm,
-                },
+            },
+            Input: {
+              props: {
+                "data-testid": "stChatInputTextArea",
               },
-            }}
-          />
-          {/* Hide the character limit in small widget sizes */}
-          {width > theme.breakpoints.hideWidgetDetails && (
-            <StyledInputInstructionsContainer>
-              <InputInstructions
-                dirty={dirty}
-                value={value}
-                maxLength={maxChars}
-                type="chat"
-                // Chat Input are not able to be used in forms
-                inForm={false}
-              />
-            </StyledInputInstructionsContainer>
-          )}
-          <StyledSendIconButtonContainer>
-            <StyledSendIconButton
-              onClick={handleSubmit}
-              disabled={!dirty || disabled}
-              extended={isInputExtended}
-              data-testid="stChatInputSubmitButton"
-            >
-              <Icon content={Send} size="xl" color="inherit" />
-            </StyledSendIconButton>
-          </StyledSendIconButtonContainer>
-        </StyledChatInput>
-      </StyledChatInputContainer>
-    </>
+              style: {
+                lineHeight: theme.lineHeights.inputWidget,
+                backgroundColor: theme.colors.transparent,
+                "::placeholder": {
+                  color: placeholderColor,
+                },
+                height: isInputExtended
+                  ? `${scrollHeight + ROUNDING_OFFSET}px`
+                  : "auto",
+                maxHeight: maxHeight ? `${maxHeight}px` : "none",
+                // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                paddingRight: "3rem",
+                paddingLeft: theme.spacing.sm,
+                paddingBottom: theme.spacing.sm,
+                paddingTop: theme.spacing.sm,
+              },
+            },
+          }}
+        />
+        {/* Hide the character limit in small widget sizes */}
+        {width > theme.breakpoints.hideWidgetDetails && (
+          <StyledInputInstructionsContainer>
+            <InputInstructions
+              dirty={dirty}
+              value={value}
+              maxLength={maxChars}
+              type="chat"
+              // Chat Input are not able to be used in forms
+              inForm={false}
+            />
+          </StyledInputInstructionsContainer>
+        )}
+        <StyledSendIconButtonContainer>
+          <StyledSendIconButton
+            onClick={handleSubmit}
+            disabled={!dirty || disabled}
+            extended={isInputExtended}
+            data-testid="stChatInputSubmitButton"
+          >
+            <Icon content={Send} size="xl" color="inherit" />
+          </StyledSendIconButton>
+        </StyledSendIconButtonContainer>
+      </StyledChatInput>
+    </StyledChatInputContainer>
   )
 }
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -403,6 +403,7 @@ function ChatInput({
       files.forEach(f => deleteFile(f.id))
     },
   })
+
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: dropHandler,
     multiple: element.acceptFile === "multiple",
@@ -423,6 +424,17 @@ function ChatInput({
 
     return scrollHeight
   }
+
+  const getTextAreaBorderStyle = (): React.CSSProperties =>
+    element.acceptFile
+      ? { border: "none" }
+      : {
+          // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+          borderLeftWidth: theme.sizes.borderWidth,
+          borderRightWidth: theme.sizes.borderWidth,
+          borderTopWidth: theme.sizes.borderWidth,
+          borderBottomWidth: theme.sizes.borderWidth,
+        }
 
   const handleSubmit = (): void => {
     // We want the chat input to always be in focus
@@ -558,13 +570,7 @@ function ChatInput({
                 minHeight: theme.sizes.minElementHeight,
                 outline: "none",
                 backgroundColor: theme.colors.transparent,
-                // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                border: element.acceptFile ? "none" : theme.sizes.borderWidth,
-                borderLeftWidth: theme.sizes.borderWidth,
-                borderRightWidth: theme.sizes.borderWidth,
-                borderTopWidth: theme.sizes.borderWidth,
-                borderBottomWidth: theme.sizes.borderWidth,
-                // width: `${width}px`,
+                ...getTextAreaBorderStyle(),
               },
             },
             InputContainer: {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -43,6 +43,9 @@ import { useDropzone } from "react-dropzone"
 import { FileRejection } from "react-dropzone"
 import zip from "lodash/zip"
 
+import BaseButton, {
+  BaseButtonKind,
+} from "@streamlit/lib/src/components/shared/BaseButton"
 import {
   StyledChatInput,
   StyledChatInputContainer,
@@ -68,6 +71,7 @@ import {
 } from "@streamlit/lib/src/proto"
 import { set } from "lodash"
 import UploadedFiles from "../FileUploader/UploadedFiles"
+import { AttachFile } from "@emotion-icons/material-outlined"
 
 export interface Props {
   disabled: boolean
@@ -506,12 +510,9 @@ function ChatInput({
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
 
+  console.log(width)
   return (
-    <StyledChatInputContainer
-      className="stChatInput"
-      data-testid="stChatInput"
-      width={width}
-    >
+    <>
       <div style={{ position: "absolute", bottom: "100%" }}>
         {files.length > 0 && (
           <UploadedFiles
@@ -522,90 +523,105 @@ function ChatInput({
           />
         )}
       </div>
-      <StyledChatInput>
-        {element.acceptFile !== "false" ? (
-          <div {...getRootProps()}>
-            <input {...getInputProps()} />
-            <button>+</button>
-          </div>
-        ) : null}
-
-        <UITextArea
-          inputRef={chatInputRef}
-          value={value}
-          placeholder={placeholder}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          aria-label={placeholder}
-          disabled={disabled}
-          rows={1}
-          overrides={{
-            Root: {
-              style: {
-                minHeight: theme.sizes.minElementHeight,
-                outline: "none",
-                backgroundColor: theme.colors.transparent,
-                // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                borderLeftWidth: theme.sizes.borderWidth,
-                borderRightWidth: theme.sizes.borderWidth,
-                borderTopWidth: theme.sizes.borderWidth,
-                borderBottomWidth: theme.sizes.borderWidth,
-                width: `${width}px`,
-              },
-            },
-            InputContainer: {
-              style: {
-                backgroundColor: theme.colors.transparent,
-              },
-            },
-            Input: {
-              props: {
-                "data-testid": "stChatInputTextArea",
-              },
-              style: {
-                lineHeight: theme.lineHeights.inputWidget,
-                backgroundColor: theme.colors.transparent,
-                "::placeholder": {
-                  color: placeholderColor,
+      <StyledChatInputContainer
+        className="stChatInput"
+        data-testid="stChatInput"
+        width={width}
+      >
+        <StyledChatInput>
+          {element.acceptFile !== "false" ? (
+            <>
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+                <BaseButton
+                  kind={BaseButtonKind.BORDERLESS_ICON}
+                  onClick={() => {}}
+                  disabled={disabled}
+                >
+                  <Icon content={AttachFile} size="lg" color="inherit" />
+                </BaseButton>
+                {/* <button>+</button> */}
+              </div>
+              <span>|</span>
+            </>
+          ) : null}
+          <UITextArea
+            inputRef={chatInputRef}
+            value={value}
+            placeholder={placeholder}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            aria-label={placeholder}
+            disabled={disabled}
+            rows={1}
+            overrides={{
+              Root: {
+                style: {
+                  minHeight: theme.sizes.minElementHeight,
+                  outline: "none",
+                  backgroundColor: theme.colors.transparent,
+                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                  borderLeftWidth: theme.sizes.borderWidth,
+                  borderRightWidth: theme.sizes.borderWidth,
+                  borderTopWidth: theme.sizes.borderWidth,
+                  borderBottomWidth: theme.sizes.borderWidth,
+                  width: `${width}px`,
                 },
-                height: isInputExtended
-                  ? `${scrollHeight + ROUNDING_OFFSET}px`
-                  : "auto",
-                maxHeight: maxHeight ? `${maxHeight}px` : "none",
-                // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                paddingRight: "3rem",
-                paddingLeft: theme.spacing.sm,
-                paddingBottom: theme.spacing.sm,
-                paddingTop: theme.spacing.sm,
               },
-            },
-          }}
-        />
-        {/* Hide the character limit in small widget sizes */}
-        {width > theme.breakpoints.hideWidgetDetails && (
-          <StyledInputInstructionsContainer>
-            <InputInstructions
-              dirty={dirty}
-              value={value}
-              maxLength={maxChars}
-              type="chat"
-              // Chat Input are not able to be used in forms
-              inForm={false}
-            />
-          </StyledInputInstructionsContainer>
-        )}
-        <StyledSendIconButtonContainer>
-          <StyledSendIconButton
-            onClick={handleSubmit}
-            disabled={!dirty || disabled}
-            extended={isInputExtended}
-            data-testid="stChatInputSubmitButton"
-          >
-            <Icon content={Send} size="xl" color="inherit" />
-          </StyledSendIconButton>
-        </StyledSendIconButtonContainer>
-      </StyledChatInput>
-    </StyledChatInputContainer>
+              InputContainer: {
+                style: {
+                  backgroundColor: theme.colors.transparent,
+                },
+              },
+              Input: {
+                props: {
+                  "data-testid": "stChatInputTextArea",
+                },
+                style: {
+                  lineHeight: theme.lineHeights.inputWidget,
+                  backgroundColor: theme.colors.transparent,
+                  "::placeholder": {
+                    color: placeholderColor,
+                  },
+                  height: isInputExtended
+                    ? `${scrollHeight + ROUNDING_OFFSET}px`
+                    : "auto",
+                  maxHeight: maxHeight ? `${maxHeight}px` : "none",
+                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                  paddingRight: "3rem",
+                  paddingLeft: theme.spacing.sm,
+                  paddingBottom: theme.spacing.sm,
+                  paddingTop: theme.spacing.sm,
+                },
+              },
+            }}
+          />
+          {/* Hide the character limit in small widget sizes */}
+          {width > theme.breakpoints.hideWidgetDetails && (
+            <StyledInputInstructionsContainer>
+              <InputInstructions
+                dirty={dirty}
+                value={value}
+                maxLength={maxChars}
+                type="chat"
+                // Chat Input are not able to be used in forms
+                inForm={false}
+              />
+            </StyledInputInstructionsContainer>
+          )}
+          <StyledSendIconButtonContainer>
+            <StyledSendIconButton
+              onClick={handleSubmit}
+              disabled={!dirty || disabled}
+              extended={isInputExtended}
+              data-testid="stChatInputSubmitButton"
+            >
+              <Icon content={Send} size="xl" color="inherit" />
+            </StyledSendIconButton>
+          </StyledSendIconButtonContainer>
+        </StyledChatInput>
+      </StyledChatInputContainer>
+    </>
   )
 }
 

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -40,6 +40,11 @@ export const StyledChatInput = styled.div(({ theme }) => {
     borderRadius: theme.radii.default,
     display: "flex",
     alignItems: "center",
+    border: `${theme.sizes.borderWidth} solid ${theme.colors.transparent}`,
+
+    ":focus-within": {
+      border: `${theme.sizes.borderWidth} solid ${theme.colors.primary}`,
+    },
   }
 })
 
@@ -106,3 +111,20 @@ export const StyledInputInstructionsContainer = styled.div({
   bottom: "0px",
   right: "3rem",
 })
+
+export interface StyledVerticalDividerProps {
+  color?: string
+}
+
+export const StyledVerticalDivider = styled.div<StyledVerticalDividerProps>(
+  ({ theme, color }) => {
+    return {
+      height: "1.125rem",
+      width: theme.sizes.borderWidth,
+      marginRight: theme.spacing.xs,
+      ...(color
+        ? { backgroundColor: color }
+        : { backgroundColor: theme.colors.fadedText20 }),
+    }
+  }
+)

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -40,10 +40,11 @@ export const StyledChatInput = styled.div(({ theme }) => {
     borderRadius: theme.radii.default,
     display: "flex",
     alignItems: "center",
-    border: `${theme.sizes.borderWidth} solid ${theme.colors.transparent}`,
+    border: `${theme.sizes.borderWidth} solid`,
+    borderColor: theme.colors.transparent,
 
     ":focus-within": {
-      border: `${theme.sizes.borderWidth} solid ${theme.colors.primary}`,
+      borderColor: theme.colors.primary,
     },
   }
 })
@@ -122,9 +123,7 @@ export const StyledVerticalDivider = styled.div<StyledVerticalDividerProps>(
       height: "1.125rem",
       width: theme.sizes.borderWidth,
       marginRight: theme.spacing.xs,
-      ...(color
-        ? { backgroundColor: color }
-        : { backgroundColor: theme.colors.fadedText20 }),
+      backgroundColor: color ?? theme.colors.fadedText20,
     }
   }
 )


### PR DESCRIPTION
## Describe your changes
[Figma](https://www.figma.com/design/sOLdImJt29L9YYrjlzGaaO/St.chat?node-id=1772-650&node-type=canvas&m=dev)
> Note: We're **not** changing the border radii to be rounded like on Figma, yet. Keeping the original set up for now.
* use attach_file icon
* fix text input border misalignment; test on text input only widget as well
* highlight entire chat input area instead of only textarea (which is the default behavior of [baseui textarea](https://baseweb.design/components/textarea/), so we need to [remove](https://github.com/streamlit/streamlit/pull/9543/files#diff-559594d48f19e6ea4c58bfa5cb445c7f4e4596c3865e7e88b7f0af13abf146eaR430) it) 
* margin/padding/gap polish

### Before
<img width="810" alt="image" src="https://github.com/user-attachments/assets/a7049191-0f57-4b68-a198-25d43c440c86">

### After
<img width="758" alt="image" src="https://github.com/user-attachments/assets/1e1b9111-e796-4971-9a89-c97be5617d88">


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
