### PR TITLE
Use `attribute` word instead of `key` in case of AttributeError in st.query_params

### DIFF
--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -201,4 +201,4 @@ class QueryParams(MutableMapping[str, str]):
 
 
 def missing_key_error_message(key: str) -> str:
-    return f'st.query_params has no key "{key}". Did you forget to initialize it?'
+    return f'st.query_params has no key "{key}".'

--- a/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
@@ -122,3 +122,15 @@ class TestQueryParamsProxy(unittest.TestCase):
         assert self.query_params_proxy["test_multi"] == "value2"
         assert self.query_params_proxy.get_all("test_multi") == ["value1", "value2"]
         assert len(self.query_params_proxy) == 2
+
+    def test_key_error_message(self):
+        with pytest.raises(KeyError) as e:
+            self.query_params_proxy["nonexistent"]
+
+        assert str(e.value) == """'st.query_params has no key "nonexistent".'"""
+
+    def test_attribute_error_message(self):
+        with pytest.raises(AttributeError) as e:
+            self.query_params_proxy.nonexistent  # noqa: B018
+
+        assert str(e.value) == 'st.query_params has no attribute "nonexistent".'


### PR DESCRIPTION
## Describe your changes

Just better exception texts for missing attribute / key for `st.query_param`
## GitHub Issue Link (if applicable)
Closes #10111 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Added
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
