### PR TITLE
Add _repr_html_ support to st.html, and avoid throwing for non-paths

### DIFF
--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from streamlit.proto.Html_pb2 import Html as HtmlProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
+from streamlit.type_util import has_callable_attr
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -46,13 +47,16 @@ class HtmlMixin:
 
         Parameters
         ----------
-        body : str, Path
+        body : str, Path, any
             The HTML code to insert, or path to an HTML code file which is
             loaded and inserted.
 
             If the provided string is the path of a local file, Streamlit will
             load the file and render its contents as HTML. Otherwise, Streamlit
             will render the string directly as HTML.
+
+            If this argument is an object with a `_repr_html_` method, this
+            will call `_repr_html_` and render the output.
 
         Example
         -------
@@ -69,15 +73,27 @@ class HtmlMixin:
         """
         html_proto = HtmlProto()
 
+        if has_callable_attr(body, "_repr_html_"):
+            html_proto.body = body._repr_html_()
+
         # Check if the body is a file path. If it's a Path object, open it directly.
-        if os.path.isfile(body) or isinstance(body, Path):
+        elif isfile(body) or isinstance(body, Path):
             with open(body, encoding="utf-8") as f:
                 html_proto.body = f.read()
+
         else:
             html_proto.body = clean_text(body)
+
         return self.dg._enqueue("html", html_proto)
 
     @property
     def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)
+
+
+def isfile(obj: Any) -> bool:
+    try:
+        return os.path.isfile(obj)
+    except TypeError:
+        return False

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -55,8 +55,9 @@ class HtmlMixin:
             load the file and render its contents as HTML. Otherwise, Streamlit
             will render the string directly as HTML.
 
-            If this argument is an object with a `_repr_html_` method, this
-            will call `_repr_html_` and render the output.
+            If anything other than a string or file path is passed, it will
+            be converted to a string behind the scenes by calling
+            `body._repr_html_()`, if present, and `str(body)`, otherwise.
 
         Example
         -------

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -18,10 +18,10 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from streamlit import type_util
 from streamlit.proto.Html_pb2 import Html as HtmlProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
+from streamlit.type_util import SupportsReprHtml, SupportsStr, has_callable_attr
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -31,7 +31,7 @@ class HtmlMixin:
     @gather_metrics("html")
     def html(
         self,
-        body: str | Path | Any,
+        body: str | Path | SupportsStr | SupportsReprHtml,
     ) -> DeltaGenerator:
         """Insert HTML into your app.
 
@@ -47,7 +47,7 @@ class HtmlMixin:
 
         Parameters
         ----------
-        body : str, Path, Any
+        body : str or Path or object
             The HTML code to insert, or path to an HTML code file which is
             loaded and inserted.
 
@@ -75,18 +75,12 @@ class HtmlMixin:
         html_proto = HtmlProto()
 
         # If body supports _repr_html_, use that.
-        if type_util.has_callable_attr(body, "_repr_html_"):
-            html_proto.body = cast(type_util.SupportsReprHtml, body)._repr_html_()
-
-        # If body is a str that doesn't look like a file path, use that.
-        # (This avoids a filesystem lookup later on. Premature optimization, I know. But
-        # it feels right!)
-        elif _is_str_but_unlikely_a_path(body):
-            html_proto.body = clean_text(body)
+        if has_callable_attr(body, "_repr_html_"):
+            html_proto.body = cast(SupportsReprHtml, body)._repr_html_()
 
         # Check if the body is a file path. May include filesystem lookup.
         elif isinstance(body, Path) or _is_file(body):
-            with open(body, encoding="utf-8") as f:
+            with open(cast(str, body), encoding="utf-8") as f:
                 html_proto.body = f.read()
 
         # OK, let's just try converting to string and hope for the best.
@@ -110,16 +104,3 @@ def _is_file(obj: Any) -> bool:
         return os.path.isfile(obj)
     except TypeError:
         return False
-
-
-def _is_str_but_unlikely_a_path(obj: Any) -> bool:
-    """Cheap test of whether a string that could be HTML looks like a file path.
-
-    File paths are extremely unlikely to have "<" or "\n", so if they're present in
-    the string we assume HTML. This is not guaranteed to be correct, but it's probably
-    correct 100% of times in real-world use cases, so it feels like a good solution.
-    """
-    if not isinstance(obj, str):
-        return False
-
-    return any(c in obj for c in ["<", "\n"])

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -85,7 +85,7 @@ class HtmlMixin:
 
         # OK, let's just try converting to string and hope for the best.
         else:
