### PR TITLE
Add shared hooks for submitForm & inputChange

### DIFF
--- a/e2e_playwright/st_text_area.py
+++ b/e2e_playwright/st_text_area.py
@@ -85,3 +85,12 @@ v13 = st.text_area(
     key="text_area_13",
 )
 st.write("text area 13 (value from state) - value: ", v13)
+
+with st.form("form"):
+    st.text_area("text area 14 (value from form)", key="text_area_14")
+    st.form_submit_button("submit")
+
+form_value = (
+    st.session_state["text_area_14"] if "text_area_14" in st.session_state else None
+)
+st.write("text area 14 (value from form) - value: ", form_value)

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -29,7 +29,7 @@ def test_text_area_widget_rendering(
 ):
     """Test that the st.text_area widgets are correctly rendered via screenshot matching."""
     text_area_widgets = themed_app.get_by_test_id("stTextArea")
-    expect(text_area_widgets).to_have_count(13)
+    expect(text_area_widgets).to_have_count(14)
 
     assert_snapshot(text_area_widgets.nth(0), name="st_text_area-default")
     assert_snapshot(text_area_widgets.nth(1), name="st_text_area-value_some_text")

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -70,7 +70,7 @@ def test_text_area_has_correct_initial_values(app: Page):
         "value 11: default text",
         "value 12: default text",
         "text area 13 (value from state) - value: xyz",
-        "text area 13 (value from state) - value: None",
+        "text area 14 (value from form) - value: ",
     ]
 
     for markdown_element, expected_text in zip(markdown_elements.all(), expected):
@@ -78,7 +78,9 @@ def test_text_area_has_correct_initial_values(app: Page):
 
 
 def test_text_area_shows_state_value(app: Page):
