### PR TITLE
Add option to `postMessage` metrics 

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1082,6 +1082,7 @@ export class App extends PureComponent<Props, State> {
 
     this.metricsMgr.initialize({
       gatherUsageStats: config.gatherUsageStats,
+      sendMessageToHost: this.hostCommunicationMgr.sendMessageToHost,
     })
 
     // Protobuf typing cannot handle complex types, so we need to cast to what

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -41,6 +41,7 @@ const getMetricsManager = (
   mm.setMetricsConfig(metricsConfig)
   mm.track = jest.fn()
   mm.identify = jest.fn()
+  mm.postMessageEvent = jest.fn()
   return mm
 }
 
@@ -333,6 +334,19 @@ describe("metrics helpers", () => {
     expect(localStorage.getItem("ajs_anonymous_id")).toHaveLength(36)
     expect(document.cookie).toContain("ajs_anonymous_id")
   })
+})
+
+test("sends events via postMessage when config set", () => {
+  const mm = getMetricsManager(undefined, "postMessage")
+  mm.initialize({ gatherUsageStats: true })
+
+  mm.enqueue("ev1", { data1: 11 })
+  mm.enqueue("ev2", { data2: 12 })
+  mm.enqueue("ev3", { data3: 13 })
+
+  expect(mm.track.mock.calls.length).toBe(0)
+  expect(mm.actuallySendMetrics).toBe(true)
+  expect(mm.postMessageEvent.mock.calls.length).toBe(3)
 })
 
 test("enqueues events before initialization", () => {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -16,6 +16,7 @@
 
 import pick from "lodash/pick"
 import { v4 as uuidv4 } from "uuid"
+import { IGuestToHostMessage } from "lib/src/hostComm/types"
 
 import { initializeSegment } from "@streamlit/app/src/vendor/Segment"
 import {
@@ -67,9 +68,9 @@ export class MetricsManager {
   private metricsUrl: string | undefined = undefined
 
   /**
-   * Function to send a message to the host.
+   * Function to send a message to the host via postMessage communication
    */
-  private sendMessageToHost: (message: any) => void = () => {}
+  private sendMessageToHost: (message: IGuestToHostMessage) => void = () => {}
 
   /**
    * The anonymous ID of the user.
@@ -101,7 +102,7 @@ export class MetricsManager {
     sendMessageToHost,
   }: {
     gatherUsageStats: boolean
-    sendMessageToHost: (message: any) => void
+    sendMessageToHost: (message: IGuestToHostMessage) => void
   }): void {
     this.initialized = true
     this.sendMessageToHost = sendMessageToHost

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -67,6 +67,11 @@ export class MetricsManager {
   private metricsUrl: string | undefined = undefined
 
   /**
+   * Function to send a message to the host.
+   */
+  private sendMessageToHost: (message: any) => void = () => {}
+
+  /**
    * The anonymous ID of the user.
    */
   private anonymousId = ""
@@ -93,10 +98,13 @@ export class MetricsManager {
 
   public initialize({
     gatherUsageStats,
+    sendMessageToHost,
   }: {
     gatherUsageStats: boolean
+    sendMessageToHost: (message: any) => void
   }): void {
     this.initialized = true
+    this.sendMessageToHost = sendMessageToHost
     // Handle if the user or the host has disabled metrics
     this.actuallySendMetrics = gatherUsageStats && this.metricsUrl !== "off"
     this.getAnonymousId()
@@ -150,6 +158,10 @@ export class MetricsManager {
     this.metricsUrl = metricsUrl
   }
 
+  public setMetadata(metadata: DeployedAppMetadata): void {
+    this.metadata = metadata
+  }
+
   // Fallback - Checks if cached in localStorage, otherwise fetches the config from a default URL
   private async requestDefaultMetricsConfig(): Promise<any> {
     const isLocalStoreAvailable = localStorageAvailable()
@@ -197,6 +209,8 @@ export class MetricsManager {
     // for all of them.
     if (IS_DEV_ENV) {
       logAlways("[Dev mode] Not tracking stat datapoint: ", evName, data)
+    } else if (this.metricsUrl === "postMessage") {
+      this.postMessageEvent(evName, data)
     } else {
       this.track(evName, data, {
         context: {
@@ -239,8 +253,17 @@ export class MetricsManager {
     await fetch(request)
   }
 
-  public setMetadata(metadata: DeployedAppMetadata): void {
-    this.metadata = metadata
+  // Helper to send metrics events to host
+  private postMessageEvent(
+    eventName: string,
+    eventData: Record<string, unknown>
+  ): void {
+    const eventProto = this.buildEventProto(eventName, eventData)
+    this.sendMessageToHost({
+      type: "METRICS_EVENT",
+      eventName,
+      data: eventProto,
+    })
   }
 
   // Helper to build the event proto

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { IAppPage, ICustomThemeConfig } from "@streamlit/lib/src/proto"
+import {
+  IAppPage,
+  ICustomThemeConfig,
+  MetricsEvent,
+} from "@streamlit/lib/src/proto"
 import { ExportedTheme } from "@streamlit/lib/src/theme"
 import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
 import { LibConfig } from "@streamlit/lib/src/components/core/LibContext"
@@ -126,6 +130,11 @@ export type IHostToGuestMessage = {
     }
   | {
       type: "TERMINATE_WEBSOCKET_CONNECTION"
+    }
+  | {
+      type: "METRICS_EVENT"
+      eventName: string
+      data: MetricsEvent
     }
 )
 

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -131,11 +131,6 @@ export type IHostToGuestMessage = {
   | {
       type: "TERMINATE_WEBSOCKET_CONNECTION"
     }
-  | {
-      type: "METRICS_EVENT"
-      eventName: string
-      data: MetricsEvent
-    }
 )
 
 export type IGuestToHostMessage =
@@ -198,6 +193,11 @@ export type IGuestToHostMessage =
     }
   | {
       type: "WEBSOCKET_CONNECTED"
+    }
+  | {
+      type: "METRICS_EVENT"
+      eventName: string
+      data: MetricsEvent
     }
 
 export type VersionedMessage<Message> = {

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -230,8 +230,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Default host configuration settings.
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
-                # TODO: Set back to empty string when finished testing
-                "metricsUrl": "postMessage",
+                "metricsUrl": "",
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -230,7 +230,8 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Default host configuration settings.
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
-                "metricsUrl": "",
+                # TODO: Set back to empty string when finished testing
+                "metricsUrl": "postMessage",
             }
         )
         self.set_status(200)


### PR DESCRIPTION
## Describe your changes
**Metrics Migration Part 3:** As a follow up to the metrics options in hostConfig endpoint (PR #9611), this PR adds the ability to send metrics events to the host via postMessage API using our existing Host <-> Guest communication.

## Testing Plan
- JS Testing: ✅ 
- Manual Testing: ✅ 
