### PR TITLE
Make number input controls responsive to font size

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/styled-components.ts
@@ -16,8 +16,6 @@
 
 import styled from "@emotion/styled"
 
-const CONTROLS_WIDTH = 32 // px
-
 export const StyledInputContainer = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
@@ -64,7 +62,7 @@ export const StyledInputControl = styled.button(({ theme }) => ({
   height: theme.sizes.full,
   display: "flex",
   alignItems: "center",
-  width: `${CONTROLS_WIDTH}px`,
+  width: theme.sizes.numberInputControlsWidth,
   justifyContent: "center",
   color: theme.colors.bodyText,
   transition: "color 300ms, backgroundColor 300ms",
@@ -102,5 +100,9 @@ export const StyledInstructionsContainer =
     position: "absolute",
     marginRight: theme.spacing.twoXS,
     left: 0,
-    right: `${CONTROLS_WIDTH * 2 + (clearable ? 12 : 0)}px`,
+    // The instructions should be placed after the two controls
+    // and the clear button if it's present.
+    right: `calc(${theme.sizes.numberInputControlsWidth} * 2 + ${
+      clearable ? "1em" : "0em"
+    })`,
   }))

--- a/frontend/lib/src/theme/primitives/sizes.ts
+++ b/frontend/lib/src/theme/primitives/sizes.ts
@@ -45,4 +45,5 @@ export const sizes = {
   chatAvatarSize: "2rem",
   // Used for the clear icon used by some Input elements
   clearIconSize: "1.5em",
+  numberInputControlsWidth: "2rem",
 }


### PR DESCRIPTION
## Describe your changes

Fix the number input control width to be responsive to the root font size (via rem) instead of using px size. This is required for the upcoming changes for advanced theming.

## Testing Plan

- No logical or visual changes. Just uses rem instead of px. Will be better tested once configuring the base font size is supported.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
