### PR TITLE
Add `MetricsEvent` proto & Fivetran infrastructure

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -74,6 +74,7 @@
     "@types/react-transition-group": "^4.4.5",
     "@types/styletron-engine-atomic": "^1.1.1",
     "@types/styletron-react": "^5.0.3",
+    "@types/ua-parser-js": "^0.7.39",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -52,7 +52,8 @@
     "sass": "^1.58.0",
     "styletron-engine-atomic": "^1.5.0",
     "styletron-react": "^6.1.0",
-    "typed-signals": "^2.5.0"
+    "typed-signals": "^2.5.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",
@@ -73,6 +74,7 @@
     "@types/react-transition-group": "^4.4.5",
     "@types/styletron-engine-atomic": "^1.1.1",
     "@types/styletron-react": "^5.0.3",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "axios-mock-adapter": "^1.21.2",

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -15,15 +15,19 @@
  */
 
 import pick from "lodash/pick"
+import { v4 as uuidv4 } from "uuid"
 
 import { initializeSegment } from "@streamlit/app/src/vendor/Segment"
 import {
   DeployedAppMetadata,
+  getCookie,
   IS_DEV_ENV,
   localStorageAvailable,
   logAlways,
   logError,
+  MetricsEvent,
   SessionInfo,
+  setCookie,
 } from "@streamlit/lib"
 
 // Default metrics config fetched when none provided by host config endpoint
