### PR TITLE
[Fix] Set text area value based on state

### DIFF
--- a/e2e_playwright/st_text_area.py
+++ b/e2e_playwright/st_text_area.py
@@ -75,3 +75,13 @@ try:
     st.text_area("text area 13 (height=65)", "default text", height=65)
 except StreamlitAPIException as ex:
     st.exception(ex)
+
+if "text_area_13" not in st.session_state:
+    st.session_state["text_area_13"] = "xyz"
+
+v13 = st.text_area(
+    "text area 13 (value from state)",
+    value=None,
+    key="text_area_13",
+)
+st.write("text area 13 (value from state) - value: ", v13)

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -77,7 +77,7 @@ def test_text_area_has_correct_initial_values(app: Page):
 
 
 def test_text_area_shows_state_value(app: Page):
-    expect(app.get_by_test_id("stTextAreaRootElement").nth(13)).to_have_text("xyz")
+    expect(app.get_by_test_id("stTextAreaRootElement").nth(12)).to_have_text("xyz")
 
 
 def test_text_area_shows_instructions_when_dirty(

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -29,7 +29,7 @@ def test_text_area_widget_rendering(
 ):
     """Test that the st.text_area widgets are correctly rendered via screenshot matching."""
     text_area_widgets = themed_app.get_by_test_id("stTextArea")
-    expect(text_area_widgets).to_have_count(12)
+    expect(text_area_widgets).to_have_count(13)
 
     assert_snapshot(text_area_widgets.nth(0), name="st_text_area-default")
     assert_snapshot(text_area_widgets.nth(1), name="st_text_area-value_some_text")
@@ -53,7 +53,7 @@ def test_help_tooltip_works(app: Page):
 def test_text_area_has_correct_initial_values(app: Page):
     """Test that st.text_area has the correct initial values."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(13)
+    expect(markdown_elements).to_have_count(14)
 
     expected = [
         "value 1: ",
@@ -69,10 +69,15 @@ def test_text_area_has_correct_initial_values(app: Page):
         "value 10: 1234",
         "value 11: default text",
         "value 12: default text",
+        "text area 13 (value from state) - value: xyz",
     ]
 
     for markdown_element, expected_text in zip(markdown_elements.all(), expected):
         expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
+
+
+def test_text_area_shows_state_value(app: Page):
+    expect(app.get_by_test_id("stTextAreaRootElement").nth(13)).to_have_text("xyz")
 
 
 def test_text_area_shows_instructions_when_dirty(

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -85,13 +85,15 @@ function TextInput({
   const [uiValue, setUiValue] = useState<string | null>(value)
 
   useEffect(() => {
+    // the UI did not sync its value
+    if (dirty) {
+      return
+    }
+    // If the incoming value changes, update the UI value (e.g. set via state)
     if (value !== uiValue) {
       setUiValue(value)
     }
-    // Don't include `uiValue` in the deps below or the slider will become
-    // jittery.
-    /* eslint-disable react-hooks/exhaustive-deps */
-  }, [value])
+  }, [value, uiValue, dirty])
 
   const theme = useTheme()
   const [id] = useState(() => uniqueId("text_input_"))
@@ -111,7 +113,7 @@ function TextInput({
       setValueWithSource({ value: uiValue, fromUi: true })
     }
     setFocused(false)
-  }, [dirty, uiValue])
+  }, [dirty, uiValue, setValueWithSource])
 
   const onFocus = useCallback((): void => {
     setFocused(true)
@@ -141,7 +143,7 @@ function TextInput({
       // update its value in the WidgetMgr. This means that individual keypresses
       // won't trigger a script re-run.
     },
-    [element]
+    [element, setValueWithSource]
   )
 
   const onKeyPress = useCallback(
@@ -158,7 +160,7 @@ function TextInput({
         widgetMgr.submitForm(element.formId, fragmentId)
       }
     },
-    [uiValue, element, fragmentId]
+    [element, fragmentId, widgetMgr, dirty, uiValue, setValueWithSource]
   )
 
   return (


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9825 (Aligned with changes in https://github.com/streamlit/streamlit/pull/9826 about a similar regression)

Fixes a regression where a text_area value is not set correctly based on the state.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
  - Add an e2e test to prevent regression in the future
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
