### PR TITLE
[WIP] Make `st.navigation` accept functions or file paths instead of `st.Page`

### DIFF
--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -55,8 +55,8 @@ def send_page_not_found(ctx: ScriptRunContext):
 
 @gather_metrics("navigation")
 def navigation(
-    pages: list[StreamlitPage | str | callable]
-    | dict[SectionHeader, list[StreamlitPage | str | callable]],
+    pages: list[StreamlitPage | str | Path | callable]
+    | dict[SectionHeader, list[StreamlitPage | str | Path | callable]],
     *,
     position: Literal["sidebar", "hidden"] = "sidebar",
     expanded: bool = False,
@@ -84,7 +84,7 @@ def navigation(
 
     Parameters
     ----------
-    pages : list[StreamlitPage | str | callable] or dict[str, list[StreamlitPage | str | callable]]
+    pages : list[StreamlitPage | str | Path | callable] or dict[str, list[StreamlitPage | str | Path | callable]]
         The available pages for the app. Can be:
         - StreamlitPage objects created with st.Page()
         - Strings representing paths to Python files

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -84,11 +84,12 @@ def navigation(
 
     Parameters
     ----------
-    pages : list[StreamlitPage | str | Path | callable] or dict[str, list[StreamlitPage | str | Path | callable]]
-        The available pages for the app. Can be:
-        - StreamlitPage objects created with st.Page()
-        - Strings representing paths to Python files
-        - Callable functions that define a page
+    pages : list of `st.Page`, str, Path, callable, or a dict mapping str to such lists
+        The pages to show in the navigation element. This can be one of the following:
+        - A list of `st.Page` objects, strings or `pathlib.Path` objects pointing to
+          the page files, or callable functions that define a page.
+        - A dictionary with section headers as keys and lists of pages as values
+          (same types as above).
 
     position : "sidebar" or "hidden"
         The position of the navigation menu. If ``position`` is ``"sidebar"``

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -86,8 +86,9 @@ def navigation(
     ----------
     pages : list of `st.Page`, str, Path, callable, or a dict mapping str to such lists
         The pages to show in the navigation element. This can be one of the following:
-        - A list of `st.Page` objects, strings or `pathlib.Path` objects pointing to
-          the page files, or callable functions that define a page.
+        - A list of pages, represented by `st.Page` objects, strings or
+          `pathlib.Path` objects pointing to the page files, or callable functions
+          that define a page.
         - A dictionary with section headers as keys and lists of pages as values
           (same types as above).
 


### PR DESCRIPTION
## Describe your changes

Today, you always need to pass a list or dict of `st.Page` objects to `st.navigation`. This can be annoying when building a quick example where you don't need to customize the page title or icon, and therefore don't really need `st.Page`. With this PR, you can directly pass a (list or dict of) functions or string file paths to `st.navigation`, and they will be wrapped in `st.Page` under the hood. 

## GitHub Issue Link (if applicable)

Closes #10069

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
