### PR TITLE
changing icon and label for st.audio_input

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -55,7 +55,7 @@ def ensure_waveform_rendered(audio_input: Locator):
 
     audio_input.hover()
     expect(audio_input.get_by_role("button", name="Clear recording")).to_be_visible()
-    expect(audio_input.get_by_role("button", name="Download recording")).to_be_visible()
+    expect(audio_input.get_by_role("button", name="Download as CSV")).to_be_visible()
 
 
 def test_audio_input_renders(app: Page):
@@ -147,7 +147,7 @@ def _test_download_audio_file(app: Page, locator: FrameLocator | Locator):
     stop_recording(audio_input, app)
 
     with app.expect_download() as download_info:
-        download_button = audio_input.get_by_role("button", name="Download recording")
+        download_button = audio_input.get_by_role("button", name="Download as CSV")
         download_button.click()
 
     download = download_info.value

--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -55,7 +55,7 @@ def ensure_waveform_rendered(audio_input: Locator):
 
     audio_input.hover()
     expect(audio_input.get_by_role("button", name="Clear recording")).to_be_visible()
-    expect(audio_input.get_by_role("button", name="Download as CSV")).to_be_visible()
+    expect(audio_input.get_by_role("button", name="Download as WAV")).to_be_visible()
 
 
 def test_audio_input_renders(app: Page):
@@ -147,7 +147,7 @@ def _test_download_audio_file(app: Page, locator: FrameLocator | Locator):
     stop_recording(audio_input, app)
 
     with app.expect_download() as download_info:
-        download_button = audio_input.get_by_role("button", name="Download as CSV")
+        download_button = audio_input.get_by_role("button", name="Download as WAV")
         download_button.click()
 
     download = download_info.value

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -25,7 +25,7 @@ import React, {
 import { useTheme } from "@emotion/react"
 import WaveSurfer from "wavesurfer.js"
 import RecordPlugin from "wavesurfer.js/dist/plugins/record"
-import { Delete, Download } from "@emotion-icons/material-outlined"
+import { Delete, FileDownload } from "@emotion-icons/material-outlined"
 import isEqual from "lodash/isEqual"
 
 import { FormClearHelper } from "@streamlit/lib/src/components/widgets/Form"
@@ -436,8 +436,8 @@ const AudioInput: React.FC<Props> = ({
         >
           {recordingUrl && (
             <ToolbarAction
-              label="Download recording"
-              icon={Download}
+              label="Download as WAV"
+              icon={FileDownload}
               onClick={() => downloadRecording()}
             />
           )}


### PR DESCRIPTION
## Describe your changes

This PR updates the tooltip string to "Download as WAV" to more closely match data frame's "Download as CSV". It also updates the icon to match.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
