### PR TITLE
[refactor] Move `st.file_uploader` file type normalization to utils

### DIFF
--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -1,0 +1,47 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Sequence
+
+TYPE_PAIRS = [
+    (".jpg", ".jpeg"),
+    (".mpg", ".mpeg"),
+    (".mp4", ".mpeg4"),
+    (".tif", ".tiff"),
+    (".htm", ".html"),
+]
+
+
+def normalize_upload_file_type(file_type: str | Sequence[str]) -> Sequence[str]:
+    if isinstance(file_type, str):
+        file_type = [file_type]
+
+    # May need a regex or a library to validate file types are valid
+    # extensions.
+    file_type = [
+        file_type_entry if file_type_entry[0] == "." else f".{file_type_entry}"
+        for file_type_entry in file_type
+    ]
+
+    file_type = [t.lower() for t in file_type]
+
+    for x, y in TYPE_PAIRS:
+        if x in file_type and y not in file_type:
+            file_type.append(y)
+        if y in file_type and x not in file_type:
+            file_type.append(x)
+
+    return file_type

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, Literal, Sequence, Union, cast, overload
 from typing_extensions import TypeAlias
 
 from streamlit import config
+from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.policies import (
     check_widget_policies,
@@ -54,15 +55,6 @@ SomeUploadedFiles: TypeAlias = Union[
     DeletedFile,
     List[Union[UploadedFile, DeletedFile]],
     None,
-]
-
-
-TYPE_PAIRS = [
-    (".jpg", ".jpeg"),
-    (".mpg", ".mpeg"),
-    (".mp4", ".mpeg4"),
-    (".tif", ".tiff"),
-    (".htm", ".html"),
 ]
 
 
@@ -417,23 +409,7 @@ class FileUploaderMixin:
         )
 
         if type:
-            if isinstance(type, str):
-                type = [type]
-
-            # May need a regex or a library to validate file types are valid
-            # extensions.
-            type = [
-                file_type if file_type[0] == "." else f".{file_type}"
-                for file_type in type
-            ]
-
-            type = [t.lower() for t in type]
-
-            for x, y in TYPE_PAIRS:
-                if x in type and y not in type:
-                    type.append(y)
-                if y in type and x not in type:
-                    type.append(x)
+            type = normalize_upload_file_type(type)
 
         file_uploader_proto = FileUploaderProto()
         file_uploader_proto.id = element_id

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import unittest
+from typing import Sequence
+
+from parameterized import parameterized
+
+from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
+
+
+class FileUploaderUtilsTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("png", [".png"]),
+            (["png", ".svg", "foo"], [".png", ".svg", ".foo"]),
+            (["jpeg"], [".jpeg", ".jpg"]),
+            (["png", ".jpg"], [".png", ".jpg", ".jpeg"]),
+            ([".JpG"], [".jpg", ".jpeg"]),
+        ]
+    )
+    def test_file_type(self, file_type: str | Sequence[str], expected: Sequence[str]):
+        """Test that it can be called using string(s) for type parameter."""
+        normalized = normalize_upload_file_type(file_type=file_type)
+        self.assertEqual(normalized, expected)


### PR DESCRIPTION
## Describe your changes
Moved the file type normalization logic to a util file -- this will be shared by `st.file_uploader` & `st.chat_input` down the line.
Also moved the [unit tests](https://github.com/streamlit/streamlit/blob/develop/lib/tests/streamlit/elements/file_uploader_test.py#L54-L85) from `file_uploader_test.py` to test against this util function.

## GitHub Issue Link (if applicable)

## Testing Plan

- pytest

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
