### PR TITLE
Adopt new normalize file type API for chat input

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, cast, overload
 
 from streamlit import runtime
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
+from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
 from streamlit.elements.lib.form_utils import is_in_form
 from streamlit.elements.lib.image_utils import AtomicImage, WidthBehavior, image_to_url
 from streamlit.elements.lib.policies import check_widget_policies
@@ -470,23 +471,7 @@ class ChatMixin:
         )
 
         if file_type:
-            if isinstance(file_type, str):
-                file_type = [file_type]
-
-            # May need a regex or a library to validate file types are valid
-            # extensions.
-            file_type = [
-                file_type_entry if file_type_entry[0] == "." else f".{file_type_entry}"
-                for file_type_entry in file_type
-            ]
-
-            file_type = [t.lower() for t in file_type]
-
-            for x, y in TYPE_PAIRS:
-                if x in file_type and y not in file_type:
-                    file_type.append(y)
-                if y in file_type and x not in file_type:
-                    file_type.append(x)
+            file_type = normalize_upload_file_type(file_type)
 
         # It doesn't make sense to create a chat input inside a form.
         # We throw an error to warn the user about this.

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -280,31 +280,9 @@ class ChatTest(DeltaGeneratorTestCase):
 
     def test_file_type(self):
         """Test that it can be called using string(s) for type parameter."""
-        st.chat_input("Placeholder", file_type="png")
+        st.chat_input(file_type="png")
         c = self.get_delta_from_queue().new_element.chat_input
         self.assertEqual(c.file_type, [".png"])
-
-        st.chat_input("Placeholder", file_type=["png", ".svg", "foo"])
-        c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.file_type, [".png", ".svg", ".foo"])
-
-    def test_jpg_expansion(self):
-        """Test that it adds jpeg when passing in just jpg (and vice versa)."""
-        st.chat_input("Placeholder", file_type=["png", ".jpg"])
-
-        c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.file_type, [".png", ".jpg", ".jpeg"])
-
-        st.chat_input("Placeholder", file_type=["jpeg"])
-
-        c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.file_type, [".jpeg", ".jpg"])
-
-        # Test that it can expand jpg to jpeg even with uppercase
-        st.chat_input("Placeholder", file_type=[".JpG"])
-
-        c = self.get_delta_from_queue().new_element.chat_input
-        self.assertEqual(c.file_type, [".jpg", ".jpeg"])
 
     @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
     def test_multiple_files(self, deserialize_patch):


### PR DESCRIPTION
## Describe your changes

* Used the new normalize file type API introduced in #9986
* Cleaned up tests covered by `file_uploader_utils_test.py`


## GitHub Issue Link (if applicable)

## Testing Plan

- pytests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