-            html_proto.body = clean_text(body)
+            html_proto.body = clean_text(cast(SupportsStr, body))
 
         return self.dg._enqueue("html", html_proto)
 

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -78,7 +78,7 @@ class HtmlMixin:
         if isinstance(body, SupportsReprHtml):
             html_proto.body = body._repr_html_()
 
-        # If body is a str that doesn't look liek a file path, use that.
+        # If body is a str that doesn't look like a file path, use that.
         # (This avoids a filesystem lookup later on. Premature optimization, I know. But
         # it feels right!)
         elif _is_str_but_unlikely_a_path(body):

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -102,6 +102,10 @@ class HtmlMixin:
 
 
 def _is_file(obj: Any) -> bool:
+    """Checks if obj is a file, and doesn't throw if not.
+
+    The "not throwing" part is important!
+    """
     try:
         return os.path.isfile(obj)
     except TypeError:
@@ -109,11 +113,13 @@ def _is_file(obj: Any) -> bool:
 
 
 def _is_str_but_unlikely_a_path(obj: Any) -> bool:
+    """Cheap test of whether a string that could be HTML looks like a file path.
+
+    File paths are extremely unlikely to have "<" or "\n", so if they're present in
+    the string we assume HTML. This is not guaranteed to be correct, but it's probably
+    correct 100% of times in real-world use cases, so it feels like a good solution.
+    """
     if not isinstance(obj, str):
         return False
 
-    # Cheap test of whether a string that could be HTML looks like a file path. File
-    # paths are extremely unlikely to have "<" or "\n", so if they're present we assume
-    # HTML. This is not guaranteed to be correct, but it's probably 100% of times in
-    # real-world use cases, so it feels like a good tradeoff.
     return any(c in obj for c in ["<", "\n"])

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 from streamlit.proto.Html_pb2 import Html as HtmlProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
-from streamlit.type_util import has_callable_attr
+from streamlit.type_util import SupportsReprHtml
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -31,7 +31,7 @@ class HtmlMixin:
     @gather_metrics("html")
     def html(
         self,
-        body: str | Path,
+        body: str | Path | Any,
     ) -> DeltaGenerator:
         """Insert HTML into your app.
 
@@ -47,7 +47,7 @@ class HtmlMixin:
 
         Parameters
         ----------
-        body : str, Path, any
+        body : str, Path, Any
             The HTML code to insert, or path to an HTML code file which is
             loaded and inserted.
 
@@ -73,14 +73,22 @@ class HtmlMixin:
         """
         html_proto = HtmlProto()
 
-        if has_callable_attr(body, "_repr_html_"):
+        # If body supports _repr_html_, use that.
+        if isinstance(body, SupportsReprHtml):
             html_proto.body = body._repr_html_()
 
-        # Check if the body is a file path. If it's a Path object, open it directly.
-        elif isfile(body) or isinstance(body, Path):
+        # If body is a str that doesn't look liek a file path, use that.
+        # (This avoids a filesystem lookup later on. Premature optimization, I know. But
+        # it feels right!)
+        elif _is_str_but_unlikely_a_path(body):
+            html_proto.body = clean_text(body)
+
+        # Check if the body is a file path. May include filesystem lookup.
+        elif isinstance(body, Path) or _is_file(body):
             with open(body, encoding="utf-8") as f:
                 html_proto.body = f.read()
 
+        # OK, let's just try converting to string and hope for the best.
         else:
             html_proto.body = clean_text(body)
 
@@ -92,8 +100,19 @@ class HtmlMixin:
         return cast("DeltaGenerator", self)
 
 
-def isfile(obj: Any) -> bool:
+def _is_file(obj: Any) -> bool:
     try:
         return os.path.isfile(obj)
     except TypeError:
         return False
