### PR TITLE
Moves the isLocalhost function into utils so that MainMenu only exports components

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -103,10 +103,11 @@ import {
   WidgetStates,
 } from "@streamlit/lib"
 import getBrowserInfo from "@streamlit/app/src/util/getBrowserInfo"
+import { isLocalhost } from "@streamlit/app/src/util/deploymentInfo"
 import { AppContext } from "@streamlit/app/src/components/AppContext"
 import AppView from "@streamlit/app/src/components/AppView"
 import StatusWidget from "@streamlit/app/src/components/StatusWidget"
-import MainMenu, { isLocalhost } from "@streamlit/app/src/components/MainMenu"
+import MainMenu from "@streamlit/app/src/components/MainMenu"
 import ToolbarActions from "@streamlit/app/src/components/ToolbarActions"
 import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -93,13 +93,6 @@ const getOpenInWindowCallback = (url: string) => (): void => {
   window.open(url, "_blank")
 }
 
-export const isLocalhost = (): boolean => {
-  return (
-    window.location.hostname === "localhost" ||
-    window.location.hostname === "127.0.0.1"
-  )
-}
-
 export interface MenuItemProps {
   item: any
   "aria-selected": boolean

--- a/frontend/app/src/components/MainMenu/index.tsx
+++ b/frontend/app/src/components/MainMenu/index.tsx
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default, isLocalhost } from "./MainMenu"
+export { default } from "./MainMenu"

--- a/frontend/app/src/util/deploymentInfo.test.ts
+++ b/frontend/app/src/util/deploymentInfo.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isLocalhost } from "@streamlit/app/src/util/deploymentInfo"
+
+describe("isLocalhost", () => {
+  const { location: originalLocation } = window
+  beforeEach(() => {
+    // Replace window.location with a mutable object that otherwise has
+    // the same contents so that we can change hostname below.
+    // @ts-expect-error
+    delete window.location
+    window.location = { ...originalLocation }
+  })
+  afterEach(() => {
+    window.location = originalLocation
+  })
+
+  it("returns true given localhost", () => {
+    window.location.hostname = "localhost"
+    expect(isLocalhost()).toBe(true)
+  })
+
+  it("returns true given 127.0.0.1", () => {
+    window.location.hostname = "localhost"
+    expect(isLocalhost()).toBe(true)
+  })
+
+  it("returns true given other", () => {
+    window.location.hostname = "190.1.1.1"
+    expect(isLocalhost()).toBe(false)
+  })
+
+  it("returns true given other ", () => {
+    window.location.hostname = "190.1.1.1"
+    expect(isLocalhost()).toBe(false)
+  })
+
+  it("returns true given null", () => {
+    window.location.hostname = null
+    expect(isLocalhost()).toBe(false)
+  })
+
+  it("returns true given undefined", () => {
+    window.location.hostname = undefined
+    expect(isLocalhost()).toBe(false)
+  })
+})

--- a/frontend/app/src/util/deploymentInfo.test.ts
+++ b/frontend/app/src/util/deploymentInfo.test.ts
@@ -39,22 +39,17 @@ describe("isLocalhost", () => {
     expect(isLocalhost()).toBe(true)
   })
 
-  it("returns true given other", () => {
+  it("returns false given other", () => {
     window.location.hostname = "190.1.1.1"
     expect(isLocalhost()).toBe(false)
   })
 
-  it("returns true given other ", () => {
-    window.location.hostname = "190.1.1.1"
-    expect(isLocalhost()).toBe(false)
-  })
-
-  it("returns true given null", () => {
+  it("returns false given null", () => {
     window.location.hostname = null
     expect(isLocalhost()).toBe(false)
   })
 
-  it("returns true given undefined", () => {
+  it("returns false given undefined", () => {
     window.location.hostname = undefined
     expect(isLocalhost()).toBe(false)
   })

--- a/frontend/app/src/util/deploymentInfo.ts
+++ b/frontend/app/src/util/deploymentInfo.ts
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-import { Config } from "@streamlit/lib"
-import { isLocalhost } from "@streamlit/app/src/util/deploymentInfo"
-
-export const showDevelopmentOptions = (
-  hostIsOwner: boolean | undefined,
-  toolbarMode: Config.ToolbarMode
-): boolean => {
-  if (toolbarMode == Config.ToolbarMode.DEVELOPER) {
-    return true
-  }
-  if (
-    Config.ToolbarMode.VIEWER == toolbarMode ||
-    Config.ToolbarMode.MINIMAL == toolbarMode
-  ) {
-    return false
-  }
-  return hostIsOwner || isLocalhost()
+export const isLocalhost = (): boolean => {
+  return (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  )
 }


### PR DESCRIPTION
## Describe your changes

Part of some ongoing work to fix all violations of [react-refresh rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) which will be followed by adding this eslint rule. 

## GitHub Issue Link (if applicable)

## Testing Plan

No functional changes so existing tests should cover this. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
