### PR TITLE
Actually fix the root cause of the st.audio_input flakey test

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -203,16 +203,24 @@ const AudioInput: React.FC<Props> = ({
   )
 
   const handleClear = useCallback(
-    ({ updateWidgetManager }: { updateWidgetManager?: boolean }) => {
+    ({
+      updateWidgetManager,
+      deleteFile,
+    }: {
+      updateWidgetManager?: boolean
+      deleteFile?: boolean
+    }) => {
       if (isNullOrUndefined(wavesurfer) || isNullOrUndefined(deleteFileUrl)) {
         return
       }
       setRecordingUrl(null)
       wavesurfer.empty()
-      uploadClient.deleteFile(deleteFileUrl)
+      if (deleteFile) {
+        uploadClient.deleteFile(deleteFileUrl)
+        setDeleteFileUrl(null)
+      }
       setProgressTime(STARTING_TIME_STRING)
       setRecordingTime(STARTING_TIME_STRING)
-      setDeleteFileUrl(null)
       if (updateWidgetManager) {
         widgetMgr.setFileUploaderStateValue(
           element,
@@ -245,7 +253,7 @@ const AudioInput: React.FC<Props> = ({
 
     const formClearHelper = new FormClearHelper()
     formClearHelper.manageFormClearListener(widgetMgr, widgetFormId, () =>
-      setTimeout(() => handleClear({ updateWidgetManager: true }), 50)
+      handleClear({ updateWidgetManager: true, deleteFile: false })
     )
 
     return () => formClearHelper.disconnect()
@@ -362,7 +370,7 @@ const AudioInput: React.FC<Props> = ({
     })
 
     if (recordingUrl) {
-      handleClear({ updateWidgetManager: false })
+      handleClear({ updateWidgetManager: false, deleteFile: true })
     }
 
     recordPlugin.startRecording({ deviceId: audioDeviceId }).then(() => {
@@ -445,7 +453,9 @@ const AudioInput: React.FC<Props> = ({
             <ToolbarAction
               label="Clear recording"
               icon={Delete}
-              onClick={() => handleClear({ updateWidgetManager: true })}
+              onClick={() =>
+                handleClear({ updateWidgetManager: true, deleteFile: true })
+              }
             />
           )}
         </Toolbar>
@@ -459,7 +469,7 @@ const AudioInput: React.FC<Props> = ({
           stopRecording={stopRecording}
           onClickPlayPause={onClickPlayPause}
           onClear={() => {
-            handleClear({ updateWidgetManager: false })
+            handleClear({ updateWidgetManager: false, deleteFile: true })
             setIsError(false)
           }}
           disabled={isDisabled}

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -244,9 +244,9 @@ const AudioInput: React.FC<Props> = ({
     if (isNullOrUndefined(widgetFormId)) return
 
     const formClearHelper = new FormClearHelper()
-    formClearHelper.manageFormClearListener(widgetMgr, widgetFormId, () => {
-      handleClear({ updateWidgetManager: true })
-    })
+    formClearHelper.manageFormClearListener(widgetMgr, widgetFormId, () =>
+      setTimeout(() => handleClear({ updateWidgetManager: true }), 50)
+    )
 
     return () => formClearHelper.disconnect()
   }, [widgetFormId, handleClear, widgetMgr])

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -217,8 +217,8 @@ const AudioInput: React.FC<Props> = ({
       wavesurfer.empty()
       if (deleteFile) {
         uploadClient.deleteFile(deleteFileUrl)
-        setDeleteFileUrl(null)
       }
+      setDeleteFileUrl(null)
       setProgressTime(STARTING_TIME_STRING)
       setRecordingTime(STARTING_TIME_STRING)
       if (updateWidgetManager) {

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -207,8 +207,8 @@ const AudioInput: React.FC<Props> = ({
       updateWidgetManager,
       deleteFile,
     }: {
-      updateWidgetManager?: boolean
-      deleteFile?: boolean
+      updateWidgetManager: boolean
+      deleteFile: boolean
     }) => {
       if (isNullOrUndefined(wavesurfer) || isNullOrUndefined(deleteFileUrl)) {
         return


### PR DESCRIPTION
## Describe your changes
https://github.com/streamlit/streamlit/pull/9755 was unsuccessful, this PR tries a different approach to prevent the test flaking. (Actually fixing the root cause, thanks @lukasmasuch for pointing out the issue.)

Root cause analysis:

I initially assumed that when a form is submitted and subsequently cleared, the variable holding the output from `st.audio_input` should also reset to `None`, reflecting the cleared state of the UI. However, Lukas insightfully pointed out that this approach would render the output inaccessible, as it would disappear immediately after submission, leaving no opportunity for user interaction. Consequently, the solution now is to clear the variable only when it’s not part of a form submission.



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
