### PR TITLE
Fix wrong dataframe return typing

### DIFF
--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -233,7 +233,7 @@ class ArrowMixin:
         column_order: Iterable[str] | None = None,
         column_config: ColumnConfigMappingInput | None = None,
         key: Key | None = None,
-        on_select: Literal["ignore"],  # No default value here to make it work with mypy
+        on_select: Literal["ignore"] = "ignore",
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
     ) -> DeltaGenerator: ...
 
@@ -249,7 +249,7 @@ class ArrowMixin:
         column_order: Iterable[str] | None = None,
         column_config: ColumnConfigMappingInput | None = None,
         key: Key | None = None,
-        on_select: Literal["rerun"] | WidgetCallback = "rerun",
+        on_select: Literal["rerun"] | WidgetCallback,
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
     ) -> DataframeState: ...
 

--- a/lib/tests/streamlit/typing/dataframe_types.py
+++ b/lib/tests/streamlit/typing/dataframe_types.py
@@ -1,0 +1,83 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform some "type checking testing"; mypy should flag any assignments that are
+# incorrect.
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.arrow import ArrowMixin, DataframeState
+
+    dataframe = ArrowMixin().dataframe
+
+    # Create some test data
+    df = pd.DataFrame({"A": [1, 2, 3], "B": ["a", "b", "c"]})
+    arr = np.array([[1, 2, 3], [4, 5, 6]])
+
+    # Test return types with on_select="ignore" (default)
+    assert_type(dataframe(df), DeltaGenerator)
+    assert_type(dataframe(arr), DeltaGenerator)
+    assert_type(dataframe(None), DeltaGenerator)
+    assert_type(dataframe([[1, 2], [3, 4]]), DeltaGenerator)
+    assert_type(dataframe({"col1": [1, 2], "col2": [3, 4]}), DeltaGenerator)
+
+    # Test return types with on_select="rerun"
+    assert_type(dataframe(df, on_select="rerun"), DataframeState)
+    assert_type(dataframe(arr, on_select="rerun"), DataframeState)
+    assert_type(dataframe(None, on_select="rerun"), DataframeState)
+
+    # Test return types with different selection modes
+    assert_type(
+        dataframe(df, on_select="rerun", selection_mode="single-row"), DataframeState
+    )
+    assert_type(
+        dataframe(df, on_select="rerun", selection_mode="multi-row"), DataframeState
+    )
+    assert_type(
+        dataframe(df, on_select="rerun", selection_mode="single-column"), DataframeState
+    )
+    assert_type(
+        dataframe(df, on_select="rerun", selection_mode="multi-column"), DataframeState
+    )
+    assert_type(
+        dataframe(df, on_select="rerun", selection_mode=["multi-row", "multi-column"]),
+        DataframeState,
+    )
+
+    # Test return types with callback function
+    assert_type(dataframe(df, on_select=lambda: None), DataframeState)
+
+    # Test with various optional parameters
+    assert_type(
+        dataframe(
+            df,
+            width=500,
+            height=300,
+            use_container_width=True,
+            hide_index=True,
+            column_order=["B", "A"],
+            column_config={"A": "Integer values"},
+            key="my_table",
+            on_select="rerun",
+        ),
+        DataframeState,
+    )


### PR DESCRIPTION
## Describe your changes

Fixes an issue with the `st.dataframe` return annotation not correctly showing that it returns DeltaGenerator when selections are deactivated. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9669

## Testing Plan

- Added typing tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
