### PR TITLE
Schedule trigger events at the end of the event loop

### DIFF
--- a/e2e_playwright/widget_state.py
+++ b/e2e_playwright/widget_state.py
@@ -34,3 +34,14 @@ if st.checkbox("Display widgets"):
 
     if st.checkbox("Show goodbye", key="c3"):
         st.write("goodbye")
+
+st.header("Test for input change & button click in one motion")
+# Test for https://github.com/streamlit/streamlit/issues/10007
+
+
+def btn_callback():
+    st.write("Input: " + st.session_state["key1"])
+
+
+st.text_area("Type something into the text area", key="key1")
+st.button("Submit text_area", on_click=btn_callback)

--- a/e2e_playwright/widget_state_test.py
+++ b/e2e_playwright/widget_state_test.py
@@ -14,7 +14,11 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.shared.app_utils import click_checkbox, expect_markdown
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    expect_markdown,
+)
 
 
 def test_clicking_a_lot_still_keeps_state(app: Page):
@@ -70,3 +74,19 @@ def test_doesnt_save_widget_state_on_redisplay_with_keyed_widget(app: Page):
     # Should not show goodbye again -> the widget state was not saved
     markdown_el = app.get_by_test_id("stMarkdown").filter(has_text="goodbye")
     expect(markdown_el).not_to_be_attached()
