### PR TITLE
Move `hr` styles from global styles to markdown component

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -88,6 +88,21 @@ export const StyledStreamlitMarkdown =
           borderLeft: `${theme.sizes.borderWidth} solid ${theme.colors.lightGray}`,
         },
 
+        hr: {
+          margin: "2em 0",
+          padding: 0,
+          // Reset Firefox's gray color
+          color: "inherit",
+          backgroundColor: "transparent",
+          border: "none",
+          borderBottom: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
+          "&:not([size])": {
+            // Set correct height and prevent the size attribute
+            // to make the hr look like an input field
+            height: theme.sizes.borderWidth,
+          },
+        },
+
         table: {
           // Add some space below the markdown tables
           marginBottom: theme.spacing.lg,

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -82,23 +82,25 @@ export const StyledStreamlitMarkdown =
           fontSize: theme.fontSizes.md,
         },
 
+        // Handles quotes:
         blockquote: {
           margin: "1em 0 1em 0",
           padding: "0 0 0 1.2em",
           borderLeft: `${theme.sizes.borderWidth} solid ${theme.colors.lightGray}`,
         },
 
+        // Handles the horizontal divider:
         hr: {
           margin: "2em 0",
           padding: 0,
-          // Reset Firefox's gray color
+          // Reset Firefox's gray color:
           color: "inherit",
           backgroundColor: "transparent",
           border: "none",
           borderBottom: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
+          // Set correct height and prevent the size attribute
+          // to make the hr look like an input field:
           "&:not([size])": {
-            // Set correct height and prevent the size attribute
-            // to make the hr look like an input field
             height: theme.sizes.borderWidth,
           },
         },

--- a/frontend/lib/src/theme/globalStyles.ts
+++ b/frontend/lib/src/theme/globalStyles.ts
@@ -93,24 +93,6 @@ export const globalStyles = (theme: EmotionTheme): SerializedStyles => css`
     outline: 0 !important;
   }
 
-  // Content grouping
-  //
-  // 1. Reset Firefox's gray color
-  // 2. Set correct height and prevent the size attribute to make the hr look like an input field
-
-  hr {
-    margin: 2em 0;
-    padding: 0;
-    color: inherit; // 1
-    background-color: transparent;
-    border: none;
-    border-bottom: ${theme.sizes.borderWidth} solid ${theme.colors.borderColor};
-  }
-
-  hr:not([size]) {
-    height: 1px; // 2
-  }
-
   h1 {
     font-family: ${theme.genericFonts.headingFont};
     font-weight: ${theme.fontWeights.extrabold};


### PR DESCRIPTION
## Describe your changes

This PR removes all the `hr`-related styles from global styles and applies them in the Markdown component instead.

## Testing Plan

- No logical or visual changes. Existing tests should be sufficient.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
