### PR TITLE
For button group commands, rename 'multiple' to 'multi' for selection_mode

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -50,7 +50,7 @@ selection = st.pills(
     "Select some options",
     pills_options,
     key="pills",
-    selection_mode="multiple",
+    selection_mode="multi",
     default=default,
     help="This is for choosing options",
 )

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -57,7 +57,7 @@ selection = st.segmented_control(
         "This is a very long text 📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝📝, yes, long long long long text",
     ],
     key="segmented_control_multi_selection",
-    selection_mode="multiple",
+    selection_mode="multi",
     default=default,
     help="You can choose multiple options",
 )
@@ -132,7 +132,7 @@ with st.form(key="my_form", clear_on_submit=True):
         "Select an emotion:",
         ["Joy", "Sadness", "Anger", "Disgust"],
         key="segmented_control_in_form",
-        selection_mode="multiple",
+        selection_mode="multi",
     )
     st.form_submit_button("Submit")
 st.write(

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -86,7 +86,7 @@ _STAR_ICON: Final = ":material/star:"
 # in base64 format and send it over the wire as an image.
 _SELECTED_STAR_ICON: Final = ":material/star_filled:"
 
-SelectionMode: TypeAlias = Literal["single", "multiple"]
+SelectionMode: TypeAlias = Literal["single", "multi"]
 
 
 class SingleSelectSerde(Generic[T]):
@@ -137,7 +137,7 @@ class SingleOrMultiSelectSerde(Generic[T]):
         self,
         options: Sequence[T],
         default_values: list[int],
-        type: Literal["single", "multiple"],
+        type: Literal["single", "multi"],
     ):
         self.options = options
         self.default_values = default_values
@@ -227,9 +227,9 @@ def _build_proto(
 
 def _maybe_raise_selection_mode_warning(selection_mode: SelectionMode):
     """Check if the selection_mode value is valid or raise exception otherwise."""
-    if selection_mode not in ["single", "multiple"]:
+    if selection_mode not in ["single", "multi"]:
         raise StreamlitAPIException(
-            "The selection_mode argument must be one of ['single', 'multiple']. "
+            "The selection_mode argument must be one of ['single', 'multi']. "
             f"The argument passed was '{selection_mode}'."
         )
 
@@ -410,7 +410,7 @@ class ButtonGroupMixin:
         label: str,
         options: OptionSequence[V],
         *,
-        selection_mode: Literal["multiple"] = "multiple",
+        selection_mode: Literal["multi"] = "multi",
         default: Sequence[V] | V | None = None,
         format_func: Callable[[Any], str] | None = None,
         key: Key | None = None,
@@ -427,7 +427,7 @@ class ButtonGroupMixin:
         label: str,
         options: OptionSequence[V],
         *,
-        selection_mode: Literal["single", "multiple"] = "single",
+        selection_mode: Literal["single", "multi"] = "single",
         default: Sequence[V] | V | None = None,
         format_func: Callable[[Any], str] | None = None,
         key: Key | None = None,
@@ -466,9 +466,9 @@ class ButtonGroupMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        selection_mode: "single" or "multiple"
+        selection_mode: "single" or "multi"
             The selection mode for the widget. If "single", only one option can be
-            selected. If "multiple", multiple options can be selected.
+            selected. If "multi", multiple options can be selected.
 
         options: Iterable of V
             Labels for the select options in an ``Iterable``. This can be a
@@ -520,7 +520,7 @@ class ButtonGroupMixin:
         -------
         list of V or V or None
             A list of selected options or an empty list if the ``selection_mode`` is
-            "multiple".
+            "multi".
             If the "selection_mode" is "single", the return value is the selected option
             or None.
 
@@ -532,7 +532,7 @@ class ButtonGroupMixin:
         >>>
         >>> options = ["one", "two", "three", "four", "five"]
         >>> selection = st.pills(label="Numbered pills",
-                                options, selection_mode="multiple")
+                                options, selection_mode="multi")
         >>> st.markdown(f"You selected option: '{selection}'.")
 
         .. output ::
@@ -600,7 +600,7 @@ class ButtonGroupMixin:
         label: str,
         options: OptionSequence[V],
         *,
