### PR TITLE
Add save_update_message method to caching to allow caching of block-type updates

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -555,9 +555,16 @@ class DeltaGenerator(
             invoked_dg_id=self.id,
             used_dg_id=dg.id,
             returned_dg_id=block_dg.id,
+            dg_type=dg_type,
         )
 
         return block_dg
+
+
+class MutableDeltaGenerator(DeltaGenerator):
+    def _get_delta_path(self) -> list[int]:
+        """Returns the container's own delta path (stored at creation time),
+        allowing it to be overwritten at a later time."""
 
 
 def _writes_directly_to_sidebar(dg: DeltaGenerator) -> bool:

--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -32,7 +32,9 @@ from streamlit.runtime.caching.legacy_cache_api import cache as _cache
 if TYPE_CHECKING:
     from google.protobuf.message import Message
 
+    from streamlit.delta_generator import DeltaGenerator
     from streamlit.proto.Block_pb2 import Block
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 
 def save_element_message(
@@ -59,17 +61,30 @@ def save_block_message(
     invoked_dg_id: str,
     used_dg_id: str,
     returned_dg_id: str,
+    dg_type: type[DeltaGenerator],
 ) -> None:
     """Save the message for a block to a thread-local callstack, so it can
     be used later to replay the block when a cache-decorated function's
     execution is skipped.
     """
     CACHE_DATA_MESSAGE_REPLAY_CTX.save_block_message(
-        block_proto, invoked_dg_id, used_dg_id, returned_dg_id
+        block_proto, invoked_dg_id, used_dg_id, returned_dg_id, dg_type
     )
     CACHE_RESOURCE_MESSAGE_REPLAY_CTX.save_block_message(
-        block_proto, invoked_dg_id, used_dg_id, returned_dg_id
+        block_proto, invoked_dg_id, used_dg_id, returned_dg_id, dg_type
     )
+
+
+def save_update_message(
+    message_proto: ForwardMsg,
+    invoked_dg_id: str,
+) -> None:
+    """Save the message updating an existing block to a thread-local call stack,
+    so that it can be used later to replay the same update message when a cache-
+    decorated function's execution is skipped.
+    """
+    CACHE_DATA_MESSAGE_REPLAY_CTX.save_update_message(message_proto, invoked_dg_id)
+    CACHE_RESOURCE_MESSAGE_REPLAY_CTX.save_update_message(message_proto, invoked_dg_id)
 
 
 def save_media_data(image_data: bytes | str, mimetype: str, image_id: str) -> None:


### PR DESCRIPTION
## Describe your changes

Possible fix for GH-10025. This change introduces a new cached replay message type (`BlockUpdateMessage`) and new replay logic to allow rewriting a previously-cached `ForwardMsg` used to update an element (such as a `StatusContainer`) at an existing `delta_path`.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/10025

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) - TODO
- E2E Tests - TODO
- Any manual testing needed?

Can test with this script
```python
import streamlit as st

@st.cache_data
def cached_update():
    stat = st.status("status block")
    stat.update(state="complete")
    stat.update(label="status block complete")

try:
    cached_update()
except Exception as exc:
    st.exception(exc)
```
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
