### PR TITLE
Improve tests for AppNodes and Quiver

### DIFF
--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -15,8 +15,8 @@
  */
 
 import { Writer } from "protobufjs"
-import { vectorFromArray } from "apache-arrow"
 
+import { arrayFromVector } from "@streamlit/lib/src/test_util"
 import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
 
 import {
@@ -104,7 +104,7 @@ describe("ElementNode.quiverElement", () => {
     const node = arrowTable()
     const q = node.quiverElement
 
-    expect(q.index).toEqual([vectorFromArray(["i1", "i2"])])
+    expect(arrayFromVector(q.index)).toEqual([["i1", "i2"]])
     expect(q.columns).toEqual([["c1", "c2"]])
     expect(q.data.toArray().map(a => a?.toArray())).toEqual([
       ["foo", "1"],
@@ -137,7 +137,7 @@ describe("ElementNode.quiverElement", () => {
     const node = arrowDataFrame()
     const q = node.quiverElement
 
-    expect(q.index).toEqual([vectorFromArray(["i1", "i2"])])
+    expect(arrayFromVector(q.index)).toEqual([["i1", "i2"]])
     expect(q.columns).toEqual([["c1", "c2"]])
     expect(q.data.toArray().map(a => a?.toArray())).toEqual([
       ["foo", "1"],
@@ -209,7 +209,7 @@ describe("ElementNode.vegaLiteChartElement", () => {
     expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
 
     // data
-    expect(element.data?.index).toEqual([vectorFromArray(["i1", "i2"])])
+    expect(arrayFromVector(element.data?.index)).toEqual([["i1", "i2"]])
     expect(element.data?.columns).toEqual([["c1", "c2"]])
     expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
       ["foo", "1"],
@@ -277,8 +277,8 @@ describe("ElementNode.vegaLiteChartElement", () => {
     expect(element.datasets[0].name).toEqual(
       MOCK_VEGA_LITE_CHART.datasets[0].name
     )
-    expect(element.datasets[0].data.index).toEqual([
-      vectorFromArray(["i1", "i2"]),
+    expect(arrayFromVector(element.datasets[0].data.index)).toEqual([
+      ["i1", "i2"],
     ])
     expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
     expect(
@@ -366,7 +366,7 @@ describe("ElementNode.arrowAddRows", () => {
       const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_SCRIPT_RUN_ID)
       const q = newNode.quiverElement
 
-      expect(q.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+      expect(arrayFromVector(q.index)).toEqual([["i1", "i2", "i1", "i2"]])
       expect(q.columns).toEqual([["c1", "c2"]])
       expect(q.data.toArray().map(a => a?.toArray())).toEqual([
         ["foo", "1"],
@@ -413,7 +413,7 @@ describe("ElementNode.arrowAddRows", () => {
       const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_SCRIPT_RUN_ID)
       const q = newNode.quiverElement
 
-      expect(q.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+      expect(arrayFromVector(q.index)).toEqual([["i1", "i2", "i1", "i2"]])
       expect(q.columns).toEqual([["c1", "c2"]])
       expect(q.data.toArray().map(a => a?.toArray())).toEqual([
         ["foo", "1"],
@@ -481,8 +481,8 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_SCRIPT_RUN_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.datasets[0].data.index).toEqual([
-          vectorFromArray(["i1", "i2", "i1", "i2"]),
+        expect(arrayFromVector(element.datasets[0].data.index)).toEqual([
+          ["i1", "i2", "i1", "i2"],
         ])
         expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
         expect(
@@ -523,8 +523,8 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_SCRIPT_RUN_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.datasets[0].data.index).toEqual([
-          vectorFromArray(["i1", "i2", "i1", "i2"]),
+        expect(arrayFromVector(element.datasets[0].data.index)).toEqual([
+          ["i1", "i2", "i1", "i2"],
         ])
         expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
         expect(
@@ -563,8 +563,8 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_SCRIPT_RUN_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data?.index).toEqual([
-          vectorFromArray(["i1", "i2", "i1", "i2"]),
+        expect(arrayFromVector(element.data?.index)).toEqual([
+          ["i1", "i2", "i1", "i2"],
         ])
         expect(element.data?.columns).toEqual([["c1", "c2"]])
         expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
@@ -606,7 +606,7 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_SCRIPT_RUN_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data?.index).toEqual([vectorFromArray(["i1", "i2"])])
+        expect(arrayFromVector(element.data?.index)).toEqual([["i1", "i2"]])
         expect(element.data?.columns).toEqual([["c1", "c2"]])
         expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -640,7 +640,7 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_SCRIPT_RUN_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data?.index).toEqual([vectorFromArray(["i1", "i2"])])
+        expect(arrayFromVector(element.data?.index)).toEqual([["i1", "i2"]])
         expect(element.data?.columns).toEqual([["c1", "c2"]])
         expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -679,8 +679,8 @@ describe("ElementNode.arrowAddRows", () => {
         )
         const element = newNode.vegaLiteChartElement
 
-        expect(element.datasets[0].data.index).toEqual([
-          vectorFromArray(["i1", "i2", "i1", "i2"]),
+        expect(arrayFromVector(element.datasets[0].data.index)).toEqual([
+          ["i1", "i2", "i1", "i2"],
         ])
         expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
         expect(
@@ -722,8 +722,8 @@ describe("ElementNode.arrowAddRows", () => {
         )
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data?.index).toEqual([
-          vectorFromArray(["i1", "i2", "i1", "i2"]),
+        expect(arrayFromVector(element.data?.index)).toEqual([
+          ["i1", "i2", "i1", "i2"],
         ])
         expect(element.data?.columns).toEqual([["c1", "c2"]])
         expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
@@ -763,7 +763,7 @@ describe("ElementNode.arrowAddRows", () => {
         )
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data?.index).toEqual([vectorFromArray(["i1", "i2"])])
+        expect(arrayFromVector(element.data?.index)).toEqual([["i1", "i2"]])
         expect(element.data?.columns).toEqual([["c1", "c2"]])
         expect(element.data?.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -814,6 +814,11 @@ describe("AppRoot.empty", () => {
   })
 
   it("creates empty tree except for a skeleton", async () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: "",
+      },
+    }))
     const empty = AppRoot.empty(FAKE_SCRIPT_HASH)
 
     // The linter is misfiring here. We're not accessing a DOM node.
@@ -826,6 +831,11 @@ describe("AppRoot.empty", () => {
   })
 
   it("sets the main script hash and active script hash", () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: "",
+      },
+    }))
     const empty = AppRoot.empty(FAKE_SCRIPT_HASH)
 
     expect(empty.mainScriptHash).toBe(FAKE_SCRIPT_HASH)
@@ -899,6 +909,11 @@ describe("AppRoot.empty", () => {
   })
 
   it("passes logo to new Root if empty is called with logo", async () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: "",
+      },
+    }))
     const logo = LogoProto.create({
       image:
         "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",

--- a/frontend/lib/src/dataframes/Quiver.test.ts
+++ b/frontend/lib/src/dataframes/Quiver.test.ts
@@ -17,6 +17,7 @@
 import { Field, Utf8, vectorFromArray } from "apache-arrow"
 import cloneDeep from "lodash/cloneDeep"
 
+import { arrayFromVector } from "@streamlit/lib/src/test_util"
 import { IndexTypeName, Quiver } from "@streamlit/lib/src/dataframes/Quiver"
 import {
   CATEGORICAL,
@@ -664,7 +665,7 @@ describe("Quiver", () => {
         const mockElement = { data: CATEGORICAL }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([vectorFromArray(["i1", "i2"])])
+        expect(arrayFromVector(q.index)).toEqual([["i1", "i2"]])
         expect(q.columns).toEqual([["c1", "c2"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", BigInt(100)],
@@ -700,8 +701,8 @@ describe("Quiver", () => {
         const mockElement = { data: DATE }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([
-          vectorFromArray([978220800000, 1009756800000]),
+        expect(arrayFromVector(q.index)).toEqual([
+          [978220800000, 1009756800000],
         ])
         expect(q.columns).toEqual([
           ["2000-12-31 00:00:00", "2001-12-31 00:00:00"],
@@ -744,7 +745,7 @@ describe("Quiver", () => {
         const mockElement = { data: FLOAT64 }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([vectorFromArray([1.24, 2.35])])
+        expect(arrayFromVector(q.index)).toEqual([[1.24, 2.35]])
         expect(q.columns).toEqual([["1.24", "2.35"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           [1.2, 1.3],
@@ -777,7 +778,7 @@ describe("Quiver", () => {
         const mockElement = { data: INT64 }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([vectorFromArray([BigInt(1), BigInt(2)])])
+        expect(arrayFromVector(q.index)).toEqual([[BigInt(1), BigInt(2)]])
         expect(q.columns).toEqual([["1", "2"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           [BigInt(0), BigInt(1)],
@@ -952,7 +953,7 @@ describe("Quiver", () => {
         const mockElement = { data: RANGE }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([[0, 1]])
+        expect(arrayFromVector(q.index)).toEqual([[0, 1]])
         expect(q.columns).toEqual([["0", "1"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -991,7 +992,7 @@ describe("Quiver", () => {
         const mockElement = { data: UINT64 }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([vectorFromArray([BigInt(1), BigInt(2)])])
+        expect(arrayFromVector(q.index)).toEqual([[BigInt(1), BigInt(2)]])
         expect(q.columns).toEqual([["1", "2"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           [BigInt(1), BigInt(2)],
@@ -1024,7 +1025,7 @@ describe("Quiver", () => {
         const mockElement = { data: UNICODE }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([vectorFromArray(["i1", "i2"])])
+        expect(arrayFromVector(q.index)).toEqual([["i1", "i2"]])
         expect(q.columns).toEqual([["c1", "c2"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -1068,7 +1069,7 @@ describe("Quiver", () => {
           columns: 1,
         })
 
-        expect(q.index).toEqual([])
+        expect(arrayFromVector(q.index)).toEqual([])
         expect(q.columns).toEqual([])
         expect(q.data.toArray()).toEqual([])
         expect(q.types).toEqual({
@@ -1081,9 +1082,9 @@ describe("Quiver", () => {
         const mockElement = { data: MULTI }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([
-          vectorFromArray([BigInt(1), BigInt(2)]),
-          vectorFromArray(["red", "blue"]),
+        expect(arrayFromVector(q.index)).toEqual([
+          [BigInt(1), BigInt(2)],
+          ["red", "blue"],
         ])
         expect(q.columns).toEqual([
           ["1", "2"],
@@ -1133,7 +1134,7 @@ describe("Quiver", () => {
         }
         const q = new Quiver(mockElement)
 
-        expect(q.index).toEqual([[0, 1]])
+        expect(arrayFromVector(q.index)).toEqual([[0, 1]])
         expect(q.columns).toEqual([["0", "1"]])
         expect(q.data.toArray().map(a => a?.toArray())).toEqual([
           [BigInt(1), BigInt(2)],
@@ -1183,7 +1184,7 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+        expect(arrayFromVector(qq.index)).toEqual([["i1", "i2", "i1", "i2"]])
         expect(qq.columns).toEqual([["c1", "c2"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", BigInt(100)],
@@ -1223,10 +1224,8 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([
-          vectorFromArray([
-            978220800000, 1009756800000, 978220800000, 1009756800000,
-          ]),
+        expect(arrayFromVector(qq.index)).toEqual([
+          [978220800000, 1009756800000, 978220800000, 1009756800000],
         ])
         expect(qq.columns).toEqual([
           ["2000-12-31 00:00:00", "2001-12-31 00:00:00"],
@@ -1278,7 +1277,7 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([vectorFromArray([1.24, 2.35, 1.24, 2.35])])
+        expect(arrayFromVector(qq.index)).toEqual([[1.24, 2.35, 1.24, 2.35]])
         expect(qq.columns).toEqual([["1.24", "2.35"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
           [1.2, 1.3],
@@ -1315,8 +1314,8 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([
-          vectorFromArray([BigInt(1), BigInt(2), BigInt(1), BigInt(2)]),
+        expect(arrayFromVector(qq.index)).toEqual([
+          [BigInt(1), BigInt(2), BigInt(1), BigInt(2)],
         ])
         expect(qq.columns).toEqual([["1", "2"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
@@ -1512,7 +1511,7 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([[0, 1, 2, 3]])
+        expect(arrayFromVector(qq.index)).toEqual([[0, 1, 2, 3]])
         expect(qq.columns).toEqual([["0", "1"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -1555,8 +1554,8 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([
-          vectorFromArray([BigInt(1), BigInt(2), BigInt(1), BigInt(2)]),
+        expect(arrayFromVector(qq.index)).toEqual([
+          [BigInt(1), BigInt(2), BigInt(1), BigInt(2)],
         ])
         expect(qq.columns).toEqual([["1", "2"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
@@ -1594,7 +1593,7 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+        expect(arrayFromVector(qq.index)).toEqual([["i1", "i2", "i1", "i2"]])
         expect(qq.columns).toEqual([["c1", "c2"]])
         expect(qq.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -1642,9 +1641,9 @@ describe("Quiver", () => {
 
         const qq = q.addRows(q)
 
-        expect(qq.index).toEqual([
-          vectorFromArray([BigInt(1), BigInt(2), BigInt(1), BigInt(2)]),
-          vectorFromArray(["red", "blue", "red", "blue"]),
+        expect(arrayFromVector(qq.index)).toEqual([
+          [BigInt(1), BigInt(2), BigInt(1), BigInt(2)],
+          ["red", "blue", "red", "blue"],
         ])
         expect(qq.columns).toEqual([
           ["1", "2"],
@@ -1692,7 +1691,7 @@ describe("Quiver", () => {
 
         const q1q2 = q1.addRows(q2)
 
-        expect(q1q2.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+        expect(arrayFromVector(q1q2.index)).toEqual([["i1", "i2", "i1", "i2"]])
         expect(q1q2.columns).toEqual([["c1", "c2"]])
         expect(q1q2.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo", "1"],
@@ -1760,7 +1759,7 @@ describe("Quiver", () => {
 
         const q1q2 = q1.addRows(q2)
 
-        expect(q1q2.index).toEqual([vectorFromArray(["i1", "i2", "i1", "i2"])])
+        expect(arrayFromVector(q1q2.index)).toEqual([["i1", "i2", "i1", "i2"]])
         expect(q1q2.columns).toEqual([["c1"]])
         expect(q1q2.data.toArray().map(a => a?.toArray())).toEqual([
           ["foo"],

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -17,6 +17,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React, { ReactElement } from "react"
 
+import { Vector } from "apache-arrow"
 import {
   render as reactTestingLibraryRender,
   RenderOptions,
@@ -28,6 +29,7 @@ import ThemeProvider from "./components/core/ThemeProvider"
 import { baseTheme } from "./theme"
 import { mockTheme } from "./mocks/mockTheme"
 import { LibContext, LibContextProps } from "./components/core/LibContext"
+import { isNullOrUndefined } from "./util/utils"
 
 /**
  * Use react-testing-library to render a ReactElement. The element will be
@@ -95,4 +97,16 @@ export const customRenderLibContext = (
       </ThemeProvider>
     ),
   })
+}
+
+export function arrayFromVector(vector: any): any {
+  if (Array.isArray(vector)) {
+    return vector.map(arrayFromVector)
+  }
+
+  if (vector instanceof Vector) {
+    return Array.from(vector)
+  }
+
+  return vector
 }

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -29,7 +29,6 @@ import ThemeProvider from "./components/core/ThemeProvider"
 import { baseTheme } from "./theme"
 import { mockTheme } from "./mocks/mockTheme"
 import { LibContext, LibContextProps } from "./components/core/LibContext"
-import { isNullOrUndefined } from "./util/utils"
 
 /**
  * Use react-testing-library to render a ReactElement. The element will be


### PR DESCRIPTION
## Describe your changes

In the move of the Vite conversion, these tests failed because vitest has slightly more strict equality check Jest seems to worry about the contents (ie the elements) whereas Vitest will test all the keys of the object (since vectors aren't strict arrays). This change extracts vectors to be an array at the end (or nested arrays) and allow the equality measure to translate.

This change also mocks out some of the window location to be explicit.

## Testing Plan

- JS unit tests updated.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
