### PR TITLE
Fixes a bug where timezones with a non- x:00 utc offset would start at a non 00:00 timer for st.audio_input

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
@@ -32,16 +32,12 @@ describe("formatTime", () => {
       expect(formatTime(0)).toBe("00:00")
     })
 
-    it('should format 60000 milliseconds as "00:01" in Pacific Time', () => {
-      expect(formatTime(60000)).toBe("00:01")
+    it('should format 1000 milliseconds as "00:01" in Pacific Time', () => {
+      expect(formatTime(1000)).toBe("00:01")
     })
 
-    it('should format 1800000 milliseconds as "00:30" in Pacific Time', () => {
-      expect(formatTime(1800000)).toBe("00:30")
-    })
-
-    it('should format 5400000 milliseconds as "01:30" in Pacific Time', () => {
-      expect(formatTime(5400000)).toBe("01:30")
+    it('should format 90000 milliseconds as "01:30" in Pacific Time', () => {
+      expect(formatTime(90000)).toBe("01:30")
     })
   })
 
@@ -58,16 +54,12 @@ describe("formatTime", () => {
       expect(formatTime(0)).toBe("00:00")
     })
 
-    it('should format 60000 milliseconds as "00:01" in Eastern Time', () => {
-      expect(formatTime(60000)).toBe("00:01")
+    it('should format 1000 milliseconds as "00:01" in Eastern Time', () => {
+      expect(formatTime(1000)).toBe("00:01")
     })
 
-    it('should format 1800000 milliseconds as "00:30" in Eastern Time', () => {
-      expect(formatTime(1800000)).toBe("00:30")
-    })
-
-    it('should format 5400000 milliseconds as "01:30" in Eastern Time', () => {
-      expect(formatTime(5400000)).toBe("01:30")
+    it('should format 90000 milliseconds as "01:30" in Eastern Time', () => {
+      expect(formatTime(90000)).toBe("01:30")
     })
   })
 
@@ -84,16 +76,12 @@ describe("formatTime", () => {
       expect(formatTime(0)).toBe("00:00")
     })
 
-    it('should format 60000 milliseconds as "00:01" in Adelaide Time', () => {
-      expect(formatTime(60000)).toBe("00:01")
+    it('should format 1000 milliseconds as "00:01" in Adelaide Time', () => {
+      expect(formatTime(1000)).toBe("00:01")
     })
 
-    it('should format 1800000 milliseconds as "00:30" in Adelaide Time', () => {
-      expect(formatTime(1800000)).toBe("00:30")
-    })
-
-    it('should format 5400000 milliseconds as "01:30" in Adelaide Time', () => {
-      expect(formatTime(5400000)).toBe("01:30")
+    it('should format 90000 milliseconds as "01:30" in Adelaide Time', () => {
+      expect(formatTime(90000)).toBe("01:30")
     })
   })
 })

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import timezoneMock from "timezone-mock"
+
+import formatTime from "./formatTime"
+
+describe("formatTime", () => {
+  describe("US/Pacific Timezone", () => {
+    beforeAll(() => {
+      timezoneMock.register("US/Pacific")
+    })
+
+    afterAll(() => {
+      timezoneMock.unregister()
+    })
+
+    it('should format 0 milliseconds as "00:00" in Pacific Time', () => {
+      expect(formatTime(0)).toBe("00:00")
+    })
+
+    it('should format 60000 milliseconds as "00:01" in Pacific Time', () => {
+      expect(formatTime(60000)).toBe("00:01")
+    })
+
+    it('should format 1800000 milliseconds as "00:30" in Pacific Time', () => {
+      expect(formatTime(1800000)).toBe("00:30")
+    })
+
+    it('should format 5400000 milliseconds as "01:30" in Pacific Time', () => {
+      expect(formatTime(5400000)).toBe("01:30")
+    })
+  })
+
+  describe("US/Eastern Timezone", () => {
+    beforeAll(() => {
+      timezoneMock.register("US/Eastern")
+    })
+
+    afterAll(() => {
+      timezoneMock.unregister()
+    })
+
+    it('should format 0 milliseconds as "00:00" in Eastern Time', () => {
+      expect(formatTime(0)).toBe("00:00")
+    })
+
+    it('should format 60000 milliseconds as "00:01" in Eastern Time', () => {
+      expect(formatTime(60000)).toBe("00:01")
+    })
+
+    it('should format 1800000 milliseconds as "00:30" in Eastern Time', () => {
+      expect(formatTime(1800000)).toBe("00:30")
+    })
+
+    it('should format 5400000 milliseconds as "01:30" in Eastern Time', () => {
+      expect(formatTime(5400000)).toBe("01:30")
+    })
+  })
+
+  describe("Australia/Adelaide Timezone", () => {
+    beforeAll(() => {
+      timezoneMock.register("Australia/Adelaide")
+    })
+
+    afterAll(() => {
+      timezoneMock.unregister()
+    })
+
+    it('should format 0 milliseconds as "00:00" in Adelaide Time', () => {
+      expect(formatTime(0)).toBe("00:00")
+    })
+
+    it('should format 60000 milliseconds as "00:01" in Adelaide Time', () => {
+      expect(formatTime(60000)).toBe("00:01")
+    })
+
+    it('should format 1800000 milliseconds as "00:30" in Adelaide Time', () => {
+      expect(formatTime(1800000)).toBe("00:30")
+    })
+
+    it('should format 5400000 milliseconds as "01:30" in Adelaide Time', () => {
+      expect(formatTime(5400000)).toBe("01:30")
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
@@ -15,17 +15,13 @@
  */
 
 const formatTime = (timeMs: number): string => {
-  const date = new Date(timeMs)
+  const totalSeconds = Math.floor(timeMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
 
-  // Create a new date object with only the UTC minutes and seconds
-  const utcDate = new Date(
-    Date.UTC(1970, 0, 1, 0, date.getUTCMinutes(), date.getUTCSeconds())
-  )
-
-  return utcDate.toLocaleTimeString(undefined, {
-    minute: "2-digit",
-    second: "2-digit",
-  })
+  return `${minutes.toString().padStart(2, "0")}:${seconds
+    .toString()
+    .padStart(2, "0")}`
 }
 
 export default formatTime

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
@@ -17,7 +17,12 @@
 const formatTime = (timeMs: number): string => {
   const date = new Date(timeMs)
 
-  return date.toLocaleTimeString(undefined, {
+  // Create a new date object with only the UTC minutes and seconds
+  const utcDate = new Date(
+    Date.UTC(1970, 0, 1, 0, date.getUTCMinutes(), date.getUTCSeconds())
+  )
+
+  return utcDate.toLocaleTimeString(undefined, {
     minute: "2-digit",
     second: "2-digit",
   })

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
@@ -15,13 +15,13 @@
  */
 
 const formatTime = (timeMs: number): string => {
-  const totalSeconds = Math.floor(timeMs / 1000)
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
+  const date = new Date(timeMs)
 
-  return `${minutes.toString().padStart(2, "0")}:${seconds
-    .toString()
-    .padStart(2, "0")}`
+  return date.toLocaleTimeString(undefined, {
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: "UTC",
+  })
 }
 
 export default formatTime


### PR DESCRIPTION
## Describe your changes

This PR makes it so that for ALL timezones, the `st.audio_input` timer starts at 00:00. We used the built in date formatting to try to format this timestamp in the most locale appropriate way, but one side effect of doing this can be seen in #9631. This PR fixes said issue.

## GitHub Issue Link (if applicable)

This PR closes https://github.com/streamlit/streamlit/issues/9631

## Testing Plan

Added unit tests for this formatting utility that checks a few different timezones, namely `Australia/Adelaide` which has a `x:30` utc offset.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
