### PR TITLE
Move `showDevelopmentOptions` out of App.tsx 

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -71,7 +71,8 @@ import {
   openMenu,
 } from "@streamlit/app/src/components/MainMenu/mainMenuTestHelpers"
 
-import { App, Props, showDevelopmentOptions } from "./App"
+import { showDevelopmentOptions } from "./showDevelopmentOptions"
+import { App, Props } from "./App"
 
 vi.mock("@streamlit/lib/src/baseconsts", async () => {
   return {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -122,6 +122,7 @@ import withScreencast, {
   ScreenCastHOC,
 } from "@streamlit/app/src/hocs/withScreencast/withScreencast"
 
+import { showDevelopmentOptions } from "./showDevelopmentOptions"
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
 import { ThemeManager } from "./util/useThemeManager"
@@ -191,22 +192,6 @@ declare global {
     streamlitDebug: any
     iFrameResizer: any
   }
-}
-
-export const showDevelopmentOptions = (
-  hostIsOwner: boolean | undefined,
-  toolbarMode: Config.ToolbarMode
-): boolean => {
-  if (toolbarMode == Config.ToolbarMode.DEVELOPER) {
-    return true
-  }
-  if (
-    Config.ToolbarMode.VIEWER == toolbarMode ||
-    Config.ToolbarMode.MINIMAL == toolbarMode
-  ) {
-    return false
-  }
-  return hostIsOwner || isLocalhost()
 }
 
 export class App extends PureComponent<Props, State> {

--- a/frontend/app/src/showDevelopmentOptions.ts
+++ b/frontend/app/src/showDevelopmentOptions.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from "@streamlit/lib"
+import { isLocalhost } from "@streamlit/app/src/components/MainMenu"
+
+export const showDevelopmentOptions = (
+  hostIsOwner: boolean | undefined,
+  toolbarMode: Config.ToolbarMode
+): boolean => {
+  if (toolbarMode == Config.ToolbarMode.DEVELOPER) {
+    return true
+  }
+  if (
+    Config.ToolbarMode.VIEWER == toolbarMode ||
+    Config.ToolbarMode.MINIMAL == toolbarMode
+  ) {
+    return false
+  }
+  return hostIsOwner || isLocalhost()
+}


### PR DESCRIPTION
## Describe your changes

I encountered an issue with Fast Refresh that was caused by exporting the `showDevelopmentOptions` function from `App.tsx`. This violates [the vite rule](https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports) `consistent-components-exports`. 

![Screenshot 2024-12-11 at 5 35 08 PM](https://github.com/user-attachments/assets/e6a28a9f-61de-4dce-9c07-5b03719614ba)


This PR moves this function into a separate non-component file since it needs to be used in the component and also the test. 

## GitHub Issue Link (if applicable)

## Testing Plan

Covered by existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
