### PR TITLE
Fix usage of hyphens in user key for CSS classes

### DIFF
--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -130,6 +130,10 @@ describe("getKeyFromId", () => {
       input: "$$ID-899e9b72e1539f21f8e82565d36609d0-None",
       expected: undefined,
     },
+    {
+      input: "$$ID-899e9b72e1539f21f8e82565d36609d0",
+      expected: undefined,
+    },
     { input: "helloWorld", expected: undefined },
     {
       input: "$$ID-899e9b72e1539f21f8e82565d36609d0-first container",
@@ -138,6 +142,10 @@ describe("getKeyFromId", () => {
     {
       input: "$$ID-foo-bar",
       expected: "bar",
+    },
+    {
+      input: "$$ID-899e9b72e1539f21f8e82565d36609d0-bar-baz",
+      expected: "bar-baz",
     },
   ]
 

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -200,6 +200,9 @@ export function getKeyFromId(
     return undefined
   }
 
-  const userKey = elementId.split("-", 3).pop()
+  // Split the elementId by hyphens
+  const parts = elementId.split("-")
+  // Extract all parts after the second hyphen
+  const userKey = parts.slice(2).join("-")
   return userKey === "None" ? undefined : userKey
 }

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -354,7 +354,8 @@ export function isValidElementId(
   }
   return (
     elementId.startsWith(GENERATED_ELEMENT_ID_PREFIX) &&
-    elementId.split("-").length >= 2
+    // There must be at least 3 parts: $$ID-<hash>-<userKey>
+    elementId.split("-").length >= 3
   )
 }
 

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -352,7 +352,10 @@ export function isValidElementId(
   if (!elementId) {
     return false
   }
-  return elementId.startsWith(GENERATED_ELEMENT_ID_PREFIX)
+  return (
+    elementId.startsWith(GENERATED_ELEMENT_ID_PREFIX) &&
+    elementId.split("-").length >= 2
+  )
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

Correctly handle hyphens within the user key when adding the key as CSS class.  

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