+
+
+def test_click_button_after_input_change_without_losing_focus_first(app: Page):
+    """Test that the input value is correctly updated when clicking a button
+    right after changing the input value without losing focus first.
+
+    Related to: https://github.com/streamlit/streamlit/issues/10007"""
+
+    text_area = app.get_by_test_id("stTextArea")
+    text_area_field = text_area.locator("textarea").first
+    new_text = "new text_area value"
+    text_area_field.fill(new_text)
+
+    click_button(app, "Submit text_area")
+
+    expect_markdown(app, f"Input: {new_text}")

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -167,6 +167,26 @@ describe("Widget State Manager", () => {
   })
 
   /**
+   * We put test setTrigger value using a setTimeout by scheduling checks
+   * in the event loop. I could imagine that the test could succeed in a
+   * false positive manner, but when removing the setTimeout in the
+   * WidgetMgr.setTriggerValueAtEndOfEventLoop, it seems to consistently fail.
+   * We have an e2e test to check the actual runtime behavior.
+   */
+  it("sets trigger value at end of event loop", () => {
+    const widget = getWidget({ insideForm: false })
+    setTimeout(() => expect(sendBackMsg).not.toHaveBeenCalled(), 0)
+    widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined)
+
+    setTimeout(() => {
+      expect(sendBackMsg).toHaveBeenCalledTimes(1)
+      // @ts-expect-error
+      expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
+      assertCallbacks({ insideForm: false })
+    }, 0)
+  })
+
+  /**
    * String Triggers can't be used within forms, so this test
    * is not parameterized on insideForm.
    */

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -158,41 +158,22 @@ describe("Widget State Manager", () => {
    * Buttons (which set trigger values) can't be used within forms, so this test
    * is not parameterized on insideForm.
    */
-  it("sets trigger value correctly", () => {
+  it("sets trigger value correctly", async () => {
     const widget = getWidget({ insideForm: false })
-    widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined)
+    await widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined)
+
     // @ts-expect-error
     expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
     assertCallbacks({ insideForm: false })
   })
 
   /**
-   * We put test setTrigger value using a setTimeout by scheduling checks
-   * in the event loop. I could imagine that the test could succeed in a
-   * false positive manner, but when removing the setTimeout in the
-   * WidgetMgr.setTriggerValueAtEndOfEventLoop, it seems to consistently fail.
-   * We have an e2e test to check the actual runtime behavior.
-   */
-  it("sets trigger value at end of event loop", () => {
-    const widget = getWidget({ insideForm: false })
-    setTimeout(() => expect(sendBackMsg).not.toHaveBeenCalled(), 0)
-    widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined)
-
-    setTimeout(() => {
-      expect(sendBackMsg).toHaveBeenCalledTimes(1)
-      // @ts-expect-error
-      expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
-      assertCallbacks({ insideForm: false })
-    }, 0)
-  })
-
-  /**
    * String Triggers can't be used within forms, so this test
    * is not parameterized on insideForm.
    */
-  it("sets string trigger value correctly", () => {
+  it("sets string trigger value correctly", async () => {
     const widget = getWidget({ insideForm: false })
-    widgetMgr.setStringTriggerValue(
+    await widgetMgr.setStringTriggerValue(
       widget,
       "sample string",
       { fromUi: true },
@@ -405,9 +386,9 @@ describe("Widget State Manager", () => {
         setterMethod: "setFileUploaderStateValue",
         value: MOCK_FILE_UPLOADER_STATE,
       },
-    ])("%p", ({ setterMethod, value }) => {
+    ])("%p", async ({ setterMethod, value }) => {
       // @ts-expect-error
-      widgetMgr[setterMethod](
+      await widgetMgr[setterMethod](
         MOCK_WIDGET,
         value,
         {
@@ -425,8 +406,8 @@ describe("Widget State Manager", () => {
 
     // This test isn't parameterized like the ones above because setTriggerValue
     // has a slightly different signature from the other setter methods.
-    it("can set fragmentId in setTriggerValue", () => {
-      widgetMgr.setTriggerValue(
+    it("can set fragmentId in setTriggerValue", async () => {
+      await widgetMgr.setTriggerValue(
         MOCK_WIDGET,
         {
           fromUi: true,

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -286,16 +286,21 @@ export class WidgetStateManager {
   /* Sometimes users change an input field and directly click on a button to trigger a rerun
    *  the setTimeout is used to ensure the input field value is sent to the server before the button click
    *  by putting the the button click in the end of the event loop
+   *
+   * Returns a promise that is resolved as soon as the timeout was triggered for testing purposes.
    */
   private setTriggerValueAtEndOfEventLoop(
     widget: WidgetInfo,
     source: Source,
     fragmentId: string | undefined
-  ): void {
-    setTimeout(() => {
-      this.onWidgetValueChanged(widget.formId, source, fragmentId)
-      this.deleteWidgetState(widget.id)
-    }, 0)
+  ): Promise<void> {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this.onWidgetValueChanged(widget.formId, source, fragmentId)
+        this.deleteWidgetState(widget.id)
+        resolve()
+      }, 0)
+    })
   }
 
   /**
@@ -308,10 +313,10 @@ export class WidgetStateManager {
     value: string,
     source: Source,
     fragmentId: string | undefined
-  ): void {
+  ): Promise<void> {
     this.createWidgetState(widget, source).stringTriggerValue =
       new StringTriggerValue({ data: value })
-    this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
+    return this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
   }
 
   /**
@@ -322,9 +327,9 @@ export class WidgetStateManager {
     widget: WidgetInfo,
     source: Source,
     fragmentId: string | undefined
-  ): void {
+  ): Promise<void> {
     this.createWidgetState(widget, source).triggerValue = true
-    this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
+    return this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
   }
 
   public getBoolValue(widget: WidgetInfo): boolean | undefined {

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -283,6 +283,21 @@ export class WidgetStateManager {
     }
   }
 
+  /* Sometimes users change an input field and directly click on a button to trigger a rerun
+   *  the setTimeout is used to ensure the input field value is sent to the server before the button click
+   *  by putting the the button click in the end of the event loop
+   */
+  private setTriggerValueAtEndOfEventLoop(
+    widget: WidgetInfo,
+    source: Source,
+    fragmentId: string | undefined
+  ): void {
+    setTimeout(() => {
+      this.onWidgetValueChanged(widget.formId, source, fragmentId)
+      this.deleteWidgetState(widget.id)
+    }, 0)
+  }
+
   /**
    * Sets the string trigger value for the given widget ID to a string value,
    * sends a rerunScript message to the server, and then immediately unsets the
@@ -296,8 +311,7 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).stringTriggerValue =
       new StringTriggerValue({ data: value })
-    this.onWidgetValueChanged(widget.formId, source, fragmentId)
-    this.deleteWidgetState(widget.id)
+    this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
   }
 
   /**
@@ -310,8 +324,7 @@ export class WidgetStateManager {
     fragmentId: string | undefined
   ): void {
     this.createWidgetState(widget, source).triggerValue = true
-    this.onWidgetValueChanged(widget.formId, source, fragmentId)
-    this.deleteWidgetState(widget.id)
+    this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
   }
 
   public getBoolValue(widget: WidgetInfo): boolean | undefined {

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -283,11 +283,14 @@ export class WidgetStateManager {
     }
   }
 
-  /* Sometimes users change an input field and directly click on a button to trigger a rerun
-   *  the setTimeout is used to ensure the input field value is sent to the server before the button click
-   *  by putting the the button click in the end of the event loop
+  /* Sometimes users change an input field and directly click on a button - which uses the trigger value -
+   * to trigger a rerun. We wrap the code that sends the trigger update in `setTimeout` so that trigger-based
+   * updates will be added to the end of JavaScript's event loop. Callbacks for other elements, for example
+   * for an onBlur event of an input field, that are already in the event loop will then be deterministically
+   * executed before the trigger-based code.
    *
-   * Returns a promise that is resolved as soon as the timeout was triggered for testing purposes.
+   * Returns a promise that is resolved as soon as the timeout was triggered, mainly to make this easier testable
+   * in our unit tests.
    */
   private setTriggerValueAtEndOfEventLoop(
     widget: WidgetInfo,

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -289,7 +289,7 @@ export class WidgetStateManager {
    * for an onBlur event of an input field, that are already in the event loop will then be deterministically
    * executed before the trigger-based code.
    *
-   * Returns a promise that is resolved as soon as the timeout was triggered, mainly to make this easier testable
+   * Returns a promise that is resolved as soon as the timeout was triggered, mainly to make this easier to test.
    * in our unit tests.
    */
   private setTriggerValueAtEndOfEventLoop(


### PR DESCRIPTION
## Describe your changes

An observed user behavior in Streamlit is to change some widget's input and then directly click on a button to submit the change and see the result in the web app.
When not losing the focus on the input field first, this can sometimes lead to the trigger rerun message being sent to the server _before_ the input's change rerun update. If the trigger button's action accesses the other widget's state, the state is read _before_ the input's change data is processed and the update is only visible upon the next rerun as reported in https://github.com/streamlit/streamlit/issues/10007.

This PR wraps the `setTriggerValue` functions in a `setTimeout(setTriggerValueLogic, 0)` call. When the input's value change is in JS' event loop, e.g. via an `onBlur` event, and the trigger value is on the event loop, e.g. via a button's `onClick`  event, this wrapper will put the trigger value at the end of the current event loop (without any measurable delay due to timeout `0`). This assumes that we usually want to process other rerun data first and the trigger value as a follow-up action of that information. Even if this assumption is not true, right now without the PR the order is random and with this we put some more deterministic behavior around the messages which should not make any situation worse.

Note that the e2e test would also fail if we use the normal execution flow and not a callback on the button. Also, the e2e test is able to trigger the bug always, whereas manually I was only able to trigger it when loading the page in Chrome's mobile device emulator as reported by the user in 
https://github.com/streamlit/streamlit/issues/10007. My assumption is that playwright and the mobile touch on the button are fast enough to schedule the event, whereas a mouse click loses focus on the text area first before triggering the click which puts the text area's onBlur event in front of the trigger event in JS' event loop.
I believe this behavior changed in recent versions where we refactored the components to functional ones using some custom hooks to sync the new value internally and committing to the server. My assumption is that this increased the likelihood of events being scheduled later in the event loop.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/10007

## Testing Plan

- Unit Tests (JS and/or Python)
  - Updated existing unit tests because with the timeout they started to fail
- E2E Tests
  - Added an e2e test with the logic reported in https://github.com/streamlit/streamlit/issues/10007. The test fails without the `setTimeout` as it mimics exactly what the user reported.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
