### PR TITLE
Deactivate translation for material icons

### DIFF
--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
@@ -43,6 +43,8 @@ describe("Dynamic icon", () => {
     expect(testId).toBeInTheDocument()
     expect(icon).toBeInTheDocument()
     expect(testId.textContent).toEqual(icon.textContent)
+    // Should have translate="no" to prevent the icon text from being translated:
+    expect(testId).toHaveAttribute("translate", "no")
   })
 
   it("renders without crashing with Emoji icon", () => {

--- a/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
@@ -55,6 +55,10 @@ const MaterialFontIcon = ({
     <StyledMaterialIcon
       {...getDefaultProps(props)}
       data-testid={props.testid || "stIconMaterial"}
+      // Prevent the icon text from being translated
+      // this would break the icon display in the UI.
+      // https://github.com/streamlit/streamlit/issues/10168
+      translate="no"
     >
       {snakeCase(iconName)}
     </StyledMaterialIcon>

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -404,6 +404,7 @@ describe("StreamlitMarkdown", () => {
     expect(markdown).toHaveStyle(`font-family: Material Symbols Rounded`)
     expect(markdown).toHaveStyle(`user-select: none`)
     expect(markdown).toHaveStyle(`vertical-align: bottom`)
+    expect(markdown).toHaveAttribute("translate", "no")
   })
 
   it("does not remove unknown directive", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -441,6 +441,10 @@ export function RenderedMarkdown({
             hProperties: {
               role: "img",
               ariaLabel: iconName + " icon",
+              // Prevent the icon text from being translated
+              // this would break the icon display in the UI.
+              // https://github.com/streamlit/streamlit/issues/10168
+              translate: "no",
               style: {
                 display: "inline-block",
                 fontFamily: theme.genericFonts.iconFont,


### PR DESCRIPTION
## Describe your changes

Adds `translate="no"` attribute for our uses of material icons to prevent the icon text from translating and, thereby, prevent it from breaking the display of the icon. 

<img width="476" alt="image" src="https://github.com/user-attachments/assets/7c50cca9-67c0-435c-b385-cc920df4acb2" />


## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10168

## Testing Plan

- Added unit tests
- Testing this e2e does not seem super easy.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
