### PR TITLE
Add back `CONTRIBUTING.md` with shortened text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+🎉 Thanks for your interest in helping improve Streamlit! 🎉
+
+Before contributing, please read our guidelines here: https://github.com/streamlit/streamlit/wiki/Contributing

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Deploy, manage and share your apps for free using our [Community Cloud](https://
 <img src="https://user-images.githubusercontent.com/7164864/214965336-64500db3-0d79-4a20-8052-2dda883902d2.gif" width="400"></img>
 
 ## Resources
+
 - Explore our [docs](https://docs.streamlit.io) to learn how Streamlit works.
 - Ask questions and get help in our [community forum](https://discuss.streamlit.io).
 - Read our [blog](https://blog.streamlit.io) for tips from developers and creators.
@@ -128,14 +129,11 @@ Deploy, manage and share your apps for free using our [Community Cloud](https://
 ```
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://share.streamlit.io/streamlit/roadmap)
 
-## Contribute 
+## Contribute
+
 🎉 Thanks for your interest in helping improve Streamlit! 🎉
 
 Before contributing, please read our guidelines here: https://github.com/streamlit/streamlit/wiki/Contributing
-
-As with most projects, prior to starting to code on a bug fix or feature request, please post in the respective Github issue saying you want to volunteer and then wait for a positive response. Ff there is no issue for it yet, create one first.
-
-This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by the community together with Streamlit's maintainers.
 
 ## License
 


### PR DESCRIPTION
## Describe your changes

https://github.com/streamlit/streamlit/pull/10051 added info about contributing to Streamlit to the Readme and removed the `CONTRIBUTING.md` file. However, the `CONTRIBUTING.md` is one of the [default repo health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) in Github with some deeper integrations. Therefore, it might still be useful to keep this file in our repo. This PR adds it back with a shortend version that links to our wiki. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
