### PR TITLE
[fix] Rename playwright-performance workflow job

### DIFF
--- a/.github/workflows/playwright-performance.yml
+++ b/.github/workflows/playwright-performance.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  playwright-e2e-tests:
+  playwright-performance:
     runs-on: ubuntu-latest-8-cores
 
     defaults:


### PR DESCRIPTION
## Describe your changes

- Fixes a name collision with existing `playwright-e2e-tests` job

## GitHub Issue Link (if applicable)

## Testing Plan

- This is a workflow change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
