### PR TITLE
Ignore broken codeql rule

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -8,6 +8,8 @@ query-filters:
       id: py/import-and-import-from
   - exclude:
       id: py/cyclic-import
+  - exclude:
+      id: py/unsafe-cyclic-import
 paths:
   - lib/streamlit
   - frontend/lib/src

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -6,6 +6,8 @@ query-filters:
       id: py/ineffectual-statement
   - exclude:
       id: py/import-and-import-from
+  - exclude:
+      id: py/cyclic-import
 paths:
   - lib/streamlit
   - frontend/lib/src


### PR DESCRIPTION
## Describe your changes

Something seems to have changed / broken with the codeql cyclic import rule. It seems to somehow include the imports under TYPE_CHECKING in the static analysis. This causes > 400 cyclic imports errors/warnings for almost every file. This PR disables these checks for now. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
