### PR TITLE
Disallow double slash paths to redirect

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -369,7 +369,12 @@ class Server:
             routes.extend(
                 [
                     (
-                        make_url_path_regex(base, "(.*)", trailing_slash="required"),
+                        # We want to remove paths with a trailing slash, but if the path
+                        # starts with a double slash //, the redirect will point
+                        # the browser to the wrong host.
+                        make_url_path_regex(
+                            base, "(?!/)(.*)", trailing_slash="required"
+                        ),
                         RemoveSlashHandler,
                     ),
                     (

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -196,7 +196,7 @@ class RemoveSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):
         return tornado.web.Application(
             [
                 (
-                    r"/(.*)/",
+                    r"^/(?!/)(.*)",
                     RemoveSlashHandler,
                 )
             ]
@@ -209,6 +209,13 @@ class RemoveSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):
         for idx, r in enumerate(responses):
             assert r.code == 301
             assert r.headers["Location"] == paths[idx].rstrip("/")
+
+    def test_parse_url_path_404(self):
+        paths = ["//page1/", "//page2/page3/"]
+        responses = [self.fetch(path, follow_redirects=False) for path in paths]
+
+        for r in responses:
+            assert r.code == 404
 
 
 class AddSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):


### PR DESCRIPTION
## Describe your changes

We amend the call to remove the slash at the end if necessary. However, paths with double slashes `//my-path` create an invalid redirect that can cause security issues. This change prevents the double slash from matching with this route.

## GitHub Issue Link (if applicable)
closes #9690

## Testing Plan

- Updated Unit Tests
- Verified manually that redirect works as needed and fails with a double slash (and with a URL encoded double slash)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
