### PR TITLE
[fix] Ensure all e2e_playwright artifacts are relative to git root

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -49,6 +49,7 @@ from playwright.sync_api import (
 )
 from pytest import FixtureRequest
 
+from e2e_playwright.shared.git_utils import get_git_root
 from e2e_playwright.shared.performance import (
     is_supported_browser,
     measure_performance,
@@ -570,7 +571,9 @@ def output_folder(pytestconfig: Any) -> Path:
     - snapshot-updates: This directory contains all the snapshots that got updated in
     the current run based on folder structure used in the main snapshots folder.
     """
-    return Path(pytestconfig.getoption("--output")).resolve()
+    return Path(
+        get_git_root() / "e2e_playwright" / pytestconfig.getoption("--output")
+    ).resolve()
 
 
 @pytest.fixture(scope="function")
@@ -578,12 +581,14 @@ def assert_snapshot(
     request: FixtureRequest, output_folder: Path
 ) -> Generator[ImageCompareFunction, None, None]:
     """Fixture that compares a screenshot with screenshot from a past run."""
-    root_path = Path(os.getcwd()).resolve()
+    root_path = get_git_root()
     platform = str(sys.platform)
     module_name = request.module.__name__.split(".")[-1]
     test_function_name = request.node.originalname
 
-    snapshot_dir: Path = root_path / "__snapshots__" / platform / module_name
+    snapshot_dir: Path = (
+        root_path / "e2e_playwright" / "__snapshots__" / platform / module_name
+    )
 
     module_snapshot_failures_dir: Path = (
         output_folder / "snapshot-tests-failures" / platform / module_name

--- a/e2e_playwright/shared/git_utils.py
+++ b/e2e_playwright/shared/git_utils.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from pathlib import Path
+
+
+def get_git_root() -> Path:
+    """Get the root directory of the git repository."""
+    return Path(
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+        .strip()
+        .decode("utf-8")
+    )

--- a/e2e_playwright/shared/git_utils.py
+++ b/e2e_playwright/shared/git_utils.py
@@ -18,8 +18,11 @@ from pathlib import Path
 
 def get_git_root() -> Path:
     """Get the root directory of the git repository."""
-    return Path(
-        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
-        .strip()
-        .decode("utf-8")
-    )
+    try:
+        return Path(
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+            .strip()
+            .decode("utf-8")
+        )
+    except subprocess.CalledProcessError:
+        raise RuntimeError("Not a git repository or git is not installed.")

--- a/e2e_playwright/shared/performance.py
+++ b/e2e_playwright/shared/performance.py
@@ -20,6 +20,8 @@ import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+from e2e_playwright.shared.git_utils import get_git_root
+
 if TYPE_CHECKING:
     from playwright.sync_api import Page
 
@@ -121,12 +123,18 @@ def measure_performance(
         captured_traces = captured_traces_result.get("value", "{}")
         parsed_captured_traces = json.loads(captured_traces)
 
+        performance_results_dir = os.path.join(
+            get_git_root(), "e2e_playwright", "performance-results"
+        )
+
         # Ensure the directory exists
-        os.makedirs("./performance-results", exist_ok=True)
+        os.makedirs(performance_results_dir, exist_ok=True)
 
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
-        with open(f"./performance-results/{timestamp}_{test_name}.json", "w") as f:
+        with open(
+            os.path.join(performance_results_dir, f"{timestamp}_{test_name}.json"), "w"
+        ) as f:
             json.dump(
                 {
                     "metrics": metrics_response["metrics"],


### PR DESCRIPTION
## Describe your changes

- Previously, artifact directories for `e2e_playwright` jobs: `test-results`, `performance-results` and `__snapshots__` were relative to the pwd when the commands were run.
- This PR ensures they are always relative to the git root so that the commands will output into the same location regardless of the pwd

## GitHub Issue Link (if applicable)

## Testing Plan

- Manually tested + covered by CI artifacts

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