-    expect(app.get_by_test_id("stTextAreaRootElement").nth(13)).to_have_text("xyz")
+    expect(
+        app.get_by_test_id("stTextArea").nth(12).locator("textarea").first
+    ).to_have_text("xyz")
 
 
 def test_text_area_shows_instructions_when_dirty(

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -53,7 +53,7 @@ def test_help_tooltip_works(app: Page):
 def test_text_area_has_correct_initial_values(app: Page):
     """Test that st.text_area has the correct initial values."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(14)
+    expect(markdown_elements).to_have_count(15)
 
     expected = [
         "value 1: ",
@@ -70,6 +70,7 @@ def test_text_area_has_correct_initial_values(app: Page):
         "value 11: default text",
         "value 12: default text",
         "text area 13 (value from state) - value: xyz",
+        "text area 13 (value from state) - value: None",
     ]
 
     for markdown_element, expected_text in zip(markdown_elements.all(), expected):
@@ -77,7 +78,7 @@ def test_text_area_has_correct_initial_values(app: Page):
 
 
 def test_text_area_shows_state_value(app: Page):
-    expect(app.get_by_test_id("stTextAreaRootElement").nth(12)).to_have_text("xyz")
+    expect(app.get_by_test_id("stTextAreaRootElement").nth(13)).to_have_text("xyz")
 
 
 def test_text_area_shows_instructions_when_dirty(
@@ -234,6 +235,17 @@ def test_calls_callback_on_change(app: Page):
     )
     expect(app.get_by_test_id("stMarkdown").nth(9)).to_have_text(
         "text area changed: False",
+        use_inner_text=True,
+    )
+
+
+def test_text_area_in_form_with_submit_by_enter(app: Page):
+    """Test that text area in form can be submitted by pressing Command+Enter"""
+    text_area_field = app.get_by_test_id("stTextArea").nth(13).locator("textarea").first
+    text_area_field.fill("hello world")
+    text_area_field.press("Control+Enter")
+    expect(app.get_by_test_id("stMarkdown").nth(14)).to_have_text(
+        "text area 14 (value from form) - value: hello world",
         use_inner_text=True,
     )
 

--- a/e2e_playwright/st_text_input.py
+++ b/e2e_playwright/st_text_input.py
@@ -75,6 +75,16 @@ v12 = st.text_input(
 )
 st.write("text input 12 (value from state) - value: ", v12)
 
+with st.form("form"):
+    st.text_input("text input 13 (value from form)", key="text_input_13")
+    st.form_submit_button("submit")
+
+form_value = (
+    st.session_state["text_input_13"] if "text_input_13" in st.session_state else None
+)
+st.write("text input 13 (value from form) - value: ", form_value)
+
+
 if "rerun_counter" not in st.session_state:
     st.session_state.rerun_counter = 0
 

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -248,6 +248,17 @@ def test_calls_callback_on_change(app: Page):
     )
 
 
+def test_text_input_in_form_with_submit_by_enter(app: Page):
+    """Test that text area in form can be submitted by pressing Command+Enter"""
+    text_area_field = app.get_by_test_id("stTextInput").nth(12).locator("input").first
+    text_area_field.fill("hello world")
+    text_area_field.press("Enter")
+    expect(app.get_by_test_id("stMarkdown").nth(13)).to_have_text(
+        "text input 13 (value from form) - value: hello world",
+        use_inner_text=True,
+    )
+
+
 def test_help_tooltip_works(app: Page):
     """Test that the help tooltip is displayed on hover."""
     element_with_help = app.get_by_test_id("stTextInput").nth(8)

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -46,7 +46,7 @@ def test_text_input_widget_rendering(
 def test_text_input_has_correct_initial_values(app: Page):
     """Test that st.text_input has the correct initial values."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(14)
+    expect(markdown_elements).to_have_count(15)
 
     expected = [
         "value 1: ",

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -28,7 +28,7 @@ def test_text_input_widget_rendering(
 ):
     """Test that the st.text_input widgets are correctly rendered via screenshot matching."""
     text_input_widgets = themed_app.get_by_test_id("stTextInput")
-    expect(text_input_widgets).to_have_count(12)
+    expect(text_input_widgets).to_have_count(13)
 
     assert_snapshot(text_input_widgets.nth(0), name="st_text_input-default")
     assert_snapshot(text_input_widgets.nth(1), name="st_text_input-value_some_text")

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -30,6 +30,7 @@ import { ChatInput as ChatInputProto } from "@streamlit/lib/src/proto"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import Icon from "@streamlit/lib/src/components/shared/Icon"
 import InputInstructions from "@streamlit/lib/src/components/shared/InputInstructions/InputInstructions"
+import { isEnterKeyPressed } from "@streamlit/lib/src/util/inputUtils"
 
 import {
   StyledChatInput,
@@ -53,20 +54,6 @@ const MAX_VISIBLE_NUM_LINES = 6.5
 // Rounding errors can arbitrarily create scrollbars. We add a rounding offset
 // to manage it better.
 const ROUNDING_OFFSET = 1
-
-const isEnterKeyPressed = (
-  event: KeyboardEvent<HTMLTextAreaElement>
-): boolean => {
-  // Using keyCode as well due to some different behaviors on Windows
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
-
-  const { keyCode, key } = event
-  return (
-    (key === "Enter" || keyCode === 13 || keyCode === 10) &&
-    // Do not send the sentence being composed when Enter is typed into the IME.
-    !(event.nativeEvent?.isComposing === true)
-  )
-}
 
 function ChatInput({
   width,

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -154,12 +154,12 @@ const TextArea: FC<Props> = ({
     setValueWithSource
   )
 
+  console.log("widgetMgr", widgetMgr)
   const onKeyDown = useSubmitFormViaEnterKey(
     element.formId,
     commitWidgetValue,
     dirty,
-    widgetMgr.allowFormEnterToSubmit,
-    widgetMgr.submitForm,
+    widgetMgr,
     fragmentId,
     true
   )

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -21,11 +21,10 @@ import { useTheme } from "@emotion/react"
 import uniqueId from "lodash/uniqueId"
 
 import { TextArea as TextAreaProto } from "@streamlit/lib/src/proto"
-import {
-  Source,
-  WidgetStateManager,
-} from "@streamlit/lib/src/WidgetStateManager"
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import useUpdateUiValue from "@streamlit/lib/src/hooks/useUpdateUiValue"
+import useSubmitFormViaEnterKey from "@streamlit/lib/src/hooks/useSubmitFormViaEnterKey"
+import useOnInputChange from "@streamlit/lib/src/hooks/useOnInputChange"
 import InputInstructions from "@streamlit/lib/src/components/shared/InputInstructions/InputInstructions"
 import {
   StyledWidgetLabelHelp,
@@ -131,17 +130,14 @@ const TextArea: FC<Props> = ({
 
   const theme: EmotionTheme = useTheme()
 
-  const commitWidgetValue = useCallback(
-    ({ fromUi }: Source): void => {
-      setValueWithSource({ value: uiValue, fromUi })
-      setDirty(false)
-    },
-    [uiValue, setValueWithSource]
-  )
+  const commitWidgetValue = useCallback((): void => {
+    setDirty(false)
+    setValueWithSource({ value: uiValue, fromUi: true })
+  }, [uiValue, setValueWithSource])
 
   const onBlur = useCallback(() => {
     if (dirty) {
-      commitWidgetValue({ fromUi: true })
+      commitWidgetValue()
     }
     setFocused(false)
   }, [dirty, commitWidgetValue])
@@ -150,53 +146,21 @@ const TextArea: FC<Props> = ({
     setFocused(true)
   }, [])
 
-  const onChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-      const { value } = e.target
-      const { maxChars } = element
-
-      if (maxChars !== 0 && value.length > maxChars) {
-        return
-      }
-
-      // mark it dirty but don't update its value in the WidgetMgr
-      // This means that individual keypresses won't trigger a script re-run.
-      setUiValue(value)
-      setDirty(true)
-    },
-    [element]
+  const onChange = useOnInputChange(
+    element.formId,
+    element.maxChars,
+    setDirty,
+    setUiValue,
+    setValueWithSource
   )
 
-  const isEnterKeyPressed = (
-    event: React.KeyboardEvent<HTMLTextAreaElement>
-  ): boolean => {
-    const { keyCode, key } = event
-
-    // Using keyCode as well due to some different behaviors on Windows
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
-    return (
-      (key === "Enter" || keyCode === 13 || keyCode === 10) &&
-      // Do not send the sentence being composed when Enter is typed into the IME.
-      !(event.nativeEvent?.isComposing === true)
-    )
-  }
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-      const { metaKey, ctrlKey } = e
-      const { formId } = element
-      const allowFormEnterToSubmit = widgetMgr.allowFormEnterToSubmit(formId)
-
-      if (isEnterKeyPressed(e) && (ctrlKey || metaKey) && dirty) {
-        e.preventDefault()
-
-        commitWidgetValue({ fromUi: true })
-        if (allowFormEnterToSubmit) {
-          widgetMgr.submitForm(formId, fragmentId)
-        }
-      }
-    },
-    [element, widgetMgr, dirty, commitWidgetValue, fragmentId]
+  const onKeyDown = useSubmitFormViaEnterKey(
+    element.formId,
+    commitWidgetValue,
+    dirty,
+    widgetMgr,
+    fragmentId,
+    true
   )
 
   const style = { width }

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -158,7 +158,8 @@ const TextArea: FC<Props> = ({
     element.formId,
     commitWidgetValue,
     dirty,
-    widgetMgr,
+    widgetMgr.allowFormEnterToSubmit,
+    widgetMgr.submitForm,
     fragmentId,
     true
   )

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -146,13 +146,13 @@ const TextArea: FC<Props> = ({
     setFocused(true)
   }, [])
 
-  const onChange = useOnInputChange(
-    element.formId,
-    element.maxChars,
+  const onChange = useOnInputChange({
+    formId: element.formId,
+    maxChars: element.maxChars,
     setDirty,
     setUiValue,
-    setValueWithSource
-  )
+    setValueWithSource,
+  })
 
   const onKeyDown = useSubmitFormViaEnterKey(
     element.formId,

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -154,7 +154,6 @@ const TextArea: FC<Props> = ({
     setValueWithSource
   )
 
-  console.log("widgetMgr", widgetMgr)
   const onKeyDown = useSubmitFormViaEnterKey(
     element.formId,
     commitWidgetValue,

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -138,7 +138,8 @@ function TextInput({
     element.formId,
     commitWidgetValue,
     dirty,
-    widgetMgr,
+    widgetMgr.allowFormEnterToSubmit,
+    widgetMgr.submitForm,
     fragmentId
   )
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -126,13 +126,13 @@ function TextInput({
     setFocused(true)
   }, [])
 
-  const onChange = useOnInputChange(
-    element.formId,
-    element.maxChars,
+  const onChange = useOnInputChange({
+    formId: element.formId,
+    maxChars: element.maxChars,
     setDirty,
     setUiValue,
-    setValueWithSource
-  )
+    setValueWithSource,
+  })
 
   const onKeyPress = useSubmitFormViaEnterKey(
     element.formId,

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -138,8 +138,7 @@ function TextInput({
     element.formId,
     commitWidgetValue,
     dirty,
-    widgetMgr.allowFormEnterToSubmit,
-    widgetMgr.submitForm,
+    widgetMgr,
     fragmentId
   )
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -20,6 +20,7 @@ import uniqueId from "lodash/uniqueId"
 import { Input as UIInput } from "baseui/input"
 import { useTheme } from "@emotion/react"
 
+import useOnInputChange from "@streamlit/lib/src/hooks/useOnInputChange"
 import { TextInput as TextInputProto } from "@streamlit/lib/src/proto"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import {
@@ -27,6 +28,7 @@ import {
   ValueWithSource,
 } from "@streamlit/lib/src/hooks/useBasicWidgetState"
 import useUpdateUiValue from "@streamlit/lib/src/hooks/useUpdateUiValue"
+import useSubmitFormViaEnterKey from "@streamlit/lib/src/hooks/useSubmitFormViaEnterKey"
 import InputInstructions from "@streamlit/lib/src/components/shared/InputInstructions/InputInstructions"
 import {
   StyledWidgetLabelHelp,
@@ -124,48 +126,20 @@ function TextInput({
     setFocused(true)
   }, [])
 
-  const onChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-      const { value: newValue } = e.target
-      const { maxChars } = element
-
-      if (maxChars !== 0 && newValue.length > maxChars) {
-        return
-      }
-
-      setDirty(true)
-      setUiValue(newValue)
-
-      // We immediately update its widgetValue on text changes in forms
-      // see here for why: https://github.com/streamlit/streamlit/issues/7101
-      // The widgetValue won't be passed to the Python script until the form
-      // is submitted, so this won't cause the script to re-run.
-      if (isInForm(element)) {
-        // Make sure dirty is true so that enter to submit form text shows
-        setValueWithSource({ value: newValue, fromUi: true })
-      }
-      // If the TextInput is *not* part of a form, we mark it dirty but don't
-      // update its value in the WidgetMgr. This means that individual keypresses
-      // won't trigger a script re-run.
-    },
-    [element, setValueWithSource]
+  const onChange = useOnInputChange(
+    element.formId,
+    element.maxChars,
+    setDirty,
+    setUiValue,
+    setValueWithSource
   )
 
-  const onKeyPress = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-      if (e.key !== "Enter") {
-        return
-      }
-
-      if (dirty) {
-        commitWidgetValue()
-      }
-
-      if (widgetMgr.allowFormEnterToSubmit(element.formId)) {
-        widgetMgr.submitForm(element.formId, fragmentId)
-      }
-    },
-    [element, fragmentId, dirty, commitWidgetValue, widgetMgr]
+  const onKeyPress = useSubmitFormViaEnterKey(
+    element.formId,
+    commitWidgetValue,
+    dirty,
+    widgetMgr,
+    fragmentId
   )
 
   return (

--- a/frontend/lib/src/hooks/useOnInputChange.test.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.test.ts
@@ -26,13 +26,13 @@ describe("useOnInputChange", () => {
     const setValueWithSource = vi.fn()
 
     const { result: onInputChange } = renderHook(() =>
-      useOnInPutChange(
-        "someFormId",
-        0,
-        setDirtyCallback,
-        setUiValueCallback,
-        setValueWithSource
-      )
+      useOnInPutChange({
+        formId: "someFormId",
+        maxChars: 0,
+        setDirty: setDirtyCallback,
+        setUiValue: setUiValueCallback,
+        setValueWithSource,
+      })
     )
 
     onInputChange.current({ target: { value: "someValue" } })
@@ -56,13 +56,13 @@ describe("useOnInputChange", () => {
     const setValueWithSource = vi.fn()
 
     const { result: onInputChange } = renderHook(() =>
-      useOnInPutChange(
-        undefined,
-        0,
-        setDirtyCallback,
-        setUiValueCallback,
-        setValueWithSource
-      )
+      useOnInPutChange({
+        formId: undefined,
+        maxChars: 0,
+        setDirty: setDirtyCallback,
+        setUiValue: setUiValueCallback,
+        setValueWithSource,
+      })
     )
 
     onInputChange.current({ target: { value: "someValue" } })
@@ -84,13 +84,13 @@ describe("useOnInputChange", () => {
     const setValueWithSource = vi.fn()
 
     const { result: onInputChange } = renderHook(() =>
-      useOnInPutChange(
-        undefined,
-        1,
-        setDirtyCallback,
-        setUiValueCallback,
-        setValueWithSource
-      )
+      useOnInPutChange({
+        formId: undefined,
+        maxChars: 1,
+        setDirty: setDirtyCallback,
+        setUiValue: setUiValueCallback,
+        setValueWithSource,
+      })
     )
 
     onInputChange.current({ target: { value: "someValue" } })

--- a/frontend/lib/src/hooks/useOnInputChange.test.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { waitFor } from "@testing-library/react"
+import { renderHook } from "@testing-library/react-hooks"
+
+import useOnInPutChange from "./useOnInputChange"
+
+describe("useOnInputChange", () => {
+  it("should call the setDirty, setUiValue, setValueWithSource callbacks because its in a form", async () => {
+    const setDirtyCallback = vi.fn()
+    const setUiValueCallback = vi.fn()
+    const setValueWithSource = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useOnInPutChange(
+        "someFormId",
+        0,
+        setDirtyCallback,
+        setUiValueCallback,
+        setValueWithSource
+      )
+    )
+
+    onInputChange.current({ target: { value: "someValue" } })
+
+    await waitFor(() => {
+      expect(setDirtyCallback).toHaveBeenCalledWith(true)
+    })
+    await waitFor(() => {
+      expect(setUiValueCallback).toHaveBeenCalledWith("someValue")
+    })
+    await waitFor(() => {
+      expect(setValueWithSource).toHaveBeenCalledWith({
+        value: "someValue",
+        fromUi: true,
+      })
+    })
+  })
+  it("should not call the setValueWithSource callback because it is not in a form", async () => {
+    const setDirtyCallback = vi.fn()
+    const setUiValueCallback = vi.fn()
+    const setValueWithSource = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useOnInPutChange(
+        undefined,
+        0,
+        setDirtyCallback,
+        setUiValueCallback,
+        setValueWithSource
+      )
+    )
+
+    onInputChange.current({ target: { value: "someValue" } })
+
+    await waitFor(() => {
+      expect(setDirtyCallback).toHaveBeenCalledWith(true)
+    })
+    await waitFor(() => {
+      expect(setUiValueCallback).toHaveBeenCalledWith("someValue")
+    })
+    await waitFor(() => {
+      expect(setValueWithSource).not.toHaveBeenCalled()
+    })
+  })
+
+  it("should not call any callbacks if value exceeds maxChars", async () => {
+    const setDirtyCallback = vi.fn()
+    const setUiValueCallback = vi.fn()
+    const setValueWithSource = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useOnInPutChange(
+        undefined,
+        1,
+        setDirtyCallback,
+        setUiValueCallback,
+        setValueWithSource
+      )
+    )
+
+    onInputChange.current({ target: { value: "someValue" } })
+
+    await waitFor(() => {
+      expect(setDirtyCallback).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(setUiValueCallback).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(setValueWithSource).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/lib/src/hooks/useOnInputChange.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.ts
@@ -23,6 +23,16 @@ type OnInputChangeEventType = {
   target: { value: string }
 } & Partial<HTMLInputElement>
 
+interface OnInputChangeProps {
+  formId: string | undefined
+  maxChars: number
+  setDirty: (dirty: boolean) => void
+  setUiValue: (value: string) => void
+  setValueWithSource: Dispatch<
+    SetStateAction<ValueWithSource<string | null> | null>
+  >
+}
+
 /**
  * Will return a memoized function that accepts an HTMLInputElement and will call
  * commitWidgetValue and setDirty with its value, unless the value is longer than
@@ -35,15 +45,13 @@ type OnInputChangeEventType = {
  * @param setValueWithSource calls setValueWithSource with the input element's value
  * @return memoized callback
  */
-export default function useOnInputChange(
-  formId: string | undefined,
-  maxChars: number,
-  setDirty: (dirty: boolean) => void,
-  setUiValue: (value: string) => void,
-  setValueWithSource: Dispatch<
-    SetStateAction<ValueWithSource<string | null> | null>
-  >
-): (e: OnInputChangeEventType) => void {
+export default function useOnInputChange({
+  formId,
+  maxChars,
+  setDirty,
+  setUiValue,
+  setValueWithSource,
+}: OnInputChangeProps): (e: OnInputChangeEventType) => void {
   return useCallback(
     (e: OnInputChangeEventType): void => {
       const { value: newValue } = e.target

--- a/frontend/lib/src/hooks/useOnInputChange.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, SetStateAction, useCallback } from "react"
+
+import { isInForm } from "@streamlit/lib/src/util/utils"
+import { ValueWithSource } from "@streamlit/lib/src/hooks/useBasicWidgetState"
+
+export default function useOnInputChange(
+  formId: string,
+  maxChars: number,
+  setDirty: (dirty: boolean) => void,
+  setUiValue: (value: string) => void,
+  setValueWithSource: Dispatch<
+    SetStateAction<ValueWithSource<string | null> | null>
+  >
+): (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void {
+  return useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+      const { value: newValue } = e.target
+
+      if (maxChars !== 0 && newValue.length > maxChars) {
+        return
+      }
+
+      setDirty(true)
+      setUiValue(newValue)
+
+      // We immediately update its widgetValue on text changes in forms
+      // see here for why: https://github.com/streamlit/streamlit/issues/7101
+      // The widgetValue won't be passed to the Python script until the form
+      // is submitted, so this won't cause the script to re-run.
+      if (isInForm({ formId })) {
+        // Make sure dirty is true so that enter to submit form text shows
+        setValueWithSource({ value: newValue, fromUi: true })
+      }
+      // If the TextInput is *not* part of a form, we mark it dirty but don't
+      // update its value in the WidgetMgr. This means that individual keypresses
+      // won't trigger a script re-run.
+    },
+    [formId, maxChars, setDirty, setUiValue, setValueWithSource]
+  )
+}

--- a/frontend/lib/src/hooks/useOnInputChange.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.ts
@@ -20,8 +20,10 @@ import { isInForm } from "@streamlit/lib/src/util/utils"
 import { ValueWithSource } from "@streamlit/lib/src/hooks/useBasicWidgetState"
 
 type OnInputChangeEventType = {
-  target: { value: string }
-} & Partial<HTMLInputElement>
+  target: {
+    value: HTMLInputElement["value"]
+  }
+}
 
 interface OnInputChangeProps {
   formId: string | undefined

--- a/frontend/lib/src/hooks/useOnInputChange.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.ts
@@ -19,17 +19,33 @@ import { Dispatch, SetStateAction, useCallback } from "react"
 import { isInForm } from "@streamlit/lib/src/util/utils"
 import { ValueWithSource } from "@streamlit/lib/src/hooks/useBasicWidgetState"
 
+type OnInputChangeEventType = {
+  target: { value: string }
+} & Partial<HTMLInputElement>
+
+/**
+ * Will return a memoized function that accepts an HTMLInputElement and will call
+ * commitWidgetValue and setDirty with its value, unless the value is longer than
+ * maxChars. Will also call the setValueWithSource callback if the input is in a form.
+ *
+ * @param formId if is in a form
+ * @param maxChars if the input element's value length is greater than this, nothing will be called. Set to 0 to disable.
+ * @param setDirty calls setDirty with true
+ * @param setUiValue calls setUiValue with the input element's value
+ * @param setValueWithSource calls setValueWithSource with the input element's value
+ * @return memoized callback
+ */
 export default function useOnInputChange(
-  formId: string,
+  formId: string | undefined,
   maxChars: number,
   setDirty: (dirty: boolean) => void,
   setUiValue: (value: string) => void,
   setValueWithSource: Dispatch<
     SetStateAction<ValueWithSource<string | null> | null>
   >
-): (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void {
+): (e: OnInputChangeEventType) => void {
   return useCallback(
-    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+    (e: OnInputChangeEventType): void => {
       const { value: newValue } = e.target
 
       if (maxChars !== 0 && newValue.length > maxChars) {

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -51,7 +51,7 @@ describe("useSubmitFormViaEnterKey", () => {
       keyCode: 0,
     })
     await waitFor(() => {
-      expect(commitWidgetValue).toHaveBeenCalled()
+      expect(commitWidgetValue).toHaveBeenCalledTimes(1)
     })
     await waitFor(() => {
       expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -162,7 +162,7 @@ describe("useSubmitFormViaEnterKey", () => {
         keyCode: 0,
       })
       await waitFor(() => {
-        expect(commitWidgetValue).toHaveBeenCalled()
+        expect(commitWidgetValue).toHaveBeenCalledTimes(1)
       })
       await waitFor(() => {
         expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")
@@ -198,7 +198,7 @@ describe("useSubmitFormViaEnterKey", () => {
       keyCode: 0,
     })
     await waitFor(() => {
-      expect(commitWidgetValue).toHaveBeenCalled()
+      expect(commitWidgetValue).toHaveBeenCalledTimes(1)
     })
     await waitFor(() => {
       expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -49,6 +49,8 @@ describe("useSubmitFormViaEnterKey", () => {
       metaKey: false,
       ctrlKey: false,
       keyCode: 0,
+      nativeEvent: undefined as never,
+      preventDefault: vi.fn(),
     })
     await waitFor(() => {
       expect(commitWidgetValue).toHaveBeenCalledTimes(1)
@@ -84,6 +86,8 @@ describe("useSubmitFormViaEnterKey", () => {
       metaKey: false,
       ctrlKey: false,
       keyCode: 0,
+      nativeEvent: undefined as never,
+      preventDefault: vi.fn(),
     })
     await waitFor(() => {
       expect(commitWidgetValue).not.toHaveBeenCalled()
@@ -119,6 +123,8 @@ describe("useSubmitFormViaEnterKey", () => {
       metaKey: false,
       ctrlKey: false,
       keyCode: 0,
+      nativeEvent: undefined as never,
+      preventDefault: vi.fn(),
     })
     await waitFor(() => {
       expect(commitWidgetValue).not.toHaveBeenCalled()
@@ -160,6 +166,8 @@ describe("useSubmitFormViaEnterKey", () => {
         metaKey: metaKey,
         ctrlKey: ctrlKey,
         keyCode: 0,
+        nativeEvent: undefined as never,
+        preventDefault: vi.fn(),
       })
       await waitFor(() => {
         expect(commitWidgetValue).toHaveBeenCalledTimes(1)
@@ -196,6 +204,8 @@ describe("useSubmitFormViaEnterKey", () => {
       metaKey: false,
       ctrlKey: false,
       keyCode: 0,
+      nativeEvent: undefined as never,
+      preventDefault: vi.fn(),
     })
     await waitFor(() => {
       expect(commitWidgetValue).toHaveBeenCalledTimes(1)
@@ -231,6 +241,8 @@ describe("useSubmitFormViaEnterKey", () => {
       metaKey: false,
       ctrlKey: false,
       keyCode: 0,
+      nativeEvent: undefined as never,
+      preventDefault: vi.fn(),
     })
     await waitFor(() => {
       expect(commitWidgetValue).not.toHaveBeenCalled()

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { waitFor } from "@testing-library/react"
+import { renderHook } from "@testing-library/react-hooks"
+
+import useSubmitFormViaEnterKey from "./useSubmitFormViaEnterKey"
+
+describe("useSubmitFormViaEnterKey", () => {
+  it("should call commitWidgetValue and submitForm when Enter is pressed", async () => {
+    const commitWidgetValue = vi.fn()
+    const allowFormEnterToSubmit = vi.fn((_: string) => true)
+    const submitForm = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useSubmitFormViaEnterKey(
+        "someFormId",
+        commitWidgetValue,
+        true,
+        allowFormEnterToSubmit,
+        submitForm,
+        "someFragmentId",
+        false
+      )
+    )
+
+    onInputChange.current({
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      keyCode: 0,
+    })
+    await waitFor(() => {
+      expect(commitWidgetValue).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")
+    })
+    await waitFor(() => {
+      expect(submitForm).toHaveBeenCalledWith("someFormId", "someFragmentId")
+    })
+  })
+
+  it("should not call anything when Enter is not pressed", async () => {
+    const commitWidgetValue = vi.fn()
+    const allowFormEnterToSubmit = vi.fn((_: string) => true)
+    const submitForm = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useSubmitFormViaEnterKey(
+        "someFormId",
+        commitWidgetValue,
+        true,
+        allowFormEnterToSubmit,
+        submitForm,
+        "someFragmentId",
+        false
+      )
+    )
+
+    onInputChange.current({
+      key: "SomeOtherKey",
+      metaKey: false,
+      ctrlKey: false,
+      keyCode: 0,
+    })
+    await waitFor(() => {
+      expect(commitWidgetValue).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(allowFormEnterToSubmit).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(submitForm).not.toHaveBeenCalled()
+    })
+  })
+
+  it("should not call anything when Enter is pressed but command key is required", async () => {
+    const commitWidgetValue = vi.fn()
+    const allowFormEnterToSubmit = vi.fn((_: string) => true)
+    const submitForm = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useSubmitFormViaEnterKey(
+        "someFormId",
+        commitWidgetValue,
+        true,
+        allowFormEnterToSubmit,
+        submitForm,
+        "someFragmentId",
+        true
+      )
+    )
+
+    onInputChange.current({
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      keyCode: 0,
+    })
+    await waitFor(() => {
+      expect(commitWidgetValue).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(allowFormEnterToSubmit).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(submitForm).not.toHaveBeenCalled()
+    })
+  })
+
+  it.each([
+    [true, true],
+    [true, false],
+    [false, true],
+  ])(
+    "should call commitWidgetValue and submitForm when Enter and command key (metaKey: %s, ctrlKey: %s) are pressed",
+    async (metaKey: boolean, ctrlKey: boolean) => {
+      const commitWidgetValue = vi.fn()
+      const allowFormEnterToSubmit = vi.fn((_: string) => true)
+      const submitForm = vi.fn()
+
+      const { result: onInputChange } = renderHook(() =>
+        useSubmitFormViaEnterKey(
+          "someFormId",
+          commitWidgetValue,
+          true,
+          allowFormEnterToSubmit,
+          submitForm,
+          "someFragmentId",
+          true
+        )
+      )
+
+      onInputChange.current({
+        key: "Enter",
+        metaKey: metaKey,
+        ctrlKey: ctrlKey,
+        keyCode: 0,
+      })
+      await waitFor(() => {
+        expect(commitWidgetValue).toHaveBeenCalled()
+      })
+      await waitFor(() => {
+        expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")
+      })
+      await waitFor(() => {
+        expect(submitForm).toHaveBeenCalledWith("someFormId", "someFragmentId")
+      })
+    }
+  )
+
+  it("should call commitWidgetValue but not submitForm when allowFormEnterToSubmit returns false", async () => {
+    const commitWidgetValue = vi.fn()
+    const allowFormEnterToSubmit = vi.fn((_: string) => false)
+    const submitForm = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useSubmitFormViaEnterKey(
+        "someFormId",
+        commitWidgetValue,
+        true,
+        allowFormEnterToSubmit,
+        submitForm,
+        "",
+        false
+      )
+    )
+
+    onInputChange.current({
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      keyCode: 0,
+    })
+    await waitFor(() => {
+      expect(commitWidgetValue).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(allowFormEnterToSubmit).toHaveBeenCalledWith("someFormId")
+    })
+    await waitFor(() => {
+      expect(submitForm).not.toHaveBeenCalled()
+    })
+  })
+
+  it("should neither call commitWidgetValue nor submitForm", async () => {
+    const commitWidgetValue = vi.fn()
+    const allowFormEnterToSubmit = vi.fn((_: string) => false)
+    const submitForm = vi.fn()
+
+    const { result: onInputChange } = renderHook(() =>
+      useSubmitFormViaEnterKey(
+        "",
+        commitWidgetValue,
+        false,
+        allowFormEnterToSubmit,
+        submitForm,
+        "",
+        false
+      )
+    )
+
+    onInputChange.current({
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      keyCode: 0,
+    })
+    await waitFor(() => {
+      expect(commitWidgetValue).not.toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(allowFormEnterToSubmit).toHaveBeenCalledWith("")
+    })
+    await waitFor(() => {
+      expect(submitForm).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -17,21 +17,27 @@
 import { waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import useSubmitFormViaEnterKey from "./useSubmitFormViaEnterKey"
 
+const widgetMgr = new WidgetStateManager({
+  sendRerunBackMsg: vi.fn(),
+  formsDataChanged: vi.fn(),
+})
 describe("useSubmitFormViaEnterKey", () => {
   it("should call commitWidgetValue and submitForm when Enter is pressed", async () => {
     const commitWidgetValue = vi.fn()
     const allowFormEnterToSubmit = vi.fn((_: string) => true)
     const submitForm = vi.fn()
+    widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+    widgetMgr.submitForm = submitForm
 
     const { result: onInputChange } = renderHook(() =>
       useSubmitFormViaEnterKey(
         "someFormId",
         commitWidgetValue,
         true,
-        allowFormEnterToSubmit,
-        submitForm,
+        widgetMgr,
         "someFragmentId",
         false
       )
@@ -58,14 +64,15 @@ describe("useSubmitFormViaEnterKey", () => {
     const commitWidgetValue = vi.fn()
     const allowFormEnterToSubmit = vi.fn((_: string) => true)
     const submitForm = vi.fn()
+    widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+    widgetMgr.submitForm = submitForm
 
     const { result: onInputChange } = renderHook(() =>
       useSubmitFormViaEnterKey(
         "someFormId",
         commitWidgetValue,
         true,
-        allowFormEnterToSubmit,
-        submitForm,
+        widgetMgr,
         "someFragmentId",
         false
       )
@@ -92,14 +99,15 @@ describe("useSubmitFormViaEnterKey", () => {
     const commitWidgetValue = vi.fn()
     const allowFormEnterToSubmit = vi.fn((_: string) => true)
     const submitForm = vi.fn()
+    widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+    widgetMgr.submitForm = submitForm
 
     const { result: onInputChange } = renderHook(() =>
       useSubmitFormViaEnterKey(
         "someFormId",
         commitWidgetValue,
         true,
-        allowFormEnterToSubmit,
-        submitForm,
+        widgetMgr,
         "someFragmentId",
         true
       )
@@ -132,14 +140,15 @@ describe("useSubmitFormViaEnterKey", () => {
       const commitWidgetValue = vi.fn()
       const allowFormEnterToSubmit = vi.fn((_: string) => true)
       const submitForm = vi.fn()
+      widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+      widgetMgr.submitForm = submitForm
 
       const { result: onInputChange } = renderHook(() =>
         useSubmitFormViaEnterKey(
           "someFormId",
           commitWidgetValue,
           true,
-          allowFormEnterToSubmit,
-          submitForm,
+          widgetMgr,
           "someFragmentId",
           true
         )
@@ -167,14 +176,15 @@ describe("useSubmitFormViaEnterKey", () => {
     const commitWidgetValue = vi.fn()
     const allowFormEnterToSubmit = vi.fn((_: string) => false)
     const submitForm = vi.fn()
+    widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+    widgetMgr.submitForm = submitForm
 
     const { result: onInputChange } = renderHook(() =>
       useSubmitFormViaEnterKey(
         "someFormId",
         commitWidgetValue,
         true,
-        allowFormEnterToSubmit,
-        submitForm,
+        widgetMgr,
         "",
         false
       )
@@ -201,14 +211,15 @@ describe("useSubmitFormViaEnterKey", () => {
     const commitWidgetValue = vi.fn()
     const allowFormEnterToSubmit = vi.fn((_: string) => false)
     const submitForm = vi.fn()
+    widgetMgr.allowFormEnterToSubmit = allowFormEnterToSubmit
+    widgetMgr.submitForm = submitForm
 
     const { result: onInputChange } = renderHook(() =>
       useSubmitFormViaEnterKey(
         "",
         commitWidgetValue,
         false,
-        allowFormEnterToSubmit,
-        submitForm,
+        widgetMgr,
         "",
         false
       )

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -18,6 +18,7 @@ import { waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
+
 import useSubmitFormViaEnterKey from "./useSubmitFormViaEnterKey"
 
 const widgetMgr = new WidgetStateManager({

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
@@ -77,10 +77,7 @@ export default function useSubmitFormViaEnterKey(
       const isCommandKeyPressed = requireCommandKey
         ? e.metaKey || e.ctrlKey
         : true
-      console.log(
-        "useSubmitFormViaEnterKey. isCommandKeyPressed",
-        isCommandKeyPressed
-      )
+
       if (!isEnterKeyPressed(e) || !isCommandKeyPressed) {
         return
       }

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
@@ -16,6 +16,8 @@
 
 import { useCallback } from "react"
 
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
+
 const isEnterKeyPressed = (
   event: Partial<React.KeyboardEvent<HTMLElement>> & {
     metaKey: boolean
@@ -43,8 +45,7 @@ const isEnterKeyPressed = (
  * @param formId of the form to submit
  * @param commitWidgetValue callback to call
  * @param callCommitWidgetValue whether to call commitWidgetValue
- * @param allowFormEnterToSubmit callback to check if the form should be submitted via Enter key
- * @param submitForm callback to submit the form
+ * @param widgetMgr used to handle form submission
  * @param fragmentId
  * @param requireCommandKey if true, the metaKey or ctrlKey must be pressed to trigger the callback
  * @returns memoized callback
@@ -53,8 +54,7 @@ export default function useSubmitFormViaEnterKey(
   formId: string,
   commitWidgetValue: () => void,
   callCommitWidgetValue: boolean,
-  allowFormEnterToSubmit: (formId: string) => boolean,
-  submitForm: (formId: string, fragmentId?: string) => void,
+  widgetMgr: WidgetStateManager,
   fragmentId?: string,
   requireCommandKey = false
 ): (
@@ -77,6 +77,10 @@ export default function useSubmitFormViaEnterKey(
       const isCommandKeyPressed = requireCommandKey
         ? e.metaKey || e.ctrlKey
         : true
+      console.log(
+        "useSubmitFormViaEnterKey. isCommandKeyPressed",
+        isCommandKeyPressed
+      )
       if (!isEnterKeyPressed(e) || !isCommandKeyPressed) {
         return
       }
@@ -86,8 +90,8 @@ export default function useSubmitFormViaEnterKey(
         commitWidgetValue()
       }
 
-      if (allowFormEnterToSubmit(formId)) {
-        submitForm(formId, fragmentId)
+      if (widgetMgr.allowFormEnterToSubmit(formId)) {
+        widgetMgr.submitForm(formId, fragmentId)
       }
     },
     [
@@ -95,8 +99,7 @@ export default function useSubmitFormViaEnterKey(
       fragmentId,
       callCommitWidgetValue,
       commitWidgetValue,
-      allowFormEnterToSubmit,
-      submitForm,
+      widgetMgr,
       requireCommandKey,
     ]
   )

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from "react"
+
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
+
+const isEnterKeyPressed = (
+  event: React.KeyboardEvent<HTMLElement>
+): boolean => {
+  const { keyCode, key } = event
+
+  // Using keyCode as well due to some different behaviors on Windows
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
+  return (
+    (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+    // Do not send the sentence being composed when Enter is typed into the IME.
+    !(event.nativeEvent?.isComposing === true)
+  )
+}
+
+/**
+ * Will return a memoized function that will call commitWidgetValue and submit the form
+ * if the Enter key (+ optionally the command key) is pressed.
+ *
+ * @param formId of the form to submit
+ * @param commitWidgetValue callback to call
+ * @param callCommitWidgetValue whether to call commitWidgetValue
+ * @param widgetMgr
+ * @param fragmentId
+ * @param requireCommandKey if true, the metaKey or ctrlKey must be pressed to trigger the callback
+ * @returns memoized callback
+ */
+export default function useSubmitFormViaEnterKey(
+  formId: string,
+  commitWidgetValue: () => void,
+  callCommitWidgetValue: boolean,
+  widgetMgr: WidgetStateManager,
+  fragmentId?: string,
+  requireCommandKey = false
+): (e: React.KeyboardEvent<HTMLElement>) => void {
+  return useCallback(
+    (e: React.KeyboardEvent<HTMLElement>): void => {
+      const isCommandKeyPressed = requireCommandKey
+        ? e.metaKey || e.ctrlKey
+        : true
+      if (!isEnterKeyPressed(e) || !isCommandKeyPressed) {
+        return
+      }
+
+      e.preventDefault()
+      if (callCommitWidgetValue) {
+        commitWidgetValue()
+      }
+
+      if (widgetMgr.allowFormEnterToSubmit(formId)) {
+        widgetMgr.submitForm(formId, fragmentId)
+      }
+    },
+    [
+      formId,
+      fragmentId,
+      callCommitWidgetValue,
+      commitWidgetValue,
+      widgetMgr,
+      requireCommandKey,
+    ]
+  )
+}

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.ts
@@ -17,26 +17,12 @@
 import { useCallback } from "react"
 
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
+import { isEnterKeyPressed } from "@streamlit/lib/src/util/inputUtils"
 
-const isEnterKeyPressed = (
-  event: Partial<React.KeyboardEvent<HTMLElement>> & {
-    metaKey: boolean
-    ctrlKey: boolean
-    /** @deprecated */
-    keyCode: number
-    key: string
-  }
-): boolean => {
-  const { keyCode, key } = event
-
-  // Using keyCode as well due to some different behaviors on Windows
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
-  return (
-    (key === "Enter" || keyCode === 13 || keyCode === 10) &&
-    // Do not send the sentence being composed when Enter is typed into the IME.
-    !(event.nativeEvent?.isComposing === true)
-  )
-}
+export type SubmitFormKeyboardEvent = Pick<
+  React.KeyboardEvent<HTMLElement>,
+  "metaKey" | "ctrlKey" | "keyCode" | "key" | "nativeEvent" | "preventDefault"
+>
 
 /**
  * Will return a memoized function that will call commitWidgetValue and submit the form
@@ -57,23 +43,9 @@ export default function useSubmitFormViaEnterKey(
   widgetMgr: WidgetStateManager,
   fragmentId?: string,
   requireCommandKey = false
-): (
-  e: Partial<React.KeyboardEvent<HTMLElement>> & {
-    metaKey: boolean
-    ctrlKey: boolean
-    keyCode: number
-    key: string
-  }
-) => void {
+): (e: SubmitFormKeyboardEvent) => void {
   return useCallback(
-    (
-      e: Partial<React.KeyboardEvent<HTMLElement>> & {
-        metaKey: boolean
-        ctrlKey: boolean
-        keyCode: number
-        key: string
-      }
-    ): void => {
+    (e: SubmitFormKeyboardEvent): void => {
       const isCommandKeyPressed = requireCommandKey
         ? e.metaKey || e.ctrlKey
         : true
@@ -82,7 +54,7 @@ export default function useSubmitFormViaEnterKey(
         return
       }
 
-      e.preventDefault?.()
+      e.preventDefault()
       if (callCommitWidgetValue) {
         commitWidgetValue()
       }

--- a/frontend/lib/src/util/inputUtils.test.ts
+++ b/frontend/lib/src/util/inputUtils.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEnterKeyPressed } from "./inputUtils"
+
+describe("inputUtils", () => {
+  it("isEnterKeyPressed should return true when Enter is pressed", () => {
+    const event = {
+      key: "Enter",
+      keyCode: 0,
+      nativeEvent: undefined as never,
+    }
+    expect(isEnterKeyPressed(event)).toBe(true)
+  })
+  it("isEnterKeyPressed should return true when keyCode is 13", () => {
+    const event = {
+      key: "SomeKey",
+      keyCode: 13,
+      nativeEvent: undefined as never,
+    }
+    expect(isEnterKeyPressed(event)).toBe(true)
+  })
+  it("isEnterKeyPressed should return true when keyCode is 10", () => {
+    const event = {
+      key: "SomeKey",
+      keyCode: 10,
+      nativeEvent: undefined as never,
+    }
+    expect(isEnterKeyPressed(event)).toBe(true)
+  })
+  it("isEnterKeyPressed should return false when key is not Enter and keycode is not an enter code", () => {
+    const event = {
+      key: "SomeKey",
+      keyCode: 9,
+      nativeEvent: undefined as never,
+    }
+    expect(isEnterKeyPressed(event)).toBe(false)
+  })
+})

--- a/frontend/lib/src/util/inputUtils.ts
+++ b/frontend/lib/src/util/inputUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type EnterKeyEvent = Pick<
+  React.KeyboardEvent<HTMLElement>,
+  "key" | "keyCode" | "nativeEvent"
+>
+
+export function isEnterKeyPressed(event: EnterKeyEvent): boolean {
+  const { keyCode, key } = event
+
+  // Using keyCode as well due to some different behaviors on Windows
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
+  return (
+    (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+    // Do not send the sentence being composed when Enter is typed into the IME.
+    !(event.nativeEvent?.isComposing === true)
+  )
+}


### PR DESCRIPTION
## Describe your changes

Closes #9841

Create shared hooks for submitting forms via enter (+ command key) and for handling onInputChange. These hooks can be used by the `TextInput` and the `TextArea` components (and potentially others?) so that their behavior is exactly the same and we can more easily have unit tests for the desired behavior.
The two hooks are:
- `useSubmitFormViaEnterKey`
- `useOnInputChange`

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Add unit tests for the two new hooks which gives us confidence about their behavior for all components that use the hooks
- E2E Tests
  - Add e2e test for `st.text_area` & `st.text_input` which are in forms and submitted via Enter (+ Control) 
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
