### PR TITLE
[Fix] Prevent rerun for text_input when value did not change

### DIFF
--- a/e2e_playwright/st_text_input.py
+++ b/e2e_playwright/st_text_input.py
@@ -64,3 +64,10 @@ st.write("value 10:", v10)
 
 v11 = st.text_input("text input 11 (type=password)", "my password", type="password")
 st.write("value 11:", v11)
+
+
+if "rerun_counter" not in st.session_state:
+    st.session_state.rerun_counter = 0
+
+st.session_state.rerun_counter += 1
+st.write("Rerun counter:", st.session_state.rerun_counter)

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -46,7 +46,7 @@ def test_text_input_widget_rendering(
 def test_text_input_has_correct_initial_values(app: Page):
     """Test that st.text_input has the correct initial values."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(12)
+    expect(markdown_elements).to_have_count(13)
 
     expected = [
         "value 1: ",
@@ -144,6 +144,36 @@ def test_text_input_has_correct_value_on_click_outside(app: Page):
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(
         "value 1: hello world", use_inner_text=True
     )
+
+
+def test_text_input_does_not_trigger_rerun_when_value_does_not_change_and_click_outside(
+    app: Page,
+):
+    """Test that st.text_input has the correct value on click outside."""
+
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="Rerun counter: 1")
+    ).to_be_attached()
+
+    first_text_input_field = (
+        app.get_by_test_id("stTextInput").first.locator("input").first
+    )
+    first_text_input_field.focus()
+    first_text_input_field.fill("hello world")
+    app.get_by_test_id("stMarkdown").first.click()
+
+    expect(app.get_by_test_id("stMarkdown").first).to_have_text(
+        "value 1: hello world", use_inner_text=True
+    )
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="Rerun counter: 2")
+    ).to_be_attached()
+
+    first_text_input_field.focus()
+    app.get_by_test_id("stMarkdown").first.click()
+    expect(
+        app.get_by_test_id("stMarkdown").filter(has_text="Rerun counter: 2")
+    ).to_be_attached()
 
 
 def test_empty_text_input_behaves_correctly(app: Page):

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -97,6 +97,11 @@ function TextInput({
   const [id] = useState(() => uniqueId("text_input_"))
   const { placeholder, formId } = element
 
+  const commitWidgetValue = useCallback((): void => {
+    setDirty(false)
+    setValueWithSource({ value: uiValue, fromUi: true })
+  }, [uiValue, setValueWithSource])
+
   // Show "Please enter" instructions if in a form & allowed, or not in form and state is dirty.
   const allowEnterToSubmit = isInForm({ formId })
     ? widgetMgr.allowFormEnterToSubmit(formId)
@@ -108,10 +113,10 @@ function TextInput({
 
   const onBlur = useCallback((): void => {
     if (dirty) {
-      setValueWithSource({ value: uiValue, fromUi: true })
+      commitWidgetValue()
     }
     setFocused(false)
-  }, [dirty, uiValue])
+  }, [dirty, commitWidgetValue])
 
   const onFocus = useCallback((): void => {
     setFocused(true)
@@ -151,14 +156,14 @@ function TextInput({
       }
 
       if (dirty) {
-        setValueWithSource({ value: uiValue, fromUi: true })
+        commitWidgetValue()
       }
 
       if (widgetMgr.allowFormEnterToSubmit(element.formId)) {
         widgetMgr.submitForm(element.formId, fragmentId)
       }
     },
-    [uiValue, element, fragmentId]
+    [element, fragmentId, dirty, commitWidgetValue]
   )
 
   return (

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -55,6 +55,24 @@ function TextInput({
   width,
   fragmentId,
 }: Props): ReactElement {
+  /**
+   * The value specified by the user via the UI. If the user didn't touch this
+   * widget's UI, the default value is used.
+   */
+  const [uiValue, setUiValue] = useState<string | null>(
+    getStateFromWidgetMgr(widgetMgr, element) ?? null
+  )
+
+  /**
+   * True if the user-specified state.value has not yet been synced to the WidgetStateManager.
+   */
+  const [dirty, setDirty] = useState(false)
+
+  const onFormCleared = useCallback(() => {
+    setUiValue(element.default ?? null)
+    setDirty(true)
+  }, [element.default])
+
   const [value, setValueWithSource] = useBasicWidgetState<
     string | null,
     TextInputProto
@@ -66,32 +84,24 @@ function TextInput({
     element,
     widgetMgr,
     fragmentId,
+    onFormCleared,
   })
 
-  /**
-   * True if the user-specified state.value has not yet been synced to the WidgetStateManager.
-   */
-  const [dirty, setDirty] = useState(false)
+  useEffect(() => {
+    // the UI did not sync its value
+    if (dirty) {
+      return
+    }
+    // If the incoming value changes, update the UI value (e.g. set via state)
+    if (value !== uiValue) {
+      setUiValue(value)
+    }
+  }, [value, uiValue, dirty])
 
   /**
    * Whether the input is currently focused.
    */
   const [focused, setFocused] = useState(false)
-
-  /**
-   * The value specified by the user via the UI. If the user didn't touch this
-   * widget's UI, the default value is used.
-   */
-  const [uiValue, setUiValue] = useState<string | null>(value)
-
-  useEffect(() => {
-    if (value !== uiValue) {
-      setUiValue(value)
-    }
-    // Don't include `uiValue` in the deps below or the slider will become
-    // jittery.
-    /* eslint-disable react-hooks/exhaustive-deps */
-  }, [value])
 
   const theme = useTheme()
   const [id] = useState(() => uniqueId("text_input_"))
@@ -146,7 +156,7 @@ function TextInput({
       // update its value in the WidgetMgr. This means that individual keypresses
       // won't trigger a script re-run.
     },
-    [element]
+    [element, setValueWithSource]
   )
 
   const onKeyPress = useCallback(
@@ -163,7 +173,7 @@ function TextInput({
         widgetMgr.submitForm(element.formId, fragmentId)
       }
     },
-    [element, fragmentId, dirty, commitWidgetValue]
+    [element, fragmentId, dirty, commitWidgetValue, widgetMgr]
   )
 
   return (


### PR DESCRIPTION
## Describe your changes

See issue: https://discuss.streamlit.io/t/way-to-find-out-what-triggered-a-rerun/77870/4?u=mathcatsand

https://github.com/streamlit/streamlit/pull/9494 introduced a regression where the text_input component was not marked as undirty after syncing to the backend, causing a re-sync every time you would unfocus the text input field even when the value did not change.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Added a new JS unit test to ensure that not-changing the value and pressing enter / losing focus does not trigger a re-run
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
