### PR TITLE
Remove usage of private snowflake-connector APIs

### DIFF
--- a/lib/integration-requirements.txt
+++ b/lib/integration-requirements.txt
@@ -1,6 +1,6 @@
 # Snowflake dependencies:
 snowflake-snowpark-python[modin]>=1.17.0
-snowflake-connector-python>=2.8.0
+snowflake-connector-python>=3.3.0
 
 # Required for testing the langchain integration
 langchain>=0.2.0

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -72,7 +72,7 @@ if not os.getenv("SNOWPARK_CONDA_BUILD"):
 EXTRA_REQUIRES = {
     "snowflake": [
         "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
-        "snowflake-connector-python>=2.8.0; python_version<'3.12'",
+        "snowflake-connector-python>=3.3.0; python_version<'3.12'",
     ]
 }
 

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -25,7 +25,10 @@ from typing import TYPE_CHECKING, cast
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import running_in_sis
 from streamlit.errors import StreamlitAPIException
+from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_data
+
+LOGGER = get_logger(__name__)
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -224,11 +227,19 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         try:
             st_secrets = self._secrets.to_dict()
             if len(st_secrets):
+                LOGGER.info(
+                    "Connect to Snowflake using the Streamlit secret defined under "
+                    "[connections.snowflake]."
+                )
                 conn_kwargs = {**st_secrets, **kwargs}
                 return snowflake.connector.connect(**conn_kwargs)
 
             # Use the default configuration as defined in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
             if self._connection_name == "snowflake":
+                LOGGER.info(
+                    "Connect to Snowflake using the default configuration as defined "
+                    "in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection"
+                )
                 return snowflake.connector.connect()
 
             return snowflake.connector.connect(**kwargs)

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -20,15 +20,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
+from streamlit import logger
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import running_in_sis
 from streamlit.errors import StreamlitAPIException
-from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_data
 
-LOGGER = get_logger(__name__)
+_LOGGER: Final = logger.get_logger(__name__)
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -227,7 +227,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         try:
             st_secrets = self._secrets.to_dict()
             if len(st_secrets):
-                LOGGER.info(
+                _LOGGER.info(
                     "Connect to Snowflake using the Streamlit secret defined under "
                     "[connections.snowflake]."
                 )
@@ -236,7 +236,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
             # Use the default configuration as defined in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
             if self._connection_name == "snowflake":
-                LOGGER.info(
+                _LOGGER.info(
                     "Connect to Snowflake using the default configuration as defined "
                     "in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection"
                 )

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -115,7 +115,11 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
     >>> import streamlit as st
     >>> conn = st.connection(
-    ...     "snowflake", account="xxx-xxx", user="xxx", authenticator="externalbrowser"
+    ...     connection_name,
+    ...     type="snowflake",
+    ...     account="xxx-xxx",
+    ...     user="xxx",
+    ...     authenticator="externalbrowser",
     ... )
     >>> df = conn.query("SELECT * FROM my_table")
 
@@ -160,7 +164,12 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     >>> conn = st.connection("snowflake")
     >>> df = conn.query("SELECT * FROM my_table")
 
-    **Example 5: Default connection with an environment variable**
+    **Snowflake Default Connection**
+    If you don't have Streamlit secret `[connections.snowflake]` and just use
+    `st.connection("snowflake")`, Streamlit will use the default connection behavior as documented in
+    https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
+
+    ***Example 5: Default connection with an environment variable***
 
     If you have a Snowflake configuration file with a connection named
     ``my_connection`` as in Example 3, you can set an environment variable to
@@ -174,7 +183,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     >>> conn = st.connection("snowflake")
     >>> df = conn.query("SELECT * FROM my_table")
 
-    **Example 6: Default connection in Snowflake's connection configuration file**
+    ***Example 6: Default connection in Snowflake's connection configuration file***
 
     If you have a Snowflake configuration file that defines your ``default``
     connection, Streamlit will automatically use it if no other connection is

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -26,6 +26,12 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
+class TestError(Exception):
+    def __init__(self, message, **kwargs):
+        self.__dict__.update(kwargs)
+        super().__init__(self, message)
+
+
 @pytest.mark.require_integration
 class SnowflakeConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
@@ -140,21 +146,16 @@ class SnowflakeConnectionTest(unittest.TestCase):
         MagicMock(),
     )
     def test_retry_behavior(self):
-        from snowflake.connector.errors import ProgrammingError
-        from snowflake.connector.network import MASTER_TOKEN_EXPIRED_GS_CODE
-
         mock_cursor = MagicMock()
         mock_cursor.fetch_pandas_all = MagicMock(
-            side_effect=ProgrammingError(
-                "oh noes :(", errno=int(MASTER_TOKEN_EXPIRED_GS_CODE)
-            )
+            side_effect=TestError("oh noes :(", sqlstate="08001")
         )
 
         conn = SnowflakeConnection("my_snowflake_connection")
         conn._instance.cursor.return_value = mock_cursor
 
         with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-            with pytest.raises(ProgrammingError):
+            with pytest.raises(TestError):
                 conn.query("SELECT 1;")
 
             # Our connection should have been reset after each failed attempt to call
@@ -170,18 +171,16 @@ class SnowflakeConnectionTest(unittest.TestCase):
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
         MagicMock(),
     )
-    def test_retry_fails_fast_for_programming_errors_with_wrong_code(self):
-        from snowflake.connector.errors import ProgrammingError
-
+    def test_retry_fails_fast_for_programming_errors_with_wrong_sqlstate(self):
         mock_cursor = MagicMock()
         mock_cursor.fetch_pandas_all = MagicMock(
-            side_effect=ProgrammingError("oh noes :(", errno=42)
+            side_effect=TestError("oh noes :(", sqlstate="42")
         )
 
         conn = SnowflakeConnection("my_snowflake_connection")
         conn._instance.cursor.return_value = mock_cursor
 
-        with pytest.raises(ProgrammingError):
+        with pytest.raises(TestError):
             conn.query("SELECT 1;")
 
         # conn._connect should have just been called once when first creating the

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -63,19 +63,7 @@ class SnowflakeConnectionTest(unittest.TestCase):
     def test_uses_config_manager_if_available(self, patched_connect):
         SnowflakeConnection("snowflake", some_kwarg="some_value")
 
-        patched_connect.assert_called_once_with(
-            connection_name="default", some_kwarg="some_value"
-        )
-
-    @patch("snowflake.connector.connection")
-    @patch("snowflake.connector.connect")
-    def test_falls_back_to_using_kwargs_last(self, patched_connect, patched_connection):
-        delattr(patched_connection, "CONFIG_MANAGER")
-
-        SnowflakeConnection("snowflake", account="account", some_kwarg="some_value")
-        patched_connect.assert_called_once_with(
-            account="account", some_kwarg="some_value"
-        )
+        patched_connect.assert_called_once_with()
 
     def test_throws_friendly_error_if_no_config_set(self):
         with pytest.raises(StreamlitAPIException) as e:


### PR DESCRIPTION
## Describe your changes

- Bump min version of snowflake-connector to where the connection-manager definitely existed
- Remove usage of private APIs and leverage the default connection handling as documented in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
- When using the `"snowflake"` connection, no `kwargs` are passed to `snowflake.connector.connect` anymore to follow the [official Snowflake documentation](https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
