### PR TITLE
add italic label for upload button, bolded drag and drop text

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -370,6 +370,22 @@ describe("StreamlitMarkdown", () => {
     expect(textTag).toHaveStyle("font-weight: 600")
   })
 
+  it("renders italic label text when italicLabel is true", () => {
+    const source = "Here is some checkbox label text"
+    render(
+      <StreamlitMarkdown
+        source={source}
+        allowHTML={false}
+        isLabel
+        italicLabel
+        largerLabel
+      />
+    )
+
+    const textTag = screen.getByText("Here is some checkbox label text")
+    expect(textTag).toHaveStyle("font-style: italic")
+  })
+
   it("colours text properly", () => {
     const colorMapping = new Map([
       ["red", colors.red80],

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -99,6 +99,11 @@ export interface Props {
   boldLabel?: boolean
 
   /**
+   * Make the label italic
+   */
+  italicLabel?: boolean
+
+  /**
    * Checkbox labels have larger font sizing
    */
   largerLabel?: boolean
@@ -621,6 +626,7 @@ const StreamlitMarkdown: React.FC<Props> = ({
   isCaption,
   isLabel,
   boldLabel,
+  italicLabel,
   largerLabel,
   disableLinks,
   isToast,
@@ -634,6 +640,7 @@ const StreamlitMarkdown: React.FC<Props> = ({
       isInSidebarOrDialog={isInSidebar || isInDialog}
       isLabel={isLabel}
       boldLabel={boldLabel}
+      italicLabel={italicLabel}
       largerLabel={largerLabel}
       isToast={isToast}
       style={style}

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -22,6 +22,7 @@ export interface StyledStreamlitMarkdownProps {
   isInSidebarOrDialog: boolean
   isLabel?: boolean
   boldLabel?: boolean
+  italicLabel?: boolean
   largerLabel?: boolean
   isToast?: boolean
 }
@@ -158,6 +159,7 @@ export const StyledStreamlitMarkdown =
       isInSidebarOrDialog,
       isLabel,
       boldLabel,
+      italicLabel,
       largerLabel,
       isToast,
     }) => {
@@ -183,6 +185,7 @@ export const StyledStreamlitMarkdown =
           wordBreak: "break-word",
           marginBottom: isLabel ? theme.spacing.none : "",
           fontWeight: boldLabel ? theme.fontWeights.bold : "",
+          fontStyle: italicLabel ? "italic" : "",
           marginTop: theme.spacing.none,
           marginLeft: theme.spacing.none,
           marginRight: theme.spacing.none,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -63,6 +63,8 @@ import {
   UploadFileInfo,
 } from "@streamlit/lib/src/components/widgets/FileUploader/UploadFileInfo"
 import { FileUploadClient } from "@streamlit/lib/src/FileUploadClient"
+import TooltipIcon from "@streamlit/lib/src/components/shared/TooltipIcon"
+import { Placement } from "@streamlit/lib/src/components/shared/Tooltip"
 
 import {
   StyledChatInput,
@@ -74,8 +76,6 @@ import {
   StyledVerticalDivider,
 } from "./styled-components"
 import ChatUploadedFiles from "./UploadedFile/ChatUploadedFiles"
-import TooltipIcon from "@streamlit/lib/src/components/shared/TooltipIcon"
-import { Placement } from "@streamlit/lib/src/components/shared/Tooltip"
 
 export interface Props {
   disabled: boolean

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -74,6 +74,8 @@ import {
   StyledVerticalDivider,
 } from "./styled-components"
 import ChatUploadedFiles from "./UploadedFile/ChatUploadedFiles"
+import TooltipIcon from "@streamlit/lib/src/components/shared/TooltipIcon"
+import { Placement } from "@streamlit/lib/src/components/shared/Tooltip"
 
 export interface Props {
   disabled: boolean
@@ -259,13 +261,19 @@ const FileUploadArea = ({
     <>
       <div {...getRootProps()}>
         <input {...getInputProps()} />
-        <BaseButton kind={BaseButtonKind.MINIMAL} disabled={disabled}>
-          <Icon
-            content={AttachFile}
-            size="lg"
-            color={theme.colors.fadedText60}
-          />
-        </BaseButton>
+        <TooltipIcon
+          content="Upload or drag and drop a file"
+          placement={Placement.TOP}
+          markdownProps={{ italicLabel: true }}
+        >
+          <BaseButton kind={BaseButtonKind.MINIMAL} disabled={disabled}>
+            <Icon
+              content={AttachFile}
+              size="lg"
+              color={theme.colors.fadedText60}
+            />
+          </BaseButton>
+        </TooltipIcon>
       </div>
       <StyledVerticalDivider />
     </>

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -129,6 +129,7 @@ export const StyledFileUploadDropzone = styled.div(({ theme }) => ({
   justifyContent: "center",
   margin: "auto",
   color: theme.colors.primary,
+  fontWeight: theme.fontWeights.bold,
 }))
 
 export interface StyledVerticalDividerProps {


### PR DESCRIPTION
## Describe your changes

1. Implemented upload button tooltip, added an `italicLabel` prop to `StreamlitMarkdown`

<img width="544" alt="image" src="https://github.com/user-attachments/assets/4c62cdfe-05e6-4fbf-b7ce-6d21073740f4" />

2. Updated font weight to 600 (700 in Figma but we typically reserve 700 for h1 header)
 
<img width="741" alt="image" src="https://github.com/user-attachments/assets/eb937412-c57e-49ea-bbb4-2636876cf7db" />




## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
