### PR TITLE
Don't update FinishedMessage status of full app runs by fragment runs

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import numpy as np
 import pandas as pd
 
@@ -181,3 +183,14 @@ def dialog_with_dataframe():
 
 if st.button("Open Dialog with dataframe"):
     dialog_with_dataframe()
+
+
+@st.dialog("Dialog with rerun")
+def dialog_with_rerun():
+    if st.button("Close Dialog"):
+        time.sleep(0.15)
+        st.rerun()
+
+
+if st.button("Open Dialog with rerun"):
+    dialog_with_rerun()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -16,6 +16,7 @@ import re
 
 import pytest
 from playwright.sync_api import Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
@@ -78,6 +79,10 @@ def open_dialog_with_deprecation_warning(app: Page):
 
 def open_dialog_with_chart(app: Page):
     app.get_by_role("button").filter(has_text="Open Chart Dialog").click()
+
+
+def open_dialog_with_rerun(app: Page):
+    app.get_by_role("button").filter(has_text="Open Dialog with rerun").click()
 
 
 def click_to_dismiss(app: Page):
@@ -409,6 +414,58 @@ def test_dialog_with_dataframe_shows_toolbar(
     expect(df_toolbar).to_have_css("opacity", "1")
     expect(df_toolbar).to_be_visible()
     assert_snapshot(df_toolbar, name="st_dialog-shows_full_dataframe_toolbar")
+
+
+def test_dialog_with_rerun_closes_even_if_button_is_clicked_multiple_times(app: Page):
+    """Check that the dialog closes even if the button that calls st.rerun is clicked
+    multiple times in fast succession. We want to test this since the button click and
+    the st.rerun trigger fragment reruns and full app reruns, respectively. We want
+    to ensure that the dialog closes in both cases and fragment-rerun messages do not
+    interfere with the full app rerun (finished messages). If they would, we have
+    observed the dialog to stay open and never closer again. So this test is more about
+    sanity-checking the interplay of fragment runs and full app reruns rather than
+    testing something dialog-specific, but with the dialog we have a visual way of
+    seeing the issue.
+
+    Important: The behavior is not deterministic as it relies on a race condition.
+    This means that the test can succeed even though the underlying issue exists.
+    However, the test will not always succeed if the issue exists. So if the test
+    sometimes fails, it might point to an underlying issue.
+    Performing this test manually triggers the issue much more often.
+    """
+    import time
+
+    for _ in range(0, 10):
+        open_dialog_with_rerun(app)
+        dialog = app.get_by_role("dialog")
+        expect(dialog).to_be_visible()
+        button = (
+            app.get_by_test_id("stButton")
+            .filter(has_text="Close Dialog")
+            .locator("button")
+        )
+        counter = 0
+        # simulate clicking the button multiple times in fast succession
+        for _ in range(0, 5):
+            counter += 1
+            try:
+                button.click(timeout=1000, no_wait_after=True)
+            except PlaywrightTimeoutError:
+                # the dialog closed and the button does not exist anymore, so
+                # do not try to click it again
+                break
+
+            # sleep to mimic human behavior. If the sleep time is too small or too high,
+            # I was not able to trigger the behavior; which makes sense given that the
+            # original issue that prompted this test to be written was rooted in timing
+            # the outgoing message queue flushing / replace behavior in
+            # forward_msg_queue.py.
+            time.sleep(0.2)
+
+        # ensure that the button was clicked at least twice, otherwise the whole test
+        # does not make sense
+        assert counter >= 2
+        expect(dialog).not_to_be_attached()
 
 
 def test_check_top_level_class(app: Page):

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -34,55 +34,51 @@ modal_test_id = "stDialog"
 
 
 def open_dialog_with_images(app: Page):
-    app.get_by_role("button").filter(has_text="Open Dialog with Images").click()
+    click_button(app, "Open Dialog with Images")
 
 
 def open_dialog_without_images(app: Page, *, delay: int = 0):
-    app.get_by_role("button").filter(has_text="Open Dialog without Images").click(
-        delay=delay
-    )
+    click_button(app, "Open Dialog without Images")
 
 
 def open_largewidth_dialog(app: Page):
-    app.get_by_role("button").filter(has_text="Open large-width Dialog").click()
+    click_button(app, "Open large-width Dialog")
 
 
 def open_headings_dialogs(app: Page):
-    app.get_by_role("button").filter(has_text="Open headings Dialog").click()
+    click_button(app, "Open headings Dialog")
 
 
 def open_sidebar_dialog(app: Page):
-    app.get_by_role("button").filter(has_text="Open Sidebar-Dialog").click()
+    click_button(app, "Open Sidebar-Dialog")
 
 
 def open_dialog_with_internal_error(app: Page):
-    app.get_by_role("button").filter(has_text="Open Dialog with Key Error").click()
+    click_button(app, "Open Dialog with Key Error")
 
 
 def open_nested_dialogs(app: Page):
-    app.get_by_role("button").filter(has_text="Open Nested Dialogs").click()
+    click_button(app, "Open Nested Dialogs")
 
 
 def open_submit_button_dialog(app: Page):
-    app.get_by_role("button").filter(has_text="Open submit-button Dialog").click()
+    click_button(app, "Open submit-button Dialog")
 
 
 def open_dialog_with_copy_buttons(app: Page):
-    app.get_by_role("button").filter(has_text="Open Dialog with Copy Buttons").click()
+    click_button(app, "Open Dialog with Copy Buttons")
 
 
 def open_dialog_with_deprecation_warning(app: Page):
-    app.get_by_role("button").filter(
-        has_text="Open Dialog with deprecation warning"
-    ).click()
+    click_button(app, "Open Dialog with deprecation warning")
 
 
 def open_dialog_with_chart(app: Page):
-    app.get_by_role("button").filter(has_text="Open Chart Dialog").click()
+    click_button(app, "Open Chart Dialog")
 
 
 def open_dialog_with_rerun(app: Page):
-    app.get_by_role("button").filter(has_text="Open Dialog with rerun").click()
+    click_button(app, "Open Dialog with rerun")
 
 
 def click_to_dismiss(app: Page):

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -283,7 +283,6 @@ class AppSession:
         """Process a BackMsg."""
         try:
             msg_type = msg.WhichOneof("type")
-            print(f"[DEBUG] handle_backmsg {msg}")
             if msg_type == "rerun_script":
                 if msg.debug_last_backmsg_id:
                     self._debug_last_backmsg_id = msg.debug_last_backmsg_id
@@ -358,7 +357,8 @@ class AppSession:
             fragment_id = client_state.fragment_id
             if fragment_id and not self._fragment_storage.contains(fragment_id):
                 _LOGGER.error(
-                    f"[DEBUG]: The fragment with id {fragment_id} does not exist anymore - it was probably removed"
+                    f"The fragment with id {fragment_id} does not exist anymore - "
+                    "it might have been removed during a preceding full-app rerun."
                 )
                 return
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -356,7 +356,7 @@ class AppSession:
         if client_state:
             fragment_id = client_state.fragment_id
             if fragment_id and not self._fragment_storage.contains(fragment_id):
-                _LOGGER.error(
+                _LOGGER.info(
                     f"The fragment with id {fragment_id} does not exist anymore - "
                     "it might have been removed during a preceding full-app rerun."
                 )

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -355,12 +355,6 @@ class AppSession:
 
         if client_state:
             fragment_id = client_state.fragment_id
-            if fragment_id and not self._fragment_storage.contains(fragment_id):
-                _LOGGER.info(
-                    f"The fragment with id {fragment_id} does not exist anymore - "
-                    "it might have been removed during a preceding full-app rerun."
-                )
-                return
 
             rerun_data = RerunData(
                 client_state.query_string,

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -283,7 +283,7 @@ class AppSession:
         """Process a BackMsg."""
         try:
             msg_type = msg.WhichOneof("type")
-
+            print(f"[DEBUG] handle_backmsg {msg}")
             if msg_type == "rerun_script":
                 if msg.debug_last_backmsg_id:
                     self._debug_last_backmsg_id = msg.debug_last_backmsg_id
@@ -356,6 +356,11 @@ class AppSession:
 
         if client_state:
             fragment_id = client_state.fragment_id
+            if fragment_id and not self._fragment_storage.contains(fragment_id):
+                _LOGGER.error(
+                    f"[DEBUG]: The fragment with id {fragment_id} does not exist anymore - it was probably removed"
+                )
+                return
 
             rerun_data = RerunData(
                 client_state.query_string,
@@ -576,7 +581,6 @@ class AppSession:
         if event == ScriptRunnerEvent.SCRIPT_STARTED:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
-
             assert (
                 page_script_hash is not None
             ), "page_script_hash must be set for the SCRIPT_STARTED event"

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -210,6 +210,15 @@ def _update_script_finished_message(
     states on the frontend.
     """
     if msg.WhichOneof("type") == "script_finished" and (
+        # If this is not a fragment run (= full app run), its okay to change the
+        # script_finished type to FINISHED_EARLY_FOR_RERUN because another full app run
+        # is about to start.
+        # If this is a fragment run, it is allowed to change the state of
+        # all script_finished states except for FINISHED_SUCCESSFULLY, which we use to
+        # indicate that a full app run has finished successfully (in other words, a
+        # fragment should not modify the finished status of a full app run, because
+        # the fragment finished state is different and the frontend might not trigger
+        # cleanups etc. correctly).
         is_fragment_run is False
         or msg.script_finished != ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
     ):

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -65,11 +65,6 @@ class FragmentStorage(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def clear_past_ids(self) -> None:
-        """Remove all fragments from the past-store saved in this FragmentStorage."""
-        raise NotImplementedError
-
-    @abstractmethod
     def get(self, key: str) -> Fragment:
         """Returns the stored fragment for the given key."""
         raise NotImplementedError
@@ -89,11 +84,6 @@ class FragmentStorage(Protocol):
         """Return whether the given key is present in this FragmentStorage."""
         raise NotImplementedError
 
-    @abstractmethod
-    def contained_in_the_past(self, key: str) -> bool:
-        """Return whether the given key was present in this FragmentStorage in the past."""
-        raise NotImplementedError
-
 
 # NOTE: Ideally, we'd like to add a MemoryFragmentStorageStatProvider implementation to
 # keep track of memory usage due to fragments, but doing something like this ends up
@@ -109,7 +99,6 @@ class MemoryFragmentStorage(FragmentStorage):
 
     def __init__(self) -> None:
         self._fragments: dict[str, Fragment] = {}
-        self._previous_fragment_ids: set[str] = set()
 
     # Weirdly, we have to define this above the `set` method, or mypy gets it confused
     # with the `set` type of `new_fragments_ids`.
@@ -123,9 +112,6 @@ class MemoryFragmentStorage(FragmentStorage):
             if fid not in new_fragment_ids:
                 del self._fragments[fid]
 
-    def clear_past_ids(self) -> None:
-        self._previous_fragment_ids.clear()
-
     def get(self, key: str) -> Fragment:
         try:
             return self._fragments[key]
@@ -133,7 +119,6 @@ class MemoryFragmentStorage(FragmentStorage):
             raise FragmentStorageKeyError(str(e))
 
     def set(self, key: str, value: Fragment) -> None:
-        self._previous_fragment_ids.add(key)
         self._fragments[key] = value
 
     def delete(self, key: str) -> None:
@@ -144,9 +129,6 @@ class MemoryFragmentStorage(FragmentStorage):
 
     def contains(self, key: str) -> bool:
         return key in self._fragments
-
-    def contained_in_the_past(self, key: str) -> bool:
-        return key in self._previous_fragment_ids
 
 
 def _fragment(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -65,6 +65,11 @@ class FragmentStorage(Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def clear_past_ids(self) -> None:
+        """Remove all fragments from the past-store saved in this FragmentStorage."""
+        raise NotImplementedError
+
+    @abstractmethod
     def get(self, key: str) -> Fragment:
         """Returns the stored fragment for the given key."""
         raise NotImplementedError
@@ -117,6 +122,9 @@ class MemoryFragmentStorage(FragmentStorage):
         for fid in fragment_ids:
             if fid not in new_fragment_ids:
                 del self._fragments[fid]
+
+    def clear_past_ids(self) -> None:
+        self._previous_fragment_ids.clear()
 
     def get(self, key: str) -> Fragment:
         try:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -177,9 +177,6 @@ class ScriptRequests:
         """
 
         with self._lock:
-            print(
-                f"[DEBUG] current_rerun_data: {self._rerun_data} | request_rerun: {new_data} | state: {self._state}"
-            )
             if self._state == ScriptRequestType.STOP:
                 # We can't rerun after being stopped.
                 return False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -52,6 +52,7 @@ class RerunData:
     # The queue of fragment_ids waiting to be run.
     fragment_id_queue: list[str] = field(default_factory=list)
     is_fragment_scoped_rerun: bool = False
+    # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
 
     def __repr__(self) -> str:
@@ -176,6 +177,9 @@ class ScriptRequests:
         """
 
         with self._lock:
+            print(
+                f"[DEBUG] current_rerun_data: {self._rerun_data} | request_rerun: {new_data} | state: {self._state}"
+            )
             if self._state == ScriptRequestType.STOP:
                 # We can't rerun after being stopped.
                 return False

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -284,11 +284,13 @@ class AppSessionTest(unittest.TestCase):
         self, mock_create_scriptrunner: MagicMock
     ):
         session = _create_test_session()
+        fragment_id = "my_fragment_id"
+        session._fragment_storage.set(fragment_id, lambda: None)
 
         mock_active_scriptrunner = MagicMock(spec=ScriptRunner)
         session._scriptrunner = mock_active_scriptrunner
 
-        session.request_rerun(ClientState(fragment_id="my_fragment_id"))
+        session.request_rerun(ClientState(fragment_id=fragment_id))
 
         # The active ScriptRunner should *not* be shut down or stopped.
         mock_active_scriptrunner.request_rerun.assert_called_once()

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -293,7 +293,7 @@ class ForwardMsgQueueTest(unittest.TestCase):
 
         expected_new_finished_message = ForwardMsg()
         expected_new_finished_message.script_finished = (
-            ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+            ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
         )
 
         fmq.clear(


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/streamlit/streamlit/issues/9921 and extracted from PR https://github.com/streamlit/streamlit/pull/9965

In https://github.com/streamlit/streamlit/pull/10130, we stopped raising a `RuntimeError` when a fragment with a specified id cannot be found. This solves the original issue in https://github.com/streamlit/streamlit/issues/9921, but surfaced a different issue where the dialog did not close anymore when the button in the dialog was clicked in fast succession. The reason for this is that in `forward_msg_queue`, the `FinishedScript` type prior to this PR here is always set to `STOPPED_EARLY_FOR_RERUN`. This is now modified so that the status is not changed for full app reruns triggered by a fragment runs. This resolves the described issue with the not-closing dialog because a second, fast subsequent click on the button does not override the initial finished-message in the queue belonging to the `st.rerun()` in the example.
This is correct since a fragment indeed does not stop full app reruns. This only happens when the fragment run is so fast that the browser queue is not cleared yet.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
  - Updated Python unit tests.
- E2E Tests
  - Added an e2e test that can catch an underlying issue where the dialog does not close correctly. However, since the cause of the particular issue addressed in the PR is a race condition, the test can succeed even if the issue exists. However, it should still fail from time to time which can help us to get aware of an underlying problem.
- Any manual testing needed
  - The test introduced in the e2e test is more likely to fail when executing manually, so that should be done if an issue arises.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
