### PR TITLE
Changes needed for public notebooks to record protobufs

### DIFF
--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -48,7 +48,6 @@ class ForwardMsgQueue:
         # an older Delta, with the same delta_path, that's still in the
         # queue).
         self._delta_index_map: dict[tuple[int, ...], int] = {}
-        self._before_enqueue_msg = None
 
     def get_debug(self) -> dict[str, Any]:
         from google.protobuf.json_format import MessageToDict

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -39,8 +39,7 @@ class ForwardMsgQueue:
     def on_before_enqueue_msg(
         before_enqueue_msg: Callable[[ForwardMsg], None] | None,
     ) -> None:
-        global _before_enqueue_msg
-        _before_enqueue_msg = before_enqueue_msg
+        ForwardMsgQueue._before_enqueue_msg = before_enqueue_msg
 
     def __init__(self):
         self._queue: list[ForwardMsg] = []
@@ -65,8 +64,9 @@ class ForwardMsgQueue:
     def enqueue(self, msg: ForwardMsg) -> None:
         """Add message into queue, possibly composing it with another message."""
 
-        if _before_enqueue_msg:
-            _before_enqueue_msg(msg)
+        if ForwardMsgQueue._before_enqueue_msg:
+            ForwardMsgQueue._before_enqueue_msg(msg)
+
         if not _is_composable_message(msg):
             self._queue.append(msg)
             return

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -63,10 +63,10 @@ class ForwardMsgQueue:
         return len(self._queue) == 0
 
     def enqueue(self, msg: ForwardMsg) -> None:
+        """Add message into queue, possibly composing it with another message."""
+
         if _before_enqueue_msg:
             _before_enqueue_msg(msg)
-
-        """Add message into queue, possibly composing it with another message."""
         if not _is_composable_message(msg):
             self._queue.append(msg)
             return

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
@@ -43,7 +43,7 @@ class ForwardMsgQueue:
         self._delta_index_map: dict[tuple[int, ...], int] = {}
         self._before_enqueue_msg = None
 
-    def on_before_enqueue_msg(self, before_enqueue_msg: callable | None) -> None:
+    def on_before_enqueue_msg(self, before_enqueue_msg: Callable | None) -> None:
         self._before_enqueue_msg = before_enqueue_msg
 
     def get_debug(self) -> dict[str, Any]:

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -21,15 +21,6 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 if TYPE_CHECKING:
     from streamlit.proto.Delta_pb2 import Delta
 
-_before_enqueue_msg = None
-
-
-def on_before_enqueue_msg(
-    before_enqueue_msg: Callable[[ForwardMsg], None] | None,
-) -> None:
-    global _before_enqueue_msg
-    _before_enqueue_msg = before_enqueue_msg
-
 
 class ForwardMsgQueue:
     """Accumulates a session's outgoing ForwardMsgs.
@@ -41,6 +32,15 @@ class ForwardMsgQueue:
     ForwardMsgQueue is not thread-safe - a queue should only be used from
     a single thread.
     """
