### PR TITLE
[WIP] Allow file type shortcuts in `st.file_uploader`

### DIFF
--- a/e2e_playwright/st_file_uploader.py
+++ b/e2e_playwright/st_file_uploader.py
@@ -15,7 +15,7 @@
 import streamlit as st
 from streamlit import runtime
 
-single_file = st.file_uploader("Drop a file:", type=["txt"], key="single")
+single_file = st.file_uploader("Drop a file:", type=["txt", "image"], key="single")
 if single_file is None:
     st.text("No upload")
 else:

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -52,7 +52,7 @@ const FileDropzoneInstructions = ({
         {`Limit ${getSizeDisplay(maxSizeBytes, FileSize.Byte, 0)} per file`}
         {acceptedExtensions.length
           ? ` • ${acceptedExtensions
-              .map(ext => ext.replace(/^\./, "").toUpperCase())
+              .map(ext => ext.replace(/^\.|\/\*$/g, "").toUpperCase())
               .join(", ")}`
           : null}
       </Small>

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -24,19 +24,23 @@ TYPE_PAIRS = [
     (".htm", ".html"),
 ]
 
+ALLOWED_MIME_TYPES = ["image", "audio", "video", "text"]
+
 
 def normalize_upload_file_type(file_type: str | Sequence[str]) -> Sequence[str]:
     if isinstance(file_type, str):
         file_type = [file_type]
 
-    # May need a regex or a library to validate file types are valid
-    # extensions.
+    file_type = [t.lower() for t in file_type]
+
+    # Convert mime types to wildcard format, otherwise add dot prefix.
+    # Note that we are not checking here if the file extension is valid.
     file_type = [
-        file_type_entry if file_type_entry[0] == "." else f".{file_type_entry}"
+        f"{file_type_entry}/*"
+        if file_type_entry in ALLOWED_MIME_TYPES
+        else (file_type_entry if file_type_entry[0] == "." else f".{file_type_entry}")
         for file_type_entry in file_type
     ]
-
-    file_type = [t.lower() for t in file_type]
 
     for x, y in TYPE_PAIRS:
         if x in file_type and y not in file_type:

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -263,8 +263,15 @@ class FileUploaderMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         type : str, list of str, or None
-            Array of allowed extensions. ['png', 'jpg']
-            The default is None, which means all extensions are allowed.
+            The allowed file types. This can be one of the following:
+
+            - None, which allows all file types to be uploaded.
+            - ``"image"``, ``"audio"``, ``"video"``, or ``"text"`` to allow all files of
+              that type. Note that different browsers may allow different file
+              extensions for these types.
+            - A single file extension, e.g. ``"png"`` or ``".png"``.
+            - A list of any of the above, e.g. ``["png", "jpg"]`` or
+              ``["image", ".csv"]``.
 
         accept_multiple_files : bool
             If True, allows the user to upload multiple files at the same time,

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -262,7 +262,7 @@ class FileUploaderMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        type : str or list of str or None
+        type : str, list of str, or None
             Array of allowed extensions. ['png', 'jpg']
             The default is None, which means all extensions are allowed.
 

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -58,12 +58,19 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, [".png"])
 
-    def test_multiple_types(self):
-        """Test that it can be called using an array for type parameter."""
-        st.file_uploader("the label", type=["png", ".svg", "foo"])
+    def test_single_mime_type(self):
+        """Test that it can be called using a mime type string for type parameter."""
+        st.file_uploader("the label", type="image")
 
         c = self.get_delta_from_queue().new_element.file_uploader
-        self.assertEqual(c.type, [".png", ".svg", ".foo"])
+        self.assertEqual(c.type, ["image/*"])
+
+    def test_multiple_types(self):
+        """Test that it can be called using an array for type parameter."""
+        st.file_uploader("the label", type=["png", ".svg", "foo", "audio"])
+
+        c = self.get_delta_from_queue().new_element.file_uploader
+        self.assertEqual(c.type, [".png", ".svg", ".foo", "audio/*"])
 
     def test_jpg_expansion(self):
         """Test that it adds jpg when passing in just jpeg (and vice versa)."""


### PR DESCRIPTION
## Describe your changes

Adds support for `"image"`, `"audio"`, `"video"`, and `"text"` for the `type` parameter in `st.file_uploader`.

## GitHub Issue Link (if applicable)

## Testing Plan

- Added a unit test for one of the types above as well as a combination with other file types. 
- Added to an existing e2e test, just to check that the display is correct. I don't think we need an extra e2e test for this as the functionality is fairly small and we also don't have e2e tests for different file extension combinations. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
