### PR TITLE
Remove protobuf version restriction in conda recipe

### DIFF
--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
       # Conda doesn't support the `platform_system` conditional that pip does.
       # We may need to figure out how to avoid installing watchdog on MacOS
       # by default in our conda distribution due to this.
-      {% elif 'watchdog' in req %}
+      {% if 'watchdog' in req %}
         - watchdog
       {% else %}
         - {{ req }}

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -40,10 +40,6 @@ requirements:
     - python {{ package_data.get('python_requires') }}
   run:
     {% for req in package_data.get('install_requires', []) %}
-      # 2022.07.01 - temporarily set protobuf's lower bound to 3.11 to work
-      # around a conda resolution issue
-      {% if 'protobuf' in req %}
-        - protobuf >=3.11, <4
       # Conda doesn't support the `platform_system` conditional that pip does.
       # We may need to figure out how to avoid installing watchdog on MacOS
       # by default in our conda distribution due to this.


### PR DESCRIPTION
## Describe your changes

We restricted protobuf due to issues in conda, but we have since upgraded protobuf. We should have it mimic reality. For this, we should try to not get involved and let the setup.py dictate. Assuming the Conda build succeeds, then new versions should be better and we can undo the check.

## Testing Plan

- Conda Build should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
