### PR TITLE
Add AcceptFile enum for proto

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -38,7 +38,7 @@ const getProps = (
     placeholder: "Enter Text Here",
     disabled: false,
     default: "",
-    acceptFile: "false",
+    acceptFile: ChatInputProto.AcceptFile.NONE,
     ...elementProps,
   }),
   width: 300,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -30,7 +30,11 @@ import { AttachFile } from "@emotion-icons/material-outlined"
 import { FileRejection, useDropzone } from "react-dropzone"
 import zip from "lodash/zip"
 
-import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
+import {
+  AcceptFileValue,
+  chatInputAcceptFileProtoValueToEnum,
+  isNullOrUndefined,
+} from "@streamlit/lib/src/util/utils"
 import {
   ChatInput as ChatInputProto,
   FileUploaderState as FileUploaderStateProto,
@@ -233,6 +237,8 @@ function ChatInput({
 }: Props): React.ReactElement {
   const theme = useTheme()
 
+  const acceptFile = chatInputAcceptFileProtoValueToEnum(element.acceptFile)
+
   // True if the user-specified state.value has not yet been synced to the WidgetStateManager.
   const [dirty, setDirty] = useState(false)
   // The value specified by the user via the UI. If the user didn't touch this widget's UI, the default value is used.
@@ -317,7 +323,7 @@ function ChatInput({
   }
 
   const dropHandler = createDropHandler({
-    acceptMultipleFiles: element.acceptFile === "multiple",
+    acceptMultipleFiles: acceptFile === AcceptFileValue.Multiple,
     uploadClient: uploadClient,
     uploadFile: createUploadFileHandler({
       getNextLocalFileId,
@@ -395,7 +401,7 @@ function ChatInput({
 
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: dropHandler,
-    multiple: element.acceptFile === "multiple",
+    multiple: acceptFile === AcceptFileValue.Multiple,
     accept: element.fileType.length > 0 ? element.fileType : undefined,
   })
 
@@ -415,7 +421,7 @@ function ChatInput({
   }
 
   const getTextAreaBorderStyle = (): React.CSSProperties =>
-    element.acceptFile
+    acceptFile !== AcceptFileValue.None
       ? { border: "none" }
       : {
           // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
@@ -531,7 +537,7 @@ function ChatInput({
         width={width}
       >
         <StyledChatInput>
-          {element.acceptFile !== "false" ? (
+          {acceptFile !== AcceptFileValue.None ? (
             <>
               <div {...getRootProps()}>
                 <input {...getInputProps()} />

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -20,6 +20,7 @@ import xxhash from "xxhashjs"
 
 import {
   Alert as AlertProto,
+  ChatInput as ChatInputProto,
   Element,
   LabelVisibilityMessage as LabelVisibilityMessageProto,
   Skeleton as SkeletonProto,
@@ -399,6 +400,27 @@ export function labelVisibilityProtoValueToEnum(
       return LabelVisibilityOptions.Collapsed
     default:
       return LabelVisibilityOptions.Visible
+  }
+}
+
+export enum AcceptFileValue {
+  None,
+  Single,
+  Multiple,
+}
+
+export function chatInputAcceptFileProtoValueToEnum(
+  value: ChatInputProto.AcceptFile | null | undefined
+): AcceptFileValue {
+  switch (value) {
+    case ChatInputProto.AcceptFile.NONE:
+      return AcceptFileValue.None
+    case ChatInputProto.AcceptFile.SINGLE:
+      return AcceptFileValue.Single
+    case ChatInputProto.AcceptFile.MULTIPLE:
+      return AcceptFileValue.Multiple
+    default:
+      return AcceptFileValue.None
   }
 }
 

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -30,6 +30,7 @@ from typing_extensions import TypeAlias
 
 from streamlit import config
 from streamlit.errors import StreamlitDuplicateElementId, StreamlitDuplicateElementKey
+from streamlit.proto.ChatInput_pb2 import ChatInput
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ScriptRunContext,
@@ -76,6 +77,21 @@ def get_label_visibility_proto_value(
         return LabelVisibilityMessage.LabelVisibilityOptions.COLLAPSED
 
     raise ValueError(f"Unknown label visibility value: {label_visibility_string}")
+
+
+def get_chat_input_accept_file_proto_value(
+    accept_file_value: bool | Literal["multiple"],
+) -> ChatInput.AcceptFile.ValueType:
+    """Returns one of ChatInput.AcceptFile enum value based on string value."""
+
+    if accept_file_value is False:
+        return ChatInput.AcceptFile.NONE
+    elif accept_file_value is True:
+        return ChatInput.AcceptFile.SINGLE
+    elif accept_file_value == "multiple":
+        return ChatInput.AcceptFile.MULTIPLE
+
+    raise ValueError(f"Unknown accept file value: {accept_file_value}")
 
 
 @overload

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -26,6 +26,7 @@ from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import (
     Key,
     compute_and_register_element_id,
+    get_chat_input_accept_file_proto_value,
     save_for_app_testing,
     to_key,
 )
@@ -519,7 +520,9 @@ class ChatMixin:
 
         chat_input_proto.default = default
 
-        chat_input_proto.accept_file = str(accept_file).lower()
+        chat_input_proto.accept_file = get_chat_input_accept_file_proto_value(
+            accept_file
+        )
 
         chat_input_proto.file_type[:] = file_type if file_type is not None else []
 

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -26,6 +26,7 @@ from streamlit.errors import (
     StreamlitValueAssignmentNotAllowedError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
+from streamlit.proto.ChatInput_pb2 import ChatInput
 from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.proto.RootContainer_pb2 import RootContainer as RootContainerProto
 from streamlit.runtime.uploaded_file_manager import (
@@ -192,7 +193,7 @@ class ChatTest(DeltaGeneratorTestCase):
         self.assertEqual(c.value, "")
         self.assertEqual(c.set_value, False)
         self.assertEqual(c.max_chars, 100)
-        self.assertEqual(c.accept_file, "false")
+        self.assertEqual(c.accept_file, ChatInput.AcceptFile.NONE)
         self.assertEqual(c.disabled, False)
         self.assertEqual(c.file_type, [])
 
@@ -258,15 +259,15 @@ class ChatTest(DeltaGeneratorTestCase):
     def test_chat_input_accept_file(self):
         st.chat_input("Placeholder", accept_file=False)
         c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.accept_file, "false")
+        self.assertEqual(c.accept_file, ChatInput.AcceptFile.NONE)
 
         st.chat_input("Placeholder", accept_file=True)
         c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.accept_file, "true")
+        self.assertEqual(c.accept_file, ChatInput.AcceptFile.SINGLE)
 
         st.chat_input("Placeholder", accept_file="multiple")
         c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.accept_file, "multiple")
+        self.assertEqual(c.accept_file, ChatInput.AcceptFile.MULTIPLE)
 
     def test_chat_input_invalid_accept_file(self):
         with self.assertRaises(StreamlitAPIException) as ex:

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -33,8 +33,14 @@ message ChatInput {
     BOTTOM = 0;
   }
   Position position = 8;
-  // TODO[kajarenc] Consider using Enum for accept_file values.
-  string accept_file = 9;
+
+  enum AcceptFile {
+    NONE = 0;
+    SINGLE = 1;
+    MULTIPLE = 2;
+  }
+  AcceptFile accept_file = 9;
+
   // Supported file types: For example: ["png","jpg","img"]
   repeated string file_type = 10;
 }


### PR DESCRIPTION
## Describe your changes

Created a new enum for accept file values.
Added mapping of `chat_input` param to proto, and the mapping of proto value to ts enum


## GitHub Issue Link (if applicable)

## Testing Plan

Locally tested on `chat_input` widget

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
