### PR TITLE
Replace deprecated ReactDOM.render API

### DIFF
--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -19,7 +19,7 @@ const streamlitExecutionStartedAt = Date.now()
 
 import React from "react"
 
-import ReactDOM from "react-dom"
+import { createRoot } from "react-dom/client"
 import { Client as Styletron } from "styletron-engine-atomic"
 import { Provider as StyletronProvider } from "styletron-react"
 
@@ -27,12 +27,12 @@ import ThemedApp from "./ThemedApp"
 
 const engine = new Styletron({ prefix: "st-" })
 
-// TODO: Deprecated in React 18 - Need to revise to new API
-// react-18-upgrade
-// eslint-disable-next-line react/no-deprecated
-ReactDOM.render(
-  <StyletronProvider value={engine}>
-    <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
-  </StyletronProvider>,
-  document.getElementById("root")
-)
+const container = document.getElementById("root")
+if (container) {
+  const root = createRoot(container)
+  root.render(
+    <StyletronProvider value={engine}>
+      <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
+    </StyletronProvider>
+  )
+}


### PR DESCRIPTION
## Describe your changes

Fixes a deprecation warning:
<img width="1704" alt="Screenshot 2024-12-17 at 22 40 28" src="https://github.com/user-attachments/assets/2eb3eef3-057e-478e-9810-b7edd89504a8" />

See docs: https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
