### PR TITLE
[Fix] Status Widget Test

### DIFF
--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -339,6 +339,9 @@ describe("Running Icon", () => {
   })
 
   it("delays render of running gif", () => {
+    // Set system time so test doesn't fail during New Years
+    vi.setSystemTime(new Date("January 7, 2023 00:00:00"))
+
     render(
       <StatusWidget
         {...getProps({ scriptRunState: ScriptRunState.RUNNING })}


### PR DESCRIPTION
## Describe your changes
One of our `StatusWidget` JS unit tests will fail during the New Years timeframe (between 12/31 & 1/06) where we display the fireworks gif instead of the running man gif as it tests the `img` tag's `src` attribute. This PR makes a small adjustment to the test to set the system time to ensure stability. See failure message below from nightly run [here](https://github.com/streamlit/streamlit/actions/runs/12556422755/job/35007726954):

<img width="750" alt="Screenshot 2024-12-30 at 11 54 19 PM" src="https://github.com/user-attachments/assets/c2f698ab-4fdc-4213-9ac3-8afa80238801" />