-        selection_mode: Literal["multiple"] = "multiple",
+        selection_mode: Literal["multi"] = "multi",
         default: Sequence[V] | V | None = None,
         format_func: Callable[[Any], str] | None = None,
         key: str | int | None = None,
@@ -618,7 +618,7 @@ class ButtonGroupMixin:
         label: str,
         options: OptionSequence[V],
         *,
-        selection_mode: Literal["single", "multiple"] = "single",
+        selection_mode: Literal["single", "multi"] = "single",
         default: Sequence[V] | V | None = None,
         format_func: Callable[[Any], str] | None = None,
         key: str | int | None = None,
@@ -657,9 +657,9 @@ class ButtonGroupMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        selection_mode: "single" or "multiple"
+        selection_mode: "single" or "multi"
             The selection mode for the widget. If "single", only one option can be
-            selected. If "multiple", multiple options can be selected.
+            selected. If "multi", multiple options can be selected.
 
         options: Iterable of V
             Labels for the select options in an ``Iterable``. This can be a
@@ -711,7 +711,7 @@ class ButtonGroupMixin:
         -------
         list of V or V or None
             A list of selected options or an empty list if the ``selection_mode`` is
-            "multiple".
+            "multi".
             If the "selection_mode" is "single", the return value is the selected option
             or None.
 
@@ -723,7 +723,7 @@ class ButtonGroupMixin:
         >>>
         >>> options = ["North", "East", "South", "West"]
         >>> selection = st.segmented_control(label="Directions",
-                                options, selection_mode="multiple")
+                                options, selection_mode="multi")
         >>> st.markdown(f"You selected options: '{selection}'.")
 
         .. output ::
@@ -775,7 +775,7 @@ class ButtonGroupMixin:
         *,
         key: Key | None = None,
         default: Sequence[V] | V | None = None,
-        selection_mode: Literal["single", "multiple"] = "single",
+        selection_mode: Literal["single", "multi"] = "single",
         disabled: bool = False,
         format_func: Callable[[Any], str] | None = None,
         style: Literal["pills", "segmented_control"] = "segmented_control",
@@ -837,7 +837,7 @@ class ButtonGroupMixin:
             label_visibility=label_visibility,
         )
 
-        if selection_mode == "multiple":
+        if selection_mode == "multi":
             return res.value
 
         return res.value

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -121,14 +121,14 @@ class TestSingleSelectSerde:
 
 
 class TestSingleOrMultiSelectSerde:
-    @parameterized.expand([("single",), ("multiple",)])
+    @parameterized.expand([("single",), ("multi",)])
     def test_serialize(self, selection_mode: SelectionMode):
         option_indices = [5, 6, 7]
         serde = SingleOrMultiSelectSerde[int](option_indices, [], selection_mode)
         res = serde.serialize(6)
         assert res == [1]
 
-    @parameterized.expand([("single",), ("multiple",)])
+    @parameterized.expand([("single",), ("multi",)])
     def test_serialize_raise_option_does_not_exist(self, selection_mode: SelectionMode):
         option_indices = [5, 6, 7]
         serde = SingleOrMultiSelectSerde[int](option_indices, [], selection_mode)
@@ -136,7 +136,7 @@ class TestSingleOrMultiSelectSerde:
         with pytest.raises(StreamlitAPIException):
             serde.serialize(8)
 
-    @parameterized.expand([("single", 6), ("multiple", [6])])
+    @parameterized.expand([("single", 6), ("multi", [6])])
     def test_deserialize(
         self, selection_mode: SelectionMode, expected: int | list[int]
     ):
@@ -145,7 +145,7 @@ class TestSingleOrMultiSelectSerde:
         res = serde.deserialize([1], "")
         assert res == expected
 
-    @parameterized.expand([("single", 7), ("multiple", [7])])
+    @parameterized.expand([("single", 7), ("multi", [7])])
     def test_deserialize_with_default_value(
         self, selection_mode: SelectionMode, expected: list[int] | int
     ):
@@ -154,7 +154,7 @@ class TestSingleOrMultiSelectSerde:
         res = serde.deserialize(None, "")
         assert res == expected
 
