### PR TITLE
Remove BaseUriParts type in favor of standard Location

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -98,10 +98,10 @@ vi.mock("@streamlit/app/src/connection/ConnectionManager", async () => {
       incrementMessageCacheRunCount: vi.fn(),
       getBaseUriParts() {
         return {
-          basePath: "",
-          host: "",
-          port: 8501,
-        }
+          pathname: "/",
+          hostname: "",
+          port: "8501",
+        } as URL
       },
     }
   })
@@ -1268,10 +1268,10 @@ describe("App", () => {
           getMockConnectionManager(),
           "getBaseUriParts"
         ).mockReturnValue({
-          basePath: "foo",
-          host: "",
-          port: 8501,
-        })
+          pathname: "/foo",
+          hostname: "",
+          port: "8501",
+        } as URL)
 
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
@@ -1791,10 +1791,10 @@ describe("App", () => {
       const connectionManager = getMockConnectionManager()
 
       vi.spyOn(connectionManager, "getBaseUriParts").mockReturnValue({
-        basePath: "foo/bar",
-        host: "",
-        port: 8501,
-      })
+        pathname: "/foo/bar",
+        hostname: "",
+        port: "8501",
+      } as URL)
 
       window.history.pushState({}, "", "/foo/bar/baz")
       widgetStateManager.sendUpdateWidgetsMessage(undefined)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -26,7 +26,6 @@ import { getLogger } from "loglevel"
 import {
   AppConfig,
   AppRoot,
-  BaseUriParts,
   CircularBuffer,
   ComponentRegistry,
   createFormsData,
@@ -964,11 +963,11 @@ export class App extends PureComponent<Props, State> {
   ): void => {
     const baseUriParts = this.getBaseUriParts()
     if (baseUriParts) {
-      const { basePath } = baseUriParts
+      const { pathname } = baseUriParts
 
       const prevPageNameInPath = extractPageNameFromPathName(
         document.location.pathname,
-        basePath
+        pathname
       )
       const prevPageName =
         prevPageNameInPath === "" ? mainPageName : prevPageNameInPath
@@ -981,7 +980,7 @@ export class App extends PureComponent<Props, State> {
         const queryString = preserveEmbedQueryParams()
         const qs = queryString ? `?${queryString}` : ""
 
-        const basePathPrefix = basePath ? `/${basePath}` : ""
+        const basePathPrefix = pathname !== "/" ? `/${pathname}` : ""
 
         const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
 
@@ -1510,7 +1509,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     const { currentPageScriptHash } = this.state
-    const { basePath } = baseUriParts
+    const { pathname } = baseUriParts
     let queryString = this.getQueryString()
     let pageName = ""
 
@@ -1538,7 +1537,7 @@ export class App extends PureComponent<Props, State> {
       // document.location.pathname.
       pageName = extractPageNameFromPathName(
         document.location.pathname,
-        basePath
+        pathname
       )
       pageScriptHash = ""
     }
@@ -1787,7 +1786,7 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
-  getBaseUriParts = (): BaseUriParts | undefined =>
+  getBaseUriParts = (): URL | undefined =>
     this.connectionManager
       ? this.connectionManager.getBaseUriParts()
       : undefined

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -980,7 +980,7 @@ export class App extends PureComponent<Props, State> {
         const queryString = preserveEmbedQueryParams()
         const qs = queryString ? `?${queryString}` : ""
 
-        const basePathPrefix = pathname !== "/" ? `/${pathname}` : ""
+        const basePathPrefix = pathname !== "/" ? pathname : ""
 
         const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -980,7 +980,7 @@ export class App extends PureComponent<Props, State> {
         const queryString = preserveEmbedQueryParams()
         const qs = queryString ? `?${queryString}` : ""
 
-        const basePathPrefix = pathname !== "/" ? pathname : ""
+        const basePathPrefix = pathname === "/" ? "" : pathname
 
         const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
 

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -18,7 +18,6 @@ import { ReactNode } from "react"
 import { getLogger } from "loglevel"
 
 import {
-  BaseUriParts,
   getPossibleBaseUris,
   IHostConfigResponse,
   StreamlitEndpoints,
@@ -109,7 +108,7 @@ export class ConnectionManager {
    * Return the BaseUriParts for the server we're connected to,
    * if we are connected to a server.
    */
-  public getBaseUriParts(): BaseUriParts | undefined {
+  public getBaseUriParts(): URL | undefined {
     if (this.websocketConnection instanceof WebsocketConnection) {
       return this.websocketConnection.getBaseUriParts()
     }

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
@@ -17,16 +17,16 @@
 import axios from "axios"
 import MockAdapter from "axios-mock-adapter"
 
-import { BaseUriParts, buildHttpUri } from "@streamlit/lib"
+import { buildHttpUri } from "@streamlit/lib"
 import { ForwardMsg } from "@streamlit/protobuf"
 
 import { DefaultStreamlitEndpoints } from "./DefaultStreamlitEndpoints"
 
 const MOCK_SERVER_URI = {
-  host: "streamlit.mock",
-  port: 80,
-  basePath: "mock/base/path",
-}
+  hostname: "streamlit.mock",
+  port: "80",
+  pathname: "/mock/base/path",
+} as URL
 
 function createMockForwardMsg(hash: string, cacheable = true): ForwardMsg {
   return ForwardMsg.fromObject({
@@ -55,7 +55,7 @@ describe("DefaultStreamlitEndpoints", () => {
   describe("buildComponentURL()", () => {
     it("errors if no serverURI", () => {
       // If we never connect to a server, getComponentURL will fail:
-      let serverURI: BaseUriParts | undefined
+      let serverURI: URL | undefined
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,
@@ -64,7 +64,7 @@ describe("DefaultStreamlitEndpoints", () => {
     })
 
     it("uses current or cached serverURI if present", () => {
-      let serverURI: BaseUriParts | undefined
+      let serverURI: URL | undefined
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -139,7 +139,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     const { pathname, hostname } = this.requireServerUri()
     const portSection = port ? `:${port}` : ""
     // Empty path names are simply "/" Anything else must have more to it
-    const basePathSection = pathname !== "/" ? `${pathname}/` : "/"
+    const basePathSection = pathname === "/" ? "/" : `${pathname}/`
 
     return `${protocol}//${hostname}${portSection}${basePathSection}${navigateTo}`
   }

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -17,7 +17,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse, CancelToken } from "axios"
 
 import {
-  BaseUriParts,
   buildHttpUri,
   FileUploadClientConfig,
   getCookie,
@@ -28,7 +27,7 @@ import {
 import { IAppPage } from "@streamlit/protobuf"
 
 interface Props {
-  getServerUri: () => BaseUriParts | undefined
+  getServerUri: () => URL | undefined
   csrfEnabled: boolean
 }
 
@@ -39,11 +38,11 @@ const FORWARD_MSG_CACHE_ENDPOINT = "/_stcore/message"
 
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
 export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
-  private readonly getServerUri: () => BaseUriParts | undefined
+  private readonly getServerUri: () => URL | undefined
 
   private readonly csrfEnabled: boolean
 
-  private cachedServerUri?: BaseUriParts
+  private cachedServerUri?: URL
 
   private fileUploadClientConfig?: FileUploadClientConfig
 
@@ -137,11 +136,12 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     // the frontend is served by the react dev server and not the
     // streamlit server).
     const { port, protocol } = window.location
-    const { basePath, host } = this.requireServerUri()
+    const { pathname, hostname } = this.requireServerUri()
     const portSection = port ? `:${port}` : ""
-    const basePathSection = basePath ? `${basePath}/` : ""
+    // Empty path names are simply "/" Anything else must have more to it
+    const basePathSection = pathname !== "/" ? `${pathname}/` : "/"
 
-    return `${protocol}//${host}${portSection}/${basePathSection}${navigateTo}`
+    return `${protocol}//${hostname}${portSection}${basePathSection}${navigateTo}`
   }
 
   public async uploadFileUploaderFile(
@@ -212,7 +212,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
    * recent cached value of the URI. If we're disconnected and have no cached
    * value, throw an Error.
    */
-  private requireServerUri(): BaseUriParts {
+  private requireServerUri(): URL {
     const serverUri = this.getServerUri()
     if (notNullOrUndefined(serverUri)) {
       this.cachedServerUri = serverUri

--- a/frontend/app/src/connection/DoInitPings.tsx
+++ b/frontend/app/src/connection/DoInitPings.tsx
@@ -33,7 +33,6 @@ import {
 } from "@streamlit/app/src/connection/constants"
 import { OnRetry } from "@streamlit/app/src/connection/types"
 import {
-  BaseUriParts,
   buildHttpUri,
   IHostConfigResponse,
   Resolver,
@@ -43,7 +42,7 @@ import {
 const log = getLogger("DoInitPings")
 
 export function doInitPings(
-  uriPartsList: BaseUriParts[],
+  uriPartsList: URL[],
   minimumTimeoutMs: number,
   maximumTimeoutMs: number,
   retryCallback: OnRetry,

--- a/frontend/app/src/connection/StaticConnection.test.tsx
+++ b/frontend/app/src/connection/StaticConnection.test.tsx
@@ -210,10 +210,10 @@ describe("StaticConnection", () => {
 
   describe("StaticConnection", () => {
     const MOCK_SERVER_URI = {
-      host: "streamlit.mock",
-      port: 80,
-      basePath: "mock/base/path",
-    }
+      hostname: "streamlit.mock",
+      port: "80",
+      pathname: "/mock/base/path",
+    } as URL
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,
       csrfEnabled: false,

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -48,10 +48,10 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     endpoints: mockEndpoints(),
     baseUriPartsList: [
       {
-        host: "localhost",
-        port: 1234,
-        basePath: "/",
-      },
+        hostname: "localhost",
+        port: "1234",
+        pathname: "/",
+      } as URL,
     ],
     onMessage: vi.fn(),
     onConnectionStateChange: vi.fn(),
@@ -66,9 +66,9 @@ function createMockArgs(overrides?: Partial<Args>): Args {
 describe("doInitPings", () => {
   const MOCK_PING_DATA = {
     uri: [
-      { host: "not.a.real.host", port: 3000, basePath: "/" },
-      { host: "not.a.real.host", port: 3001, basePath: "/" },
-    ],
+      { hostname: "not.a.real.host", port: "3000", pathname: "/" },
+      { hostname: "not.a.real.host", port: "3001", pathname: "/" },
+    ] as URL[],
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: vi.fn(),
@@ -266,9 +266,9 @@ describe("doInitPings", () => {
     const MOCK_PING_DATA_LOCALHOST = {
       ...MOCK_PING_DATA,
       uri: [
-        { host: "localhost", port: 3000, basePath: "/" },
-        { host: "localhost", port: 3001, basePath: "/" },
-      ],
+        { hostname: "localhost", port: "3000", pathname: "/" },
+        { hostname: "localhost", port: "3001", pathname: "/" },
+      ] as URL[],
     }
 
     const TEST_ERROR = {
@@ -444,7 +444,13 @@ describe("doInitPings", () => {
     }
 
     await doInitPings(
-      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
+      [
+        {
+          hostname: "not.a.real.host",
+          port: "3000",
+          pathname: "/",
+        } as URL,
+      ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
@@ -545,7 +551,13 @@ describe("doInitPings", () => {
     }
 
     await doInitPings(
-      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
+      [
+        {
+          hostname: "not.a.real.host",
+          port: "3000",
+          pathname: "/",
+        } as URL,
+      ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
@@ -562,7 +574,13 @@ describe("doInitPings", () => {
     }
 
     await doInitPings(
-      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
+      [
+        {
+          hostname: "not.a.real.host",
+          port: "3000",
+          pathname: "/",
+        } as URL,
+      ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -31,7 +31,6 @@ import {
   OnRetry,
 } from "@streamlit/app/src/connection/types"
 import {
-  BaseUriParts,
   buildWsUri,
   ForwardMsgCache,
   getCookie,
@@ -56,7 +55,7 @@ export interface Args {
    * all fail, we'll retry from the top. The number of retries depends on
    * whether this is a local connection.
    */
-  baseUriPartsList: BaseUriParts[]
+  baseUriPartsList: URL[]
 
   /**
    * Function called when our ConnectionState changes.
@@ -185,7 +184,7 @@ export class WebsocketConnection {
    * Return the BaseUriParts for the server we're connected to,
    * if we are connected to a server.
    */
-  public getBaseUriParts(): BaseUriParts | undefined {
+  public getBaseUriParts(): URL | undefined {
     if (this.state === ConnectionState.CONNECTED) {
       return this.args.baseUriPartsList[this.uriIndex]
     }

--- a/frontend/lib/src/baseconsts.ts
+++ b/frontend/lib/src/baseconsts.ts
@@ -15,17 +15,10 @@
  */
 
 /**
- * When in dev mode, this is the port used to connect to the web server that is
- * serving the current page (i.e. the actual web page server, not the API
- * server, which in dev are actually different servers.)
- */
-export const WWW_PORT_DEV = 3000
-
-/**
  * This is the port used to connect to the server web socket when in dev.
  * IMPORTANT: If changed, also change config.py
  */
-export const WEBSOCKET_PORT_DEV = 8501
+export const WEBSOCKET_PORT_DEV = "8501"
 
 /**
  * True when in development mode. We disable if we are testing to ensure

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -122,7 +122,6 @@ export {
   getPossibleBaseUris,
   makePath,
 } from "./util/UriUtil"
-export type { BaseUriParts } from "./util/UriUtil"
 export {
   extractPageNameFromPathName,
   generateUID,

--- a/frontend/lib/src/util/UriUtil.test.ts
+++ b/frontend/lib/src/util/UriUtil.test.ts
@@ -28,65 +28,51 @@ global.window = Object.create(window)
 Object.defineProperty(window, "location", { value: location })
 
 test("gets all window URI parts", () => {
-  location.hostname = "the_host"
-  location.port = "9988"
-  location.pathname = "foo"
+  location.href = "https://the_host:9988/foo"
 
-  const parts = getWindowBaseUriParts()
-  expect(parts).toStrictEqual({
-    host: "the_host",
-    port: 9988,
-    basePath: "foo",
-  })
+  const { hostname, port, pathname } = getWindowBaseUriParts()
+  expect(hostname).toBe("the_host")
+  expect(port).toBe("9988")
+  expect(pathname).toBe("/foo")
 })
 
 test("gets window URI parts without basePath", () => {
-  location.hostname = "the_host"
-  location.port = "9988"
-  location.pathname = ""
+  location.href = "https://the_host:9988"
 
   const parts = getWindowBaseUriParts()
-  expect(parts).toStrictEqual({
-    host: "the_host",
-    port: 9988,
-    basePath: "",
+  expect(parts).toMatchObject({
+    hostname: "the_host",
+    port: "9988",
+    pathname: "/",
   })
 })
 
 test("gets window URI parts with long basePath", () => {
-  location.hostname = "the_host"
-  location.port = "9988"
-  location.pathname = "/foo/bar"
+  location.href = "https://the_host:9988/foo/bar"
 
-  const parts = getWindowBaseUriParts()
-  expect(parts).toStrictEqual({
-    host: "the_host",
-    port: 9988,
-    basePath: "foo/bar",
-  })
+  const { hostname, port, pathname } = getWindowBaseUriParts()
+  expect(hostname).toBe("the_host")
+  expect(port).toBe("9988")
+  expect(pathname).toBe("/foo/bar")
 })
 
 test("gets window URI parts with weird basePath", () => {
-  location.hostname = "the_host"
-  location.port = "9988"
-  location.pathname = "///foo/bar//"
+  location.href = "https://the_host:9988///foo/bar//"
 
-  const parts = getWindowBaseUriParts()
-  expect(parts).toStrictEqual({
-    host: "the_host",
-    port: 9988,
-    basePath: "foo/bar",
-  })
+  const { hostname, port, pathname } = getWindowBaseUriParts()
+  expect(hostname).toBe("the_host")
+  expect(port).toBe("9988")
+  expect(pathname).toBe("/foo/bar")
 })
 
 test("builds HTTP URI correctly", () => {
   location.href = "http://something"
   const uri = buildHttpUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "foo/bar",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "foo/bar",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("http://the_host:9988/foo/bar/baz")
@@ -96,10 +82,10 @@ test("builds HTTPS URI correctly", () => {
   location.href = "https://something"
   const uri = buildHttpUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "foo/bar",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "foo/bar",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("https://the_host:9988/foo/bar/baz")
@@ -109,10 +95,10 @@ test("builds HTTP URI with no base path", () => {
   location.href = "http://something"
   const uri = buildHttpUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("http://the_host:9988/baz")
@@ -122,10 +108,10 @@ test("builds WS URI correctly", () => {
   location.href = "http://something"
   const uri = buildWsUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "foo/bar",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "foo/bar",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("ws://the_host:9988/foo/bar/baz")
@@ -135,10 +121,10 @@ test("builds WSS URI correctly", () => {
   location.href = "https://something"
   const uri = buildWsUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "foo/bar",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "foo/bar",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("wss://the_host:9988/foo/bar/baz")
@@ -148,10 +134,10 @@ test("builds WS URI with no base path", () => {
   location.href = "http://something"
   const uri = buildWsUri(
     {
-      host: "the_host",
-      port: 9988,
-      basePath: "",
-    },
+      hostname: "the_host",
+      port: "9988",
+      pathname: "",
+    } as URL,
     "baz"
   )
   expect(uri).toBe("ws://the_host:9988/baz")
@@ -473,31 +459,31 @@ describe("getPossibleBaseUris", () => {
   const testCases = [
     {
       description: "empty pathnames",
-      pathname: "",
-      expectedBasePaths: [""],
+      pathname: "/",
+      expectedBasePaths: ["/"],
     },
     {
       description: "pathnames with a single part",
-      pathname: "foo",
-      expectedBasePaths: ["foo", ""],
+      pathname: "/foo",
+      expectedBasePaths: ["/foo", "/"],
     },
     {
       description: "pathnames with two parts",
-      pathname: "foo/bar",
-      expectedBasePaths: ["foo/bar", "foo"],
+      pathname: "/foo/bar",
+      expectedBasePaths: ["/foo/bar", "/foo"],
     },
     {
       description: "pathnames with more than two parts",
-      pathname: "foo/bar/baz/qux",
-      expectedBasePaths: ["foo/bar/baz/qux", "foo/bar/baz"],
+      pathname: "/foo/bar/baz/qux",
+      expectedBasePaths: ["/foo/bar/baz/qux", "/foo/bar/baz"],
     },
   ]
 
   testCases.forEach(({ description, pathname, expectedBasePaths }) => {
     it(`handles ${description}`, () => {
-      window.location.pathname = pathname
+      window.location.href = `https://not_a_host:80${pathname}`
 
-      expect(getPossibleBaseUris().map(b => b.basePath)).toEqual(
+      expect(getPossibleBaseUris().map(b => b.pathname)).toEqual(
         expectedBasePaths
       )
     })

--- a/frontend/lib/src/util/UriUtil.ts
+++ b/frontend/lib/src/util/UriUtil.ts
@@ -77,11 +77,6 @@ export function getPossibleBaseUris(): Array<URL> {
     parts.pop()
   }
 
-  const newURL = new URL(baseUriParts)
-
-  newURL.pathname = "/"
-  possibleBaseUris.push(newURL)
-
   return take(possibleBaseUris, 2)
 }
 

--- a/frontend/lib/src/util/UriUtil.ts
+++ b/frontend/lib/src/util/UriUtil.ts
@@ -22,41 +22,29 @@ import take from "lodash/take"
 
 import { IS_DEV_ENV, WEBSOCKET_PORT_DEV } from "~lib/baseconsts"
 
-/**
- * host:port tuple
- */
-export interface BaseUriParts {
-  host: string
-  port: number
-  basePath: string
-}
-
 const FINAL_SLASH_RE = /\/+$/
 const INITIAL_SLASH_RE = /^\/+/
 
 /**
  * Return the BaseUriParts for the global window
  */
-export function getWindowBaseUriParts(): BaseUriParts {
+export function getWindowBaseUriParts(): URL {
+  const currentUrl = new URL(window.location.href)
   // If dev, always connect to 8501, since window.location.port is the Node
   // server's port 3000.
   // If changed, also change config.py
-  const host = window.location.hostname
 
-  let port
   if (IS_DEV_ENV) {
-    port = WEBSOCKET_PORT_DEV
-  } else if (window.location.port) {
-    port = Number(window.location.port)
-  } else {
-    port = isHttps() ? 443 : 80
+    currentUrl.port = WEBSOCKET_PORT_DEV
+  } else if (!currentUrl.port) {
+    currentUrl.port = isHttps() ? "443" : "80"
   }
 
-  const basePath = window.location.pathname
+  currentUrl.pathname = currentUrl.pathname
     .replace(FINAL_SLASH_RE, "")
     .replace(INITIAL_SLASH_RE, "")
 
-  return { host, port, basePath }
+  return currentUrl
 }
 
 // NOTE: In the multipage apps world, there is some ambiguity around whether a
@@ -71,29 +59,28 @@ export function getWindowBaseUriParts(): BaseUriParts {
 // We'll want to improve this situation in the near future, but figuring out
 // the best path forward may be tricky as I wasn't able to come up with an
 // easy solution covering every deployment scenario.
-export function getPossibleBaseUris(): Array<BaseUriParts> {
+export function getPossibleBaseUris(): Array<URL> {
   const baseUriParts = getWindowBaseUriParts()
-  const { basePath } = baseUriParts
+  const { pathname } = baseUriParts
 
-  if (!basePath) {
+  if (pathname === "/") {
     return [baseUriParts]
   }
 
-  const parts = basePath.split("/")
-  const possibleBaseUris: Array<BaseUriParts> = []
+  const parts = pathname.split("/")
+  const possibleBaseUris: Array<URL> = []
 
   while (parts.length > 0) {
-    possibleBaseUris.push({
-      ...baseUriParts,
-      basePath: parts.join("/"),
-    })
+    const newURL = new URL(baseUriParts)
+    newURL.pathname = parts.join("/")
+    possibleBaseUris.push(newURL)
     parts.pop()
   }
 
-  possibleBaseUris.push({
-    ...baseUriParts,
-    basePath: "",
-  })
+  const newURL = new URL(baseUriParts)
+
+  newURL.pathname = "/"
+  possibleBaseUris.push(newURL)
 
   return take(possibleBaseUris, 2)
 }
@@ -102,24 +89,24 @@ export function getPossibleBaseUris(): Array<BaseUriParts> {
  * Create a ws:// or wss:// URI for the given path.
  */
 export function buildWsUri(
-  { host, port, basePath }: BaseUriParts,
+  { hostname, port, pathname }: URL,
   path: string
 ): string {
   const protocol = isHttps() ? "wss" : "ws"
-  const fullPath = makePath(basePath, path)
-  return `${protocol}://${host}:${port}/${fullPath}`
+  const fullPath = makePath(pathname, path)
+  return `${protocol}://${hostname}:${port}/${fullPath}`
 }
 
 /**
  * Create an HTTP URI for the given path.
  */
 export function buildHttpUri(
-  { host, port, basePath }: BaseUriParts,
+  { hostname, port, pathname }: URL,
   path: string
 ): string {
   const protocol = isHttps() ? "https" : "http"
-  const fullPath = makePath(basePath, path)
-  return `${protocol}://${host}:${port}/${fullPath}`
+  const fullPath = makePath(pathname, path)
+  return `${protocol}://${hostname}:${port}/${fullPath}`
 }
 
 export function makePath(basePath: string, subPath: string): string {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -521,7 +521,7 @@ export function extractPageNameFromPathName(
   // weird-looking triple `replace()`.
   return decodeURIComponent(
     document.location.pathname
-      .replace(`/${basePath}`, "")
+      .replace(basePath, "")
       .replace(new RegExp("^/?"), "")
       .replace(new RegExp("/$"), "")
   )


### PR DESCRIPTION
## Describe your changes

In the effort to decouple a connection package from @streamlit/lib, we are looking for easy ways to consolidate imports so that the dependency tree is simpler (and lib is less the keeper of all things).

Here BaseUriParts is a subset of URL in properties. The key difference is that the pathname by default has a `"/"` always in front. While it can be helpful, I believe it's better to leverage the URL type/convenience and just adjust the code for these differences.

## Testing Plan

- Tests should pass.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
