### PR TITLE
Initialize mimetypes on server initialization

### DIFF
--- a/lib/streamlit/web/server/app_static_file_handler.py
+++ b/lib/streamlit/web/server/app_static_file_handler.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import mimetypes
 import os
 from pathlib import Path
 from typing import Final
@@ -37,7 +36,6 @@ SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".pdf", ".gif", ".we
 class AppStaticFileHandler(tornado.web.StaticFileHandler):
     def initialize(self, path: str, default_filename: str | None = None) -> None:
         super().initialize(path, default_filename)
-        mimetypes.add_type("image/webp", ".webp")
 
     def validate_absolute_path(self, root: str, absolute_path: str) -> str | None:
         full_path = os.path.abspath(absolute_path)

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -33,12 +33,6 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
     def initialize(self, registry: BaseComponentRegistry):
         self._registry = registry
 
-        # This ensures that common mime-types are robust against
-        # system misconfiguration.
-        mimetypes.add_type("text/html", ".html")
-        mimetypes.add_type("application/javascript", ".js")
-        mimetypes.add_type("text/css", ".css")
-
     def get(self, path: str) -> None:
         parts = path.split("/")
         component_name = parts[0]

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -260,8 +260,7 @@ class Server:
 
     @classmethod
     def initialize_mimetypes(cls) -> None:
-        # This ensures that common mime-types are robust against
-        # system misconfiguration.
+        """Ensures that common mime-types are robust against system misconfiguration."""
         mimetypes.add_type("text/html", ".html")
         mimetypes.add_type("application/javascript", ".js")
         mimetypes.add_type("text/css", ".css")

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import errno
 import logging
+import mimetypes
 import os
 import sys
 from pathlib import Path
@@ -231,6 +232,7 @@ class Server:
     def __init__(self, main_script_path: str, is_hello: bool):
         """Create the server. It won't be started yet."""
         _set_tornado_log_levels()
+        self.initialize_mimetypes()
 
         self._main_script_path = main_script_path
 
@@ -255,6 +257,15 @@ class Server:
         )
 
         self._runtime.stats_mgr.register_provider(media_file_storage)
+
+    @classmethod
+    def initialize_mimetypes(self) -> None:
+        # This ensures that common mime-types are robust against
+        # system misconfiguration.
+        mimetypes.add_type("text/html", ".html")
+        mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("text/css", ".css")
+        mimetypes.add_type("image/webp", ".webp")
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -259,7 +259,7 @@ class Server:
         self._runtime.stats_mgr.register_provider(media_file_storage)
 
     @classmethod
-    def initialize_mimetypes(self) -> None:
+    def initialize_mimetypes(cls) -> None:
         # This ensures that common mime-types are robust against
         # system misconfiguration.
         mimetypes.add_type("text/html", ".html")

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -27,7 +27,7 @@ from streamlit.runtime import Runtime, RuntimeConfig
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import add_script_run_ctx
-from streamlit.web.server import ComponentRequestHandler
+from streamlit.web.server import ComponentRequestHandler, Server
 from tests.testutil import create_mock_script_run_ctx
 
 URL = "http://not.a.real.url:3001"
@@ -199,7 +199,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             response.body,
         )
 
-    def test_mimetype_is_overridden_by_component_request_handler(self):
+    def test_mimetype_is_overridden_by_server(self):
         """Test get_content_type function."""
         mimetypes.add_type("custom/html", ".html")
         mimetypes.add_type("custom/js", ".js")
@@ -209,11 +209,8 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert ComponentRequestHandler.get_content_type("test.js") == "custom/js"
         assert ComponentRequestHandler.get_content_type("test.css") == "custom/css"
 
-        # make a request so that our ComponentRequestHandler.initialize function is
-        # called by tornado
-        self._request_component(
-            "tests.streamlit.web.server.component_request_handler_test.test"
-        )
+        # Have the server reinitialize the mimetypes
+        Server.initialize_mimetypes()
 
         assert ComponentRequestHandler.get_content_type("test.html") == "text/html"
         assert (

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import mimetypes
 import os
 import tempfile
 from unittest.mock import MagicMock
@@ -26,6 +27,7 @@ import tornado.websocket
 
 from streamlit.runtime.forward_msg_cache import ForwardMsgCache, populate_hash_if_needed
 from streamlit.runtime.runtime_util import serialize_forward_msg
+from streamlit.web.server import Server
 from streamlit.web.server.routes import _DEFAULT_ALLOWED_MESSAGE_ORIGINS
 from streamlit.web.server.server import (
     HEALTH_ENDPOINT,
@@ -130,7 +132,19 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._tmpfile = tempfile.NamedTemporaryFile(dir=self._tmpdir.name, delete=False)
+        self._tmp_js_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="script.js", delete=False
+        )
+        self._tmp_html_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="file.html", delete=False
+        )
+        self._tmp_css_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="stylesheet.css", delete=False
+        )
         self._filename = os.path.basename(self._tmpfile.name)
+        self._js_filename = os.path.basename(self._tmp_js_file.name)
+        self._html_filename = os.path.basename(self._tmp_html_file.name)
+        self._css_filename = os.path.basename(self._tmp_css_file.name)
 
         super().setUp()
 
@@ -189,6 +203,32 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         for r in responses:
             assert r.code == 404
+
+    def test_mimetype_is_overridden_by_server(self):
+        """Test get_content_type function."""
+        mimetypes.add_type("custom/html", ".html")
+        mimetypes.add_type("custom/js", ".js")
+        mimetypes.add_type("custom/css", ".css")
+
+        r = self.fetch(f"/{self._html_filename}")
+        assert r.headers["Content-Type"] == "custom/html"
+
+        r = self.fetch(f"/{self._js_filename}")
+        assert r.headers["Content-Type"] == "custom/js"
+
+        r = self.fetch(f"/{self._css_filename}")
+        assert r.headers["Content-Type"] == "custom/css"
+
+        Server.initialize_mimetypes()
+
+        r = self.fetch(f"/{self._html_filename}")
+        assert r.headers["Content-Type"] == "text/html"
+
+        r = self.fetch(f"/{self._js_filename}")
+        assert r.headers["Content-Type"] == "application/javascript"
+
+        r = self.fetch(f"/{self._css_filename}")
+        assert r.headers["Content-Type"] == "text/css"
 
 
 class RemoveSlashHandlerTest(tornado.testing.AsyncHTTPTestCase):


### PR DESCRIPTION
## Describe your changes

Python/Tornado uses `mimetypes.guess_type` to determine the content type. On some Windows machines, the registry (which Python uses to get the mimetype) is misconfigured leading to issues on the frontend. We have solutions in other request handlers, namely the custom component handler. The solution is to add the mimetypes explicitly on Server load, so that no issue exists on the request handlers.

Python pretty much says there is [nothing they plan to do](https://bugs.python.org/issue32462).

Tornado suggests [adding the mimetype](https://github.com/tornadoweb/tornado/issues/1690) like we do to confirm.

## GitHub Issue Link (if applicable)

Closes #10004

## Testing Plan

- Python unit tests for the request handlers that rely on this explicitly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
