### PR TITLE
Fix typo in docstring for `selection_mode` of `st.dataframe`

### DIFF
--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -402,7 +402,7 @@ class ArrowMixin:
               In this case, ``st.dataframe`` will return the selection data
               as a dictionary.
 
-        selection_mode : "single-row", "multi-row", single-column", \
+        selection_mode : "single-row", "multi-row", "single-column", \
             "multi-column", or Iterable of these
             The types of selections Streamlit should allow. This can be one of
             the following:


### PR DESCRIPTION
## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
