### PR TITLE
[chore] Remove unnecessary nightly performance step

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,12 +89,6 @@ jobs:
     with:
       ref: ${{needs.create-nightly-tag.outputs.tag}}
 
-  performance-lighthouse:
-    uses: ./.github/workflows/performance-lighthouse.yml
-    with:
-      ref: ${{needs.create-nightly-tag.outputs.tag}}
-      externalCall: true
-
   test-status-notification:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Describe your changes

- https://github.com/streamlit/streamlit/pull/10180 Refactored the performance github actions such that they are run on every PR + merge to `develop`
- This removes the unnecessary performance job call from the nightly build. Due to the refactor, this would not give us any additional fidelity that the other runs would, so there is no need to run it

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
