### PR TITLE
Decouple SessionInfo from connection

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -415,7 +415,7 @@ export class App extends PureComponent<Props, State> {
 
   initializeConnectionManager(): void {
     this.connectionManager = new ConnectionManager({
-      sessionInfo: this.sessionInfo,
+      getLastSessionId: () => this.sessionInfo.last?.sessionId,
       endpoints: this.endpoints,
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -19,10 +19,8 @@ import { getLogger } from "loglevel"
 
 import {
   BaseUriParts,
-  ensureError,
   getPossibleBaseUris,
   IHostConfigResponse,
-  SessionInfo,
   StreamlitEndpoints,
 } from "@streamlit/lib"
 import { BackMsg, ForwardMsg } from "@streamlit/protobuf"
@@ -43,7 +41,7 @@ const log = getLogger("ConnectionManager")
 
 interface Props {
   /** The app's SessionInfo instance */
-  sessionInfo: SessionInfo
+  getLastSessionId: () => string | undefined
 
   /** The app's StreamlitEndpoints instance */
   endpoints: StreamlitEndpoints
@@ -174,7 +172,7 @@ export class ConnectionManager {
       try {
         this.websocketConnection = await this.connectToRunningServer()
       } catch (e) {
-        const err = ensureError(e)
+        const err = e instanceof Error ? e : new Error(`${e}`)
         log.error(err.message)
         this.setConnectionState(
           ConnectionState.DISCONNECTED_FOREVER,
@@ -219,7 +217,7 @@ export class ConnectionManager {
     const baseUriPartsList = getPossibleBaseUris()
 
     return new WebsocketConnection({
-      sessionInfo: this.props.sessionInfo,
+      getLastSessionId: this.props.getLastSessionId,
       endpoints: this.props.endpoints,
       baseUriPartsList,
       onMessage: this.props.onMessage,

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -39,7 +39,6 @@ import {
   isNullOrUndefined,
   notNullOrUndefined,
   PerformanceEvents,
-  SessionInfo,
   StreamlitEndpoints,
 } from "@streamlit/lib"
 import { BackMsg, ForwardMsg, IBackMsg } from "@streamlit/protobuf"
@@ -48,7 +47,7 @@ import { doInitPings } from "@streamlit/app/src/connection/DoInitPings"
 
 export interface Args {
   /** The application's SessionInfo instance */
-  sessionInfo: SessionInfo
+  getLastSessionId: () => string | undefined
 
   endpoints: StreamlitEndpoints
 
@@ -340,13 +339,12 @@ export class WebsocketConnection {
     const hostAuthToken = await this.args.claimHostAuthToken()
     const xsrfCookie = getCookie("_streamlit_xsrf")
     this.args.resetHostAuthToken()
+    const lastSessionId = this.args.getLastSessionId()
     return [
       // NOTE: We have to set the auth token to some arbitrary placeholder if
       // not provided since the empty string is an invalid protocol option.
       hostAuthToken ?? xsrfCookie ?? "PLACEHOLDER_AUTH_TOKEN",
-      ...(this.args.sessionInfo.last?.sessionId
-        ? [this.args.sessionInfo.last?.sessionId]
-        : []),
+      ...(lastSessionId ? [lastSessionId] : []),
     ]
   }
 


### PR DESCRIPTION
## Describe your changes
In the effort to decouple a connection package from @streamlit/lib, we are looking for easy ways to consolidate imports so that the dependency tree is simpler (and lib is less the keeper of all things).

Right now the connection relies on SessionInfo for one thing, getting the last sessionId. This change converts it to a function that can be provided easily.

Small, but I also refactored out `ensureError`. It's one of those, "Sure, it's convenient, but do we really need it?" This was designed mostly to ensure typescript compatibility, so incorrect usage will be flagged and the conditional is just as easy.

## Testing Plan

- Tests should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
