### PR TITLE
Fix URI decoding of link column display text

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -24,6 +24,7 @@ import {
   formatNumber,
   getEmptyCell,
   getErrorCell,
+  getLinkDisplayValueFromRegex,
   getTextCell,
   isErrorCell,
   isMissingValueCell,
@@ -602,4 +603,87 @@ describe("formatMoment", () => {
 test("removeLineBreaks should remove line breaks", () => {
   expect(removeLineBreaks("\n")).toBe(" ")
   expect(removeLineBreaks("\nhello\n\nworld")).toBe(" hello  world")
+})
+
+describe("getLinkDisplayValueFromRegex", () => {
+  it.each([
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://example.streamlit.app",
+      "example",
+    ],
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://my-cool-app.streamlit.app",
+      "my-cool-app",
+    ],
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://example.streamlit.app?param=value",
+      "example",
+    ],
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://example.streamlit.app?param1=value1&param2=value2",
+      "example",
+    ],
+    [new RegExp("id=(.*?)&"), "https://example.com?id=123&type=user", "123"],
+    [
+      new RegExp("[?&]user=(.*?)(?:&|$)"),
+      "https://example.com?page=1&user=john_doe&sort=desc",
+      "john_doe",
+    ],
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://my%20cool%20app.streamlit.app",
+      "my cool app",
+    ],
+    [
+      new RegExp("https://(.*?).streamlit.app"),
+      "https://special%21chars%40app.streamlit.app",
+      "special!chars@app",
+    ],
+    [
+      new RegExp("user=(.*?)(?:&|$)"),
+      "https://example.com?user=john%20doe%40email.com",
+      "john doe@email.com",
+    ],
+    [
+      new RegExp("name=(.*?)&"),
+      "https://example.com?name=%E2%9C%A8special%20user%E2%9C%A8&type=vip",
+      "✨special user✨",
+    ],
+    [
+      new RegExp("q=(.*?)&"),
+      "https://example.com?q=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82&lang=ru",
+      "привет",
+    ],
+    [
+      new RegExp("path/(.*?)/"),
+      "https://example.com/path/user%20name%20%26%20company/settings",
+      "user name & company",
+    ],
+    [
+      new RegExp("search/(.*?)\\?"),
+      "https://example.com/search/space%20%26%20time?page=1",
+      "space & time",
+    ],
+    [
+      new RegExp("https://(.*?).other.app"),
+      "https://example.streamlit.app",
+      "https://example.streamlit.app",
+    ],
+    [new RegExp("https://(.*?).streamlit.app"), null, ""],
+    [new RegExp("https://(.*?).streamlit.app"), undefined, ""],
+    [
+      new RegExp(".*meal=(.*)"),
+      "https://example.com/feedme?meal=fish+%26+chips%3A+%C2%A39",
+      "fish & chips: £9",
+    ],
+  ])(
+    "extracts display value from %p with href %p to be %p",
+    (regex: RegExp, href: string | null | undefined, expected: string) => {
+      expect(getLinkDisplayValueFromRegex(regex, href)).toBe(expected)
+    }
+  )
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -670,7 +670,7 @@ export function getLinkDisplayValueFromRegex(
     if (patternMatch && patternMatch[1] !== undefined) {
       // return the first matching group
       // Since this might be a URI encoded value, we decode it.
-      return decodeURI(patternMatch[1])
+      return decodeURIComponent(patternMatch[1].replace(/\+/g, "%20"))
     }
 
     // if the regex doesn't find a match with the url, just use the url as display value

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -670,6 +670,7 @@ export function getLinkDisplayValueFromRegex(
     if (patternMatch && patternMatch[1] !== undefined) {
       // return the first matching group
       // Since this might be a URI encoded value, we decode it.
+      // Note: we replace + with %20 to correctly convert + to whitespaces.
       return decodeURIComponent(patternMatch[1].replace(/\+/g, "%20"))
     }
 


### PR DESCRIPTION
## Describe your changes

Fixes the decoding of regex-matched URL fragments when display_text is provided as a regex for LinkColumn.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9893

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
