### PR TITLE
Remove table styles from global styling

### DIFF
--- a/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
@@ -29,8 +29,16 @@ export const StyledTable = styled.table(({ theme }) => ({
   width: theme.sizes.full,
   marginBottom: theme.spacing.lg,
   color: theme.colors.bodyText,
+  // Prevent double borders
   borderCollapse: "collapse",
+  captionSide: "bottom",
   border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColorLight}`,
+  "& caption": {
+    paddingTop: theme.spacing.sm,
+    paddingBottom: 0,
+    color: theme.colors.fadedText60,
+    textAlign: "left",
+  },
 }))
 
 const styleCellFunction = (theme: EmotionTheme): CSSObject => ({
@@ -46,7 +54,7 @@ export const StyledTableCell = styled.td(({ theme }) =>
 )
 export const StyledTableCellHeader = styled.th(({ theme }) => ({
   ...styleCellFunction(theme),
-
+  textAlign: "inherit",
   color: theme.colors.fadedText60,
 }))
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -91,10 +91,16 @@ export const StyledStreamlitMarkdown =
         table: {
           // Add some space below the markdown tables
           marginBottom: theme.spacing.lg,
+          // Prevent double borders
+          borderCollapse: "collapse",
         },
 
         tr: {
           borderTop: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
+        },
+
+        th: {
+          textAlign: "inherit",
         },
 
         "th, td": {

--- a/frontend/lib/src/theme/globalStyles.ts
+++ b/frontend/lib/src/theme/globalStyles.ts
@@ -320,41 +320,6 @@ export const globalStyles = (theme: EmotionTheme): SerializedStyles => css`
     vertical-align: middle;
   }
 
-  // Tables
-  //
-  // Prevent double borders
-
-  table {
-    caption-side: bottom;
-    border-collapse: collapse;
-  }
-
-  table caption {
-    padding-top: ${theme.spacing.sm};
-    padding-bottom: 0;
-    color: ${theme.colors.gray60};
-    text-align: left;
-  }
-
-  // 1. Matches default <td> alignment by inheriting text-align.
-  // 2. Fix alignment for Safari
-
-  th {
-    text-align: inherit; // 1
-    text-align: -webkit-match-parent; // 2
-  }
-
-  thead,
-  tbody,
-  tfoot,
-  tr,
-  td,
-  th {
-    border-color: inherit;
-    border-style: solid;
-    border-width: 0;
-  }
-
   // Forms
   //
   // 1. Allow labels to use margin for spacing.


### PR DESCRIPTION
## Describe your changes

This PR removes all the table-related styles from global styles and applies it within the ArrowTable and Markdown instead.

## Testing Plan

- No logical changes. Existing tests should be sufficient.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
