### PR TITLE
Remove old JWT pair from Auth message

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -333,14 +333,6 @@ export class App extends PureComponent<Props, State> {
       themeChanged: this.handleThemeMessage,
       pageChanged: this.onPageChange,
       isOwnerChanged: isOwner => this.setState({ isOwner }),
-      jwtHeaderChanged: ({ jwtHeaderName, jwtHeaderValue }) => {
-        if (
-          this.endpoints.setJWTHeader !== undefined &&
-          this.state.appConfig.useExternalAuthToken
-        ) {
-          this.endpoints.setJWTHeader({ jwtHeaderName, jwtHeaderValue })
-        }
-      },
       fileUploadClientConfigChanged: config => {
         if (this.endpoints.setFileUploadClientConfig !== undefined) {
           this.endpoints.setFileUploadClientConfig(config)

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -22,7 +22,6 @@ import {
   FileUploadClientConfig,
   getCookie,
   IAppPage,
-  JWTHeader,
   makePath,
   notNullOrUndefined,
   StreamlitEndpoints,
@@ -46,8 +45,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   private cachedServerUri?: BaseUriParts
 
-  private jwtHeader?: JWTHeader
-
   private fileUploadClientConfig?: FileUploadClientConfig
 
   public constructor(props: Props) {
@@ -60,10 +57,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       this.requireServerUri(),
       `${COMPONENT_ENDPOINT_BASE}/${componentName}/${path}`
     )
-  }
-
-  public setJWTHeader(jwtHeader: JWTHeader): void {
-    this.jwtHeader = jwtHeader
   }
 
   public setFileUploadClientConfig({
@@ -154,9 +147,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   private getAdditionalHeaders(): Record<string, string> {
     let headers: Record<string, string> = {}
-    if (this.jwtHeader !== undefined) {
-      headers[this.jwtHeader.jwtHeaderName] = this.jwtHeader.jwtHeaderValue
-    }
 
     if (this.fileUploadClientConfig) {
       headers = {

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -116,7 +116,6 @@ describe("AppNavigation", () => {
       themeChanged: () => {},
       pageChanged: () => {},
       isOwnerChanged: () => {},
-      jwtHeaderChanged: () => {},
       hostMenuItemsChanged: () => {},
       hostToolbarItemsChanged: () => {},
       hostHideSidebarNavChanged: () => {},

--- a/frontend/hostframe.html
+++ b/frontend/hostframe.html
@@ -106,14 +106,12 @@ Usage:
   }
 
   function setAuthToken() {
-    // We handle auth token and jwt header name/value in child iframe,
+    // We handle auth token in child iframe,
     // only when `useExternalAuthToken` is set to True in
     // "_stcore/host-config" endpoint. Otherwise, we ignore this message.
     sendMessage({
       type: "SET_AUTH_TOKEN",
       authToken: "AUTH_TOKEN",
-      jwtHeaderName: "X-JWT-HEADER-NAME",
-      jwtHeaderValue: "X-JWT-HEADER-VALUE",
     })
   }
 

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -18,11 +18,6 @@ import { CancelToken } from "axios"
 
 import { IAppPage } from "./proto"
 
-export type JWTHeader = {
-  jwtHeaderName: string
-  jwtHeaderValue: string
-}
-
 export type FileUploadClientConfig = {
   prefix: string
   headers: Record<string, string>
@@ -101,12 +96,6 @@ export interface StreamlitEndpoints {
    * from the server. Callers can use `ForwardMsg.decode` to deserialize the data.
    */
   fetchCachedForwardMsg(hash: string): Promise<Uint8Array>
-
-  /**
-   * Set JWT Header.
-   * @param jwtHeader the object that contains jwtHeaderName and jwtHeaderValue
-   */
-  setJWTHeader?(jwtHeader: JWTHeader): void
 
   /**
    * setFileUploadClientConfig.

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -57,7 +57,6 @@ describe("HostCommunicationManager messaging", () => {
       sendAppHeartbeat: vi.fn(),
       setInputsDisabled: vi.fn(),
       isOwnerChanged: vi.fn(),
-      jwtHeaderChanged: vi.fn(),
       fileUploadClientConfigChanged: vi.fn(),
       hostMenuItemsChanged: vi.fn(),
       hostToolbarItemsChanged: vi.fn(),
@@ -480,24 +479,6 @@ describe("HostCommunicationManager messaging", () => {
     ).toHaveBeenCalledWith("Light", undefined)
   })
 
-  it("can process a received SET_AUTH_TOKEN message with JWT pair", () => {
-    const message = new MessageEvent("message", {
-      data: {
-        stCommVersion: HOST_COMM_VERSION,
-        type: "SET_AUTH_TOKEN",
-        jwtHeaderName: "X-JWT-HEADER-NAME",
-        jwtHeaderValue: "X-JWT-HEADER-VALUE",
-      },
-      origin: "https://devel.streamlit.test",
-    })
-    dispatchEvent("message", message)
-
-    expect(
-      // @ts-expect-error - props are private
-      hostCommunicationMgr.props.jwtHeaderChanged
-    ).toHaveBeenCalledWith(message.data)
-  })
-
   it("can process a received SET_FILE_UPLOAD_CLIENT_CONFIG message", () => {
     const message = new MessageEvent("message", {
       data: {
@@ -574,7 +555,6 @@ describe("Test different origins", () => {
       clearCache: vi.fn(),
       sendAppHeartbeat: vi.fn(),
       setInputsDisabled: vi.fn(),
-      jwtHeaderChanged: vi.fn(),
       fileUploadClientConfigChanged: vi.fn(),
       isOwnerChanged: vi.fn(),
       hostMenuItemsChanged: vi.fn(),
@@ -674,7 +654,6 @@ describe("HostCommunicationManager external auth token handling", () => {
       clearCache: vi.fn(),
       sendAppHeartbeat: vi.fn(),
       setInputsDisabled: vi.fn(),
-      jwtHeaderChanged: vi.fn(),
       fileUploadClientConfigChanged: vi.fn(),
       isOwnerChanged: vi.fn(),
       hostMenuItemsChanged: vi.fn(),

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -49,10 +49,6 @@ export interface HostCommunicationProps {
   ) => void
   readonly pageChanged: (pageScriptHash: string) => void
   readonly isOwnerChanged: (isOwner: boolean) => void
-  readonly jwtHeaderChanged: (jwtPayload: {
-    jwtHeaderName: string
-    jwtHeaderValue: string
-  }) => void
   readonly fileUploadClientConfigChanged: (payload: {
     prefix: string
     headers: Record<string, string>
@@ -214,9 +210,6 @@ export default class HostCommunicationManager {
       // is a no-op, and we already resolved the promise to undefined
       // above.
       this.deferredAuthToken.resolve(message.authToken)
-      if (message.jwtHeaderName !== undefined) {
-        this.props.jwtHeaderChanged(message)
-      }
     }
 
     if (message.type === "SET_FILE_UPLOAD_CLIENT_CONFIG") {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -68,8 +68,6 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_AUTH_TOKEN"
       authToken: string
-      jwtHeaderName?: string
-      jwtHeaderValue?: string
     }
   | {
       type: "SET_IS_OWNER"

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -80,7 +80,6 @@ export { ScriptRunState } from "./ScriptRunState"
 export { SessionInfo } from "./SessionInfo"
 export type {
   FileUploadClientConfig,
-  JWTHeader,
   StreamlitEndpoints,
 } from "./StreamlitEndpoints"
 export {


### PR DESCRIPTION
## Describe your changes
Remove handling the old JWT header name header value pair from the AUTH_TOKEN host to guest message; we don't need it anymore since that has been replaced with the new `fileUploadClientConfig`. 

## GitHub Issue Link (if applicable)

## Testing Plan
**This PR contains purely deletions, no new functionality has been introduced**
- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
