### PR TITLE
Re-introduce "Allow array parameters in CLI"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ coverage/
 # Streamlit
 ########################################################################
 .streamlit/
+!e2e_playwright/.streamlit/
 lib/streamlit/static
 streamlit-storage
 

--- a/e2e_playwright/.streamlit/secrets.toml
+++ b/e2e_playwright/.streamlit/secrets.toml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 [fake]
-FAKE_CONFIG="value"
+FAKE_SECRET="value"

--- a/e2e_playwright/.streamlit/secrets.toml
+++ b/e2e_playwright/.streamlit/secrets.toml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 [fake]
-FAKE_CONFIG="alt-value"
+FAKE_CONFIG="value"

--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -37,8 +37,7 @@ lazy_loaded_modules = [
     "rich",
     "tenacity",
     # toml is automatically loaded if there is a secret.toml, config.toml or
-    # a local credentials.toml file.
-    "toml",
+    # a local credentials.toml file. So, we cannot test this here.
     "unittest",
     # Internal modules:
     "streamlit.emojis",

--- a/e2e_playwright/lazy_loaded_modules_test.py
+++ b/e2e_playwright/lazy_loaded_modules_test.py
@@ -20,6 +20,6 @@ from playwright.sync_api import Page, expect
 def test_lazy_loaded_modules_are_not_imported(app: Page):
     """Test that lazy loaded modules are not imported when the page is loaded."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(19)
+    expect(markdown_elements).to_have_count(18)
     for element in markdown_elements.all():
         expect(element).to_have_text(re.compile(r".*not loaded.*"))

--- a/e2e_playwright/st_secrets.py
+++ b/e2e_playwright/st_secrets.py
@@ -20,7 +20,7 @@ from streamlit import runtime
 
 if runtime.exists():
     original_option = st.get_option("secrets.files")
-    st.write("Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+    st.write("Secret: ", st.secrets["fake"]["FAKE_SECRET"])
 
     # We are hacking here, but we are setting the secrets file to a different file to determine if it works
     TEST_ASSETS_DIR: Final[str] = os.path.join(
@@ -31,16 +31,16 @@ if runtime.exists():
     st.set_option("secrets.files", [alt_secrets_file1])
     st.secrets._secrets = None
 
-    st.write("Alt Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+    st.write("Alt Secret: ", st.secrets["fake"]["FAKE_SECRET"])
     st.write("Alt Secret From File 2 visible: ", "other-fake" in st.secrets)
 
     st.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
     st.secrets._secrets = None
 
-    st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_CONFIG"])
+    st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_SECRET"])
     st.write(
         "Alt Secret From File 2 (Multiple): ",
-        st.secrets["other-fake"]["OTHER_FAKE_CONFIG"],
+        st.secrets["other-fake"]["OTHER_FAKE_SECRET"],
     )
 
     # Reset the secrets file to the original to avoid affecting other tests

--- a/e2e_playwright/st_secrets.py
+++ b/e2e_playwright/st_secrets.py
@@ -1,0 +1,45 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Final
+
+import streamlit as st
+
+original_option = st.get_option("secrets.files")
+st.write("Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+
+# We are hacking here, but we are setting the secrets file to a different file to determine if it works
+TEST_ASSETS_DIR: Final[str] = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "test_assets"
+)
+alt_secrets_file1 = os.path.join(TEST_ASSETS_DIR, "alt_secrets.toml")
+alt_secrets_file2 = os.path.join(TEST_ASSETS_DIR, "alt_secrets2.toml")
+st.set_option("secrets.files", [alt_secrets_file1])
+st.secrets._secrets = None
+
+st.write("Alt Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+st.write("Alt Secret From File 2 visible: ", "other-fake" in st.secrets)
+
+st.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
+st.secrets._secrets = None
+
+st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_CONFIG"])
+st.write(
+    "Alt Secret From File 2 (Multiple): ", st.secrets["other-fake"]["OTHER_FAKE_CONFIG"]
+)
+
+# Reset the secrets file to the original to avoid affecting other tests
+st.set_option("secrets.files", original_option)
+st.secrets._secrets = None

--- a/e2e_playwright/st_secrets.py
+++ b/e2e_playwright/st_secrets.py
@@ -16,30 +16,33 @@ import os
 from typing import Final
 
 import streamlit as st
+from streamlit import runtime
 
 original_option = st.get_option("secrets.files")
 st.write("Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
 
-# We are hacking here, but we are setting the secrets file to a different file to determine if it works
-TEST_ASSETS_DIR: Final[str] = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "test_assets"
-)
-alt_secrets_file1 = os.path.join(TEST_ASSETS_DIR, "alt_secrets.toml")
-alt_secrets_file2 = os.path.join(TEST_ASSETS_DIR, "alt_secrets2.toml")
-st.set_option("secrets.files", [alt_secrets_file1])
-st.secrets._secrets = None
+if runtime.exists():
+    # We are hacking here, but we are setting the secrets file to a different file to determine if it works
+    TEST_ASSETS_DIR: Final[str] = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_assets"
+    )
+    alt_secrets_file1 = os.path.join(TEST_ASSETS_DIR, "alt_secrets.toml")
+    alt_secrets_file2 = os.path.join(TEST_ASSETS_DIR, "alt_secrets2.toml")
+    st.set_option("secrets.files", [alt_secrets_file1])
+    st.secrets._secrets = None
 
-st.write("Alt Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
-st.write("Alt Secret From File 2 visible: ", "other-fake" in st.secrets)
+    st.write("Alt Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+    st.write("Alt Secret From File 2 visible: ", "other-fake" in st.secrets)
 
-st.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
-st.secrets._secrets = None
+    st.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
+    st.secrets._secrets = None
 
-st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_CONFIG"])
-st.write(
-    "Alt Secret From File 2 (Multiple): ", st.secrets["other-fake"]["OTHER_FAKE_CONFIG"]
-)
+    st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_CONFIG"])
+    st.write(
+        "Alt Secret From File 2 (Multiple): ",
+        st.secrets["other-fake"]["OTHER_FAKE_CONFIG"],
+    )
 
-# Reset the secrets file to the original to avoid affecting other tests
-st.set_option("secrets.files", original_option)
-st.secrets._secrets = None
+    # Reset the secrets file to the original to avoid affecting other tests
+    st.set_option("secrets.files", original_option)
+    st.secrets._secrets = None

--- a/e2e_playwright/st_secrets.py
+++ b/e2e_playwright/st_secrets.py
@@ -18,10 +18,10 @@ from typing import Final
 import streamlit as st
 from streamlit import runtime
 
-original_option = st.get_option("secrets.files")
-st.write("Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
-
 if runtime.exists():
+    original_option = st.get_option("secrets.files")
+    st.write("Secret: ", st.secrets["fake"]["FAKE_CONFIG"])
+
     # We are hacking here, but we are setting the secrets file to a different file to determine if it works
     TEST_ASSETS_DIR: Final[str] = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_assets"

--- a/e2e_playwright/st_secrets.py
+++ b/e2e_playwright/st_secrets.py
@@ -16,7 +16,7 @@ import os
 from typing import Final
 
 import streamlit as st
-from streamlit import runtime
+from streamlit import config, runtime
 
 if runtime.exists():
     original_option = st.get_option("secrets.files")
@@ -28,13 +28,13 @@ if runtime.exists():
     )
     alt_secrets_file1 = os.path.join(TEST_ASSETS_DIR, "alt_secrets.toml")
     alt_secrets_file2 = os.path.join(TEST_ASSETS_DIR, "alt_secrets2.toml")
-    st.set_option("secrets.files", [alt_secrets_file1])
+    config.set_option("secrets.files", [alt_secrets_file1])
     st.secrets._secrets = None
 
     st.write("Alt Secret: ", st.secrets["fake"]["FAKE_SECRET"])
     st.write("Alt Secret From File 2 visible: ", "other-fake" in st.secrets)
 
-    st.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
+    config.set_option("secrets.files", [alt_secrets_file1, alt_secrets_file2])
     st.secrets._secrets = None
 
     st.write("Alt Secret (Multiple): ", st.secrets["fake"]["FAKE_SECRET"])
@@ -44,5 +44,5 @@ if runtime.exists():
     )
 
     # Reset the secrets file to the original to avoid affecting other tests
-    st.set_option("secrets.files", original_option)
+    config.set_option("secrets.files", original_option)
     st.secrets._secrets = None

--- a/e2e_playwright/st_secrets_test.py
+++ b/e2e_playwright/st_secrets_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+
+def test_default_secrets_specified(app: Page):
+    """Test that secrets can be accessed from the default secrets file."""
+
+    expect(app.get_by_text("Secret: value")).to_be_attached()
+
+
+def test_alternative_secrets_specified(app: Page):
+    """Test that secrets can be accessed from a specific secrets file."""
+
+    expect(app.get_by_text("Alt Secret: alt-value")).to_be_attached()
+    expect(app.get_by_text("Alt Secret From File 2 visible: False")).to_be_attached()
+
+
+def test_multiple_alternative_secrets_specified(app: Page):
+    """Test that secrets can be accessed from multiple secrets file."""
+
+    expect(app.get_by_text("Alt Secret (Multiple): alt-value")).to_be_attached()
+    expect(
+        app.get_by_text("Alt Secret From File 2 (Multiple): other-alt-value")
+    ).to_be_attached()

--- a/e2e_playwright/test_assets/alt_secrets.toml
+++ b/e2e_playwright/test_assets/alt_secrets.toml
@@ -1,0 +1,2 @@
+[fake]
+FAKE_CONFIG="alt-value"

--- a/e2e_playwright/test_assets/alt_secrets.toml
+++ b/e2e_playwright/test_assets/alt_secrets.toml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 [fake]
-FAKE_CONFIG="alt-value"
+FAKE_SECRET="alt-value"

--- a/e2e_playwright/test_assets/alt_secrets2.toml
+++ b/e2e_playwright/test_assets/alt_secrets2.toml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 [other-fake]
-OTHER_FAKE_CONFIG="other-alt-value"
+OTHER_FAKE_SECRET="other-alt-value"

--- a/e2e_playwright/test_assets/alt_secrets2.toml
+++ b/e2e_playwright/test_assets/alt_secrets2.toml
@@ -1,2 +1,16 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [other-fake]
 OTHER_FAKE_CONFIG="other-alt-value"

--- a/e2e_playwright/test_assets/alt_secrets2.toml
+++ b/e2e_playwright/test_assets/alt_secrets2.toml
@@ -1,0 +1,2 @@
+[other-fake]
+OTHER_FAKE_CONFIG="other-alt-value"

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -129,7 +129,7 @@ def set_user_option(key: str, value: Any) -> None:
     except KeyError as ke:
         raise StreamlitAPIException(f"Unrecognized config option: {key}") from ke
     # Allow e2e tests to set any option
-    if opt.scriptable or get_option("global.e2eTest"):
+    if opt.scriptable:
         set_option(key, value)
         return
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -128,7 +128,8 @@ def set_user_option(key: str, value: Any) -> None:
         opt = _config_options_template[key]
     except KeyError as ke:
         raise StreamlitAPIException(f"Unrecognized config option: {key}") from ke
-    if opt.scriptable:
+    # Allow e2e tests to set any option
+    if opt.scriptable or get_option("global.e2eTest"):
         set_option(key, value)
         return
 

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -179,6 +179,8 @@ class ConfigOption:
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
         self.sensitive = sensitive
+        # infer multiple values if the default value is a list or tuple
+        self.multiple = isinstance(default_val, (list, tuple))
 
         if self.replaced_by:
             self.deprecated = True

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -270,10 +270,13 @@ def load_config_options(flag_options: dict[str, Any]) -> None:
         A dict of config options where the keys are the CLI flag version of the
         config option names.
     """
+    # We want to filter out two things: values that are None, and values that
+    # are empty tuples. The latter is a special case that indicates that the
+    # no values were provided, and the config should reset to the default
     options_from_flags = {
         name.replace("_", "."): val
         for name, val in flag_options.items()
-        if val is not None
+        if val is not None and val != ()
     }
 
     # Force a reparse of config files (if they exist). The result is cached

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -59,6 +59,7 @@ def _convert_config_option_to_click_option(
         "type": config_option.type,
         "option": option,
         "envvar": config_option.env_var,
+        "multiple": config_option.multiple,
     }
 
 
@@ -101,6 +102,7 @@ def configurator_options(func: F) -> F:
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
+            multiple=parsed_parameter["multiple"],
             **click_option_kwargs,
         )
         func = config_option(func)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -84,13 +84,31 @@ class ConfigTest(unittest.TestCase):
         )
 
         # Test that it works.
