### PR TITLE
Follow-up refactor of StatusWidget after functional component conversion

### DIFF
--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -22,8 +22,7 @@ import React, {
   useState,
 } from "react"
 
-import { EmotionIcon } from "@emotion-icons/emotion-icon"
-import { Ellipses, Info, Warning } from "@emotion-icons/open-iconic"
+import { Info } from "@emotion-icons/open-iconic"
 import { useTheme } from "@emotion/react"
 import Hotkeys from "react-hot-keys"
 import { CSSTransition } from "react-transition-group"
@@ -82,12 +81,6 @@ export interface StatusWidgetProps {
 
   /** Allows users to change user settings to allow rerun on save */
   allowRunOnSave: boolean
-}
-
-interface ConnectionStateUI {
-  icon: EmotionIcon
-  label: string
-  tooltip: string
 }
 
 // Amount of time to display the "Script Changed. Rerun?" prompt when it first appears.
@@ -231,38 +224,6 @@ const StatusWidget: React.FC<StatusWidgetProps> = ({
     // Check if Jan 1st through 6th
     if (month === 0 && date <= 6) return true
     return false
-  }
-
-  function getConnectionStateUI(
-    state: ConnectionState
-  ): ConnectionStateUI | undefined {
-    switch (state) {
-      case ConnectionState.INITIAL:
-      case ConnectionState.PINGING_SERVER:
-      case ConnectionState.CONNECTING:
-        return {
-          icon: Ellipses,
-          label: "Connecting",
-          tooltip: "Connecting to Streamlit server",
-        }
-      case ConnectionState.CONNECTED:
-        return undefined
-      case ConnectionState.STATIC_CONNECTING:
-        return {
-          icon: Ellipses,
-          label: "Connecting",
-          tooltip: "Connecting to static app",
-        }
-      case ConnectionState.STATIC_CONNECTED:
-        return undefined
-      case ConnectionState.DISCONNECTED_FOREVER:
-      default:
-        return {
-          icon: Warning,
-          label: "Error",
-          tooltip: "Unable to connect to Streamlit server",
-        }
-    }
   }
 
   useEffect(() => {

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -55,6 +55,7 @@ import {
   StyledShortcutLabel,
   StyledStatusWidget,
 } from "./styled-components"
+import { getConnectionStateUI } from "./getConnectionStateUI"
 
 /** Component props */
 export interface StatusWidgetProps {

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
@@ -20,8 +20,8 @@ import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 
 import {
   CONNECTING_LABEL,
-  CONNECTING_TOOLTIP_TEXT,
   CONNECTING_STATIC_TOOLTIP_TEXT,
+  CONNECTING_TOOLTIP_TEXT,
   ERROR_LABEL,
   ERROR_TOOLTIP_TEXT,
   getConnectionStateUI,

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
@@ -21,6 +21,7 @@ import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
 import {
   CONNECTING_LABEL,
   CONNECTING_TOOLTIP_TEXT,
+  CONNECTING_STATIC_TOOLTIP_TEXT,
   ERROR_LABEL,
   ERROR_TOOLTIP_TEXT,
   getConnectionStateUI,
@@ -28,8 +29,13 @@ import {
 
 describe("getConnectionStateUI", () => {
   it("Returns undefined for connected", () => {
-    const uiState = getConnectionStateUI(ConnectionState.CONNECTED)
-    expect(uiState).toBeUndefined()
+    for (const state of [
+      ConnectionState.CONNECTED,
+      ConnectionState.STATIC_CONNECTED,
+    ]) {
+      const uiState = getConnectionStateUI(state)
+      expect(uiState).toBeUndefined()
+    }
   })
 
   it("Returns connecting UI state correctly", () => {
@@ -45,11 +51,15 @@ describe("getConnectionStateUI", () => {
     }
   })
 
+  it("Returns static connecting UI state correctly", () => {
+    const uiState = getConnectionStateUI(ConnectionState.STATIC_CONNECTING)
+    expect(uiState?.icon).toBe(Ellipses)
+    expect(uiState?.label).toBe(CONNECTING_LABEL)
+    expect(uiState?.tooltip).toBe(CONNECTING_STATIC_TOOLTIP_TEXT)
+  })
+
   it("Returns error UI state correctly", () => {
-    for (const state of [
-      ConnectionState.DISCONNECTED_FOREVER,
-      "NOT_DEFINED",
-    ]) {
+    for (const state of [ConnectionState.DISCONNECTED_FOREVER, undefined]) {
       const uiState = getConnectionStateUI(state)
       expect(uiState?.icon).toBe(Warning)
       expect(uiState?.label).toBe(ERROR_LABEL)

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
@@ -59,11 +59,9 @@ describe("getConnectionStateUI", () => {
   })
 
   it("Returns error UI state correctly", () => {
-    for (const state of [ConnectionState.DISCONNECTED_FOREVER, undefined]) {
-      const uiState = getConnectionStateUI(state)
-      expect(uiState?.icon).toBe(Warning)
-      expect(uiState?.label).toBe(ERROR_LABEL)
-      expect(uiState?.tooltip).toBe(ERROR_TOOLTIP_TEXT)
-    }
+    const uiState = getConnectionStateUI(ConnectionState.DISCONNECTED_FOREVER)
+    expect(uiState?.icon).toBe(Warning)
+    expect(uiState?.label).toBe(ERROR_LABEL)
+    expect(uiState?.tooltip).toBe(ERROR_TOOLTIP_TEXT)
   })
 })

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Ellipses, Warning } from "@emotion-icons/open-iconic"
+
+import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
+
+import {
+  CONNECTING_LABEL,
+  CONNECTING_TOOLTIP_TEXT,
+  ERROR_LABEL,
+  ERROR_TOOLTIP_TEXT,
+  getConnectionStateUI,
+} from "./getConnectionStateUI"
+
+describe("getConnectionStateUI", () => {
+  it("Returns undefined for connected", () => {
+    const uiState = getConnectionStateUI(ConnectionState.CONNECTED)
+    expect(uiState).toBeUndefined()
+  })
+
+  it("Returns returns connecting UI state correctly", () => {
+    for (const state of [
+      ConnectionState.INITIAL,
+      ConnectionState.PINGING_SERVER,
+      ConnectionState.CONNECTING,
+    ]) {
+      const uiState = getConnectionStateUI(state)
+      expect(uiState?.icon).toBe(Ellipses)
+      expect(uiState?.label).toBe(CONNECTING_LABEL)
+      expect(uiState?.tooltip).toBe(CONNECTING_TOOLTIP_TEXT)
+    }
+  })
+
+  it("Returns returns error UI state correctly", () => {
+    for (const state of [
+      ConnectionState.DISCONNECTED_FOREVER,
+      "NOT_DEFINED",
+    ]) {
+      const uiState = getConnectionStateUI(state)
+      expect(uiState?.icon).toBe(Warning)
+      expect(uiState?.label).toBe(ERROR_LABEL)
+      expect(uiState?.tooltip).toBe(ERROR_TOOLTIP_TEXT)
+    }
+  })
+})

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.test.ts
@@ -32,7 +32,7 @@ describe("getConnectionStateUI", () => {
     expect(uiState).toBeUndefined()
   })
 
-  it("Returns returns connecting UI state correctly", () => {
+  it("Returns connecting UI state correctly", () => {
     for (const state of [
       ConnectionState.INITIAL,
       ConnectionState.PINGING_SERVER,
@@ -45,7 +45,7 @@ describe("getConnectionStateUI", () => {
     }
   })
 
-  it("Returns returns error UI state correctly", () => {
+  it("Returns error UI state correctly", () => {
     for (const state of [
       ConnectionState.DISCONNECTED_FOREVER,
       "NOT_DEFINED",

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Ellipses, Warning } from "@emotion-icons/open-iconic"
+import { EmotionIcon } from "@emotion-icons/emotion-icon"
+
+import { ConnectionState } from "@streamlit/app/src/connection/ConnectionState"
+
+interface ConnectionStateUI {
+  icon: EmotionIcon
+  label: string
+  tooltip: string
+}
+
+export const CONNECTING_LABEL = "Connecting"
+export const CONNECTING_TOOLTIP_TEXT = "Connecting to Streamlit server"
+export const ERROR_LABEL = "Error"
+export const ERROR_TOOLTIP_TEXT = "Unable to connect to Streamlit server"
+
+export function getConnectionStateUI(
+  state: ConnectionState
+): ConnectionStateUI | undefined {
+  switch (state) {
+    case ConnectionState.INITIAL:
+    case ConnectionState.PINGING_SERVER:
+    case ConnectionState.CONNECTING:
+      return {
+        icon: Ellipses,
+        label: CONNECTING_LABEL,
+        tooltip: CONNECTING_TOOLTIP_TEXT,
+      }
+    case ConnectionState.CONNECTED:
+      return undefined
+    case ConnectionState.STATIC_CONNECTING:
+      return {
+        icon: Ellipses,
+        label: "Connecting",
+        tooltip: "Connecting to static app",
+      }
+    case ConnectionState.STATIC_CONNECTED:
+      return undefined
+    case ConnectionState.DISCONNECTED_FOREVER:
+    default:
+      return {
+        icon: Warning,
+        label: ERROR_LABEL,
+        tooltip: ERROR_TOOLTIP_TEXT,
+      }
+  }
+}

--- a/frontend/app/src/components/StatusWidget/getConnectionStateUI.ts
+++ b/frontend/app/src/components/StatusWidget/getConnectionStateUI.ts
@@ -27,6 +27,7 @@ interface ConnectionStateUI {
 
 export const CONNECTING_LABEL = "Connecting"
 export const CONNECTING_TOOLTIP_TEXT = "Connecting to Streamlit server"
+export const CONNECTING_STATIC_TOOLTIP_TEXT = "Connecting to static app"
 export const ERROR_LABEL = "Error"
 export const ERROR_TOOLTIP_TEXT = "Unable to connect to Streamlit server"
 
@@ -47,8 +48,8 @@ export function getConnectionStateUI(
     case ConnectionState.STATIC_CONNECTING:
       return {
         icon: Ellipses,
-        label: "Connecting",
-        tooltip: "Connecting to static app",
+        label: CONNECTING_LABEL,
+        tooltip: CONNECTING_STATIC_TOOLTIP_TEXT,
       }
     case ConnectionState.STATIC_CONNECTED:
       return undefined


### PR DESCRIPTION
## Describe your changes

Simple PR to move `getConnectionStateUI` outside of the `StatusWidget` component and add unit tests. 

## GitHub Issue Link (if applicable)

## Testing Plan

- No functional changes. Adds some unit test coverage for `getConnectionStateUI`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
