### PR TITLE
`AppView` prop refactor - Part 1

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1971,7 +1971,6 @@ export class App extends PureComponent<Props, State> {
 
               <AppView
                 endpoints={this.endpoints}
-                sessionInfo={this.sessionInfo}
                 sendMessageToHost={this.hostCommunicationMgr.sendMessageToHost}
                 elements={elements}
                 scriptRunId={scriptRunId}

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -200,7 +200,6 @@ class StreamlitLibExample extends PureComponent<Props, State> {
       <VerticalBlock
         node={blockNode}
         endpoints={this.endpoints}
-        sessionInfo={this.sessionInfo}
         scriptRunId={this.state.scriptRunId}
         scriptRunState={this.state.scriptRunState}
         widgetMgr={this.widgetMgr}

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -82,7 +82,6 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     endpoints: mockEndpointProp,
     elements: AppRoot.empty(FAKE_SCRIPT_HASH, true),
     sendMessageToHost: vi.fn(),
-    sessionInfo,
     scriptRunId: "script run 123",
     scriptRunState: ScriptRunState.NOT_RUNNING,
     widgetMgr: new WidgetStateManager({
@@ -90,7 +89,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
       formsDataChanged: vi.fn(),
     }),
     uploadClient: new FileUploadClient({
-      sessionInfo,
+      sessionInfo: sessionInfo,
       endpoints: mockEndpointProp,
       formsWithPendingRequestsChanged: () => {},
       requestFileURLs: vi.fn(),

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -89,7 +89,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
       formsDataChanged: vi.fn(),
     }),
     uploadClient: new FileUploadClient({
-      sessionInfo: sessionInfo,
+      sessionInfo,
       endpoints: mockEndpointProp,
       formsWithPendingRequestsChanged: () => {},
       requestFileURLs: vi.fn(),

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -27,7 +27,6 @@ import {
   LibContext,
   Logo,
   ScriptRunState,
-  SessionInfo,
   StreamlitEndpoints,
   VerticalBlock,
   WidgetStateManager,
@@ -59,8 +58,6 @@ export interface AppViewProps {
   elements: AppRoot
 
   endpoints: StreamlitEndpoints
-
-  sessionInfo: SessionInfo
 
   sendMessageToHost: (message: IGuestToHostMessage) => void
 
@@ -101,7 +98,6 @@ export interface AppViewProps {
 function AppView(props: AppViewProps): ReactElement {
   const {
     elements,
-    sessionInfo,
     scriptRunId,
     scriptRunState,
     widgetMgr,
@@ -220,7 +216,6 @@ function AppView(props: AppViewProps): ReactElement {
     <VerticalBlock
       node={node}
       endpoints={endpoints}
-      sessionInfo={sessionInfo}
       scriptRunId={scriptRunId}
       scriptRunState={scriptRunState}
       widgetMgr={widgetMgr}

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -75,7 +75,6 @@ function getProps(
   return {
     endpoints: endpoints,
     scriptRunState: ScriptRunState.RUNNING,
-    sessionInfo: sessionInfo,
     widgetMgr: new WidgetStateManager({
       sendRerunBackMsg: vi.fn(),
       formsDataChanged: vi.fn(),

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -18,7 +18,6 @@ import { AppNode, BlockNode } from "@streamlit/lib/src/AppNode"
 import { ComponentRegistry } from "@streamlit/lib/src/components/widgets/CustomComponent"
 import { FileUploadClient } from "@streamlit/lib/src/FileUploadClient"
 import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
-import { SessionInfo } from "@streamlit/lib/src/SessionInfo"
 import { StreamlitEndpoints } from "@streamlit/lib/src/StreamlitEndpoints"
 import { EmotionTheme, getDividerColors } from "@streamlit/lib/src/theme"
 import { isValidElementId } from "@streamlit/lib/src/util/utils"
@@ -112,11 +111,6 @@ export interface BaseBlockProps {
    * used by various Streamlit elements.
    */
   endpoints: StreamlitEndpoints
-
-  /**
-   * The app's SessionInfo instance. Exposes session-specific properties.
-   */
-  sessionInfo: SessionInfo
 
   /**
    * The app's WidgetStateManager instance. Used by all widget elements to


### PR DESCRIPTION
## Describe your changes
This PR is the first in series to refactor our `AppView` props in favor of using AppContext & LibContext - starting with removal of the unused prop, `sessionInfo`.

## Testing Plan
No additional tests needed as PR just removes unused prop - tests validate prop unnecessary