### PR TITLE
Revert "Update pytest version (#9258)"

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -15,7 +15,9 @@ vega_datasets
 # Testing infrastructure dependencies:
 hypothesis>=6.17.4
 parameterized
-pytest>=8.3.3
+# Pinned for now because AsyncTest doesn't work with pytest 8.2.0
+# https://github.com/pytest-dev/pytest/issues/12263
+pytest<8.2.0
 pytest-cov
 requests-mock
 testfixtures

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -65,17 +65,6 @@ text_no_encoding = text_utf
 text_latin = "complete! ð\x9f\x91¨â\x80\x8dð\x9f\x8e¤"
 
 
-# Workaround for https://github.com/pytest-dev/pytest/issues/12263:
-# Newer pytest version require this method to exist, but its not implemented
-# in older Tornado versions for AsyncTestCase.
-# Adding this to the test harmless and not affecting the ScriptRunnerTest below.
-def runTest(*args, **kwargs):
-    pass
-
-
-AsyncTestCase.runTest = runTest
-
-
 def _create_widget(id: str, states: WidgetStates) -> WidgetState:
     """
     Returns


### PR DESCRIPTION
## Describe your changes

This reverts commit 1dea15e9bde4e0f17910afb0386934b11497d9ef.

I suspect that the pytest update is causing some issue together with the usage of pytest-xdist leading to test runs somehow use wrong app ports. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
