### PR TITLE
[WIP] Add `sort_by` and `order` to `st.bar_chart`

### DIFF
--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -998,6 +998,8 @@ class VegaChartsMixin:
         color: str | Color | list[Color] | None = None,
         horizontal: bool = False,
         stack: bool | ChartStackType | None = None,
+        sort_by: str | None = None,
+        order: Literal["ascending", "descending"] = "ascending",
         width: int | None = None,
         height: int | None = None,
         use_container_width: bool = True,
@@ -1097,6 +1099,15 @@ class VegaChartsMixin:
               normalized to 100% of the height of the chart.
             - ``"center"``: The bars are stacked and shifted to center the
               total height around an axis.
+
+        sort_by : str or None
+            Column name to sort the bars by. If provided, bars will be sorted based on
+            the values in this column. If None (default), bars keep their original order.
+            This does not work for multiple y columns.
+
+        order : "ascending" or "descending"
+            The order to sort the bars when `sort_by` is specified. Defaults to
+            `"ascending"`.
 
         width : int or None
             Desired width of the chart expressed in pixels. If ``width`` is
@@ -1241,6 +1252,8 @@ class VegaChartsMixin:
             width=width,
             height=height,
             stack=stack,
+            sort_by=sort_by,
+            order=order,
         )
         return cast(
             "DeltaGenerator",


### PR DESCRIPTION
## Describe your changes

Today, `st.bar_chart` always sorts the bars by the data column on the X-axis (or Y-axis for a horizontal bar chart). That's not always desirable, see #7111. This PR adds the parameters `sort_by` and `order` to `st.bar_chart` to sort the bars by a different column in ascending or descending order. 

This is a cool addition that got a lot of requests (71 upvotes on the issue) and it's not really complex. But it does add 2 more parameters to our charting API and pushes us a bit further into charting library territory. I'm unsure whether we should merge this or just tell users to create their own Altair chart instead. 

![CleanShot 2024-12-26 at 04 02 25@2x](https://github.com/user-attachments/assets/290cf5ea-327f-41db-a470-6243593a4e4a)


## GitHub Issue Link (if applicable)

Closes #7111

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
