### PR TITLE
[Advanced Theming] Add theming for sidebar colors

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1132,6 +1132,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   processThemeInput(themeInput: CustomThemeConfig): void {
+    console.log("DEBUG: processThemeInput", themeInput)
     const themeHash = this.createThemeHash(themeInput)
     if (themeHash === this.state.themeHash) {
       return

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
@@ -30,7 +30,7 @@ const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
   console.log(
     "DEBUG: createSidebarTheme",
     theme,
-    theme.emotion.colors.sidebarBackgroundColor ?? theme.emotion.colors.bgColor
+    theme.emotion.colors.sidebarTextColor ?? theme.emotion.colors.bodyText
   )
   return createTheme(
     "Sidebar",
@@ -41,7 +41,8 @@ const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
       backgroundColor:
         theme.emotion.colors.sidebarBackgroundColor ??
         theme.emotion.colors.secondaryBg,
-
+      textColor:
+        theme.emotion.colors.sidebarTextColor ?? theme.emotion.colors.bodyText,
       // Explictly pass these props to the sidebar theming as well.
       // This ensures custom fonts passed through postMessage propagate to the sidebar as well.
       bodyFont: theme.emotion.genericFonts.bodyFont,
@@ -61,6 +62,7 @@ const ThemedSidebar = ({
     React.useContext(AppContext)
   const { activeTheme } = React.useContext(LibContext)
   const sidebarTheme = createSidebarTheme(activeTheme)
+  console.log("DEBUG: ThemedSidebar", sidebarTheme)
 
   return (
     <ThemeProvider

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
@@ -27,11 +27,20 @@ import { AppContext } from "@streamlit/app/src/components/AppContext"
 import Sidebar, { SidebarProps } from "./Sidebar"
 
 const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
+  console.log(
+    "DEBUG: createSidebarTheme",
+    theme,
+    theme.emotion.colors.sidebarBackgroundColor ?? theme.emotion.colors.bgColor
+  )
   return createTheme(
     "Sidebar",
     {
-      secondaryBackgroundColor: theme.emotion.colors.bgColor,
-      backgroundColor: theme.emotion.colors.secondaryBg,
+      secondaryBackgroundColor:
+        theme.emotion.colors.sidebarSecondaryBackgroundColor ??
+        theme.emotion.colors.bgColor,
+      backgroundColor:
+        theme.emotion.colors.sidebarBackgroundColor ??
+        theme.emotion.colors.secondaryBg,
 
       // Explictly pass these props to the sidebar theming as well.
       // This ensures custom fonts passed through postMessage propagate to the sidebar as well.

--- a/frontend/app/src/styled-components.ts
+++ b/frontend/app/src/styled-components.ts
@@ -21,6 +21,8 @@ import { hasLightBackgroundColor } from "@streamlit/lib"
 export const StyledApp = styled.div(({ theme }) => {
   const lightBackground = hasLightBackgroundColor(theme)
 
+  console.log("DEBUG: StyledApp", theme.colors.bgColor, theme.colors.bodyText)
+
   return {
     position: "absolute",
     background: theme.colors.bgColor,

--- a/frontend/lib/src/components/elements/TextElement/styled-components.ts
+++ b/frontend/lib/src/components/elements/TextElement/styled-components.ts
@@ -20,4 +20,5 @@ export const StyledText = styled.div(({ theme }) => ({
   fontFamily: theme.genericFonts.bodyFont,
   whiteSpace: "pre-line",
   workdbreak: "break-word",
+  color: theme.colors.bodyText,
 }))

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -187,6 +187,7 @@ export const createEmotionTheme = (
   const {
     secondaryBackgroundColor: secondaryBg,
     backgroundColor: bgColor,
+    sidebarTextColor: sidebarTextColor,
     sidebarBackgroundColor: sidebarBackgroundColor,
     sidebarSecondaryBackgroundColor: sidebarSecondaryBackgroundColor,
     primaryColor: primary,
@@ -195,6 +196,14 @@ export const createEmotionTheme = (
     widgetBackgroundColor,
     widgetBorderColor,
   } = parsedColors
+  console.log(
+    "DEBUG parsedColors",
+    primary,
+    bodyText,
+    sidebarTextColor,
+    sidebarBackgroundColor,
+    sidebarSecondaryBackgroundColor
+  )
 
   const newGenericColors = { ...colors }
 
@@ -202,6 +211,7 @@ export const createEmotionTheme = (
   if (bodyText) newGenericColors.bodyText = bodyText
   if (secondaryBg) newGenericColors.secondaryBg = secondaryBg
   if (bgColor) newGenericColors.bgColor = bgColor
+  if (sidebarTextColor) newGenericColors.sidebarTextColor = sidebarTextColor
   if (sidebarBackgroundColor)
     newGenericColors.sidebarBackgroundColor = sidebarBackgroundColor
   if (sidebarSecondaryBackgroundColor)
@@ -420,6 +430,7 @@ export const createTheme = (
   baseThemeConfig?: ThemeConfig,
   inSidebar = false
 ): ThemeConfig => {
+  console.log("DEBUG", themeInput, baseThemeConfig)
   if (baseThemeConfig) {
     themeInput = completeThemeInput(themeInput, baseThemeConfig)
   } else if (themeInput.base === CustomThemeConfig.BaseTheme.DARK) {

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -178,6 +178,8 @@ export const createEmotionTheme = (
   const {
     secondaryBackgroundColor: secondaryBg,
     backgroundColor: bgColor,
+    sidebarBackgroundColor: sidebarBackgroundColor,
+    sidebarSecondaryBackgroundColor: sidebarSecondaryBackgroundColor,
     primaryColor: primary,
     textColor: bodyText,
     skeletonBackgroundColor,
@@ -191,6 +193,11 @@ export const createEmotionTheme = (
   if (bodyText) newGenericColors.bodyText = bodyText
   if (secondaryBg) newGenericColors.secondaryBg = secondaryBg
   if (bgColor) newGenericColors.bgColor = bgColor
+  if (sidebarBackgroundColor)
+    newGenericColors.sidebarBackgroundColor = sidebarBackgroundColor
+  if (sidebarSecondaryBackgroundColor)
+    newGenericColors.sidebarSecondaryBackgroundColor =
+      sidebarSecondaryBackgroundColor
   if (widgetBackgroundColor)
     newGenericColors.widgetBackgroundColor = widgetBackgroundColor
   if (widgetBorderColor) newGenericColors.widgetBorderColor = widgetBorderColor

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1005,7 +1005,7 @@ _create_option(
     "theme.linkColor",
     description="""
         The color of links in the app.
-    """,
+""",
 )
 
 _create_option(
@@ -1041,6 +1041,13 @@ _create_option(
         The base font size in pixels.
     """,
     type_=int,
+)
+
+_create_option(
+    "theme.sidebarTextColor",
+    description="""
+        Text color of sidebar
+    """,
 )
 
 _create_option(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -982,6 +982,20 @@ _create_option(
     """,
 )
 
+_create_option(
+    "theme.sidebarBackgroundColor",
+    description="""
+        Primary background color of the sidebar
+    """,
+)
+
+_create_option(
+    "theme.sidebarSecondaryBackgroundColor",
+    description="""
+        Secondary background color of the sidebar
+    """,
+)
+
 # Config Section: Secrets #
 
 _create_section("secrets", "Secrets configuration.")

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -159,6 +159,8 @@ message CustomThemeConfig {
   repeated FontFace font_faces = 15;
   FontSizes font_sizes = 16;
   string skeleton_background_color = 17;
+  string sidebar_secondary_background_color = 18;
+  string sidebar_background_color = 19;
 }
 
 message FontFace {

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -166,8 +166,9 @@ message CustomThemeConfig {
   optional string link_color = 19;
   string heading_font = 20;
   optional float spacing = 21;
-  string sidebar_secondary_background_color = 22;
-  string sidebar_background_color = 23;
+  string sidebar_text_color = 22;
+  string sidebar_secondary_background_color = 23;
+  string sidebar_background_color = 24;
 }
 
 message FontFace {


### PR DESCRIPTION
## Describe your changes

Allow theming of the sidebar background colors.

Example `.streamlit/config.toml`:

```toml
[theme]
sidebarTextColor = "green"
sidebarBackgroundColor = "red"
sidebarSecondaryBackgroundColor = "blue"
```

Example app:

```python
import streamlit as st

with st.sidebar:
    st.text_input("")
```

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
