### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -218,6 +218,7 @@ def test_audio_input_remount_keep_value(app: Page):
     ensure_waveform_rendered(audio_input)
 
 
+@pytest.mark.skip(reason="This test is flaky at the moment.")
 @pytest.mark.only_browser("chromium")
 def test_audio_input_works_in_forms(app: Page):
     """Test the functionality of the audio input component within a form."""

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -54,7 +54,9 @@ def test_lasso_select_on_line_chart_displays_a_df(app: Page):
 
 
 # This test could be flaky because https://github.com/plotly/plotly.js/issues/6898
+# Only run on chromium.
 @pytest.mark.flaky(reruns=3)
+@pytest.mark.only_browser("chromium")
 def test_click_on_bar_chart_displays_a_df_and_double_click_resets_properly(
     app: Page, assert_snapshot: ImageCompareFunction
 ):


### PR DESCRIPTION
## Describe your changes

This PR addresses a couple of flaky e2e tests. I added a temporary skip for the `test_audio_input_works_in_forms` since it might require more effort to get this fixed which Nico will look into in the coming days. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
