### PR TITLE
[PoC] Run fragment callbacks in fragment context

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -43,11 +43,6 @@ if TYPE_CHECKING:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
-
-# class FragmentArg(Protocol):
-#     def __call__(self, fragment_id: str | None) -> None: ...
-
-
 Fragment = Callable[..., Any]
 
 
@@ -184,7 +179,7 @@ def _fragment(
         initialized_active_script_hash = ctx.active_script_hash
 
         def wrapped_fragment(
-            callback: Callable[[str | None], None] | None = None,
+            callback: Callable[[], None] | None = None,
         ) -> Any:
             """The actual fragment function that gets called when the fragment is run.
 
@@ -261,7 +256,7 @@ def _fragment(
                                 else []
                             )[:-1]
                             if callback:
-                                callback(fragment_id)
+                                callback()
                             result = non_optional_func(*args, **kwargs)
                         except (
                             RerunException,
@@ -294,7 +289,7 @@ def _fragment(
             ctx.enqueue(msg)
 
         # Immediate execute the wrapped fragment since we are in a full app run
-        return wrapped_fragment()
+        return wrapped_fragment(None)
 
     with contextlib.suppress(AttributeError):
         # Make this a well-behaved decorator by preserving important function

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -42,7 +42,13 @@ if TYPE_CHECKING:
 
 
 F = TypeVar("F", bound=Callable[..., Any])
-Fragment = Callable[[Callable[[str], None] | None], Any]
+
+
+# class FragmentArg(Protocol):
+#     def __call__(self, fragment_id: str | None) -> None: ...
+
+
+Fragment = Callable[..., Any]
 
 
 class FragmentStorage(Protocol):
@@ -97,7 +103,7 @@ class MemoryFragmentStorage(FragmentStorage):
     the FragmentStorage protocol.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._fragments: dict[str, Fragment] = {}
 
     # Weirdly, we have to define this above the `set` method, or mypy gets it confused
@@ -178,7 +184,7 @@ def _fragment(
         initialized_active_script_hash = ctx.active_script_hash
 
         def wrapped_fragment(
-            callback: Callable[[str], None] | None = None,
+            callback: Callable[[str | None], None] | None = None,
         ) -> Any:
             """The actual fragment function that gets called when the fragment is run.
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -556,7 +556,7 @@ class ScriptRunner:
                                 )
 
                                 def call_callbacks(fragment_id=fragment_id):
-                                    if fragment_id not in callbacks:
+                                    if not callbacks or fragment_id not in callbacks:
                                         return
                                     for callback in callbacks[fragment_id]:
                                         callback()

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -57,8 +57,8 @@ class SafeSessionState:
             return self._state.register_widget(metadata, user_key)
 
     def on_script_will_rerun(
-        self, latest_widget_states: WidgetStatesProto
-    ) -> Callable[[str | None], None]:
+        self, latest_widget_states: WidgetStatesProto, fragment_id: str | None = None
+    ) -> dict[str, list[Callable[[], None]]]:
         self._yield_callback()
         with self._lock:
             # TODO: rewrite this to copy the callbacks list into a local

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -56,14 +56,16 @@ class SafeSessionState:
         with self._lock:
             return self._state.register_widget(metadata, user_key)
 
-    def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
+    def on_script_will_rerun(
+        self, latest_widget_states: WidgetStatesProto
+    ) -> Callable[[str | None], None]:
         self._yield_callback()
         with self._lock:
             # TODO: rewrite this to copy the callbacks list into a local
             #  variable so that we don't need to hold our lock for the
             #  duration. (This will also allow us to downgrade our RLock
             #  to a Lock.)
-            self._state.on_script_will_rerun(latest_widget_states)
+            return self._state.on_script_will_rerun(latest_widget_states)
 
     def on_script_finished(self, widget_ids_this_run: set[str]) -> None:
         with self._lock:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -276,7 +276,7 @@ class WStates(MutableMapping[str, Any]):
             from streamlit.runtime.scriptrunner import RerunException
 
             try:
-                callback(*args, **kwargs)
+                callback(*args, **kwargs)  # type: ignore
             except RerunException:
                 st.warning("Calling st.rerun() within a callback is a no-op.")
 
@@ -577,7 +577,7 @@ class SessionState:
         changed_widget_ids = [
             wid for wid in self._new_widget_state if self._widget_changed(wid)
         ]
-        callbacks: dict[str, list[Callable]] = {}
+        callbacks: dict[str, list[Callable[[], None]]] = {}
         for wid in changed_widget_ids:
             id = "main"
             metadata = self._new_widget_state.widget_metadata.get(wid)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -271,15 +271,7 @@ class WStates(MutableMapping[str, Any]):
 
         args = metadata.callback_args or ()
         kwargs = metadata.callback_kwargs or {}
-        ctx = get_script_run_ctx()
-        previous_fragment_id = None
-        if ctx:
-            previous_fragment_id = ctx.current_fragment_id
-            ctx.current_fragment_id = metadata.fragment_id
         callback(*args, **kwargs)
-
-        if ctx:
-            ctx.current_fragment_id = previous_fragment_id
 
 
 def _missing_key_error_message(key: str) -> str:

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -542,7 +542,8 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         callbacks = self.script_run_ctx.session_state.on_script_will_rerun(
             WidgetStates(widgets=[new_widget_state])
         )
-        callbacks()
+        for callback in callbacks["main"]:
+            callback()
         self.assertEqual(callback_call_value[0], expected_element_value)
 
     def assertJSONEqual(self, a, b):

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -539,9 +539,10 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         new_widget_state.CopyFrom(current_widget_states[0])
         # update the widget's value so that the rerun will execute the callback
         new_widget_state.json_value = '{"key": "key", "default": "baz2"}'
-        self.script_run_ctx.session_state.on_script_will_rerun(
+        callbacks = self.script_run_ctx.session_state.on_script_will_rerun(
             WidgetStates(widgets=[new_widget_state])
         )
+        callbacks()
         self.assertEqual(callback_call_value[0], expected_element_value)
 
     def assertJSONEqual(self, a, b):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -243,7 +243,7 @@ class WStateTests(unittest.TestCase):
             callback_kwargs={"y": 2},
         )
         self.wstates.widget_metadata["widget_id_1"] = metadata
-        self.wstates.call_callback("widget_id_1")
+        self.wstates.call_callback("widget_id_1")()
 
         metadata.callback.assert_called_once_with(1, y=2)
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -156,7 +156,9 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("int", states).int_value = 321
         _create_widget("string", states).string_value = "!ydwoh"
 
-        session_state.on_script_will_rerun(states)
+        callbacks = session_state.on_script_will_rerun(states)
+        for cb in callbacks["main"]:
+            cb()
 
         mock_callback.assert_has_calls([call(), call(1), call(x=2), call(1, x=2)])
 


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9621

Callbacks registered in a fragment run are right now not executed in the fragment context when rerunning the fragment only. This results in `st.*` commands not writing correctly as investigated in https://github.com/streamlit/streamlit/issues/9621. The issue is that the callback does not leverage the fragment's context snapshot and, thus, does not start the delta path index at the correct place, basically leading to overrides of elements in the path.
This PR here is a PoC where callbacks registered within a fragment are executed in the fragment's context, leading to the correct behavior.
A workaround for the issue without this potential fix here is described in [this comment](https://github.com/streamlit/streamlit/issues/9621#issuecomment-2528058849). 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
