### PR TITLE
Enable `no-console` eslint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -70,15 +70,14 @@ module.exports = {
     ...vitest.configs.recommended.rules,
     // Use `const` or `let` instead of `var`
     "no-var": "error",
+    // Prevent unintentional use of `console.log`
+    "no-console": "error",
     // We don't use PropTypes
     "react/prop-types": "off",
     // We don't escape entities
     "react/no-unescaped-entities": "off",
     // Some of these are being caught erroneously
     "@typescript-eslint/camelcase": "off",
-    // Console statements are currently allowed,
-    // but we may want to reconsider this!
-    "@typescript-eslint/no-console": "off",
     // Empty interfaces are ok
     "@typescript-eslint/no-empty-interface": "off",
     // Empty functions are ok


### PR DESCRIPTION
## Describe your changes

We want to prevent `console.log` from sneaking in into the codebase. If we need it, we can intentionally disable the rule for the given line(s) / file(s).
Follow-up from this comment: https://github.com/streamlit/streamlit/pull/9847#discussion_r1838381099

## GitHub Issue Link (if applicable)

## Testing Plan

Eslint only

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
