### PR TITLE
Add authlib to metric attributions

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -152,6 +152,7 @@ _ATTRIBUTIONS_TO_CHECK: Final = [
     "streamlit_pydantic",
     "pydantic",
     "plost",
+    "authlib",
 ]
 
 _ETC_MACHINE_ID_PATH = "/etc/machine-id"


### PR DESCRIPTION
## Describe your changes

Adds the optional dependency `authlib` to the metric attributions.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
