### PR TITLE
[fix] Ensure we utilize memo where we previously used PureComponent

### DIFF
--- a/frontend/lib/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import React, { FC, memo } from "react"
 
 import { FullscreenEnter, FullscreenExit } from "@emotion-icons/open-iconic"
 
@@ -97,4 +97,4 @@ const FullScreenWrapper: FC<FullScreenWrapperProps> = ({
   )
 }
 
-export default FullScreenWrapper
+export default memo(FullScreenWrapper)

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentType, ReactElement } from "react"
+import React, { ComponentType, memo, ReactElement } from "react"
 
 import hoistNonReactStatics from "hoist-non-react-statics"
 
@@ -35,9 +35,9 @@ function withFullScreenWrapper<P>(
   WrappedComponent: ComponentType<React.PropsWithChildren<P>>,
   forceDisableFullScreenMode = false
 ): ComponentType<React.PropsWithChildren<WrapperProps<P>>> {
-  const ComponentWithFullScreenWrapper = (
+  const ComponentWithFullScreenWrapper = memo(function (
     props: WrapperProps<P>
-  ): ReactElement => {
+  ): ReactElement {
     const { width, height, disableFullscreenMode } = props
 
     return (
@@ -62,7 +62,7 @@ function withFullScreenWrapper<P>(
         )}
       </FullScreenWrapper>
     )
-  }
+  })
   ComponentWithFullScreenWrapper.displayName = `withFullScreenWrapper(${
     WrappedComponent.displayName || WrappedComponent.name
   })`

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useCallback } from "react"
+import React, { FC, memo, useCallback } from "react"
 
 import { ColorPicker as ColorPickerProto } from "@streamlit/lib/src/proto"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -114,4 +114,4 @@ const ColorPicker: FC<Props> = ({
   )
 }
 
-export default ColorPicker
+export default memo(ColorPicker)

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useCallback, useMemo } from "react"
+import React, { FC, memo, useCallback, useMemo } from "react"
 
 import { ChevronDown } from "baseui/icon"
 import {
@@ -378,4 +378,4 @@ const Multiselect: FC<Props> = props => {
   )
 }
 
-export default Multiselect
+export default memo(Multiselect)

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useCallback } from "react"
+import React, { FC, memo, useCallback } from "react"
 
 import { Selectbox as SelectboxProto } from "@streamlit/lib/src/proto"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -118,4 +118,4 @@ const Selectbox: FC<Props> = ({
   )
 }
 
-export default Selectbox
+export default memo(Selectbox)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useCallback, useRef, useState } from "react"
+import React, { FC, memo, useCallback, useRef, useState } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 import { useTheme } from "@emotion/react"
@@ -279,4 +279,4 @@ const TextArea: FC<Props> = ({
   )
 }
 
-export default TextArea
+export default memo(TextArea)


### PR DESCRIPTION
## Describe your changes

- In some of my previous modernization PRs, I accidentally omitted a `React.memo` call for components that were previously using `PureComponent`
- This PR puts `memo` calls where they should be to match prior behavior.
- See the [React Docs](https://react.dev/reference/react/PureComponent#alternatives) on this

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed ✅
  - Existing tests cover this
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