-        self.assertEqual(config_option.key, "_test.simpleParam")
-        self.assertEqual(config_option.section, "_test")
-        self.assertEqual(config_option.name, "simpleParam")
-        self.assertEqual(config_option.description, "Simple config option.")
-        self.assertEqual(config_option.where_defined, ConfigOption.DEFAULT_DEFINITION)
-        self.assertEqual(config_option.value, 12345)
-        self.assertEqual(config_option.env_var, "STREAMLIT__TEST_SIMPLE_PARAM")
+        assert config_option.key == "_test.simpleParam"
+        assert config_option.section == "_test"
+        assert config_option.name == "simpleParam"
+        assert config_option.description == "Simple config option."
+        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
+        assert config_option.value == 12345
+        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
+        assert not config_option.multiple
+
+    def test_multiple_config_option(self):
+        """Test creating a multiple value config option."""
+        config_option = ConfigOption(
+            "_test.simpleParam",
+            description="Simple config option.",
+            default_val=[12345],
+        )
+
+        assert config_option.key == "_test.simpleParam"
+        assert config_option.section == "_test"
+        assert config_option.name == "simpleParam"
+        assert config_option.description == "Simple config option."
+        assert config_option.where_defined == ConfigOption.DEFAULT_DEFINITION
+        assert config_option.value == [12345]
+        assert config_option.env_var == "STREAMLIT__TEST_SIMPLE_PARAM"
+        assert config_option.multiple
 
     def test_complex_config_option(self):
         """Test setting a complex (functional) config option."""
