### PR TITLE
Preserve target='_blank' for html elements

### DIFF
--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -82,4 +82,35 @@ describe("HTML element", () => {
     render(<Html {...props} />)
     expect(screen.getByTestId("stHtml")).toHaveTextContent("")
   })
+
+  describe("sanitizes anchor tags", () => {
+    it("does not add target when not present", () => {
+      const props = getProps({
+        body: '<a href="https://streamlit.io">Click Me</a>',
+      })
+      render(<Html {...props} />)
+      const anchorElement = screen.getByRole("link", { name: "Click Me" })
+      expect(anchorElement).not.toHaveAttribute("target")
+    })
+
+    it("preserves target='_blank' and adds rel attributes", () => {
+      const props = getProps({
+        body: '<a href="https://streamlit.io" target="_blank">Click Me</a>',
+      })
+      render(<Html {...props} />)
+      const anchorElement = screen.getByRole("link", { name: "Click Me" })
+      expect(anchorElement).toHaveAttribute("target", "_blank")
+      expect(anchorElement).toHaveAttribute("rel", "noopener noreferrer")
+    })
+
+    it("removes non-_blank target attributes", () => {
+      const props = getProps({
+        body: '<a href="https://streamlit.io" target="_self">Click Me</a>',
+      })
+      render(<Html {...props} />)
+      const anchorElement = screen.getByRole("link", { name: "Click Me" })
+      expect(anchorElement).not.toHaveAttribute("target")
+      expect(anchorElement).not.toHaveAttribute("rel")
+    })
+  })
 })


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9972

`DOMPurify` removes the `target` attribute on element nodes. Based on this [Google doc article](https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener) and this conversation in the [DOMPurify repository](https://github.com/cure53/DOMPurify/issues/317), it is secure to keep `target=_blank` when at the same time `rel=noopener noreferrer` is set. So we use a DOMPurify hook to preserve the attribute if the user set it

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/9972

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Added unit tests to ensure the sanitization behavior
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
