### PR TITLE
Default to MPA to v2

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
+++ b/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
@@ -100,7 +100,7 @@ def test_page_link_href(
     """Test that page link href set properly."""
     page_links = app.get_by_test_id("stPageLink-NavLink")
 
-    expect(page_links.nth(0)).to_have_attribute("href", "mpa_configure_sidebar")
+    expect(page_links.nth(0)).to_have_attribute("href", "")
     expect(page_links.nth(1)).to_have_attribute("href", "page2")
     expect(page_links.nth(2)).to_have_attribute("href", "page3")
     expect(page_links.nth(3)).to_have_attribute("href", "page_with_duplicate_name")

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -131,7 +131,7 @@ import { showDevelopmentOptions } from "./showDevelopmentOptions"
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
 import { ThemeManager } from "./util/useThemeManager"
-import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
+import { AppNavigation } from "./util/AppNavigation"
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -817,7 +817,10 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
-    this.maybeSetState(this.appNavigation.handlePageNotFound(pageNotFound))
+    const [newState, callback] =
+      this.appNavigation.handlePageNotFound(pageNotFound)
+
+    this.setState(newState as State, callback)
   }
 
   onPageIconChanged = (iconUrl: string): void => {
@@ -829,11 +832,17 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
-    this.maybeSetState(this.appNavigation.handlePagesChanged(pagesChangedMsg))
+    const [newState, callback] =
+      this.appNavigation.handlePagesChanged(pagesChangedMsg)
+
+    this.setState(newState as State, callback)
   }
 
   handleNavigation = (navigationMsg: Navigation): void => {
-    this.maybeSetState(this.appNavigation.handleNavigation(navigationMsg))
+    const [newState, callback] =
+      this.appNavigation.handleNavigation(navigationMsg)
+
+    this.setState(newState as State, callback)
   }
 
   handlePageProfileMsg = (pageProfile: PageProfile): void => {
@@ -972,14 +981,6 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
-  maybeSetState(stateUpdate: MaybeStateUpdate): void {
-    if (stateUpdate) {
-      const [newState, callback] = stateUpdate
-
-      this.setState(newState as State, callback)
-    }
-  }
-
   /**
    * Handler for ForwardMsg.newSession messages. This runs on each rerun
    * @param newSessionProto a NewSession protobuf
@@ -1028,7 +1029,10 @@ export class App extends PureComponent<Props, State> {
         // empty array.
         fragmentIdsThisRun,
       })
-      this.maybeSetState(this.appNavigation.handleNewSession(newSessionProto))
+      const [newState, callback] =
+        this.appNavigation.handleNewSession(newSessionProto)
+
+      this.setState(newState as State, callback)
 
       // Set the favicon to its default values
       this.onPageIconChanged(`${import.meta.env.BASE_URL}favicon.png`)

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -126,176 +126,16 @@ describe("AppNavigation", () => {
     )
   })
 
-  describe("MPA v1", () => {
-    it("sets appPages on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession())
-      expect(maybeState).not.toBeUndefined()
+  it("continues to set hideSidebarNav on new session", () => {
+    const cleanAppNavigation = new AppNavigation(
+      hostCommunicationMgr,
+      onUpdatePageUrl,
+      onPageNotFound,
+      onPageIconChange
+    )
 
-      const [newState] = maybeState!
-      expect(newState.appPages).toEqual([
-        {
-          pageScriptHash: "page_script_hash",
-          pageName: "streamlit app",
-          urlPathname: "streamlit_app",
-        },
-      ])
-    })
-
-    it("sets currentPageScriptHash on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession())
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("page_script_hash")
-    })
-
-    it("calls host communication on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession({}))
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
-        appPages: [
-          {
-            pageScriptHash: "page_script_hash",
-            pageName: "streamlit app",
-            urlPathname: "streamlit_app",
-          },
-        ],
-      })
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
-    })
-
-    it("calls onUpdatePageUrl with the right information", () => {
-      appNavigation.handleNewSession(generateNewSession())
-      expect(onUpdatePageUrl).toHaveBeenCalledWith(
-        "streamlit_app",
-        "streamlit_app",
-        true
-      )
-    })
-
-    it("sets appPages on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.appPages).toEqual([
-        {
-          pageScriptHash: "other_page_script_hash",
-          pageName: "foo bar",
-          urlPathname: "foo_bar",
-        },
-      ])
-    })
-
-    it("calls host communication on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
-        appPages: [
-          {
-            pageScriptHash: "other_page_script_hash",
-            pageName: "foo bar",
-            urlPathname: "foo_bar",
-          },
-        ],
-      })
-    })
-
-    it("sets currentPageScriptHash on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "foo" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("page_script_hash")
-    })
-
-    it("calls host communication on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "foo" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
-    })
-
-    it("calls onPageNotFound when page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      appNavigation.handlePageNotFound(new PageNotFound({ pageName: "foo" }))
-      expect(onPageNotFound).toHaveBeenCalledWith("foo")
-    })
-
-    it("finds url by path when path is valid", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const page = appNavigation.findPageByUrlPath("/streamlit_app")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
-    })
-
-    it("returns default url by path when path is invalid", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const page = appNavigation.findPageByUrlPath("foo")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
-    })
-  })
-
-  describe("MPA v2", () => {
-    beforeEach(() => {
-      // Switch to V2
-      const navigation = new Navigation({
+    cleanAppNavigation.handleNavigation(
+      new Navigation({
         sections: ["section1", "section2"],
         appPages: [
           new AppPage({
@@ -311,354 +151,330 @@ describe("AppNavigation", () => {
             sectionHeader: "section2",
           }),
         ],
-        position: Navigation.Position.SIDEBAR,
+        position: Navigation.Position.HIDDEN,
         pageScriptHash: "page_script_hash",
         expanded: false,
       })
-      appNavigation.handleNavigation(navigation)
+    )
+
+    const maybeState = cleanAppNavigation.handleNewSession(
+      generateNewSession()
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      hideSidebarNav: true,
     })
+  })
 
-    it("continues to set hideSidebarNav on new session", () => {
-      const cleanAppNavigation = new AppNavigation(
-        hostCommunicationMgr,
-        onUpdatePageUrl,
-        onPageNotFound,
-        onPageIconChange
-      )
-
-      cleanAppNavigation.handleNavigation(
-        new Navigation({
-          sections: ["section1", "section2"],
-          appPages: [
-            new AppPage({
-              pageName: "streamlit_app",
-              pageScriptHash: "page_script_hash",
-              isDefault: true,
-              sectionHeader: "section1",
-            }),
-            new AppPage({
-              pageName: "streamlit_app2",
-              pageScriptHash: "page_script_hash2",
-              isDefault: false,
-              sectionHeader: "section2",
-            }),
-          ],
-          position: Navigation.Position.HIDDEN,
-          pageScriptHash: "page_script_hash",
-          expanded: false,
-        })
-      )
-
-      const maybeState = cleanAppNavigation.handleNewSession(
-        generateNewSession()
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        hideSidebarNav: true,
-      })
-    })
-
-    it("does not set anything on on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).toBeUndefined()
-    })
-
-    it("sets currentPageScriptHash on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("main_script_hash")
-    })
-
-    it("calls host communication on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "main_script_hash",
-      })
-    })
-
-    it("calls onPageNotFound when page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      appNavigation.handlePageNotFound(new PageNotFound({ pageName: "" }))
-      expect(onPageNotFound).toHaveBeenCalledWith("")
-    })
-
-    it("calls onUpdatePageUrl with the right information", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
+  it("does not set anything on on pages changed", () => {
+    const maybeState = appNavigation.handlePagesChanged(
+      new PagesChanged({
         appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            urlPathname: "streamlit_app2",
-          }),
+          {
+            pageScriptHash: "other_page_script_hash",
+            pageName: "foo bar",
+            urlPathname: "foo_bar",
+          },
         ],
-        position: Navigation.Position.HIDDEN,
+      })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    const [newState] = maybeState!
+    expect(newState.appPages).toEqual([
+      {
+        pageScriptHash: "other_page_script_hash",
+        pageName: "foo bar",
+        urlPathname: "foo_bar",
+      },
+    ])
+  })
+
+  it("sets currentPageScriptHash on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "" })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    const [newState] = maybeState!
+    expect(newState.currentPageScriptHash).toEqual("main_script_hash")
+  })
+
+  it("calls host communication on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "" })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    const callback = maybeState![1]
+
+    callback()
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "main_script_hash",
+    })
+  })
+
+  it("calls onPageNotFound when page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    appNavigation.handlePageNotFound(new PageNotFound({ pageName: "" }))
+    expect(onPageNotFound).toHaveBeenCalledWith("")
+  })
+
+  it("calls onUpdatePageUrl with the right information", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
+          pageScriptHash: "page_script_hash",
+          isDefault: true,
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash2",
+      expanded: false,
+    })
+    appNavigation.handleNavigation(navigation)
+    expect(onUpdatePageUrl).toHaveBeenCalledWith(
+      "streamlit_app",
+      "streamlit_app2",
+      false
+    )
+  })
+
+  it("finds url by path when path is valid", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
+          pageScriptHash: "page_script_hash",
+          isDefault: true,
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
+    })
+    appNavigation.handleNavigation(navigation)
+    const page = appNavigation.findPageByUrlPath("/streamlit_app2")
+
+    expect(page!.pageScriptHash).toEqual("page_script_hash2")
+    expect(page!.pageName).toEqual("streamlit app2")
+  })
+
+  it("returns default url by path when path is invalid", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
+          pageScriptHash: "page_script_hash",
+          isDefault: true,
+          sectionHeader: "section1",
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          sectionHeader: "section2",
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
+    })
+    appNavigation.handleNavigation(navigation)
+    const page = appNavigation.findPageByUrlPath("foo")
+
+    expect(page!.pageScriptHash).toEqual("page_script_hash")
+    expect(page!.pageName).toEqual("streamlit app")
+  })
+
+  it("sets navigation state to hidden on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
+        pageScriptHash: "page_script_hash",
+        isDefault: true,
+        sectionHeader: "section1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
         pageScriptHash: "page_script_hash2",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      expect(onUpdatePageUrl).toHaveBeenCalledWith(
-        "streamlit_app",
-        "streamlit_app2",
-        false
-      )
+        isDefault: false,
+        sectionHeader: "section2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-    it("finds url by path when path is valid", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            urlPathname: "streamlit_app2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      appPages,
+      hideSidebarNav: true,
+      expandSidebarNav: false,
+      currentPageScriptHash: "page_script_hash",
+      navSections: ["section1", "section2"],
+    })
+  })
+
+  it("sets navigation state to expanded on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
         pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const page = appNavigation.findPageByUrlPath("/streamlit_app2")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash2")
-      expect(page!.pageName).toEqual("streamlit app2")
+        isDefault: true,
+        sectionHeader: "section1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
+        pageScriptHash: "page_script_hash2",
+        isDefault: false,
+        sectionHeader: "section2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.SIDEBAR,
+      pageScriptHash: "page_script_hash",
+      expanded: true,
     })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-    it("returns default url by path when path is invalid", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            sectionHeader: "section1",
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            sectionHeader: "section2",
-            urlPathname: "streamlit_app2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      appPages,
+      hideSidebarNav: false,
+      expandSidebarNav: true,
+      currentPageScriptHash: "page_script_hash",
+      navSections: ["section1", "section2"],
+    })
+  })
+
+  it("calls host communication on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
         pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const page = appNavigation.findPageByUrlPath("foo")
+        isDefault: true,
+        sectionHeader: "section1",
+        icon: "icon1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
+        pageScriptHash: "page_script_hash2",
+        isDefault: false,
+        sectionHeader: "section2",
+        icon: "icon2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
+    })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
+    const callback = maybeState![1]
+    callback()
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_PAGE_TITLE",
+      title: "streamlit_app",
     })
 
-    it("sets navigation state to hidden on navigation", () => {
-      const appPages = [
+    expect(onPageIconChange).toBeCalled()
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_APP_PAGES",
+      appPages,
+    })
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "page_script_hash",
+    })
+  })
+
+  it("does not set the icon if set page config sets title or icon", () => {
+    // Clear the mock calls to avoid any confusion from setup
+    sendMessageToHost.mockClear()
+    appNavigation.handlePageConfigChanged(
+      new PageConfig({
+        title: "foo",
+        favicon: "bar",
+      })
+    )
+
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
         new AppPage({
-          pageName: "streamlit_app",
+          pageName: "streamlit app",
           pageScriptHash: "page_script_hash",
           isDefault: true,
           sectionHeader: "section1",
-        }),
-        new AppPage({
-          pageName: "streamlit_app2",
-          pageScriptHash: "page_script_hash2",
-          isDefault: false,
-          sectionHeader: "section2",
-        }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        appPages,
-        hideSidebarNav: true,
-        expandSidebarNav: false,
-        currentPageScriptHash: "page_script_hash",
-        navSections: ["section1", "section2"],
-      })
-    })
-
-    it("sets navigation state to expanded on navigation", () => {
-      const appPages = [
-        new AppPage({
-          pageName: "streamlit_app",
-          pageScriptHash: "page_script_hash",
-          isDefault: true,
-          sectionHeader: "section1",
-        }),
-        new AppPage({
-          pageName: "streamlit_app2",
-          pageScriptHash: "page_script_hash2",
-          isDefault: false,
-          sectionHeader: "section2",
-        }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.SIDEBAR,
-        pageScriptHash: "page_script_hash",
-        expanded: true,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        appPages,
-        hideSidebarNav: false,
-        expandSidebarNav: true,
-        currentPageScriptHash: "page_script_hash",
-        navSections: ["section1", "section2"],
-      })
-    })
-
-    it("calls host communication on navigation", () => {
-      const appPages = [
-        new AppPage({
-          pageName: "streamlit_app",
-          pageScriptHash: "page_script_hash",
-          isDefault: true,
-          sectionHeader: "section1",
+          urlPathname: "streamlit_app",
           icon: "icon1",
         }),
         new AppPage({
-          pageName: "streamlit_app2",
+          pageName: "streamlit app2",
           pageScriptHash: "page_script_hash2",
           isDefault: false,
           sectionHeader: "section2",
+          urlPathname: "streamlit_app2",
           icon: "icon2",
         }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-      callback()
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_PAGE_TITLE",
-        title: "streamlit_app",
-      })
-
-      expect(onPageIconChange).toBeCalled()
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
-        appPages,
-      })
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    appNavigation.handleNavigation(navigation)
+    const hostCommCalls = sendMessageToHost.mock.calls
 
-    it("does not set the icon if set page config sets title or icon", () => {
-      // Clear the mock calls to avoid any confusion from setup
-      sendMessageToHost.mockClear()
-      appNavigation.handlePageConfigChanged(
-        new PageConfig({
-          title: "foo",
-          favicon: "bar",
-        })
-      )
-
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            sectionHeader: "section1",
-            urlPathname: "streamlit_app",
-            icon: "icon1",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            sectionHeader: "section2",
-            urlPathname: "streamlit_app2",
-            icon: "icon2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const hostCommCalls = sendMessageToHost.mock.calls
-
-      expect(
-        hostCommCalls.some(call => call[0].type === "SET_PAGE_TITLE")
-      ).toBe(false)
-      expect(onPageIconChange).not.toBeCalled()
-    })
+    expect(hostCommCalls.some(call => call[0].type === "SET_PAGE_TITLE")).toBe(
+      false
+    )
+    expect(onPageIconChange).not.toBeCalled()
   })
 })

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -164,6 +164,7 @@ describe("AppNavigation", () => {
 
     const [newState] = maybeState!
     expect(newState).toEqual({
+      currentPageScriptHash: "page_script_hash",
       hideSidebarNav: true,
     })
   })

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -332,7 +332,7 @@ export class AppNavigation {
     this.isPageTitleSet = false
 
     // Start with the V1 strategy as it will apply to V0 as well
-    this.strategy = new StrategyV1(this)
+    this.strategy = new StrategyV2(this)
   }
 
   handleNewSession(newSession: NewSession): MaybeStateUpdate {

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -74,6 +74,8 @@ export class AppNavigation {
 
   mainPage: IAppPage | null
 
+  isMPAv1: boolean
+
   constructor(
     hostCommunicationMgr: HostCommunicationManager,
     onUpdatePageUrl: PageUrlUpdateCallback,
@@ -91,6 +93,7 @@ export class AppNavigation {
     this.currentPageScriptHash = null
     this.appPages = []
     this.mainPage = null
+    this.isMPAv1 = false
   }
 
   handleNewSession(newSession: NewSession): StateUpdate {
@@ -117,8 +120,9 @@ export class AppNavigation {
   }
 
   handleNavigation(navigationMsg: Navigation): StateUpdate {
-    const { sections, position, appPages } = navigationMsg
+    const { sections, position, appPages, isMpaV1 } = navigationMsg
 
+    this.isMPAv1 = isMpaV1
     this.appPages = appPages
     this.hideSidebarNav = position === Navigation.Position.HIDDEN
 
@@ -224,7 +228,15 @@ export class AppNavigation {
     mainScriptHash: string,
     sidebarElements: BlockNode | undefined
   ): AppRoot {
-    // return AppRoot.empty(mainScriptHash, false, sidebarElements, elements.logo)
+    if (this.isMPAv1) {
+      return AppRoot.empty(
+        mainScriptHash,
+        false,
+        sidebarElements,
+        elements.logo
+      )
+    }
+
     return elements.filterMainScriptElements(mainScriptHash)
   }
 }

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -34,9 +34,7 @@ interface AppNavigationState {
   navSections: string[]
 }
 
-export type MaybeStateUpdate =
-  | [Partial<AppNavigationState>, () => void]
-  | undefined
+export type StateUpdate = [Partial<AppNavigationState>, () => void]
 export type PageUrlUpdateCallback = (
   mainPageName: string,
   newPageName: string,
@@ -53,145 +51,53 @@ function getTitle(pageName: string): string {
   return pageName
 }
 
-export class StrategyV1 {
-  private appPages: IAppPage[]
+export class AppNavigation {
+  readonly hostCommunicationMgr: HostCommunicationManager
+
+  readonly onUpdatePageUrl: PageUrlUpdateCallback
+
+  readonly onPageNotFound: PageNotFoundCallback
+
+  readonly onPageIconChange: SetIconCallback
+
+  isPageTitleSet: boolean
+
+  isPageIconSet: boolean
 
   private currentPageScriptHash: string | null
 
-  private hideSidebarNav: boolean | null
-
-  private readonly appNav: AppNavigation
-
-  constructor(appNav: AppNavigation) {
-    this.appNav = appNav
-    this.appPages = []
-    this.currentPageScriptHash = null
-    this.hideSidebarNav = null
-  }
-
-  handleNewSession(newSession: NewSession): MaybeStateUpdate {
-    this.appPages = newSession.appPages
-    this.currentPageScriptHash = newSession.pageScriptHash
-    this.hideSidebarNav = newSession.config?.hideSidebarNav ?? false
-
-    // mainPage must be a string as we're guaranteed at this point that
-    // newSessionProto.appPages is nonempty and has a truthy pageName.
-    // Otherwise, we'd either have no main script or a nameless main script,
-    // neither of which can happen.
-    const mainPage = this.appPages[0] as IAppPage
-    const mainPageName = mainPage.urlPathname ?? ""
-    // We're similarly guaranteed that newPageName will be found / truthy
-    // here.
-    const newPageName =
-      this.appPages.find(
-        page => page.pageScriptHash === this.currentPageScriptHash
-      )?.urlPathname ?? ""
-
-    const isViewingMainPage =
-      mainPage.pageScriptHash === this.currentPageScriptHash
-    this.appNav.onUpdatePageUrl(mainPageName, newPageName, isViewingMainPage)
-
-    // Set the title to its default value
-    document.title = getTitle(newPageName ?? "")
-
-    return [
-      {
-        hideSidebarNav: this.hideSidebarNav,
-        appPages: this.appPages,
-        currentPageScriptHash: this.currentPageScriptHash,
-      },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_APP_PAGES",
-          appPages: this.appPages,
-        })
-
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: isViewingMainPage ? "" : newPageName,
-          currentPageScriptHash: this.currentPageScriptHash as string,
-        })
-      },
-    ]
-  }
-
-  handlePagesChanged(pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    const { appPages } = pagesChangedMsg
-    return [
-      { appPages },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_APP_PAGES",
-          appPages,
-        })
-      },
-    ]
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    const { pageName } = pageNotFound
-    this.appNav.onPageNotFound(pageName)
-    const currentPageScriptHash = this.appPages[0]?.pageScriptHash ?? ""
-    this.currentPageScriptHash = currentPageScriptHash
-
-    return [
-      { currentPageScriptHash },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: "",
-          currentPageScriptHash,
-        })
-      },
-    ]
-  }
-
-  handleNavigation(_navigationMsg: Navigation): MaybeStateUpdate {
-    // This message does not apply to V1
-    return undefined
-  }
-
-  findPageByUrlPath(pathname: string): IAppPage | null {
-    if (this.appPages.length === 0) {
-      return null
-    }
-
-    return (
-      this.appPages.find(appPage =>
-        pathname.endsWith("/" + appPage.urlPathname)
-      ) ?? this.appPages[0]
-    )
-  }
-
-  clearPageElements(
-    elements: AppRoot,
-    mainScriptHash: string,
-    sidebarElements: BlockNode | undefined
-  ): AppRoot {
-    return AppRoot.empty(mainScriptHash, false, sidebarElements, elements.logo)
-  }
-}
-
-export class StrategyV2 {
-  readonly appNav: AppNavigation
-
   mainScriptHash: string | null
+
+  hideSidebarNav: boolean | null
 
   appPages: IAppPage[]
 
   mainPage: IAppPage | null
 
-  hideSidebarNav: boolean | null
-
-  constructor(appNav: AppNavigation) {
-    this.appNav = appNav
+  constructor(
+    hostCommunicationMgr: HostCommunicationManager,
+    onUpdatePageUrl: PageUrlUpdateCallback,
+    onPageNotFound: PageNotFoundCallback,
+    onPageIconChange: SetIconCallback
+  ) {
+    this.hostCommunicationMgr = hostCommunicationMgr
+    this.onUpdatePageUrl = onUpdatePageUrl
+    this.onPageNotFound = onPageNotFound
+    this.onPageIconChange = onPageIconChange
+    this.isPageIconSet = false
+    this.isPageTitleSet = false
     this.mainScriptHash = null
+    this.hideSidebarNav = null
+    this.currentPageScriptHash = null
     this.appPages = []
     this.mainPage = null
-    this.hideSidebarNav = null
   }
 
-  handleNewSession(newSession: NewSession): MaybeStateUpdate {
+  handleNewSession(newSession: NewSession): StateUpdate {
+    this.isPageTitleSet = false
+    this.isPageIconSet = false
+    this.currentPageScriptHash = newSession.pageScriptHash
+
     this.mainScriptHash = newSession.mainScriptHash
     // Initialize to the config value if provided
     if (this.hideSidebarNav === null) {
@@ -201,31 +107,16 @@ export class StrategyV2 {
     // We do not know the page name, so use an empty string version
     document.title = getTitle("")
 
-    return [{ hideSidebarNav: this.hideSidebarNav ?? false }, () => {}]
-  }
-
-  handlePagesChanged(_pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    // This message does not apply to V2
-    return undefined
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    const { pageName } = pageNotFound
-    this.appNav.onPageNotFound(pageName)
-
     return [
-      { currentPageScriptHash: this.mainScriptHash ?? "" },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: "",
-          currentPageScriptHash: this.mainScriptHash ?? "",
-        })
+      {
+        hideSidebarNav: this.hideSidebarNav ?? false,
+        currentPageScriptHash: this.currentPageScriptHash,
       },
+      () => {},
     ]
   }
 
-  handleNavigation(navigationMsg: Navigation): MaybeStateUpdate {
+  handleNavigation(navigationMsg: Navigation): StateUpdate {
     const { sections, position, appPages } = navigationMsg
 
     this.appPages = appPages
@@ -239,20 +130,20 @@ export class StrategyV2 {
     this.mainPage = mainPage
     const currentPageName = currentPage.urlPathname as string
 
-    if (!this.appNav.isPageTitleSet) {
+    if (!this.isPageTitleSet) {
       const title = getTitle(currentPage.pageName as string)
       document.title = title
-      this.appNav.hostCommunicationMgr.sendMessageToHost({
+      this.hostCommunicationMgr.sendMessageToHost({
         type: "SET_PAGE_TITLE",
         title: currentPage.pageName ?? "",
       })
     }
 
-    if (!this.appNav.isPageIconSet && currentPage.icon) {
-      this.appNav.onPageIconChange(currentPage.icon)
+    if (!this.isPageIconSet && currentPage.icon) {
+      this.onPageIconChange(currentPage.icon)
     }
 
-    this.appNav.onUpdatePageUrl(
+    this.onUpdatePageUrl(
       mainPage.urlPathname ?? "",
       currentPageName,
       currentPage.isDefault ?? false
@@ -267,18 +158,47 @@ export class StrategyV2 {
         currentPageScriptHash,
       },
       () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
+        this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_APP_PAGES",
           appPages,
         })
 
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
+        this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_CURRENT_PAGE_NAME",
           // Make sure we don't send the official page name for the main page
           // This command is used to update the URL in the url bar, so the main page
           // should not have a page name in the URL.
           currentPageName: currentPage.isDefault ? "" : currentPageName,
           currentPageScriptHash,
+        })
+      },
+    ]
+  }
+
+  handlePagesChanged(pagesChangedMsg: PagesChanged): StateUpdate {
+    const { appPages } = pagesChangedMsg
+    return [
+      { appPages },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_APP_PAGES",
+          appPages,
+        })
+      },
+    ]
+  }
+
+  handlePageNotFound(pageNotFound: PageNotFound): StateUpdate {
+    const { pageName } = pageNotFound
+    this.onPageNotFound(pageName)
+
+    return [
+      { currentPageScriptHash: this.mainScriptHash ?? "" },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_CURRENT_PAGE_NAME",
+          currentPageName: "",
+          currentPageScriptHash: this.mainScriptHash ?? "",
         })
       },
     ]
@@ -294,76 +214,6 @@ export class StrategyV2 {
     )
   }
 
-  clearPageElements(
-    elements: AppRoot,
-    mainScriptHash: string,
-    _sidebarElements: BlockNode | undefined
-  ): AppRoot {
-    return elements.filterMainScriptElements(mainScriptHash)
-  }
-}
-
-export class AppNavigation {
-  readonly hostCommunicationMgr: HostCommunicationManager
-
-  readonly onUpdatePageUrl: PageUrlUpdateCallback
-
-  readonly onPageNotFound: PageNotFoundCallback
-
-  readonly onPageIconChange: SetIconCallback
-
-  isPageTitleSet: boolean
-
-  isPageIconSet: boolean
-
-  strategy: StrategyV1 | StrategyV2
-
-  constructor(
-    hostCommunicationMgr: HostCommunicationManager,
-    onUpdatePageUrl: PageUrlUpdateCallback,
-    onPageNotFound: PageNotFoundCallback,
-    onPageIconChange: SetIconCallback
-  ) {
-    this.hostCommunicationMgr = hostCommunicationMgr
-    this.onUpdatePageUrl = onUpdatePageUrl
-    this.onPageNotFound = onPageNotFound
-    this.onPageIconChange = onPageIconChange
-    this.isPageIconSet = false
-    this.isPageTitleSet = false
-
-    // Start with the V1 strategy as it will apply to V0 as well
-    this.strategy = new StrategyV2(this)
-  }
-
-  handleNewSession(newSession: NewSession): MaybeStateUpdate {
-    this.isPageTitleSet = false
-    this.isPageIconSet = false
-
-    return this.strategy.handleNewSession(newSession)
-  }
-
-  handleNavigation(navigationMsg: Navigation): MaybeStateUpdate {
-    // Navigation call (through st.navigation) indicates we are using
-    // MPA v2. We can change strategy here. It will set the state properly
-    if (this.strategy instanceof StrategyV1) {
-      this.strategy = new StrategyV2(this)
-    }
-
-    return this.strategy.handleNavigation(navigationMsg)
-  }
-
-  handlePagesChanged(pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    return this.strategy.handlePagesChanged(pagesChangedMsg)
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    return this.strategy.handlePageNotFound(pageNotFound)
-  }
-
-  findPageByUrlPath(pathname: string): IAppPage | null {
-    return this.strategy.findPageByUrlPath(pathname)
-  }
-
   handlePageConfigChanged(pageConfig: PageConfig): void {
     this.isPageIconSet = Boolean(pageConfig.favicon)
     this.isPageTitleSet = Boolean(pageConfig.title)
@@ -374,10 +224,7 @@ export class AppNavigation {
     mainScriptHash: string,
     sidebarElements: BlockNode | undefined
   ): AppRoot {
-    return this.strategy.clearPageElements(
-      elements,
-      mainScriptHash,
-      sidebarElements
-    )
+    // return AppRoot.empty(mainScriptHash, false, sidebarElements, elements.logo)
+    return elements.filterMainScriptElements(mainScriptHash)
   }
 }

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -74,6 +74,7 @@ export class AppNavigation {
 
   mainPage: IAppPage | null
 
+  // MPAv1 = Multi Page App Version 1 (with a pages folder)
   isMPAv1: boolean
 
   constructor(

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -320,6 +320,7 @@ def navigation(
     ctx.set_mpa_v2_page(page_to_return._script_hash)
 
     # This will either navigation or yield if the page is not found
+    msg.navigation.is_mpa_v1 = False
     ctx.enqueue(msg)
 
     return page_to_return

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -298,9 +298,7 @@ def navigation(
 
     # Inform our page manager about the set of pages we have
     ctx.pages_manager.set_pages(pagehash_to_pageinfo)
-    found_page = ctx.pages_manager.get_page_script(
-        fallback_page_hash=default_page._script_hash
-    )
+    found_page = ctx.find_intended_page(fallback_page_hash=default_page._script_hash)
 
     page_to_return = None
     if found_page:

--- a/lib/streamlit/components/v1/__init__.py
+++ b/lib/streamlit/components/v1/__init__.py
@@ -21,8 +21,8 @@ from streamlit.components.v1.component_registry import declare_component
 
 # `html` and `iframe` are part of Custom Components, so they appear in this
 # `streamlit.components.v1` namespace.
-html = streamlit._main._html
-iframe = streamlit._main._iframe
+html = streamlit._main._html  # type: ignore[has-type]
+iframe = streamlit._main._iframe  # type: ignore[has-type]
 
 __all__ = [
     "declare_component",

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -855,7 +855,7 @@ class ButtonMixin:
             # Handle retrieving the page_script_hash & page
             for page_data in all_app_pages.values():
                 full_path = page_data["script_path"]
-                page_name = page_data["page_name"]
+                page_name = page_data["url_pathname"]
                 if requested_page == full_path:
                     if label is None:
                         page_link_proto.label = page_name.replace("_", " ")

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -865,7 +865,7 @@ class ButtonMixin:
 
             if page_link_proto.page_script_hash == "":
                 is_mpa_v2 = (
-                    ctx.pages_manager is not None and ctx.pages_manager.mpa_version == 2
+                    ctx.pages_manager is not None and not ctx.pages_manager.is_mpa_v1
                 )
 
                 raise StreamlitPageNotFoundError(

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Callable
 
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime import get_instance
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.source_util import page_icon_and_name
@@ -296,7 +297,8 @@ class StreamlitPage:
                 self._page()
                 return
             else:
-                code = ctx.pages_manager.get_page_script_byte_code(str(self._page))
+                runtime = get_instance()
+                code = runtime.get_page_script_byte_code(str(self._page))
 
                 # We create a module named __page__ for this specific
                 # script. This is differentiate it from the `__main__` module

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -130,9 +130,7 @@ class AppSession:
         self._script_data = script_data
         self._uploaded_file_mgr = uploaded_file_manager
         self._script_cache = script_cache
-        self._pages_manager = PagesManager(
-            script_data.main_script_path, self._script_cache
-        )
+        self._pages_manager = PagesManager(script_data.main_script_path)
 
         # The browser queue contains messages that haven't yet been
         # delivered to the browser. Periodically, the server flushes

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -722,9 +722,6 @@ class AppSession:
         if fragment_ids_this_run:
             msg.new_session.fragment_ids_this_run.extend(fragment_ids_this_run)
 
-        self._populate_app_pages(
-            msg.new_session, pages or self._pages_manager.get_pages()
-        )
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
 

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -41,17 +41,20 @@ class PagesManager:
         self._current_page_script_hash: PageHash = ""
         pages_dir = self.main_script_parent / "pages"
         self._is_mpa_v1 = os.path.exists(pages_dir)
+        self._pages = {}
         if self._is_mpa_v1:
             if setup_watcher:
                 source_util.setup_pages_watcher(pages_dir)
             self._pages = source_util.get_pages(self._main_script_path)
-        else:
-            self._pages = {}
 
     def get_pages(self) -> dict[PageHash, PageInfo]:
         return self._pages
 
     def set_pages(self, pages: dict[PageHash, PageInfo]):
+        """
+        Overwrites the PagesManager's `pages` dictionary. Also, indicates that
+        multi-page app version 2 will be used from here on.
+        """
         if self._is_mpa_v1:
             # Log the warning and reset the "strategy" to V2
             _LOGGER.warning(
@@ -87,8 +90,8 @@ class PagesManager:
         return self._current_page_script_hash
 
     @property
-    def mpa_version(self) -> int:
-        return 1 if self._is_mpa_v1 else 2
+    def is_mpa_v1(self) -> bool:
+        return self._is_mpa_v1
 
     @property
     def main_script_path(self) -> ScriptPath:
@@ -127,7 +130,7 @@ class PagesManager:
         if page_script_hash:
             return self.get_page_script_by_hash(page_script_hash)
         # We allow page_name to have an empty string because that represents the main page
-        elif page_name is not None:
+        if page_name is not None:
             return self.get_page_script_by_name(page_name)
 
         return self.get_page_script_by_hash(fallback_page_hash)

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -15,228 +15,80 @@
 from __future__ import annotations
 
 import os
-import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Final
+from typing import TYPE_CHECKING, Callable, Final
 
 from streamlit import source_util
 from streamlit.logger import get_logger
 from streamlit.util import calc_md5
-from streamlit.watcher import watch_dir
 
 if TYPE_CHECKING:
-    from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.source_util import PageHash, PageInfo, PageName, ScriptPath
 
 _LOGGER: Final = get_logger(__name__)
 
 
-class PagesStrategyV1:
-    """
-    Strategy for MPA v1. This strategy handles pages being set directly
-    by a call to `st.navigation`. The key differences here are:
-    - The pages are defined by the existence of a `pages` directory
-    - We will ensure one watcher is watching the scripts in the directory.
-    - Only one script runs for a full rerun.
-    - We know at the beginning the intended page script to run.
-
-    NOTE: Thread safety of the pages is handled by the source_util module
-    """
-
-    is_watching_pages_dir: bool = False
-    pages_watcher_lock = threading.Lock()
-
-    # This is a static method because we only want to watch the pages directory
-    # once on initial load.
-    @staticmethod
-    def watch_pages_dir(pages_manager: PagesManager):
-        with PagesStrategyV1.pages_watcher_lock:
-            if PagesStrategyV1.is_watching_pages_dir:
-                return
-
-            def _handle_page_changed(_path: str) -> None:
-                source_util.invalidate_pages_cache()
-
-            pages_dir = pages_manager.main_script_parent / "pages"
-            watch_dir(
-                str(pages_dir),
-                _handle_page_changed,
-                glob_pattern="*.py",
-                allow_nonexistent=True,
-            )
-            PagesStrategyV1.is_watching_pages_dir = True
-
-    def __init__(self, pages_manager: PagesManager, setup_watcher: bool = True):
-        self.pages_manager = pages_manager
-
-        if setup_watcher:
-            PagesStrategyV1.watch_pages_dir(pages_manager)
-
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_manager.current_page_script_hash
-
-    def get_initial_active_script(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> PageInfo | None:
-        pages = self.get_pages()
-
-        if page_script_hash:
-            return pages.get(page_script_hash, None)
-        elif not page_script_hash and page_name:
-            # If a user navigates directly to a non-main page of an app, we get
-            # the first script run request before the list of pages has been
-            # sent to the frontend. In this case, we choose the first script
-            # with a name matching the requested page name.
-            return next(
-                filter(
-                    # There seems to be this weird bug with mypy where it
-                    # thinks that p can be None (which is impossible given the
-                    # types of pages), so we add `p and` at the beginning of
-                    # the predicate to circumvent this.
-                    lambda p: p and (p["page_name"] == page_name),
-                    pages.values(),
-                ),
-                None,
-            )
-
-        # If no information about what page to run is given, default to
-        # running the main page.
-        # Safe because pages will at least contain the app's main page.
-        main_page_info = list(pages.values())[0]
-        return main_page_info
-
-    def get_pages(self) -> dict[PageHash, PageInfo]:
-        return source_util.get_pages(self.pages_manager.main_script_path)
-
-    def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
-    ) -> Callable[[], None]:
-        return source_util.register_pages_changed_callback(callback)
-
-    def set_pages(self, _pages: dict[PageHash, PageInfo]) -> None:
-        raise NotImplementedError("Unable to set pages in this V1 strategy")
-
-    def get_page_script(self, _fallback_page_hash: PageHash) -> PageInfo | None:
-        raise NotImplementedError("Unable to get page script in this V1 strategy")
-
-
-class PagesStrategyV2:
-    """
-    Strategy for MPA v2. This strategy handles pages being set directly
-    by a call to `st.navigation`. The key differences here are:
-    - The pages are set directly by the user
-    - The initial active script will always be the main script
-    - More than one script can run in a single app run (sequentially),
-      so we must keep track of the active script hash
-    - We rely on pages manager to retrieve the intended page script per run
-
-    NOTE: We don't provide any locks on the pages since the pages are not
-    shared across sessions. Only the user script thread can write to
-    pages and the event loop thread only reads
-    """
-
-    def __init__(self, pages_manager: PagesManager, **kwargs):
-        self.pages_manager = pages_manager
-        self._pages: dict[PageHash, PageInfo] | None = None
-
-    def get_initial_active_script(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> PageInfo:
-        return {
-            # We always run the main script in V2 as it's the common code
-            "script_path": self.pages_manager.main_script_path,
-            "page_script_hash": page_script_hash
-            or self.pages_manager.main_script_hash,  # Default Hash
-        }
-
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_manager.main_script_hash
-
-    def get_page_script(self, fallback_page_hash: PageHash) -> PageInfo | None:
-        if self._pages is None:
-            return None
-
-        if self.pages_manager.intended_page_script_hash:
-            # We assume that if initial page hash is specified, that a page should
-            # exist, so we check out the page script hash or the default page hash
-            # as a backup
-            return self._pages.get(
-                self.pages_manager.intended_page_script_hash,
-                self._pages.get(fallback_page_hash, None),
-            )
-        elif self.pages_manager.intended_page_name:
-            # If a user navigates directly to a non-main page of an app, the
-            # the page name can identify the page script to run
-            return next(
-                filter(
-                    # There seems to be this weird bug with mypy where it
-                    # thinks that p can be None (which is impossible given the
-                    # types of pages), so we add `p and` at the beginning of
-                    # the predicate to circumvent this.
-                    lambda p: p
-                    and (p["url_pathname"] == self.pages_manager.intended_page_name),
-                    self._pages.values(),
-                ),
-                None,
-            )
-
-        return self._pages.get(fallback_page_hash, None)
-
-    def get_pages(self) -> dict[PageHash, PageInfo]:
-        # If pages are not set, provide the common page info where
-        # - the main script path is the executing script to start
-        # - the page script hash and name reflects the intended page requested
-        return self._pages or {
-            self.pages_manager.main_script_hash: {
-                "page_script_hash": self.pages_manager.intended_page_script_hash or "",
-                "page_name": self.pages_manager.intended_page_name or "",
-                "icon": "",
-                "script_path": self.pages_manager.main_script_path,
-            }
-        }
-
-    def set_pages(self, pages: dict[PageHash, PageInfo]) -> None:
-        self._pages = pages
-
-    def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
-    ) -> Callable[[], None]:
-        # V2 strategy does not handle any pages changed event
-        return lambda: None
-
-
 class PagesManager:
-    """
-    PagesManager is responsible for managing the set of pages based on the
-    strategy. By default, PagesManager uses V1 which relies on the original
-    assumption that there exists a `pages` directory with all the scripts.
-
-    If the `pages` are being set directly, the strategy is switched to V2.
-    This indicates someone has written an `st.navigation` call in their app
-    which informs us of the pages.
-
-    NOTE: Each strategy handles its own thread safety when accessing the pages
-    """
-
-    DefaultStrategy: type[PagesStrategyV1 | PagesStrategyV2] = PagesStrategyV1
-
     def __init__(
         self,
         main_script_path: ScriptPath,
-        script_cache: ScriptCache | None = None,
-        **kwargs,
+        *,
+        # setup_watcher is a convenience flag to allow disabling the watcher for testing
+        setup_watcher: bool = True,
     ):
         self._main_script_path = main_script_path
         self._main_script_hash: PageHash = calc_md5(main_script_path)
-        self.pages_strategy = PagesManager.DefaultStrategy(self, **kwargs)
-        self._script_cache = script_cache
-        self._intended_page_script_hash: PageHash | None = None
-        self._intended_page_name: PageName | None = None
         self._current_page_script_hash: PageHash = ""
+        pages_dir = self.main_script_parent / "pages"
+        self._is_mpa_v1 = os.path.exists(pages_dir)
+        if self._is_mpa_v1:
+            if setup_watcher:
+                source_util.setup_pages_watcher(pages_dir)
+            self._pages = source_util.get_pages(self._main_script_path)
+        else:
+            self._pages = {}
+
+    def get_pages(self) -> dict[PageHash, PageInfo]:
+        return self._pages
+
+    def set_pages(self, pages: dict[PageHash, PageInfo]):
+        if self._is_mpa_v1:
+            # Log the warning and reset the "strategy" to V2
+            _LOGGER.warning(
+                "st.navigation was called in an app with a pages/ directory. "
+                "This may cause unusual app behavior. You may want to rename the "
+                "pages/ directory."
+            )
+            self._is_mpa_v1 = False
+        self._pages = pages
+
+    def get_main_page(self) -> PageInfo:
+        return {
+            "script_path": self._main_script_path,
+            "page_script_hash": self._main_script_hash,
+            "url_pathname": "",
+        }
+
+    def get_page_script_by_hash(self, page_script_hash: PageHash) -> PageInfo | None:
+        if page_script_hash in self._pages:
+            return self._pages[page_script_hash]
+
+        return None
+
+    def get_page_script_by_name(self, page_name: PageName) -> PageInfo | None:
+        for page in self._pages.values():
+            if page["url_pathname"] == page_name:
+                return page
+
+        return None
+
+    @property
+    def current_page_script_hash(self) -> PageHash:
+        return self._current_page_script_hash
+
+    @property
+    def mpa_version(self) -> int:
+        return 1 if self._is_mpa_v1 else 2
 
     @property
     def main_script_path(self) -> ScriptPath:
@@ -250,87 +102,32 @@ class PagesManager:
     def main_script_hash(self) -> PageHash:
         return self._main_script_hash
 
-    @property
-    def current_page_script_hash(self) -> PageHash:
-        return self._current_page_script_hash
-
-    @property
-    def intended_page_name(self) -> PageName | None:
-        return self._intended_page_name
-
-    @property
-    def intended_page_script_hash(self) -> PageHash | None:
-        return self._intended_page_script_hash
-
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_strategy.initial_active_script_hash
-
-    @property
-    def mpa_version(self) -> int:
-        return 2 if isinstance(self.pages_strategy, PagesStrategyV2) else 1
-
     def set_current_page_script_hash(self, page_script_hash: PageHash) -> None:
         self._current_page_script_hash = page_script_hash
 
-    def get_main_page(self) -> PageInfo:
-        return {
-            "script_path": self._main_script_path,
-            "page_script_hash": self._main_script_hash,
-        }
-
-    def set_script_intent(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> None:
-        self._intended_page_script_hash = page_script_hash
-        self._intended_page_name = page_name
-
-    def get_initial_active_script(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> PageInfo | None:
-        return self.pages_strategy.get_initial_active_script(
-            page_script_hash, page_name
-        )
-
-    def get_pages(self) -> dict[PageHash, PageInfo]:
-        return self.pages_strategy.get_pages()
-
-    def set_pages(self, pages: dict[PageHash, PageInfo]) -> None:
-        # Manually setting the pages indicates we are using MPA v2.
-        if isinstance(self.pages_strategy, PagesStrategyV1):
-            if os.path.exists(self.main_script_parent / "pages"):
-                _LOGGER.warning(
-                    "st.navigation was called in an app with a pages/ directory. "
-                    "This may cause unusual app behavior. You may want to rename the "
-                    "pages/ directory."
-                )
-            PagesManager.DefaultStrategy = PagesStrategyV2
-            self.pages_strategy = PagesStrategyV2(self)
-
-        self.pages_strategy.set_pages(pages)
-
-    def get_page_script(self, fallback_page_hash: PageHash = "") -> PageInfo | None:
-        # We assume the pages strategy is V2 cause this is used
-        # in the st.navigation call, but we just swallow the error
-        try:
-            return self.pages_strategy.get_page_script(fallback_page_hash)
-        except NotImplementedError:
-            return None
-
     def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
+        self, callback: Callable[[str], None]
     ) -> Callable[[], None]:
-        """Register a callback to be called when the set of pages changes.
+        if self._is_mpa_v1:
+            return source_util.register_pages_changed_callback(callback)
 
-        The callback will be called with the path changed.
-        """
+        return lambda: None
 
-        return self.pages_strategy.register_pages_changed_callback(callback)
+    def find_page_info(
+        self,
+        page_script_hash: PageHash,
+        page_name: PageName | None,
+        *,
+        fallback_page_hash=None,
+    ) -> PageInfo | None:
+        # If a fallback hash is not provided, there's not much we can do, so we default to the main script hash
+        if fallback_page_hash is None:
+            fallback_page_hash = self.main_script_hash
+        # We want to check if the page_script_hash is set to some non-empty string
+        if page_script_hash:
+            return self.get_page_script_by_hash(page_script_hash)
+        # We allow page_name to have an empty string because that represents the main page
+        elif page_name is not None:
+            return self.get_page_script_by_name(page_name)
 
-    def get_page_script_byte_code(self, script_path: str) -> Any:
-        if self._script_cache is None:
-            # Returning an empty string for an empty script
-            return ""
-
-        return self._script_cache.get_bytecode(script_path)
+        return self.get_page_script_by_hash(fallback_page_hash)

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -19,7 +19,7 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Awaitable, Final, NamedTuple
+from typing import TYPE_CHECKING, Any, Awaitable, Final, NamedTuple
 
 from streamlit import config
 from streamlit.components.lib.local_component_registry import LocalComponentRegistry
@@ -272,6 +272,13 @@ class Runtime:
         if session_info is None:
             return None
         return session_info.client
+
+    def get_page_script_byte_code(self, script_path: str) -> Any:
+        if self._script_cache is None:
+            # Returning an empty string for an empty script
+            return ""
+
+        return self._script_cache.get_bytecode(script_path)
 
     def clear_user_info_for_session(self, session_id: str) -> None:
         """Clear the user_info for the given session_id.

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -274,10 +274,6 @@ class Runtime:
         return session_info.client
 
     def get_page_script_byte_code(self, script_path: str) -> Any:
-        if self._script_cache is None:
-            # Returning an empty string for an empty script
-            return ""
-
         return self._script_cache.get_bytecode(script_path)
 
     def clear_user_info_for_session(self, session_id: str) -> None:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -515,7 +515,8 @@ class ScriptRunner:
                 pages={},
             )
             if ctx.pages_manager.is_mpa_v1:
-                # Send Navigation to Frontend
+                # We spoof a navigation message to the frontend to provide
+                # information about all of its pages.
                 msg = ForwardMsg()
                 msg.navigation.is_mpa_v1 = True
                 msg.navigation.expanded = False
@@ -662,7 +663,8 @@ class ScriptRunner:
                     )
                 )
             ):
-                # We are a single page
+                # We are a single page and the user is trying to navigate to a
+                # non-existent page. We should send a page_not_found message.
                 msg = ForwardMsg()
                 msg.page_not_found.page_name = intended_page_name
                 ctx.enqueue(msg)

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -511,7 +511,11 @@ class ScriptRunner:
                 # Send Navigation to Frontend
                 msg = ForwardMsg()
                 msg.navigation.expanded = False
-                msg.navigation.position = NavigationProto.Position.SIDEBAR
+                msg.navigation.position = (
+                    NavigationProto.Position.HIDDEN
+                    if config.get_option("client.showSidebarNavigation") is False
+                    else NavigationProto.Position.SIDEBAR
+                )
                 msg.navigation.page_script_hash = active_script["page_script_hash"]
                 for page in ctx.pages_manager.get_pages().values():
                     page_info = msg.navigation.app_pages.add()

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -512,6 +512,7 @@ class ScriptRunner:
             if ctx.pages_manager.mpa_version == 1:
                 # Send Navigation to Frontend
                 msg = ForwardMsg()
+                msg.navigation.is_mpa_v1 = True
                 msg.navigation.expanded = False
                 msg.navigation.position = (
                     NavigationProto.Position.HIDDEN

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -465,7 +465,9 @@ class ScriptRunner:
                     page_script_hash = active_script["page_script_hash"]
             else:
                 active_script = main_page
-                page_script_hash = main_page["page_script_hash"]
+                page_script_hash = (
+                    intended_page_script_hash or main_page["page_script_hash"]
+                )
 
             active_script_hash = active_script["page_script_hash"]
             # Clear widget state on page change. This normally happens implicitly

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -406,7 +406,7 @@ class ScriptRunner:
             self._execing = False
 
     def _resolve_active_and_page_script(
-        self, intended_page_script_hash: str, intended_page_name: str | None
+        self, intended_page_script_hash: str, intended_page_name: str
     ) -> tuple[PageInfo, str]:
         ctx = self._get_script_run_ctx()
         main_page = self._pages_manager.get_main_page()

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -140,7 +140,7 @@ class ScriptRunContext:
 
     def find_intended_page(
         self, *, fallback_page_hash: PageHash | None = None
-    ) -> PageInfo:
+    ) -> PageInfo | None:
         return self.pages_manager.find_page_info(
             self._script_intent.page_script_hash,
             self._script_intent.page_name,

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -174,6 +174,8 @@ def get_pages(main_script_path_str: ScriptPath) -> dict[PageHash, PageInfo]:
         return pages
 
 
+# MPA v1 requires a pages watcher to be set up specifically for the pages
+# directory (identifying pages that are added/removed).
 def pages_watcher_factory() -> Callable[[Path], None]:
     _is_watching_pages_dir = False
     _pages_watcher_lock = threading.Lock()

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -31,6 +31,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.secrets import Secrets
 from streamlit.runtime.state.common import TESTING_KEY
 from streamlit.runtime.state.safe_session_state import SafeSessionState
@@ -322,11 +323,13 @@ class AppTest:
 
         # setup
         mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime._script_cache = ScriptCache()
         mock_runtime.media_file_mgr = MediaFileManager(
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
         Runtime._instance = mock_runtime
+        source_util.invalidate_pages_cache()
         pages_manager = PagesManager(self._script_path, setup_watcher=False)
         with source_util._pages_cache_lock:
             saved_cached_pages = source_util._cached_pages

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -24,7 +24,6 @@ from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import RerunData, ScriptRunner, ScriptRunnerEvent
-from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.testing.v1.element_tree import ElementTree, parse_tree_from_messages
 
 if TYPE_CHECKING:
@@ -61,7 +60,7 @@ class LocalScriptRunner(ScriptRunner):
             main_script_path=script_path,
             session_state=self.session_state._state,
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
-            script_cache=ScriptCache(),
+            script_cache=runtime.get_instance()._script_cache,
             initial_rerun_data=RerunData(),
             user_info={"email": "test@example.com"},
             fragment_storage=MemoryFragmentStorage(),

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -87,6 +87,11 @@ class LocalSourcesWatcher:
                 self._deregister_watcher(old_page_path)
                 self._watched_pages.remove(old_page_path)
 
+        # Add the main script path.
+        if self._main_script_path not in self._watched_pages:
+            self._register_watcher(self._main_script_path, module_name=None)
+            new_pages_paths.add(self._main_script_path)
+
         self._watched_pages = self._watched_pages.union(new_pages_paths)
 
     def register_file_change_callback(self, cb: Callable[[str], None]) -> None:

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -93,11 +93,6 @@ def pytest_configure(config: pytest.Config):
 
 
 def pytest_runtest_setup(item: pytest.Item):
-    # Ensure Default Strategy is V1 to start
-    from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV1
-
-    PagesManager.DefaultStrategy = PagesStrategyV1
-
     is_require_integration = item.config.getoption(
         "--require-integration", default=False
     )

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -769,20 +769,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         init_msg = new_session_msg.initialize
         assert init_msg.HasField("user_info")
 
-        assert list(new_session_msg.app_pages) == [
-            AppPage(
-                page_script_hash="hash1",
-                page_name="page 1",
-                icon="",
-                url_pathname="page_1",
-            ),
-            AppPage(
-                page_script_hash="hash2",
-                page_name="page 2",
-                icon="🎉",
-                url_pathname="page_2",
-            ),
-        ]
+        assert list(new_session_msg.app_pages) == []
 
         add_script_run_ctx(ctx=orig_ctx)
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -550,6 +550,7 @@ class AppSessionTest(unittest.TestCase):
         "get_pages",
         MagicMock(return_value={}),
     )
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     def test_recreates_local_sources_watcher_if_none(self):
         session = _create_test_session()
         session._local_sources_watcher = None

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -124,6 +124,7 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.stopped
         self.assertEqual(RuntimeState.STOPPED, self.runtime.state)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_connect_session(self):
         """We can create and remove a single session."""
         await self.runtime.start()
@@ -223,6 +224,7 @@ class RuntimeTest(RuntimeTestCase):
                 "create_session is deprecated! Use connect_session instead."
             )
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_disconnect_session_disconnects_appsession(self):
         """Closing a session should disconnect its associated AppSession."""
         await self.runtime.start()
@@ -244,6 +246,7 @@ class RuntimeTest(RuntimeTestCase):
             patched_on_session_disconnected.assert_called_once()
             patched_remove_refs_for_session.assert_called_once_with(session)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_close_session_closes_appsession(self):
         await self.runtime.start()
 
@@ -264,6 +267,7 @@ class RuntimeTest(RuntimeTestCase):
             patched_on_session_disconnected.assert_called_once()
             patched_remove_refs_for_session.assert_called_once_with(session)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_multiple_sessions(self):
         """Multiple sessions can be connected."""
         await self.runtime.start()
@@ -291,6 +295,7 @@ class RuntimeTest(RuntimeTestCase):
 
         self.assertEqual(RuntimeState.NO_SESSIONS_CONNECTED, self.runtime.state)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_disconnect_invalid_session(self):
         """Disconnecting a session that doesn't exist is a no-op: no error raised."""
         await self.runtime.start()
@@ -305,6 +310,7 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.disconnect_session(session_id)
         self.runtime.disconnect_session(session_id)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_close_invalid_session(self):
         """Closing a session that doesn't exist is a no-op: no error raised."""
         await self.runtime.start()
@@ -319,6 +325,7 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.close_session(session_id)
         self.runtime.close_session(session_id)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_is_active_session(self):
         """`is_active_session` should work as expected."""
         await self.runtime.start()
@@ -331,6 +338,7 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.disconnect_session(session_id)
         self.assertFalse(self.runtime.is_active_session(session_id))
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_closes_app_sessions_on_stop(self):
         """When the Runtime stops, it should close all AppSessions."""
         await self.runtime.start()
@@ -356,6 +364,7 @@ class RuntimeTest(RuntimeTestCase):
             # All sessions should be shut down via self._session_mgr.close_session
             patched_close_session.assert_has_calls(call(s.id) for s in app_sessions)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     @patch("streamlit.runtime.app_session.AppSession.handle_backmsg", new=MagicMock())
     async def test_handle_backmsg(self):
         """BackMsgs should be delivered to the appropriate AppSession."""
@@ -381,6 +390,7 @@ class RuntimeTest(RuntimeTestCase):
         "streamlit.runtime.app_session.AppSession.handle_backmsg_exception",
         new=MagicMock(),
     )
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_handle_backmsg_deserialization_exception(self):
         """BackMsg deserialization Exceptions should be delivered to the
         appropriate AppSession.
@@ -424,6 +434,7 @@ class RuntimeTest(RuntimeTestCase):
         with self.assertRaises(RuntimeStoppedError):
             self.runtime.handle_backmsg("not_a_session_id", MagicMock())
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_handle_session_client_disconnected(self):
         """Runtime should gracefully handle `SessionClient.write_forward_msg`
         raising a `SessionClientDisconnectedError`.
@@ -450,6 +461,7 @@ class RuntimeTest(RuntimeTestCase):
         raise_disconnected_error.assert_called_once()
         self.assertFalse(self.runtime.is_active_session(session_id))
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_stable_number_of_async_tasks(self):
         """Test that the number of async tasks remains stable.
 
@@ -468,6 +480,7 @@ class RuntimeTest(RuntimeTestCase):
         # It is expected that there are a couple of tasks, but not one per loop:
         self.assertLess(len(asyncio.all_tasks()), 10)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
         await self.runtime.start()
@@ -485,6 +498,7 @@ class RuntimeTest(RuntimeTestCase):
         received = client.forward_msgs.pop()
         self.assertEqual(populate_hash_if_needed(msg), received.hash)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_forwardmsg_cacheable_flag(self):
         """Test that the metadata.cacheable flag is set properly on outgoing
         ForwardMsgs."""
@@ -511,6 +525,7 @@ class RuntimeTest(RuntimeTestCase):
             self.assertFalse(cacheable_msg.metadata.cacheable)
             self.assertFalse(received.metadata.cacheable)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_duplicate_forwardmsg_caching(self):
         """Test that duplicate ForwardMsgs are sent only once."""
         with patch_config_options({"global.minCachedMessageSize": 0}):
@@ -544,6 +559,7 @@ class RuntimeTest(RuntimeTestCase):
             # And the same *metadata* as msg2:
             self.assertEqual(msg2.metadata, cached.metadata)
 
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=MagicMock())
     async def test_forwardmsg_cache_clearing(self):
         """Test that the ForwardMsgCache gets properly cleared when scripts
         finish running.

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -346,7 +346,10 @@ class ScriptRunContextTest(unittest.TestCase):
             pages_manager=pages_manager,
             current_fragment_id="my_fragment_id",
         )
-        ctx.reset(page_script_hash=pages_manager.main_script_hash)
+        ctx.reset(
+            page_script_hash=pages_manager.main_script_hash,
+            active_script_hash=pages_manager.main_script_hash,
+        )
         assert ctx.active_script_hash == pages_manager.main_script_hash
 
         pages_manager.set_pages({})

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -152,32 +152,37 @@ def test_get_pages(tmpdir):
     assert received_pages == {
         calc_md5(main_script_path): {
             "page_script_hash": calc_md5(main_script_path),
-            "page_name": "streamlit_app",
+            "page_name": "streamlit app",
             "script_path": main_script_path,
             "icon": "",
+            "url_pathname": "",
         },
         calc_md5(str(pages_dir / "01-page.py")): {
             "page_script_hash": calc_md5(str(pages_dir / "01-page.py")),
             "page_name": "page",
             "script_path": str(pages_dir / "01-page.py"),
             "icon": "",
+            "url_pathname": "page",
         },
         calc_md5(str(pages_dir / "03_other_page.py")): {
             "page_script_hash": calc_md5(str(pages_dir / "03_other_page.py")),
-            "page_name": "other_page",
+            "page_name": "other page",
             "script_path": str(pages_dir / "03_other_page.py"),
             "icon": "",
+            "url_pathname": "other_page",
         },
         calc_md5(str(pages_dir / "04 last numbered page.py")): {
             "page_script_hash": calc_md5(str(pages_dir / "04 last numbered page.py")),
-            "page_name": "last_numbered_page",
+            "page_name": "last numbered page",
             "script_path": str(pages_dir / "04 last numbered page.py"),
             "icon": "",
+            "url_pathname": "last_numbered_page",
         },
         calc_md5(str(pages_dir / "page.py")): {
             "page_script_hash": calc_md5(str(pages_dir / "page.py")),
             "page_name": "page",
             "script_path": str(pages_dir / "page.py"),
             "icon": "",
+            "url_pathname": "page",
         },
     }

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -382,13 +382,15 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         args1, _ = fob.call_args_list[0]
         args2, _ = fob.call_args_list[1]
+        args3, _ = fob.call_args_list[2]
 
         assert args1[0] == "streamlit_app.py"
         assert args2[0] == "streamlit_app2.py"
+        assert args3[0] == SCRIPT_PATH
 
         lsw.update_watched_pages()
-        args3, _ = fob.call_args_list[2]
-        assert args3[0] == "streamlit_app3.py"
+        args4, _ = fob.call_args_list[3]
+        assert args4[0] == "streamlit_app3.py"
 
     @patch(
         "streamlit.runtime.pages_manager.PagesManager.get_pages",
@@ -420,14 +422,19 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher", MagicMock())
     def test_watches_union_of_page_scripts(self):
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        assert lsw._watched_pages == {"page1.py", "page2.py"}
+        assert lsw._watched_pages == {"page1.py", "page2.py", SCRIPT_PATH}
 
         def isfile_mock(x):
             return True
 
         with patch("os.path.isfile", wraps=isfile_mock):
             lsw.update_watched_pages()
-            assert lsw._watched_pages == {"page1.py", "page2.py", "page3.py"}
+            assert lsw._watched_pages == {
+                "page1.py",
+                "page2.py",
+                "page3.py",
+                SCRIPT_PATH,
+            }
 
     @patch(
         "streamlit.runtime.pages_manager.PagesManager.get_pages",
@@ -459,14 +466,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher", MagicMock())
     def test_unwatches_invalid_page_script_paths(self):
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
-        assert lsw._watched_pages == {"page1.py", "page2.py"}
+        assert lsw._watched_pages == {"page1.py", "page2.py", SCRIPT_PATH}
 
         def isfile_mock(x):
             return x != "page2.py"
 
         with patch("os.path.isfile", wraps=isfile_mock):
             lsw.update_watched_pages()
-            assert lsw._watched_pages == {"page1.py", "page3.py"}
+            assert lsw._watched_pages == {"page1.py", "page3.py", SCRIPT_PATH}
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_passes_filepath_to_callback(self, fob):

--- a/proto/streamlit/proto/Navigation.proto
+++ b/proto/streamlit/proto/Navigation.proto
@@ -30,6 +30,7 @@ message Navigation {
   string page_script_hash = 4;
 
   bool expanded = 5;
+  bool is_mpa_v1 = 6;
 
   // Position of the Navigation
   enum Position {

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -57,7 +57,7 @@ message NewSession {
   // See the "theme" config section.
   CustomThemeConfig custom_theme = 7;
 
-  // A list of all of this app's pages, in order and including the main page.
+  // DEPRECATED - A list of all of this app's pages, in order and including the main page.
   repeated AppPage app_pages = 8;
 
   // A hash of the script corresponding to the page currently being viewed.


### PR DESCRIPTION
## Describe your changes

This removes the strategy pattern used in both the frontend and backend and conforms it to one strategy with some small deviations.

Specifically:
- We say we are MPAv1 if there is a pages folder.
- We send down a navigation message for MPAv1 at the beginning of the script run.
   - We unfortunately had to add a field in the proto to indicate v1 or v2. This is because there are some differences in approach on the frontend (e.g. clearing Page Elements) that required some form of knowledge (originally the navigation message _was_ the differentiator)
- Fixing tests to adjust given above.
- Adjustment of location of things outside of pages_manager (like context and runtime)

The key behavioral difference is that for single page apps, we will not know if the page was not found. This means two things:
 - The dialog will not pop up until the script finishes
 - Naturally, if the script never finishes (infinite loop), the dialog will never show.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
