### PR TITLE
Fix issue #9198: Add 🚫 icon for disconnected websocket

### DIFF
--- a/frontend/app/src/components/Sidebar/SidebarNav.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.tsx
@@ -24,6 +24,8 @@ import React, {
   useState,
 } from "react"
 
+import { DisabledIcon } from "./styled-components"
+
 import groupBy from "lodash/groupBy"
 // We import react-device-detect in this way so that tests can mock its
 // isMobile field sanely.
@@ -54,6 +56,7 @@ export interface Props {
   hasSidebarElements: boolean
   expandSidebarNav: boolean
   onPageChange: (pageName: string) => void
+  isConnected: boolean
 }
 
 // We make the sidebar nav collapsible when there are more than 12 pages.
@@ -223,7 +226,11 @@ const SidebarNav = ({
   return (
     <StyledSidebarNavContainer data-testid="stSidebarNav">
       <StyledSidebarNavItems data-testid="stSidebarNavItems">
-        {contents}
+        {isConnected ? (
+          contents
+        ) : (
+          <DisabledIcon>🚫</DisabledIcon>
+        )}
       </StyledSidebarNavItems>
       {shouldShowViewButton && (
         <StyledViewButton

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -37,12 +37,20 @@ const conditionalCustomColor = (
 
   return customTextColor ? customThemeColor : defaultThemeColor
 }
-
+ 
 export interface StyledSidebarProps {
   isCollapsed: boolean
   adjustTop: boolean
   sidebarWidth: string
 }
+
+export const DisabledIcon = styled.div(({ theme }) => ({
+  color: theme.colors.fadedText40,
+  cursor: "not-allowed",
+  "&:hover": {
+    color: theme.colors.danger,
+  },
+}));
 
 export const StyledSidebar = styled.section<StyledSidebarProps>(
   ({ theme, isCollapsed, adjustTop, sidebarWidth }) => {


### PR DESCRIPTION
## Describe your changes
Added a check for if the websocket is disconnected and if so, all the nav bar icons will be set to 🚫 to show the proper disabled icons. 
## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/9198
## Testing Plan
Manually testing the issue on the frontend and disconnecting the websocket to see if the navbar icons are shown correctly.

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Testswalgreens
- Any manual testing needed?

 The manual testing was all that is necessary since there are no logical changes in the code. The changes are only able to be seen on the frontend when the websocket is disconnected. 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
