### PR TITLE
[WIP] Remove metrics for internal exception usage

### DIFF
--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -64,8 +64,6 @@ class ExceptionMixin:
         return cast("DeltaGenerator", self)
 
 
-# TODO(lawilby): confirm whether we want to track metrics here with lukasmasuch.
-@gather_metrics("exception")
 def _exception(
     dg: DeltaGenerator,
     exception: BaseException,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -657,8 +657,7 @@ class ScriptRunnerTest(AsyncTestCase):
             patched_create_page_profile_message.assert_called_once()
             call_kwargs = patched_create_page_profile_message.call_args_list[0].kwargs
 
-            # Check the
-            assert len(call_kwargs["commands"]) == 2  # text & exception command
+            assert len(call_kwargs["commands"]) == 1  # text command
             assert call_kwargs["exec_time"] > 0
             assert call_kwargs["prep_time"] > 0
             assert call_kwargs["uncaught_exception"] == "AttributeError"


### PR DESCRIPTION
## Describe your changes

Remove tracking of metrics for our internal `_exception` command. Uncaught exceptions are already tracked via the `uncaught_exception` field and should not be tracked via the `exception` name.

The exception command has already been tracked for quite some time, also in case it was called in uncaught exceptions. Changing this might require a small change within our metrics app code.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
