### PR TITLE
Force react-syntax-highlighter to cjs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ frontend-build-with-profiler:
 
 .PHONY: frontend-fast
 frontend-fast:
-	cd frontend/ ; yarn workspace @streamlit/app buildFast
+	cd frontend/ ; yarn workspace @streamlit/app build
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -71,6 +71,13 @@ export default defineConfig({
         find: "@streamlit/lib",
         replacement: path.resolve(__dirname, "../lib/src"),
       },
+      // Alias react-syntax-highlighter to the cjs version to avoid
+      // issues with the esm version causing a bug in rendering
+      // See https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/565
+      {
+        find: "react-syntax-highlighter",
+        replacement: "react-syntax-highlighter/dist/cjs/index.js",
+      },
       ...profilerAliases,
     ],
   },


### PR DESCRIPTION
## Describe your changes

There are issues with react-syntax-highlighter as an ESM module with Vite. As a result, we explicitly choose the common js format in order to fix the issue.

The steps here https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/565 help illustrate the issue

## GitHub Issue Link (if applicable)
closes #10231

## Testing Plan

- Automated testing should still test everything works properly
- Manual testing to attempt to reproduce the issue.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