@@ -314,6 +332,20 @@ class ConfigTest(unittest.TestCase):
         )
 
         config._delete_option("_test.testDeleteOption")
+
+    def test_multiple_value_option(self):
+        option = config._create_option(
+            "_test.testMultipleValueOption",
+            description="This option tests multiple values for an option",
+            default_val=["Option 1", "Option 2"],
+        )
+
+        assert option.multiple
+        config.get_config_options(force_reparse=True)
+        assert config.get_option("_test.testMultipleValueOption") == [
+            "Option 1",
+            "Option 2",
+        ]
 
     def test_sections_order(self):
         sections = sorted(

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -175,6 +175,41 @@ class CliTest(unittest.TestCase):
         self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
         self.assertEqual(0, result.exit_code)
 
+    def test_run_command_with_multiple_secrets_path_single_value(self):
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
+            "streamlit.web.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+            result = self.runner.invoke(
+                cli, ["run", "file_name.py", "--secrets.files=secrets1.toml"]
+            )
+
+        streamlit.web.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
+        assert kwargs["flag_options"]["secrets_files"] == ("secrets1.toml",)
+        assert result.exit_code == 0
+
+    def test_run_command_with_multiple_secrets_path_multiple_value(self):
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
+            "streamlit.web.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+            result = self.runner.invoke(
+                cli,
+                [
+                    "run",
+                    "file_name.py",
+                    "--secrets.files=secrets1.toml",
+                    "--secrets.files=secrets2.toml",
+                ],
+            )
+
+        streamlit.web.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = streamlit.web.bootstrap.load_config_options.call_args
+        assert kwargs["flag_options"]["secrets_files"] == (
+            "secrets1.toml",
+            "secrets2.toml",
+        )
+        assert result.exit_code == 0
+
     @parameterized.expand(["mapbox.token", "server.cookieSecret"])
     def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
         with patch("streamlit.url_util.is_url", return_value=False), patch(


### PR DESCRIPTION
## Describe your changes

**Original Description**

Streamlit has two config options that support multiple values. It works with `config.toml`, but it does not work with the CLI arguments. This is because we are not leveraging Click's [multiple](https://click.palletsprojects.com/en/8.1.x/options/#multiple-options) parameter. This change allows us to specify it. We infer the multiple value if the default val is a list or tuple.

**Additional Changes**

I found out that we do not explicitly set defaults in click which is a little weird. We filter out `None` values which does not affect single values. However multiple values will get an empty tuple. We fix this by just filtering out empty tuples because it's already either the default, or there is no way to set it as an empty list.

Also added E2E tests. The biggest difference is that I included example secrets and I script out the options and reset them explicitly. It's a hack, but it makes things easier.

## Testing Plan

- Python Unit Tests updated
- E2E tests created.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
