### PR TITLE
Restrict upper-bound of langchain requirement for integration tests

### DIFF
--- a/lib/integration-requirements.txt
+++ b/lib/integration-requirements.txt
@@ -3,8 +3,8 @@ snowflake-snowpark-python[modin]>=1.17.0
 snowflake-connector-python>=3.3.0
 
 # Required for testing the langchain integration
-langchain>=0.2.0
-langchain-community>=0.2.0
+langchain>=0.2.0,<=0.3.14
+langchain-community>=0.2.0,<=0.3.14
 
 # Additional dataframe formats for testing:
 polars


### PR DESCRIPTION
## Describe your changes

Last night, [langchain](https://pypi.org/project/langchain/#history) released a new pypi version (0.3.15). It looks like a (transient) dependency is installed that conflicts with our pytest setup. 

<details>
<summary>When running `make pytest-integration`, following error can be seen:</summary>

```text
(venv) (base) ➜  streamlit git:(develop) ✗ make pytest-integration
cd lib; \
		PYTHONPATH=. \
		pytest -v \
			--require-integration \
			-l tests/ \
			-m "not performance" \
			 /Users/braethlein/Projects/streamlit/lib/streamlit  /Users/braethlein/Projects/streamlit/lib/tests
Traceback (most recent call last):
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/bin/pytest", line 8, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 197, in console_main
    code = main()
           ^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 155, in main
    config = _prepareconfig(args, plugins)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 337, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/helpconfig.py", line 105, in pytest_cmdline_parse
    config = yield
             ^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1143, in pytest_cmdline_parse
    self.parse(args)
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1492, in parse
    self._preparse(args, addopts=addopts)
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1382, in _preparse
    self.known_args_namespace = self._parser.parse_known_args(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/argparsing.py", line 160, in parse_known_args
    return self.parse_known_and_unknown_args(args, namespace=namespace)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/argparsing.py", line 174, in parse_known_and_unknown_args
    optparser = self._getparser()
                ^^^^^^^^^^^^^^^^^
  File "/Users/braethlein/Documents/streamlit-apps/debug/venv/lib/python3.11/site-packages/_pytest/config/argparsing.py", line 133, in _getparser
    arggroup.add_argument(*n, **a)
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1473, in add_argument
    return self._add_action(action)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1675, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1487, in _add_action
    self._check_conflict(action)
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1624, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1633, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --output: conflicting option string: --output
make: *** [pytest-integration] Error 1
```

</details>

The error apparently stems from the fact that two pytest plugins have an `output` argument. Uninstall `pytest-playwright` seems to fix the issue as well, but since we need that to run our suite, we rather pin the langchain version.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
