### PR TITLE
add ability to reload page on version mismatch based on hardcoded client version

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -533,7 +533,7 @@ describe("App", () => {
       window.streamlit = undefined
 
       // @ts-expect-error
-      __STREAMLIT_APP_VERSION__ = undefined
+      STREAMLIT_APP_VERSION = undefined
     })
 
     it("triggers page reload", () => {
@@ -547,7 +547,7 @@ describe("App", () => {
       window.location = { reload: vi.fn() }
 
       // @ts-expect-error
-      __STREAMLIT_APP_VERSION__ = "oldStreamlitVersion"
+      STREAMLIT_APP_VERSION = "oldStreamlitVersion"
 
       sendForwardMessage("newSession", {
         config: {},
@@ -575,7 +575,7 @@ describe("App", () => {
       window.location = { reload: vi.fn() }
 
       // @ts-expect-error
-      __STREAMLIT_APP_VERSION__ = "oldStreamlitVersion"
+      STREAMLIT_APP_VERSION = "oldStreamlitVersion"
 
       sendForwardMessage("newSession", {
         config: {},

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -480,6 +480,117 @@ describe("App", () => {
 
       expect(window.location.reload).toHaveBeenCalled()
     })
+
+    it("does not trigger page reload if version has not changed", () => {
+      renderApp(getProps())
+
+      // A HACK to mock `window.location.reload`.
+      // NOTE: The mocking must be done after mounting, but before `handleMessage` is called.
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = { reload: vi.fn() }
+
+      // Ensure SessionInfo is initialized
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      sessionInfo.setCurrent(
+        mockSessionInfoProps({ streamlitVersion: "oldStreamlitVersion" })
+      )
+      expect(sessionInfo.isSet).toBe(true)
+
+      sendForwardMessage("newSession", {
+        config: {},
+        initialize: {
+          environmentInfo: {
+            streamlitVersion: "oldStreamlitVersion",
+          },
+          sessionId: "sessionId",
+          userInfo: {},
+          sessionStatus: {},
+        },
+      })
+
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("streamlit server version changes using hardcoded streamlit client version to detect version mismatch", () => {
+    let prevWindowLocation: Location
+
+    beforeEach(() => {
+      prevWindowLocation = window.location
+
+      // @ts-expect-error
+      window.__streamlit = {
+        ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION: true,
+      }
+    })
+
+    afterEach(() => {
+      window.location = prevWindowLocation
+
+      // @ts-expect-error
+      window.streamlit = undefined
+
+      // @ts-expect-error
+      __STREAMLIT_APP_VERSION__ = undefined
+    })
+
+    it("triggers page reload", () => {
+      renderApp(getProps())
+
+      // A HACK to mock `window.location.reload`.
+      // NOTE: The mocking must be done after mounting, but before `handleMessage` is called.
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = { reload: vi.fn() }
+
+      // @ts-expect-error
+      __STREAMLIT_APP_VERSION__ = "oldStreamlitVersion"
+
+      sendForwardMessage("newSession", {
+        config: {},
+        initialize: {
+          environmentInfo: {
+            streamlitVersion: "newStreamlitVersion",
+          },
+          sessionId: "sessionId",
+          userInfo: {},
+          sessionStatus: {},
+        },
+      })
+
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it("does not trigger page reload if version has not changed", () => {
+      renderApp(getProps())
+
+      // A HACK to mock `window.location.reload`.
+      // NOTE: The mocking must be done after mounting, but before `handleMessage` is called.
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = { reload: vi.fn() }
+
+      // @ts-expect-error
+      __STREAMLIT_APP_VERSION__ = "oldStreamlitVersion"
+
+      sendForwardMessage("newSession", {
+        config: {},
+        initialize: {
+          environmentInfo: {
+            streamlitVersion: "oldStreamlitVersion",
+          },
+          sessionId: "sessionId",
+          userInfo: {},
+          sessionStatus: {},
+        },
+      })
+
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
   })
 
   it("hides the top bar if hideTopBar === true", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -529,11 +529,12 @@ describe("App", () => {
     afterEach(() => {
       window.location = prevWindowLocation
 
-      // @ts-expect-error
-      window.streamlit = undefined
+      window.__streamlit = undefined
 
       // @ts-expect-error
-      PACKAGE_METADATA = undefined
+      PACKAGE_METADATA = {
+        version: "tbd",
+      }
     })
 
     it("triggers page reload", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -533,7 +533,7 @@ describe("App", () => {
       window.streamlit = undefined
 
       // @ts-expect-error
-      STREAMLIT_APP_VERSION = undefined
+      PACKAGE_METADATA = undefined
     })
 
     it("triggers page reload", () => {
@@ -547,7 +547,9 @@ describe("App", () => {
       window.location = { reload: vi.fn() }
 
       // @ts-expect-error
-      STREAMLIT_APP_VERSION = "oldStreamlitVersion"
+      PACKAGE_METADATA = {
+        version: "oldStreamlitVersion",
+      }
 
       sendForwardMessage("newSession", {
         config: {},
@@ -575,7 +577,9 @@ describe("App", () => {
       window.location = { reload: vi.fn() }
 
       // @ts-expect-error
-      STREAMLIT_APP_VERSION = "oldStreamlitVersion"
+      PACKAGE_METADATA = {
+        version: "oldStreamlitVersion",
+      }
 
       sendForwardMessage("newSession", {
         config: {},

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -588,14 +588,15 @@ export class App extends PureComponent<Props, State> {
       currentStreamlitVersion = this.sessionInfo.current.streamlitVersion
     }
 
-    const { environmentInfo } = initializeMsg
+    if (currentStreamlitVersion) {
+      const { environmentInfo } = initializeMsg
 
-    if (
-      currentStreamlitVersion &&
-      notNullOrUndefined(environmentInfo) &&
-      notNullOrUndefined(environmentInfo.streamlitVersion)
-    ) {
-      return currentStreamlitVersion != environmentInfo.streamlitVersion
+      if (
+        notNullOrUndefined(environmentInfo) &&
+        notNullOrUndefined(environmentInfo.streamlitVersion)
+      ) {
+        return currentStreamlitVersion != environmentInfo.streamlitVersion
+      }
     }
 
     return false

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -133,8 +133,8 @@ import "@streamlit/app/src/assets/css/theme.scss"
 import { ThemeManager } from "./util/useThemeManager"
 import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
 
-// vite config builds global variable __STREAMLIT_APP_VERSION__ from frontend/app/package.json's version
-declare const __STREAMLIT_APP_VERSION__: string
+// vite config builds global variable STREAMLIT_APP_VERSION from frontend/app/package.json's version
+declare const STREAMLIT_APP_VERSION: string
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -581,9 +581,9 @@ export class App extends PureComponent<Props, State> {
     if (
       window.__streamlit
         ?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION === true &&
-      __STREAMLIT_APP_VERSION__
+      STREAMLIT_APP_VERSION
     ) {
-      currentStreamlitVersion = __STREAMLIT_APP_VERSION__
+      currentStreamlitVersion = STREAMLIT_APP_VERSION
     } else if (this.sessionInfo.isSet) {
       currentStreamlitVersion = this.sessionInfo.current.streamlitVersion
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -133,6 +133,9 @@ import "@streamlit/app/src/assets/css/theme.scss"
 import { ThemeManager } from "./util/useThemeManager"
 import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
 
+// vite config builds global variable __STREAMLIT_APP_VERSION__ from frontend/app/package.json's version
+declare const __STREAMLIT_APP_VERSION__: string
+
 export interface Props {
   screenCast: ScreenCastHOC
   theme: ThemeManager
@@ -573,16 +576,26 @@ export class App extends PureComponent<Props, State> {
    * Checks if the code version from the backend is different than the frontend
    */
   private hasStreamlitVersionChanged(initializeMsg: Initialize): boolean {
-    if (this.sessionInfo.isSet) {
-      const currentStreamlitVersion = this.sessionInfo.current.streamlitVersion
-      const { environmentInfo } = initializeMsg
+    let currentStreamlitVersion: string | undefined = undefined
 
-      if (
-        notNullOrUndefined(environmentInfo) &&
-        notNullOrUndefined(environmentInfo.streamlitVersion)
-      ) {
-        return currentStreamlitVersion != environmentInfo.streamlitVersion
-      }
+    if (
+      window.__streamlit
+        ?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION === true &&
+      __STREAMLIT_APP_VERSION__
+    ) {
+      currentStreamlitVersion = __STREAMLIT_APP_VERSION__
+    } else if (this.sessionInfo.isSet) {
+      currentStreamlitVersion = this.sessionInfo.current.streamlitVersion
+    }
+
+    const { environmentInfo } = initializeMsg
+
+    if (
+      currentStreamlitVersion &&
+      notNullOrUndefined(environmentInfo) &&
+      notNullOrUndefined(environmentInfo.streamlitVersion)
+    ) {
+      return currentStreamlitVersion != environmentInfo.streamlitVersion
     }
 
     return false

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -133,8 +133,10 @@ import "@streamlit/app/src/assets/css/theme.scss"
 import { ThemeManager } from "./util/useThemeManager"
 import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
 
-// vite config builds global variable STREAMLIT_APP_VERSION from frontend/app/package.json's version
-declare const STREAMLIT_APP_VERSION: string
+// vite config builds global variable PACKAGE_METADATA
+declare const PACKAGE_METADATA: {
+  version: string
+}
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -581,9 +583,9 @@ export class App extends PureComponent<Props, State> {
     if (
       window.__streamlit
         ?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION === true &&
-      STREAMLIT_APP_VERSION
+      PACKAGE_METADATA?.version
     ) {
-      currentStreamlitVersion = STREAMLIT_APP_VERSION
+      currentStreamlitVersion = PACKAGE_METADATA.version
     } else if (this.sessionInfo.isSet) {
       currentStreamlitVersion = this.sessionInfo.current.streamlitVersion
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -582,8 +582,7 @@ export class App extends PureComponent<Props, State> {
 
     if (
       window.__streamlit
-        ?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION === true &&
-      PACKAGE_METADATA?.version
+        ?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION === true
     ) {
       currentStreamlitVersion = PACKAGE_METADATA.version
     } else if (this.sessionInfo.isSet) {

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -52,7 +52,7 @@ const profilerAliases = IS_PROFILER_BUILD
 export default defineConfig({
   base: BASE,
   define: {
-    __STREAMLIT_APP_VERSION__: JSON.stringify(version),
+    STREAMLIT_APP_VERSION: JSON.stringify(version),
   },
   plugins: [
     react({

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -52,7 +52,7 @@ const profilerAliases = IS_PROFILER_BUILD
 export default defineConfig({
   base: BASE,
   define: {
-    STREAMLIT_APP_VERSION: JSON.stringify(version),
+    STREAMLIT_APP_VERSION: version,
   },
   plugins: [
     react({

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -15,6 +15,7 @@
  */
 
 import { defineConfig } from "vite"
+import { version } from "./package.json"
 import react from "@vitejs/plugin-react-swc"
 import viteTsconfigPaths from "vite-tsconfig-paths"
 import { default as checker } from "vite-plugin-checker"
@@ -50,6 +51,9 @@ const profilerAliases = IS_PROFILER_BUILD
 // https://vitejs.dev/config/
 export default defineConfig({
   base: BASE,
+  define: {
+    __STREAMLIT_APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [
     react({
       jsxImportSource: "@emotion/react",

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -52,7 +52,9 @@ const profilerAliases = IS_PROFILER_BUILD
 export default defineConfig({
   base: BASE,
   define: {
-    STREAMLIT_APP_VERSION: version,
+    PACKAGE_METADATA: {
+      version,
+    },
   },
   plugins: [
     react({

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -57,7 +57,7 @@ declare global {
     __streamlit?: {
       LIGHT_THEME: ICustomThemeConfig
       DARK_THEME: ICustomThemeConfig
-      ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION: boolean
+      ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION?: boolean
     }
     __streamlit_profiles__?: Record<
       string,

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -57,6 +57,7 @@ declare global {
     __streamlit?: {
       LIGHT_THEME: ICustomThemeConfig
       DARK_THEME: ICustomThemeConfig
+      ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION: boolean
     }
     __streamlit_profiles__?: Record<
       string,


### PR DESCRIPTION
## Describe your changes

- Changes the `hasStreamlitVersionChanged` logic to compare the version between the `initializeMessage` and the variable `PACKAGE_METADATA.version`. `PACKAGE_METADATA.version` is a global variable that gets set by vite and is read from the `version` field in streamlit/app's package.json.
- The previous logic relied on having sent a prior NewSession message so that `sessionInfo.isSet` is true when the subsequent NewSession message comes in. The new logic should suffice and remove the need to send multiple NewSession messages to detect a version mismatch. The frontend knows what version it is based on what's in package.json, which gets revved for every streamlit release.
- SiS currently sends an initialization sequence of NewSession, Alert FwdMessage pairs. We are removing this initialization sequence so that we can show the built-in streamlit skeleton during loading. SiS will render the loading sequence outside of streamlit as a page footer. Therefore, the current logic that assumes the host will send multiple NewSession messages will no longer be correct.
- This new behavior is only enabled if `window.__streamlit?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION` is set to `true`, allowing it to be enabled behind a feature flag.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) ✅ 
- E2E Tests
- Any manual testing needed? ✅

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
