### PR TITLE
Revert "Allow array parameters in CLI (#9539)"

### DIFF
--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -179,8 +179,6 @@ class ConfigOption:
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
         self.sensitive = sensitive
-        # infer multiple values if the default value is a list or tuple
-        self.multiple = isinstance(default_val, (list, tuple))
 
         if self.replaced_by:
             self.deprecated = True

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -59,7 +59,6 @@ def _convert_config_option_to_click_option(
         "type": config_option.type,
         "option": option,
         "envvar": config_option.env_var,
-        "multiple": config_option.multiple,
     }
 
 
@@ -102,7 +101,6 @@ def configurator_options(func: F) -> F:
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
-            multiple=parsed_parameter["multiple"],
             **click_option_kwargs,
         )
         func = config_option(func)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -84,31 +84,13 @@ class ConfigTest(unittest.TestCase):
         )
 
         # Test that it works.
-        assert config_option.key == "_test.simpleParam"
-        assert config_option.section == "_test"
-        assert config_option.name == "simpleParam"
-        assert config_option.description == "Simple config option."
-        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
-        assert config_option.value == 12345
-        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
-        assert not config_option.multiple
-
-    def test_multiple_config_option(self):
-        """Test creating a multiple value config option."""
-        config_option = ConfigOption(
-            "_test.simpleParam",
-            description="Simple config option.",
-            default_val=[12345],
-        )
-
-        assert config_option.key == "_test.simpleParam"
-        assert config_option.section == "_test"
-        assert config_option.name == "simpleParam"
-        assert config_option.description == "Simple config option."
-        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
-        assert config_option.value == [12345]
-        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
-        assert config_option.multiple
+        self.assertEqual(config_option.key, "_test.simpleParam")
+        self.assertEqual(config_option.section, "_test")
+        self.assertEqual(config_option.name, "simpleParam")
+        self.assertEqual(config_option.description, "Simple config option.")
+        self.assertEqual(config_option.where_defined, ConfigOption.DEFAULT_DEFINITION)
+        self.assertEqual(config_option.value, 12345)
+        self.assertEqual(config_option.env_var, "STREAMLIT__TEST_SIMPLE_PARAM")
 
     def test_complex_config_option(self):
         """Test setting a complex (functional) config option."""
@@ -332,20 +314,6 @@ class ConfigTest(unittest.TestCase):
         )
 
         config._delete_option("_test.testDeleteOption")
-
-    def test_multiple_value_option(self):
-        option = config._create_option(
-            "_test.testMultipleValueOption",
-            description="This option tests multiple values for an option",
-            default_val=["Option 1", "Option 2"],
-        )
-
-        assert option.multiple
-        config.get_config_options(force_reparse=True)
-        assert config.get_option("_test.testMultipleValueOption") == [
-            "Option 1",
-            "Option 2",
-        ]
 
     def test_sections_order(self):
         sections = sorted(

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -175,41 +175,6 @@ class CliTest(unittest.TestCase):
         self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
         self.assertEqual(0, result.exit_code)
 
-    def test_run_command_with_multiple_secrets_path_single_value(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
-            result = self.runner.invoke(
-                cli, ["run", "file_name.py", "--secrets.files=secrets1.toml"]
-            )
-
-        streamlit.web.bootstrap.load_config_options.assert_called_once()
-        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
-        assert kwargs["flag_options"]["secrets_files"] == ("secrets1.toml",)
-        assert result.exit_code == 0
-
-    def test_run_command_with_multiple_secrets_path_multiple_value(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
-            result = self.runner.invoke(
-                cli,
-                [
-                    "run",
-                    "file_name.py",
-                    "--secrets.files=secrets1.toml",
-                    "--secrets.files=secrets2.toml",
-                ],
-            )
-
-        streamlit.web.bootstrap.load_config_options.assert_called_once()
-        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
-        assert kwargs["flag_options"]["secrets_files"] == (
-            "secrets1.toml",
-            "secrets2.toml",
-        )
-        assert result.exit_code == 0
-
     @parameterized.expand(["mapbox.token", "server.cookieSecret"])
     def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
         with patch("streamlit.url_util.is_url", return_value=False), patch(


### PR DESCRIPTION
This reverts commit f61a6b55401c8169be3e130a7f876fe8555c22c7.

## Describe your changes

Default Secrets behavior was broken. For release, let's focus on reverting this first.