### PR TITLE
Support URLPattern-compatible patterns in allowed domain matching

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -19423,6 +19423,30 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: urlpattern-polyfill. A copy of the source code may be downloaded from https://github.com/kenchris/urlpattern-polyfill. This software contains the following license and notice below:
+
+Copyright 2020 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
 The following software may be included in this product: use-isomorphic-layout-effect. A copy of the source code may be downloaded from git+https://github.com/Andarist/use-isomorphic-layout-effect.git. This software contains the following license and notice below:
 
 MIT License

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -79,6 +79,7 @@
     "native-file-system-adapter": "^3.0.1",
     "node-emoji": "^1.11.0",
     "numbro": "^2.5.0",
+    "urlpattern-polyfill": "^10.0.0",
     "plotly.js": "^2.34.0",
     "protobufjs": "^7.2.5",
     "query-string": "^8.1.0",

--- a/frontend/lib/src/util/UriUtil.test.ts
+++ b/frontend/lib/src/util/UriUtil.test.ts
@@ -162,24 +162,24 @@ describe("isValidOrigin", () => {
     // allowedOrigin doesn't have a protocol
     expect(
       isValidOrigin("devel.streamlit.io", "http://devel.streamlit.io")
-    ).toBeFalsy()
+    ).toBe(false)
   })
 
   it("returns false if testOrigin is invalid", () => {
     // testOrigin doesn't have a protocol
     expect(
       isValidOrigin("http://devel.streamlit.io", "devel.streamlit.io")
-    ).toBeFalsy()
+    ).toBe(false)
   })
 
   it("returns true if testUrl's hostname is localhost w/ various ports", () => {
     expect(
       isValidOrigin(
-        "http:localhost",
+        "http://localhost",
         // Example of localhost url used for manual testing
         "http://localhost:8000"
       )
-    ).toBeTruthy()
+    ).toBe(true)
 
     expect(
       isValidOrigin(
@@ -187,13 +187,37 @@ describe("isValidOrigin", () => {
         // Example of localhost url used by e2e test
         "http://localhost:35475"
       )
-    ).toBeTruthy()
+    ).toBe(true)
+  })
+
+  it("returns false if testUrl's hostname is localhost but protocol doesn't match", () => {
+    expect(isValidOrigin("http://localhost", "https://localhost")).toBe(false)
+
+    expect(
+      isValidOrigin("https://localhost:8000", "http://localhost:8000")
+    ).toBe(false)
+
+    expect(
+      isValidOrigin(
+        "https:localhost",
+        // Example of localhost url used for manual testing
+        "http://localhost:8000"
+      )
+    ).toBe(false)
+
+    expect(
+      isValidOrigin(
+        "http://localhost",
+        // Example of localhost url used by e2e test
+        "https://localhost:35475"
+      )
+    ).toBe(false)
   })
 
   it("returns false if protocols don't match", () => {
     expect(
       isValidOrigin("https://devel.streamlit.io", "http://devel.streamlit.io")
-    ).toBeFalsy()
+    ).toBe(false)
   })
 
   it("returns false if ports don't match", () => {
@@ -202,32 +226,236 @@ describe("isValidOrigin", () => {
         "https://devel.streamlit.io:8080",
         "https://devel.streamlit.io"
       )
-    ).toBeFalsy()
+    ).toBe(false)
   })
 
   it("returns true when the pattern and url are the same", () => {
     expect(
       isValidOrigin("http://devel.streamlit.io", "http://devel.streamlit.io")
-    ).toBeTruthy()
+    ).toBe(true)
   })
 
