### PR TITLE
[feat] Raise StreamlitAPIException if use_container_width and use_column_width are both given

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -162,6 +162,12 @@ class ImageMixin:
 
         """
 
+        if use_container_width is not None and use_column_width is not None:
+            raise StreamlitAPIException(
+                "`use_container_width` and `use_column_width` cannot be set at the same time.",
+                "Please utilize `use_container_width` since `use_column_width` is deprecated.",
+            )
+
         if use_column_width is not None:
             if use_column_width == "auto" or (
                 use_column_width is None and width is None

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -501,3 +501,15 @@ class ImageProtoTest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.imgs.width, image.WidthBehaviour.MIN_IMAGE_OR_CONTAINER)
+
+    def test_st_image_use_container_width_and_use_column_width(self):
+        """Test st.image with use_container_width and use_column_width."""
+        img = Image.new("RGB", (64, 64), color="red")
+
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.image(img, use_container_width=True, use_column_width=True)
+
+        self.assertTrue(
+            "`use_container_width` and `use_column_width` cannot be set at the same time."
+            in str(e.exception)
+        )


### PR DESCRIPTION
## Describe your changes

Note: In order to build this feature in smaller stages, this PR is to go into `bnisco/st_image_width-add_use_container_width`, which in turn leads to the overall feature branch of `bnisco/st_image_width`

- Adds an API exception if both use_container_width and use_column_width are given

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) ✅
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
