### PR TITLE
Fix clear cached class method regression

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -174,7 +174,14 @@ class BoundCachedFunc:
         return f"<BoundCachedFunc: {self._cached_func._info.func} of {self._instance}>"
 
     def clear(self, *args, **kwargs):
-        self._cached_func.clear(self._instance, *args, **kwargs)
+        if args or kwargs:
+            # The instance is required as first parameter to allow
+            # args to be correctly resolved to the parameter names:
+            self._cached_func.clear(self._instance, *args, **kwargs)
+        else:
+            # if no args/kwargs are specified, we just want to clear the
+            # entire cache of this method:
+            self._cached_func.clear()
 
 
 class CachedFunc:

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -228,7 +228,7 @@ If you think this is actually a Streamlit bug, please
         foo.clear(1)
         assert foo(1) == 2
 
-    def test_cached_st_method_clear_args(self):
+    def test_cached_class_method_clear_args(self):
         self.x = 0
 
         class ExampleClass:
@@ -251,6 +251,26 @@ If you think this is actually a Streamlit bug, please
         # calling foo.clear(1) should clear the cache for the argument 1,
         # therefore calling foo(1) should return the new value 2
         example_instance.foo.clear(1)
+        assert example_instance.foo(1) == 2
+
+    def test_cached_class_method_clear(self):
+        self.x = 0
+
+        class ExampleClass:
+            @st.cache_data
+            def foo(_self, y):
+                self.x += y
+                return self.x
+
+        example_instance = ExampleClass()
+        # Calling method foo produces the side effect of incrementing self.x
+        # and returning it as the result.
+
+        # calling foo(1) should return 1
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear()
+        # calling foo.clear() should clear all cached values:
+        # So the call to foo() should return the new value 2
         assert example_instance.foo(1) == 2
 
 

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -253,6 +253,10 @@ If you think this is actually a Streamlit bug, please
         example_instance.foo.clear(1)
         assert example_instance.foo(1) == 2
 
+        # Try the same with a keyword argument:
+        example_instance.foo.clear(y=1)
+        assert example_instance.foo(1) == 3
+
     def test_cached_class_method_clear(self):
         self.x = 0
 

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -193,7 +193,7 @@ If you think this is actually a Streamlit bug, please
         foo.clear(1)
         assert foo(1) == 2
 
-    def test_cached_st_method_clear_args(self):
+    def test_cached_class_method_clear_args(self):
         self.x = 0
 
         class ExampleClass:
@@ -216,6 +216,26 @@ If you think this is actually a Streamlit bug, please
         # calling foo.clear(1) should clear the cache for the argument 1,
         # therefore calling foo(1) should return the new value 2
         example_instance.foo.clear(1)
+        assert example_instance.foo(1) == 2
+
+    def test_cached_class_method_clear(self):
+        self.x = 0
+
+        class ExampleClass:
+            @st.cache_resource()
+            def foo(_self, y):
+                self.x += y
+                return self.x
+
+        example_instance = ExampleClass()
+        # Calling method foo produces the side effect of incrementing self.x
+        # and returning it as the result.
+
+        # calling foo(1) should return 1
+        assert example_instance.foo(1) == 1
+        example_instance.foo.clear()
+        # calling foo.clear() should clear all cached values:
+        # So the call to foo() should return the new value 2
         assert example_instance.foo(1) == 2
 
 

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -218,6 +218,10 @@ If you think this is actually a Streamlit bug, please
         example_instance.foo.clear(1)
         assert example_instance.foo(1) == 2
 
+        # Try the same with a keyword argument:
+        example_instance.foo.clear(y=1)
+        assert example_instance.foo(1) == 3
+
     def test_cached_class_method_clear(self):
         self.x = 0
 


### PR DESCRIPTION
## Describe your changes

https://github.com/streamlit/streamlit/pull/9101 caused a small regression with clearing the full cache of a cached class method. This PR fixes it by only passing the self instance if the clear method actually has args or kwargs defined.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9633

## Testing Plan

- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