-  it("returns false if it has different form", () => {
-    expect(isValidOrigin("https://*.com", "https://test.test.com")).toBeFalsy()
-  })
-
-  it("returns true if it matches the pattern", () => {
-    expect(isValidOrigin("https://*.com", "https://a.com")).toBeTruthy()
-    expect(isValidOrigin("https://*.a.com", "https://asd.a.com")).toBeTruthy()
+  it("returns true when the pattern and url are the same for localhost", () => {
     expect(
-      isValidOrigin("https://www.*.a.com", "https://www.asd.a.com")
-    ).toBeTruthy()
-    expect(
-      isValidOrigin("https://abc.*.*.a.com", "https://abc.def.xyz.a.com")
-    ).toBeTruthy()
+      isValidOrigin("http://localhost:3000", "http://localhost:3000")
+    ).toBe(true)
   })
 
-  it("returns false if it doesn't match the pattern", () => {
-    expect(isValidOrigin("https://*.b.com", "https://www.c.com")).toBeFalsy()
+  it("should recognize wildcards in Firefox", () => {
+    // In Firefox, the URL constructor crashes on URLs containing `*`,
+    // for example `new URL("https://*.streamlit.app"). This used to not
+    // allow to receive messages from Cloud Community apps. Make sure this
+    // issue is fixed.
+    const OrigURL = globalThis.URL
+    try {
+      globalThis.URL = function (url: string, ...rest: any[]) {
+        if (url.includes("*")) {
+          throw new Error("Invalid URL")
+        }
+        return new OrigURL(url, ...rest)
+      } as any
+      expect(
+        isValidOrigin(
+          "https://*.streamlit.app",
+          "https://example.streamlit.app"
+        )
+      ).toBe(true)
+    } finally {
+      globalThis.URL = OrigURL
+    }
+  })
+
+  describe("pattern matching", () => {
+    it("handles the '*.' pattern", () => {
+      expect(isValidOrigin("https://*.com", "https://a.com")).toBe(true)
+      expect(isValidOrigin("https://*.a.com", "https://asd.a.com")).toBe(true)
+      expect(
+        isValidOrigin("https://www.*.a.com", "https://www.asd.a.com")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://abc.*.*.a.com", "https://abc.def.xyz.a.com")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://*.com", "https://example.example.com")
+      ).toBe(true)
+
+      expect(isValidOrigin("https://*.b.com", "https://www.c.com")).toBe(false)
+    })
+
+    it("handles the '{*.}?' pattern", () => {
+      expect(
+        isValidOrigin("https://{*.}?example.com", "https://cdn.example.com")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://{*.}?example.com", "https://example.com")
+      ).toBe(true)
+
+      expect(
+        isValidOrigin("https://{*.}?example.com", "https://www-example.com")
+      ).toBe(false)
+    })
+
+    it("handles the '{cdn.}?' pattern", () => {
+      expect(
+        isValidOrigin("https://{cdn.}?example.com", "https://cdn.example.com")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://{cdn.}?example.com", "https://example.com")
+      ).toBe(true)
+
+      expect(
+        isValidOrigin("https://{cdn.}?example.com", "https://www.example.com")
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://{cdn.}?example.com", "https://cdn-example.com")
+      ).toBe(false)
+    })
+
+    it("handles the '{www.cdn.}?' pattern", () => {
+      expect(
+        isValidOrigin(
+          "https://{www.cdn.}?example.com",
+          "https://www.cdn.example.com"
+        )
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://{www.cdn.}?example.com", "https://example.com")
+      ).toBe(true)
+
+      expect(
+        isValidOrigin(
+          "https://{www.cdn.}?example.com",
+          "https://cdn.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin(
+          "https://{www.cdn.}?example.com",
+          "https://www.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin(
+          "https://{www.cdn.}?example.com",
+          "https://www.cdn-example.com"
+        )
+      ).toBe(false)
+    })
+
+    it("handles the 'cdn-*' pattern", () => {
+      expect(
+        isValidOrigin(
+          "https://cdn-*.example.com",
+          "https://cdn-123.example.com"
+        )
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://cdn-*.example.com", "https://cdn-.example.com")
+      ).toBe(true)
+
+      expect(
+        isValidOrigin(
+          "https://cdn-*.example.com",
+          "https://cdn.123.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://cdn-*.example.com", "https://cdn.example.com")
+      ).toBe(false)
+    })
+
+    it("handles the ':id' pattern", () => {
+      expect(
+        isValidOrigin(
+          "https://cdn-:id.example.com",
+          "https://cdn-123.example.com"
+        )
+      ).toBe(true)
+
+      expect(
+        isValidOrigin(
+          "https://cdn-:id.example.com",
+          "https://cdn-.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin(
+          "https://cdn-:id.example.com",
+          "https://cdn.123.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://cdn-:id.example.com", "https://cdn.example.com")
+      ).toBe(false)
+    })
+
+    it("handles regex patterns", () => {
+      expect(
+        isValidOrigin(
+          "https://(cdn|www).example.com",
+          "https://cdn.example.com"
+        )
+      ).toBe(true)
+      expect(
+        isValidOrigin(
+          "https://(cdn|www).example.com",
+          "https://www.example.com"
+        )
+      ).toBe(true)
+      expect(isValidOrigin("https://(\\w+).com", "https://example.com")).toBe(
+        true
+      )
+
+      expect(
+        isValidOrigin(
+          "https://(cdn|www).example.com",
+          "https://dev.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin(
+          "https://(cdn|www).example.com",
+          "https://ww.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin(
+          "https://(cdn|www).example.com",
+          "https://cdn.123.example.com"
+        )
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://(\\w+).com", "https://example.example.com")
+      ).toBe(false)
+    })
+
+    it("handles patterns in the protocol part", () => {
+      expect(
+        isValidOrigin("https://example.com:*", "https://example.com")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://example.com:*", "https://example.com:8080")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://example.com:80*", "https://example.com:8080")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://example.com:80*", "https://example.com:8091")
+      ).toBe(true)
+      expect(
+        isValidOrigin("https://example.com:80*", "https://example.com:80")
+      ).toBe(true)
+
+      expect(
+        isValidOrigin("https://example.com:*", "https://example.www.com:8080")
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://example.com:80*", "https://example.com:3000")
+      ).toBe(false)
+      expect(
+        isValidOrigin("https://example.com:80*", "https://example.com:91")
+      ).toBe(false)
+    })
   })
 })
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11296,6 +11296,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+urlpattern-polyfill@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz#f0a03a97bfb03cdf33553e5e79a2aadd22cac8ec"
+  integrity sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==
+
 use-callback-ref@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"


### PR DESCRIPTION
## Describe your changes

Support [URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API)-compatible patterns in allowed domain matching.

This also fixes an issue where in Firefox domain patterns like `https://*.streamlit.app` were never matched - this was because previously the pattern was converted to a `URL` object by passing it to the `URL` constructor and Firefox throws on such URLs.

The issue meant that in Firefox no messages sent from Community Cloud apps were reaching Firefox, breaking URLs, making CC-specific menu items not applied, etc.

In UriUtil tests, replace all `.toBeFalsy()` occurrences with `.toBe(false)` and `.toBeTruthy()` with `.toBe(true)` to better reflect the API is supposed to return a boolean.

Fixes #9848

## GitHub Issue Link (if applicable)

* #9848

## Testing Plan

JS Unit tests added.

I also tested it in Firefox on the app https://app-navigation-test-app-5e8tdhuv6wvkscfe8vwxcn.streamlit.app/ by using network overrides in Firefox DevTools and replacing the relevant function in the minified JS code of the file https://app-navigation-test-app-5e8tdhuv6wvkscfe8vwxcn.streamlit.app/~/+/static/js/main.75ac1cb6.js. After the refresh, the problems described in issue #9848 disappeared.

**NOTE:** There's one change - previously, the pattern `"https://*.com"` would not match `https://example.example.com` and now it does. If one wants to forbid it, a more detailed regex pattern can be used, e.g. `"https://(\w+).com"`.

As I understand, for now the list of allowed domains is not exposed as a public API, so perhaps such a change is fine.

There's an open issue for this (https://github.com/streamlit/streamlit/issues/6389) and a PR for it labded (https://github.com/streamlit/streamlit/pull/7180) but to the `feature/host-security-config` branch.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
