### PR TITLE
Expose the st.pills command again

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -15,7 +15,6 @@
 import time
 
 import streamlit as st
-from streamlit.elements.widgets.button_group import ButtonGroupMixin
 
 st.header("Pills - standard")
 
@@ -47,8 +46,7 @@ pills_options = [
     "📦 Collections of components",
     "📦 Very very long text" * 20,  # pill with very long text
 ]
-selection = ButtonGroupMixin._pills(
-    st._main,
+selection = st.pills(
     "Select some options",
     pills_options,
     key="pills",
@@ -66,8 +64,7 @@ option_to_icon_map = {
     2: ":material/zoom_out:",
     3: ":material/zoom_out_map:",
 }
-selection = ButtonGroupMixin._pills(
-    st._main,
+selection = st.pills(
     "Select a single option",
     options=[0, 1, 2, 3],
     format_func=lambda option: option_to_icon_map[option],
@@ -78,8 +75,7 @@ st.write(f"Single selection: {selection}")
 
 
 st.header("Pills - on_change callback")
-ButtonGroupMixin._pills(
-    st._main,
+st.pills(
     "Elements (label collapsed)",
     ["Water", "Fire", "Earth", "Air"],
     key="pills_on_change",
@@ -91,8 +87,7 @@ ButtonGroupMixin._pills(
 
 
 st.header("Pills - disabled")
-selection = ButtonGroupMixin._pills(
-    st._main,
+selection = st.pills(
     "Elements",
     ["Water", "Fire", "Earth", "Air"],
     key="pills_disabled",
@@ -103,8 +98,7 @@ st.write("pills-disabled:", str(selection))
 
 st.header("Pills in form")
 with st.form(key="my_form", clear_on_submit=True):
-    selection = ButtonGroupMixin._pills(
-        st._main,
+    selection = st.pills(
         "Elements  (label hidden)",
         ["Water", "Fire", "Earth", "Air"],
         key="pills_in_form",
@@ -124,8 +118,8 @@ st.header("Pills in fragment")
 
 @st.experimental_fragment()
 def test_fragment():
-    selection = ButtonGroupMixin._pills(
-        st._main, "Elements", ["Water", "Fire", "Earth", "Air"], key="pills_in_fragment"
+    selection = st.pills(
+        "Elements", ["Water", "Fire", "Earth", "Air"], key="pills_in_fragment"
     )
     st.write("pills-in-fragment:", str(selection))
 
@@ -141,8 +135,8 @@ if st.button("Create some elements to unmount component"):
         time.sleep(1)
         st.write("Another element")
 
-selection = ButtonGroupMixin._pills(
-    st._main, "Elements", ["Water", "Fire", "Earth", "Air"], key="pills_after_sleep"
+selection = st.pills(
+    "Elements", ["Water", "Fire", "Earth", "Air"], key="pills_after_sleep"
 )
 st.write("pills-after-sleep:", str(selection))
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -204,6 +204,7 @@ metric = _main.metric
 multiselect = _main.multiselect
 number_input = _main.number_input
 page_link = _main.page_link
+pills = _main.pills
 plotly_chart = _main.plotly_chart
 popover = _main.popover
 progress = _main.progress

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -388,7 +388,7 @@ class ButtonGroupMixin:
         return sentiment.value
 
     @gather_metrics("pills")
-    def _pills(
+    def pills(
         self,
         label: str,
         options: OptionSequence[V],

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -404,6 +404,130 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
     ) -> list[V] | V | None:
+        r"""Display a pills widget.
+
+        A pills widget is similar to a single- or multiselect widget where the passed
+        ``options`` are visually shown as pills-button.
+
+        Parameters
+        ----------
+        label : str
+            A short label explaining to the user what this widget is for.
+            The label can optionally contain GitHub-flavored Markdown of the
+            following types: Bold, Italics, Strikethroughs, Inline Code, and
+            Links.
+
+            Unsupported Markdown elements are unwrapped so only their children
+            (text contents) render. Display unsupported elements as literal
+            characters by backslash-escaping them. E.g.,
+            ``"1\. Not an ordered list"``.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            For accessibility reasons, you should never set an empty label (label="")
+            but hide it with label_visibility if needed. In the future, we may disallow
+            empty labels by raising an exception.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        selection_mode: "single" or "multiple"
+            The selection mode for the widget. If "single", only one option can be
+            selected. If "multiple", multiple options can be selected.
+
+        options: Iterable of V
+            Labels for the select options in an ``Iterable``. This can be a
+            ``list``, ``set``, or anything supported by ``st.dataframe``. If
+            ``options`` is dataframe-like, the first column will be used. Each
+            label will be cast to ``str`` internally by default.
+
+        default: Iterable of V, V, or None
+            List of default value or a single value. If the ``selection_mode``
+            is "single", only a single value is allowed to be passed.
+
+        format_func : function
+            Function to modify the display of the options. It receives
+            the raw option as an argument and should output the label to be
+            shown for that option. This has no impact on the return value of
+            the command.
+
+        key : str or int
+            An optional string or integer to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
+
+        help : str
+            An optional tooltip that gets displayed next to the multiselect.
+
+        on_change : callable
+            An optional callback invoked when this feedback widget's value
+            changes.
+
+        args : tuple
+            An optional tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
+
+        disabled : bool
+            An optional boolean, which disables the widget if set
+            to True. The default is False. This argument can only be supplied
+            by keyword.
+
+        label_visibility : "visible", "hidden", or "collapsed"
+            The visibility of the label. If "hidden", the label doesn't show but there
+            is still empty space for it above the widget (equivalent to label="").
+            If "collapsed", both the label and the space are removed. Default is
+            "visible".
+
+        Returns
+        -------
+        list of V or V or None
+            A list of selected options or an empty list if the ``selection_mode`` is
+            "multiple".
+            If the "selection_mode" is "single", the return value is the selected option
+            or None.
+
+        Examples
+        --------
+        Display a pills widget with multi select, and show the option:
+
+        >>> import streamlit as st
+        >>>
+        >>> options = ["one", "two", "three", "four", "five"]
+        >>> selection = st.pills(label="Numbered pills",
+                                options, selection_mode="multiple")
+        >>> st.markdown(f"You selected option: '{selection}'.")
+
+        .. output ::
+            TBD
+
+
+        Display a pills widget that renders icons-only:
+
+        >>> import streamlit as st
+        >>>
+        >>> option_to_icon_map = {
+        >>>     0: ":material/add:",
+        >>>     1: ":material/zoom_in:",
+        >>>     2: ":material/zoom_out:",
+        >>>     3: ":material/zoom_out_map:",
+        >>> }
+        >>> selection = st.pills(
+        >>>     "Icon-only pills",
+        >>>     options=option_to_icon_map.keys(),
+        >>>     format_func=lambda option: option_to_icon_map[option],
+        >>>     selection_mode="single",
+        >>> )
+        >>> st.write(f"Single selection: {selection}")
+
+        .. output ::
+            TBD
+
+        """
+
         maybe_raise_label_warnings(label, label_visibility)
 
         def _transformed_format_func(option: V) -> ButtonGroupProto.Option:

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -55,7 +55,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ),
     # checkboxes
     ("checkbox", lambda: st.checkbox("Check me")),
-    # ("pills", lambda: st.pills("Some pills", ["a", "b", "c"])),
+    ("pills", lambda: st.pills("Some pills", ["a", "b", "c"])),
     ("toggle", lambda: st.toggle("Toggle me")),
     # arrows
     ("data_editor", lambda: st.data_editor(pd.DataFrame())),
@@ -67,13 +67,13 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("camera_input", lambda: st.camera_input("Take a picture")),
     ("file_uploader", lambda: st.file_uploader("Upload me")),
     # selectors
+    ("feedback", lambda: st.feedback()),
     ("multiselect", lambda: st.multiselect("Show me", ["a", "b", "c"])),
     ("number_input", lambda: st.number_input("Enter a number")),
     ("radio", lambda: st.radio("Choose me", ["a", "b", "c"])),
     ("slider", lambda: st.slider("Slide me")),
     ("selectbox", lambda: st.selectbox("Select me", ["a", "b", "c"])),
     ("select_slider", lambda: st.select_slider("Select me", ["a", "b", "c"])),
-    ("feedback", lambda: st.feedback()),
     # text_widgets
     ("text_area", lambda: st.text_area("Write me")),
     ("text_input", lambda: st.text_input("Write me")),

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -218,9 +218,7 @@ def get_command_matrix(
     matrix = []
 
     commands: list[Callable[..., Any]] = [
-        lambda *args, **kwargs: ButtonGroupMixin._pills(
-            st._main, "label", *args, **kwargs
-        ),
+        lambda *args, **kwargs: st.pills("label", *args, **kwargs),
         lambda *args, **kwargs: ButtonGroupMixin._internal_button_group(
             st._main, *args, **kwargs
         ),
@@ -254,9 +252,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                 False,
             ),
             (
-                lambda *args, **kwargs: ButtonGroupMixin._pills(
-                    st._main, *args, **kwargs
-                ),
+                st.pills,
                 ("label", ["a", "b", "c"]),
                 {"help": "Test help param"},
                 ["a", "b", "c"],
@@ -327,13 +323,8 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (st.feedback, ("thumbs",)),
-            (ButtonGroupMixin._pills, (st._main, "label", ["a", "b", "c"])),
-            (
-                ButtonGroupMixin._pills,
-                (st._main, "label", ["a", "b", "c"]),
-                {"default": "b"},
-                "b",
-            ),
+            (st.pills, ("label", ["a", "b", "c"])),
+            (st.pills, ("label", ["a", "b", "c"]), {"default": "b"}, "b"),
             (
                 lambda *args, **kwargs: ButtonGroupMixin._internal_button_group(
                     st._main, *args, **kwargs
@@ -343,8 +334,8 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                 "b",
             ),
             (
-                ButtonGroupMixin._pills,
-                (st._main, "label", ["a", "b", "c"]),
+                st.pills,
+                ("label", ["a", "b", "c"]),
                 {"default": "b", "selection_mode": "multiple"},
                 ["b"],
             ),
@@ -373,7 +364,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (st.feedback, ("thumbs",)),
-            (ButtonGroupMixin._pills, (st._main, "label", ["a", "b", "c"])),
+            (st.pills, ("label", ["a", "b", "c"])),
         ]
     )
     def test_disabled(self, command: Callable, command_args: tuple[Any, ...]):
@@ -593,7 +584,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (st.feedback, ("thumbs",)),
-            (ButtonGroupMixin._pills, (st._main, "label", ["a", "b", "c"])),
+            (st.pills, ("label", ["a", "b", "c"])),
         ]
     )
     def test_on_change_is_registered(

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -29,7 +29,6 @@ from streamlit.elements.lib.utils import (
     _compute_element_id,
     compute_and_register_element_id,
 )
-from streamlit.elements.widgets.button_group import ButtonGroupMixin
 from streamlit.proto.Common_pb2 import StringTriggerValue as StringTriggerValueProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.scriptrunner_utils.script_requests import _coalesce_widget_states
@@ -540,9 +539,7 @@ class ComputeElementIdTests(DeltaGeneratorTestCase):
                 disabled=False,
                 default=[],
                 click_mode=0,
-                style="": ButtonGroupMixin._pills(
-                    st._main, "some_label", options, disabled=disabled
-                ),
+                style="": st.pills("some_label", options, disabled=disabled),
                 "button_group",
             ),
             (st.multiselect, "multiselect"),

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -89,7 +89,7 @@ class StreamlitTest(unittest.TestCase):
     def test_get_option(self):
         """Test streamlit.get_option."""
         # This is set in lib/tests/conftest.py to False
-        self.assertEqual(False, st.get_option("browser.gatherUsageStats"))
+        self.assertFalse(st.get_option("browser.gatherUsageStats"))
 
     def test_matplotlib_uses_agg(self):
         """Test that Streamlit uses the 'Agg' backend for matplotlib."""


### PR DESCRIPTION
## Describe your changes

This reverts commit 568af05c7059c6782894ab1c29847e60f181949c and exposes the `st.pills` command again in our public API.

## GitHub Issue Link (if applicable)

## Testing Plan

- All tests were added in the https://github.com/streamlit/streamlit/pull/9283 PR, no new tests need to be added. The commands were just renamed to expose them publicly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
