### PR TITLE
Remove eval from frontend bundle

### DIFF
--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -159,6 +159,8 @@
     "jest-environment-jsdom": "^27.4.3",
     "jest-fetch-mock": "^3.0.3",
     "node-fetch": "2.6.7",
+    "patch-package": "^8.0.0",
+    "postinstall-postinstall": "^2.1.0",
     "protobufjs-cli": "^1.1.0",
     "timezone-mock": "^1.3.6",
     "tsc-alias": "^1.8.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "scripts": {
+    "postinstall": "patch-package",
     "start": "yarn workspace @streamlit/app start",
     "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
     "buildFast": "yarn buildLib && yarn workspace @streamlit/app buildFast",

--- a/frontend/patches/@protobufjs+inquire+1.1.0.patch
+++ b/frontend/patches/@protobufjs+inquire+1.1.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
+index 33778b5..153aa65 100644
+--- a/node_modules/@protobufjs/inquire/index.js
++++ b/node_modules/@protobufjs/inquire/index.js
+@@ -8,10 +8,5 @@ module.exports = inquire;
+  * @returns {?Object} Required module if available and not empty, otherwise `null`
+  */
+ function inquire(moduleName) {
+-    try {
+-        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
+-        if (mod && (mod.length || Object.keys(mod).length))
+-            return mod;
+-    } catch (e) {} // eslint-disable-line no-empty
+     return null;
+ }

--- a/frontend/patches/@protobufjs+inquire+1.1.0.patch
+++ b/frontend/patches/@protobufjs+inquire+1.1.0.patch
@@ -1,15 +1,17 @@
 diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
-index 33778b5..153aa65 100644
+index 33778b5..0ac5288 100644
 --- a/node_modules/@protobufjs/inquire/index.js
 +++ b/node_modules/@protobufjs/inquire/index.js
-@@ -8,10 +8,5 @@ module.exports = inquire;
+@@ -8,8 +8,11 @@ module.exports = inquire;
   * @returns {?Object} Required module if available and not empty, otherwise `null`
   */
  function inquire(moduleName) {
--    try {
++    if (typeof document !== "undefined") {
++        return null;
++    }
+     try {
 -        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
--        if (mod && (mod.length || Object.keys(mod).length))
--            return mod;
--    } catch (e) {} // eslint-disable-line no-empty
-     return null;
- }
++        var mod = require(moduleName);
+         if (mod && (mod.length || Object.keys(mod).length))
+             return mod;
+     } catch (e) {} // eslint-disable-line no-empty

--- a/frontend/patches/@protobufjs+inquire+1.1.0.patch
+++ b/frontend/patches/@protobufjs+inquire+1.1.0.patch
@@ -1,11 +1,12 @@
 diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
-index 33778b5..a0963a1 100644
+index 33778b5..e1a3dc5 100644
 --- a/node_modules/@protobufjs/inquire/index.js
 +++ b/node_modules/@protobufjs/inquire/index.js
