### PR TITLE
added server.FolderWatchList to cli + LocalSourcesWatcher

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -664,12 +664,17 @@ _create_section("server", "Settings for the Streamlit server")
 
 
 _create_option(
-    "server.customWatchPath",
+    "server.folderWatchList",
     description="""
-        Custom path to watch for changes.
+        List of folders to watch for changes.
+
+        By default, Streamlit watches for files in the current working directory.
+        Use this parameter to specify additional folders to watch.
+
+        Note: This is a list of absolute paths.
     """,
-    default_val=None,
-    type_=str,
+    default_val=[],
+    type_=list,
 )
 
 _create_option(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -674,7 +674,6 @@ _create_option(
         Note: This is a list of absolute paths.
     """,
     default_val=[],
-    type_=list,
 )
 
 _create_option(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -662,6 +662,16 @@ _create_option(
 
 _create_section("server", "Settings for the Streamlit server")
 
+
+_create_option(
+    "server.customWatchPath",
+    description="""
+        Custom path to watch for changes.
+    """,
+    default_val=None,
+    type_=str,
+)
+
 _create_option(
     "server.folderWatchBlacklist",
     description="""

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -105,9 +105,6 @@ class RuntimeConfig:
     # True if the command used to start Streamlit was `streamlit hello`.
     is_hello: bool = False
 
-    # Custom path to watch for changes.
-    custom_watch_path: str | None = None
-
     # TODO(vdonato): Eventually add a new fragment_storage_class field enabling the code
     # creating a new Streamlit Runtime to configure the FragmentStorage instances
     # created by each new AppSession. We choose not to do this for now to avoid adding

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -105,6 +105,9 @@ class RuntimeConfig:
     # True if the command used to start Streamlit was `streamlit hello`.
     is_hello: bool = False
 
+    # Custom path to watch for changes.
+    custom_watch_path: str | None = None
+
     # TODO(vdonato): Eventually add a new fragment_storage_class field enabling the code
     # creating a new Streamlit Runtime to configure the FragmentStorage instances
     # created by each new AppSession. We choose not to do this for now to avoid adding

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -82,6 +82,7 @@ class EventBasedPathWatcher:
         *,  # keyword-only arguments:
         glob_pattern: str | None = None,
         allow_nonexistent: bool = False,
+        custom_watch_path: str | None = None,
     ) -> None:
         """Constructor for EventBasedPathWatchers.
 
@@ -99,6 +100,8 @@ class EventBasedPathWatcher:
             If True, the watcher will not raise an exception if the path does
             not exist. This can be used to watch for the creation of a file or
             directory at a given path.
+        custom_watch_path : str or None
+
         """
         self._path = os.path.abspath(path)
         self._on_changed = on_changed
@@ -111,6 +114,17 @@ class EventBasedPathWatcher:
             allow_nonexistent=allow_nonexistent,
         )
         _LOGGER.debug("Watcher created for %s", self._path)
+
+        if custom_watch_path:
+            _LOGGER.debug("Watching custom path: %s", custom_watch_path)
+            custom_path = os.path.abspath(custom_watch_path)
+            path_watcher.watch_path(
+                custom_path,
+                on_changed,
+                glob_pattern=glob_pattern,
+                allow_nonexistent=allow_nonexistent,
+            )
+            _LOGGER.debug("Additional watcher created for %s", custom_path)
 
     def __repr__(self) -> str:
         return repr_(self)
@@ -147,6 +161,7 @@ class _MultiPathWatcher:
 
     def __init__(self) -> None:
         """Constructor."""
+        _LOGGER.debug("Initializing MultiPathWatcher")
         _MultiPathWatcher._singleton = self
 
         # Map of folder_to_watch -> _FolderEventHandler.

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -82,7 +82,6 @@ class EventBasedPathWatcher:
         *,  # keyword-only arguments:
         glob_pattern: str | None = None,
         allow_nonexistent: bool = False,
