### PR TITLE
[Fix] `st.navigation` reconciles `client.showSidebarNavigation` config

### DIFF
--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -229,8 +229,7 @@ export class StrategyV2 {
     const { sections, position, appPages } = navigationMsg
 
     this.appPages = appPages
-    this.hideSidebarNav =
-      position === Navigation.Position.HIDDEN || this.hideSidebarNav === true
+    this.hideSidebarNav = position === Navigation.Position.HIDDEN
 
     const currentPageScriptHash = navigationMsg.pageScriptHash
     const currentPage = appPages.find(

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import TypeAlias
 
+from streamlit import config
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.Navigation_pb2 import Navigation as NavigationProto
@@ -224,6 +225,8 @@ def navigation(
 
     msg = ForwardMsg()
     if position == "hidden":
+        msg.navigation.position = NavigationProto.Position.HIDDEN
+    elif config.get_option("client.showSidebarNavigation") is False:
         msg.navigation.position = NavigationProto.Position.HIDDEN
     else:
         msg.navigation.position = NavigationProto.Position.SIDEBAR

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -20,6 +20,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Navigation_pb2 import Navigation as NavigationProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.testutil import patch_config_options
 
 
 @patch("pathlib.Path.is_file", MagicMock(return_value=True))
@@ -132,6 +133,24 @@ class NavigationTest(DeltaGeneratorTestCase):
         st.navigation(
             [st.Page("page1.py"), st.Page("page2.py"), st.Page("page3.py")],
             position="hidden",
+        )
+
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 3
+        assert c.app_pages[0].section_header == ""
+        assert c.app_pages[1].section_header == ""
+        assert c.app_pages[2].section_header == ""
+        assert c.app_pages[0].is_default
+        assert not c.app_pages[1].is_default
+        assert not c.app_pages[2].is_default
+        assert c.position == NavigationProto.Position.HIDDEN
+        assert not c.expanded
+        assert c.sections == [""]
+
+    @patch_config_options({"client.showSidebarNavigation": False})
+    def test_navigation_message_with_sidebar_nav_config(self):
+        st.navigation(
+            [st.Page("page1.py"), st.Page("page2.py"), st.Page("page3.py")],
         )
 
         c = self.get_message_from_queue().navigation


### PR DESCRIPTION
## Describe your changes
Moves the reconciliation of the config.toml option `showSidebarNavigation` for MPAv2 to BE to avoid bug where multiple `st.navigation` calls are made.

## GitHub Issue Link (if applicable)
Closes #9581 

## Testing Plan
- Python Unit Test: Added ✅ 
- Manual Testing: ✅ 
