### PR TITLE
Do not include source map files in release builds

### DIFF
--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -39,7 +39,7 @@ jobs:
         timeout-minutes: 120
         run: |
           sudo apt install rsync
-          BUILD_AS_FAST_AS_POSSIBLE=1 make package
+          make package
       - name: Run CLI regression tests
         run: |
           export SKIP_VERSION_CHECK=true; make cli-regression-tests

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Package
         timeout-minutes: 120
-        run: BUILD_AS_FAST_AS_POSSIBLE=1 make package
+        run: make package
 
       - name: Return path to Streamlit wheel
         id: streamlit_wheel

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -47,4 +47,4 @@ jobs:
         run: |
           sudo apt install rsync
           conda config --set conda_build.pkg_format 2
-          SNOWPARK_CONDA_BUILD=1 BUILD_AS_FAST_AS_POSSIBLE=1 make conda-package
+          SNOWPARK_CONDA_BUILD=1 make conda-package

--- a/.github/workflows/performance-lighthouse.yml
+++ b/.github/workflows/performance-lighthouse.yml
@@ -47,8 +47,8 @@ jobs:
           python-version: "${{ env.PYTHON_MAX_VERSION }}"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
-      - name: Run make frontend-fast
-        run: make frontend-fast
+      - name: Run make frontend
+        run: make frontend
       - name: Run Performance Lighthouse
         run: make performance-lighthouse
       - name: Set MY_DATE_TIME env var

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -67,8 +67,8 @@ jobs:
         name: Install playwright
         run: python -m playwright install --with-deps
       - if: steps.check_changed_files.outputs.run_tests == 'true'
-        name: Run make frontend-fast
-        run: make frontend-fast
+        name: Run make frontend
+        run: make frontend
       - if: steps.check_changed_files.outputs.run_tests == 'true'
         name: Run changed playwright tests
         run: |

--- a/.github/workflows/playwright-custom-components.yml
+++ b/.github/workflows/playwright-custom-components.yml
@@ -43,8 +43,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Install playwright
         run: python -m playwright install --with-deps
-      - name: Run make frontend-fast
-        run: make frontend-fast
+      - name: Run make frontend
+        run: make frontend
       - name: Run make playwright-custom-components
         run: make playwright-custom-components
       - name: Upload failed test results

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,8 +44,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Install playwright
         run: python -m playwright install --with-deps
-      - name: Run make frontend-fast
-        run: make frontend-fast
+      - name: Run make frontend
+        run: make frontend
       - name: Run make playwright
         run: make playwright
       - name: Upload failed test results

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install rsync
-          BUILD_AS_FAST_AS_POSSIBLE=1 make package
+          make package
       - name: Store Whl File
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -292,13 +292,6 @@ react-build:
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 
-.PHONY: frontend-fast
-# Build frontend into static files faster by setting BUILD_AS_FAST_AS_POSSIBLE=true flag, which disables eslint and typechecking.
-frontend-fast:
-	cd frontend/ ; yarn run buildFast
-	rsync -av --delete --delete-excluded --exclude=reports \
-		frontend/app/build/ lib/streamlit/static/
-
 .PHONY: frontend-lib
 # Build the frontend library.
 frontend-lib:

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -9,7 +9,6 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "vite",
     "build": "env NODE_OPTIONS=--max_old_space_size=8192 vite build",
-    "buildFast": "env BUILD_AS_FAST_AS_POSSIBLE=1 vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "testWatch": "vitest",

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -23,6 +23,8 @@ import path from "path"
 
 const BASE = "./"
 const HASH = process.env.OMIT_HASH_FROM_MAIN_FILES ? "" : ".[hash]"
+// We do not explicitly set the DEV_BUILD in any of our processes
+// This is a convenience for developers for debugging purposes
 const DEV_BUILD = process.env.DEV_BUILD || false
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -23,8 +23,7 @@ import path from "path"
 
 const BASE = "./"
 const HASH = process.env.OMIT_HASH_FROM_MAIN_FILES ? "" : ".[hash]"
-const BUILD_AS_FAST_AS_POSSIBLE =
-  process.env.BUILD_AS_FAST_AS_POSSIBLE || false
+const DEV_BUILD = process.env.DEV_BUILD || false
 // https://vitejs.dev/config/
 export default defineConfig({
   base: BASE,
@@ -52,7 +51,7 @@ export default defineConfig({
   build: {
     outDir: "build",
     assetsDir: "static",
-    sourcemap: !BUILD_AS_FAST_AS_POSSIBLE,
+    sourcemap: DEV_BUILD,
     rollupOptions: {
       output: {
         // Customize the chunk file naming pattern to match static/js/[name].[hash].js

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -20,6 +20,8 @@ import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
+const DEV_BUILD = process.env.DEV_BUILD || false
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
@@ -32,7 +34,7 @@ export default defineConfig({
   ],
   build: {
     outDir: "dist",
-    sourcemap: true,
+    sourcemap: DEV_BUILD,
     rollupOptions: {
       input: "src/index.ts",
     },

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -20,6 +20,8 @@ import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
+// We do not explicitly set the DEV_BUILD in any of our processes
+// This is a convenience for developers for debugging purposes
 const DEV_BUILD = process.env.DEV_BUILD || false
 
 // https://vitejs.dev/config/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "patch-package",
     "start": "yarn workspace @streamlit/app start",
-    "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
+    "build": "yarn workspace @streamlit/app build",
     "buildLib": "yarn workspace @streamlit/lib build",
     "buildLibProd": "yarn workspace @streamlit/lib build:prod",
     "buildApp": "yarn workspace @streamlit/app build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "postinstall": "patch-package",
     "start": "yarn workspace @streamlit/app start",
     "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
-    "buildFast": "yarn workspace @streamlit/app buildFast",
     "buildLib": "yarn workspace @streamlit/lib build",
     "buildLibProd": "yarn workspace @streamlit/lib build:prod",
     "buildApp": "yarn workspace @streamlit/app build",


### PR DESCRIPTION
## Describe your changes

The move to Vite accidentally included source map files in the release build. This bloats the package size by a large amount. This change modifies `BUILD_AS_FAST_AS_POSSIBLE` to be `DEV_BUILD` where users can decide whether to enable source maps for the production build with `DEV_BUILD=1 make frontend`. As a result `make frontend` and `make frontend-fast` are the same, so we remove the `frontend-fast` option.

Note `BUILD_AS_FAST_AS_POSSIBLE` is the opposite of `DEV_BUILD`, so we update the sourcemap config to be whether we want a DEV_BUILD or not.

## GitHub Issue Link (if applicable)
closes #10008

## Testing Plan

- Tests should pass (and manually checked file size of wheel build) as sourcemaps don't affect the build.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