-        custom_watch_path: str | None = None,
     ) -> None:
         """Constructor for EventBasedPathWatchers.
 
@@ -114,17 +113,6 @@ class EventBasedPathWatcher:
             allow_nonexistent=allow_nonexistent,
         )
         _LOGGER.debug("Watcher created for %s", self._path)
-
-        if custom_watch_path:
-            _LOGGER.debug("Watching custom path: %s", custom_watch_path)
-            custom_path = os.path.abspath(custom_watch_path)
-            path_watcher.watch_path(
-                custom_path,
-                on_changed,
-                glob_pattern=glob_pattern,
-                allow_nonexistent=allow_nonexistent,
-            )
-            _LOGGER.debug("Additional watcher created for %s", custom_path)
 
     def __repr__(self) -> str:
         return repr_(self)

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -359,7 +359,12 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         abs_changed_path = os.path.abspath(changed_path)
 
+        # First check if the exact path is being watched
         changed_path_info = self._watched_paths.get(abs_changed_path, None)
+
+        # If the exact path isn't found, check if it's inside any watched directories
+        # This is necessary for the folder watching feature to detect changes to files
+        # within watched directories, not just the directories themselves
         for path, info in self._watched_paths.items():
             if (
                 os.path.isdir(path)
@@ -367,6 +372,8 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             ):
                 changed_path_info = info
                 break
+
+        # If we still haven't found a matching path, ignore this event
         if changed_path_info is None:
             _LOGGER.debug(
                 "Ignoring changed path %s.\nWatched_paths: %s",

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -361,6 +361,14 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         changed_path_info = self._watched_paths.get(abs_changed_path, None)
         if changed_path_info is None:
+            for path, info in self._watched_paths.items():
+                if (
+                    os.path.isdir(path)
+                    and os.path.commonpath([path, abs_changed_path]) == path
+                ):
+                    changed_path_info = info
+                    break
+        if changed_path_info is None:
             _LOGGER.debug(
                 "Ignoring changed path %s.\nWatched_paths: %s",
                 abs_changed_path,

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -99,8 +99,6 @@ class EventBasedPathWatcher:
             If True, the watcher will not raise an exception if the path does
             not exist. This can be used to watch for the creation of a file or
             directory at a given path.
-        custom_watch_path : str or None
-
         """
         self._path = os.path.abspath(path)
         self._on_changed = on_changed
@@ -149,7 +147,6 @@ class _MultiPathWatcher:
 
     def __init__(self) -> None:
         """Constructor."""
-        _LOGGER.debug("Initializing MultiPathWatcher")
         _MultiPathWatcher._singleton = self
 
         # Map of folder_to_watch -> _FolderEventHandler.

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -360,14 +360,13 @@ class _FolderEventHandler(events.FileSystemEventHandler):
         abs_changed_path = os.path.abspath(changed_path)
 
         changed_path_info = self._watched_paths.get(abs_changed_path, None)
