### PR TITLE
Fix issue with local storage in Android webview

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -123,6 +123,13 @@ module.exports = {
       "LabeledStatement",
       "WithStatement",
     ],
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "localStorage",
+        message: "Please use window.localStorage instead.",
+      },
+    ],
     // Allow foo.hasOwnProperty("bar")
     "no-prototype-builtins": "off",
     // Imports should be `import "./FooModule"`, not `import "./FooModule.js"`

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -127,7 +127,9 @@ module.exports = {
       "error",
       {
         name: "localStorage",
-        message: "Please use window.localStorage instead.",
+        message:
+          "Please use window.localStorage instead since localStorage is not " +
+          "supported in some browsers (e.g. Android WebView).",
       },
     ],
     // Allow foo.hasOwnProperty("bar")

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -95,7 +95,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
     )
 
     const cachedSidebarWidth = localStorageAvailable()
-      ? localStorage.getItem("sidebarWidth")
+      ? window.localStorage.getItem("sidebarWidth")
       : undefined
 
     this.state = {

--- a/frontend/app/src/components/Sidebar/SidebarNav.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.tsx
@@ -161,9 +161,9 @@ const SidebarNav = ({
     const nextState = !expanded
     if (localStorageAvailable()) {
       if (nextState) {
-        localStorage.setItem("sidebarNavState", "expanded")
+        window.localStorage.setItem("sidebarNavState", "expanded")
       } else {
-        localStorage.removeItem("sidebarNavState")
+        window.localStorage.removeItem("sidebarNavState")
       }
     }
     setExpanded(nextState)


### PR DESCRIPTION
## Describe your changes

The local storage in an Android WebView is only available when accessed via `window.localStorage` and not `localStorage` directly (see [here](https://stackoverflow.com/questions/5822256/error-web-console-uncaught-typeerror-cannot-call-method-getitem-of-null-at-h)). This PR makes sure that `window.localStorage` is used everywhere. 

This also adds a lint rule to prevent the usage of localStorage.

## GitHub Issue Link (if applicable)

- Closes: https://github.com/streamlit/streamlit/issues/9740

## Testing Plan

- No logical changes and we cannot test usage of Android WebView easily.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