+
+    _before_enqueue_msg = None
+
+    @staticmethod
+    def on_before_enqueue_msg(
+        before_enqueue_msg: Callable[[ForwardMsg], None] | None,
+    ) -> None:
+        global _before_enqueue_msg
+        _before_enqueue_msg = before_enqueue_msg
 
     def __init__(self):
         self._queue: list[ForwardMsg] = []

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -33,7 +33,7 @@ class ForwardMsgQueue:
     a single thread.
     """
 
-    _before_enqueue_msg = None
+    _before_enqueue_msg: Callable[[ForwardMsg], None] | None = None
 
     @staticmethod
     def on_before_enqueue_msg(

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -39,6 +39,8 @@ class ForwardMsgQueue:
     def on_before_enqueue_msg(
         before_enqueue_msg: Callable[[ForwardMsg], None] | None,
     ) -> None:
+        """Set a callback to be called before a message is enqueued.
+        Used in static streamlit app generation."""
         ForwardMsgQueue._before_enqueue_msg = before_enqueue_msg
 
     def __init__(self):

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -56,25 +56,22 @@ class ForwardMsgQueue:
         return len(self._queue) == 0
 
     def enqueue(self, msg: ForwardMsg) -> None:
-        streamlit_proto_path = os.environ.get("STREAMLIT_PROTO_PATH", False)
+        streamlit_proto_path = os.getenv("STREAMLIT_PROTO_PATH")
+
         if streamlit_proto_path:
-            if msg.delta:
-                if msg.delta.new_element:
-                    new_element = msg.delta.new_element
-                    element_type = new_element.WhichOneof("type")
-                    if element_type is not None:
-                        if (
-                            "disabled"
-                            in getattr(
-                                new_element, element_type
-                            ).DESCRIPTOR.fields_by_name
-                        ):
-                            getattr(msg.delta.new_element, element_type).disabled = True
+            if msg.delta and msg.delta.new_element:
+                new_element = msg.delta.new_element
+                element_type = new_element.WhichOneof("type")
+
+                if element_type:
+                    element = getattr(new_element, element_type, None)
+                    if element and "disabled" in element.DESCRIPTOR.fields_by_name:
+                        element.disabled = True
 
             with open(streamlit_proto_path, "a") as f:
                 serialized_message = msg.SerializeToString()
                 b64_message = base64.b64encode(serialized_message).decode("utf-8")
-                f.write(b64_message + "\n")
+                f.write(f"{b64_message}\n")
 
         """Add message into queue, possibly composing it with another message."""
         if not _is_composable_message(msg):
@@ -91,7 +88,7 @@ class ForwardMsgQueue:
             index = self._delta_index_map[delta_key]
             old_msg = self._queue[index]
             composed_delta = _maybe_compose_deltas(old_msg.delta, msg.delta)
-            if composed_delta is not None:
+            if composed_delta:
                 new_msg = ForwardMsg()
                 new_msg.delta.CopyFrom(composed_delta)
                 new_msg.metadata.CopyFrom(msg.metadata)

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
 _before_enqueue_msg = None
 
 
-def on_before_enqueue_msg(before_enqueue_msg: Callable | None) -> None:
+def on_before_enqueue_msg(
+    before_enqueue_msg: Callable[[ForwardMsg], None] | None,
+) -> None:
     global _before_enqueue_msg
     _before_enqueue_msg = before_enqueue_msg
 

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -81,7 +81,7 @@ class ForwardMsgQueue:
             index = self._delta_index_map[delta_key]
             old_msg = self._queue[index]
             composed_delta = _maybe_compose_deltas(old_msg.delta, msg.delta)
-            if composed_delta:
+            if composed_delta is not None:
                 new_msg = ForwardMsg()
                 new_msg.delta.CopyFrom(composed_delta)
                 new_msg.metadata.CopyFrom(msg.metadata)

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -43,7 +43,7 @@ class ForwardMsgQueue:
         self._delta_index_map: dict[tuple[int, ...], int] = {}
         self._before_enqueue_msg = None
 
-    def on_before_enqueue_msg(self, before_enqueue_msg: callable) -> None:
+    def on_before_enqueue_msg(self, before_enqueue_msg: callable | None) -> None:
         self._before_enqueue_msg = before_enqueue_msg
 
     def get_debug(self) -> dict[str, Any]:

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 _before_enqueue_msg = None
 
 
-def on_before_enqueue_msg(self, before_enqueue_msg: Callable | None) -> None:
+def on_before_enqueue_msg(before_enqueue_msg: Callable | None) -> None:
     global _before_enqueue_msg
     _before_enqueue_msg = before_enqueue_msg
 

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -319,7 +319,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
     def test_on_before_enqueue_msg(self):
         count = 0
 
-        def increase_counter():
+        def increase_counter(_msg):
             nonlocal count
             count += 1
 

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -315,3 +315,48 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         fmq.clear()
         assert fmq._queue == []
+
+    def test_on_before_enqueue_msg(self):
+        count = 0
+
+        def increase_counter():
+            nonlocal count
+            count += 1
+
+        fmq = ForwardMsgQueue()
+        fmq.on_before_enqueue_msg(increase_counter)
+
+        assert count == 0
+
+        fmq.enqueue(NEW_SESSION_MSG)
+
+        TEXT_DELTA_MSG1.metadata.delta_path[:] = make_delta_path(
+            RootContainer.MAIN, (), 0
+        )
+        fmq.enqueue(TEXT_DELTA_MSG1)
+
+        TEXT_DELTA_MSG2.metadata.delta_path[:] = make_delta_path(
+            RootContainer.MAIN, (), 1
+        )
+        fmq.enqueue(TEXT_DELTA_MSG2)
+
+        assert count == 3
+
+        count = 0
+
+        fmq.clear()
+        fmq.on_before_enqueue_msg(None)
+
+        fmq.enqueue(NEW_SESSION_MSG)
+
+        TEXT_DELTA_MSG1.metadata.delta_path[:] = make_delta_path(
+            RootContainer.MAIN, (), 0
+        )
+        fmq.enqueue(TEXT_DELTA_MSG1)
+
+        TEXT_DELTA_MSG2.metadata.delta_path[:] = make_delta_path(
+            RootContainer.MAIN, (), 1
+        )
+        fmq.enqueue(TEXT_DELTA_MSG2)
+
+        assert count == 0

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -25,7 +25,7 @@ from streamlit.cursor import make_delta_path
 from streamlit.elements import arrow
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.RootContainer_pb2 import RootContainer
-from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.forward_msg_queue import ForwardMsgQueue, on_before_enqueue_msg
 
 # For the messages below, we don't really care about their contents so much as
 # their general type.
@@ -323,8 +323,8 @@ class ForwardMsgQueueTest(unittest.TestCase):
             nonlocal count
             count += 1
 
+        on_before_enqueue_msg(increase_counter)
         fmq = ForwardMsgQueue()
-        fmq.on_before_enqueue_msg(increase_counter)
 
         assert count == 0
 

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -344,8 +344,8 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         count = 0
 
+        on_before_enqueue_msg(None)
         fmq.clear()
-        fmq.on_before_enqueue_msg(None)
 
         fmq.enqueue(NEW_SESSION_MSG)
 

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -25,7 +25,7 @@ from streamlit.cursor import make_delta_path
 from streamlit.elements import arrow
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.RootContainer_pb2 import RootContainer
-from streamlit.runtime.forward_msg_queue import ForwardMsgQueue, on_before_enqueue_msg
+from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 
 # For the messages below, we don't really care about their contents so much as
 # their general type.
@@ -323,7 +323,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
             nonlocal count
             count += 1
 
-        on_before_enqueue_msg(increase_counter)
+        ForwardMsgQueue.on_before_enqueue_msg(increase_counter)
         fmq = ForwardMsgQueue()
 
         assert count == 0
@@ -344,7 +344,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         count = 0
 
-        on_before_enqueue_msg(None)
+        ForwardMsgQueue.on_before_enqueue_msg(None)
         fmq.clear()
 
         fmq.enqueue(NEW_SESSION_MSG)

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -135,6 +135,11 @@ message ElementDimensionSpec {
   uint32 height = 2;
 }
 
+// This is a list of ForwardMessages used to have a single protobuf message
+// that encapsulates multiple ForwardMessages. This is used in static streamlit app
+// generation in replaying all of the protobuf messages of a streamlit app. The
+// ForwardMsgList allows us to leverage the built-ins of protobuf in delimiting the ForwardMsgs
+// instead of needing to do that ourselves.
 message ForwardMsgList {
   repeated ForwardMsg messages = 1;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -134,3 +134,7 @@ message ElementDimensionSpec {
   // height in pixels
   uint32 height = 2;
 }
+
+message ForwardMsgList {
+  repeated ForwardMsg messages = 1;
+}


### PR DESCRIPTION
## Describe your changes

These changes are needed for the public notebooks project and accomplishes two main things:

1. Introduces `ForwardMsgList` allowing us to store all of the protobuf messages as 1 protobuf message.
2. Adds a new lifecycle method that if set, will be called with the message before it is enqueued.

But Nico! Why not utilize the newly added `ForwardMsgList` and avoid this base64 tomfoolery? Great question! It boils down wanting to be able to write the message as its enqueued. Why? For starters, it simplifies the code a bit to be able to just append these base64 lines, but more importantly, as we're recording these protobufs, we're watching this file and waiting for it to stop getting updates and using that to determine that the app is "done" rendering.


## Testing Plan
Added a unit test for this new method.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
