### PR TITLE
[test] Add dedicated playwright-performance CI job

### DIFF
--- a/.github/workflows/playwright-performance.yml
+++ b/.github/workflows/playwright-performance.yml
@@ -1,0 +1,62 @@
+name: Playwright E2E Tests - Performance
+
+on:
+  push:
+    branches:
+      - "develop"
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Allows workflow to be called from other workflows
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+# Avoid duplicate workflows on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-playwright-performance
+  cancel-in-progress: true
+
+jobs:
+  playwright-e2e-tests:
+    runs-on: ubuntu-latest-8-cores
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: 2
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+      - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_MAX_VERSION }}"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+      - name: Install playwright
+        run: python -m playwright install --with-deps
+      - name: Run make frontend-build-with-profiler
+        run: make frontend-build-with-profiler
+      - name: Run make playwright-performance
+        run: make playwright-performance
+      - name: Upload failed test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright_test_results
+          path: e2e_playwright/test-results
+      - name: Upload performance results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright_performance_results
+          path: e2e_playwright/performance-results

--- a/Makefile
+++ b/Makefile
@@ -251,10 +251,10 @@ check-protoc:
 	PROTOC_VERSION=$$(protoc --version | cut -d ' ' -f 2); \
 	\
 	if [[ $$(echo -e "$$PROTOC_VERSION\n$(MIN_PROTOC_VERSION)" | sort -V | head -n1) != $(MIN_PROTOC_VERSION) ]]; then \
-	  echo "Error: protoc version $${PROTOC_VERSION} is < $(MIN_PROTOC_VERSION)"; \
-	  exit 1; \
+		echo "Error: protoc version $${PROTOC_VERSION} is < $(MIN_PROTOC_VERSION)"; \
+		exit 1; \
 	else \
-	  echo "protoc version $${PROTOC_VERSION} is >= than $(MIN_PROTOC_VERSION)"; \
+		echo "protoc version $${PROTOC_VERSION} is >= than $(MIN_PROTOC_VERSION)"; \
 	fi
 
 .PHONY: protobuf
@@ -342,7 +342,14 @@ custom_components_test_folder = ./custom_components
 playwright:
 	cd e2e_playwright; \
 	rm -rf ./test-results; \
-	pytest --ignore ${custom_components_test_folder} --browser webkit --browser chromium --browser firefox --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto --reruns 1 --reruns-delay 1 --rerun-except "Missing snapshot" --durations=5 -r aR -v
+	pytest --ignore ${custom_components_test_folder} --browser webkit --browser chromium --browser firefox --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto --reruns 1 --reruns-delay 1 --rerun-except "Missing snapshot" --durations=5 -r aR -v -m "not performance"
+
+.PHONY: playwright-performance
+playwright-performance:
+	cd e2e_playwright; \
+	rm -rf ./test-results; \
+	pytest --browser chromium --output ./test-results/ -n 1 --reruns 1 --reruns-delay 1 --rerun-except "Missing snapshot" --durations=5 -r aR -v -m "performance" --count=10
+
 .PHONY: playwright-custom-components
 # Run playwright custom component E2E tests.
 playwright-custom-components:

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     early: prioritize the execution of a fixture
+    performance: performance tests
 filterwarnings =
     # PyTest filter syntax cheatsheet -> action:message:category:module:line
     ignore::UserWarning:altair.*:

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
@@ -22,6 +23,7 @@ from e2e_playwright.shared.app_utils import (
 )
 
 
+@pytest.mark.performance
 def test_form_input_performance(app: Page):
     """
     Tests the re-render performance when typing in an input that is in a form.

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -31,4 +31,4 @@ pixelmatch>=0.3.0
 pytest-xdist
 pytest-rerunfailures
 pytest-github-actions-annotate-failures
-
+pytest-repeat==0.9.3


### PR DESCRIPTION
## Describe your changes

- Moves Playwright tests that have the `@pytest.marker.performance` to a dedicated CI job that runs them 10 times in a controlled environment to reduce variance
- The output of this job is then used to feed the CI perf regression suite (see the follow-up that builds on top of this: https://github.com/streamlit/streamlit/pull/10127)

## GitHub Issue Link (if applicable)

## Testing Plan

- This is a net-new test job in CI

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
