### PR TITLE
[chore] Replace `getByTestId` with `getByText` for Input tests

### DIFF
--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -76,7 +76,9 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByText("Press ⌘+Enter to apply3/3")).toBeVisible()
+      expect(screen.getByTestId("InputInstructions").textContent).toBe(
+        "Press ⌘+Enter to apply3/3"
+      )
     })
   })
 
@@ -86,7 +88,9 @@ describe("InputInstructions", () => {
     })
     render(<InputInstructions {...props} />)
 
-    expect(screen.getByText("Press Enter to apply3/3")).toBeVisible()
+    expect(screen.getByTestId("InputInstructions").textContent).toBe(
+      "Press Enter to apply3/3"
+    )
   })
 
   describe("Chat type", () => {

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -42,9 +42,7 @@ describe("InputInstructions", () => {
   it("should show Enter instructions by default", () => {
     render(<InputInstructions {...props} />)
 
-    expect(screen.getByTestId("InputInstructions").textContent).toBe(
-      "Press Enter to apply"
-    )
+    expect(screen.getByText("Press Enter to apply")).toBeVisible()
   })
 
   describe("Multiline type", () => {
@@ -54,9 +52,7 @@ describe("InputInstructions", () => {
 
     it("should show Ctrl+Enter instructions", () => {
       render(<InputInstructions {...props} />)
-      expect(screen.getByTestId("InputInstructions").textContent).toBe(
-        "Press Ctrl+Enter to apply"
-      )
+      expect(screen.getByText("Press Ctrl+Enter to apply")).toBeVisible()
     })
 
     it("show ⌘+Enter instructions", () => {
@@ -70,9 +66,7 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByTestId("InputInstructions").textContent).toBe(
-        "Press ⌘+Enter to apply"
-      )
+      expect(screen.getByText("Press ⌘+Enter to apply")).toBeVisible()
     })
 
     it("should show instructions for max length", () => {
@@ -82,9 +76,7 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByTestId("InputInstructions").textContent).toBe(
-        "Press ⌘+Enter to apply3/3"
-      )
+      expect(screen.getByText("Press ⌘+Enter to apply3/3")).toBeVisible()
     })
   })
 
@@ -94,9 +86,7 @@ describe("InputInstructions", () => {
     })
     render(<InputInstructions {...props} />)
 
-    expect(screen.getByTestId("InputInstructions").textContent).toBe(
-      "Press Enter to apply3/3"
-    )
+    expect(screen.getByText("Press Enter to apply3/3")).toBeVisible()
   })
 
   describe("Chat type", () => {
@@ -116,7 +106,7 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByTestId("InputInstructions").textContent).toBe("3/3")
+      expect(screen.getByText("3/3")).toBeVisible()
     })
   })
 
@@ -128,9 +118,7 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByTestId("InputInstructions").textContent).toBe(
-        "Press Enter to submit form"
-      )
+      expect(screen.getByText("Press Enter to submit form")).toBeVisible()
     })
 
     it("should show correct instructions to submit form with multiline input", () => {
@@ -140,9 +128,7 @@ describe("InputInstructions", () => {
       })
       render(<InputInstructions {...props} />)
 
-      expect(screen.getByTestId("InputInstructions").textContent).toBe(
-        "Press ⌘+Enter to submit form"
-      )
+      expect(screen.getByText("Press ⌘+Enter to submit form")).toBeVisible()
     })
 
     it("should not show enter instructions if allowEnterToSubmit is false", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -120,9 +120,7 @@ describe("NumberInput widget", () => {
     const props = getIntProps()
     render(<NumberInput {...props} />)
 
-    expect(screen.getByTestId("stWidgetLabel")).toHaveTextContent(
-      props.element.label
-    )
+    expect(screen.getByText(props.element.label)).toBeVisible()
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when hidden", () => {
@@ -214,9 +212,7 @@ describe("NumberInput widget", () => {
     await user.click(numberInput)
     await user.keyboard("{backspace}5")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press Enter to apply"
-    )
+    expect(screen.getByText("Press Enter to apply")).toBeVisible()
   })
 
   it("shows Input Instructions if in form that allows submit on enter", async () => {
@@ -231,9 +227,7 @@ describe("NumberInput widget", () => {
     await user.click(numberInput)
     await user.keyboard("{backspace}5")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press Enter to submit form"
-    )
+    expect(screen.getByText("Press Enter to submit form")).toBeVisible()
   })
 
   it("shows Input Instructions if focused again and in form that allows submit on enter", async () => {
@@ -432,9 +426,7 @@ describe("NumberInput widget", () => {
 
       // Check that the value is updated & state dirty
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(15)
-      expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-        "Press Enter to apply"
-      )
+      expect(screen.getByText("Press Enter to apply")).toBeVisible()
     })
 
     it("sets value on Enter", () => {
@@ -642,9 +634,7 @@ describe("NumberInput widget", () => {
       await user.click(numberInput)
       await user.keyboard("20")
 
-      expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-        "Press Enter to apply"
-      )
+      expect(screen.getByText("Press Enter to apply")).toBeVisible()
     })
   })
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -283,9 +283,7 @@ describe("TextArea widget", () => {
     await user.click(textArea)
     await user.keyboard("TEST")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press ⌘+Enter to apply"
-    )
+    expect(screen.getByText("Press ⌘+Enter to apply")).toBeVisible()
   })
 
   it("shows Input Instructions if in form that allows submit on enter", async () => {
@@ -300,9 +298,7 @@ describe("TextArea widget", () => {
     await user.click(textArea)
     await user.keyboard("TEST")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press ⌘+Enter to submit form"
-    )
+    expect(screen.getByText("Press ⌘+Enter to submit form")).toBeVisible()
   })
 
   // For this scenario https://github.com/streamlit/streamlit/issues/7079

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -333,9 +333,7 @@ describe("TextInput widget", () => {
     await user.click(textInput)
     await user.keyboard("TEST")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press Enter to apply"
-    )
+    expect(screen.getByText("Press Enter to apply")).toBeVisible()
   })
 
   it("shows Input Instructions if in form that allows submit on enter", async () => {
@@ -350,9 +348,7 @@ describe("TextInput widget", () => {
     await user.click(textInput)
     await user.keyboard("TEST")
 
-    expect(screen.getByTestId("InputInstructions")).toHaveTextContent(
-      "Press Enter to submit form"
-    )
+    expect(screen.getByText("Press Enter to submit form")).toBeVisible()
   })
 
   // For this scenario https://github.com/streamlit/streamlit/issues/7079


### PR DESCRIPTION
## Describe your changes
Quick follow-up for [this](https://github.com/streamlit/streamlit/pull/9576/files/6bf2ac1f6646f7beb484e7f0e8882c2c3c6dce30#r1784822145). Per the [RTL best practices](https://testing-library.com/docs/queries/about#priority), the `expect` statements changed in this PR could be covered by `getByText`.

#7079 

## Testing Plan

- [x] Unit Tests (JS)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
