### PR TITLE
Don't request_rerun for fragments that do not exist anymore

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -356,6 +356,28 @@ class AppSession:
         if client_state:
             fragment_id = client_state.fragment_id
 
+            # Early check whether this fragment still exists in the fragment storage or
+            # might have been removed by a full app run. This is not merely a
+            # performance optimization, but also fixes following potential situation:
+            # A fragment run might create a new ScriptRunner when the current
+            # ScriptRunner is in state STOPPED (in this case, the 'success' variable
+            # below is false and the new ScriptRunner is created). This will lead to all
+            # events that were not sent / received from the previous script runner to be
+            # ignored in _handle_scriptrunner_event_on_event_loop, because the
+            # _script_runner changed. When the full app rerun ScriptRunner is done
+            # (STOPPED) but its events are not processed before the new ScriptRunner is
+            # created, its finished message is not sent to the frontend and no
+            # full-app-run cleanup is happening. This scenario can be triggered by the
+            # example app described in
+            # https://github.com/streamlit/streamlit/issues/9921, where the dialog
+            # sometimes stays open.
+            if fragment_id and not self._fragment_storage.contains(fragment_id):
+                _LOGGER.info(
+                    f"The fragment with id {fragment_id} does not exist anymore - "
+                    "it might have been removed during a preceding full-app rerun."
+                )
+                return
+
             rerun_data = RerunData(
                 client_state.query_string,
                 client_state.widget_states,

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -299,6 +299,33 @@ class AppSessionTest(unittest.TestCase):
         # And a new ScriptRunner should *not* be created.
         mock_create_scriptrunner.assert_not_called()
 
+    @patch_config_options({"runner.fastReruns": True})
+    @patch("streamlit.runtime.app_session.AppSession._create_scriptrunner")
+    def test_rerun_fragment_does_not_request_existing_scriptrunner_when_not_existing(
+        self, mock_create_scriptrunner: MagicMock
+    ):
+        """In case the fragment was removed by a preceding full app run, we want to exit
+        early and not request a rerun on the existing ScriptRunner.
+        """
+        session = _create_test_session()
+        fragment_id = "my_fragment_id"
+
+        # leaving the following code line in to show that the fragment id
+        # is not set in the fragment storage!
+        # session._fragment_storage.set(fragment_id, lambda: None)
+
+        mock_active_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_active_scriptrunner
+
+        session.request_rerun(ClientState(fragment_id=fragment_id))
+
+        # The active ScriptRunner should *not* be requested at all.
+        mock_active_scriptrunner.request_rerun.assert_not_called()
+        mock_active_scriptrunner.request_stop.assert_not_called()
+
+        # And a new ScriptRunner should *not* be created.
+        mock_create_scriptrunner.assert_not_called()
+
     @patch("streamlit.runtime.app_session.ScriptRunner")
     def test_create_scriptrunner(self, mock_scriptrunner: MagicMock):
         """Test that _create_scriptrunner does what it should."""


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/streamlit/streamlit/issues/9921 and extracted from PR https://github.com/streamlit/streamlit/pull/9965
Related to https://github.com/streamlit/streamlit/pull/10132

In https://github.com/streamlit/streamlit/pull/10130, we stopped raising a RuntimeError when a fragment with a specified id cannot be found. This solves the original issue in https://github.com/streamlit/streamlit/issues/9921, but surfaced a different issue where the dialog did not always close when the button in the dialog was clicked in fast succession.

The reason for this is that in app_session, a fragment run might create a new ScriptRunner when the current ScriptRunner is in state STOPPED (in this case, success [here](https://github.com/streamlit/streamlit/blob/6567621dcad71ecefaaac6762ddcba7d4719ecde/lib/streamlit/runtime/app_session.py#L386) is false and the new ScriptRunner is created). This will lead to all events from the previous script runner being ignored (see [here](https://github.com/streamlit/streamlit/blob/6567621dcad71ecefaaac6762ddcba7d4719ecde/lib/streamlit/runtime/app_session.py#L561)). When the full app rerun ScriptRunner is done (STOPPED) but its events are not processed before the new ScriptRunner is created, its finished message is not sent to the frontend and no cleanup is happening.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
  - Add unit test to ensure that the scriptrunner is not requested if the fragment does not even exist anymore
- E2E Tests
  - The e2e test that was added in https://github.com/streamlit/streamlit/pull/10132 _could_ catch this one here, although it happens more rarely than the race condition tackled in that PR

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
