### PR TITLE
Consolidate border radii value and remove redundant css attr

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -410,17 +410,6 @@ function ChatInput({
     return scrollHeight
   }
 
-  const getTextAreaBorderStyle = (): React.CSSProperties =>
-    acceptFile !== AcceptFileValue.None
-      ? { border: "none" }
-      : {
-          // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-          borderLeftWidth: theme.sizes.borderWidth,
-          borderRightWidth: theme.sizes.borderWidth,
-          borderTopWidth: theme.sizes.borderWidth,
-          borderBottomWidth: theme.sizes.borderWidth,
-        }
-
   const handleSubmit = (): void => {
     // We want the chat input to always be in focus
     // even if the user clicks the submit button
@@ -556,7 +545,7 @@ function ChatInput({
                 style: {
                   minHeight: theme.sizes.minElementHeight,
                   outline: "none",
-                  ...getTextAreaBorderStyle(),
+                  border: "none",
                 },
               },
               Input: {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -414,7 +414,6 @@ function ChatInput({
     acceptFile !== AcceptFileValue.None
       ? { border: "none" }
       : {
-          borderRadius: theme.radii.xxxl,
           // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
           borderLeftWidth: theme.sizes.borderWidth,
           borderRightWidth: theme.sizes.borderWidth,
@@ -557,13 +556,7 @@ function ChatInput({
                 style: {
                   minHeight: theme.sizes.minElementHeight,
                   outline: "none",
-                  backgroundColor: theme.colors.transparent,
                   ...getTextAreaBorderStyle(),
-                },
-              },
-              InputContainer: {
-                style: {
-                  backgroundColor: theme.colors.transparent,
                 },
               },
               Input: {
@@ -572,7 +565,6 @@ function ChatInput({
                 },
                 style: {
                   lineHeight: theme.lineHeights.inputWidget,
-                  backgroundColor: theme.colors.transparent,
                   "::placeholder": {
                     opacity: "0.7",
                   },

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import styled from "@emotion/styled"
-
 import { Theme } from "@emotion/react"
+
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
 
 const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -17,6 +17,10 @@ import styled from "@emotion/styled"
 
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
 
+import { Theme } from "@emotion/react"
+
+const chatBorderRadius = (theme: Theme) => theme.radii.xxxl
+
 export interface StyledChatInputContainerProps {
   width: number
 }
@@ -26,7 +30,7 @@ export const StyledChatInputContainer =
     return {
       border: `${theme.sizes.borderWidth} solid`,
       borderColor: theme.colors.transparent,
-      borderRadius: theme.radii.xxxl,
+      borderRadius: chatBorderRadius(theme),
       display: "flex",
       backgroundColor:
         theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
@@ -62,9 +66,9 @@ export const StyledSendIconButton = styled.button<StyledSendIconButtonProps>(
     return {
       border: "none",
       backgroundColor: theme.colors.transparent,
-      borderTopRightRadius: extended ? "0" : theme.radii.xxxl,
+      borderTopRightRadius: extended ? "0" : chatBorderRadius(theme),
       borderTopLeftRadius: extended ? theme.radii.default : "0",
-      borderBottomRightRadius: theme.radii.xxxl,
+      borderBottomRightRadius: chatBorderRadius(theme),
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -24,28 +24,27 @@ export interface StyledChatInputContainerProps {
 export const StyledChatInputContainer =
   styled.div<StyledChatInputContainerProps>(({ theme, width }) => {
     return {
+      border: `${theme.sizes.borderWidth} solid`,
+      borderColor: theme.colors.transparent,
       borderRadius: theme.radii.xxxl,
       display: "flex",
       backgroundColor:
         theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
       width: `${width}px`,
+      overflow: "hidden",
+
+      ":focus-within": {
+        borderColor: theme.colors.primary,
+      },
     }
   })
 
 export const StyledChatInput = styled.div(({ theme }) => {
   return {
-    backgroundColor: theme.colors.transparent,
     position: "relative",
     flexGrow: 1,
-    borderRadius: theme.radii.xxxl,
     display: "flex",
     alignItems: "center",
-    border: `${theme.sizes.borderWidth} solid`,
-    borderColor: theme.colors.transparent,
-
-    ":focus-within": {
-      borderColor: theme.colors.primary,
-    },
   }
 })
 

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -15,11 +15,10 @@
  */
 import styled from "@emotion/styled"
 
+import { Theme } from "@emotion/react"
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
 
-import { Theme } from "@emotion/react"
-
-const chatBorderRadius = (theme: Theme) => theme.radii.xxxl
+const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
 export interface StyledChatInputContainerProps {
   width: number
@@ -43,7 +42,7 @@ export const StyledChatInputContainer =
     }
   })
 
-export const StyledChatInput = styled.div(({ theme }) => {
+export const StyledChatInput = styled.div(({}) => {
   return {
     position: "relative",
     flexGrow: 1,


### PR DESCRIPTION
## Describe your changes

1. Move border radii (xxxl) to const so we have 1 source of truth for its value throughout this component. In the future when we want to change it to consume advanced theming's config we only need to modify 1 const.
2. There are quite a few places where we set `backgroundColor: theme.colors.transparent` but they did not change the rendered outcome, or could be handled by setting `overflow: "hidden"` in their parent. So I re-organized the css attributes in these parent-children element and a) move the `focus` attr to `StyledChatInputContainer` and b) remove redundant attr after adding `overflow: hidden`


## GitHub Issue Link (if applicable)

## Testing Plan

Manual tested that chat input w or w/o file upload behaves the same

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