-@@ -8,6 +8,9 @@ module.exports = inquire;
+@@ -8,6 +8,10 @@ module.exports = inquire;
   * @returns {?Object} Required module if available and not empty, otherwise `null`
   */
  function inquire(moduleName) {
++    // This check ensures that the code below is only run in a non-browser environment.
 +    if (typeof document !== "undefined") {
 +        return null;
 +    }

--- a/frontend/patches/@protobufjs+inquire+1.1.0.patch
+++ b/frontend/patches/@protobufjs+inquire+1.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
-index 33778b5..e1a3dc5 100644
+index 33778b5..eb0d85b 100644
 --- a/node_modules/@protobufjs/inquire/index.js
 +++ b/node_modules/@protobufjs/inquire/index.js
 @@ -8,6 +8,10 @@ module.exports = inquire;
@@ -7,7 +7,7 @@ index 33778b5..e1a3dc5 100644
   */
  function inquire(moduleName) {
 +    // This check ensures that the code below is only run in a non-browser environment.
-+    if (typeof document !== "undefined") {
++    if (typeof process === "undefined" && typeof document !== "undefined") {
 +        return null;
 +    }
      try {

--- a/frontend/patches/@protobufjs+inquire+1.1.0.patch
+++ b/frontend/patches/@protobufjs+inquire+1.1.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
-index 33778b5..0ac5288 100644
+index 33778b5..a0963a1 100644
 --- a/node_modules/@protobufjs/inquire/index.js
 +++ b/node_modules/@protobufjs/inquire/index.js
-@@ -8,8 +8,11 @@ module.exports = inquire;
+@@ -8,6 +8,9 @@ module.exports = inquire;
   * @returns {?Object} Required module if available and not empty, otherwise `null`
   */
  function inquire(moduleName) {
@@ -10,8 +10,5 @@ index 33778b5..0ac5288 100644
 +        return null;
 +    }
      try {
--        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
-+        var mod = require(moduleName);
+         var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
          if (mod && (mod.length || Object.keys(mod).length))
-             return mod;
-     } catch (e) {} // eslint-disable-line no-empty

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4163,6 +4163,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -4966,7 +4971,7 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind@^1.0.2, call-bind@^1.0.7:
+call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
   integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
@@ -5186,6 +5191,11 @@ ci-info@^3.2.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.1.tgz#708a6cdae38915d597afdf3b145f2f8e1ff55f3f"
   integrity sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -8057,6 +8067,13 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -10342,6 +10359,16 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz#52d4361b47d49168bcc4e564189a42e5a7439454"
+  integrity sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==
+  dependencies:
+    call-bind "^1.0.5"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-stringify-pretty-compact@^3.0.0, json-stringify-pretty-compact@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
@@ -10367,6 +10394,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonpointer@^5.0.0:
   version "5.0.1"
@@ -10426,6 +10458,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 klaw@^3.0.0:
   version "3.0.0"
@@ -11799,7 +11838,7 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^7.3.1:
+open@^7.3.1, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -11849,6 +11888,11 @@ orderedmap@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.0.0.tgz#12ff5ef6ea9d12d6430b80c701b35475e1c9ff34"
   integrity sha512-buf4PoAMlh45b8a8gsGy/X6w279TSqkyAS0C0wdTSJwFSU+ljQFJON5I8NfjLHoCXwpSROIo2wr0g33T+kQshQ==
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
@@ -12001,6 +12045,27 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -12753,6 +12818,11 @@ postcss@^8.3.5, postcss@^8.4.18, postcss@^8.4.19, postcss@^8.4.4:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 potpack@^1.0.1:
   version "1.0.2"
@@ -14070,7 +14140,7 @@ right-now@^1.0.0:
   resolved "https://registry.yarnpkg.com/right-now/-/right-now-1.0.0.tgz#6e89609deebd7dcdaf8daecc9aea39cf585a0918"
   integrity sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==
 
-rimraf@^2.6.2:
+rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -14273,7 +14343,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.2, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.6.2:
+semver@^7.1.2, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.6.2:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -15208,6 +15278,13 @@ tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmp@^0.2.1:
   version "0.2.1"
@@ -16831,6 +16908,11 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.2.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.0.tgz#14059ad9d0b1680d0f04d3a60fe00f3a857303c3"
+  integrity sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==
 
 yargs-parser@^20.2.2:
   version "20.2.4"

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -63,6 +63,8 @@ IGNORE_PATTERN = re.compile(
     # Exclude vendored files.
     r"|/vendor/|^vendor/|^component-lib/declarations/apache-arrow"
     r"|proto/streamlit/proto/openmetrics_data_model\.proto",
+    # Exclude patch files.
+    r"\.patch$",
     re.IGNORECASE,
 )
 

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -62,9 +62,9 @@ IGNORE_PATTERN = re.compile(
     r"|/(fixtures|__snapshots__|test_data|data|test)/"
     # Exclude vendored files.
     r"|/vendor/|^vendor/|^component-lib/declarations/apache-arrow"
-    r"|proto/streamlit/proto/openmetrics_data_model\.proto",
+    r"|proto/streamlit/proto/openmetrics_data_model\.proto"
     # Exclude patch files.
-    r"\.patch$",
+    r"|\.patch$",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Describe your changes

This PR blocks the use of `eval` in a browser environment. Please see [this](https://docs.google.com/document/d/1g-fczG7eV5CIIUDd5pnwvGkUn-SLf2vMZeBk9qj1Yk4/) spec for more info on why we need to remove it.

This PR adds 2 packages: [patch-package](https://www.npmjs.com/package/patch-package) and [postinstall-postinstall](https://www.npmjs.com/package/postinstall-postinstall). The first one is used to patch `@protobufjs/inquire` which includes the `eval` (see https://github.com/protobufjs/protobuf.js/issues/997 and https://github.com/protobufjs/protobuf.js/pull/1548), and the second one is used to call `postinstall` on `yarn remove` as Yarn v1 only calls it on `yarn install` and `yarn add`.

## GitHub Issue Link (if applicable)
[SNOW-1554237](https://snowflakecomputing.atlassian.net/browse/SNOW-1554237)

## Testing Plan

- No tests required as there are no implementation changes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
