### PR TITLE
auto focus on text input after file upload

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -90,6 +90,7 @@ interface CreateDropHandlerParams {
   addFiles: (files: UploadFileInfo[]) => void
   getNextLocalFileId: () => number
   deleteExistingFiles: () => void
+  onUploadComplete: () => void
 }
 
 const createDropHandler =
@@ -100,6 +101,7 @@ const createDropHandler =
     addFiles,
     getNextLocalFileId,
     deleteExistingFiles,
+    onUploadComplete,
   }: CreateDropHandlerParams) =>
   (acceptedFiles: File[], rejectedFiles: FileRejection[]): void => {
     // If this is a single-file uploader and multiple files were dropped,
@@ -157,6 +159,8 @@ const createDropHandler =
       })
       addFiles(rejectedInfos)
     }
+
+    onUploadComplete()
   }
 
 interface CreateUploadFileParams {
@@ -401,6 +405,11 @@ function ChatInput({
     getNextLocalFileId,
     deleteExistingFiles: () => {
       files.forEach(f => deleteFile(f.id))
+    },
+    onUploadComplete: () => {
+      if (chatInputRef.current) {
+        chatInputRef.current.focus()
+      }
     },
   })
 


### PR DESCRIPTION
## Describe your changes

After uploading files, we want to focus on the text input area so that users can either continue with text input or hit enter to submit.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
