### PR TITLE
Keep SessionInfo active after initialization, but include connection information

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1005,6 +1005,7 @@ describe("App", () => {
       sendForwardMessage("newSession", NEW_SESSION_JSON)
       expect(setCurrentSpy).not.toHaveBeenCalled()
       expect(sessionInfo.isSet).toBe(true)
+      expect(sessionInfo.current.isConnected).toBe(true)
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -1012,7 +1013,9 @@ describe("App", () => {
         )
       })
 
-      expect(sessionInfo.isSet).toBe(false)
+      // the sessioninfo is set but is now marked as disconnected
+      expect(sessionInfo.isSet).toBe(true)
+      expect(sessionInfo.current.isConnected).toBe(false)
       // For clearing the current session info
       expect(setCurrentSpy).toHaveBeenCalledTimes(1)
 
@@ -1026,6 +1029,7 @@ describe("App", () => {
 
       expect(setCurrentSpy).toHaveBeenCalledTimes(2)
       expect(sessionInfo.isSet).toBe(true)
+      expect(sessionInfo.current.isConnected).toBe(true)
     })
 
     it("should set window.prerenderReady to true after app script is run successfully first time", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -727,7 +727,7 @@ export class App extends PureComponent<Props, State> {
       }
 
       if (this.sessionInfo.isSet) {
-        this.sessionInfo.clearCurrent()
+        this.sessionInfo.disconnect()
       }
     }
 
@@ -1085,8 +1085,9 @@ export class App extends PureComponent<Props, State> {
 
     // First, handle initialization logic. Each NewSession message has
     // initialization data. If this is the _first_ time we're receiving
-    // the NewSession message, we perform some one-time initialization.
-    if (!this.sessionInfo.isSet) {
+    // the NewSession message (or the first time since disconnect), we
+    // perform some one-time initialization.
+    if (!this.sessionInfo.isSet || !this.sessionInfo.current.isConnected) {
       // We're not initialized. Perform one-time initialization.
       this.handleOneTimeInitialization(newSessionProto)
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -927,7 +927,8 @@ export class App extends PureComponent<Props, State> {
   handlePageProfileMsg = (pageProfile: PageProfile): void => {
     const pageProfileObj = PageProfile.toObject(pageProfile)
     const browserInfo = getBrowserInfo()
-    const metricsToSend = {
+
+    this.metricsMgr.enqueue("pageProfile", {
       ...pageProfileObj,
       isFragmentRun: Boolean(pageProfileObj.isFragmentRun),
       numPages: this.state.appPages?.length,
@@ -937,25 +938,6 @@ export class App extends PureComponent<Props, State> {
         (performance.now() - this.state.latestRunTime) * 1000
       ),
       browserInfo,
-    }
-
-    // We do not expect the session info to not be set since we know
-    // that new session messages are sent to the client before any
-    // page profile messages, and the session info is never reset.
-    // That being said, we should not error here for the sake of a
-    // page profile for any edge cases that are created. So we send
-    // what we can provide. We can detect this scenario in metrics
-    // if the appId, sessionId, and pythonVersion are missing.
-    if (!this.sessionInfo.isSet) {
-      this.metricsMgr.enqueue("pageProfile", metricsToSend)
-      return
-    }
-
-    this.metricsMgr.enqueue("pageProfile", {
-      ...metricsToSend,
-      appId: this.sessionInfo.current.appId,
-      sessionId: this.sessionInfo.current.sessionId,
-      pythonVersion: this.sessionInfo.current.pythonVersion,
     })
   }
 
@@ -1173,7 +1155,8 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Performs one-time initialization. This is called from `handleNewSession`.
+   * Performs initialization based on first connection and reconnection.
+   * This is called from `handleNewSession`.
    */
   handleInitialization = (newSessionProto: NewSession): void => {
     const initialize = newSessionProto.initialize as Initialize
@@ -1919,7 +1902,9 @@ export class App extends PureComponent<Props, State> {
   }
 
   requestFileURLs = (requestId: string, files: File[]): void => {
-    if (this.isServerConnected() && this.sessionInfo.isSet) {
+    const isConnected = this.isServerConnected()
+    const isSessionInfoSet = this.sessionInfo.isSet
+    if (isConnected && isSessionInfoSet) {
       const backMsg = new BackMsg({
         fileUrlsRequest: {
           requestId,
@@ -1929,6 +1914,10 @@ export class App extends PureComponent<Props, State> {
       })
       backMsg.type = "fileUrlsRequest"
       this.sendBackMsg(backMsg)
+    } else {
+      LOG.warn(
+        `Cannot request file URLs (isServerConnected: ${isConnected}, isSessionInfoSet: ${isSessionInfoSet})`
+      )
     }
   }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -926,21 +926,36 @@ export class App extends PureComponent<Props, State> {
 
   handlePageProfileMsg = (pageProfile: PageProfile): void => {
     const pageProfileObj = PageProfile.toObject(pageProfile)
-
     const browserInfo = getBrowserInfo()
-    this.metricsMgr.enqueue("pageProfile", {
+    const metricsToSend = {
       ...pageProfileObj,
       isFragmentRun: Boolean(pageProfileObj.isFragmentRun),
-      appId: this.sessionInfo.current.appId,
       numPages: this.state.appPages?.length,
-      sessionId: this.sessionInfo.current.sessionId,
-      pythonVersion: this.sessionInfo.current.pythonVersion,
       pageScriptHash: this.state.currentPageScriptHash,
       activeTheme: this.props.theme?.activeTheme?.name,
       totalLoadTime: Math.round(
         (performance.now() - this.state.latestRunTime) * 1000
       ),
       browserInfo,
+    }
+
+    // We do not expect the session info to not be set since we know
+    // that new session messages are sent to the client before any
+    // page profile messages, and the session info is never reset.
+    // That being said, we should not error here for the sake of a
+    // page profile for any edge cases that are created. So we send
+    // what we can provide. We can detect in metrics if the appId,
+    // sessionId, and pythonVersion are missing.
+    if (!this.sessionInfo.isSet) {
+      this.metricsMgr.enqueue("pageProfile", metricsToSend)
+      return
+    }
+
+    this.metricsMgr.enqueue("pageProfile", {
+      ...metricsToSend,
+      appId: this.sessionInfo.current.appId,
+      sessionId: this.sessionInfo.current.sessionId,
+      pythonVersion: this.sessionInfo.current.pythonVersion,
     })
   }
 
@@ -1904,7 +1919,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   requestFileURLs = (requestId: string, files: File[]): void => {
-    if (this.isServerConnected()) {
+    if (this.isServerConnected() && this.sessionInfo.isSet) {
       const backMsg = new BackMsg({
         fileUrlsRequest: {
           requestId,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -944,8 +944,8 @@ export class App extends PureComponent<Props, State> {
     // page profile messages, and the session info is never reset.
     // That being said, we should not error here for the sake of a
     // page profile for any edge cases that are created. So we send
-    // what we can provide. We can detect in metrics if the appId,
-    // sessionId, and pythonVersion are missing.
+    // what we can provide. We can detect this scenario in metrics
+    // if the appId, sessionId, and pythonVersion are missing.
     if (!this.sessionInfo.isSet) {
       this.metricsMgr.enqueue("pageProfile", metricsToSend)
       return
@@ -1103,8 +1103,8 @@ export class App extends PureComponent<Props, State> {
     // the NewSession message (or the first time since disconnect), we
     // perform some one-time initialization.
     if (!this.sessionInfo.isSet || !this.sessionInfo.current.isConnected) {
-      // We're not initialized. Perform one-time initialization.
-      this.handleOneTimeInitialization(newSessionProto)
+      // We're not initialized (this is our first time, or we are reconnected)
+      this.handleInitialization(newSessionProto)
     }
 
     const { appHash, currentPageScriptHash: prevPageScriptHash } = this.state
@@ -1175,7 +1175,7 @@ export class App extends PureComponent<Props, State> {
   /**
    * Performs one-time initialization. This is called from `handleNewSession`.
    */
-  handleOneTimeInitialization = (newSessionProto: NewSession): void => {
+  handleInitialization = (newSessionProto: NewSession): void => {
     const initialize = newSessionProto.initialize as Initialize
     const config = newSessionProto.config as Config
 

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -241,6 +241,9 @@ export class MetricsManager {
       source: "browser",
       streamlitVersion: this.sessionInfo.current.streamlitVersion,
       isHello: this.sessionInfo.isHello,
+      appId: this.sessionInfo.current.appId,
+      sessionId: this.sessionInfo.current.sessionId,
+      pythonVersion: this.sessionInfo.current.pythonVersion,
       ...this.getContextData(),
     })
 

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -168,6 +168,7 @@ class StreamlitLibExample extends PureComponent<Props, State> {
       installationIdV3: "",
       commandLine: "",
       isHello: false,
+      isConnected: true,
     })
 
     // Initialize React state

--- a/frontend/lib/src/SessionInfo.ts
+++ b/frontend/lib/src/SessionInfo.ts
@@ -37,6 +37,7 @@ export interface Props {
   readonly maxCachedMessageAge: number
   readonly commandLine?: string // Unused, but kept around for compatibility
   readonly isHello: boolean
+  readonly isConnected: boolean
 }
 
 export class SessionInfo {
@@ -73,9 +74,14 @@ export class SessionInfo {
     this._current = notNullOrUndefined(props) ? { ...props } : undefined
   }
 
-  /** Clear `SessionInfo.current` and copy its previous props to `SessionInfo.last`. */
-  public clearCurrent(): void {
-    this.setCurrent(undefined)
+  /** Marks `SessionInfo.current` as not connected and copy its previous props to `SessionInfo.last`. */
+  public disconnect(): void {
+    if (this._current) {
+      this.setCurrent({
+        ...this._current,
+        isConnected: false,
+      })
+    }
   }
 
   /** True if `SessionInfo.current` exists. */
@@ -103,6 +109,8 @@ export class SessionInfo {
       installationIdV3: userInfo.installationIdV3,
       maxCachedMessageAge: config.maxCachedMessageAge,
       isHello: initialize.isHello,
+      // We assume we are always connected because the message came directly from the server.
+      isConnected: true,
     }
   }
 }

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -32,6 +32,7 @@ export function mockSessionInfoProps(
     installationIdV3: "mockInstallationIdV3",
     maxCachedMessageAge: 123,
     isHello: false,
+    isConnected: true,
     ...overrides,
   }
 }

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -33,6 +33,9 @@ message MetricsEvent {
   string source = 6;
   string streamlit_version = 7;
   bool is_hello = 8;
+  string app_id = 33;
+  string session_id = 35;
+  string python_version = 36;
 
   // Host tracking fields:
   string hosted_at = 9;
@@ -70,10 +73,7 @@ message MetricsEvent {
   bool is_fragment_run = 32;
 
   // Addtl for page profile metrics
-  string app_id = 33;
   int64 numPages = 34;
-  string session_id = 35;
-  string python_version = 36;
   string page_script_hash = 37;
   string active_theme = 38;
   int64 total_load_time = 39;


### PR DESCRIPTION
## Describe your changes

We hit race conditions where the session info is cleared (on disconnect) and reconnected before a page profile message is sent. We've hit multiple issues with this, so the safest option is to not completely delete the sessionInfo. In the event of the page profile, the message is sent with the latest information it knows. We save the connection state in the session info and update it to be disconnected on disconnect. It will reset once a new NewSession message arrives.

## GitHub Issue Link (if applicable)
closes #9767

## Testing Plan

- Unit tests are updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
