### PR TITLE
Make st.expander summary respect isStale.

### DIFF
--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -20,7 +20,7 @@ import styled from "@emotion/styled"
 
 import { StyledCheckbox } from "@streamlit/lib/src/components/widgets/Checkbox/styled-components"
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
-import { EmotionTheme } from "@streamlit/lib/src/theme"
+import { EmotionTheme, STALE_STYLES } from "@streamlit/lib/src/theme"
 
 function translateGapWidth(gap: string, theme: EmotionTheme): string {
   let gapWidth = theme.spacing.lg
@@ -87,12 +87,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
       marginBottom: `-${theme.spacing.xs}`,
     },
 
-    ...(isStale && elementType !== "skeleton"
-      ? {
-          opacity: 0.33,
-          transition: "opacity 1s ease-in 0.5s",
-        }
-      : {}),
+    ...(isStale && elementType !== "skeleton" && STALE_STYLES),
     ...(elementType === "empty"
       ? {
           // Use display: none for empty elements to avoid the flexbox gap.

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -232,7 +232,12 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   return (
     <StyledExpandableContainer className="stExpander" data-testid="stExpander">
       <StyledDetails isStale={isStale} ref={detailsRef}>
-        <StyledSummary onClick={toggle} empty={empty} ref={summaryRef}>
+        <StyledSummary
+          onClick={toggle}
+          empty={empty}
+          ref={summaryRef}
+          isStale={isStale}
+        >
           <StyledSummaryHeading>
             {element.icon && <ExpanderIcon icon={element.icon} />}
             <StreamlitMarkdown source={label} allowHTML={false} isLabel />

--- a/frontend/lib/src/components/elements/Expander/styled-components.ts
+++ b/frontend/lib/src/components/elements/Expander/styled-components.ts
@@ -15,6 +15,10 @@
  */
 
 import styled from "@emotion/styled"
+import {
+  STALE_STYLES,
+  STALE_TRANSITION_PARAMS,
+} from "@streamlit/lib/src/theme"
 
 export interface StyledExpandableContainerProps {
   empty: boolean
@@ -39,7 +43,7 @@ export const StyledDetails = styled.details<StyledDetailsProps>(
     ...(isStale
       ? {
           borderColor: theme.colors.borderColorLight,
-          transition: "border 1s ease-in 0.5s",
+          transition: `border ${STALE_TRANSITION_PARAMS}`,
         }
       : {}),
   })
@@ -54,10 +58,11 @@ export const StyledSummaryHeading = styled.span(({ theme }) => ({
 
 interface StyledSummaryProps {
   empty: boolean
+  isStale: boolean
 }
 
 export const StyledSummary = styled.summary<StyledSummaryProps>(
-  ({ theme, empty }) => ({
+  ({ theme, empty, isStale }) => ({
     position: "relative",
     display: "flex",
     width: "100%",
@@ -85,6 +90,7 @@ export const StyledSummary = styled.summary<StyledSummaryProps>(
     ...(empty && {
       cursor: "default",
     }),
+    ...(isStale && STALE_STYLES),
   })
 )
 

--- a/frontend/lib/src/components/elements/Expander/styled-components.ts
+++ b/frontend/lib/src/components/elements/Expander/styled-components.ts
@@ -15,6 +15,7 @@
  */
 
 import styled from "@emotion/styled"
+
 import {
   STALE_STYLES,
   STALE_TRANSITION_PARAMS,

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -32,6 +32,7 @@ import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
 
 import { StyledTabContainer } from "./styled-components"
+import { STALE_STYLES } from "@streamlit/lib/src/theme"
 
 export interface TabProps extends BlockPropsWithoutWidth {
   widgetsDisabled: boolean
@@ -132,12 +133,7 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
               marginBottom: `-${TAB_BORDER_HEIGHT}`,
               paddingBottom: TAB_BORDER_HEIGHT,
               overflowY: "hidden",
-              ...(isStale
-                ? {
-                    opacity: 0.33,
-                    transition: "opacity 1s ease-in 0.5s",
-                  }
-                : {}),
+              ...(isStale && STALE_STYLES),
             }),
           },
           Root: {
@@ -232,21 +228,16 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
                             : theme.colors.primary,
                         }
                       : {}),
+                    // Add minimal required padding to hide the overscroll gradient
+                    // This is calculated based on the width of the gradient (spacing.lg)
                     ...(isOverflowing && isLast
                       ? {
-                          // Add minimal required padding to hide the overscroll gradient
-                          // This is calculated based on the width of the gradient (spacing.lg)
                           paddingRight: `calc(${theme.spacing.lg} * 0.6)`,
                         }
                       : {}),
-                    ...(!isStale && isStaleTab
-                      ? {
-                          // Apply stale effect if only this specific
-                          // tab is stale but not the entire tab container.
-                          opacity: 0.33,
-                          transition: "opacity 1s ease-in 0.5s",
-                        }
-                      : {}),
+                    // Apply stale effect if only this specific
+                    // tab is stale but not the entire tab container.
+                    ...(!isStale && isStaleTab && STALE_STYLES),
                   }),
                 },
               }}

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -30,9 +30,9 @@ import { BlockPropsWithoutWidth } from "@streamlit/lib/src/components/core/Block
 import { isElementStale } from "@streamlit/lib/src/components/core/Block/utils"
 import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
+import { STALE_STYLES } from "@streamlit/lib/src/theme"
 
 import { StyledTabContainer } from "./styled-components"
-import { STALE_STYLES } from "@streamlit/lib/src/theme"
 
 export interface TabProps extends BlockPropsWithoutWidth {
   widgetsDisabled: boolean

--- a/frontend/lib/src/theme/consts.ts
+++ b/frontend/lib/src/theme/consts.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-export * from "./baseui"
-export * from "./getColors"
-export * from "./globalStyles"
-export * from "./themeConfigs"
-export * from "./types"
-export * from "./utils"
-export * from "./consts"
+export const STALE_TRANSITION_PARAMS = "1s ease-in 0.5s"
+
+export const STALE_STYLES = {
+  opacity: 0.33,
+  transition: `opacity ${STALE_TRANSITION_PARAMS}`,
+}


### PR DESCRIPTION
## Describe your changes

Today, when an app reruns, widgets turn slightly transparent to denote `isStale`. However, `st.expander`'s summary doesn't follow this behavior (i.e. the header that always shows, even when the expander is collapsed).

This PR makes `st.expander` respect `isStale` like everything else.

### Before

https://github.com/user-attachments/assets/0cb5291c-4795-4993-9556-d0a3629ea1ce


### After

https://github.com/user-attachments/assets/d82ad1ae-e2c2-42b5-977e-e69690d32642


## GitHub Issue Link (if applicable)

None

## Testing Plan

- Explanation of why no additional tests are needed:
   This behavior can only be properly tested with screenshot tests, but since the `isStale` behavior depends on timing and animations, any screenshot test is going to be flaky. The only way to reduce flakiness would be to make the test longer, and in fact I did exactly that with a 10s-long `time.sleep` a few moments ago. But I decided not to commit the test because I don't think this test case is worth the cost of slowing down our test suite by 10s. 

- Unit Tests (JS and/or Python): No
- E2E Tests: No
- Any manual testing needed? No

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