@@ -63,6 +67,11 @@ export class MetricsManager {
   private metricsUrl: string | undefined = undefined
 
   /**
+   * The anonymous ID of the user.
+   */
+  private anonymousId = ""
+
+  /**
    * Queue of metrics events that were enqueued before this MetricsManager was
    * initialized.
    */
@@ -90,6 +99,7 @@ export class MetricsManager {
     this.initialized = true
     // Handle if the user or the host has disabled metrics
     this.actuallySendMetrics = gatherUsageStats && this.metricsUrl !== "off"
+    this.getAnonymousId()
 
     // Trigger fallback to fetch default metrics config if not provided by host
     if (this.actuallySendMetrics && !this.metricsUrl) {
@@ -207,12 +217,57 @@ export class MetricsManager {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  private track(
+  private async track(
     evName: string,
     data: Record<string, unknown>,
     context: Record<string, unknown>
-  ): void {
+  ): Promise<void> {
+    // Send the event to Segment
     analytics.track(evName, data, context)
+
+    // Send the event to the metrics URL
+    const eventJson = this.buildEventProto(evName, data).toJSON()
+
+    // @ts-expect-error - send func calls track & checks metricsUrl defined
+    const request = new Request(this.metricsUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(eventJson),
+    })
+    await fetch(request)
+  }
+
+  public setMetadata(metadata: DeployedAppMetadata): void {
+    this.metadata = metadata
+  }
+
+  // Helper to build the event proto
+  private buildEventProto(
+    evName: string,
+    data: Record<string, unknown>
+  ): MetricsEvent {
+    const eventProto = new MetricsEvent({
+      event: evName,
+      anonymousId: this.anonymousId,
+      ...this.getContextData(),
+      dev: IS_DEV_ENV,
+      isHello: this.sessionInfo.isHello,
+      ...this.getInstallationData(),
+      reportHash: this.appHash,
+      source: "browser",
+      streamlitVersion: this.sessionInfo.current.streamlitVersion,
+      ...this.getHostTrackingData(),
+    })
+
+    if (evName === "menuClick") {
+      eventProto.label = data.label as string
+    } else if (evName === "pageProfile") {
+      return new MetricsEvent({ ...eventProto, ...data })
+    }
+
+    return eventProto
   }
 
   // Get the installation IDs from the session
@@ -220,10 +275,6 @@ export class MetricsManager {
     return {
       machineIdV3: this.sessionInfo.current.installationIdV3,
     }
-  }
-
-  public setMetadata(metadata: DeployedAppMetadata): void {
-    this.metadata = metadata
   }
 
   // Use the tracking data injected by the host of the app if included.
@@ -239,5 +290,55 @@ export class MetricsManager {
       ])
     }
     return {}
+  }
+
+  // Get context data for events
+  private getContextData(): Record<string, unknown> {
+    return {
+      contextPageUrl: window.location.href,
+      contextPageTitle: document.title,
+      contextPagePath: window.location.pathname,
+      contextPageReferrer: document.referrer,
+      contextPageSearch: window.location.search,
+      contextLocale:
+        // @ts-expect-error
+        window.navigator.userLanguage || window.navigator.language,
+      contextUserAgent: window.navigator.userAgent,
+    }
+  }
+
+  /**
+   * Get/Create user's anonymous ID
+   * Checks if existing in cookie or localStorage, otherwise generates
+   * a new UUID and stores it in both.
+   */
+  private getAnonymousId(): void {
+    // If metrics disabled, anonymous ID unnecessary
+    if (!this.actuallySendMetrics) return
+
+    const isLocalStoreAvailable = localStorageAvailable()
+    const anonymousIdCookie = getCookie("ajs_anonymous_id")
+    const anonymousIdLocalStorage = isLocalStoreAvailable
+      ? localStorage.getItem("ajs_anonymous_id")
+      : null
+
+    const expiration = new Date()
+    expiration.setFullYear(new Date().getFullYear() + 1)
+
+    if (anonymousIdCookie) {
+      this.anonymousId = anonymousIdCookie
+      if (isLocalStoreAvailable) {
+        localStorage.setItem("ajs_anonymous_id", anonymousIdCookie)
+      }
+    } else if (anonymousIdLocalStorage) {
+      this.anonymousId = anonymousIdLocalStorage
+      setCookie("ajs_anonymous_id", anonymousIdLocalStorage, expiration)
+    } else {
+      this.anonymousId = uuidv4()
+      setCookie("ajs_anonymous_id", this.anonymousId, expiration)
+      if (isLocalStoreAvailable) {
+        localStorage.setItem("ajs_anonymous_id", this.anonymousId)
+      }
+    }
   }
 }

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -251,14 +251,14 @@ export class MetricsManager {
     const eventProto = new MetricsEvent({
       event: evName,
       anonymousId: this.anonymousId,
-      ...this.getContextData(),
-      dev: IS_DEV_ENV,
-      isHello: this.sessionInfo.isHello,
+      ...this.getHostTrackingData(),
       ...this.getInstallationData(),
       reportHash: this.appHash,
+      dev: IS_DEV_ENV,
       source: "browser",
       streamlitVersion: this.sessionInfo.current.streamlitVersion,
-      ...this.getHostTrackingData(),
+      isHello: this.sessionInfo.isHello,
+      ...this.getContextData(),
     })
 
     if (evName === "menuClick") {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -104,12 +104,12 @@ export class MetricsManager {
     // Trigger fallback to fetch default metrics config if not provided by host
     if (this.actuallySendMetrics && !this.metricsUrl) {
       this.requestDefaultMetricsConfig()
-    }
 
-    // If metricsUrl still undefined, deactivate metrics
-    if (!this.metricsUrl) {
-      logError("Undefined metrics config")
-      this.actuallySendMetrics = false
+      // If metricsUrl still undefined, deactivate metrics
+      if (!this.metricsUrl) {
+        logError("Undefined metrics config")
+        this.actuallySendMetrics = false
+      }
     }
 
     if (this.actuallySendMetrics) {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -300,9 +300,7 @@ export class MetricsManager {
       contextPagePath: window.location.pathname,
       contextPageReferrer: document.referrer,
       contextPageSearch: window.location.search,
-      contextLocale:
-        // @ts-expect-error
-        window.navigator.userLanguage || window.navigator.language,
+      contextLocale: window.navigator.language,
       contextUserAgent: window.navigator.userAgent,
     }
   }
@@ -316,10 +314,12 @@ export class MetricsManager {
     // If metrics disabled, anonymous ID unnecessary
     if (!this.actuallySendMetrics) return
 
+    const anonymousIdKey = "ajs_anonymous_id"
     const isLocalStoreAvailable = localStorageAvailable()
-    const anonymousIdCookie = getCookie("ajs_anonymous_id")
+
+    const anonymousIdCookie = getCookie(anonymousIdKey)
     const anonymousIdLocalStorage = isLocalStoreAvailable
-      ? localStorage.getItem("ajs_anonymous_id")
+      ? localStorage.getItem(anonymousIdKey)
       : null
 
     const expiration = new Date()
@@ -328,16 +328,16 @@ export class MetricsManager {
     if (anonymousIdCookie) {
       this.anonymousId = anonymousIdCookie
       if (isLocalStoreAvailable) {
-        localStorage.setItem("ajs_anonymous_id", anonymousIdCookie)
+        localStorage.setItem(anonymousIdKey, anonymousIdCookie)
       }
     } else if (anonymousIdLocalStorage) {
       this.anonymousId = anonymousIdLocalStorage
-      setCookie("ajs_anonymous_id", anonymousIdLocalStorage, expiration)
+      setCookie(anonymousIdKey, anonymousIdLocalStorage, expiration)
     } else {
       this.anonymousId = uuidv4()
-      setCookie("ajs_anonymous_id", this.anonymousId, expiration)
+      setCookie(anonymousIdKey, this.anonymousId, expiration)
       if (isLocalStoreAvailable) {
-        localStorage.setItem("ajs_anonymous_id", this.anonymousId)
+        localStorage.setItem(anonymousIdKey, this.anonymousId)
       }
     }
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1936,11 +1936,6 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
-
 "@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -1958,11 +1953,6 @@
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/sourcemap-codec@1.4.14":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.5.0"
@@ -4976,7 +4966,7 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.7:
+call-bind@^1.0.2, call-bind@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
   integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
@@ -8287,7 +8277,7 @@ get-canvas-context@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-canvas-context/-/get-canvas-context-1.0.2.tgz#d6e7b50bc4e4c86357cd39f22647a84b73601e93"
   integrity sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
+get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
   integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
@@ -10661,13 +10651,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -11441,7 +11424,7 @@ moment-timezone@^0.5.33, moment-timezone@^0.5.40, moment-timezone@^0.5.45:
   dependencies:
     moment "^2.29.4"
 
-"moment@>= 2.9.0", moment@^2.29.4, moment@^2.30.1:
+moment@^2.29.4, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
@@ -11699,7 +11682,7 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.12.2, object-inspect@^1.13.1, object-inspect@^1.9.0:
+object-inspect@^1.12.2, object-inspect@^1.13.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
   integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
@@ -16843,11 +16826,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -27,27 +27,29 @@ message MetricsEvent {
   // Common Event Fields:
   string event = 1;
   string anonymous_id = 2;
-  string context_page_url = 3;
-  string context_page_title = 4;
-  string context_page_path = 5;
-  string context_page_referrer = 6;
-  string context_page_search = 7;
-  string context_locale = 8;
-  string context_user_agent = 9;
-  bool dev = 10;
-  bool is_hello = 11;
-  string machine_id_v3 = 12;
-  string report_hash = 13;
-  string source = 14;
-  string streamlit_version = 15;
+  string machine_id_v3 = 3;
+  string report_hash = 4;
+  bool dev = 5;
+  string source = 6;
+  string streamlit_version = 7;
+  bool is_hello = 8;
 
     // Host tracking fields:
-  string hosted_at = 16;
-  string owner = 17;
-  string repo = 18;
-  string branch = 19;
-  string main_module = 20;
-  string creator_id = 21;
+  string hosted_at = 9;
+  string owner = 10;
+  string repo = 11;
+  string branch = 12;
+  string main_module = 13;
+  string creator_id = 14;
+
+    // Context fields:
+  string context_page_url = 15;
+  string context_page_title = 16;
+  string context_page_path = 17;
+  string context_page_referrer = 18;
+  string context_page_search = 19;
+  string context_locale = 20;
+  string context_user_agent = 21;
 
 
   // Menu Click Event field:

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -1,0 +1,83 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "MetricsEventProto";
+
+import "streamlit/proto/PageProfile.proto";
+
+// Metrics events:
+message MetricsEvent {
+
+  // Common Event Fields:
+  string event = 1;
+  string anonymous_id = 2;
+  string context_page_url = 3;
+  string context_page_title = 4;
+  string context_page_path = 5;
+  string context_page_referrer = 6;
+  string context_page_search = 7;
+  string context_locale = 8;
+  string context_user_agent = 9;
+  bool dev = 10;
+  bool is_hello = 11;
+  string machine_id_v3 = 12;
+  string report_hash = 13;
+  string source = 14;
+  string streamlit_version = 15;
+
+    // Host tracking fields:
+  string hosted_at = 16;
+  string owner = 17;
+  string repo = 18;
+  string branch = 19;
+  string main_module = 20;
+  string creator_id = 21;
+
+
+  // Menu Click Event field:
+  string label = 22;
+
+
+  // Page Profile Event fields:
+    // Same as PageProfile msg
+  repeated Command commands = 23;
+  int64 exec_time = 24;
+  int64 prep_time = 25;
+  repeated string config = 26;
+  string uncaught_exception = 27;
+  repeated string attributions = 28;
+  string os = 29;
+  string timezone = 30;
+  bool headless = 31;
+  bool is_fragment_run = 32;
+
+    // Addtl for page profile metrics
+  string app_id = 33;
+  int64 numPages = 34;
+  string session_id = 35;
+  string python_version = 36;
+  string page_script_hash = 37;
+  string active_theme = 38;
+  int64 total_load_time = 39;
+  string browser_name = 40;
+  string browser_version = 41;
+  string device_type = 42;
+
+  // Next ID: 43
+}

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -34,7 +34,7 @@ message MetricsEvent {
   string streamlit_version = 7;
   bool is_hello = 8;
 
-    // Host tracking fields:
+  // Host tracking fields:
   string hosted_at = 9;
   string owner = 10;
   string repo = 11;
@@ -42,7 +42,7 @@ message MetricsEvent {
   string main_module = 13;
   string creator_id = 14;
 
-    // Context fields:
+  // Context fields:
   string context_page_url = 15;
   string context_page_title = 16;
   string context_page_path = 17;
@@ -57,7 +57,7 @@ message MetricsEvent {
 
 
   // Page Profile Event fields:
-    // Same as PageProfile msg
+  // Same as PageProfile msg
   repeated Command commands = 23;
   int64 exec_time = 24;
   int64 prep_time = 25;
@@ -69,7 +69,7 @@ message MetricsEvent {
   bool headless = 31;
   bool is_fragment_run = 32;
 
-    // Addtl for page profile metrics
+  // Addtl for page profile metrics
   string app_id = 33;
   int64 numPages = 34;
   string session_id = 35;


### PR DESCRIPTION
## Describe your changes
**Metrics Migration Part 2:** This PR adds a `MetricsEvent` proto for a single source of truth for event fields, as well as the infrastructure necessary to send event data to the testing Fivetran webhook in parallel with Segment. This includes building the `anonymousId` & `context` data fields for FW that we received by default from Segment.

## Testing Plan
- JS Unit Tests: ✅ 
- Manual Testing: ✅ 
See demo app [here](https://metrics-migration.streamlit.app/) & metrics comparison app [here](https://app.snowflake.com/sfcogsops/snowhouse_aws_us_west_2/#/streamlit-apps/SNOWPUBLIC.STREAMLIT.I04F9Z_MYIC9MF7P/edit)