+
+
+def _is_str_but_unlikely_a_path(obj: Any) -> bool:
+    if not isinstance(obj, str):
+        return False
+
+    # Cheap test of whether a string that could be HTML looks like a file path. File
+    # paths are extremely unlikely to have "<" or "\n", so if they're present we assume
+    # HTML. This is not guaranteed to be correct, but it's probably 100% of times in
+    # real-world use cases, so it feels like a good tradeoff.
+    return any(c in obj for c in ["<", "\n"])

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -18,10 +18,10 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from streamlit import type_util
 from streamlit.proto.Html_pb2 import Html as HtmlProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
-from streamlit.type_util import SupportsReprHtml
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -75,8 +75,8 @@ class HtmlMixin:
         html_proto = HtmlProto()
 
         # If body supports _repr_html_, use that.
-        if isinstance(body, SupportsReprHtml):
-            html_proto.body = body._repr_html_()
+        if type_util.has_callable_attr(body, "_repr_html_"):
+            html_proto.body = cast(type_util.SupportsReprHtml, body)._repr_html_()
 
         # If body is a str that doesn't look like a file path, use that.
         # (This avoids a filesystem lookup later on. Premature optimization, I know. But

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -42,9 +42,11 @@ class MarkdownMixin:
 
         Parameters
         ----------
-        body : str
-            The string to display as GitHub-flavored Markdown. Syntax
+        body : str, Any
+            The text to display as GitHub-flavored Markdown. Syntax
             information can be found at: https://github.github.com/gfm.
+            If anything other than a string is passed, it will be converted
+            into a string behind the scenes using `str()`.
 
             This also supports:
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -42,7 +42,7 @@ class MarkdownMixin:
 
         Parameters
         ----------
-        body : str, Any
+        body : str or object
             The text to display as GitHub-flavored Markdown. Syntax
             information can be found at: https://github.github.com/gfm.
             If anything other than a string is passed, it will be converted

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -499,7 +499,7 @@ class WriteMixin:
                 # https://github.com/python/mypy/issues/12933
                 self.dg.help(cast(type, arg))
             elif (
-                isinstance(arg, type_util.SupportsReprHtml)
+                type_util.has_callable_attr(arg, "_repr_html_")
                 and (repr_html := arg._repr_html_())
                 and (unsafe_allow_html or not probably_contains_html_tags(repr_html))
             ):

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -499,7 +499,7 @@ class WriteMixin:
                 # https://github.com/python/mypy/issues/12933
                 self.dg.help(cast(type, arg))
             elif (
-                type_util.has_callable_attr(arg, "_repr_html_")
+                isinstance(arg, type_util.SupportsReprHtml)
                 and (repr_html := arg._repr_html_())
                 and (unsafe_allow_html or not probably_contains_html_tags(repr_html))
             ):

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -67,6 +67,7 @@ class SupportsReprHtml(Protocol):
     def _repr_html_(self) -> str: ...
 
 
+@runtime_checkable
 class CustomDict(Protocol):
     """Protocol for Streamlit native custom dictionaries (e.g. session state, secrets, query params).
     that can be converted to a dict.
@@ -337,7 +338,7 @@ def is_custom_dict(obj: object) -> TypeGuard[CustomDict]:
     return (
         isinstance(obj, Mapping)
         and _is_from_streamlit(obj)
-        and has_callable_attr(obj, "to_dict")
+        and isinstance(obj, CustomDict)
     )
 
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -36,7 +36,6 @@ from typing import (
     TypeVar,
     Union,
     overload,
-    runtime_checkable,
 )
 
 from typing_extensions import TypeAlias, TypeGuard
@@ -62,12 +61,10 @@ class SupportsStr(Protocol):
     def __str__(self) -> str: ...
 
 
-@runtime_checkable
 class SupportsReprHtml(Protocol):
     def _repr_html_(self) -> str: ...
 
 
-@runtime_checkable
 class CustomDict(Protocol):
     """Protocol for Streamlit native custom dictionaries (e.g. session state, secrets, query params).
     that can be converted to a dict.
@@ -338,7 +335,7 @@ def is_custom_dict(obj: object) -> TypeGuard[CustomDict]:
     return (
         isinstance(obj, Mapping)
         and _is_from_streamlit(obj)
-        and isinstance(obj, CustomDict)
+        and has_callable_attr(obj, "to_dict")
     )
 
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -36,6 +36,7 @@ from typing import (
     TypeVar,
     Union,
     overload,
+    runtime_checkable,
 )
 
 from typing_extensions import TypeAlias, TypeGuard
