### PR TITLE
FIx button cursor regression

### DIFF
--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -131,4 +131,4 @@ def test_custom_css_class_via_key(app: Page):
 def test_shows_cursor_pointer(app: Page):
     """Test that the button shows cursor pointer when hovered."""
     button_element = app.get_by_test_id("stButton").first
-    expect(button_element).to_have_css("cursor", "pointer")
+    expect(button_element.locator("button")).to_have_css("cursor", "pointer")

--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -126,3 +126,9 @@ def test_check_top_level_class(app: Page):
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
     expect(get_element_by_key(app, "button")).to_be_visible()
+
+
+def test_shows_cursor_pointer(app: Page):
+    """Test that the button shows cursor pointer when hovered."""
+    button_element = app.get_by_test_id("stButton").first
+    expect(button_element).to_have_css("cursor", "pointer")

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -102,6 +102,7 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       lineHeight: theme.lineHeights.base,
       color: "inherit",
       width: fluidWidth ? buttonWidth : "auto",
+      cursor: "pointer",
       userSelect: "none",
       "&:focus": {
         outline: "none",

--- a/frontend/lib/src/theme/globalStyles.ts
+++ b/frontend/lib/src/theme/globalStyles.ts
@@ -446,6 +446,13 @@ export const globalStyles = (theme: EmotionTheme): SerializedStyles => css`
     cursor: pointer;
   }
 
+  // Set the cursor for all buttons buttons
+  button {
+    &:not(:disabled) {
+      cursor: pointer;
+    }
+  }
+
   // Remove the inheritance of word-wrap in Safari.
   // See https://github.com/twbs/bootstrap/issues/24990
 


### PR DESCRIPTION
## Describe your changes

Fix a regression that removed showing the pointer cursor on hovering buttons.

## Testing Plan

- Added e2e test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
