### PR TITLE
Update file uploader to uses new `accept` value

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -20,7 +20,7 @@ import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 
-import FileDropzone, { Props } from "./FileDropzone"
+import FileDropzone, { Props, STREAMLIT_MIME_TYPE } from "./FileDropzone"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   disabled: false,
@@ -57,6 +57,6 @@ describe("FileDropzone widget", () => {
     render(<FileDropzone {...props} />)
     expect(
       screen.queryByTestId("stFileUploaderDropzoneInput")
-    ).toHaveAttribute("accept", ".jpg")
+    ).toHaveAttribute("accept", `${STREAMLIT_MIME_TYPE},.jpg`)
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -20,7 +20,7 @@ import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 
-import FileDropzone, { Props, STREAMLIT_MIME_TYPE } from "./FileDropzone"
+import FileDropzone, { Props } from "./FileDropzone"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   disabled: false,
@@ -57,6 +57,6 @@ describe("FileDropzone widget", () => {
     render(<FileDropzone {...props} />)
     expect(
       screen.queryByTestId("stFileUploaderDropzoneInput")
-    ).toHaveAttribute("accept", `${STREAMLIT_MIME_TYPE},.jpg`)
+    ).toHaveAttribute("accept", ".jpg")
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -35,6 +35,14 @@ export interface Props {
   label: string
 }
 
+function getAccept(acceptedExtensions: string[]): Accept | undefined {
+  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
+  // to allow file types defined in acceptedExtensions.
+  return acceptedExtensions.length
+    ? { "application/streamlit": acceptedExtensions }
+    : undefined
+}
+
 const FileDropzone = ({
   onDrop,
   multiple,
@@ -42,51 +50,43 @@ const FileDropzone = ({
   maxSizeBytes,
   disabled,
   label,
-}: Props): React.ReactElement => {
-  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
-  // to allow file types defined in acceptedExtensions.
-  const accept: Accept | undefined = acceptedExtensions.length
-    ? { "application/streamlit": acceptedExtensions }
-    : undefined
-
-  return (
-    <Dropzone
-      onDrop={onDrop}
-      multiple={multiple}
-      accept={accept}
-      maxSize={maxSizeBytes}
-      disabled={disabled}
-      // react-dropzone v12+ uses the File System Access API by default,
-      // causing the bug described in https://github.com/streamlit/streamlit/issues/6176.
-      useFsAccessApi={false}
-    >
-      {({ getRootProps, getInputProps }) => (
-        <StyledFileDropzoneSection
-          {...getRootProps()}
-          data-testid="stFileUploaderDropzone"
-          isDisabled={disabled}
-          aria-label={label}
+}: Props): React.ReactElement => (
+  <Dropzone
+    onDrop={onDrop}
+    multiple={multiple}
+    accept={getAccept(acceptedExtensions)}
+    maxSize={maxSizeBytes}
+    disabled={disabled}
+    // react-dropzone v12+ uses the File System Access API by default,
+    // causing the bug described in https://github.com/streamlit/streamlit/issues/6176.
+    useFsAccessApi={false}
+  >
+    {({ getRootProps, getInputProps }) => (
+      <StyledFileDropzoneSection
+        {...getRootProps()}
+        data-testid="stFileUploaderDropzone"
+        isDisabled={disabled}
+        aria-label={label}
+      >
+        <input
+          data-testid="stFileUploaderDropzoneInput"
+          {...getInputProps()}
+        />
+        <FileDropzoneInstructions
+          multiple={multiple}
+          acceptedExtensions={acceptedExtensions}
+          maxSizeBytes={maxSizeBytes}
+        />
+        <BaseButton
+          kind={BaseButtonKind.SECONDARY}
+          disabled={disabled}
+          size={BaseButtonSize.SMALL}
         >
-          <input
-            data-testid="stFileUploaderDropzoneInput"
-            {...getInputProps()}
-          />
-          <FileDropzoneInstructions
-            multiple={multiple}
-            acceptedExtensions={acceptedExtensions}
-            maxSizeBytes={maxSizeBytes}
-          />
-          <BaseButton
-            kind={BaseButtonKind.SECONDARY}
-            disabled={disabled}
-            size={BaseButtonSize.SMALL}
-          >
-            Browse files
-          </BaseButton>
-        </StyledFileDropzoneSection>
-      )}
-    </Dropzone>
-  )
-}
+          Browse files
+        </BaseButton>
+      </StyledFileDropzoneSection>
+    )}
+  </Dropzone>
+)
 
 export default FileDropzone

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import Dropzone, { FileRejection } from "react-dropzone"
+import Dropzone, { Accept, FileRejection } from "react-dropzone"
 
 import BaseButton, {
   BaseButtonKind,
@@ -43,9 +43,12 @@ const FileDropzone = ({
   disabled,
   label,
 }: Props): React.ReactElement => {
-  const accept = acceptedExtensions.length
-    ? { "application/octet-stream": acceptedExtensions }
+  const accept: Accept | undefined = acceptedExtensions.length
+    ? { "text/plain": [".txt"] }
     : undefined
+
+  console.log(acceptedExtensions)
+  console.log(accept)
 
   return (
     <Dropzone

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -35,11 +35,13 @@ export interface Props {
   label: string
 }
 
+// Before we support official MIME types, using the custom "application/streamlit" as a wild card
+// to allow file types defined in acceptedExtensions.
+export const STREAMLIT_MIME_TYPE = "application/streamlit"
+
 function getAccept(acceptedExtensions: string[]): Accept | undefined {
-  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
-  // to allow file types defined in acceptedExtensions.
   return acceptedExtensions.length
-    ? { "application/streamlit": acceptedExtensions }
+    ? { STREAMLIT_MIME_TYPE: acceptedExtensions }
     : undefined
 }
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -42,43 +42,49 @@ const FileDropzone = ({
   maxSizeBytes,
   disabled,
   label,
-}: Props): React.ReactElement => (
-  <Dropzone
-    onDrop={onDrop}
-    multiple={multiple}
-    accept={acceptedExtensions.length ? { acceptedExtensions } : undefined}
-    maxSize={maxSizeBytes}
-    disabled={disabled}
-    // react-dropzone v12+ uses the File System Access API by default,
-    // causing the bug described in https://github.com/streamlit/streamlit/issues/6176.
-    useFsAccessApi={false}
-  >
-    {({ getRootProps, getInputProps }) => (
-      <StyledFileDropzoneSection
-        {...getRootProps()}
-        data-testid="stFileUploaderDropzone"
-        isDisabled={disabled}
-        aria-label={label}
-      >
-        <input
-          data-testid="stFileUploaderDropzoneInput"
-          {...getInputProps()}
-        />
-        <FileDropzoneInstructions
-          multiple={multiple}
-          acceptedExtensions={acceptedExtensions}
-          maxSizeBytes={maxSizeBytes}
-        />
-        <BaseButton
-          kind={BaseButtonKind.SECONDARY}
-          disabled={disabled}
-          size={BaseButtonSize.SMALL}
+}: Props): React.ReactElement => {
+  const accept = acceptedExtensions.length
+    ? { "application/octet-stream": acceptedExtensions }
+    : undefined
+
+  return (
+    <Dropzone
+      onDrop={onDrop}
+      multiple={multiple}
+      accept={accept}
+      maxSize={maxSizeBytes}
+      disabled={disabled}
+      // react-dropzone v12+ uses the File System Access API by default,
+      // causing the bug described in https://github.com/streamlit/streamlit/issues/6176.
+      useFsAccessApi={false}
+    >
+      {({ getRootProps, getInputProps }) => (
+        <StyledFileDropzoneSection
+          {...getRootProps()}
+          data-testid="stFileUploaderDropzone"
+          isDisabled={disabled}
+          aria-label={label}
         >
-          Browse files
-        </BaseButton>
-      </StyledFileDropzoneSection>
-    )}
-  </Dropzone>
-)
+          <input
+            data-testid="stFileUploaderDropzoneInput"
+            {...getInputProps()}
+          />
+          <FileDropzoneInstructions
+            multiple={multiple}
+            acceptedExtensions={acceptedExtensions}
+            maxSizeBytes={maxSizeBytes}
+          />
+          <BaseButton
+            kind={BaseButtonKind.SECONDARY}
+            disabled={disabled}
+            size={BaseButtonSize.SMALL}
+          >
+            Browse files
+          </BaseButton>
+        </StyledFileDropzoneSection>
+      )}
+    </Dropzone>
+  )
+}
 
 export default FileDropzone

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -40,6 +40,7 @@ export interface Props {
 export const STREAMLIT_MIME_TYPE = "application/streamlit"
 
 function getAccept(acceptedExtensions: string[]): Accept | undefined {
+  // Remove mimetype when this component moves to functional
   return acceptedExtensions.length
     ? { STREAMLIT_MIME_TYPE: acceptedExtensions }
     : undefined

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -43,6 +43,8 @@ const FileDropzone = ({
   disabled,
   label,
 }: Props): React.ReactElement => {
+  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
+  // to allow file types defined in acceptedExtensions.
   const accept: Accept | undefined = acceptedExtensions.length
     ? { "application/streamlit": acceptedExtensions }
     : undefined

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -44,11 +44,8 @@ const FileDropzone = ({
   label,
 }: Props): React.ReactElement => {
   const accept: Accept | undefined = acceptedExtensions.length
-    ? { "text/plain": [".txt"] }
+    ? { "application/streamlit": acceptedExtensions }
     : undefined
-
-  console.log(acceptedExtensions)
-  console.log(accept)
 
   return (
     <Dropzone


### PR DESCRIPTION
## Describe your changes

The `accept` props changed to accepting object of mimetypes as keys in the new `react-dropzone` dependency.
This would break existing widgets that uses the `type` param in `st.file_uploader` to define accepted extensions.

Here we added a custom mimetype `application/streamlit` as a wild card type to still allow us to enforce the accepted extensions to satisfy the version upgrade, with #10068 being the work in progress to support official mimetypes.


## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
- E2E Tests
- Also manually tested with `st_file_uploader.py` on a couple file types (txt, png, mov)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
