### PR TITLE
Disallow invalid scopes for st.rerun

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -128,6 +128,11 @@ def rerun(  # type: ignore[misc]
 
     """
 
+    if scope not in ["app", "fragment"]:
+        raise StreamlitAPIException(
+            f"'{scope}'is not a valid rerun scope. Valid scopes are 'app' and 'fragment'."
+        )
+
     ctx = get_script_run_ctx()
 
     if ctx and ctx.script_requests:

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -96,3 +96,8 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_True(patched_get_script_run_ctx)
             is_fragment_scoped_rerun=True,
         )
     )
+
+
+def test_st_rerun_invalid_scope_throws_error():
+    with pytest.raises(StreamlitAPIException):
+        rerun(scope="foo")


### PR DESCRIPTION
## Describe your changes

Reviewing #9908, we noticed a misuse of the scope and realized it's typed correctly, but users without type checking will not get an error. This PR adjusts that.

## Testing Plan

- Python Unit Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
