### PR TITLE
Fix CI issues with ubuntu 24 update

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -190,8 +190,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CORE_PREVIEWS_S3_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CORE_PREVIEWS_S3_SECRET_KEY }}
         run: |
-          sudo apt update
-          sudo apt install -y awscli
+          # Install awscli via pip/uv:
+          uv pip install awscli
 
           cd lib/dist
           export WHEELFILE="$(ls -t *.whl | head -n 1)"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -74,7 +74,8 @@ jobs:
         # To create a consistent location for the release/demo whl file, we need a
         # stagnent version number (streamlit-11.11.11)
         run: |
-          sudo apt install -y awscli
+          # Install awscli via pip/uv:
+          uv pip install awscli
 
           cd lib/dist
           export WHEELFILE="$(ls -t *.whl | head -n 1)"

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -27,7 +27,9 @@ env:
 
 jobs:
   py-min-deps-test:
-    runs-on: ubuntu-latest
+    # The min pillow version we support in Streamlit cannot be installed on
+    # Ubuntu 24 -> thats why we use Ubuntu 22.04 here instead.
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Describe your changes

The `ubuntu-latest` version got updated to ubuntu 24.x which breaks two of our workflows:
- `pre-preview`: fixed by installing awscli via pip.
- `min-depts`: fixed by enforcing Ubuntu 22.04. The alternative solution would be to use a higher Pillow pin. But it kind of makes sense to run our min dependency tests also with older versions of Ubuntu.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
