### PR TITLE
Support rendering ChatInputValue as dictionary in st.write

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -16,7 +16,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Iterator, Literal, Mapping, Sequence, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterator,
+    Literal,
+    Mapping,
+    Sequence,
+    cast,
+    overload,
+)
 
 from streamlit import runtime
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
@@ -53,7 +62,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class ChatInputValue(Mapping[str, str | list[UploadedFile]]):
+class ChatInputValue(Mapping[str, Any]):
     text: str
     files: list[UploadedFile]
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class ChatInputValue(Mapping):
+class ChatInputValue(Mapping[str, str | list[UploadedFile]]):
     text: str
     files: list[UploadedFile]
 
@@ -64,12 +64,10 @@ class ChatInputValue(Mapping):
         return iter(self.__dict__)
 
     @overload
-    def __getitem__(self, item: Literal["text"]) -> str:
-        pass
+    def __getitem__(self, item: Literal["text"]) -> str: ...
 
     @overload
-    def __getitem__(self, item: Literal["files"]) -> list[UploadedFile]:
-        pass
+    def __getitem__(self, item: Literal["files"]) -> list[UploadedFile]: ...
 
     def __getitem__(self, item: str) -> str | list[UploadedFile]:
         try:

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -67,16 +67,10 @@ class ChatInputValue(Mapping[str, Any]):
     files: list[UploadedFile]
 
     def __len__(self) -> int:
-        return len(self.__dict__)
+        return len(vars(self))
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self.__dict__)
-
-    @overload
-    def __getitem__(self, item: Literal["text"]) -> str: ...
-
-    @overload
-    def __getitem__(self, item: Literal["files"]) -> list[UploadedFile]: ...
+        return iter(vars(self))
 
     def __getitem__(self, item: str) -> str | list[UploadedFile]:
         try:
@@ -85,7 +79,7 @@ class ChatInputValue(Mapping[str, Any]):
             raise KeyError(f"Invalid key: {item}") from None
 
     def to_dict(self) -> dict[str, str | list[UploadedFile]]:
-        return self.__dict__
+        return vars(self)
 
 
 TYPE_PAIRS = [

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, Sequence, cast, overload
+from typing import TYPE_CHECKING, Iterator, Literal, Mapping, Sequence, cast, overload
 
 from streamlit import runtime
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
@@ -52,13 +52,16 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
-class ChatInputValue:
+@dataclass
+class ChatInputValue(Mapping):
     text: str
     files: list[UploadedFile]
 
-    def __init__(self, text: str, files: list[UploadedFile]):
-        self.text = text
-        self.files = files
+    def __len__(self) -> int:
+        return len(self.__dict__)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__dict__)
 
     @overload
     def __getitem__(self, item: Literal["text"]) -> str:
@@ -73,6 +76,9 @@ class ChatInputValue:
             return getattr(self, item)  # type: ignore[no-any-return]
         except AttributeError:
             raise KeyError(f"Invalid key: {item}") from None
+
+    def to_dict(self) -> dict[str, str | list[UploadedFile]]:
+        return self.__dict__
 
 
 TYPE_PAIRS = [

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -299,13 +299,19 @@ class ChatTest(DeltaGeneratorTestCase):
         self.assertEqual(b"3", file0.read())
         self.assertEqual(b"123", file1.read())
 
-    def test_chat_input_value_is_custom_dict(self):
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_is_custom_dict(self, deserialize_patch):
         """Test that ChatInputValue is a custom dict."""
+        files = [
+            UploadedFile(
+                UploadedFileRec("file0", "name0", "type", b"123"),
+                FileURLsProto(file_id="file0", delete_url="d0", upload_url="u0"),
+            ),
+        ]
+        deserialize_patch.return_value = ChatInputValue(text="placeholder", files=files)
+
         value = st.chat_input("Placeholder", accept_file=True)
         self.assertTrue(is_custom_dict(value))
 
         value = st.chat_input("Placeholder", accept_file="multiple")
         self.assertTrue(is_custom_dict(value))
-
-        value = st.chat_input("Placeholder")
-        self.assertFalse(is_custom_dict(value))

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -33,6 +33,7 @@ from streamlit.runtime.uploaded_file_manager import (
     UploadedFile,
     UploadedFileRec,
 )
+from streamlit.type_util import is_custom_dict
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -297,3 +298,14 @@ class ChatTest(DeltaGeneratorTestCase):
         file0.seek(2)
         self.assertEqual(b"3", file0.read())
         self.assertEqual(b"123", file1.read())
+
+    def test_chat_input_value_is_custom_dict(self):
+        """Test that ChatInputValue is a custom dict."""
+        value = st.chat_input("Placeholder", accept_file=True)
+        self.assertTrue(is_custom_dict(value))
+
+        value = st.chat_input("Placeholder", accept_file="multiple")
+        self.assertTrue(is_custom_dict(value))
+
+        value = st.chat_input("Placeholder")
+        self.assertFalse(is_custom_dict(value))


### PR DESCRIPTION
## Describe your changes
Render `ChatInputValue` as a proper dict in `st.write` by making it inherits `Mapping` and implementing `to_dict` method. `st.write` could then render it as [custom_dict](https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L484). 

#### Before
<img width="517" alt="Screenshot 2025-01-08 at 6 08 50 PM" src="https://github.com/user-attachments/assets/c95ce322-86f3-4367-ada8-b3e8533270b0" /> 

#### After
<img width="513" alt="Screenshot 2025-01-08 at 6 03 39 PM" src="https://github.com/user-attachments/assets/12b8b457-a82c-4e78-a10a-c3ae0e1b8f24" /> |



## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
