### PR TITLE
Correctly handle `DeltaGenerator` in `st.write`

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -418,6 +418,9 @@ class WriteMixin:
             elif isinstance(arg, Exception):
                 flush_buffer()
                 self.dg.exception(arg)
+            elif type_util.is_delta_generator(arg):
+                flush_buffer()
+                self.dg.help(arg)
             elif dataframe_util.is_dataframe_like(arg):
                 flush_buffer()
                 self.dg.dataframe(arg)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from plotly.graph_objs import Figure
     from pydeck import Deck
 
+    from streamlit.delta_generator import DeltaGenerator
 
 T = TypeVar("T")
 
@@ -264,6 +265,10 @@ def _is_probably_plotly_dict(obj: object) -> TypeGuard[dict[str, Any]]:
     return False
 
 
+def is_delta_generator(obj: object) -> TypeGuard[DeltaGenerator]:
+    return is_type(obj, "streamlit.delta_generator.DeltaGenerator")
+
+
 def is_function(x: object) -> TypeGuard[types.FunctionType]:
     """Return True if x is a function."""
     return isinstance(x, types.FunctionType)
@@ -271,7 +276,13 @@ def is_function(x: object) -> TypeGuard[types.FunctionType]:
 
 def has_callable_attr(obj: object, name: str) -> bool:
     """True if obj has the specified attribute that is callable."""
-    return hasattr(obj, name) and callable(getattr(obj, name))
+    return (
+        hasattr(obj, name)
+        and callable(getattr(obj, name))
+        # DeltaGenerator will return a callable wrapper for any method name,
+        # even if it doesn't exist.
+        and not is_delta_generator(obj)
+    )
 
 
 def is_namedtuple(x: object) -> TypeGuard[NamedTuple]:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -266,6 +266,10 @@ def _is_probably_plotly_dict(obj: object) -> TypeGuard[dict[str, Any]]:
 
 
 def is_delta_generator(obj: object) -> TypeGuard[DeltaGenerator]:
+    """True if input looks like a DeltaGenerator."""
+
+    # We are using a string here to avoid circular import warnings
+    # when importing DeltaGenerator.
     return is_type(obj, "streamlit.delta_generator.DeltaGenerator")
 
 

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -182,3 +182,10 @@ class TypeUtilTest(unittest.TestCase):
     def test_is_custom_dict(self, dict_obj: Any, is_custom_dict: bool):
         """Test that `is_custom_dict` returns True for all Streamlit custom dicts."""
         assert type_util.is_custom_dict(dict_obj) is is_custom_dict
+
+    def test_is_delta_generator(self):
+        """Test that `is_delta_generator` returns True for DeltaGenerator."""
+        from streamlit.delta_generator import DeltaGenerator
+
+        assert type_util.is_delta_generator(DeltaGenerator()) is True
+        assert type_util.is_delta_generator("not a DeltaGenerator") is False

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -26,6 +26,7 @@ import pytest
 from parameterized import parameterized
 
 from streamlit import type_util
+from streamlit.delta_generator import DeltaGenerator
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.context import StreamlitCookies, StreamlitHeaders
 from streamlit.runtime.secrets import Secrets
@@ -168,6 +169,8 @@ class TypeUtilTest(unittest.TestCase):
         assert type_util.has_callable_attr(TestClass, "also_not_callable") is False
         assert type_util.has_callable_attr(TestClass, "not_a_real_attr") is False
 
+        assert type_util.has_callable_attr(DeltaGenerator(), "foo") is False
+
     @parameterized.expand(
         [
             ({"key": "value"}, False),
@@ -185,7 +188,6 @@ class TypeUtilTest(unittest.TestCase):
 
     def test_is_delta_generator(self):
         """Test that `is_delta_generator` returns True for DeltaGenerator."""
-        from streamlit.delta_generator import DeltaGenerator
 
         assert type_util.is_delta_generator(DeltaGenerator()) is True
         assert type_util.is_delta_generator("not a DeltaGenerator") is False

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -253,6 +253,13 @@ class StreamlitWriteTest(unittest.TestCase):
 
             p.assert_called_once()
 
+    def test_delta_generator_input(self):
+        """Test st.write with DeltaGenerator as input uses st.html."""
+        with patch("streamlit.delta_generator.DeltaGenerator.html") as p:
+            st.write(st.container())
+
+            p.assert_called_once()
+
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_streamlit_secrets(self, *mocks):
         """Test st.write with st.secrets."""

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -254,8 +254,8 @@ class StreamlitWriteTest(unittest.TestCase):
             p.assert_called_once()
 
     def test_delta_generator_input(self):
-        """Test st.write with DeltaGenerator as input uses st.html."""
-        with patch("streamlit.delta_generator.DeltaGenerator.html") as p:
+        """Test st.write with DeltaGenerator as input uses st.help."""
+        with patch("streamlit.delta_generator.DeltaGenerator.help") as p:
             st.write(st.container())
 
             p.assert_called_once()


### PR DESCRIPTION
## Describe your changes

Fixes handling for delta generator in `st.write`. Instead of an exception, it will show  the delta generator via `st.help`.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9827

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