-    @parameterized.expand([("single",), ("multiple",)])
+    @parameterized.expand([("single",), ("multi",)])
     def test_deserialize_raise_indexerror(self, selection_mode: SelectionMode):
         option_indices = [5, 6, 7]
         serde = SingleOrMultiSelectSerde[int](option_indices, [], selection_mode)
@@ -339,7 +339,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
             (
                 st.pills,
                 ("label", ["a", "b", "c"]),
-                {"default": "b", "selection_mode": "multiple"},
+                {"default": "b", "selection_mode": "multi"},
                 ["b"],
             ),
             (
@@ -347,7 +347,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                     st._main, *args, **kwargs
                 ),
                 (["a", "b", "c"],),
-                {"default": "b", "selection_mode": "multiple"},
+                {"default": "b", "selection_mode": "multi"},
                 ["b"],
             ),
         ]
@@ -470,7 +470,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         expected_defaults: list[int],
     ):
         """Test that it supports different types of options and works with defaults."""
-        command(options, default=defaults, selection_mode="multiple")
+        command(options, default=defaults, selection_mode="multi")
 
         c = self.get_delta_from_queue().new_element.button_group
         assert [option.content for option in c.options] == proto_options
@@ -495,7 +495,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         if callable(defaults):
             defaults = defaults()
 
-        command(["Coffee", "Tea", "Water"], default=defaults, selection_mode="multiple")
+        command(["Coffee", "Tea", "Water"], default=defaults, selection_mode="multi")
 
         c = self.get_delta_from_queue().new_element.button_group
         assert c.default[:] == expected
@@ -511,7 +511,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         command(
             ["Coffee", "Tea", "Water"],
             default=defaults,
-            selection_mode="multiple",
+            selection_mode="multi",
         )
         c = self.get_delta_from_queue().new_element.button_group
         assert c.default[:] == expected
@@ -738,7 +738,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exception:
             command(["a", "b"], selection_mode="foo")
         assert (
-            "The selection_mode argument must be one of ['single', 'multiple']. "
+            "The selection_mode argument must be one of ['single', 'multi']. "
             "The argument passed was 'foo'." == str(exception.value)
         )
 
@@ -755,7 +755,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         self, command: Callable[..., None]
     ):
         st.session_state.command_key = ["stars"]
-        val = command(["thumbs", "stars"], key="command_key", selection_mode="multiple")
+        val = command(["thumbs", "stars"], key="command_key", selection_mode="multi")
         assert val == ["stars"]
 
     def test_invalid_style(self):

--- a/lib/tests/streamlit/typing/pills.py
+++ b/lib/tests/streamlit/typing/pills.py
@@ -34,14 +34,14 @@ if TYPE_CHECKING:
         Union[int, None],
     )
     assert_type(
-        pills("foo", options, selection_mode="multiple"),
+        pills("foo", options, selection_mode="multi"),
         list[int],
     )
     assert_type(
-        pills("foo", options, selection_mode="multiple", default=1),
+        pills("foo", options, selection_mode="multi", default=1),
         list[int],
     )
     assert_type(
-        pills("foo", options, selection_mode="multiple", default=[1]),
+        pills("foo", options, selection_mode="multi", default=[1]),
         list[int],
     )

--- a/lib/tests/streamlit/typing/segmented_control.py
+++ b/lib/tests/streamlit/typing/segmented_control.py
@@ -34,14 +34,14 @@ if TYPE_CHECKING:
         Union[int, None],
     )
     assert_type(
-        segmented_control("foo", options, selection_mode="multiple"),
+        segmented_control("foo", options, selection_mode="multi"),
         list[int],
     )
     assert_type(
-        segmented_control("foo", options, selection_mode="multiple", default=1),
+        segmented_control("foo", options, selection_mode="multi", default=1),
         list[int],
     )
     assert_type(
-        segmented_control("foo", options, selection_mode="multiple", default=[1]),
+        segmented_control("foo", options, selection_mode="multi", default=[1]),
         list[int],
     )


### PR DESCRIPTION
## Describe your changes

The decision was made to call the selection_mode literal `multi` instead of `multiple`.

## GitHub Issue Link (if applicable)

## Testing Plan

- No new tests needed and existing tests are updated
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
