### PR TITLE
Rename jest with vi in useUpdateUiValue test

### DIFF
--- a/frontend/lib/src/hooks/useUpdateUiValue.test.ts
+++ b/frontend/lib/src/hooks/useUpdateUiValue.test.ts
@@ -21,19 +21,19 @@ import useUpdateUiValue from "./useUpdateUiValue"
 
 describe("useUpdateUiValue", () => {
   it("should update ui value if values are different and ui value is not dirty", async () => {
-    const callback = jest.fn()
+    const callback = vi.fn()
     renderHook(() => useUpdateUiValue(4, 2, callback, false))
     await waitFor(() => expect(callback).toHaveBeenCalledWith(4))
   })
 
   it("shoud not update ui value if values are different and ui value is dirty", async () => {
-    const callback = jest.fn()
+    const callback = vi.fn()
     renderHook(() => useUpdateUiValue(4, 2, callback, true))
     await waitFor(() => expect(callback).not.toHaveBeenCalled())
   })
 
   it("shoud not update ui value if values are same", async () => {
-    const callback = jest.fn()
+    const callback = vi.fn()
     renderHook(() => useUpdateUiValue(4, 4, callback, false))
     await waitFor(() => expect(callback).not.toHaveBeenCalled())
   })


### PR DESCRIPTION
## Describe your changes

Fixes an issue in the CI pipeline:

```
$ cp ./src/proto* ./dist
$ tsc -p ./tsconfig.json && tsc-alias -p ./tsconfig.json
Error: src/hooks/useUpdateUiValue.test.ts(24,22): error TS2708: Cannot use namespace 'jest' as a value.
Error: src/hooks/useUpdateUiValue.test.ts(30,22): error TS2708: Cannot use namespace 'jest' as a value.
Error: src/hooks/useUpdateUiValue.test.ts(36,22): error TS2708: Cannot use namespace 'jest' as a value.
```

## GitHub Issue Link (if applicable)

## Testing Plan

- No functional changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
