### PR TITLE
Add vitest to recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "ms-python.python",
     "ms-python.debugpy",
     "charliermarsh.ruff",
-    "EditorConfig.EditorConfig"
+    "EditorConfig.EditorConfig",
+    "vitest.explorer",
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,6 @@
     "ms-python.debugpy",
     "charliermarsh.ruff",
     "EditorConfig.EditorConfig",
-    "vitest.explorer",
+    "vitest.explorer"
   ]
 }


### PR DESCRIPTION
## Describe your changes

Adds the official [vitest-explorer](https://github.com/vitest-dev/vscode) to the list of recommended VSCode extensions.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
