### PR TITLE
Rename `SegmentMetricsManager`

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -65,7 +65,7 @@ import {
   SessionEvent,
   SessionStatus,
 } from "@streamlit/lib/src/proto"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import { ConnectionManager } from "@streamlit/app/src/connection/ConnectionManager"
 import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import {
@@ -175,20 +175,18 @@ jest.mock("@streamlit/lib/src/WidgetStateManager", () => {
   }
 })
 
-jest.mock("@streamlit/app/src/SegmentMetricsManager", () => {
-  const actualModule = jest.requireActual(
-    "@streamlit/app/src/SegmentMetricsManager"
-  )
+jest.mock("@streamlit/app/src/MetricsManager", () => {
+  const actualModule = jest.requireActual("@streamlit/app/src/MetricsManager")
 
   const MockedClass = jest.fn().mockImplementation((...props) => {
-    const metricsMgr = new actualModule.SegmentMetricsManager(...props)
+    const metricsMgr = new actualModule.MetricsManager(...props)
     jest.spyOn(metricsMgr, "enqueue")
     return metricsMgr
   })
 
   return {
     ...actualModule,
-    SegmentMetricsManager: MockedClass,
+    MetricsManager: MockedClass,
   }
 })
 
@@ -486,9 +484,7 @@ describe("App", () => {
   it("sends updateReport to our metrics manager", () => {
     renderApp(getProps())
 
-    const metricsManager = getStoredValue<SegmentMetricsManager>(
-      SegmentMetricsManager
-    )
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
 
     sendForwardMessage("newSession", NEW_SESSION_JSON)
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -119,7 +119,7 @@ import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import { SessionEventDispatcher } from "@streamlit/app/src/SessionEventDispatcher"
 import { UserSettings } from "@streamlit/app/src/components/StreamlitDialog/UserSettings"
 import { DefaultStreamlitEndpoints } from "@streamlit/app/src/connection/DefaultStreamlitEndpoints"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import { StyledApp } from "@streamlit/app/src/styled-components"
 import withScreencast, {
   ScreenCastHOC,
@@ -217,7 +217,7 @@ export class App extends PureComponent<Props, State> {
 
   private readonly sessionInfo = new SessionInfo()
 
-  private readonly metricsMgr = new SegmentMetricsManager(this.sessionInfo)
+  private readonly metricsMgr = new MetricsManager(this.sessionInfo)
 
   private readonly sessionEventDispatcher = new SessionEventDispatcher()
 

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -23,12 +23,10 @@ import {
   SessionInfo,
 } from "@streamlit/lib"
 
-import { SegmentMetricsManager } from "./SegmentMetricsManager"
+import { MetricsManager } from "./MetricsManager"
 
-const getSegmentMetricsManager = (
-  sessionInfo?: SessionInfo
-): SegmentMetricsManager => {
-  const mm = new SegmentMetricsManager(sessionInfo || mockSessionInfo())
+const getMetricsManager = (sessionInfo?: SessionInfo): MetricsManager => {
+  const mm = new MetricsManager(sessionInfo || mockSessionInfo())
   mm.track = jest.fn()
   mm.identify = jest.fn()
   return mm
@@ -39,7 +37,7 @@ afterEach(() => {
 })
 
 test("does not track while uninitialized", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
 
   mm.enqueue("ev1", { data1: 11 })
   mm.enqueue("ev2", { data2: 12 })
@@ -49,7 +47,7 @@ test("does not track while uninitialized", () => {
 })
 
 test("does not track when initialized with gatherUsageStats=false", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   mm.initialize({ gatherUsageStats: false })
 
   mm.enqueue("ev1", { data1: 11 })
@@ -60,14 +58,14 @@ test("does not track when initialized with gatherUsageStats=false", () => {
 })
 
 test("does not initialize Segment analytics when gatherUsageStats=false", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   expect(window.analytics).toBeUndefined()
   mm.initialize({ gatherUsageStats: false })
   expect(window.analytics).toBeUndefined()
 })
 
 test("initializes Segment analytics when gatherUsageStats=true", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   expect(window.analytics).toBeUndefined()
   mm.initialize({ gatherUsageStats: true })
   expect(window.analytics).toBeDefined()
@@ -78,7 +76,7 @@ test("initializes Segment analytics when gatherUsageStats=true", () => {
 
 test("enqueues events before initialization", () => {
   const sessionInfo = mockSessionInfo()
-  const mm = getSegmentMetricsManager(sessionInfo)
+  const mm = getMetricsManager(sessionInfo)
 
   mm.enqueue("ev1", { data1: 11 })
   mm.enqueue("ev2", { data2: 12 })
@@ -93,7 +91,7 @@ test("enqueues events before initialization", () => {
 
 test("enqueues events when disconnected, then sends them when connected again", () => {
   const sessionInfo = mockSessionInfo()
-  const mm = getSegmentMetricsManager(sessionInfo)
+  const mm = getMetricsManager(sessionInfo)
   mm.initialize({ gatherUsageStats: true })
 
   // "Disconnect" our SessionInfo. Enqueued events should not be tracked.
@@ -114,7 +112,7 @@ test("enqueues events when disconnected, then sends them when connected again", 
 })
 
 test("tracks events immediately after initialized", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   mm.initialize({ gatherUsageStats: true })
 
   expect(mm.track.mock.calls.length).toBe(0)
@@ -127,7 +125,7 @@ test("tracks events immediately after initialized", () => {
 })
 
 test("tracks host data when in an iFrame", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   mm.setMetadata({
     hostedAt: "S4A",
     k: "v",
@@ -146,7 +144,7 @@ test("tracks host data when in an iFrame", () => {
 
 test("tracks installation data", () => {
   const sessionInfo = mockSessionInfo()
-  const mm = getSegmentMetricsManager(sessionInfo)
+  const mm = getMetricsManager(sessionInfo)
   mm.initialize({ gatherUsageStats: true })
   mm.enqueue("ev1", { data1: 11 })
 
@@ -156,7 +154,7 @@ test("tracks installation data", () => {
 })
 
 test("ip address is overwritten", () => {
-  const mm = getSegmentMetricsManager()
+  const mm = getMetricsManager()
   mm.initialize({ gatherUsageStats: true })
 
   mm.enqueue("ev1", { data1: 11 })

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -41,7 +41,7 @@ export interface CustomComponentCounter {
   [name: string]: number
 }
 
-export class SegmentMetricsManager {
+export class MetricsManager {
   /** The app's SessionInfo instance. */
   private readonly sessionInfo: SessionInfo
 

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -20,7 +20,7 @@ import "@testing-library/jest-dom"
 import { screen, waitFor, within } from "@testing-library/react"
 
 import { Config, IMenuItem, mockSessionInfo, render } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import { getMenuStructure, openMenu } from "./mainMenuTestHelpers"
 import MainMenu, { Props } from "./MainMenu"
@@ -38,7 +38,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
   settingsCallback: jest.fn(),
   menuItems: {},
   developmentMode: true,
-  metricsMgr: new SegmentMetricsManager(mockSessionInfo()),
+  metricsMgr: new MetricsManager(mockSessionInfo()),
   toolbarMode: Config.ToolbarMode.AUTO,
   ...extend,
 })

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -33,7 +33,7 @@ import {
   PageConfig,
 } from "@streamlit/lib"
 import ScreenCastRecorder from "@streamlit/app/src/util/ScreenCastRecorder"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import {
   StyledCoreItem,
@@ -86,7 +86,7 @@ export interface Props {
 
   toolbarMode: Config.ToolbarMode
 
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 }
 
 const getOpenInWindowCallback = (url: string) => (): void => {
@@ -113,7 +113,7 @@ export interface SubMenuProps {
   menuItems: any[]
   closeMenu: () => void
   isDevMenu: boolean
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 }
 
 // BaseWeb provides a very basic list item (or option) for its dropdown
@@ -130,7 +130,7 @@ export interface SubMenuProps {
 //  * creating a forward ref to add properties to the DOM element.
 function buildMenuItemComponent(
   StyledMenuItemType: typeof StyledCoreItem | typeof StyledDevItem,
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 ): any {
   const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
     (

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -19,7 +19,7 @@ import React, { ReactElement, ReactNode, useCallback, useContext } from "react"
 import { StyledAction, StyledBody } from "baseui/card"
 
 import { BaseButton, BaseButtonKind, GitInfo, IGitInfo } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import {
   DialogType,
   PlainEventHandler,
@@ -78,7 +78,7 @@ export interface DeployDialogProps {
     onContinue?: () => void
   ) => void
   isDeployErrorModalOpen: boolean
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 }
 
 export function DeployDialog(props: DeployDialogProps): ReactElement {

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
@@ -27,7 +27,7 @@ import {
   lightTheme,
   mockSessionInfo,
 } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import { Props, SettingsDialog } from "./SettingsDialog"
 
@@ -53,7 +53,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
   developerMode: true,
   animateModal: true,
   openThemeCreator: jest.fn(),
-  metricsMgr: new SegmentMetricsManager(mockSessionInfo()),
+  metricsMgr: new MetricsManager(mockSessionInfo()),
   ...extend,
 })
 

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
@@ -32,7 +32,7 @@ import {
   ThemeConfig,
   UISelectbox,
 } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import {
   StyledButtonContainer,
@@ -54,7 +54,7 @@ export interface Props {
   developerMode: boolean
   openThemeCreator: () => void
   animateModal: boolean
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 }
 
 /**

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -20,7 +20,7 @@ import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
 
 import { mockSessionInfo, render } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import ToolbarActions, {
   ActionButton,
@@ -72,7 +72,7 @@ describe("ToolbarActions", () => {
       { key: "share", label: "Share" },
     ],
     sendMessageToHost: jest.fn(),
-    metricsMgr: new SegmentMetricsManager(mockSessionInfo()),
+    metricsMgr: new MetricsManager(mockSessionInfo()),
     ...extended,
   })
 

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -22,7 +22,7 @@ import {
   IGuestToHostMessage,
   IToolbarItem,
 } from "@streamlit/lib"
-import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 
 import {
   StyledActionButtonContainer,
@@ -63,7 +63,7 @@ export function ActionButton({
 export interface ToolbarActionsProps {
   sendMessageToHost: (message: IGuestToHostMessage) => void
   hostToolbarItems: IToolbarItem[]
-  metricsMgr: SegmentMetricsManager
+  metricsMgr: MetricsManager
 }
 
 function ToolbarActions({


### PR DESCRIPTION
## Describe your changes
Initial renaming of `SegmentMetricsManager` class, files, & imports to `MetricsManager` - setting stage for telemetry migration.

## Testing Plan
No new tests needed - just naming 😄 