### PR TITLE
[refactor] Utilize userEvent in tests

### DIFF
--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -17,7 +17,8 @@
 import React from "react"
 
 import * as reactDeviceDetect from "react-device-detect"
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { IAppPage, mockEndpoints, render } from "@streamlit/lib"
 
@@ -240,6 +241,7 @@ describe("SidebarNav", () => {
   })
 
   it("renders View less button when expanded", async () => {
+    const user = userEvent.setup()
     render(
       <SidebarNav
         {...getProps({
@@ -264,9 +266,7 @@ describe("SidebarNav", () => {
     )
 
     // Click on the separator to expand the nav component.
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
 
     const viewLessButton = await screen.findByText("View less")
     expect(viewLessButton).toBeInTheDocument()
@@ -332,7 +332,8 @@ describe("SidebarNav", () => {
     expect(navLinks).toHaveLength(10)
   })
 
-  it("toggles to expanded and back when the View more/less buttons are clicked", () => {
+  it("toggles to expanded and back when the View more/less buttons are clicked", async () => {
+    const user = userEvent.setup()
     render(
       <SidebarNav
         {...getProps({
@@ -359,19 +360,16 @@ describe("SidebarNav", () => {
     expect(screen.getByTestId("stSidebarNavSeparator")).toBeInTheDocument()
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(10)
     // Expand the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
 
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(14)
     // Collapse the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(10)
   })
 
-  it("displays partial sections", () => {
+  it("displays partial sections", async () => {
+    const user = userEvent.setup()
     render(
       <SidebarNav
         {...getProps({
@@ -403,21 +401,18 @@ describe("SidebarNav", () => {
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(2)
 
     // Expand the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
 
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(14)
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(2)
     // Collapse the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(10)
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(2)
   })
 
-  it("will not display a section if no pages in it are visible", () => {
+  it("will not display a section if no pages in it are visible", async () => {
+    const user = userEvent.setup()
     // First section has 6 pages, second section has 4 pages, third section has 4 pages
     // Since 6+4 = 10, only the first two sections should be visible
     render(
@@ -451,34 +446,30 @@ describe("SidebarNav", () => {
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(2)
 
     // Expand the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
 
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(14)
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(3)
     // Collapse the pages menu
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByTestId("stSidebarNavViewButton"))
+    await user.click(screen.getByTestId("stSidebarNavViewButton"))
     expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(10)
     expect(screen.getAllByTestId("stNavSectionHeader")).toHaveLength(2)
   })
 
-  it("passes the pageScriptHash to onPageChange if a link is clicked", () => {
+  it("passes the pageScriptHash to onPageChange if a link is clicked", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<SidebarNav {...props} />)
 
     const links = screen.getAllByTestId("stSidebarNavLink")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(links[1])
+    await user.click(links[1])
 
     expect(props.onPageChange).toHaveBeenCalledWith("other_page_hash")
     expect(props.collapseSidebar).not.toHaveBeenCalled()
   })
 
-  it("collapses sidebar on page change when on mobile", () => {
+  it("collapses sidebar on page change when on mobile", async () => {
+    const user = userEvent.setup()
     // @ts-expect-error
     reactDeviceDetect.isMobile = true
 
@@ -486,9 +477,7 @@ describe("SidebarNav", () => {
     render(<SidebarNav {...props} />)
 
     const links = screen.getAllByTestId("stSidebarNavLink")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(links[1])
+    await user.click(links[1])
 
     expect(props.onPageChange).toHaveBeenCalledWith("other_page_hash")
     expect(props.collapseSidebar).toHaveBeenCalled()

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { mockSessionInfo, render } from "@streamlit/lib"
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"
@@ -85,23 +86,20 @@ describe("ToolbarActions", () => {
     expect(screen.getByTestId("stToolbarActions")).toHaveStyle("display: flex")
   })
 
-  it("calls sendMessageToHost with correct args when clicked", () => {
+  it("calls sendMessageToHost with correct args when clicked", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ToolbarActions {...props} />)
 
     const favoriteButton = screen.getAllByTestId("stBaseButton-header")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(favoriteButton)
+    await user.click(favoriteButton)
     expect(props.sendMessageToHost).toHaveBeenLastCalledWith({
       type: "TOOLBAR_ITEM_CALLBACK",
       key: "favorite",
     })
 
     const shareButton = screen.getByRole("button", { name: "Share" })
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(shareButton)
+    await user.click(shareButton)
     expect(props.sendMessageToHost).toHaveBeenLastCalledWith({
       type: "TOOLBAR_ITEM_CALLBACK",
       key: "share",

--- a/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
@@ -16,8 +16,9 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib"
 
@@ -53,7 +54,8 @@ describe("ScreencastDialog", () => {
   })
 
   describe("Modal body", () => {
-    it("should have a record audio option to be selected", () => {
+    it("should have a record audio option to be selected", async () => {
+      const user = userEvent.setup()
       render(
         <BaseProvider theme={LightTheme}>
           <ScreencastDialog {...props} />
@@ -63,9 +65,7 @@ describe("ScreencastDialog", () => {
         screen.getByTestId("stScreencastAudioCheckbox")
       ).toHaveTextContent("Also record audio")
       const audioCheckbox = screen.getByRole("checkbox")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(audioCheckbox)
+      await user.click(audioCheckbox)
       expect(audioCheckbox).toBeChecked()
       expect(props.toggleRecordAudio).toHaveBeenCalled()
     })
@@ -84,7 +84,8 @@ describe("ScreencastDialog", () => {
   })
 
   describe("Modal footer", () => {
-    it("should have an start button", () => {
+    it("should have an start button", async () => {
+      const user = userEvent.setup()
       render(
         <BaseProvider theme={LightTheme}>
           <ScreencastDialog {...props} />
@@ -92,9 +93,7 @@ describe("ScreencastDialog", () => {
       )
       const startButton = screen.getByText("Start recording!")
       expect(startButton).toBeInTheDocument()
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(startButton)
+      await user.click(startButton)
       expect(props.startRecording).toHaveBeenCalled()
       expect(props.onClose).toHaveBeenCalled()
     })

--- a/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -17,7 +17,8 @@
 import React from "react"
 
 import { BaseProvider, LightTheme } from "baseui"
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib"
 
@@ -68,7 +69,8 @@ describe("VideoRecordedDialog", () => {
     expect(URL.createObjectURL).toHaveBeenCalled()
   })
 
-  it("should render a download button", () => {
+  it("should render a download button", async () => {
+    const user = userEvent.setup()
     render(
       <BaseProvider theme={LightTheme}>
         <VideoRecordedDialog {...props} />
@@ -79,9 +81,7 @@ describe("VideoRecordedDialog", () => {
     })
 
     expect(downloadButton).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(downloadButton)
+    await user.click(downloadButton)
     expect(props.onClose).toHaveBeenCalled()
   })
 })

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -282,6 +282,7 @@ describe("#useDeckGl", () => {
     })
 
     it("should call JSON5.parse when isFullScreen changes", async () => {
+      const user = userEvent.setup()
       const MyComponent: FC<UseDeckGlProps> = props => {
         useDeckGl(props)
         const { expand } = useRequiredContext(ElementFullscreenContext)
@@ -293,7 +294,7 @@ describe("#useDeckGl", () => {
 
       expect(JSON5.parse).toHaveBeenCalledTimes(1)
 
-      await userEvent.click(screen.getByText("Expand"))
+      await user.click(screen.getByText("Expand"))
 
       expect(JSON5.parse).toHaveBeenCalledTimes(2)
     })

--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
@@ -72,7 +73,8 @@ describe("Dialog container", () => {
     expect(() => screen.getByText("test")).toThrow()
   })
 
-  it("should close when dismissible", () => {
+  it("should close when dismissible", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(
       <Dialog {...props}>
@@ -81,9 +83,7 @@ describe("Dialog container", () => {
     )
 
     expect(screen.getByText("test")).toBeVisible()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByLabelText("Close"))
+    await user.click(screen.getByLabelText("Close"))
     // dialog should be closed by clicking outside and, thus, the content should be gone
     expect(() => screen.getByText("test")).toThrow()
   })

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
@@ -151,7 +152,8 @@ describe("Expander container", () => {
     expect(screen.getByText("test")).not.toBeVisible()
   })
 
-  it("should render the text when expanded", () => {
+  it("should render the text when expanded", async () => {
+    const user = userEvent.setup()
     const props = getProps({ expanded: false })
     render(
       <Expander {...props}>
@@ -159,9 +161,7 @@ describe("Expander container", () => {
       </Expander>
     )
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByText("hi"))
+    await user.click(screen.getByText("hi"))
     expect(screen.getByText("test")).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
+++ b/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Markdown as MarkdownProto } from "@streamlit/lib/src/proto"
@@ -50,13 +51,12 @@ describe("Markdown element", () => {
 
 describe("Markdown element with help", () => {
   it("renders markdown with help tooltip as expected", async () => {
+    const user = userEvent.setup()
     const props = getProps({ help: "help text" })
     render(<Markdown {...props} />)
     const tooltip = screen.getByTestId("stTooltipHoverTarget")
     expect(tooltip).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltip)
+    await user.hover(tooltip)
 
     const helpText = await screen.findByText("help text")
     expect(helpText).toBeInTheDocument()

--- a/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { customRenderLibContext, render } from "@streamlit/lib/src/test_util"
 import IsSidebarContext from "@streamlit/lib/src/components/core/IsSidebarContext"
@@ -120,7 +121,8 @@ describe("PageLink", () => {
     expect(pageNavLink).toHaveStyle("width: fit-content")
   })
 
-  it("triggers onPageChange with pageScriptHash when clicked", () => {
+  it("triggers onPageChange with pageScriptHash when clicked", async () => {
+    const user = userEvent.setup()
     const props = getProps()
 
     customRenderLibContext(<PageLink {...props} />, {
@@ -128,13 +130,12 @@ describe("PageLink", () => {
     })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(pageNavLink)
+    await user.click(pageNavLink)
     expect(mockOnPageChange).toHaveBeenCalledWith("main_page_hash")
   })
 
-  it("does not trigger onPageChange when disabled", () => {
+  it("does not trigger onPageChange when disabled", async () => {
+    const user = userEvent.setup()
     const props = getProps({}, { disabled: true })
 
     customRenderLibContext(<PageLink {...props} />, {
@@ -142,13 +143,12 @@ describe("PageLink", () => {
     })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(pageNavLink)
+    await user.click(pageNavLink)
     expect(mockOnPageChange).not.toHaveBeenCalled()
   })
 
-  it("does not trigger onPageChange for external links", () => {
+  it("does not trigger onPageChange for external links", async () => {
+    const user = userEvent.setup()
     const props = getProps({ page: "http://example.com", external: true })
 
     customRenderLibContext(<PageLink {...props} />, {
@@ -156,9 +156,7 @@ describe("PageLink", () => {
     })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(pageNavLink)
+    await user.click(pageNavLink)
     expect(mockOnPageChange).not.toHaveBeenCalled()
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
@@ -66,7 +67,8 @@ describe("Popover container", () => {
     expect(popover).toBeInTheDocument()
   })
 
-  it("should render the text when opened", () => {
+  it("should render the text when opened", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(
       <Popover {...props}>
@@ -74,9 +76,7 @@ describe("Popover container", () => {
       </Popover>
     )
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByText("label"))
+    await user.click(screen.getByText("label"))
     // Text should be visible now
     expect(screen.queryByText("test")).toBeVisible()
   })

--- a/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
+++ b/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Text as TextProto } from "@streamlit/lib/src/proto"
@@ -47,9 +48,7 @@ describe("TextElement element", () => {
     render(<TextElement {...props} />)
     const tooltip = screen.getByTestId("stTooltipHoverTarget")
     expect(tooltip).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltip)
+    await userEvent.hover(tooltip)
 
     const helpText = await screen.findAllByText("help text")
     expect(helpText[0].textContent).toBe("help text")

--- a/frontend/lib/src/components/elements/Toast/Toast.test.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.test.tsx
@@ -16,14 +16,9 @@
 
 import React, { ReactElement } from "react"
 
-import {
-  fireEvent,
-  RenderResult,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react"
+import { RenderResult, screen, waitFor, within } from "@testing-library/react"
 import { PLACEMENT, ToasterContainer } from "baseui/toast"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { Toast as ToastProto } from "@streamlit/lib/src/proto"
@@ -109,7 +104,8 @@ describe("Toast Component", () => {
     expect(toast).toContainElement(expandButton)
   })
 
-  test("can expand to see the full toast message & collapse to truncate", () => {
+  test("can expand to see the full toast message & collapse to truncate", async () => {
+    const user = userEvent.setup()
     const props = getProps({
       icon: "",
       body: "Random toast message that is a really really really really really really really really really long message, going way past the 3 line limit",
@@ -127,9 +123,7 @@ describe("Toast Component", () => {
     expect(toast).toContainElement(expandButton)
 
     // Click view more button & expand the message
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandButton)
+    await user.click(expandButton)
     expect(toast).toHaveTextContent(
       "Random toast message that is a really really really really really really really really really long message, going way past the 3 line limit"
     )
@@ -137,9 +131,7 @@ describe("Toast Component", () => {
     // Click view less button & collapse the message
     const collapseButton = screen.getByRole("button", { name: "view less" })
     expect(toast).toContainElement(collapseButton)
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(collapseButton)
+    await user.click(collapseButton)
     expect(toastText).toHaveTextContent(
       "Random toast message that is a really really really really really really really really really long"
     )
@@ -147,6 +139,7 @@ describe("Toast Component", () => {
   })
 
   test("can close toast", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     renderComponent(props)
 
@@ -155,9 +148,7 @@ describe("Toast Component", () => {
     expect(toast).toBeInTheDocument()
     expect(closeButton).toBeInTheDocument()
     // Click close button
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(closeButton)
+    await user.click(closeButton)
     // Wait for toast to be removed from DOM
     await waitFor(() => expect(toast).not.toBeInTheDocument())
   })
@@ -210,7 +201,8 @@ describe("Toast Component", () => {
     expect(toastText).toHaveLength(expectedTruncatedMessage.length)
   })
 
-  test("expands and collapses long messages with explicit line breaks correctly", () => {
+  test("expands and collapses long messages with explicit line breaks correctly", async () => {
+    const user = userEvent.setup()
     const messageWithBreaks =
       "First line of the message.\nSecond line of the message, which is very long and meant to test the expand and collapse functionality.\nThird line, which should initially be hidden."
     const expectedTruncatedMessage = shortenMessage(messageWithBreaks)
@@ -218,9 +210,7 @@ describe("Toast Component", () => {
     renderComponent(props)
 
     const expandButton = screen.getByRole("button", { name: "view more" })
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandButton) // Expand
+    await user.click(expandButton) // Expand
 
     const toastExpanded = screen
       .getByRole("alert")
@@ -228,9 +218,7 @@ describe("Toast Component", () => {
     expect(toastExpanded).toEqual(messageWithBreaks) // Check full message is displayed
 
     const collapseButton = screen.getByRole("button", { name: "view less" })
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(collapseButton) // Collapse
+    await user.click(collapseButton) // Collapse
 
     const toastCollapsed = screen
       .getByRole("alert")

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { lightTheme } from "@streamlit/lib/src/theme"
@@ -89,13 +90,12 @@ describe("Button element", () => {
     expect(buttonWidget).toBeDisabled()
   })
 
-  it("calls onClick when button is clicked", () => {
+  it("calls onClick when button is clicked", async () => {
+    const user = userEvent.setup()
     const onClick = vi.fn()
     render(<BaseButton {...getProps({ onClick })}>Hello</BaseButton>)
     const buttonWidget = screen.getByRole("button")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(buttonWidget)
+    await user.click(buttonWidget)
 
     expect(onClick).toHaveBeenCalled()
   })

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { fireEvent, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { LabelVisibilityOptions } from "@streamlit/lib/src/util/utils"
@@ -78,14 +79,13 @@ describe("ColorPicker widget", () => {
     expect(colorPicker).toHaveStyle(`width: ${props.width}px`)
   })
 
-  it("should render a default color in the preview and the color picker", () => {
+  it("should render a default color in the preview and the color picker", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<BaseColorPicker {...props} />)
 
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     expect(colorBlock).toHaveStyle("background-color: #000000")
 
@@ -93,14 +93,13 @@ describe("ColorPicker widget", () => {
     expect(colorInput).toHaveValue("#000000")
   })
 
-  it("supports hex shorthand", () => {
+  it("supports hex shorthand", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<BaseColorPicker {...props} />)
 
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     const colorInput = screen.getByRole("textbox")
     // TODO: Utilize user-event instead of fireEvent
@@ -111,20 +110,18 @@ describe("ColorPicker widget", () => {
     expect(colorBlock).toHaveStyle("background-color: #333333")
   })
 
-  it("should update the widget value when it's changed", () => {
+  it("should update the widget value when it's changed", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<BaseColorPicker {...props} />)
 
     const newColor = "#E91E63"
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     const colorInput = screen.getByRole("textbox")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(colorInput, { target: { value: newColor } })
+    await user.clear(colorInput)
+    await user.type(colorInput, newColor)
 
     expect(colorInput).toHaveValue(newColor)
     expect(colorBlock).toHaveStyle(`background-color: ${newColor}`)

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { fireEvent, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { LabelVisibilityOptions } from "@streamlit/lib/src/util/utils"
@@ -108,12 +109,11 @@ describe("Selectbox widget", () => {
     expect(screen.getByRole("combobox")).toBeDisabled()
   })
 
-  it("renders options", () => {
+  it("renders options", async () => {
+    const user = userEvent.setup()
     render(<Selectbox {...props} />)
     const selectbox = screen.getByRole("combobox")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(selectbox)
+    await user.click(selectbox)
     const options = screen.getAllByRole("option")
 
     expect(options).toHaveLength(props.options.length)
@@ -130,13 +130,12 @@ describe("Selectbox widget", () => {
     expect(screen.getByRole("combobox")).toBeDisabled()
   })
 
-  it("is able to select an option", () => {
+  it("is able to select an option", async () => {
+    const user = userEvent.setup()
     render(<Selectbox {...props} />)
     const selectbox = screen.getByRole("combobox")
     // Open the dropdown
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(selectbox)
+    await user.click(selectbox)
     const options = screen.getAllByRole("option")
     // TODO: Utilize user-event instead of fireEvent
     // eslint-disable-next-line testing-library/prefer-user-event
@@ -146,29 +145,26 @@ describe("Selectbox widget", () => {
     expect(screen.getByText(props.options[1])).toBeInTheDocument()
   })
 
-  it("doesn't filter options based on index", () => {
+  it("doesn't filter options based on index", async () => {
+    const user = userEvent.setup()
     render(<Selectbox {...props} />)
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } })
+    await user.type(screen.getByRole("combobox"), "1")
     expect(screen.getByText("No results")).toBeInTheDocument()
   })
 
-  it("filters options based on label with case insensitive", () => {
+  it("filters options based on label with case insensitive", async () => {
+    const user = userEvent.setup()
     render(<Selectbox {...props} />)
     const selectbox = screen.getByRole("combobox")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(selectbox, { target: { value: "b" } })
+    await user.type(selectbox, "b")
     let options = screen.getAllByRole("option")
     expect(options).toHaveLength(1)
     expect(options[0]).toHaveTextContent("b")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(selectbox, { target: { value: "B" } })
+    await user.clear(selectbox)
+    await user.type(selectbox, "B")
     options = screen.getAllByRole("option")
     expect(options).toHaveLength(1)
     expect(options[0]).toHaveTextContent("b")

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { LabelVisibilityOptions } from "@streamlit/lib/src/util/utils"
@@ -161,16 +162,15 @@ describe("Radio widget", () => {
     expect(noOptionLabel).toBeInTheDocument()
   })
 
-  it("handles value changes", () => {
+  it("handles value changes", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<Radio {...props} />)
     const radioOptions = screen.getAllByRole("radio")
 
     const secondOption = radioOptions[1]
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(secondOption)
+    await user.click(secondOption)
 
     expect(secondOption).toBeChecked()
   })

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.test.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.test.tsx
@@ -16,8 +16,9 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { Info } from "@emotion-icons/material-outlined"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -86,6 +87,7 @@ describe("Toolbar element", () => {
   })
 
   it("allows expanding into fullscreen mode", async () => {
+    const user = userEvent.setup()
     render(
       <Toolbar {...getToolbarProps()}>
         <ToolbarAction {...getToolbarActionsProps()} />
@@ -100,15 +102,14 @@ describe("Toolbar element", () => {
     const toolbarButton = screen.getAllByRole("button")
     expect(toolbarButton).toHaveLength(2)
     // Clicking the second button should close the fullscreen mode
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(toolbarButton[1])
+    await user.click(toolbarButton[1])
 
     // Check that onCollapse was clicked
     expect(onExpand).toHaveBeenCalled()
   })
 
   it("adapts to fullscreen mode", async () => {
+    const user = userEvent.setup()
     render(
       <Toolbar {...getToolbarProps({ locked: false, isFullScreen: true })}>
         <ToolbarAction {...getToolbarActionsProps()} />
@@ -123,9 +124,7 @@ describe("Toolbar element", () => {
     const toolbarButton = screen.getAllByRole("button")
     expect(toolbarButton).toHaveLength(2)
     // Clicking the second button should close the fullscreen mode
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(toolbarButton[1])
+    await user.click(toolbarButton[1])
 
     // Check that onCollapse was clicked
     expect(onCollapse).toHaveBeenCalled()
@@ -184,6 +183,7 @@ describe("ToolbarAction Button element", () => {
   })
 
   it("calls callback on click", async () => {
+    const user = userEvent.setup()
     const onClickMock = vi.fn()
 
     render(
@@ -193,9 +193,7 @@ describe("ToolbarAction Button element", () => {
     const toolbarButton = screen.getByRole("button")
     expect(toolbarButton).toBeInTheDocument()
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(toolbarButton)
+    await user.click(toolbarButton)
 
     // Check that onClick callback was clicked
     expect(onClickMock).toHaveBeenCalled()

--- a/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, render, screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { mockTheme } from "@streamlit/lib/src/mocks/mockTheme"
 import ThemeProvider from "@streamlit/lib/src/components/core/ThemeProvider"
@@ -29,7 +30,8 @@ describe("Tooltip component", () => {
     vi.restoreAllMocks()
   })
 
-  it("should render when it fits onscreen", () => {
+  it("should render when it fits onscreen", async () => {
+    const user = userEvent.setup()
     const useRefSpy = vi.spyOn(React, "useRef").mockReturnValue({
       current: {
         // Pretend the body is greater than its onscreen area.
@@ -56,9 +58,7 @@ describe("Tooltip component", () => {
     )
 
     const tooltip = screen.getByTestId("stTooltipHoverTarget")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltip)
+    await user.hover(tooltip)
 
     expect(screen.queryByText("the content")).not.toBeInTheDocument()
 
@@ -66,6 +66,7 @@ describe("Tooltip component", () => {
   })
 
   it("should render when ellipsized", async () => {
+    const user = userEvent.setup()
     const useRefSpy = vi.spyOn(React, "useRef").mockReturnValue({
       current: {
         // Pretend the body is smaller than its onscreen area.
@@ -92,9 +93,7 @@ describe("Tooltip component", () => {
     )
 
     const tooltip = screen.getByTestId("stTooltipHoverTarget")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltip)
+    await user.hover(tooltip)
 
     const tooltipContent = await screen.findByText("the content")
     expect(tooltipContent).toBeInTheDocument()

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -16,8 +16,9 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -43,15 +44,14 @@ const renderTooltip = (props: Partial<TooltipProps> = {}): any => {
 
 describe("Tooltip element", () => {
   it("renders a Tooltip", async () => {
+    const user = userEvent.setup()
     renderTooltip()
 
     const tooltipTarget = screen.getByTestId("stTooltipHoverTarget")
     expect(tooltipTarget).toBeInTheDocument()
 
     // Hover to see tooltip content
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltipTarget)
+    await user.hover(tooltipTarget)
 
     const tooltipContent = await screen.findByTestId("stTooltipContent")
     expect(tooltipContent).toHaveTextContent("Tooltip content text.")
@@ -65,6 +65,7 @@ describe("Tooltip element", () => {
   })
 
   it("sets the same content", async () => {
+    const user = userEvent.setup()
     const content = <span>Help Text</span>
     renderTooltip({ content })
 
@@ -72,9 +73,7 @@ describe("Tooltip element", () => {
     expect(tooltipTarget).toBeInTheDocument()
 
     // Hover to see tooltip content
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseOver(tooltipTarget)
+    await user.hover(tooltipTarget)
 
     const tooltipContent = await screen.findByTestId("stTooltipContent")
     expect(tooltipContent).toHaveTextContent("Help Text")

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.test.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -44,7 +45,8 @@ describe("AudioInputActionButton", () => {
     expect(screen.getByTestId("stAudioInputActionButton")).toBeInTheDocument()
   })
 
-  it("should start recording when recording button is pressed", () => {
+  it("should start recording when recording button is pressed", async () => {
+    const user = userEvent.setup()
     const startRecording = vi.fn()
     render(
       <AudioInputActionButtons
@@ -54,13 +56,12 @@ describe("AudioInputActionButton", () => {
     )
 
     expect(screen.getByLabelText("Record")).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByLabelText("Record"))
+    await user.click(screen.getByLabelText("Record"))
     expect(startRecording).toHaveBeenCalled()
   })
 
-  it("should stop recording when recording button is pressed", () => {
+  it("should stop recording when recording button is pressed", async () => {
+    const user = userEvent.setup()
     const stopRecording = vi.fn()
     render(
       <AudioInputActionButtons
@@ -71,13 +72,12 @@ describe("AudioInputActionButton", () => {
     )
 
     expect(screen.getByLabelText("Stop recording")).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByLabelText("Stop recording"))
+    await user.click(screen.getByLabelText("Stop recording"))
     expect(stopRecording).toHaveBeenCalled()
   })
 
-  it("should play when play button is pressed", () => {
+  it("should play when play button is pressed", async () => {
+    const user = userEvent.setup()
     const onClickPlayPause = vi.fn()
     render(
       <AudioInputActionButtons
@@ -89,13 +89,12 @@ describe("AudioInputActionButton", () => {
 
     expect(screen.getByLabelText("Record")).toBeInTheDocument()
     expect(screen.getByLabelText("Play")).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByLabelText("Play"))
+    await user.click(screen.getByLabelText("Play"))
     expect(onClickPlayPause).toHaveBeenCalled()
   })
 
-  it("should pause when pause button is pressed", () => {
+  it("should pause when pause button is pressed", async () => {
+    const user = userEvent.setup()
     const onClickPlayPause = vi.fn()
     render(
       <AudioInputActionButtons
@@ -108,14 +107,13 @@ describe("AudioInputActionButton", () => {
 
     expect(screen.getByLabelText("Record")).toBeInTheDocument()
     expect(screen.getByLabelText("Pause")).toBeInTheDocument()
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByLabelText("Pause"))
+    await user.click(screen.getByLabelText("Pause"))
     expect(onClickPlayPause).toHaveBeenCalled()
   })
 
   describe("when disabled", () => {
-    it("should not start recording when recording button is pressed", () => {
+    it("should not start recording when recording button is pressed", async () => {
+      const user = userEvent.setup()
       const startRecording = vi.fn()
       render(
         <AudioInputActionButtons
@@ -126,9 +124,7 @@ describe("AudioInputActionButton", () => {
       )
 
       expect(screen.getByLabelText("Record")).toBeInTheDocument()
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(screen.getByLabelText("Record"))
+      await user.click(screen.getByLabelText("Record"))
       expect(startRecording).not.toHaveBeenCalled()
     })
   })

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -75,14 +76,13 @@ describe("Button widget", () => {
   })
 
   describe("BaseButton props should work", () => {
-    it("onClick prop", () => {
+    it("onClick prop", async () => {
+      const user = userEvent.setup()
       const props = getProps()
       render(<Button {...props} />)
 
       const buttonWidget = screen.getByRole("button")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(buttonWidget)
+      await user.click(buttonWidget)
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
@@ -91,16 +91,15 @@ describe("Button widget", () => {
       )
     })
 
-    it("passes fragmentId to onClick prop", () => {
+    it("passes fragmentId to onClick prop", async () => {
+      const user = userEvent.setup()
       const props = getProps(undefined, {
         fragmentId: "myFragmentId",
       })
       render(<Button {...props} />)
 
       const buttonWidget = screen.getByRole("button")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(buttonWidget)
+      await user.click(buttonWidget)
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { act, fireEvent, screen, within } from "@testing-library/react"
+import { act, screen, within } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -182,7 +183,8 @@ describe("ButtonGroup widget", () => {
       expect(buttons).toHaveLength(0)
     })
 
-    it("onClick prop for single select", () => {
+    it("onClick prop for single select", async () => {
+      const user = userEvent.setup()
       const props = getProps()
       vi.spyOn(props.widgetMgr, "setIntArrayValue")
 
@@ -199,9 +201,7 @@ describe("ButtonGroup widget", () => {
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(1)
 
       // click element at index 1 to select it
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(buttons[1])
+      await user.click(buttons[1])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [1],
@@ -211,9 +211,7 @@ describe("ButtonGroup widget", () => {
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(2)
 
       // click element at index 0 to select it
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(getButtonGroupButtons()[0])
+      await user.click(getButtonGroupButtons()[0])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [0],
@@ -223,9 +221,7 @@ describe("ButtonGroup widget", () => {
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(3)
 
       // click on same button does deselect it
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(getButtonGroupButtons()[0])
+      await user.click(getButtonGroupButtons()[0])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [],
@@ -235,7 +231,8 @@ describe("ButtonGroup widget", () => {
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(4)
     })
 
-    it("onClick prop for multi select", () => {
+    it("onClick prop for multi select", async () => {
+      const user = userEvent.setup()
       const props = getProps({
         clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
       })
@@ -250,9 +247,7 @@ describe("ButtonGroup widget", () => {
         undefined
       )
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(buttons[1])
+      await user.click(buttons[1])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         // the 2 is default value
@@ -261,9 +256,7 @@ describe("ButtonGroup widget", () => {
         undefined
       )
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(getButtonGroupButtons()[0])
+      await user.click(getButtonGroupButtons()[0])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [2, 1, 0],
@@ -272,9 +265,7 @@ describe("ButtonGroup widget", () => {
       )
 
       // unselect the second button
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(getButtonGroupButtons()[1])
+      await user.click(getButtonGroupButtons()[1])
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [2, 0],
@@ -283,7 +274,8 @@ describe("ButtonGroup widget", () => {
       )
     })
 
-    it("passes fragmentId to onClick prop", () => {
+    it("passes fragmentId to onClick prop", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         {},
         {
@@ -301,9 +293,7 @@ describe("ButtonGroup widget", () => {
       )
 
       const button = getButtonGroupButtons()[0]
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(button)
+      await user.click(button)
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
         [0],
@@ -404,6 +394,7 @@ describe("ButtonGroup widget", () => {
     })
 
     it("renders help prop correctly", async () => {
+      const user = userEvent.setup()
       const props = getProps({
         help: "help text",
       })
@@ -411,25 +402,22 @@ describe("ButtonGroup widget", () => {
       const tooltip = screen.getByTestId("stTooltipHoverTarget")
       expect(tooltip).toBeInTheDocument()
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.mouseOver(tooltip)
+      await user.hover(tooltip)
       const helpText = await screen.findByText("help text")
       expect(helpText).toBeInTheDocument()
     })
 
     describe("visualizes selection behavior", () => {
       // eslint-disable-next-line vitest/expect-expect
-      it("visualize only selected option", () => {
+      it("visualize only selected option", async () => {
+        const user = userEvent.setup()
         const props = getProps({
           selectionVisualization:
             ButtonGroupProto.SelectionVisualization.ONLY_SELECTED,
         })
         render(<ButtonGroup {...props} />)
 
-        // TODO: Utilize user-event instead of fireEvent
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.click(getButtonGroupButtons()[0])
+        await user.click(getButtonGroupButtons()[0])
         const buttons = getButtonGroupButtons()
         expectHighlightStyle(buttons[0])
         expectHighlightStyle(buttons[1], false)
@@ -437,7 +425,8 @@ describe("ButtonGroup widget", () => {
       })
 
       // eslint-disable-next-line vitest/expect-expect
-      it("visualizes all up to the selected option", () => {
+      it("visualizes all up to the selected option", async () => {
+        const user = userEvent.setup()
         const props = getProps({
           selectionVisualization:
             ButtonGroupProto.SelectionVisualization.ALL_UP_TO_SELECTED,
@@ -447,9 +436,7 @@ describe("ButtonGroup widget", () => {
         const buttonGroupWidget = screen.getByTestId("stButtonGroup")
         const buttons = within(buttonGroupWidget).getAllByRole("button")
         const buttonToClick = buttons[2]
-        // TODO: Utilize user-event instead of fireEvent
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.click(buttonToClick)
+        await user.click(buttonToClick)
         expectHighlightStyle(buttonToClick)
         expectHighlightStyle(buttons[0])
         // the second button has selectedContent set, so it should not be highlighted visually
@@ -458,7 +445,8 @@ describe("ButtonGroup widget", () => {
       })
 
       // eslint-disable-next-line vitest/expect-expect
-      it("has no default visualization when selected content present", () => {
+      it("has no default visualization when selected content present", async () => {
+        const user = userEvent.setup()
         // used for example by feedback stars
         const disabledVisualizationOption = [
           ButtonGroupProto.Option.create({
@@ -480,15 +468,14 @@ describe("ButtonGroup widget", () => {
         const buttonGroupWidget = screen.getByTestId("stButtonGroup")
         const buttons = within(buttonGroupWidget).getAllByRole("button")
         const buttonToClick = buttons[1]
-        // TODO: Utilize user-event instead of fireEvent
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.click(buttonToClick)
+        await user.click(buttonToClick)
         expectHighlightStyle(buttonToClick, false)
         expectHighlightStyle(buttons[0], false)
       })
     })
 
-    it("shows selection content when selected and available", () => {
+    it("shows selection content when selected and available", async () => {
+      const user = userEvent.setup()
       const props = getProps({ default: [], options: materialIconOnlyOptions })
       render(<ButtonGroup {...props} />)
 
@@ -499,9 +486,7 @@ describe("ButtonGroup widget", () => {
         expect(icon.textContent).toContain(materialIconNames[index])
       })
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(buttons[1])
+      await user.click(buttons[1])
       expect(getButtonGroupButtons()[1].textContent).toContain(
         "icon_2_selected"
       )
@@ -536,7 +521,8 @@ describe("ButtonGroup widget", () => {
     })
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getProps({
       formId: "form",
@@ -550,12 +536,8 @@ describe("ButtonGroup widget", () => {
 
     // Change the widget value
     // de-select default value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(getButtonGroupButtons()[0])
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(getButtonGroupButtons()[1])
+    await user.click(getButtonGroupButtons()[0])
+    await user.click(getButtonGroupButtons()[1])
     let buttons = getButtonGroupButtons()
     expectHighlightStyle(buttons[0])
     // the second button has selectedContent set, so it should not be highlighted visually

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen, within } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -113,7 +114,8 @@ describe("Test Webcam Component", () => {
     expect(screen.getByTestId("stCameraInputSwitchButton")).toBeInTheDocument()
   })
 
-  it("changes `facingMode` when SwitchFacingMode button clicked", () => {
+  it("changes `facingMode` when SwitchFacingMode button clicked", async () => {
+    const user = userEvent.setup()
     const props = getProps({ testOverride: WebcamPermission.SUCCESS })
     render(<WebcamComponent {...props} />)
 
@@ -123,23 +125,20 @@ describe("Test Webcam Component", () => {
       screen.getByTestId("stCameraInputSwitchButton")
     ).getByRole("button")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(switchButton)
+    await user.click(switchButton)
 
     expect(props.setFacingMode).toHaveBeenCalledTimes(1)
   })
 
   it("test handle capture function", async () => {
+    const user = userEvent.setup()
     const props = getProps({ testOverride: WebcamPermission.SUCCESS })
     render(<WebcamComponent {...props} />)
     expect(
       screen.getByTestId("stCameraInputWebcamComponent")
     ).toBeInTheDocument()
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByRole("button", { name: "Take Photo" }))
+    await user.click(screen.getByRole("button", { name: "Take Photo" }))
 
     expect(props.handleCapture).toHaveBeenCalled()
   })

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { fireEvent, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { ChatInput as ChatInputProto } from "@streamlit/lib/src/proto"
@@ -81,45 +82,36 @@ describe("ChatInput widget", () => {
     expect(chatInput).toHaveTextContent(props.element.default)
   })
 
-  it("sets the value when values are typed in", () => {
+  it("sets the value when values are typed in", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "Sample text" } })
+    await user.type(chatInput, "Sample text")
     expect(chatInput).toHaveTextContent("Sample text")
   })
 
-  it("does not increase text value when maxChars is set", () => {
+  it("does not increase text value when maxChars is set", async () => {
+    const user = userEvent.setup()
     const props = getProps({ maxChars: 10 })
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    await user.type(chatInput, "1234567890")
     expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "12345678901" } })
+    await user.type(chatInput, "1")
     expect(chatInput).toHaveTextContent("1234567890")
   })
 
-  it("sends and resets the value on enter", () => {
+  it("sends and resets the value on enter", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
-    expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter" })
+    await user.type(chatInput, "1234567890{enter}")
     expect(spy).toHaveBeenCalledWith(
       props.element,
       "1234567890",
@@ -131,49 +123,36 @@ describe("ChatInput widget", () => {
     expect(chatInput).toHaveTextContent("")
   })
 
-  it("ensures chat input has focus on submit by keyboard", () => {
+  it("ensures chat input has focus on submit by keyboard", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
-    expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter" })
+    await user.type(chatInput, "1234567890{enter}")
     expect(chatInput).toHaveFocus()
   })
 
-  it("ensures chat input has focus on submit by button click", () => {
+  it("ensures chat input has focus on submit by button click", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
     const chatButton = screen.getByTestId("stChatInputSubmitButton")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
-    expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(chatButton)
+    await user.type(chatInput, "1234567890")
+    await user.click(chatButton)
     expect(chatInput).toHaveFocus()
   })
 
-  it("can set fragmentId when sending value", () => {
+  it("can set fragmentId when sending value", async () => {
+    const user = userEvent.setup()
     const props = getProps(undefined, { fragmentId: "myFragmentId" })
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter" })
+    await user.type(chatInput, "1234567890{enter}")
     expect(spy).toHaveBeenCalledWith(
       props.element,
       "1234567890",
@@ -184,22 +163,22 @@ describe("ChatInput widget", () => {
     )
   })
 
-  it("will not send an empty value on enter if empty", () => {
+  it("will not send an empty value on enter if empty", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter" })
+    await user.type(chatInput, "{enter}")
     expect(spy).not.toHaveBeenCalledWith(props.element, "", {
       fromUi: true,
     })
     expect(chatInput).toHaveTextContent("")
   })
 
-  it("will not show instructions when the text has changed", () => {
+  it("will not show instructions when the text has changed", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ChatInput {...props} />)
 
@@ -207,40 +186,32 @@ describe("ChatInput widget", () => {
     const instructions = screen.getByTestId("InputInstructions")
     expect(instructions).toHaveTextContent("")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    await user.type(chatInput, "1234567890")
     expect(instructions).toHaveTextContent("")
   })
 
-  it("does not send/clear on shift + enter", () => {
+  it("does not send/clear on shift + enter", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
     const chatInput = screen.getByTestId("stChatInputTextArea")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    await user.type(chatInput, "1234567890")
     expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter", shiftKey: true })
-    // We cannot test the value to be changed cause that is essentially a
-    // change event.
+    await user.type(chatInput, "{shift>}{enter}{/shift}")
     expect(chatInput).not.toHaveTextContent("")
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it("does not send/clear on ctrl + enter", () => {
+  it("does not send/clear on ctrl + enter", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    await user.type(chatInput, "1234567890")
     expect(chatInput).toHaveTextContent("1234567890")
     // TODO: Utilize user-event instead of fireEvent
     // eslint-disable-next-line testing-library/prefer-user-event
@@ -251,21 +222,16 @@ describe("ChatInput widget", () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it("does not send/clear on meta + enter", () => {
+  it("does not send/clear on meta + enter", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     const spy = vi.spyOn(props.widgetMgr, "setStringTriggerValue")
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    await user.type(chatInput, "1234567890")
     expect(chatInput).toHaveTextContent("1234567890")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(chatInput, { key: "Enter", metaKey: true })
-    // We cannot test the value to be changed cause that is essentially a
-    // change event.
+    await user.type(chatInput, "{meta>}{enter}{/meta}")
     expect(chatInput).not.toHaveTextContent("")
     expect(spy).not.toHaveBeenCalled()
   })
@@ -316,21 +282,19 @@ describe("ChatInput widget", () => {
     expect(button).toBeDisabled()
   })
 
-  it("enables the send button when text is set, disables it when removed", () => {
+  it("enables the send button when text is set, disables it when removed", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ChatInput {...props} />)
 
     const chatInput = screen.getByTestId("stChatInputTextArea")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "Sample text" } })
+    await user.type(chatInput, "Sample text")
 
     const button = screen.getByRole("button")
     expect(button).not.toBeDisabled()
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(chatInput, { target: { value: "" } })
+    await user.clear(chatInput)
+    // await user.type(chatInput, "")
     expect(button).toBeDisabled()
   })
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import { render } from "@streamlit/lib/src/test_util"
@@ -123,15 +124,14 @@ describe("Checkbox widget", () => {
     expect(screen.getByRole("checkbox")).not.toBeDisabled()
   })
 
-  it("handles the onChange event", () => {
+  it("handles the onChange event", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setBoolValue")
 
     render(<Checkbox {...props} />)
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("checkbox"))
 
     expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
       props.element,
@@ -142,15 +142,14 @@ describe("Checkbox widget", () => {
     expect(screen.getByRole("checkbox")).toBeChecked()
   })
 
-  it("can pass fragmentId to setBoolValue", () => {
+  it("can pass fragmentId to setBoolValue", async () => {
+    const user = userEvent.setup()
     const props = getProps(undefined, { fragmentId: "myFragmentId" })
     vi.spyOn(props.widgetMgr, "setBoolValue")
 
     render(<Checkbox {...props} />)
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("checkbox"))
 
     expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
       props.element,
@@ -160,7 +159,8 @@ describe("Checkbox widget", () => {
     )
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -170,9 +170,7 @@ describe("Checkbox widget", () => {
     render(<Checkbox {...props} />)
 
     // Change the widget value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("checkbox"))
 
     expect(screen.getByRole("checkbox")).toBeChecked()
     expect(props.widgetMgr.setBoolValue).toHaveBeenLastCalledWith(

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { act, fireEvent, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { ColorPicker as ColorPickerProto } from "@streamlit/lib/src/proto"
@@ -80,21 +81,21 @@ describe("ColorPicker widget", () => {
     )
   })
 
-  it("renders a default color in the preview and the color picker", () => {
+  it("renders a default color in the preview and the color picker", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<ColorPicker {...props} />)
 
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
     expect(colorBlock).toHaveStyle("background-color: #000000")
 
     const colorInput = screen.getByRole("textbox")
     expect(colorInput).toHaveValue("#000000")
   })
 
-  it("updates its widget value when it's changed", () => {
+  it("updates its widget value when it's changed", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setStringValue")
 
@@ -102,9 +103,7 @@ describe("ColorPicker widget", () => {
 
     const newColor = "#e91e63"
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     // Our widget should be updated.
     const colorInput = screen.getByRole("textbox")
@@ -112,9 +111,7 @@ describe("ColorPicker widget", () => {
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(colorInput, { target: { value: newColor } })
     // Close out of the popover
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     // And the WidgetMgr should also be updated.
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
@@ -125,8 +122,9 @@ describe("ColorPicker widget", () => {
     )
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
+    const user = userEvent.setup()
     const props = getProps({ formId: "form" })
     vi.spyOn(props.widgetMgr, "setStringValue")
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -136,19 +134,14 @@ describe("ColorPicker widget", () => {
     // Choose a new color
     const newColor = "#e91e63"
     const colorBlock = screen.getByTestId("stColorPickerBlock")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
-    // Update the color
     const colorInput = screen.getByRole("textbox")
     // TODO: Utilize user-event instead of fireEvent
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(colorInput, { target: { value: newColor } })
     // Close out of the popover
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(colorBlock)
+    await user.click(colorBlock)
 
     expect(colorInput).toHaveValue(newColor)
     expect(colorBlock).toHaveStyle(`background-color: ${newColor}`)

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -199,14 +199,14 @@ describe("DateInput widget", () => {
     expect(dateInput).toHaveValue(fullOriginalDate)
   })
 
-  it("has a minDate", () => {
+  it("has a minDate", async () => {
+    const user = userEvent.setup()
     const props = getProps({})
 
     render(<DateInput {...props} />)
 
     const dateInput = screen.getByTestId("stDateInputField")
-
-    fireEvent.focus(dateInput)
+    await user.click(dateInput)
 
     expect(
       screen.getByLabelText("Not available. Monday, January 19th 1970.")
@@ -218,7 +218,8 @@ describe("DateInput widget", () => {
     ).toBeTruthy()
   })
 
-  it("has a minDate if passed", () => {
+  it("has a minDate if passed", async () => {
+    const user = userEvent.setup()
     const props = getProps({
       min: "2020/01/05",
       // Choose default so min is in the default page when the widget is opened.
@@ -228,8 +229,7 @@ describe("DateInput widget", () => {
     render(<DateInput {...props} />)
 
     const dateInput = screen.getByTestId("stDateInputField")
-
-    fireEvent.focus(dateInput)
+    await user.click(dateInput)
 
     expect(
       screen.getByLabelText("Not available. Saturday, January 4th 2020.")
@@ -240,7 +240,8 @@ describe("DateInput widget", () => {
     ).toBeTruthy()
   })
 
-  it("has a maxDate if it is passed", () => {
+  it("has a maxDate if it is passed", async () => {
+    const user = userEvent.setup()
     const props = getProps({
       max: "2020/01/25",
       // Choose default so min is in the default page when the widget is opened.
@@ -250,8 +251,7 @@ describe("DateInput widget", () => {
     render(<DateInput {...props} />)
 
     const dateInput = screen.getByTestId("stDateInputField")
-
-    fireEvent.focus(dateInput)
+    await user.click(dateInput)
 
     expect(
       screen.getByLabelText(

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -79,15 +80,13 @@ describe("DownloadButton widget", () => {
   })
 
   describe("wrapped BaseButton", () => {
-    it("sets widget triggerValue and creates a download URL on click", () => {
+    it("sets widget triggerValue and creates a download URL on click", async () => {
+      const user = userEvent.setup()
       const props = getProps()
       render(<DownloadButton {...props} />)
 
       const downloadButton = screen.getByRole("button")
-
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(downloadButton)
+      await user.click(downloadButton)
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
@@ -117,14 +116,13 @@ describe("DownloadButton widget", () => {
       expect(newTabLink.getAttribute("target")).toBe("_blank")
     })
 
-    it("can set fragmentId on click", () => {
+    it("can set fragmentId on click", async () => {
+      const user = userEvent.setup()
       const props = getProps(undefined, { fragmentId: "myFragmentId" })
       render(<DownloadButton {...props} />)
 
       const downloadButton = screen.getByRole("button")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(downloadButton)
+      await user.click(downloadButton)
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -17,7 +17,8 @@
 import React from "react"
 
 import { CancelTokenSource } from "axios"
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -62,7 +63,8 @@ describe("FileStatus widget", () => {
 })
 
 describe("UploadedFile widget", () => {
-  it("renders without crashing", () => {
+  it("renders without crashing", async () => {
+    const user = userEvent.setup()
     const props = getProps({
       type: "uploaded",
       fileId: "fileId",
@@ -71,9 +73,7 @@ describe("UploadedFile widget", () => {
     render(<UploadedFile {...props} />)
     expect(screen.getByTestId("stFileUploaderFile")).toBeInTheDocument()
     const deleteBtn = screen.getByRole("button")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
     expect(props.onDelete).toHaveBeenCalledWith(1)
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 
@@ -49,25 +50,23 @@ describe("Pagination widget", () => {
     expect(screen.getByText("Showing page 1 of 10")).toBeInTheDocument()
   })
 
-  it("should be able to go to previous page", () => {
+  it("should be able to go to previous page", async () => {
+    const user = userEvent.setup()
     render(<Pagination {...props} />)
     const prevPaginationButton = screen.getAllByTestId(
       "stBaseButton-minimal"
     )[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(prevPaginationButton)
+    await user.click(prevPaginationButton)
     expect(props.onPrevious).toHaveBeenCalledTimes(1)
   })
 
-  it("should be able to go to next page", () => {
+  it("should be able to go to next page", async () => {
+    const user = userEvent.setup()
     render(<Pagination {...props} />)
     const nextPaginationButton = screen.getAllByTestId(
       "stBaseButton-minimal"
     )[1]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(nextPaginationButton)
+    await user.click(nextPaginationButton)
     expect(props.onNext).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -15,7 +15,8 @@
  */
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 import { enableAllPlugins } from "immer"
 
 import { render } from "@streamlit/lib/src/test_util"
@@ -93,15 +94,14 @@ describe("FormSubmitButton", () => {
   })
 
   it("calls submitForm when clicked", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "submitForm")
     render(<FormSubmitButton {...props} />)
 
     const formSubmitButton = screen.getByRole("button")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(formSubmitButton)
+    await user.click(formSubmitButton)
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
       props.element.formId,
       undefined,
@@ -110,15 +110,14 @@ describe("FormSubmitButton", () => {
   })
 
   it("can pass fragmentId to submitForm", async () => {
+    const user = userEvent.setup()
     const props = getProps({ fragmentId: "myFragmentId" })
     vi.spyOn(props.widgetMgr, "submitForm")
     render(<FormSubmitButton {...props} />)
 
     const formSubmitButton = screen.getByRole("button")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(formSubmitButton)
+    await user.click(formSubmitButton)
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
       props.element.formId,
       "myFragmentId",

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
+import { act, fireEvent, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -154,14 +155,13 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("renders options", () => {
+  it("renders options", async () => {
+    const user = userEvent.setup()
     const props = getProps({ default: [] })
     render(<Multiselect {...props} />)
 
     const expandListButton = screen.getAllByTitle("open")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandListButton)
+    await user.click(expandListButton)
 
     const options = screen.getAllByRole("option")
     expect(options.length).toBe(props.element.options.length)
@@ -170,20 +170,18 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("filters based on label, not value", () => {
+  it("filters based on label, not value", async () => {
+    const user = userEvent.setup()
     const props = getProps({ default: [] })
     render(<Multiselect {...props} />)
 
     const multiSelect = screen.getByRole("combobox")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(multiSelect, { target: { value: "1" } })
+    await user.type(multiSelect, "1")
     expect(screen.getByText("No results")).toBeInTheDocument()
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(multiSelect, { target: { value: "a" } })
+    await user.clear(multiSelect)
+    await user.type(multiSelect, "a")
     const match = screen.getByRole("option")
     expect(match).toHaveTextContent("a")
   })
@@ -195,7 +193,8 @@ describe("Multiselect widget", () => {
     expect(multiSelect).toBeDisabled()
   })
 
-  it("can select multiple options", () => {
+  it("can select multiple options", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<Multiselect {...props} />)
 
@@ -204,30 +203,25 @@ describe("Multiselect widget", () => {
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(multiSelect, { target: { value: "b" } })
     const match = screen.getByRole("option")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(match)
+    await user.click(match)
 
     const selections = screen.getAllByRole("button")
     expect(selections[0]).toHaveTextContent("a")
     expect(selections[1]).toHaveTextContent("b")
   })
 
-  it("can remove options", () => {
+  it("can remove options", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<Multiselect {...props} />)
 
     // Clear current selection
     const deleteOptionButton = screen.getAllByTitle("Delete")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(deleteOptionButton)
+    await user.click(deleteOptionButton)
 
     // Should now see all options available again
     const expandListButton = screen.getAllByTitle("open")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandListButton)
+    await user.click(expandListButton)
 
     const options = screen.getAllByRole("option")
     expect(options.length).toBe(props.element.options.length)
@@ -236,21 +230,18 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("can clear all", () => {
+  it("can clear all", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<Multiselect {...props} />)
 
     // Clear all selections
     const clearAllButton = screen.getByRole("button", { name: "Clear all" })
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(clearAllButton)
+    await user.click(clearAllButton)
 
     // Should now see all options available again
     const expandListButton = screen.getAllByTitle("open")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandListButton)
+    await user.click(expandListButton)
 
     const options = screen.getAllByRole("option")
     expect(options.length).toBe(props.element.options.length)
@@ -259,8 +250,9 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
     // Create a widget in a clearOnSubmit form
+    const user = userEvent.setup()
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
 
@@ -275,9 +267,7 @@ describe("Multiselect widget", () => {
     fireEvent.change(multiSelect, { target: { value: "b" } })
     const match = screen.getByRole("option")
     // Select b
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(match)
+    await user.click(match)
 
     // Options list should only have c available - a & b selected
     const remainingOptions = screen.getAllByRole("option")
@@ -293,14 +283,14 @@ describe("Multiselect widget", () => {
       undefined
     )
 
-    // "Submit" the form
-    props.widgetMgr.submitForm("form", undefined)
+    act(() => {
+      // "Submit" the form
+      props.widgetMgr.submitForm("form", undefined)
+    })
 
     // Our widget should be reset, and the widgetMgr should be updated
     const expandListButton = screen.getAllByTitle("open")[0]
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(expandListButton)
+    await user.click(expandListButton)
     // Options list should only have b & c available - default a selected
     const updatedOptions = screen.getAllByRole("option")
     expect(updatedOptions.length).toBe(2)
@@ -318,7 +308,8 @@ describe("Multiselect widget", () => {
   })
 
   describe("properly invalidates going over max selections", () => {
-    it("has correct noResultsMsg when maxSelections is not passed", () => {
+    it("has correct noResultsMsg when maxSelections is not passed", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
@@ -331,14 +322,13 @@ describe("Multiselect widget", () => {
 
       // Type something with no matches
       const multiSelect = screen.getByRole("combobox")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(multiSelect, { target: { value: "z" } })
+      await user.type(multiSelect, "z")
 
       expect(screen.getByText("No results")).toBeInTheDocument()
     })
 
-    it("has correct noResultsMsg when no match and selections < maxSelections", () => {
+    it("has correct noResultsMsg when no match and selections < maxSelections", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
@@ -352,14 +342,13 @@ describe("Multiselect widget", () => {
 
       // Type something with no matches
       const multiSelect = screen.getByRole("combobox")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(multiSelect, { target: { value: "z" } })
+      await user.type(multiSelect, "z")
 
       expect(screen.getByText("No results")).toBeInTheDocument()
     })
 
-    it("has correct noResultsMsg when maxSelections reached", () => {
+    it("has correct noResultsMsg when maxSelections reached", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
@@ -377,9 +366,7 @@ describe("Multiselect widget", () => {
       // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.change(multiSelect, { target: { value: "b" } })
       const match = screen.getByRole("option")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(match)
+      await user.click(match)
 
       expect(
         screen.getByText(
@@ -388,7 +375,8 @@ describe("Multiselect widget", () => {
       ).toBeInTheDocument()
     })
 
-    it("does not allow for more selection when an option is picked & maxSelections === 1", () => {
+    it("does not allow for more selection when an option is picked & maxSelections === 1", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
@@ -401,9 +389,7 @@ describe("Multiselect widget", () => {
       render(<Multiselect {...props} />)
 
       const multiSelect = screen.getByRole("combobox")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(multiSelect)
+      await user.click(multiSelect)
 
       expect(
         screen.getByText(
@@ -412,7 +398,8 @@ describe("Multiselect widget", () => {
       ).toBeInTheDocument()
     })
 
-    it("does allow an option to be removed when we are at max selections", () => {
+    it("does allow an option to be removed when we are at max selections", async () => {
+      const user = userEvent.setup()
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
@@ -426,15 +413,11 @@ describe("Multiselect widget", () => {
 
       // Clear a selection
       const deleteOptionButton = screen.getAllByTitle("Delete")[0]
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(deleteOptionButton)
+      await user.click(deleteOptionButton)
 
       // Options list should only have a & c available - b selected
       const expandListButton = screen.getAllByTitle("open")[0]
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(expandListButton)
+      await user.click(expandListButton)
       const updatedOptions = screen.getAllByRole("option")
       expect(updatedOptions.length).toBe(2)
       expect(updatedOptions[0]).toHaveTextContent("a")

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -15,7 +15,7 @@
  */
 import React from "react"
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import {
@@ -82,22 +82,24 @@ describe("NumberInput widget", () => {
     expect(numberInput).toHaveClass("stNumberInput")
   })
 
-  it("adds a focused class when running onFocus", () => {
+  it("adds a focused class when running onFocus", async () => {
+    const user = userEvent.setup()
     const props = getIntProps()
     render(<NumberInput {...props} />)
 
-    fireEvent.focus(screen.getByTestId("stNumberInputField"))
+    await user.click(screen.getByTestId("stNumberInputField"))
     expect(screen.getByTestId("stNumberInputContainer")).toHaveClass("focused")
   })
 
-  it("removes the focused class when running onBlur", () => {
+  it("removes the focused class when running onBlur", async () => {
+    const user = userEvent.setup()
     const props = getIntProps()
     render(<NumberInput {...props} />)
 
-    fireEvent.focus(screen.getByTestId("stNumberInputField"))
+    await user.click(screen.getByTestId("stNumberInputField"))
     expect(screen.getByTestId("stNumberInputContainer")).toHaveClass("focused")
 
-    fireEvent.blur(screen.getByTestId("stNumberInputField"))
+    await user.tab()
     expect(screen.getByTestId("stNumberInputContainer")).not.toHaveClass(
       "focused"
     )
@@ -188,7 +190,8 @@ describe("NumberInput widget", () => {
     expect(numberInput).toHaveAttribute("max", "10")
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getIntProps({ formId: "form", default: 10 })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -197,12 +200,8 @@ describe("NumberInput widget", () => {
     render(<NumberInput {...props} />)
 
     const numberInput = screen.getByTestId("stNumberInputField")
-    // Change the widget value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(numberInput, {
-      target: { value: 15 },
-    })
+    await user.clear(numberInput)
+    await user.type(numberInput, "15")
 
     // "Submit" the form
     act(() => {
@@ -261,10 +260,10 @@ describe("NumberInput widget", () => {
     await user.click(numberInput)
     await user.keyboard("{backspace}5")
 
-    fireEvent.blur(numberInput)
+    await user.tab()
     expect(screen.queryByTestId("InputInstructions")).not.toBeInTheDocument()
 
-    fireEvent.focus(numberInput)
+    await user.click(numberInput)
     expect(screen.getByText("Press Enter to submit form")).toBeVisible()
   })
 
@@ -284,7 +283,8 @@ describe("NumberInput widget", () => {
   })
 
   describe("FloatData", () => {
-    it("changes state on ArrowDown", () => {
+    it("changes state on ArrowDown", async () => {
+      const user = userEvent.setup()
       const props = getFloatProps({
         format: "%0.2f",
         default: 11.0,
@@ -294,11 +294,7 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
       const numberInput = screen.getByTestId("stNumberInputField")
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(numberInput, {
-        key: "ArrowDown",
-      })
+      await user.type(numberInput, "{arrowdown}")
 
       expect(numberInput).toHaveValue(10.9)
     })
@@ -319,17 +315,14 @@ describe("NumberInput widget", () => {
       )
     })
 
-    it("sets value on Enter", () => {
+    it("sets value on Enter", async () => {
+      const user = userEvent.setup()
       const props = getFloatProps({ default: 10 })
       vi.spyOn(props.widgetMgr, "setDoubleValue")
 
       render(<NumberInput {...props} />)
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyPress(screen.getByTestId("stNumberInputField"), {
-        key: "Enter",
-      })
+      await user.type(screen.getByTestId("stNumberInputField"), "{enter}")
 
       expect(props.widgetMgr.setDoubleValue).toHaveBeenCalled()
     })
@@ -441,7 +434,6 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
       const numberInput = screen.getByTestId("stNumberInputField")
 
-      // userEvent necessary to trigger dirty state
       await user.click(numberInput)
       await user.keyboard("{backspace}{backspace}15")
 
@@ -450,22 +442,20 @@ describe("NumberInput widget", () => {
       expect(screen.getByText("Press Enter to apply")).toBeVisible()
     })
 
-    it("sets value on Enter", () => {
+    it("sets value on Enter", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({ default: 10 })
       vi.spyOn(props.widgetMgr, "setIntValue")
 
       render(<NumberInput {...props} />)
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyPress(screen.getByTestId("stNumberInputField"), {
-        key: "Enter",
-      })
+      await user.type(screen.getByTestId("stNumberInputField"), "{enter}")
 
       expect(props.widgetMgr.setIntValue).toHaveBeenCalled()
     })
 
-    it("can pass fragmentId to setIntValue", () => {
+    it("can pass fragmentId to setIntValue", async () => {
+      const user = userEvent.setup()
       const props = {
         ...getIntProps({ default: 10 }),
         fragmentId: "myFragmentId",
@@ -474,11 +464,7 @@ describe("NumberInput widget", () => {
 
       render(<NumberInput {...props} />)
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyPress(screen.getByTestId("stNumberInputField"), {
-        key: "Enter",
-      })
+      await user.type(screen.getByTestId("stNumberInputField"), "{enter}")
 
       expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
         expect.anything(),
@@ -500,47 +486,45 @@ describe("NumberInput widget", () => {
 
   describe("Step", () => {
     describe("rapid interactions", () => {
-      it("handles stepUp button clicks correctly", () => {
+      it("handles stepUp button clicks correctly", async () => {
+        const user = userEvent.setup()
         const props = getIntProps({ default: 10, step: 1 })
         render(<NumberInput {...props} />)
 
         const stepUpButton = screen.getByTestId("stNumberInputStepUp")
         for (let i = 0; i < 5; i++) {
-          // TODO: Utilize user-event instead of fireEvent
-          // eslint-disable-next-line testing-library/prefer-user-event
-          fireEvent.click(stepUpButton)
+          await user.click(stepUpButton)
         }
         expect(screen.getByTestId("stNumberInputField")).toHaveValue(15)
       })
 
-      it("handles stepDown button clicks correctly", () => {
+      it("handles stepDown button clicks correctly", async () => {
+        const user = userEvent.setup()
         const props = getIntProps({ default: 10, step: 1 })
         render(<NumberInput {...props} />)
 
         const stepDownButton = screen.getByTestId("stNumberInputStepDown")
         for (let i = 0; i < 5; i++) {
-          // TODO: Utilize user-event instead of fireEvent
-          // eslint-disable-next-line testing-library/prefer-user-event
-          fireEvent.click(stepDownButton)
+          await user.click(stepDownButton)
         }
         expect(screen.getByTestId("stNumberInputField")).toHaveValue(5)
       })
     })
 
-    it("passes the step prop", () => {
+    it("passes the step prop", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({ default: 10, step: 1 })
       render(<NumberInput {...props} />)
 
       // Increment
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(screen.getByTestId("stNumberInputStepUp"))
+      await user.click(screen.getByTestId("stNumberInputStepUp"))
 
       // Check step properly enforced
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(11)
     })
 
-    it("changes state on ArrowUp", () => {
+    it("changes state on ArrowUp", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -549,15 +533,12 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       const numberInput = screen.getByTestId("stNumberInputField")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(numberInput, {
-        key: "ArrowUp",
-      })
+      await user.type(numberInput, "{arrowup}")
       expect(numberInput).toHaveValue(11)
     })
 
-    it("changes state on ArrowDown", () => {
+    it("changes state on ArrowDown", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -566,15 +547,12 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       const numberInput = screen.getByTestId("stNumberInputField")
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(numberInput, {
-        key: "ArrowDown",
-      })
+      await user.type(numberInput, "{arrowdown}")
       expect(numberInput).toHaveValue(9)
     })
 
-    it("handles stepDown button clicks", () => {
+    it("handles stepDown button clicks", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -583,13 +561,12 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       // Decrement
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(screen.getByTestId("stNumberInputStepDown"))
+      await user.click(screen.getByTestId("stNumberInputStepDown"))
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(9)
     })
 
-    it("handles stepUp button clicks", () => {
+    it("handles stepUp button clicks", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -598,37 +575,33 @@ describe("NumberInput widget", () => {
       render(<NumberInput {...props} />)
 
       // Increment
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(screen.getByTestId("stNumberInputStepUp"))
+      await user.click(screen.getByTestId("stNumberInputStepUp"))
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(11)
     })
 
-    it("disables stepDown button when at min", () => {
+    it("disables stepDown button when at min", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({ default: 1, step: 1, min: 0, hasMin: true })
       render(<NumberInput {...props} />)
 
       const stepDownButton = screen.getByTestId("stNumberInputStepDown")
       expect(stepDownButton).not.toBeDisabled()
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(stepDownButton)
+      await user.click(stepDownButton)
 
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(0)
       expect(stepDownButton).toBeDisabled()
     })
 
-    it("disables stepUp button when at max", () => {
+    it("disables stepUp button when at max", async () => {
+      const user = userEvent.setup()
       const props = getIntProps({ default: 1, step: 1, max: 2, hasMax: true })
       render(<NumberInput {...props} />)
 
       const stepUpButton = screen.getByTestId("stNumberInputStepUp")
       expect(stepUpButton).not.toBeDisabled()
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(stepUpButton)
+      await user.click(stepUpButton)
 
       expect(screen.getByTestId("stNumberInputField")).toHaveValue(2)
       expect(stepUpButton).toBeDisabled()
@@ -682,17 +655,18 @@ describe("NumberInput widget", () => {
   })
 
   it("focuses input when clicking label", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<NumberInput {...props} />)
     const numberInput = screen.getByTestId("stNumberInputField")
     expect(numberInput).not.toHaveFocus()
     const label = screen.getByText(props.element.label)
-    const user = userEvent.setup()
     await user.click(label)
     expect(numberInput).toHaveFocus()
   })
 
-  it("ensures id doesn't change on rerender", () => {
+  it("ensures id doesn't change on rerender", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     render(<NumberInput {...props} />)
 
@@ -702,11 +676,8 @@ describe("NumberInput widget", () => {
     // Make some change to cause a rerender
     const numberInput = screen.getByTestId("stNumberInputField")
     // Change the widget value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(numberInput, {
-      target: { value: 15 },
-    })
+    await user.clear(numberInput)
+    await user.type(numberInput, "15")
     expect(screen.getByTestId("stNumberInputField")).toHaveValue(15)
 
     const numberInputLabel2 = screen.getByTestId("stWidgetLabel")

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -16,7 +16,8 @@
 
 import React from "react"
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -165,16 +166,15 @@ describe("Radio widget", () => {
     expect(noOptionLabel).toBeInTheDocument()
   })
 
-  it("sets the widget value when an option is selected", () => {
+  it("sets the widget value when an option is selected", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setIntValue")
     render(<Radio {...props} />)
     const radioOptions = screen.getAllByRole("radio")
     const secondOption = radioOptions[1]
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(secondOption)
+    await user.click(secondOption)
 
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
@@ -185,7 +185,8 @@ describe("Radio widget", () => {
     expect(secondOption).toBeChecked()
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -197,9 +198,7 @@ describe("Radio widget", () => {
     const secondOption = radioOptions[1]
 
     // Change the widget value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(secondOption)
+    await user.click(secondOption)
     expect(secondOption).toBeChecked()
 
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -16,8 +16,8 @@
 
 import React from "react"
 
-import { fireEvent, screen } from "@testing-library/react"
-import { act } from "react-dom/test-utils"
+import { act, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render } from "@streamlit/lib/src/test_util"
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
@@ -153,7 +153,8 @@ describe("TimeInput widget", () => {
     expect(inputNode).toBeInTheDocument()
   })
 
-  it("sets the widget value on change", () => {
+  it("sets the widget value on change", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setStringValue")
 
@@ -164,17 +165,11 @@ describe("TimeInput widget", () => {
     // Change the widget value
     if (timeDisplay) {
       // Select the time input dropdown
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(timeDisplay)
+      await user.click(timeDisplay)
       // Arrow up from 12:45 to 12:30 (since step in 15 min intervals)
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(timeDisplay, { key: "ArrowUp", code: 38 })
+      await user.keyboard("{ArrowUp}")
       // Hit enter to select the new time
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(timeDisplay, { key: "Enter", code: 13 })
+      await user.keyboard("{Enter}")
     }
 
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
@@ -188,7 +183,8 @@ describe("TimeInput widget", () => {
     expect(timeDisplay).toHaveTextContent("12:30")
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -202,20 +198,11 @@ describe("TimeInput widget", () => {
     // Change the widget value
     if (timeDisplay) {
       // Select the time input dropdown
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(timeDisplay)
+      await user.click(timeDisplay)
       // Arrow down twice from 12:45 to 13:15 (since step in 15 min intervals)
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(timeDisplay, { key: "ArrowDown", code: 40 })
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(timeDisplay, { key: "ArrowDown", code: 40 })
+      await user.keyboard("{ArrowDown}{ArrowDown}")
       // Hit enter to select the new time
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(timeDisplay, { key: "Enter", code: 13 })
+      await user.keyboard("{Enter}")
     }
 
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -17,7 +17,8 @@
 import React, { FC } from "react"
 
 import { act, renderHook } from "@testing-library/react-hooks"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import { Form } from "@streamlit/lib/src/components/widgets/Form"
@@ -79,6 +80,7 @@ describe("useWidgetManagerElementState hook", () => {
   })
 
   it("should properly clear state on form clear", async () => {
+    const user = userEvent.setup()
     const formId = "formId"
     const stateKey = "stateKey"
     const defaultValue = "initial"
@@ -133,9 +135,8 @@ describe("useWidgetManagerElementState hook", () => {
     expect(widgetMgr.getElementState(elementId, stateKey)).toBe(defaultValue)
 
     // change the input value
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(inputElement, { target: { value: newValue } })
+    await user.clear(inputElement)
+    await user.type(inputElement, newValue)
 
     // verify new value is set
     expect(inputElement.value).toBe(newValue)


### PR DESCRIPTION
## Describe your changes

- Migrates a vast majority of test files to utilize `userEvent` rather than `fireEvent`.
- Before this, there were 200 usages of `fireEvent`. After, there are 38, representing an **81% decrease**.
  - Any remaining usages of `fireEvent` require some extra changes to get them to work with `userEvent`. I decided this was out of scope for this PR since I wanted this to not touch any source, and be non-invasive/repetitive as possible
- As a reminder for why `userEvent` is preferred over `fireEvent`, read [this section on their docs](https://testing-library.com/docs/user-event/intro/#differences-from-fireevent)

## GitHub Issue Link (if applicable)

## Testing Plan

- This updates vitest tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
