### PR TITLE
Fix #9763. Don't show text keyboard for number input on IOS

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -156,6 +156,15 @@ describe("NumberInput widget", () => {
     expect(numberInput).toHaveAttribute("max", "Infinity")
   })
 
+  it("sets input mode", () => {
+    const props = getIntProps()
+    render(<NumberInput {...props} />)
+
+    const numberInput = screen.getByTestId("stNumberInputField")
+
+    expect(numberInput).toHaveAttribute("inputmode", "decimal")
+  })
+
   it("sets min/max values", () => {
     const props = getIntProps({
       hasMin: true,

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -156,13 +156,22 @@ describe("NumberInput widget", () => {
     expect(numberInput).toHaveAttribute("max", "Infinity")
   })
 
-  it("sets input mode", () => {
+  it("sets input mode to empty string", () => {
     const props = getIntProps()
     render(<NumberInput {...props} />)
 
     const numberInput = screen.getByTestId("stNumberInputField")
 
-    expect(numberInput).toHaveAttribute("inputmode", "decimal")
+    expect(numberInput).toHaveAttribute("inputmode", "")
+  })
+
+  it("sets input type to number", () => {
+    const props = getIntProps()
+    render(<NumberInput {...props} />)
+
+    const numberInput = screen.getByTestId("stNumberInputField")
+
+    expect(numberInput).toHaveAttribute("type", "number")
   })
 
   it("sets min/max values", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -467,6 +467,7 @@ export const NumberInput: React.FC<Props> = ({
                 step: step,
                 min: min,
                 max: max,
+                inputMode: "decimal",
               },
               style: {
                 lineHeight: theme.lineHeights.inputWidget,

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -467,6 +467,9 @@ export const NumberInput: React.FC<Props> = ({
                 step: step,
                 min: min,
                 max: max,
+                // We specify the type as "number" to have numeric keyboard on mobile devices.
+                // We also set inputMode to "" since by default BaseWeb sets "text",
+                // and for "decimal" / "numeric" IOS shows keyboard without a minus sign.
                 type: "number",
                 inputMode: "",
               },

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -467,7 +467,8 @@ export const NumberInput: React.FC<Props> = ({
                 step: step,
                 min: min,
                 max: max,
-                inputMode: "decimal",
+                type: "number",
+                inputMode: "",
               },
               style: {
                 lineHeight: theme.lineHeights.inputWidget,


### PR DESCRIPTION
## Describe your changes

Fixes #9763 . 
Setting `inputMode` to `decimal` doesn't work, because in that case IOS show number input without `-` (minus) sign. 
And by default, BaseWeb sets `input mode` to `text,` so we need to set it to an empty string to overwrite the `text` value. 


Keyboard on IOS before changes:

![before](https://github.com/user-attachments/assets/5d0749f0-a4d7-4bc5-bb36-8bb9a9aaddfa)


Keyboard for IOS after changes:

![photo_5282903056930964690_y](https://github.com/user-attachments/assets/997019bf-5a65-4871-938e-c9bc32aaad88)

Keyboard for Android:
![photo_5289518165560255500_y](https://github.com/user-attachments/assets/2375e095-609e-45ab-85a4-9ff23577ac26)


## GitHub Issue Link (if applicable)
Closes #9763

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) JS unit test added
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
