### PR TITLE
Update clean command to ignore the e2e_playwright/.streamlit directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ clean:
 	rm -rf frontend/lib/dist
 	rm -rf ~/.cache/pre-commit
 	rm -rf e2e_playwright/test-results
-	find . -name .streamlit -type d -exec rm -rfv {} \; || true
+	find . -name .streamlit -not -path './e2e_playwright/.streamlit' -type d -exec rm -rfv {} \; || true
 	cd lib; rm -rf .coverage .coverage\.*
 
 MIN_PROTOC_VERSION = 3.20


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9967

Ignore the directory that is required for playwright tests when running `make clean`

Before:
![Screenshot 2024-12-05 at 11 49 55](https://github.com/user-attachments/assets/2eb664eb-0b77-4cfe-a270-f79a380464cf)

 After:
![Screenshot 2024-12-05 at 11 49 34](https://github.com/user-attachments/assets/8ca51de5-ab54-4052-9c3e-4963b7e19036)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