-        if changed_path_info is None:
-            for path, info in self._watched_paths.items():
-                if (
-                    os.path.isdir(path)
-                    and os.path.commonpath([path, abs_changed_path]) == path
-                ):
-                    changed_path_info = info
-                    break
+        for path, info in self._watched_paths.items():
+            if (
+                os.path.isdir(path)
+                and os.path.commonpath([path, abs_changed_path]) == path
+            ):
+                changed_path_info = info
+                break
         if changed_path_info is None:
             _LOGGER.debug(
                 "Ignoring changed path %s.\nWatched_paths: %s",

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -25,6 +25,7 @@ from streamlit.watcher.folder_black_list import FolderBlackList
 from streamlit.watcher.path_watcher import (
     NoOpPathWatcher,
     get_default_path_watcher_class,
+    watch_dir,
 )
 
 if TYPE_CHECKING:
@@ -83,17 +84,17 @@ class LocalSourcesWatcher:
         # Add custom watch path if it exists
 
         for watch_folder in self._watch_folders:
+            # check if it is folder
+            if not os.path.isdir(watch_folder):
+                _LOGGER.warning("Watch folder is not a directory: %s", watch_folder)
+                continue
             _LOGGER.debug("Registering watch folder: %s", watch_folder)
-            if os.path.exists(watch_folder):
-                new_pages_paths.add(watch_folder)
-                if watch_folder not in self._watched_pages:
-                    self._register_watcher(
-                        watch_folder,
-                        module_name=None,
-                        is_directory=True,
-                    )
-            else:
-                _LOGGER.warning("Watch folder does not exist: %s", watch_folder)
+            if watch_folder not in self._watched_pages:
+                self._register_watcher(
+                    watch_folder,
+                    module_name=None,
+                    is_directory=True,
+                )
 
         for old_page_path in old_page_paths:
             # Only remove pages that are no longer valid files
@@ -108,8 +109,23 @@ class LocalSourcesWatcher:
     def register_file_change_callback(self, cb: Callable[[str], None]) -> None:
         self._on_file_changed.append(cb)
 
+    def on_dir_changed(self, filepath: str):
+        """
+        Callback for directory-level changes. Handles file changes within watched directories.
+        """
+        for watched_dir in self._watched_modules:
+            if (
+                os.path.isdir(watched_dir)
+                and os.path.commonpath([watched_dir, filepath]) == watched_dir
+            ):
+                _LOGGER.info("File changed in watched directory: %s", filepath)
+                for cb in self._on_file_changed:
+                    cb(filepath)
+                return
+        _LOGGER.debug("File not in any watched directory: %s", filepath)
+
     def on_file_changed(self, filepath):
-        _LOGGER.debug(f"File changed: {filepath}")
+        _LOGGER.debug("File changed: %s", filepath)
         if filepath not in self._watched_modules:
             _LOGGER.error("Received event for non-watched file: %s", filepath)
             return
@@ -150,19 +166,19 @@ class LocalSourcesWatcher:
 
         try:
             if is_directory:
-                for root, _, files in os.walk(filepath):
-                    for file in files:
-                        file_path = os.path.join(root, file)
-                        wm = WatchedModule(
-                            watcher=PathWatcher(file_path, self.on_file_changed),
-                            module_name=module_name,
-                        )
-                        self._watched_modules[file_path] = wm
+                # Watch the directory instead of individual files
+                watch_dir(filepath, self.on_dir_changed, glob_pattern="**/*")
+                wm = WatchedModule(
+                    watcher=None,
+                    module_name=module_name,
+                )
+                self._watched_modules[filepath] = wm
             else:
                 wm = WatchedModule(
                     watcher=PathWatcher(filepath, self.on_file_changed),
                     module_name=module_name,
                 )
+                self._watched_modules[filepath] = wm
         except PermissionError:
             # If you don't have permission to read this file, don't even add it
             # to watchers.

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -49,7 +49,7 @@ class LocalSourcesWatcher:
     def __init__(self, pages_manager: PagesManager):
         self._pages_manager = pages_manager
         self._main_script_path = os.path.abspath(self._pages_manager.main_script_path)
-        self._custom_watch_path = config.get_option("server.customWatchPath")
+        self._watch_folders = config.get_option("server.folderWatchList")
         self._script_folder = os.path.dirname(self._main_script_path)
         self._on_file_changed: list[Callable[[str], None]] = []
         self._is_closed = False
@@ -81,15 +81,19 @@ class LocalSourcesWatcher:
                 )
 
         # Add custom watch path if it exists
-        if self._custom_watch_path:
-            _LOGGER.debug(f"Registering custom watch path: {self._custom_watch_path}")
-            new_pages_paths.add(self._custom_watch_path)
-            if self._custom_watch_path not in self._watched_pages:
-                self._register_watcher(
-                    self._custom_watch_path,
-                    module_name=None,
-                    is_directory=True,
-                )
+
+        for watch_folder in self._watch_folders:
+            _LOGGER.debug("Registering watch folder: %s", watch_folder)
+            if os.path.exists(watch_folder):
+                new_pages_paths.add(watch_folder)
+                if watch_folder not in self._watched_pages:
+                    self._register_watcher(
+                        watch_folder,
+                        module_name=None,
+                        is_directory=True,
+                    )
+            else:
+                _LOGGER.warning("Watch folder does not exist: %s", watch_folder)
 
         for old_page_path in old_page_paths:
             # Only remove pages that are no longer valid files

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -49,6 +49,7 @@ class LocalSourcesWatcher:
     def __init__(self, pages_manager: PagesManager):
         self._pages_manager = pages_manager
         self._main_script_path = os.path.abspath(self._pages_manager.main_script_path)
