### PR TITLE
Add a delay before displaying the running man icon. 

### DIFF
--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 /**
  * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
  *

--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -343,7 +343,12 @@ describe("Running Icon", () => {
       />
     )
 
-    const icon = screen.queryByRole("img")
+    let icon = screen.queryByRole("img")
     expect(icon).not.toBeInTheDocument()
+
+    jest.runAllTimers()
+
+    icon = screen.queryByRole("img")
+    expect(icon).toHaveAttribute("src", "icon_running.gif")
   })
 })

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -294,15 +294,8 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
         // In the latter case, the server should get around to actually
         // re-running the script in a second or two, but we can appear
         // more responsive by claiming it's started immemdiately.
-        const params = new URLSearchParams(document.location.search)
-        const delay = params.get("delay")
-        if (delay !== null) {
-          this.showRunningManAfterInitialDelay(parseInt(delay))
-        } else {
-          this.showRunningManAfterInitialDelay(
-            RUNNING_MAN_DISPLAY_DELAY_TIME_MS
-          )
-        }
+
+        this.showRunningManAfterInitialDelay(RUNNING_MAN_DISPLAY_DELAY_TIME_MS)
         return this.renderScriptIsRunning()
       }
       if (this.state.scriptChangedOnDisk) {

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -115,7 +115,7 @@ interface State {
   promptHovered: boolean
 
   /**
-   * True if the running man animation should be displayed after an initial delay.
+   * True if the running man animation should be displayed.
    */
   showRunningMan: boolean
 }


### PR DESCRIPTION
## Describe your changes

The running man animation appears while the script re-run is being performed and for re-runs that complete quickly it introduces a flicker and creates the perception of a longer wait. This PR introduces a delay when showing the running man animation. 

## GitHub Issue Link (if applicable)

## Testing Plan
- Unit Tests (one added to confirm not visible without delay, plus coverage by existing running man tests)
- Manual testing by PM and Engineer to confirm expected visual behaviour. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
