### PR TITLE
Eliminate symlink requirement in component request handler

### DIFF
--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -51,7 +51,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         # follow symlinks to get an accurate normalized path
         component_root = os.path.realpath(component_root)
         filename = "/".join(parts[1:])
-        abspath = os.path.realpath(os.path.join(component_root, filename))
+        abspath = os.path.normpath(os.path.join(component_root, filename))
 
         # Do NOT expose anything outside of the component root.
         if os.path.commonpath([component_root, abspath]) != component_root:

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -135,25 +135,6 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(403, response.code)
         self.assertEqual(b"forbidden", response.body)
 
-    def test_symlink_outside_component_root_request(self):
-        """Tests to ensure a path symlinked to a file outside the component
-        root directory is disallowed."""
-
-        with mock.patch(MOCK_IS_DIR_PATH):
-            # We don't need the return value in this case.
-            declare_component("test", path=PATH)
-
-        with mock.patch(
-            "streamlit.web.server.component_request_handler.os.path.realpath",
-            side_effect=[PATH, "/etc/hosts"],
-        ):
-            response = self._request_component(
-                "tests.streamlit.web.server.component_request_handler_test.test"
-            )
-
-        self.assertEqual(403, response.code)
-        self.assertEqual(b"forbidden", response.body)
-
     def test_invalid_component_request(self):
         """Test request failure when invalid component name is provided."""
 


### PR DESCRIPTION
## Describe your changes

On first implementation, we were extra stringent and disallowed symlinks in the component path in order to determine whether a URL is valid. It turns out, it's not a strict requirement so long as the original path (once normalized) is still a valid path. Furthermore, use cases have appeared where build systems leverage symbolic links, so valid components are unable to work. So, we will remove this requirement.

## Testing Plan

- Removed the python test for symlinks, and kept the relative path test to cover the security issue.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