+        self._custom_watch_path = config.get_option("server.customWatchPath")
         self._script_folder = os.path.dirname(self._main_script_path)
         self._on_file_changed: list[Callable[[str], None]] = []
         self._is_closed = False
@@ -79,6 +80,17 @@ class LocalSourcesWatcher:
                     module_name=None,
                 )
 
+        # Add custom watch path if it exists
+        if self._custom_watch_path:
+            _LOGGER.debug(f"Registering custom watch path: {self._custom_watch_path}")
+            new_pages_paths.add(self._custom_watch_path)
+            if self._custom_watch_path not in self._watched_pages:
+                self._register_watcher(
+                    self._custom_watch_path,
+                    module_name=None,
+                    is_directory=True,
+                )
+
         for old_page_path in old_page_paths:
             # Only remove pages that are no longer valid files
             if old_page_path not in new_pages_paths and not os.path.isfile(
@@ -93,6 +105,7 @@ class LocalSourcesWatcher:
         self._on_file_changed.append(cb)
 
     def on_file_changed(self, filepath):
+        _LOGGER.debug(f"File changed: {filepath}")
         if filepath not in self._watched_modules:
             _LOGGER.error("Received event for non-watched file: %s", filepath)
             return
@@ -123,7 +136,7 @@ class LocalSourcesWatcher:
         self._watched_pages = set()
         self._is_closed = True
 
-    def _register_watcher(self, filepath, module_name):
+    def _register_watcher(self, filepath, module_name, is_directory=False):
         global PathWatcher  # noqa: PLW0603
         if PathWatcher is None:
             PathWatcher = get_default_path_watcher_class()
@@ -132,10 +145,20 @@ class LocalSourcesWatcher:
             return
 
         try:
-            wm = WatchedModule(
-                watcher=PathWatcher(filepath, self.on_file_changed),
-                module_name=module_name,
-            )
+            if is_directory:
+                for root, _, files in os.walk(filepath):
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        wm = WatchedModule(
+                            watcher=PathWatcher(file_path, self.on_file_changed),
+                            module_name=module_name,
+                        )
+                        self._watched_modules[file_path] = wm
+            else:
+                wm = WatchedModule(
+                    watcher=PathWatcher(filepath, self.on_file_changed),
+                    module_name=module_name,
+                )
         except PermissionError:
             # If you don't have permission to read this file, don't even add it
             # to watchers.

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -159,12 +159,16 @@ class LocalSourcesWatcher:
             return
 
         try:
-            kwargs = {}
-            if is_directory:
-                kwargs["glob_pattern"] = "**/*"
+            # Instead of using **kwargs, explicitly pass the named parameters
+            glob_pattern = "**/*" if is_directory else None
 
             wm = WatchedModule(
-                watcher=PathWatcher(filepath, self.on_path_changed, **kwargs),
+                watcher=PathWatcher(
+                    filepath,
+                    self.on_path_changed,
+                    glob_pattern=glob_pattern,  # Pass as named parameter
+                    allow_nonexistent=False,
+                ),
                 module_name=module_name,
             )
             self._watched_modules[filepath] = wm

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -25,7 +25,6 @@ from streamlit.watcher.folder_black_list import FolderBlackList
 from streamlit.watcher.path_watcher import (
     NoOpPathWatcher,
     get_default_path_watcher_class,
-    watch_dir,
 )
 
 if TYPE_CHECKING:
@@ -52,7 +51,7 @@ class LocalSourcesWatcher:
         self._main_script_path = os.path.abspath(self._pages_manager.main_script_path)
         self._watch_folders = config.get_option("server.folderWatchList")
         self._script_folder = os.path.dirname(self._main_script_path)
-        self._on_file_changed: list[Callable[[str], None]] = []
+        self._on_path_changed: list[Callable[[str], None]] = []
         self._is_closed = False
         self._cached_sys_modules: set[str] = set()
 
@@ -107,27 +106,22 @@ class LocalSourcesWatcher:
         self._watched_pages = self._watched_pages.union(new_pages_paths)
 
     def register_file_change_callback(self, cb: Callable[[str], None]) -> None:
-        self._on_file_changed.append(cb)
+        self._on_path_changed.append(cb)
 
-    def on_dir_changed(self, filepath: str):
-        """
-        Callback for directory-level changes. Handles file changes within watched directories.
-        """
-        for watched_dir in self._watched_modules:
-            if (
-                os.path.isdir(watched_dir)
-                and os.path.commonpath([watched_dir, filepath]) == watched_dir
-            ):
-                _LOGGER.info("File changed in watched directory: %s", filepath)
-                for cb in self._on_file_changed:
-                    cb(filepath)
-                return
-        _LOGGER.debug("File not in any watched directory: %s", filepath)
-
-    def on_file_changed(self, filepath):
-        _LOGGER.debug("File changed: %s", filepath)
+    def on_path_changed(self, filepath):
+        _LOGGER.debug("Path changed: %s", filepath)
         if filepath not in self._watched_modules:
-            _LOGGER.error("Received event for non-watched file: %s", filepath)
+            # Check if this is a file in a watched directory
+            for watched_dir in self._watched_modules:
+                if (
+                    os.path.isdir(watched_dir)
+                    and os.path.commonpath([watched_dir, filepath]) == watched_dir
+                ):
+                    _LOGGER.info("File changed in watched directory: %s", filepath)
+                    for cb in self._on_path_changed:
+                        cb(filepath)
+                    return
+            _LOGGER.error("Received event for non-watched path: %s", filepath)
             return
 
         # Workaround:
@@ -146,7 +140,7 @@ class LocalSourcesWatcher:
             if wm.module_name is not None and wm.module_name in sys.modules:
                 del sys.modules[wm.module_name]
 
-        for cb in self._on_file_changed:
+        for cb in self._on_path_changed:
             cb(filepath)
 
     def close(self):
@@ -165,20 +159,15 @@ class LocalSourcesWatcher:
             return
 
         try:
+            kwargs = {}
             if is_directory:
-                # Watch the directory instead of individual files
-                watch_dir(filepath, self.on_dir_changed, glob_pattern="**/*")
-                wm = WatchedModule(
-                    watcher=None,
-                    module_name=module_name,
-                )
-                self._watched_modules[filepath] = wm
-            else:
-                wm = WatchedModule(
-                    watcher=PathWatcher(filepath, self.on_file_changed),
-                    module_name=module_name,
-                )
-                self._watched_modules[filepath] = wm
+                kwargs["glob_pattern"] = "**/*"
+
+            wm = WatchedModule(
+                watcher=PathWatcher(filepath, self.on_path_changed, **kwargs),
+                module_name=module_name,
+            )
+            self._watched_modules[filepath] = wm
         except PermissionError:
             # If you don't have permission to read this file, don't even add it
             # to watchers.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -525,6 +525,7 @@ class ConfigTest(unittest.TestCase):
                 "server.enableWebsocketCompression",
                 "server.enableXsrfProtection",
                 "server.fileWatcherType",
+                "server.folderWatchList",
                 "server.folderWatchBlacklist",
                 "server.headless",
                 "server.address",

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -487,30 +487,36 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     @patch("os.walk")
     @patch("os.path.isfile")
-    def test_custom_watch_path(self, mock_isfile, mock_walk, mock_path_watcher):
-        custom_watch_path = "/custom/watch/path"
-        config.set_option("server.customWatchPath", custom_watch_path)
+    @patch("os.path.exists")
+    def test_folder_watch_list(
+        self, mock_exists, mock_isfile, mock_walk, mock_path_watcher
+    ):
+        watch_folders = ["/watch/path1", "/watch/path2"]
+        config.set_option("server.folderWatchList", watch_folders)
 
+        mock_exists.return_value = True
         mock_isfile.return_value = True
         mock_walk.return_value = [
-            ("/custom/watch/path", [], ["file1.py", "file2.py"]),
+            ("/watch/path1", [], ["file1.py"]),
+            ("/watch/path2", [], ["file2.py"]),
         ]
 
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
-        # Check if the custom watch path was added to watched pages
-        self.assertIn(custom_watch_path, lsw._watched_pages)
+        # Check if watch folders were added to watched pages
+        for folder in watch_folders:
+            self.assertIn(folder, lsw._watched_pages)
 
-        # Check if PathWatcher was called for each file in the custom watch path
+        # Check if PathWatcher was called for each file in the watch folders
         expected_calls = [
-            call("/custom/watch/path/file1.py", lsw.on_file_changed),
-            call("/custom/watch/path/file2.py", lsw.on_file_changed),
+            call("/watch/path1/file1.py", lsw.on_file_changed),
+            call("/watch/path2/file2.py", lsw.on_file_changed),
         ]
         mock_path_watcher.assert_has_calls(expected_calls, any_order=True)
 
         # Clean up
-        config.set_option("server.customWatchPath", None)
+        config.set_option("server.folderWatchList", [])
 
 
 def test_get_module_paths_outputs_abs_paths():

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -496,14 +496,35 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
-        # Check that PathWatcher was called for each directory with the glob_pattern
-        expected_calls = []
-        for folder in watch_folders:
-            expected_calls.append(
-                call(folder, lsw.on_path_changed, glob_pattern="**/*")
-            )
+        # Check that PathWatcher was called for the main script and each directory
+        # with the glob_pattern
+        expected_calls = [
+            # Watcher for the main script file (always created)
+            call(
+                lsw._main_script_path,
+                lsw.on_path_changed,
+                glob_pattern=None,
+                allow_nonexistent=False,
+            ),
+            # Watchers for the specified folders
+            call(
+                "/watch/path1",
+                lsw.on_path_changed,
+                glob_pattern="**/*",
+                allow_nonexistent=False,
+            ),
+            call(
+                "/watch/path2",
+                lsw.on_path_changed,
+                glob_pattern="**/*",
+                allow_nonexistent=False,
+            ),
+        ]
 
-        mock_path_watcher.assert_has_calls(expected_calls, any_order=True)
+        # Check if all expected calls were made, regardless of order or extra calls
+        actual_calls = mock_path_watcher.call_args_list
+        self.assertIn(expected_calls[1], actual_calls)
+        self.assertIn(expected_calls[2], actual_calls)
 
         # Simulate file changes in watched directories
         test_file = "/watch/path1/test.txt"

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -484,36 +484,28 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         self.assertEqual(saved_filepath, SCRIPT_PATH)
 
+    @patch("streamlit.watcher.local_sources_watcher.watch_dir")
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    @patch("os.walk")
-    @patch("os.path.isfile")
-    @patch("os.path.exists")
-    def test_folder_watch_list(
-        self, mock_exists, mock_isfile, mock_walk, mock_path_watcher
-    ):
+    @patch("os.path.isdir")
+    def test_folder_watch_list(self, mock_isdir, mock_path_watcher, mock_watch_dir):
         watch_folders = ["/watch/path1", "/watch/path2"]
         config.set_option("server.folderWatchList", watch_folders)
 
-        mock_exists.return_value = True
-        mock_isfile.return_value = True
-        mock_walk.return_value = [
-            ("/watch/path1", [], ["file1.py"]),
-            ("/watch/path2", [], ["file2.py"]),
-        ]
+        mock_isdir.return_value = True
 
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
-        # Check if watch folders were added to watched pages
-        for folder in watch_folders:
-            self.assertIn(folder, lsw._watched_pages)
-
-        # Check if PathWatcher was called for each file in the watch folders
-        expected_calls = [
-            call("/watch/path1/file1.py", lsw.on_file_changed),
-            call("/watch/path2/file2.py", lsw.on_file_changed),
+        # Check that watch_dir was called for each directory
+        expected_watch_dir_calls = [
+            call(folder, lsw.on_dir_changed, glob_pattern="**/*")
+            for folder in watch_folders
         ]
-        mock_path_watcher.assert_has_calls(expected_calls, any_order=True)
+        mock_watch_dir.assert_has_calls(expected_watch_dir_calls, any_order=True)
+
+        # Simulate file changes in watched directories
+        test_file = "/watch/path1/test.txt"
+        lsw.on_dir_changed(test_file)
 
         # Clean up
         config.set_option("server.folderWatchList", [])

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -176,7 +176,8 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         fob.assert_called_once()  # Just __init__.py
 
-        patched_logger.warning.assert_called_once_with(
+        # Check that the warning was called with the expected message
+        patched_logger.warning.assert_any_call(
             "Examining the path of MisbehavedModule raised:",
             exc_info=True,
         )
@@ -199,7 +200,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             lsw.update_watched_modules()
 
             # Simulate a change to the child module
-            lsw.on_file_changed(NESTED_MODULE_CHILD_FILE)
+            lsw.on_path_changed(NESTED_MODULE_CHILD_FILE)
 
             # Assert that both the parent and child are unloaded, ready for reload
             self.assertNotIn("NESTED_MODULE_CHILD", sys.modules)
@@ -286,7 +287,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             lsw.update_watched_modules()
 
             # Simulate a change to the child module
-            lsw.on_file_changed(pkg_path)
+            lsw.on_path_changed(pkg_path)
 
             # Assert that both the parent and child are unloaded, ready for reload
             self.assertNotIn("pkg", sys.modules)
@@ -480,14 +481,13 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lsw.register_file_change_callback(callback)
 
         # Simulate a change to the report script
-        lsw.on_file_changed(SCRIPT_PATH)
+        lsw.on_path_changed(SCRIPT_PATH)
 
         self.assertEqual(saved_filepath, SCRIPT_PATH)
 
-    @patch("streamlit.watcher.local_sources_watcher.watch_dir")
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     @patch("os.path.isdir")
-    def test_folder_watch_list(self, mock_isdir, mock_path_watcher, mock_watch_dir):
+    def test_folder_watch_list(self, mock_isdir, mock_path_watcher):
         watch_folders = ["/watch/path1", "/watch/path2"]
         config.set_option("server.folderWatchList", watch_folders)
 
@@ -496,16 +496,18 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
-        # Check that watch_dir was called for each directory
-        expected_watch_dir_calls = [
-            call(folder, lsw.on_dir_changed, glob_pattern="**/*")
-            for folder in watch_folders
-        ]
-        mock_watch_dir.assert_has_calls(expected_watch_dir_calls, any_order=True)
+        # Check that PathWatcher was called for each directory with the glob_pattern
+        expected_calls = []
+        for folder in watch_folders:
+            expected_calls.append(
+                call(folder, lsw.on_path_changed, glob_pattern="**/*")
+            )
+
+        mock_path_watcher.assert_has_calls(expected_calls, any_order=True)
 
         # Simulate file changes in watched directories
         test_file = "/watch/path1/test.txt"
-        lsw.on_dir_changed(test_file)
+        lsw.on_path_changed(test_file)
 
         # Clean up
         config.set_option("server.folderWatchList", [])


### PR DESCRIPTION
## Describe your changes

This PR adds a new configuration option `server.folderWatchList` to allow users to specify a custom path to watch for file changes. Currently, Streamlit only supports watching the directory of the main script or excluding files via a blacklist, but this change provides the flexibility to monitor external directories or specific folders. Additionally, logic has been added to ensure the new path is recursively watched for file changes, and tests have been updated to cover this feature.

Note: This is my first time doing a PR to open source, so any feedback would be appreciated.

## GitHub Issue Link (if applicable)

Issue Number: #9655 

## Testing Plan

- Unit tests were added to `local_sources_watcher_test.py` to ensure the custom watch path feature behaves as expected.

### MANUAL TEST
`streamlit run app/hello.py --server.runOnSave=true --server.folderWatchList=<BASE_PATH>/test_folder --logger.level=debug`

```
...
...
├── app/
│   ├── hello.py
└── test_folder
    └── test_file.txt
```

**app/hello.py**
```app/hello.py
import streamlit as st

st.write("Hello, World!")

with open("test_folder_1/test_file.txt", "r") as f:
    st.write("test_folder_1/test_file.txt")
    st.write(f.read())

with open("test_folder_2/test_file.txt", "r") as f:
    st.write("test_folder_2/test_file.txt")
    st.write(f.read())
```

**.streamlit/config.toml**
```.streamlit/config.toml
[server]
folderWatchList = [
    "test_folder_1",
    "test_folder_2"
]
runOnSave = true
```

**Note**: the list of folders should be _absolute paths_ currently, thought this is a good first step and then we can add regex search or relative paths in another PR if possible, since smaller PR's are more manageable/




**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


