### PR TITLE
[Fix] Clear fragment autoreruns when changing pages

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2802,6 +2802,59 @@ describe("App", () => {
       })
     })
 
+    it("clears fragment auto rerun intervals when page changes", async () => {
+      prepareHostCommunicationManager()
+
+      // autoRerun uses setInterval under-the-hood, so use fake timers
+      jest.useFakeTimers()
+      sendForwardMessage("autoRerun", {
+        interval: 1, // in seconds
+        fragmentId: "fragmentId",
+      })
+
+      // advance timer X times to trigger the interval-function
+      const times = 3
+      for (let i = 0; i < times; i++) {
+        jest.advanceTimersByTime(1000) // in milliseconds
+      }
+
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.sendMessage).toBeCalledTimes(times)
+      // ensure that all calls came from the autoRerun by checking the fragment id
+      for (let i = 0; i < times; i++) {
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[i][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            isAutoRerun: true,
+            fragmentId: "fragmentId",
+          })
+        )
+      }
+
+      // trigger a page change. we use a post message instead
+      // of triggering a pange change via a newSession message,
+      // because a new session also clears the autoRerun intervals
+      fireWindowPostMessage({
+        type: "REQUEST_PAGE_CHANGE",
+        pageScriptHash: "hash1",
+      })
+
+      for (let i = 0; i < times; i++) {
+        jest.advanceTimersByTime(1000) // in milliseconds
+      }
+
+      // make sure that no new messages were sent after switching the page
+      // despite advancing the timer. We could check whether clearInterval
+      // was called, but this check is more observing the behavior than checking
+      // the exact interals.
+      const oldCallCountPlusPageChangeRequest = times + 1
+      expect(connectionManager.sendMessage).toBeCalledTimes(
+        oldCallCountPlusPageChangeRequest
+      )
+    })
+
     it("shows hostMenuItems", async () => {
       // We need this to use the Main Menu Button
       // eslint-disable-next-line testing-library/render-result-naming-convention

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1020,7 +1020,6 @@ export class App extends PureComponent<Props, State> {
       appHash,
       pageLayouts,
       currentPageScriptHash: prevPageScriptHash,
-      autoReruns,
     } = this.state
     const {
       scriptRunId,
@@ -1033,10 +1032,7 @@ export class App extends PureComponent<Props, State> {
 
     if (!fragmentIdsThisRun.length) {
       // This is a normal rerun, remove all the auto reruns intervals
-      autoReruns.forEach((value: NodeJS.Timer) => {
-        clearInterval(value)
-      })
-      this.setState({ autoReruns: [] })
+      this.cleanupAutoReruns()
 
       const config = newSessionProto.config as Config
       const themeInput = newSessionProto.customTheme as CustomThemeConfig
@@ -1410,6 +1406,18 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
+   * Clear all auto reruns that were registered. This should be called whenever
+   * the content of the auto rerun function might not be valid anymore and could
+   * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
+   */
+  cleanupAutoReruns = (): void => {
+    this.state.autoReruns.forEach((value: NodeJS.Timer) => {
+      clearInterval(value)
+    })
+    this.setState({ autoReruns: [] })
+  }
+
+  /**
    * Reruns the script.
    *
    * @param alwaysRunOnSave a boolean. If true, UserSettings.runOnSave
@@ -1461,16 +1469,13 @@ export class App extends PureComponent<Props, State> {
   }
 
   onPageChange = (pageScriptHash: string): void => {
-    const { elements, mainScriptHash, autoReruns } = this.state
+    const { elements, mainScriptHash } = this.state
 
     // We are about to change the page, so clear all auto reruns
     // This also happens in handleNewSession, but it might be too late compared
     // to small interval values, which might trigger a rerun before the new
     // session message is processed
-    autoReruns.forEach((value: NodeJS.Timer) => {
-      clearInterval(value)
-    })
-    this.setState({ autoReruns: [] })
+    this.cleanupAutoReruns()
 
     // We want to keep widget states for widgets that are still active
     // from the common script

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1020,6 +1020,7 @@ export class App extends PureComponent<Props, State> {
       appHash,
       pageLayouts,
       currentPageScriptHash: prevPageScriptHash,
+      autoReruns,
     } = this.state
     const {
       scriptRunId,
@@ -1032,7 +1033,7 @@ export class App extends PureComponent<Props, State> {
 
     if (!fragmentIdsThisRun.length) {
       // This is a normal rerun, remove all the auto reruns intervals
-      this.state.autoReruns.forEach((value: NodeJS.Timer) => {
+      autoReruns.forEach((value: NodeJS.Timer) => {
         clearInterval(value)
       })
       this.setState({ autoReruns: [] })
@@ -1460,7 +1461,13 @@ export class App extends PureComponent<Props, State> {
   }
 
   onPageChange = (pageScriptHash: string): void => {
-    const { elements, mainScriptHash } = this.state
+    const { elements, mainScriptHash, autoReruns } = this.state
+
+    // We are about to change the page, so clear all auto reruns
+    autoReruns.forEach((value: NodeJS.Timer) => {
+      clearInterval(value)
+    })
+    this.setState({ autoReruns: [] })
 
     // We want to keep widget states for widgets that are still active
     // from the common script

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1464,6 +1464,9 @@ export class App extends PureComponent<Props, State> {
     const { elements, mainScriptHash, autoReruns } = this.state
 
     // We are about to change the page, so clear all auto reruns
+    // This also happens in handleNewSession, but it might be too late compared
+    // to small interval values, which might trigger a rerun before the new
+    // session message is processed
     autoReruns.forEach((value: NodeJS.Timer) => {
       clearInterval(value)
     })


### PR DESCRIPTION
## Describe your changes

When changing pages, the autoReruns might be cleared to late, leading to a `Bad ‘setIn’ index` issue (see https://discuss.streamlit.io/t/bad-setin-index-issue-with-using-fragments-that-do-not-render-anything-within-multipage-app/82675)
This PR clears the autoRerun interval `onPageChange` so that no updates happen anymore until the new session info arrived.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) ✅ 
  - Add JS unit test to ensure that the autoRerun interval is cleared
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
