### PR TITLE
In st.multiselect, make mouse cursor only be a pointer when hovering the X

### DIFF
--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -296,6 +296,7 @@ const Multiselect: FC<Props> = props => {
                       padding: theme.spacing.threeXS,
                       height: theme.sizes.clearIconSize,
                       width: theme.sizes.clearIconSize,
+                      cursor: "pointer",
                       ":hover": {
                         fill: theme.colors.bodyText,
                       },
@@ -327,6 +328,11 @@ const Multiselect: FC<Props> = props => {
                       // to nicely fit into the input field.
                       height: `calc(${theme.sizes.minElementHeight} - 2 * ${theme.spacing.xs})`,
                       maxWidth: `calc(100% - ${theme.spacing.lg})`,
+                      // Using !important because the alternative would be
+                      // uglier: we'd have to put it under a selector like
+                      // "&[role="button"]:not(:disabled)" in order to win in
+                      // the order of the precendence.
+                      cursor: "default !important",
                     },
                   },
                   Action: {


### PR DESCRIPTION
## Describe your changes

Today, when you hover over any part of a selected item in an `st.multiselect` you get a "👆" cursor. This is confusing because the only part of a selected item that's actually interactive is the "×" icon.

With this PR, only the "×" icon of an `st.multiselect` will show a  "👆" cursor on hover.

### Before

https://github.com/user-attachments/assets/65f5dec1-484a-468c-929e-3b519d78d7ae


### After

https://github.com/user-attachments/assets/f54cd611-3e12-43cb-83ae-a6bf5daa6ccb


## GitHub Issue Link (if applicable)

None

## Testing Plan

- Explanation of why no additional tests are needed: not sure if there's a good way to test this. Also: is it even worth tests? Not sure we should be testing _every_ cursor behavior in Streamlit...
- Unit Tests (JS and/or Python): No
- E2E Tests: No
- Any manual testing needed? **I'm not sure...** Might be good to make sure this works as intended in all browsers and OSes. But I'm not doing anything crazy here, so not really required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
