### PR TITLE
Handle media for `StaticConnection`

### DIFF
--- a/e2e_playwright/static_app_test.py
+++ b/e2e_playwright/static_app_test.py
@@ -17,6 +17,10 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 
+# TODO: Change this to a stable location and eventually make it configurable
+# Holds url for static asset location
+STATIC_ASSET_CONFIG = "https://s3.us-west-2.amazonaws.com/notebooks.streamlit.io"
+
 
 @pytest.mark.query_param("?staticAppId=Ingest_Public_JSON")
 def test_static_app(static_app: Page, assert_snapshot: ImageCompareFunction):
@@ -33,3 +37,21 @@ def test_static_app(static_app: Page, assert_snapshot: ImageCompareFunction):
 
     first_cell = app_cells.nth(1)
     assert_snapshot(first_cell, name="example_static_app")
+
+
+@pytest.mark.query_param("?staticAppId=Visual_Data_Stories_with_Snowflake_Notebooks")
+def test_static_app_media(static_app: Page):
+    """Test that static app media is sourced properly"""
+    main_app_body = static_app.locator(".stMainBlockContainer .stVerticalBlock").first
+    app_cells = main_app_body.locator("> div")
+
+    # App always has an empty cell at the beginning (34 displayed cells + 1 empty cell)
+    expect(app_cells).to_have_count(35)
+
+    image_cell = app_cells.nth(29)
+    image = image_cell.locator("img")
+
+    expect(image).to_have_attribute(
+        "src",
+        f"{STATIC_ASSET_CONFIG}/Visual_Data_Stories_with_Snowflake_Notebooks/media/3954fdb11794f07e22076cd644b22d4931ba829c9474cd7c3126362e.png",
+    )

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -42,6 +42,10 @@ import {
  * Example StreamlitEndpoints implementation.
  */
 class Endpoints implements StreamlitEndpoints {
+  public setStaticConfigUrl(url: string | null): void {
+    throw new Error("Unimplemented")
+  }
+
   public buildComponentURL(): string {
     throw new Error("Unimplemented")
   }

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -162,7 +162,8 @@ export class ConnectionManager {
         staticAppId,
         this.setConnectionState,
         this.props.onMessage,
-        this.props.onConnectionError
+        this.props.onConnectionError,
+        this.props.endpoints
       )
       // Static apps are not connected to server, so saving the
       // connection is unnecessary.

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
@@ -90,11 +90,24 @@ describe("DefaultStreamlitEndpoints", () => {
       csrfEnabled: false,
     })
 
+    afterEach(() => {
+      endpoints.setStaticConfigUrl(null)
+    })
+
     it("builds URL correctly for streamlit-served media", () => {
       const url = endpoints.buildMediaURL("/media/1234567890.png")
       expect(url).toBe(
         "http://streamlit.mock:80/mock/base/path/media/1234567890.png"
       )
+    })
+
+    it("builds URL correctly for static-served media", () => {
+      // Set staticConfigUrl & staticAppId in query params to replicate static connection
+      endpoints.setStaticConfigUrl("www.example.com")
+      vi.spyOn(URLSearchParams.prototype, "get").mockReturnValue("staticAppId")
+
+      const url = endpoints.buildMediaURL("/media/1234567890.png")
+      expect(url).toBe("www.example.com/staticAppId/media/1234567890.png")
     })
 
     it("passes through other media uris", () => {

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -49,9 +49,16 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   private fileUploadClientConfig?: FileUploadClientConfig
 
+  private staticConfigUrl: string | null
+
   public constructor(props: Props) {
     this.getServerUri = props.getServerUri
     this.csrfEnabled = props.csrfEnabled
+    this.staticConfigUrl = null
+  }
+
+  public setStaticConfigUrl(url: string | null): void {
+    this.staticConfigUrl = url
   }
 
   public buildComponentURL(componentName: string, path: string): string {
@@ -74,28 +81,24 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   /**
    * If we are using a static connection, return S3 URL for that file. Otherwise, return null.
    */
-  // @ts-expect-error
-  private async buildStaticUrl(file: string): string | null {
+  private buildStaticUrl(file: string): string {
     const queryParams = new URLSearchParams(document.location.search)
     const staticAppId = queryParams.get("staticAppId")
-    if (staticAppId) {
-      const staticAssetUrl = await getStaticConfig()
-      return `${staticAssetUrl}/${staticAppId}${file}`
-    }
-    return null
+    return `${this.staticConfigUrl}/${staticAppId}${file}`
   }
 
   /**
-   * Construct a URL for a media file. If the url is relative and starts with
-   * "/media", check connection type - static connections will serve media from
-   * S3 - otherwise it's being served from Streamlit, construct it appropriately.
-   * Leave it alone if not starting with "/media".
+   * Construct a URL for a media file. If the `staticConfigUrl` is set, we have a static app
+   * and will serve media from S3. If the url is relative and starts with  "/media",
+   * assume it's being served from Streamlit and construct it appropriately.
+   * Otherwise leave it alone.
    */
   public buildMediaURL(url: string): string {
+    if (this.staticConfigUrl && url.startsWith(MEDIA_ENDPOINT)) {
+      return this.buildStaticUrl(url)
+    }
     if (url.startsWith(MEDIA_ENDPOINT)) {
-      return (
-        this.buildStaticUrl(url) ?? buildHttpUri(this.requireServerUri(), url)
-      )
+      return buildHttpUri(this.requireServerUri(), url)
     }
     return url
   }

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -27,6 +27,8 @@ import {
   StreamlitEndpoints,
 } from "@streamlit/lib"
 
+import { getStaticConfig } from "./StaticConnection"
+
 interface Props {
   getServerUri: () => BaseUriParts | undefined
   csrfEnabled: boolean
@@ -70,14 +72,32 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   }
 
   /**
+   * If we are using a static connection, return S3 URL for that file. Otherwise, return null.
+   */
+  // @ts-expect-error
+  private async buildStaticUrl(file: string): string | null {
+    const queryParams = new URLSearchParams(document.location.search)
+    const staticAppId = queryParams.get("staticAppId")
+    if (staticAppId) {
+      const staticAssetUrl = await getStaticConfig()
+      return `${staticAssetUrl}/${staticAppId}${file}`
+    }
+    return null
+  }
+
+  /**
    * Construct a URL for a media file. If the url is relative and starts with
-   * "/media", assume it's being served from Streamlit and construct it
-   * appropriately. Otherwise leave it alone.
+   * "/media", check connection type - static connections will serve media from
+   * S3 - otherwise it's being served from Streamlit, construct it appropriately.
+   * Leave it alone if not starting with "/media".
    */
   public buildMediaURL(url: string): string {
-    return url.startsWith(MEDIA_ENDPOINT)
-      ? buildHttpUri(this.requireServerUri(), url)
-      : url
+    if (url.startsWith(MEDIA_ENDPOINT)) {
+      return (
+        this.buildStaticUrl(url) ?? buildHttpUri(this.requireServerUri(), url)
+      )
+    }
+    return url
   }
 
   /**

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -27,8 +27,6 @@ import {
   StreamlitEndpoints,
 } from "@streamlit/lib"
 
-import { getStaticConfig } from "./StaticConnection"
-
 interface Props {
   getServerUri: () => BaseUriParts | undefined
   csrfEnabled: boolean

--- a/frontend/lib/src/FileUploadClient.test.ts
+++ b/frontend/lib/src/FileUploadClient.test.ts
@@ -36,6 +36,7 @@ describe("FileUploadClient Upload", () => {
     uploader = new FileUploadClient({
       sessionInfo: mockSessionInfo(),
       endpoints: {
+        setStaticConfigUrl: vi.fn(),
         buildComponentURL: vi.fn(),
         buildMediaURL: vi.fn(),
         buildFileUploadURL: vi.fn(),

--- a/frontend/lib/src/ForwardMessageCache.test.ts
+++ b/frontend/lib/src/ForwardMessageCache.test.ts
@@ -30,6 +30,7 @@ function createCache(): MockCache {
   const mockFetchCachedForwardMsg = vi.fn()
 
   const cache = new ForwardMsgCache({
+    setStaticConfigUrl: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildFileUploadURL: vi.fn(),

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -26,6 +26,13 @@ export type FileUploadClientConfig = {
 /** Exposes non-websocket endpoints used by the frontend. */
 export interface StreamlitEndpoints {
   /**
+   * Set the static config url for static connection media assets.
+   *
+   * @param url The URL to set.
+   */
+  setStaticConfigUrl(url: string): void
+
+  /**
    * Return a URL to fetch data for the given custom component.
    * @param componentName The registered name of the component.
    * @param path The path of the component resource to fetch, e.g. "index.html".

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -50,6 +50,7 @@ export function mockEndpoints(
   overrides: Partial<StreamlitEndpoints> = {}
 ): StreamlitEndpoints {
   return {
+    setStaticConfigUrl: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildFileUploadURL: vi.fn(),


### PR DESCRIPTION
## Describe your changes
As a follow-up to implementing `StaticConnection`, we need to re-engineer handling of media commands on the FE (`st.image`, `st.audio`, `st.video`, `st.logo`, etc) in the static connection scenario, as there is no server to access the `"/media"` endpoint. We instead source the static app's media from hosted S3 content.

**How this works:**
* When a `StaticConnection` is established by the `ConnectionManager`, we fetch the `staticConfigUrl` - currently an S3 bucket that holds static app assets (including protobuf files to render the app and the app's media files)
* Once the config is received, we set the `staticConfigUrl` property in `DefaultStreamlitEndpoints`
* When `buildMediaURL` is called in our media commands (`st.image` etc) it checks if the `staticConfigUrl` property is set, if so we build the static media url using the `staticConfigUrl`, `staticAppId`, & file url.

## Testing Plan
- Unit Tests (JS): ✅ Added & Updated
- E2E Tests: ✅  Added & Updated
- Manual Testing: ✅ 