### PR TITLE
Harden more e2e test: graphviz_chart_test & video_test

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -48,6 +48,28 @@ def get_checkbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
     return element
 
 
+def get_radio_button(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
+    """Get a radio button widget with the given label.
+
+    Parameters
+    ----------
+
+    locator : Locator
+        The locator to search for the 'radio' element.
+
+    label : str or Pattern[str]
+        The label of the radio element to get.
+
+    Returns
+    -------
+    Locator
+        The element.
+    """
+    element = locator.locator('[data-baseweb="radio"]').filter(has_text=label)
+    expect(element).to_be_visible()
+    return element
+
+
 def get_image(locator: Locator | Page, caption: str | Pattern[str]) -> Locator:
     """Get an image element with the given caption.
 

--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -15,7 +15,7 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
-from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.app_utils import check_top_level_class, get_radio_button
 
 
 def get_first_graph_svg(app: Page):
@@ -101,11 +101,12 @@ def test_renders_with_specified_engines(
     """Test if it renders with specified engines."""
 
     engines = ["dot", "neato", "twopi", "circo", "fdp", "osage", "patchwork"]
+    radio_group = app.get_by_test_id("stRadio")
+    radios = radio_group.get_by_role("radio")
+    expect(radios).to_have_count(len(engines))
 
-    radios = app.query_selector_all('label[data-baseweb="radio"]')
-
-    for idx, engine in enumerate(engines):
-        radios[idx].click(force=True)
+    for engine in engines:
+        get_radio_button(radio_group, engine).click(force=True)
         wait_for_app_run(app)
         expect(app.get_by_test_id("stMarkdown").nth(0)).to_have_text(engine)
 


### PR DESCRIPTION
## Describe your changes

Based on https://issues.streamlit.app/Flaky_Tests we have seen the two tests `graphviz_chart_test` & `video_test` to still be flaky. This is an attempt to harden them and reduce flakiness.

Also this PR adds a new convenient function: `get_radio_button`

## Testing Plan

- harden e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
