### PR TITLE
Only show log but don't raise an error when fragment id is not found

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -553,11 +553,14 @@ class ScriptRunner:
                                 wrapped_fragment()
 
                             except FragmentStorageKeyError:
-                                # Only raise an error if the fragment is not an
-                                # auto_rerun. If it is an auto_rerun, we might have a
-                                # race condition where the fragment_id is removed
-                                # but the webapp sends a rerun request before the
-                                # removal information has reached the web app
+                                # This can happen if the fragment_id is removed from the
+                                # storage before the script runner gets to it. In this
+                                # case, the fragment is simply skipped.
+                                # Also, only log an error if the fragment is not an
+                                # auto_rerun to avoid noise. If it is an auto_rerun, we
+                                # might have a race condition where the fragment_id is
+                                # removed but the webapp sends a rerun request before
+                                # the removal information has reached the web app
                                 # (see https://github.com/streamlit/streamlit/issues/9080).
                                 if not rerun_data.is_auto_rerun:
                                     _LOGGER.error(

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -560,7 +560,7 @@ class ScriptRunner:
                                 # removal information has reached the web app
                                 # (see https://github.com/streamlit/streamlit/issues/9080).
                                 if not rerun_data.is_auto_rerun:
-                                    raise RuntimeError(
+                                    _LOGGER.error(
                                         f"Could not find fragment with id {fragment_id}"
                                     )
                             except (RerunException, StopException) as e:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -563,8 +563,14 @@ class ScriptRunner:
                                 # the removal information has reached the web app
                                 # (see https://github.com/streamlit/streamlit/issues/9080).
                                 if not rerun_data.is_auto_rerun:
-                                    _LOGGER.error(
-                                        f"Could not find fragment with id {fragment_id}"
+                                    _LOGGER.warning(
+                                        f"Couldn't find fragment with id {fragment_id}."
+                                        " This can happen if the fragment does not"
+                                        " exist anymore when this request is processed,"
+                                        " for example because a full app rerun happened"
+                                        " that did not register the fragment."
+                                        " Usually this doesn't happen or no action is"
+                                        " required, so its mainly for debugging."
                                     )
                             except (RerunException, StopException) as e:
                                 # The wrapped_fragment function is executed


### PR DESCRIPTION
## Describe your changes

After the discussion in context of this PR: https://github.com/streamlit/streamlit/pull/9965, we want to show a log instead of raising an error in all cases to keep it simple and not introduce another list / more tech debt.

Changing this surfaced two race conditions that were subsequently tackled in https://github.com/streamlit/streamlit/pull/10132 and https://github.com/streamlit/streamlit/pull/10147

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
  - Remove a couple of unit tests that checked for the exception to be thrown

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
