### PR TITLE
Pin down langsmith integration dependency to fix CI

### DIFF
--- a/lib/integration-requirements.txt
+++ b/lib/integration-requirements.txt
@@ -5,6 +5,9 @@ snowflake-connector-python>=3.3.0
 # Required for testing the langchain integration
 langchain>=0.2.0
 langchain-community>=0.2.0
+# Langsmith 0.3 adds a pytest integration that is incompatible with
+# playwright pytest since it uses the same --outputs argument.
+langsmith<0.3.0
 
 # Additional dataframe formats for testing:
 polars


### PR DESCRIPTION
## Describe your changes

The new pytest integration in langsmith (https://github.com/langchain-ai/langsmith-sdk/pull/1362) broke our CI since it adds an `--output` argument which overlaps with the `--output` of playwright-pytest. This PR pins down the dependency to resolve the issue. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
