### PR TITLE
[test] Add withTimezones test harness

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -213,6 +213,17 @@ module.exports = {
     ],
     "streamlit-custom/no-hardcoded-theme-values": "error",
     "streamlit-custom/use-strict-null-equality-checks": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "timezone-mock",
+            message: "Please use the withTimezones test harness instead",
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     {

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
@@ -14,73 +14,21 @@
  * limitations under the License.
  */
 
-import timezoneMock from "timezone-mock"
+import { withTimezones } from "@streamlit/lib/src/util/withTimezones"
 
 import formatTime from "./formatTime"
 
-describe("formatTime", () => {
-  describe("US/Pacific Timezone", () => {
-    beforeAll(() => {
-      timezoneMock.register("US/Pacific")
-    })
-
-    afterAll(() => {
-      timezoneMock.unregister()
-    })
-
-    it('should format 0 milliseconds as "00:00" in Pacific Time', () => {
+withTimezones(() => {
+  describe("formatTime", () => {
+    it('should format 0 milliseconds as "00:00"', () => {
       expect(formatTime(0)).toBe("00:00")
     })
 
-    it('should format 1000 milliseconds as "00:01" in Pacific Time', () => {
+    it('should format 1000 milliseconds as "00:01"', () => {
       expect(formatTime(1000)).toBe("00:01")
     })
 
-    it('should format 90000 milliseconds as "01:30" in Pacific Time', () => {
-      expect(formatTime(90000)).toBe("01:30")
-    })
-  })
-
-  describe("US/Eastern Timezone", () => {
-    beforeAll(() => {
-      timezoneMock.register("US/Eastern")
-    })
-
-    afterAll(() => {
-      timezoneMock.unregister()
-    })
-
-    it('should format 0 milliseconds as "00:00" in Eastern Time', () => {
-      expect(formatTime(0)).toBe("00:00")
-    })
-
-    it('should format 1000 milliseconds as "00:01" in Eastern Time', () => {
-      expect(formatTime(1000)).toBe("00:01")
-    })
-
-    it('should format 90000 milliseconds as "01:30" in Eastern Time', () => {
-      expect(formatTime(90000)).toBe("01:30")
-    })
-  })
-
-  describe("Australia/Adelaide Timezone", () => {
-    beforeAll(() => {
-      timezoneMock.register("Australia/Adelaide")
-    })
-
-    afterAll(() => {
-      timezoneMock.unregister()
-    })
-
-    it('should format 0 milliseconds as "00:00" in Adelaide Time', () => {
-      expect(formatTime(0)).toBe("00:00")
-    })
-
-    it('should format 1000 milliseconds as "00:01" in Adelaide Time', () => {
-      expect(formatTime(1000)).toBe("00:01")
-    })
-
-    it('should format 90000 milliseconds as "01:30" in Adelaide Time', () => {
+    it('should format 90000 milliseconds as "01:30"', () => {
       expect(formatTime(90000)).toBe("01:30")
     })
   })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -15,7 +15,8 @@
  */
 import { GridCell, GridCellKind } from "@glideapps/glide-data-grid"
 import moment, { Moment } from "moment-timezone"
-import timezoneMock from "timezone-mock"
+
+import { withTimezones } from "@streamlit/lib/src/util/withTimezones"
 
 import {
   BaseColumnProps,
@@ -531,72 +532,72 @@ describe("truncateDecimals", () => {
   )
 })
 
-describe("formatMoment", () => {
-  beforeAll(() => {
-    const d = new Date("2022-04-28T00:00:00Z")
-    vi.useFakeTimers()
-    vi.setSystemTime(d)
-    timezoneMock.register("UTC")
-  })
+withTimezones(() => {
+  describe("formatMoment", () => {
+    beforeAll(() => {
+      const d = new Date("2022-04-28T00:00:00Z")
+      vi.useFakeTimers()
+      vi.setSystemTime(d)
+    })
 
-  afterAll(() => {
-    timezoneMock.unregister()
-    vi.useRealTimers()
-  })
+    afterAll(() => {
+      vi.useRealTimers()
+    })
 
-  it.each([
-    [
-      "YYYY-MM-DD HH:mm:ss z",
-      moment.utc("2023-04-27T10:20:30Z"),
-      "2023-04-27 10:20:30 UTC",
-    ],
-    [
-      "YYYY-MM-DD HH:mm:ss z",
-      moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
-      "2023-04-27 03:20:30 PDT",
-    ],
-    [
-      "YYYY-MM-DD HH:mm:ss Z",
-      moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
-      "2023-04-27 03:20:30 -07:00",
-    ],
-    [
-      "YYYY-MM-DD HH:mm:ss Z",
-      moment.utc("2023-04-27T10:20:30Z").utcOffset("+04:00"),
-      "2023-04-27 14:20:30 +04:00",
-    ],
-    ["YYYY-MM-DD", moment.utc("2023-04-27T10:20:30Z"), "2023-04-27"],
-    [
-      "MMM Do, YYYY [at] h:mm A",
-      moment.utc("2023-04-27T15:45:00Z"),
-      "Apr 27th, 2023 at 3:45 PM",
-    ],
-    [
-      "MMMM Do, YYYY Z",
-      moment.utc("2023-04-27T10:20:30Z").utcOffset("-02:30"),
-      "April 27th, 2023 -02:30",
-    ],
-    // Distance:
-    ["distance", moment.utc("2022-04-10T20:20:30Z"), "17 days ago"],
-    ["distance", moment.utc("2020-04-10T20:20:30Z"), "2 years ago"],
-    ["distance", moment.utc("2022-04-27T23:59:59Z"), "a few seconds ago"],
-    ["distance", moment.utc("2022-04-20T00:00:00Z"), "8 days ago"],
-    ["distance", moment.utc("2022-05-27T23:59:59Z"), "in a month"],
-    // Relative:
-    ["relative", moment.utc("2022-04-30T15:30:00Z"), "Saturday at 3:30 PM"],
-    [
-      "relative",
-      moment.utc("2022-04-24T12:20:30Z"),
-      "Last Sunday at 12:20 PM",
-    ],
-    ["relative", moment.utc("2022-04-28T12:00:00Z"), "Today at 12:00 PM"],
-    ["relative", moment.utc("2022-04-29T12:00:00Z"), "Tomorrow at 12:00 PM"],
-  ])(
-    "uses %s format to format %p to %p",
-    (format: string, momentDate: Moment, expected: string) => {
-      expect(formatMoment(momentDate, format)).toBe(expected)
-    }
-  )
+    it.each([
+      [
+        "YYYY-MM-DD HH:mm:ss z",
+        moment.utc("2023-04-27T10:20:30Z"),
+        "2023-04-27 10:20:30 UTC",
+      ],
+      [
+        "YYYY-MM-DD HH:mm:ss z",
+        moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
+        "2023-04-27 03:20:30 PDT",
+      ],
+      [
+        "YYYY-MM-DD HH:mm:ss Z",
+        moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
+        "2023-04-27 03:20:30 -07:00",
+      ],
+      [
+        "YYYY-MM-DD HH:mm:ss Z",
+        moment.utc("2023-04-27T10:20:30Z").utcOffset("+04:00"),
+        "2023-04-27 14:20:30 +04:00",
+      ],
+      ["YYYY-MM-DD", moment.utc("2023-04-27T10:20:30Z"), "2023-04-27"],
+      [
+        "MMM Do, YYYY [at] h:mm A",
+        moment.utc("2023-04-27T15:45:00Z"),
+        "Apr 27th, 2023 at 3:45 PM",
+      ],
+      [
+        "MMMM Do, YYYY Z",
+        moment.utc("2023-04-27T10:20:30Z").utcOffset("-02:30"),
+        "April 27th, 2023 -02:30",
+      ],
+      // Distance:
+      ["distance", moment.utc("2022-04-10T20:20:30Z"), "17 days ago"],
+      ["distance", moment.utc("2020-04-10T20:20:30Z"), "2 years ago"],
+      ["distance", moment.utc("2022-04-27T23:59:59Z"), "a few seconds ago"],
+      ["distance", moment.utc("2022-04-20T00:00:00Z"), "8 days ago"],
+      ["distance", moment.utc("2022-05-27T23:59:59Z"), "in a month"],
+      // Relative:
+      ["relative", moment.utc("2022-04-30T15:30:00Z"), "Saturday at 3:30 PM"],
+      [
+        "relative",
+        moment.utc("2022-04-24T12:20:30Z"),
+        "Last Sunday at 12:20 PM",
+      ],
+      ["relative", moment.utc("2022-04-28T12:00:00Z"), "Today at 12:00 PM"],
+      ["relative", moment.utc("2022-04-29T12:00:00Z"), "Tomorrow at 12:00 PM"],
+    ])(
+      "uses %s format to format %p to %p",
+      (format: string, momentDate: Moment, expected: string) => {
+        expect(formatMoment(momentDate, format)).toBe(expected)
+      }
+    )
+  })
 })
 
 test("removeLineBreaks should remove line breaks", () => {

--- a/frontend/lib/src/util/withTimezones.ts
+++ b/frontend/lib/src/util/withTimezones.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line no-restricted-imports, import/no-extraneous-dependencies
+import timezoneMock from "timezone-mock"
+
+/**
+ * Executes tests for many different timezones. This test harness is used to
+ * ensure the expected behavior works in important and unique timezones.
+ *
+ * @param {function(string): void} fn - The describe/test block to be executed
+ * in each timezone.
+ */
+export const withTimezones = (fn: (timezone: string) => void): void => {
+  const TIMEZONES = [
+    "UTC",
+    "Australia/Adelaide",
+    "Brazil/East",
+    "Europe/London",
+    "US/Eastern",
+    "US/Pacific",
+  ] as const
+
+  // eslint-disable-next-line vitest/expect-expect
+  describe.each(TIMEZONES)("with %s timezone", timezone => {
+    beforeAll(() => {
+      timezoneMock.register(timezone)
+    })
+
+    fn(timezone)
+
+    afterAll(() => {
+      timezoneMock.unregister()
+    })
+  })
+}


### PR DESCRIPTION
## Describe your changes

- Follow-up item from post-mortem
- Writes a reusable `withTimezones` test harness. Applies it in tests that were previously using `timezone-mock` directly
- Restricts the direct importing of `timezone-mock` and instead guides users to utilize `withTimezones` so that we get consistent testing coverage for timezones

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) ✅ - This is a test change
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
