### PR TITLE
Harden selection e2e tests

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -737,7 +737,7 @@ def wait_for_app_run(
     page_or_locator.locator(
         "[data-testid='stApp'][data-test-connection-state='CONNECTED']"
     ).wait_for(
-        timeout=20000,
+        timeout=25000,
         state="attached",
     )
     # Wait until we know the script has started. We determine this by checking
@@ -746,7 +746,7 @@ def wait_for_app_run(
     page_or_locator.locator(
         "[data-testid='stApp'][data-test-script-state='notRunning']"
     ).wait_for(
-        timeout=20000,
+        timeout=25000,
         state="attached",
     )
 

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -375,6 +375,8 @@ def test_selection_state_remains_after_unmounting(
 ):
     """Test that the selection state remains after unmounting the component."""
     canvas = _get_multi_row_and_column_select_df(app)
+    expect_canvas_to_be_visible(canvas)
+
     _select_some_rows_and_columns(app, canvas)
     _expect_multi_row_multi_column_selection(app)
 

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -217,6 +217,14 @@ def test_selection_state_remains_after_unmounting(
     wait_for_app_run(app)
 
     click_button(app, "Create some elements to unmount component")
+    # wait for the "Another elements" texts to appear on the screen before
+    # getting the chart element to make sure that the chart is the new one
+    # and not the old one which is going to be replaced and can lead to a
+    # "Element not in DOM" error when trying to take the snapshot.
+    added_elements = app.get_by_text("Another element")
+    # for each added element, we sleep 1 second, so let's add some more seconds to the
+    # timeout
+    expect(added_elements).to_have_count(3, timeout=8000)
 
     chart = app.get_by_test_id("stPlotlyChart").nth(5)
     expect(chart).to_be_visible()

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -217,7 +217,7 @@ def test_selection_state_remains_after_unmounting(
     wait_for_app_run(app)
 
     click_button(app, "Create some elements to unmount component")
-    # wait for the "Another elements" texts to appear on the screen before
+    # wait for the "Another element" texts to appear on the screen before
     # getting the chart element to make sure that the chart is the new one
     # and not the old one which is going to be replaced and can lead to a
     # "Element not in DOM" error when trying to take the snapshot.

--- a/e2e_playwright/st_tabs_selection_test.py
+++ b/e2e_playwright/st_tabs_selection_test.py
@@ -15,6 +15,7 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.shared.app_utils import click_button
 
 EXPANDER_HEADER_IDENTIFIER = ".streamlit-expanderHeader"
 
@@ -28,12 +29,12 @@ def test_maintains_selection_when_other_tab_added(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test st.tabs maintains selected tab if additional tab added."""
-    control_buttons = app.get_by_test_id("stButton")
     tab_buttons = app.get_by_test_id("stTabs").locator("button[role=tab]")
     # Select Tab 2
     tab_buttons.nth(1).click()
-    # Select Add Tab 3 button
-    control_buttons.nth(0).click()
+
+    click_button(app, "Add Tab 3")
+
     # Wait for tabs to properly load
     wait_for_app_run(app, wait_delay=500)
     assert_snapshot(app.get_by_test_id("stTabs"), name="st_tabs-selection_add_tab")
@@ -43,17 +44,15 @@ def test_maintains_selection_when_other_tab_removed(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test st.tabs maintains selected tab if non-selected tab removed."""
-    control_buttons = app.get_by_test_id("stButton")
-    # Reset Tabs
-    control_buttons.nth(5).click()
-    wait_for_app_run(app)
-    # Add Tab 3
-    control_buttons.nth(0).click()
+    click_button(app, "Reset Tabs")
+    click_button(app, "Add Tab 3")
+
     # Select Tab 3
     tab_buttons = app.get_by_test_id("stTabs").locator("button[role=tab]")
     tab_buttons.nth(2).click()
-    # Select Remove Tab 1 button
-    control_buttons.nth(1).click()
+
+    click_button(app, "Remove Tab 1")
+
     # Wait for tabs to properly load
     wait_for_app_run(app, wait_delay=500)
     assert_snapshot(app.get_by_test_id("stTabs"), name="st_tabs-selection_remove_tab")
@@ -63,15 +62,16 @@ def test_resets_selection_when_selected_tab_removed(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test st.tabs resets selected tab to 1 if previously selected tab removed."""
-    control_buttons = app.get_by_test_id("stButton")
     # Reset Tabs
-    control_buttons.nth(5).click()
+    click_button(app, "Reset Tabs")
+
     wait_for_app_run(app)
     # Select Tab 2
     tab_buttons = app.get_by_test_id("stTabs").locator("button[role=tab]")
     tab_buttons.nth(1).click()
-    # Select Remove Tab 2 button
-    control_buttons.nth(2).click()
+
+    click_button(app, "Remove Tab 2")
+
     # Wait for tabs to properly load
     wait_for_app_run(app, wait_delay=500)
     assert_snapshot(app.get_by_test_id("stTabs"), name="st_tabs-remove_selected")
@@ -80,25 +80,21 @@ def test_resets_selection_when_selected_tab_removed(
 def test_maintains_selection_when_same_name_exists(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
-    """Test when tabs names change, keeps selected tab if matching label still exists."""
-    control_buttons = app.get_by_test_id("stButton")
-    # Reset Tabs
-    control_buttons.nth(5).click()
-    wait_for_app_run(app)
-    # Add Tab 3
-    control_buttons.nth(0).click()
-    wait_for_app_run(app)
-    # Select Tab 2
+    """Test when tabs names change, keep selected tab if matching label still exists."""
+
+    click_button(app, "Reset Tabs")
+    click_button(app, "Add Tab 3")
+
     tab_buttons = app.get_by_test_id("stTabs").locator("button[role=tab]")
     tab_buttons.nth(1).click()
 
     # Ensure that the click worked and the highlight animation finished
-    # to avoid issues with the snapshot later
+    # to avoid issues with the snapshot later. The 'tab-highlight' element
+    # is always visible for the selected tab and its always the same element
+    # that simply changes the position using CSS transform.
     expect(tab_buttons.nth(1)).to_have_attribute("aria-selected", "true")
-    tab_highlight_element = app.query_selector(
-        "[data-baseweb='tab-highlight']", strict=True
-    )
-    assert tab_highlight_element is not None
+    tab_highlight_element = app.locator("[data-baseweb='tab-highlight']")
+    expect(tab_highlight_element).to_be_visible()
     tab_highlight_element.evaluate(
         """
         element => Promise.all(
@@ -108,7 +104,7 @@ def test_maintains_selection_when_same_name_exists(
     )
 
     # Change Tab 1 & 3 Names
-    control_buttons.nth(3).click()
+    click_button(app, "Change Tab 1 & 3")
     # Wait for tabs to properly load
     wait_for_app_run(app, wait_delay=500)
     assert_snapshot(app.get_by_test_id("stTabs"), name="st_tabs-change_some_names")
@@ -118,15 +114,16 @@ def test_resets_selection_when_tab_names_change(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test when tabs names change, reset selected tab if no matching label exists."""
-    control_buttons = app.get_by_test_id("stButton")
     # Reset Tabs
-    control_buttons.nth(5).click()
+    click_button(app, "Reset Tabs")
+
     wait_for_app_run(app)
     # Select Tab 2
     tab_buttons = app.get_by_test_id("stTabs").locator("button[role=tab]")
     tab_buttons.nth(1).click()
-    # Change All Tab Names
-    control_buttons.nth(4).click()
+
+    click_button(app, "Change All Tabs")
+
     # Wait for tabs to properly load
     wait_for_app_run(app, wait_delay=500)
     assert_snapshot(app.get_by_test_id("stTabs"), name="st_tabs-change_all_names")


### PR DESCRIPTION
## Describe your changes

The nightly-run https://github.com/streamlit/streamlit/actions/runs/12045075844 failed with this error:

```
[run-playwright-tests / playwright-e2e-tests: e2e_playwright/st_plotly_chart_select_test.py#L225](https://github.com/streamlit/streamlit/commit/a1d6cb01a1740e3210f3dfc19827f3f1b7b6b427#annotation_29084932824)
test_selection_state_remains_after_unmounting[webkit]

playwright._impl._errors.Error: Locator.screenshot: Element is not attached to the DOM
```

The error texts led me to following hypothesis: the `"Create some elements to unmount component"` button was clicked and then the *original* chart element was retrieved by `chart = app.get_by_test_id("stPlotlyChart").nth(5)`, which was then replaced via the unmounting. Later, when `assert_snapshot(chart, ...)` was called, the *original* chart did not exist anymore leading to the error above.
The test is modified in a way where we wait for the three texts to show up before grabbing the chart element as by this time it should be the *new* one.

Also updated a couple of other e2e tests that were flaky and made the merge gate for this PR fail.

## Testing Plan

- E2E Tests: hardens existing test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
