### PR TITLE
Fix fragment runtime errors for just removed fragments

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -283,7 +283,6 @@ class AppSession:
         """Process a BackMsg."""
         try:
             msg_type = msg.WhichOneof("type")
-            print(f"[DEBUG] handle_backmsg {msg}")
             if msg_type == "rerun_script":
                 if msg.debug_last_backmsg_id:
                     self._debug_last_backmsg_id = msg.debug_last_backmsg_id
@@ -358,7 +357,8 @@ class AppSession:
             fragment_id = client_state.fragment_id
             if fragment_id and not self._fragment_storage.contains(fragment_id):
                 _LOGGER.error(
-                    f"[DEBUG]: The fragment with id {fragment_id} does not exist anymore - it was probably removed"
+                    f"The fragment with id {fragment_id} does not exist anymore - "
+                    "it might have been removed during a preceding full-app rerun."
                 )
                 return
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -356,7 +356,7 @@ class AppSession:
         if client_state:
             fragment_id = client_state.fragment_id
             if fragment_id and not self._fragment_storage.contains(fragment_id):
-                _LOGGER.error(
+                _LOGGER.info(
                     f"The fragment with id {fragment_id} does not exist anymore - "
                     "it might have been removed during a preceding full-app rerun."
                 )

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -283,7 +283,7 @@ class AppSession:
         """Process a BackMsg."""
         try:
             msg_type = msg.WhichOneof("type")
-
+            print(f"[DEBUG] handle_backmsg {msg}")
             if msg_type == "rerun_script":
                 if msg.debug_last_backmsg_id:
                     self._debug_last_backmsg_id = msg.debug_last_backmsg_id
@@ -356,6 +356,11 @@ class AppSession:
 
         if client_state:
             fragment_id = client_state.fragment_id
+            if fragment_id and not self._fragment_storage.contains(fragment_id):
+                _LOGGER.error(
+                    f"[DEBUG]: The fragment with id {fragment_id} does not exist anymore - it was probably removed"
+                )
+                return
 
             rerun_data = RerunData(
                 client_state.query_string,
@@ -572,7 +577,6 @@ class AppSession:
         if event == ScriptRunnerEvent.SCRIPT_STARTED:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
-
             assert (
                 page_script_hash is not None
             ), "page_script_hash must be set for the SCRIPT_STARTED event"

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -210,6 +210,15 @@ def _update_script_finished_message(
     states on the frontend.
     """
     if msg.WhichOneof("type") == "script_finished" and (
+        # If this is not a fragment run (= full app run), its okay to change the
+        # script_finished type to FINISHED_EARLY_FOR_RERUN because another full app run
+        # is about to start.
+        # If this is a fragment run, it is allowed to change the state of
+        # all script_finished states except for FINISHED_SUCCESSFULLY, which we use to
+        # indicate that a full app run has finished successfully (in other words, a
+        # fragment should not modify the finished status of a full app run, because
+        # the fragment finished state is different and the frontend might not trigger
+        # cleanups etc. correctly).
         is_fragment_run is False
         or msg.script_finished != ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
     ):

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -65,6 +65,11 @@ class FragmentStorage(Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def clear_past_ids(self) -> None:
+        """Remove all fragments from the past-store saved in this FragmentStorage."""
+        raise NotImplementedError
+
+    @abstractmethod
     def get(self, key: str) -> Fragment:
         """Returns the stored fragment for the given key."""
         raise NotImplementedError
@@ -117,6 +122,9 @@ class MemoryFragmentStorage(FragmentStorage):
         for fid in fragment_ids:
             if fid not in new_fragment_ids:
                 del self._fragments[fid]
+
+    def clear_past_ids(self) -> None:
+        self._previous_fragment_ids.clear()
 
     def get(self, key: str) -> Fragment:
         try:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -556,7 +556,6 @@ class ScriptRunner:
                                 error_msg = (
                                     f"Could not find fragment with id {fragment_id}"
                                 )
-                                print(f"[DEBUG] Rerun {rerun_data}")
                                 if self._fragment_storage.contained_in_the_past(
                                     fragment_id
                                 ):

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -553,16 +553,24 @@ class ScriptRunner:
                                 wrapped_fragment()
 
                             except FragmentStorageKeyError:
+                                error_msg = (
+                                    f"Could not find fragment with id {fragment_id}"
+                                )
+                                print(f"[DEBUG] Rerun {rerun_data}")
+                                if self._fragment_storage.contained_in_the_past(
+                                    fragment_id
+                                ):
+                                    # if fragment_id == rerun_data.fragment_id:
+                                    _LOGGER.warning(error_msg)
                                 # Only raise an error if the fragment is not an
                                 # auto_rerun. If it is an auto_rerun, we might have a
                                 # race condition where the fragment_id is removed
                                 # but the webapp sends a rerun request before the
                                 # removal information has reached the web app
                                 # (see https://github.com/streamlit/streamlit/issues/9080).
-                                if not rerun_data.is_auto_rerun:
-                                    raise RuntimeError(
-                                        f"Could not find fragment with id {fragment_id}"
-                                    )
+                                elif fragment_id and not rerun_data.is_auto_rerun:
+                                    raise RuntimeError(error_msg)
+
                             except (RerunException, StopException) as e:
                                 # The wrapped_fragment function is executed
                                 # inside of a exec_func_with_error_handling call, so

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -177,9 +177,6 @@ class ScriptRequests:
         """
 
         with self._lock:
-            print(
-                f"[DEBUG] current_rerun_data: {self._rerun_data} | request_rerun: {new_data} | state: {self._state}"
-            )
             if self._state == ScriptRequestType.STOP:
                 # We can't rerun after being stopped.
                 return False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -52,6 +52,7 @@ class RerunData:
     # The queue of fragment_ids waiting to be run.
     fragment_id_queue: list[str] = field(default_factory=list)
     is_fragment_scoped_rerun: bool = False
+    # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
 
     def __repr__(self) -> str:
@@ -176,6 +177,9 @@ class ScriptRequests:
         """
 
         with self._lock:
+            print(
+                f"[DEBUG] current_rerun_data: {self._rerun_data} | request_rerun: {new_data} | state: {self._state}"
+            )
             if self._state == ScriptRequestType.STOP:
                 # We can't rerun after being stopped.
                 return False

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -284,11 +284,13 @@ class AppSessionTest(unittest.TestCase):
         self, mock_create_scriptrunner: MagicMock
     ):
         session = _create_test_session()
+        fragment_id = "my_fragment_id"
+        session._fragment_storage.set(fragment_id, lambda: None)
 
         mock_active_scriptrunner = MagicMock(spec=ScriptRunner)
         session._scriptrunner = mock_active_scriptrunner
 
-        session.request_rerun(ClientState(fragment_id="my_fragment_id"))
+        session.request_rerun(ClientState(fragment_id=fragment_id))
 
         # The active ScriptRunner should *not* be shut down or stopped.
         mock_active_scriptrunner.request_rerun.assert_called_once()

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -293,7 +293,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         expected_new_finished_message = ForwardMsg()
         expected_new_finished_message.script_finished = (
-            ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+            ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
         )
 
         fmq.clear(


### PR DESCRIPTION
## Describe your changes

Split into following PRs: https://github.com/streamlit/streamlit/pull/10132, https://github.com/streamlit/streamlit/pull/10147, https://github.com/streamlit/streamlit/pull/10130

---

Closes #9921 

In issue #9921, the problem is that the `st.rerun` call inside of the dialog triggers a rerun. If you click on the button again before the dialog closes, another RequestRerun is sent to the server. By the time this second request is processed, the full-app rerun has already happened and cleared the fragment storage. So when the second RequestRerun is processed, the fragment id cannot be found anymore and the error is thrown.

This PR adds a `previous_fragment_ids` list to the `FragmentStorage` and only raises an error if the fragment id has never been seen. Otherwise, just log is emitted.
Discussion 1: We could always just emit a log and do not introduce the additional list.

After making this change, another issue surfaced: the error itself was gone, but the Dialog stayed open sometimes. There are two different root causes for this (both race conditions interplaying with the ScriptRunner threads etc.):
1. In `forward_msg_queue`, the FinishedScript type was always set to `STOPPED_EARLY_FOR_RERUN`. Now, the status is not changed for full app reruns by fragment runs. This is correct since a fragment indeed does not stop full app reruns. This only happens when the fragment run is so fast that the browser queue is not cleared yet.
2. In `app_session`, a fragment run might create a new `ScriptRunner` when the current ScriptRunner is in state `STOPPED` (in this case, `success` [here](https://github.com/streamlit/streamlit/blob/6567621dcad71ecefaaac6762ddcba7d4719ecde/lib/streamlit/runtime/app_session.py#L386) is `false` and the new ScriptRunner is created). This will lead to all events from the previous script runner being ignored (see [here](https://github.com/streamlit/streamlit/blob/6567621dcad71ecefaaac6762ddcba7d4719ecde/lib/streamlit/runtime/app_session.py#L561)). When the full app rerun ScriptRunner is done (STOPPED) but its events are not processed before the new ScriptRunner is created, its finished message is not sent to the frontend and no cleanup is happening.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python): Added unit tests for the new behavior
- E2E Tests: Reproducing the issues requires multiple tries as the issue is caused by some race conditions. This would lead to flaky E2E tests so the unit tests should be sufficient.
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
