### PR TITLE
File upload drag and drop UI

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -67,7 +67,6 @@ import UploadedFiles from "@streamlit/lib/src/components/widgets/FileUploader/Up
 import {
   StyledChatInput,
   StyledChatInputContainer,
-  StyledDropOverlay,
   StyledFileUploadDropzone,
   StyledInputInstructionsContainer,
   StyledSendIconButton,
@@ -247,27 +246,18 @@ const FileUploadArea = ({
   getRootProps,
   getInputProps,
   disabled,
-}: FileUploadAreaProps) =>
-  fileDragged ? (
-    <StyledFileUploadDropzone {...getRootProps()}>
-      <input {...getInputProps()} />
-      Drag and drop files here
-    </StyledFileUploadDropzone>
-  ) : (
-    <>
-      <div {...getRootProps()}>
-        <input {...getInputProps()} />
-        <BaseButton
-          kind={BaseButtonKind.BORDERLESS_ICON}
-          onClick={() => {}}
-          disabled={disabled}
-        >
-          <Icon content={AttachFile} size="base" color="inherit" />
-        </BaseButton>
-      </div>
-      <StyledVerticalDivider />
-    </>
-  )
+}: FileUploadAreaProps) => (
+  <StyledFileUploadDropzone showDropzone={fileDragged} {...getRootProps()}>
+    <input {...getInputProps()} />
+    {fileDragged ? (
+      "Drag and drop files here"
+    ) : (
+      <BaseButton kind={BaseButtonKind.BORDERLESS_ICON} disabled={disabled}>
+        <Icon content={AttachFile} size="base" color="inherit" />
+      </BaseButton>
+    )}
+  </StyledFileUploadDropzone>
+)
 
 function ChatInput({
   width,
@@ -279,7 +269,6 @@ function ChatInput({
   const theme = useTheme()
 
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
-  const overlayRef = useRef<HTMLDivElement>(null)
   const counterRef = useRef(0)
   const heightGuidance = useRef({ minHeight: 0, maxHeight: 0 })
 
@@ -527,39 +516,48 @@ function ChatInput({
   }, [chatInputRef])
 
   useEffect(() => {
-    const handleDragEnter = (event: DragEvent) => {
+    const handleDragEnter = (event: DragEvent): void => {
       event.preventDefault()
+      event.stopPropagation()
       if (!fileDragged) {
         setFileDragged(true)
       }
     }
 
-    const handleDragLeave = () => {
-      console.log("leave file")
+    const handleDragLeave = (event: DragEvent): void => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (fileDragged) {
+        // This check prevents the dropzone from flickering since the dragleave
+        // event could fire when user is dragging within the window
+        if (
+          (event.clientX <= 0 && event.clientY <= 0) ||
+          (event.clientX >= window.innerWidth &&
+            event.clientY >= window.innerHeight)
+        ) {
+          setFileDragged(false)
+        }
+      }
+    }
+
+    const handleDrop = (event: DragEvent): void => {
+      event.preventDefault()
+      event.stopPropagation()
       if (fileDragged) {
         setFileDragged(false)
       }
     }
 
-    const handleDrop = (event: DragEvent) => {
-      event.preventDefault()
-      handleDragLeave()
-    }
-
     window.addEventListener("dragover", handleDragEnter)
     window.addEventListener("drop", handleDrop)
-    if (overlayRef.current) {
-      overlayRef.current.addEventListener("dragleave", handleDragLeave)
-    }
+    window.addEventListener("dragleave", handleDragLeave)
 
     return () => {
       window.removeEventListener("dragover", handleDragEnter)
       window.removeEventListener("drop", handleDrop)
-      if (overlayRef.current) {
-        overlayRef.current.removeEventListener("dragleave", handleDragLeave)
-      }
+      window.removeEventListener("drop", handleDragLeave)
     }
-  }, [fileDragged, overlayRef])
+  }, [fileDragged])
 
   const { disabled, placeholder, maxChars } = element
   const { minHeight, maxHeight } = heightGuidance.current
@@ -569,7 +567,7 @@ function ChatInput({
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
 
-  const showOnlyDropzone = acceptFile !== AcceptFileValue.None && fileDragged
+  const showDropzone = acceptFile !== AcceptFileValue.None && fileDragged
 
   return (
     <>
@@ -587,10 +585,9 @@ function ChatInput({
         />
       )}
       <StyledChatInputContainer
-        className="stChatInput"
+        className={showDropzone ? "stChatInput dropzone" : "stChatInput"}
         data-testid="stChatInput"
         width={width}
-        showOnlyDropzone={showOnlyDropzone}
       >
         <StyledChatInput>
           {acceptFile === AcceptFileValue.None ? null : (
@@ -601,7 +598,7 @@ function ChatInput({
               disabled={disabled}
             />
           )}
-          {showOnlyDropzone ? null : (
+          {showDropzone ? null : (
             <>
               <UITextArea
                 inputRef={chatInputRef}
@@ -674,11 +671,6 @@ function ChatInput({
           )}
         </StyledChatInput>
       </StyledChatInputContainer>
-      <StyledDropOverlay
-        ref={overlayRef}
-        id="dropOverlay"
-        showOnlyDropzone={showOnlyDropzone}
-      />
     </>
   )
 }

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -247,16 +247,19 @@ const FileUploadArea = ({
   showDropzone,
   disabled,
 }: FileUploadAreaProps) => (
-  <StyledFileUploadDropzone showDropzone={showDropzone} {...getRootProps()}>
-    <input {...getInputProps()} />
-    {showDropzone ? (
-      "Drag and drop files here"
-    ) : (
-      <BaseButton kind={BaseButtonKind.BORDERLESS_ICON} disabled={disabled}>
-        <Icon content={AttachFile} size="base" color="inherit" />
-      </BaseButton>
-    )}
-  </StyledFileUploadDropzone>
+  <>
+    <StyledFileUploadDropzone showDropzone={showDropzone} {...getRootProps()}>
+      <input {...getInputProps()} />
+      {showDropzone ? (
+        "Drag and drop files here"
+      ) : (
+        <BaseButton kind={BaseButtonKind.BORDERLESS_ICON} disabled={disabled}>
+          <Icon content={AttachFile} size="base" color="inherit" />
+        </BaseButton>
+      )}
+    </StyledFileUploadDropzone>
+    {showDropzone ? null : <StyledVerticalDivider />}
+  </>
 )
 
 function ChatInput({

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -246,7 +246,7 @@ const FileUploadArea = ({
   getInputProps,
   showDropzone,
   disabled,
-}: FileUploadAreaProps) => (
+}: FileUploadAreaProps): React.ReactElement => (
   <>
     <StyledFileUploadDropzone showDropzone={showDropzone} {...getRootProps()}>
       <input {...getInputProps()} />

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -235,21 +235,21 @@ const MAX_VISIBLE_NUM_LINES = 6.5
 const ROUNDING_OFFSET = 1
 
 interface FileUploadAreaProps {
-  fileDragged: boolean
   getRootProps: any
   getInputProps: any
+  showDropzone: boolean
   disabled: boolean
 }
 
 const FileUploadArea = ({
-  fileDragged,
   getRootProps,
   getInputProps,
+  showDropzone,
   disabled,
 }: FileUploadAreaProps) => (
-  <StyledFileUploadDropzone showDropzone={fileDragged} {...getRootProps()}>
+  <StyledFileUploadDropzone showDropzone={showDropzone} {...getRootProps()}>
     <input {...getInputProps()} />
-    {fileDragged ? (
+    {showDropzone ? (
       "Drag and drop files here"
     ) : (
       <BaseButton kind={BaseButtonKind.BORDERLESS_ICON} disabled={disabled}>
@@ -592,9 +592,9 @@ function ChatInput({
         <StyledChatInput>
           {acceptFile === AcceptFileValue.None ? null : (
             <FileUploadArea
-              fileDragged={fileDragged}
               getRootProps={getRootProps}
               getInputProps={getInputProps}
+              showDropzone={showDropzone}
               disabled={disabled}
             />
           )}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -234,6 +234,50 @@ const MAX_VISIBLE_NUM_LINES = 6.5
 // to manage it better.
 const ROUNDING_OFFSET = 1
 
+interface UploadZoneProps {
+  acceptFile: AcceptFileValue
+  fileDragged: boolean
+  getRootProps: any
+  getInputProps: any
+  disabled: boolean
+}
+
+const UploadZone = ({
+  acceptFile,
+  fileDragged,
+  getRootProps,
+  getInputProps,
+  disabled,
+}: UploadZoneProps) =>
+  fileDragged ? (
+    <div
+      {...getRootProps()}
+      style={{
+        width: "100%",
+        border: "2px dashed #cccccc",
+        padding: "20px",
+        textAlign: "center",
+      }}
+    >
+      <input {...getInputProps()} />
+      <p>Drag 'n' drop some files here, or click to select files</p>
+    </div>
+  ) : (
+    <>
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <BaseButton
+          kind={BaseButtonKind.BORDERLESS_ICON}
+          onClick={() => {}}
+          disabled={disabled}
+        >
+          <Icon content={AttachFile} size="base" color="inherit" />
+        </BaseButton>
+      </div>
+      <StyledVerticalDivider />
+    </>
+  )
+
 function ChatInput({
   width,
   element,
@@ -516,7 +560,6 @@ function ChatInput({
     window.addEventListener("dragover", handleDragOver)
     window.addEventListener("drop", handleDrop)
     window.addEventListener("dragleave", handleDragLeave)
-
     return () => {
       window.removeEventListener("dragover", handleDragOver)
       window.removeEventListener("drop", handleDrop)
@@ -531,39 +574,8 @@ function ChatInput({
     scrollHeight > 0 && chatInputRef.current
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
-  const height = undefined // fileDragged ? theme.sizes.emptyDropdownHeight : undefined
 
-  const uploadZone =
-    acceptFile !== AcceptFileValue.None ? (
-      fileDragged ? (
-        <div
-          {...getRootProps()}
-          style={{
-            width: "100%",
-            border: "2px dashed #cccccc",
-            padding: "20px",
-            textAlign: "center",
-          }}
-        >
-          <input {...getInputProps()} />
-          <p>Drag 'n' drop some files here, or click to select files</p>
-        </div>
-      ) : (
-        <>
-          <div {...getRootProps()}>
-            <input {...getInputProps()} />
-            <BaseButton
-              kind={BaseButtonKind.BORDERLESS_ICON}
-              onClick={() => {}}
-              disabled={disabled}
-            >
-              <Icon content={AttachFile} size="base" color="inherit" />
-            </BaseButton>
-          </div>
-          <StyledVerticalDivider />
-        </>
-      )
-    ) : null
+  const showDropZone = acceptFile !== AcceptFileValue.None && fileDragged
 
   return (
     <>
@@ -587,8 +599,16 @@ function ChatInput({
         height={height}
       >
         <StyledChatInput>
-          {uploadZone}
-          {fileDragged ? null : (
+          {acceptFile === AcceptFileValue.None ? null : (
+            <UploadZone
+              acceptFile={acceptFile}
+              fileDragged={fileDragged}
+              getRootProps={getRootProps}
+              getInputProps={getInputProps}
+              disabled={disabled}
+            />
+          )}
+          {showDropZone ? null : (
             <>
               <UITextArea
                 inputRef={chatInputRef}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -67,12 +67,12 @@ import UploadedFiles from "@streamlit/lib/src/components/widgets/FileUploader/Up
 import {
   StyledChatInput,
   StyledChatInputContainer,
+  StyledFileUploadDropzone,
   StyledInputInstructionsContainer,
   StyledSendIconButton,
   StyledSendIconButtonContainer,
   StyledVerticalDivider,
 } from "./styled-components"
-import { fi } from "date-fns/locale"
 
 export interface Props {
   disabled: boolean
@@ -248,18 +248,10 @@ const FileUploadArea = ({
   disabled,
 }: FileUploadAreaProps) =>
   fileDragged ? (
-    <div
-      {...getRootProps()}
-      // style={{
-      //   // width: "100%",
-      //   // border: "2px dashed #cccccc",
-      //   // padding: "20px",
-      //   // textAlign: "center",
-      // }}
-    >
+    <StyledFileUploadDropzone {...getRootProps()}>
       <input {...getInputProps()} />
-      <p>Drag and Drop Files Here</p>
-    </div>
+      Drag and drop files here
+    </StyledFileUploadDropzone>
   ) : (
     <>
       <div {...getRootProps()}>
@@ -571,7 +563,7 @@ function ChatInput({
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
 
-  const showDropZone = acceptFile !== AcceptFileValue.None && fileDragged
+  const showOnlyDropzone = acceptFile !== AcceptFileValue.None && fileDragged
 
   return (
     <>
@@ -592,6 +584,7 @@ function ChatInput({
         className="stChatInput"
         data-testid="stChatInput"
         width={width}
+        showOnlyDropzone={showOnlyDropzone}
       >
         <StyledChatInput>
           {acceptFile === AcceptFileValue.None ? null : (
@@ -602,7 +595,7 @@ function ChatInput({
               disabled={disabled}
             />
           )}
-          {showDropZone ? null : (
+          {showOnlyDropzone ? null : (
             <>
               <UITextArea
                 inputRef={chatInputRef}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -234,33 +234,31 @@ const MAX_VISIBLE_NUM_LINES = 6.5
 // to manage it better.
 const ROUNDING_OFFSET = 1
 
-interface UploadZoneProps {
-  acceptFile: AcceptFileValue
+interface FileUploadAreaProps {
   fileDragged: boolean
   getRootProps: any
   getInputProps: any
   disabled: boolean
 }
 
-const UploadZone = ({
-  acceptFile,
+const FileUploadArea = ({
   fileDragged,
   getRootProps,
   getInputProps,
   disabled,
-}: UploadZoneProps) =>
+}: FileUploadAreaProps) =>
   fileDragged ? (
     <div
       {...getRootProps()}
-      style={{
-        width: "100%",
-        border: "2px dashed #cccccc",
-        padding: "20px",
-        textAlign: "center",
-      }}
+      // style={{
+      //   // width: "100%",
+      //   // border: "2px dashed #cccccc",
+      //   // padding: "20px",
+      //   // textAlign: "center",
+      // }}
     >
       <input {...getInputProps()} />
-      <p>Drag 'n' drop some files here, or click to select files</p>
+      <p>Drag and Drop Files Here</p>
     </div>
   ) : (
     <>
@@ -299,7 +297,6 @@ function ChatInput({
   const [scrollHeight, setScrollHeight] = useState(0)
   const [files, setFiles] = useState<UploadFileInfo[]>([])
 
-  const [placeholder, setPlaceholder] = useState(element.placeholder)
   const [fileDragged, setFileDragged] = useState(false)
 
   const acceptFile = chatInputAcceptFileProtoValueToEnum(element.acceptFile)
@@ -539,16 +536,14 @@ function ChatInput({
     const handleDragOver = (event: DragEvent) => {
       event.preventDefault()
       if (!fileDragged) {
-        console.log("hello file")
+        // console.log("hello file")
         setFileDragged(true)
-        setPlaceholder("Drop file here")
       }
     }
 
     const handleDragLeave = () => {
       if (fileDragged) {
         setFileDragged(false)
-        setPlaceholder(element.placeholder)
       }
     }
 
@@ -560,6 +555,7 @@ function ChatInput({
     window.addEventListener("dragover", handleDragOver)
     window.addEventListener("drop", handleDrop)
     window.addEventListener("dragleave", handleDragLeave)
+
     return () => {
       window.removeEventListener("dragover", handleDragOver)
       window.removeEventListener("drop", handleDrop)
@@ -567,7 +563,7 @@ function ChatInput({
     }
   }, [fileDragged])
 
-  const { disabled, maxChars } = element
+  const { disabled, placeholder, maxChars } = element
   const { minHeight, maxHeight } = heightGuidance.current
 
   const isInputExtended =
@@ -596,12 +592,10 @@ function ChatInput({
         className="stChatInput"
         data-testid="stChatInput"
         width={width}
-        height={height}
       >
         <StyledChatInput>
           {acceptFile === AcceptFileValue.None ? null : (
-            <UploadZone
-              acceptFile={acceptFile}
+            <FileUploadArea
               fileDragged={fileDragged}
               getRootProps={getRootProps}
               getInputProps={getInputProps}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
   StyledSendIconButtonContainer,
   StyledVerticalDivider,
 } from "./styled-components"
+import { fi } from "date-fns/locale"
 
 export interface Props {
   disabled: boolean
@@ -253,6 +254,9 @@ function ChatInput({
   // The value of the height of the textarea. It depends on a variety of factors including the default height, and autogrowing
   const [scrollHeight, setScrollHeight] = useState(0)
   const [files, setFiles] = useState<UploadFileInfo[]>([])
+
+  const [placeholder, setPlaceholder] = useState(element.placeholder)
+  const [fileDragged, setFileDragged] = useState(false)
 
   const acceptFile = chatInputAcceptFileProtoValueToEnum(element.acceptFile)
   const addFiles = (filesToAdd: UploadFileInfo[]): void => {
@@ -487,7 +491,40 @@ function ChatInput({
     }
   }, [chatInputRef])
 
-  const { disabled, placeholder, maxChars } = element
+  useEffect(() => {
+    const handleDragOver = (event: DragEvent) => {
+      event.preventDefault()
+      if (!fileDragged) {
+        console.log("hello file")
+        setFileDragged(true)
+        setPlaceholder("Drop file here")
+      }
+    }
+
+    const handleDragLeave = () => {
+      if (fileDragged) {
+        setFileDragged(false)
+        setPlaceholder(element.placeholder)
+      }
+    }
+
+    const handleDrop = (event: DragEvent) => {
+      event.preventDefault()
+      handleDragLeave()
+    }
+
+    window.addEventListener("dragover", handleDragOver)
+    window.addEventListener("drop", handleDrop)
+    window.addEventListener("dragleave", handleDragLeave)
+
+    return () => {
+      window.removeEventListener("dragover", handleDragOver)
+      window.removeEventListener("drop", handleDrop)
+      window.removeEventListener("dragleave", handleDragLeave)
+    }
+  }, [fileDragged])
+
+  const { disabled, maxChars } = element
   const { minHeight, maxHeight } = heightGuidance.current
 
   const isInputExtended =

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -531,6 +531,39 @@ function ChatInput({
     scrollHeight > 0 && chatInputRef.current
       ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
       : false
+  const height = undefined // fileDragged ? theme.sizes.emptyDropdownHeight : undefined
+
+  const uploadZone =
+    acceptFile !== AcceptFileValue.None ? (
+      fileDragged ? (
+        <div
+          {...getRootProps()}
+          style={{
+            width: "100%",
+            border: "2px dashed #cccccc",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          <input {...getInputProps()} />
+          <p>Drag 'n' drop some files here, or click to select files</p>
+        </div>
+      ) : (
+        <>
+          <div {...getRootProps()}>
+            <input {...getInputProps()} />
+            <BaseButton
+              kind={BaseButtonKind.BORDERLESS_ICON}
+              onClick={() => {}}
+              disabled={disabled}
+            >
+              <Icon content={AttachFile} size="base" color="inherit" />
+            </BaseButton>
+          </div>
+          <StyledVerticalDivider />
+        </>
+      )
+    ) : null
 
   return (
     <>
@@ -551,90 +584,81 @@ function ChatInput({
         className="stChatInput"
         data-testid="stChatInput"
         width={width}
+        height={height}
       >
         <StyledChatInput>
-          {acceptFile !== AcceptFileValue.None ? (
+          {uploadZone}
+          {fileDragged ? null : (
             <>
-              <div {...getRootProps()}>
-                <input {...getInputProps()} />
-                <BaseButton
-                  kind={BaseButtonKind.BORDERLESS_ICON}
-                  onClick={() => {}}
-                  disabled={disabled}
-                >
-                  <Icon content={AttachFile} size="base" color="inherit" />
-                </BaseButton>
-              </div>
-              <StyledVerticalDivider />
-            </>
-          ) : null}
-          <UITextArea
-            inputRef={chatInputRef}
-            value={value}
-            placeholder={placeholder}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            aria-label={placeholder}
-            disabled={disabled}
-            rows={1}
-            overrides={{
-              Root: {
-                style: {
-                  minHeight: theme.sizes.minElementHeight,
-                  outline: "none",
-                  border: "none",
-                },
-              },
-              Input: {
-                props: {
-                  "data-testid": "stChatInputTextArea",
-                },
-                style: {
-                  lineHeight: theme.lineHeights.inputWidget,
-                  "::placeholder": {
-                    opacity: "0.7",
-                  },
-                  height: isInputExtended
-                    ? `${scrollHeight + ROUNDING_OFFSET}px`
-                    : "auto",
-                  maxHeight: maxHeight ? `${maxHeight}px` : "none",
-                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                  paddingLeft:
-                    acceptFile !== AcceptFileValue.None
-                      ? theme.spacing.sm
-                      : theme.spacing.lg,
-                  paddingBottom: theme.spacing.sm,
-                  paddingTop: theme.spacing.sm,
-                  // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
-                  // and some additional margin between the icon and the text (spacing.sm).
-                  paddingRight: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
-                },
-              },
-            }}
-          />
-          {/* Hide the character limit in small widget sizes */}
-          {width > theme.breakpoints.hideWidgetDetails && (
-            <StyledInputInstructionsContainer>
-              <InputInstructions
-                dirty={dirty}
+              <UITextArea
+                inputRef={chatInputRef}
                 value={value}
-                maxLength={maxChars}
-                type="chat"
-                // Chat Input are not able to be used in forms
-                inForm={false}
+                placeholder={placeholder}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                aria-label={placeholder}
+                disabled={disabled}
+                rows={1}
+                overrides={{
+                  Root: {
+                    style: {
+                      minHeight: theme.sizes.minElementHeight,
+                      outline: "none",
+                      border: "none",
+                    },
+                  },
+                  Input: {
+                    props: {
+                      "data-testid": "stChatInputTextArea",
+                    },
+                    style: {
+                      lineHeight: theme.lineHeights.inputWidget,
+                      "::placeholder": {
+                        opacity: "0.7",
+                      },
+                      height: isInputExtended
+                        ? `${scrollHeight + ROUNDING_OFFSET}px`
+                        : "auto",
+                      maxHeight: maxHeight ? `${maxHeight}px` : "none",
+                      // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                      paddingLeft:
+                        acceptFile !== AcceptFileValue.None
+                          ? theme.spacing.sm
+                          : theme.spacing.lg,
+                      paddingBottom: theme.spacing.sm,
+                      paddingTop: theme.spacing.sm,
+                      // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
+                      // and some additional margin between the icon and the text (spacing.sm).
+                      paddingRight: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
+                    },
+                  },
+                }}
               />
-            </StyledInputInstructionsContainer>
+              {/* Hide the character limit in small widget sizes */}
+              {width > theme.breakpoints.hideWidgetDetails && (
+                <StyledInputInstructionsContainer>
+                  <InputInstructions
+                    dirty={dirty}
+                    value={value}
+                    maxLength={maxChars}
+                    type="chat"
+                    // Chat Input are not able to be used in forms
+                    inForm={false}
+                  />
+                </StyledInputInstructionsContainer>
+              )}
+              <StyledSendIconButtonContainer>
+                <StyledSendIconButton
+                  onClick={handleSubmit}
+                  disabled={!dirty || disabled}
+                  extended={isInputExtended}
+                  data-testid="stChatInputSubmitButton"
+                >
+                  <Icon content={Send} size="xl" color="inherit" />
+                </StyledSendIconButton>
+              </StyledSendIconButtonContainer>
+            </>
           )}
-          <StyledSendIconButtonContainer>
-            <StyledSendIconButton
-              onClick={handleSubmit}
-              disabled={!dirty || disabled}
-              extended={isInputExtended}
-              data-testid="stChatInputSubmitButton"
-            >
-              <Icon content={Send} size="xl" color="inherit" />
-            </StyledSendIconButton>
-          </StyledSendIconButtonContainer>
         </StyledChatInput>
       </StyledChatInputContainer>
     </>

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -67,6 +67,7 @@ import UploadedFiles from "@streamlit/lib/src/components/widgets/FileUploader/Up
 import {
   StyledChatInput,
   StyledChatInputContainer,
+  StyledDropOverlay,
   StyledFileUploadDropzone,
   StyledInputInstructionsContainer,
   StyledSendIconButton,
@@ -278,6 +279,7 @@ function ChatInput({
   const theme = useTheme()
 
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
   const counterRef = useRef(0)
   const heightGuidance = useRef({ minHeight: 0, maxHeight: 0 })
 
@@ -525,15 +527,15 @@ function ChatInput({
   }, [chatInputRef])
 
   useEffect(() => {
-    const handleDragOver = (event: DragEvent) => {
+    const handleDragEnter = (event: DragEvent) => {
       event.preventDefault()
       if (!fileDragged) {
-        // console.log("hello file")
         setFileDragged(true)
       }
     }
 
     const handleDragLeave = () => {
+      console.log("leave file")
       if (fileDragged) {
         setFileDragged(false)
       }
@@ -544,16 +546,20 @@ function ChatInput({
       handleDragLeave()
     }
 
-    window.addEventListener("dragover", handleDragOver)
+    window.addEventListener("dragover", handleDragEnter)
     window.addEventListener("drop", handleDrop)
-    window.addEventListener("dragleave", handleDragLeave)
+    if (overlayRef.current) {
+      overlayRef.current.addEventListener("dragleave", handleDragLeave)
+    }
 
     return () => {
-      window.removeEventListener("dragover", handleDragOver)
+      window.removeEventListener("dragover", handleDragEnter)
       window.removeEventListener("drop", handleDrop)
-      window.removeEventListener("dragleave", handleDragLeave)
+      if (overlayRef.current) {
+        overlayRef.current.removeEventListener("dragleave", handleDragLeave)
+      }
     }
-  }, [fileDragged])
+  }, [fileDragged, overlayRef])
 
   const { disabled, placeholder, maxChars } = element
   const { minHeight, maxHeight } = heightGuidance.current
@@ -668,6 +674,11 @@ function ChatInput({
           )}
         </StyledChatInput>
       </StyledChatInputContainer>
+      <StyledDropOverlay
+        ref={overlayRef}
+        id="dropOverlay"
+        showOnlyDropzone={showOnlyDropzone}
+      />
     </>
   )
 }

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -23,29 +23,31 @@ const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
 export interface StyledChatInputContainerProps {
   width: number
-  showOnlyDropzone: boolean
 }
 
 export const StyledChatInputContainer =
-  styled.div<StyledChatInputContainerProps>(
-    ({ theme, width, showOnlyDropzone }) => {
-      return {
-        border: showOnlyDropzone ? `${theme.sizes.borderWidth} solid` : "none",
-        borderColor: theme.colors.transparent,
-        borderRadius: chatBorderRadius(theme),
-        display: "flex",
-        backgroundColor:
-          theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
-        width: `${width}px`,
-        overflow: "hidden",
-        // pointerEvents: "none",
+  styled.div<StyledChatInputContainerProps>(({ theme, width }) => {
+    return {
+      border: `${theme.sizes.borderWidth} solid`,
+      borderColor: theme.colors.transparent,
+      borderRadius: chatBorderRadius(theme),
+      display: "flex",
+      backgroundColor:
+        theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
+      width: `${width}px`,
+      overflow: "hidden",
 
-        ":focus-within": {
-          borderColor: theme.colors.primary,
-        },
-      }
+      ":focus-within": {
+        borderColor: theme.colors.primary,
+      },
+
+      "&.dropzone": {
+        borderColor: theme.colors.primary,
+        borderRadius: theme.radii.full,
+        height: theme.sizes.emptyDropdownHeight,
+      },
     }
-  )
+  })
 
 export const StyledChatInput = styled.div(({}) => {
   return {
@@ -121,14 +123,24 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
   right: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
 }))
 
-export const StyledFileUploadDropzone = styled.div(({ theme }) => ({
-  height: theme.sizes.emptyDropdownHeight,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  margin: "auto",
-  color: theme.colors.primary,
-}))
+export interface StyledFileUploadDropzoneProps {
+  showOnlyDropzone: boolean
+}
+
+export const StyledFileUploadDropzone =
+  styled.div<StyledFileUploadDropzoneProps>(({ theme, showOnlyDropzone }) => {
+    return showOnlyDropzone
+      ? {
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          margin: "auto",
+          color: theme.colors.primary,
+        }
+      : {}
+  })
 
 export interface StyledVerticalDividerProps {
   color?: string
@@ -142,24 +154,6 @@ export const StyledVerticalDivider = styled.div<StyledVerticalDividerProps>(
       marginLeft: `-${theme.spacing.twoXS}`,
       marginRight: theme.spacing.twoXS,
       backgroundColor: color ?? theme.colors.fadedText20,
-    }
-  }
-)
-
-export interface StyledDropOverlayProps {
-  showOnlyDropzone: boolean
-}
-
-export const StyledDropOverlay = styled.div<StyledDropOverlayProps>(
-  ({ theme, showOnlyDropzone }) => {
-    return {
-      height: "100vh",
-      width: "100vw",
-      visibility: showOnlyDropzone ? "visible" : "hidden",
-      zIndex: theme.zIndices.priority,
-      // ".stChatInput, .stChatInput *": {
-      //   pointerEvents: "none",
-      // },
     }
   }
 )

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -17,7 +17,6 @@ import styled from "@emotion/styled"
 import { Theme } from "@emotion/react"
 
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
-import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
 
 const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
@@ -124,12 +123,12 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
 }))
 
 export interface StyledFileUploadDropzoneProps {
-  showOnlyDropzone: boolean
+  showDropzone: boolean
 }
 
 export const StyledFileUploadDropzone =
-  styled.div<StyledFileUploadDropzoneProps>(({ theme, showOnlyDropzone }) => {
-    return showOnlyDropzone
+  styled.div<StyledFileUploadDropzoneProps>(({ theme, showDropzone }) => {
+    return showDropzone
       ? {
           height: "100%",
           width: "100%",

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -120,10 +120,6 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
   right: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
 }))
 
-// export interface StyledFileUploadDropzoneProps {
-
-// }
-
 export const StyledFileUploadDropzone = styled.div(({ theme }) => ({
   height: theme.sizes.emptyDropdownHeight,
   display: "flex",

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -17,16 +17,18 @@ import styled from "@emotion/styled"
 import { Theme } from "@emotion/react"
 
 import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
+import { isNullOrUndefined } from "@streamlit/lib/src/util/utils"
 
 const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
 export interface StyledChatInputContainerProps {
   width: number
+  height: string | undefined
 }
 
 export const StyledChatInputContainer =
-  styled.div<StyledChatInputContainerProps>(({ theme, width }) => {
-    return {
+  styled.div<StyledChatInputContainerProps>(({ theme, width, height }) => {
+    const props = {
       border: `${theme.sizes.borderWidth} solid`,
       borderColor: theme.colors.transparent,
       borderRadius: chatBorderRadius(theme),
@@ -40,6 +42,12 @@ export const StyledChatInputContainer =
         borderColor: theme.colors.primary,
       },
     }
+    return isNullOrUndefined(height)
+      ? props
+      : {
+          ...props,
+          height: height,
+        }
   })
 
 export const StyledChatInput = styled.div(({}) => {

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -38,6 +38,7 @@ export const StyledChatInputContainer =
           theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
         width: `${width}px`,
         overflow: "hidden",
+        // pointerEvents: "none",
 
         ":focus-within": {
           borderColor: theme.colors.primary,
@@ -141,6 +142,24 @@ export const StyledVerticalDivider = styled.div<StyledVerticalDividerProps>(
       marginLeft: `-${theme.spacing.twoXS}`,
       marginRight: theme.spacing.twoXS,
       backgroundColor: color ?? theme.colors.fadedText20,
+    }
+  }
+)
+
+export interface StyledDropOverlayProps {
+  showOnlyDropzone: boolean
+}
+
+export const StyledDropOverlay = styled.div<StyledDropOverlayProps>(
+  ({ theme, showOnlyDropzone }) => {
+    return {
+      height: "100vh",
+      width: "100vw",
+      visibility: showOnlyDropzone ? "visible" : "hidden",
+      zIndex: theme.zIndices.priority,
+      // ".stChatInput, .stChatInput *": {
+      //   pointerEvents: "none",
+      // },
     }
   }
 )

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -117,6 +117,14 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
   right: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
 }))
 
+// export interface StyledFileUploadDropzoneProps {
+
+// }
+
+export const StyledFileUploadDropzone = styled.div(({ theme }) => ({
+  borderRadius: theme.radii.xxxl,
+}))
+
 export interface StyledVerticalDividerProps {
   color?: string
 }

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -23,12 +23,11 @@ const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
 export interface StyledChatInputContainerProps {
   width: number
-  height: string | undefined
 }
 
 export const StyledChatInputContainer =
-  styled.div<StyledChatInputContainerProps>(({ theme, width, height }) => {
-    const props = {
+  styled.div<StyledChatInputContainerProps>(({ theme, width }) => {
+    return {
       border: `${theme.sizes.borderWidth} solid`,
       borderColor: theme.colors.transparent,
       borderRadius: chatBorderRadius(theme),
@@ -42,12 +41,6 @@ export const StyledChatInputContainer =
         borderColor: theme.colors.primary,
       },
     }
-    return isNullOrUndefined(height)
-      ? props
-      : {
-          ...props,
-          height: height,
-        }
   })
 
 export const StyledChatInput = styled.div(({}) => {

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -23,25 +23,28 @@ const chatBorderRadius = (theme: Theme): string => theme.radii.xxxl
 
 export interface StyledChatInputContainerProps {
   width: number
+  showOnlyDropzone: boolean
 }
 
 export const StyledChatInputContainer =
-  styled.div<StyledChatInputContainerProps>(({ theme, width }) => {
-    return {
-      border: `${theme.sizes.borderWidth} solid`,
-      borderColor: theme.colors.transparent,
-      borderRadius: chatBorderRadius(theme),
-      display: "flex",
-      backgroundColor:
-        theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
-      width: `${width}px`,
-      overflow: "hidden",
+  styled.div<StyledChatInputContainerProps>(
+    ({ theme, width, showOnlyDropzone }) => {
+      return {
+        border: showOnlyDropzone ? `${theme.sizes.borderWidth} solid` : "none",
+        borderColor: theme.colors.transparent,
+        borderRadius: chatBorderRadius(theme),
+        display: "flex",
+        backgroundColor:
+          theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
+        width: `${width}px`,
+        overflow: "hidden",
 
-      ":focus-within": {
-        borderColor: theme.colors.primary,
-      },
+        ":focus-within": {
+          borderColor: theme.colors.primary,
+        },
+      }
     }
-  })
+  )
 
 export const StyledChatInput = styled.div(({}) => {
   return {
@@ -122,7 +125,12 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
 // }
 
 export const StyledFileUploadDropzone = styled.div(({ theme }) => ({
-  borderRadius: theme.radii.xxxl,
+  height: theme.sizes.emptyDropdownHeight,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  margin: "auto",
+  color: theme.colors.primary,
 }))
 
 export interface StyledVerticalDividerProps {


### PR DESCRIPTION
## Describe your changes

Added drag and drop UI:


Introduced `fileDragged` state and a `showDropzone` flag. In "drop" mode, multiple components have the following changes
* ChatInputContainer - border and height changes
* Input button - expand to fill the entire chat input container to allow larger dropzone
* Text area - removed when user is dragging a file

### Demo (observe the following events)
* chat input changes upon dragged target entering page
* chat input returns to normal upon target leaving page
* dropping target inside the input uploads the file
* chat input returns to normal form upon dropping target outside the input 

https://github.com/user-attachments/assets/23af6044-ff9b-4815-8b6b-02a32e5b0a62



## GitHub Issue Link (if applicable)

## Testing Plan

- E2E test todo

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
