### PR TITLE
Extend `host_config` endpoint with `metricsUrl` configuration

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2451,6 +2451,7 @@ describe("App", () => {
           disableFullscreenMode: false,
           enableCustomParentMessages: false,
           mapboxToken: "",
+          metricsUrl: "test.streamlit.io",
           ...options,
         })
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -427,6 +427,7 @@ export class App extends PureComponent<Props, State> {
           enableCustomParentMessages,
           mapboxToken,
           enforceDownloadInNewTab,
+          metricsUrl,
         } = response
 
         const appConfig: AppConfig = {
@@ -440,6 +441,8 @@ export class App extends PureComponent<Props, State> {
           enforceDownloadInNewTab,
         }
 
+        // Set the metrics configuration:
+        this.metricsMgr.setMetricsConfig(metricsUrl)
         // Set the allowed origins configuration for the host communication:
         this.hostCommunicationMgr.setAllowedOrigins(appConfig)
         // Set the streamlit-app specific config settings in AppContext:

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -51,7 +51,6 @@ global.fetch = jest.fn(() =>
 
 afterEach(() => {
   window.analytics = undefined
-  window.localStorage.clear()
 })
 
 test("does not track while uninitialized", () => {
@@ -75,10 +74,22 @@ describe("setMetricsConfig", () => {
     expect(mm.track.mock.calls.length).toBe(0)
   })
 
-  test("attempts to fetch default metrics config when none received", () => {
+  test("calls requestDefaultMetricsConfig when none received", () => {
     const mm = getMetricsManager(undefined, "")
 
     expect(mm.requestDefaultMetricsConfig.mock.calls.length).toBe(1)
+  })
+
+  test("attempts fetch when no metrics config received", () => {
+    // eslint-disable-next-line no-proto
+    const getItemSpy = jest.spyOn(window.localStorage.__proto__, "getItem")
+    const mm = getMetricsManager(undefined, "", false)
+
+    // Checks for cached config first
+    expect(getItemSpy).toBeCalledWith("stMetricsConfig")
+    // Fetches if no cached config
+    expect(fetch.mock.calls.length).toBe(1)
+    expect(fetch.mock.calls[0][0]).toEqual(DEFAULT_METRICS_CONFIG)
   })
 })
 

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -83,7 +83,7 @@ describe("setMetricsConfig", () => {
   test("attempts fetch when no metrics config received", () => {
     // eslint-disable-next-line no-proto
     const getItemSpy = jest.spyOn(window.localStorage.__proto__, "getItem")
-    const mm = getMetricsManager(undefined, "", false)
+    getMetricsManager(undefined, "", false)
 
     // Checks for cached config first
     expect(getItemSpy).toBeCalledWith("stMetricsConfig")

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -49,6 +49,11 @@ global.fetch = jest.fn(() =>
   })
 )
 
+// Mock AbortSignal, otherwise TypeError timeout is not a function
+global.AbortSignal = {
+  timeout: jest.fn(),
+}
+
 afterEach(() => {
   window.analytics = undefined
 })

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -68,19 +68,41 @@ test("does not track while uninitialized", () => {
   expect(mm.track.mock.calls.length).toBe(0)
 })
 
-describe("setMetricsConfig", () => {
-  test("does not track when metrics config set to off", () => {
-    const mm = getMetricsManager(undefined, "off")
+describe("initialize", () => {
+  test("does not track when initialized with gatherUsageStats=false", () => {
+    const mm = getMetricsManager()
+    mm.initialize({ gatherUsageStats: false })
 
     mm.enqueue("ev1", { data1: 11 })
     mm.enqueue("ev2", { data2: 12 })
     mm.enqueue("ev3", { data3: 13 })
 
     expect(mm.track.mock.calls.length).toBe(0)
+    expect(mm.actuallySendMetrics).toBe(false)
   })
 
-  test("calls requestDefaultMetricsConfig when none received", () => {
+  test("does not track when metrics config set to off", () => {
+    const mm = getMetricsManager(undefined, "off")
+    mm.initialize({ gatherUsageStats: true })
+
+    mm.enqueue("ev1", { data1: 11 })
+    mm.enqueue("ev2", { data2: 12 })
+    mm.enqueue("ev3", { data3: 13 })
+
+    expect(mm.track.mock.calls.length).toBe(0)
+    expect(mm.actuallySendMetrics).toBe(false)
+  })
+
+  test("does not call requestDefaultMetricsConfig when metrics config set", () => {
+    const mm = getMetricsManager()
+    mm.initialize({ gatherUsageStats: true })
+
+    expect(mm.requestDefaultMetricsConfig.mock.calls.length).toBe(0)
+  })
+
+  test("calls requestDefaultMetricsConfig when no metrics config received", () => {
     const mm = getMetricsManager(undefined, "")
+    mm.initialize({ gatherUsageStats: true })
 
     expect(mm.requestDefaultMetricsConfig.mock.calls.length).toBe(1)
   })
@@ -88,7 +110,8 @@ describe("setMetricsConfig", () => {
   test("attempts fetch when no metrics config received", () => {
     // eslint-disable-next-line no-proto
     const getItemSpy = jest.spyOn(window.localStorage.__proto__, "getItem")
-    getMetricsManager(undefined, "", false)
+    const mm = getMetricsManager(undefined, "", false)
+    mm.initialize({ gatherUsageStats: true })
 
     // Checks for cached config first
     expect(getItemSpy).toBeCalledWith("stMetricsConfig")
@@ -96,34 +119,23 @@ describe("setMetricsConfig", () => {
     expect(fetch.mock.calls.length).toBe(1)
     expect(fetch.mock.calls[0][0]).toEqual(DEFAULT_METRICS_CONFIG)
   })
-})
 
-test("does not track when initialized with gatherUsageStats=false", () => {
-  const mm = getMetricsManager()
-  mm.initialize({ gatherUsageStats: false })
+  test("does not initialize Segment analytics when gatherUsageStats=false", () => {
+    const mm = getMetricsManager()
+    expect(window.analytics).toBeUndefined()
+    mm.initialize({ gatherUsageStats: false })
+    expect(window.analytics).toBeUndefined()
+  })
 
-  mm.enqueue("ev1", { data1: 11 })
-  mm.enqueue("ev2", { data2: 12 })
-  mm.enqueue("ev3", { data3: 13 })
-
-  expect(mm.track.mock.calls.length).toBe(0)
-})
-
-test("does not initialize Segment analytics when gatherUsageStats=false", () => {
-  const mm = getMetricsManager()
-  expect(window.analytics).toBeUndefined()
-  mm.initialize({ gatherUsageStats: false })
-  expect(window.analytics).toBeUndefined()
-})
-
-test("initializes Segment analytics when gatherUsageStats=true", () => {
-  const mm = getMetricsManager()
-  expect(window.analytics).toBeUndefined()
-  mm.initialize({ gatherUsageStats: true })
-  expect(window.analytics).toBeDefined()
-  expect(window.analytics.invoked).toBe(true)
-  expect(window.analytics.methods).toHaveLength(20)
-  expect(window.analytics.load).toBeDefined()
+  test("initializes Segment analytics when gatherUsageStats=true", () => {
+    const mm = getMetricsManager()
+    expect(window.analytics).toBeUndefined()
+    mm.initialize({ gatherUsageStats: true })
+    expect(window.analytics).toBeDefined()
+    expect(window.analytics.invoked).toBe(true)
+    expect(window.analytics.methods).toHaveLength(20)
+    expect(window.analytics.load).toBeDefined()
+  })
 })
 
 test("enqueues events before initialization", () => {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -22,6 +22,7 @@ import {
   IS_DEV_ENV,
   localStorageAvailable,
   logAlways,
+  logError,
   SessionInfo,
 } from "@streamlit/lib"
 
@@ -146,9 +147,12 @@ export class MetricsManager {
       }
     }
 
-    const response = await fetch(DEFAULT_METRICS_CONFIG)
+    const response = await fetch(DEFAULT_METRICS_CONFIG, {
+      signal: AbortSignal.timeout(5000),
+    })
     if (!response.ok) {
-      throw new Error(`Failed to fetch metrics config: ${response.status}`)
+      this.metricsUrl = undefined
+      logError("Failed to fetch metrics config: ", response.status)
     } else {
       const data = await response.json()
       this.metricsUrl = data.url ?? undefined

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -125,9 +125,9 @@ export class MetricsManager {
   // Set metrics url if sent by the host_config, otherwise fallback to retrieving the default
   public setMetricsConfig = (metricsUrl = ""): void => {
     // Don't send metrics if explicitly set to "off"
-    if (metricsUrl === "off") return
-
-    if (metricsUrl) {
+    if (metricsUrl === "off") {
+      return
+    } else if (metricsUrl) {
       this.metricsUrl = metricsUrl
     } else {
       this.requestDefaultMetricsConfig()
@@ -151,12 +151,9 @@ export class MetricsManager {
       throw new Error(`Failed to fetch metrics config: ${response.status}`)
     } else {
       const data = await response.json()
-      const metricsUrl = data.url
-      if (metricsUrl) {
-        this.metricsUrl = metricsUrl
-        if (isLocalStoreAvailable) {
-          localStorage.setItem("stMetricsConfig", metricsUrl)
-        }
+      this.metricsUrl = data.url ?? undefined
+      if (isLocalStoreAvailable && this.metricsUrl) {
+        localStorage.setItem("stMetricsConfig", this.metricsUrl)
       }
     }
   }

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -96,6 +96,12 @@ export class MetricsManager {
       this.requestDefaultMetricsConfig()
     }
 
+    // If metricsUrl still undefined, deactivate metrics
+    if (!this.metricsUrl) {
+      logError("Undefined metrics config")
+      this.actuallySendMetrics = false
+    }
+
     if (this.actuallySendMetrics) {
       // Segment will not initialize if this is rendered with SSR
       initializeSegment()

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -136,7 +136,9 @@ export class MetricsManager {
 
   // Fallback - Checks if cached in localStorage, otherwise fetches the config from a default URL
   private async requestDefaultMetricsConfig(): Promise<any> {
-    if (localStorageAvailable()) {
+    const isLocalStoreAvailable = localStorageAvailable()
+
+    if (isLocalStoreAvailable) {
       const cachedConfig = localStorage.getItem("stMetricsConfig")
       if (cachedConfig) {
         this.metricsUrl = cachedConfig
@@ -152,7 +154,7 @@ export class MetricsManager {
       const metricsUrl = data.url
       if (metricsUrl) {
         this.metricsUrl = metricsUrl
-        if (localStorageAvailable()) {
+        if (isLocalStoreAvailable) {
           localStorage.setItem("stMetricsConfig", metricsUrl)
         }
       }

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -181,7 +181,7 @@ export class MetricsManager {
     // for all of them.
     if (IS_DEV_ENV) {
       logAlways("[Dev mode] Not tracking stat datapoint: ", evName, data)
-    } else if (this.metricsUrl) {
+    } else {
       this.track(evName, data, {
         context: {
           // Segment automatically attaches the IP address. But we don't use, process,

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -221,9 +221,16 @@ export type AppConfig = {
   enableCustomParentMessages?: boolean
 }
 
+export type MetricsConfig = {
+  /**
+   * URL to send metrics data to.
+   */
+  metricsUrl?: string
+}
+
 /**
  * The response structure of the `_stcore/host-config` endpoint.
  * This combines streamlit-lib specific configuration options with
  * streamlit-app specific options (e.g. allowed message origins).
  */
-export type IHostConfigResponse = LibConfig & AppConfig
+export type IHostConfigResponse = LibConfig & AppConfig & MetricsConfig

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -223,9 +223,11 @@ export type AppConfig = {
 
 export type MetricsConfig = {
   /**
-   * URL to send metrics data to.
+   * URL to send metrics data to via POST request.
+   * Setting to "postMessage" sends metrics events via postMessage to host.
+   * Setting to "off" disables metrics collection.
    */
-  metricsUrl?: string
+  metricsUrl?: string | "postMessage" | "off"
 }
 
 /**

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -228,10 +228,10 @@ class HostConfigHandler(_SpecialRequestHandler):
             response_json = requests.get(
                 "https://data.streamlit.io/metrics.json", timeout=2
             ).json()
-            self._metrics_url = response_json["url"]
+            self._metrics_url = response_json.get("url", "")
         except Exception:
-            cli_util.print_to_cli("Failed to fetch metrics URL", fg="red")
             self._metrics_url = ""
+            cli_util.print_to_cli("Failed to fetch metrics URL", fg="red")
 
     async def get(self) -> None:
         self.write(

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 import os
 from typing import Final, Sequence
 
-import requests
 import tornado.web
 
-from streamlit import cli_util, config, file_util
+from streamlit import config, file_util
 from streamlit.logger import get_logger
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.web.server.server_util import emit_endpoint_deprecation_notice
@@ -223,16 +222,6 @@ class HostConfigHandler(_SpecialRequestHandler):
             # Allow messages from localhost in dev mode for testing of host <-> guest communication
             self._allowed_origins.append("http://localhost")
 
-        # Fetch the metrics URL
-        try:
-            response_json = requests.get(
-                "https://data.streamlit.io/metrics.json", timeout=2
-            ).json()
-            self._metrics_url = response_json.get("url", "")
-        except Exception:
-            self._metrics_url = ""
-            cli_util.print_to_cli("Failed to fetch metrics URL", fg="red")
-
     async def get(self) -> None:
         self.write(
             {
@@ -241,7 +230,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Default host configuration settings.
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
-                "metricsUrl": self._metrics_url,
+                "metricsUrl": "",
             }
         )
         self.set_status(200)

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -19,6 +19,7 @@ import os
 import tempfile
 from unittest.mock import MagicMock
 
+import requests
 import tornado.httpserver
 import tornado.testing
 import tornado.web
@@ -247,6 +248,10 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     @patch_config_options({"global.developmentMode": False})
     def test_allowed_message_origins(self):
+        metrics_response = requests.get(
+            "https://data.streamlit.io/metrics.json", timeout=2
+        ).json()
+        metrics_url = metrics_response["url"]
         response = self.fetch("/_stcore/host-config")
         response_body = json.loads(response.body)
         self.assertEqual(200, response.code)
@@ -257,6 +262,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 # Default host configuration settings:
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
+                "metricsUrl": metrics_url,
             },
             response_body,
         )

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -19,7 +19,6 @@ import os
 import tempfile
 from unittest.mock import MagicMock
 
-import requests
 import tornado.httpserver
 import tornado.testing
 import tornado.web
@@ -248,10 +247,6 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     @patch_config_options({"global.developmentMode": False})
     def test_allowed_message_origins(self):
-        metrics_response = requests.get(
-            "https://data.streamlit.io/metrics.json", timeout=2
-        ).json()
-        metrics_url = metrics_response["url"]
         response = self.fetch("/_stcore/host-config")
         response_body = json.loads(response.body)
         self.assertEqual(200, response.code)
@@ -262,7 +257,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 # Default host configuration settings:
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
-                "metricsUrl": metrics_url,
+                "metricsUrl": "",
             },
             response_body,
         )


### PR DESCRIPTION
## Describe your changes
**Metrics Migration Part 1**: This PR extends the `host_config` endpoint to add a `metricsUrl`, which will serve as the destination URL for metrics data.

`metricsUrl` for `host_config` endpoint will handle 4 options:
* **`"off"`**: Turns off metrics collection
* **`"<url>"`**: Sends metrics events to the passed URL
    * _The logic to build/send event with necessary fields will be added in a separate PR_
* **`"postMessage"`**: Sends metrics events via `postMessage` API
    *  _This logic will be added in a separate PR_
* **`" "`**: Default (OS) -  telemetry destination url will be fetched

Should no url be received from the BE, the FE will attempt to fetch the telemetry url from `data.streamlit.io/metrics.json`, caching it in localStorage if successful. If there is no `metricsUrl`, no telemetry is sent.

_**Note: Currently using a test Fivetran Webhook**_

## Testing Plan
- Python Unit Tests: Updated ✅ 
- JS Unit Tests:  ✅ 
- Manual Testing: ✅  