### PR TITLE
[Fix] `MetricsManager` parse error

### DIFF
--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -317,7 +317,13 @@ export class MetricsManager {
         window.localStorage.setItem(anonymousIdKey, anonymousIdCookie)
       }
     } else if (anonymousIdLocalStorage) {
-      this.anonymousId = anonymousIdLocalStorage
+      try {
+        // parse handles legacy anonymousId logic with excess quotes
+        this.anonymousId = JSON.parse(anonymousIdLocalStorage)
+      } catch {
+        // if parse fails, anonymousId is not legacy and we can use as is
+        this.anonymousId = anonymousIdLocalStorage
+      }
 
       setCookie(anonymousIdKey, this.anonymousId, expiration)
     } else {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -317,8 +317,7 @@ export class MetricsManager {
         window.localStorage.setItem(anonymousIdKey, anonymousIdCookie)
       }
     } else if (anonymousIdLocalStorage) {
-      // Removes excess quotes from localStorage string value
-      this.anonymousId = JSON.parse(anonymousIdLocalStorage)
+      this.anonymousId = anonymousIdLocalStorage
 
       setCookie(anonymousIdKey, this.anonymousId, expiration)
     } else {


### PR DESCRIPTION
## Describe your changes
When the `anonymousId` used for our metrics is available in localStorage only, we previously used `JSON.parse` to resolve excess quotes coming from Segment's `anonymousId` logic. This is causing a console error and is no longer necessary with Segment's removal.

## Testing Plan
- **Manual Testing**: ✅ Tested across the 4 scenarios below in Chrome, Firefox, Safari & Edge: 
    - No storage of `anonymousId`
    - `anonymousId` in localStorage only 
    - `anonymousId` in cookies only 
    - `anonymousId` in both 