### PR TITLE
Add size limitation note to audio_input

### DIFF
--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -159,9 +159,16 @@ class AudioInputMixin:
         Returns
         -------
         None or UploadedFile
-            The UploadedFile class is a subclass of BytesIO, and therefore is
-            "file-like". This means you can pass an instance of it anywhere a
-            file is expected. The MIME type for the audio data is ``audio/wav``.
+            The ``UploadedFile`` class is a subclass of ``BytesIO``, and
+            therefore is "file-like". This means you can pass an instance of it
+            anywhere a file is expected. The MIME type for the audio data is
+            ``audio/wav``.
+
+            .. Note::
+                The resulting ``UploadedFile`` is subject to the size
+                limitation configured in ``server.maxUploadSize``. If you
+                expect large sound files, update the configuration option
+                appropriately.
 
         Examples
         --------


### PR DESCRIPTION
## Describe your changes
Docstring update to add size limitation note to `st.audio_input`

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/04da7224-16f3-4f05-a54e-acee4766277b" />


## GitHub Issue Link (if applicable)
Closes #9717

## Testing Plan
None. Docstring only.


**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
