### PR TITLE
fixes _does_file_end_in_semicolon function to handle empty tree body

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/magic.py
+++ b/lib/streamlit/runtime/scriptrunner/magic.py
@@ -241,6 +241,9 @@ def _does_file_end_in_semicolon(tree, code: str) -> bool:
     # Avoid spending time with this operation if magic.displayLastExprIfNoSemicolon is
     # not set.
     if config.get_option("magic.displayLastExprIfNoSemicolon"):
+        if len(tree.body) == 0:
+            return False
+
         last_line_num = getattr(tree.body[-1], "end_lineno", None)
 
         if last_line_num is not None:

--- a/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
@@ -55,6 +55,11 @@ b
 """
         self._testCode(CODE_SIMPLE_STATEMENTS, 2)
 
+    def test_empty_ast(self):
+        """Test empty AST"""
+        CODE_EMPTY_AST = ""
+        self._testCode(CODE_EMPTY_AST, 0)
+
     def test_if_statement(self):
         """Test if statements"""
         CODE_IF_STATEMENT = """


### PR DESCRIPTION
## Describe your changes

This PR makes it so that if you pass an empty ast (such as a commented out block of code) to this function, it will not get an out of bounds error by trying to index [-1] of an empty array.


-----

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
