### PR TITLE
[WIP] Move popover down if it is outside of viewport

### DIFF
--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -55,7 +55,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   const lightBackground = hasLightBackgroundColor(theme)
 
   const popoverRef = useRef<any>(null)
-  function calcYOffsite() {
+  function calcYOffsite(): undefined {
     window.clearTimeout(timeoutId)
     if (!open) return
     const parentElement = popoverRef?.current?.popperRef?.current


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/streamlit/streamlit/issues/9387#issuecomment-2613267892

Similar fix as the fix for tooltips made in https://github.com/streamlit/streamlit/pull/9983

This is the popover from the issue in https://github.com/streamlit/streamlit/issues/9387#issuecomment-2613267892
 with the fix here:

<img width="600" alt="Screenshot 2025-01-26 at 20 12 13" src="https://github.com/user-attachments/assets/c01a9f35-80bc-430d-925c-4a286e7d11ab" />
<img width="663" alt="Screenshot 2025-01-26 at 20 12 16" src="https://github.com/user-attachments/assets/7cf71533-3d87-420f-8c99-71a2a8e8da06" />


Note: I am thinking about moving the logic to a shared hook / function

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
