### PR TITLE
Make dropdown menu responsive to root font size 

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -68,6 +68,8 @@ const VirtualDropdown = React.forwardRef<any, any>((props, ref) => {
           height: theme.sizes.emptyDropdownHeight,
           paddingBottom: theme.spacing.none,
           paddingTop: theme.spacing.none,
+          paddingLeft: theme.spacing.none,
+          paddingRight: theme.spacing.none,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -64,11 +64,27 @@ const VirtualDropdown = React.forwardRef<any, any>((props, ref) => {
     const childrenProps = children[0] ? children[0].props : {}
     return (
       <StyledList
-        $style={{ height: theme.sizes.emptyDropdownHeight }}
+        $style={{
+          height: theme.sizes.emptyDropdownHeight,
+          paddingBottom: theme.spacing.none,
+          paddingTop: theme.spacing.none,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
         ref={ref}
         data-testid="stSelectboxVirtualDropdownEmpty"
       >
-        <StyledEmptyState {...childrenProps} />
+        <StyledEmptyState
+          $style={{
+            paddingBottom: theme.spacing.none,
+            paddingTop: theme.spacing.none,
+            paddingLeft: theme.spacing.none,
+            paddingRight: theme.spacing.none,
+            color: theme.colors.fadedText60,
+          }}
+          {...childrenProps}
+        />
       </StyledList>
     )
   }

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -119,6 +119,15 @@ function TimeInput({
             }),
           },
 
+          DropdownListItem: {
+            style: () => ({
+              paddingRight: theme.spacing.lg,
+              paddingLeft: theme.spacing.lg,
+              paddingTop: theme.spacing.sm,
+              paddingBottom: theme.spacing.sm,
+            }),
+          },
+
           // Nudge the dropdown menu by 1px so the focus state doesn't get cut off
           Popover: {
             props: {


### PR DESCRIPTION
## Describe your changes

Makes the dropdown menus (timeinput dropdown & shared dropdown empty state) responsive to the root font size by using rem instead of using px size. This is required for the upcoming changes for advanced theming.

## Testing Plan

- No logical or visual changes. Just uses rem instead of px. Will be better tested once configuring the base font size is supported.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
