### PR TITLE
Set Python 3.9 as minimum version and remove unused type-ignore comment

### DIFF
--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -77,7 +77,7 @@ FILES_WITH_PYTHON_DEPENDENCIES = [
     "lib/setup.py",
 ]
 # +1 to make range inclusive.
-ALL_PYTHON_VERSIONS = [f"3.{d}" for d in range(8, 12 + 1)]
+ALL_PYTHON_VERSIONS = [f"3.{d}" for d in range(9, 12 + 1)]
 PYTHON_MIN_VERSION = ALL_PYTHON_VERSIONS[0]
 PYTHON_MAX_VERSION = ALL_PYTHON_VERSIONS[-1]
 

--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -3,7 +3,7 @@ blinker==1.0.0
 cachetools==4.0
 click==7.0
 gitpython==3.0.7
-numpy==1.20
+numpy==1.23
 packaging==20
 pandas==1.4.0
 pillow==7.1.0

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -33,7 +33,7 @@ INSTALL_REQUIRES = [
     "blinker>=1.0.0, <2",
     "cachetools>=4.0, <6",
     "click>=7.0, <9",
-    "numpy>=1.20, <3",
+    "numpy>=1.23, <3",
     "packaging>=20, <25",
     # Pandas <1.4 has a bug related to deleting columns in a DataFrame changing
     # the index dtype.
@@ -62,8 +62,7 @@ INSTALL_REQUIRES = [
 SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython>=3.0.7, <4, !=3.1.19",
     "pydeck>=0.8.0b4, <1",
-    # Tornado 6.0.3 was the current Tornado version when Python 3.8, our earliest supported Python version,
-    # was released (Oct 14, 2019).
+    # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
     "tornado>=6.0.3, <7",
 ]
 
@@ -126,7 +125,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -141,7 +139,7 @@ setup(
     # We exclude Python 3.9.7 from our compatible versions due to a bug in that version
     # with typing.Protocol. See https://github.com/streamlit/streamlit/issues/5140 and
     # https://bugs.python.org/issue45121
-    python_requires=">=3.8, !=3.9.7",
+    python_requires=">=3.9, !=3.9.7",
     # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
     package_data={"streamlit": ["py.typed", "hello/**/*.py"]},
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -706,8 +706,7 @@ def _get_offset_encoding(
     x_offset = alt.XOffset()
     y_offset = alt.YOffset()
 
-    # our merge gate does not find the alt.UndefinedType type for some reason
-    _color_column: str | alt.UndefinedType = (  # type: ignore[name-defined]
+    _color_column: str | alt.UndefinedType = (
         color_column if color_column is not None else alt.utils.Undefined
     )
 


### PR DESCRIPTION
## Describe your changes

Fixes an issue in our build pipeline when mypy is run (see [here](https://github.com/streamlit/streamlit/actions/runs/12004642925)) by removing the comment. We set Python 3.9 as the new min as 3.8 would still require the comment. We are about to bump the max version to 3.13 and want to retire 3.8: https://github.com/streamlit/streamlit/pull/9635

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
