### PR TITLE
Add `make update-snapshots-changed` to update snapshots for changed files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,11 @@ playwright-custom-components:
 update-snapshots:
 	python ./scripts/update_e2e_snapshots.py
 
+.PHONY: update-snapshots-changed
+# Update e2e playwright snapshots of changed files based on the latest completed CI run.
+update-snapshots-changed:
+	python ./scripts/update_e2e_snapshots.py --changed
+
 .PHONY: update-material-icons
 # Update material icon names and font file based on latest google material symbol rounded font version.
 update-material-icons:

--- a/scripts/update_e2e_snapshots.py
+++ b/scripts/update_e2e_snapshots.py
@@ -31,6 +31,7 @@ SNAPSHOT_UPDATE_FOLDER = "snapshot-updates"
 GITHUB_OWNER = "streamlit"
 GITHUB_REPO = "streamlit"
 GITHUB_WORKFLOW_FILE_NAME = "playwright.yml"
+GITHUB_WORKFLOW_FILE_NAME_CHANGED_FILES = "playwright-changed-files.yml"
 PLAYWRIGHT_RESULT_ARTIFACT_NAME = "playwright_test_results"
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 E2E_SNAPSHOTS_DIR = os.path.join(BASE_DIR, "e2e_playwright", "__snapshots__")
@@ -201,6 +202,11 @@ def main() -> None:
         required=False,
         help="GitHub Personal Access Token (only requires the repo/public_repo scope)",
     )
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Only update snapshots for changed files",
+    )
     args = parser.parse_args()
     token = args.token
 
@@ -233,8 +239,13 @@ def main() -> None:
         print(f"Current head SHA: {commit_sha}")
 
         # Wait for the workflow to complete with status 'failure'
+        workflow_file_name = (
+            GITHUB_WORKFLOW_FILE_NAME_CHANGED_FILES
+            if args.changed
+            else GITHUB_WORKFLOW_FILE_NAME
+        )
         workflow_run = wait_for_workflow_completion(
-            GITHUB_OWNER, GITHUB_REPO, GITHUB_WORKFLOW_FILE_NAME, commit_sha, token
+            GITHUB_OWNER, GITHUB_REPO, workflow_file_name, commit_sha, token
         )
         run_id = workflow_run["id"]
         print(f"Found completed workflow run with ID: {run_id}")


### PR DESCRIPTION
## Describe your changes

Today, we have `make update-snapshots` to download changed snapshots from the GitHub action that runs our e2e tests. These tests take quite long to complete though, so you need to wait a while before updating snapshots. 

We also have another GitHub action that runs the e2e tests only for changed files. This PR adds a new command `make update-snapshots-changed` that donwloads and updates the snapshots from that GitHub action. This can make it faster to update snapshots. 

## GitHub Issue Link (if applicable)

## Testing Plan

No tests needed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