@@ -59,6 +60,11 @@ NumpyShape: TypeAlias = Tuple[int, ...]
 
 class SupportsStr(Protocol):
     def __str__(self) -> str: ...
+
+
+@runtime_checkable
+class SupportsReprHtml(Protocol):
+    def _repr_html_(self) -> str: ...
 
 
 class CustomDict(Protocol):

--- a/lib/tests/streamlit/elements/html_test.py
+++ b/lib/tests/streamlit/elements/html_test.py
@@ -41,3 +41,17 @@ class StHtmlAPITest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.html.body, "<button>Corgi</button>")
+
+    def test_st_html_with_repr_html(self):
+        """Test st.html with _repr_html_."""
+
+        class MyClass:
+            def _repr_html_(self):
+                return "<div>hi</div>"
+
+        obj = MyClass()
+
+        st.html(obj)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.html.body, "<div>hi</div>")

--- a/lib/tests/streamlit/elements/html_test.py
+++ b/lib/tests/streamlit/elements/html_test.py
@@ -42,16 +42,54 @@ class StHtmlAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.html.body, "<button>Corgi</button>")
 
-    def test_st_html_with_repr_html(self):
-        """Test st.html with _repr_html_."""
+    def test_st_html_with_dunderstr(self):
+        """Test st.html with __str__."""
 
         class MyClass:
-            def _repr_html_(self):
-                return "<div>hi</div>"
+            def __str__(self):
+                return "mystr"
 
         obj = MyClass()
 
         st.html(obj)
 
         el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.html.body, "<div>hi</div>")
+        self.assertEqual(el.html.body, "mystr")
+
+    def test_st_html_with_repr_html(self):
+        """Test st.html with _repr_html_."""
+
+        class MyClass:
+            def _repr_html_(self):
+                return "<div>html</div>"
+
+        obj = MyClass()
+
+        st.html(obj)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.html.body, "<div>html</div>")
+
+    def test_st_html_with_repr_html_and_dunderstr(self):
+        """Test st.html with _repr_html_ and dunderstr: html should win."""
+
+        class MyClass:
+            def __str__(self):
+                return "mystr"
+
+            def _repr_html_(self):
+                return "<div>html</div>"
+
+        obj = MyClass()
+
+        st.html(obj)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.html.body, "<div>html</div>")
+
+    def test_st_html_with_nonhtml_filelike_str(self):
+        """Test st.html with a string that's neither HTML-like nor a real file."""
+        st.html("foo/fake.html")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.html.body, "foo/fake.html")


### PR DESCRIPTION
## Describe your changes

Today, `st.html(body)` will throw if `body` is neither a string nor a valid file path. This means we don't support objects that have a `__str__` method (like [htbuilder](https://github.com/tvst/htbuilder)).

Further, we don't currently support objects that have `_repr_html_` either. This seems like an even greater disgrace 😆 

This PR fixes that.

Included changes in the PR:
1. Use `_repr_html_`, if present.
1. When `body` is of a type that's not supported by `os.path.isfile` (`str`, `byte`, `os.PathLike`, `int`) don't throw! Instead, try casting to `str`.
1. ~~Avoid a filesystem lookup for many cases that previously would require one.~~

   ~~This is done with a heuristic that, while not _guaranteed_ to be correct, should be correct 100% of times in real-world use cases. See code for more info. (I can roll this back if you like. It's just an optimization, but it feels right to me)~~

   Removed.

1. ~~Replace `has_callable_attr` with real typing (`Protocol`, `instanceof`, etc.) in a couple of places. This is just a cleanup. I'd remove `has_callable_attr` everywhere, but the other uses seem more complex.~~

   This was removed from the PR. Apparently runtime checks against a `Protocol` don't verify whether something is a method vs just a property, which broke some tests.

## GitHub Issue Link (if applicable)

None.

## Testing Plan

- Explanation of why no additional tests are needed: Unit tests cover everything.
- Unit Tests (JS and/or Python): ✅
- E2E Tests: ❌ no need
- Any manual testing needed? ❌ This seems safe enough, given the unit tests. But it's always good to include in the pre-launch manual tests!

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
