### PR TITLE
[fix] Utilize profiler build for e2e tests

### DIFF
--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -67,8 +67,8 @@ jobs:
         name: Install playwright
         run: python -m playwright install --with-deps
       - if: steps.check_changed_files.outputs.run_tests == 'true'
-        name: Run make frontend
-        run: make frontend
+        name: Run make frontend-build-with-profiler
+        run: make frontend-build-with-profiler
       - if: steps.check_changed_files.outputs.run_tests == 'true'
         name: Run changed playwright tests
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,8 +44,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Install playwright
         run: python -m playwright install --with-deps
-      - name: Run make frontend
-        run: make frontend
+      - name: Run make frontend-build-with-profiler
+        run: make frontend-build-with-profiler
       - name: Run make playwright
         run: make playwright
       - name: Upload failed test results


### PR DESCRIPTION
## Describe your changes

In order to get the React Profiler data from Playwright, we need to use the profiler build

## GitHub Issue Link (if applicable)

## Testing Plan

- This updates how e2e tests run

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
