### PR TITLE
Ensure that error is only logged once with rich installed

### DIFF
--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -83,17 +83,23 @@ def handle_uncaught_app_exception(ex: BaseException) -> None:
     warning in the frontend instead.
     """
 
+    error_logged = False
+
     if config.get_option("logger.enableRich"):
         try:
             # Print exception via rich
             # Rich is only a soft dependency
             # -> if not installed, we will use the default traceback formatting
             _print_rich_exception(ex)
+            error_logged = True
         except Exception:
             # Rich is not installed or not compatible to our config
             # -> Use normal traceback formatting as fallback
             # Catching all exceptions because we don't want to leave any possibility of breaking here.
-            pass
+            error_logged = False
 
-    _LOGGER.warning("Uncaught app execution", exc_info=ex)
+    if not error_logged:
+        # Only log error to console if not already logged by rich
+        _LOGGER.error("Uncaught app execution", exc_info=ex)
+
     _show_exception(ex)

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -657,8 +657,7 @@ class ScriptRunnerTest(AsyncTestCase):
             patched_create_page_profile_message.assert_called_once()
             call_kwargs = patched_create_page_profile_message.call_args_list[0].kwargs
 
-            # Check the
-            assert len(call_kwargs["commands"]) == 2  # text & exception command
+            assert len(call_kwargs["commands"]) == 1  # text command
             assert call_kwargs["exec_time"] > 0
             assert call_kwargs["prep_time"] > 0
             assert call_kwargs["uncaught_exception"] == "AttributeError"

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -657,7 +657,8 @@ class ScriptRunnerTest(AsyncTestCase):
             patched_create_page_profile_message.assert_called_once()
             call_kwargs = patched_create_page_profile_message.call_args_list[0].kwargs
 
-            assert len(call_kwargs["commands"]) == 1  # text command
+            # Check the
+            assert len(call_kwargs["commands"]) == 2  # text & exception command
             assert call_kwargs["exec_time"] > 0
             assert call_kwargs["prep_time"] > 0
             assert call_kwargs["uncaught_exception"] == "AttributeError"


### PR DESCRIPTION
## Describe your changes

If rich is installed and enabled, only print the error to the console via `rich` and not via the default logger. 

## Testing Plan

- Added additional unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
