### PR TITLE
Remove React from connection logic

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -68,6 +68,7 @@ import {
   ScriptRunState,
   SessionInfo,
   StreamlitEndpoints,
+  StreamlitMarkdown,
   ThemeConfig,
   toExportedTheme,
   toThemeInput,
@@ -549,12 +550,12 @@ export class App extends PureComponent<Props, State> {
     window.removeEventListener("popstate", this.onHistoryChange, false)
   }
 
-  showError(title: string, errorNode: ReactNode): void {
-    log.error(errorNode)
+  showError(title: string, errorMarkdown: string): void {
+    log.error(errorMarkdown)
     const newDialog: DialogProps = {
       type: DialogType.WARNING,
       title,
-      msg: errorNode,
+      msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
       onClose: () => {},
     }
     this.openDialog(newDialog)
@@ -1664,8 +1665,8 @@ export class App extends PureComponent<Props, State> {
   /**
    * Updates the app body when there's a connection error.
    */
-  handleConnectionError = (errNode: ReactNode): void => {
-    this.showError("Connection error", errNode)
+  handleConnectionError = (errMarkdown: string): void => {
+    this.showError("Connection error", errMarkdown)
   }
 
   /**

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReactNode } from "react"
 
 import { getLogger } from "loglevel"
 
@@ -53,7 +52,7 @@ interface Props {
   /**
    * Function to be called when the connection errors out.
    */
-  onConnectionError: (errNode: ReactNode) => void
+  onConnectionError: (errNode: string) => void
 
   /**
    * Called when our ConnectionState is changed.
@@ -201,7 +200,7 @@ export class ConnectionManager {
 
   private showRetryError = (
     totalRetries: number,
-    latestError: ReactNode,
+    latestError: string,
     // The last argument of this function is unused and exists because the
     // WebsocketConnection.OnRetry type allows a third argument to be set to be
     // used in tests.

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from "react"
-
 import axios from "axios"
 import { default as WS } from "vitest-websocket-mock"
 import zip from "lodash/zip"
@@ -308,16 +306,9 @@ describe("doInitPings", () => {
       },
     }
 
-    const Forbidden = (
-      <Fragment>
-        <p>Cannot connect to Streamlit (HTTP status: 403).</p>
-        <p>
-          If you are trying to access a Streamlit app running on another
-          server, this could be due to the app's{" "}
-          <a href={CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}>CORS</a> settings.
-        </p>
-      </Fragment>
-    )
+    const forbiddenMarkdown = `Cannot connect to Streamlit (HTTP status: 403).
+
+If you are trying to access a Streamlit app running on another server, this could be due to the app's [CORS](${CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}) settings.`
 
     axios.get = vi
       .fn()
@@ -338,7 +329,7 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      Forbidden,
+      forbiddenMarkdown,
       expect.anything()
     )
   })

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import styled from "@emotion/styled"
 import { getLogger } from "loglevel"
 
 import {
-  LOG,
   PING_MAXIMUM_RETRY_PERIOD_MS,
   PING_MINIMUM_RETRY_PERIOD_MS,
   WEBSOCKET_STREAM_PATH,
@@ -196,7 +194,7 @@ export class WebsocketConnection {
 
   // This should only be called inside stepFsm().
   private setFsmState(state: ConnectionState, errMsg?: string): void {
-    log.info(LOG, `New state: ${state}`)
+    log.info(`New state: ${state}`)
     this.state = state
 
     // Perform pre-callback actions when entering certain states.
@@ -235,7 +233,7 @@ export class WebsocketConnection {
    * will be displayed to the user in a "Connection Error" dialog.
    */
   private stepFsm(event: Event, errMsg?: string): void {
-    log.info(LOG, `State: ${this.state}; Event: ${event}`)
+    log.info(`State: ${this.state}; Event: ${event}`)
 
     if (
       event === "FATAL_ERROR" &&
@@ -293,7 +291,6 @@ export class WebsocketConnection {
         // of a fatal error. Just log these events rather than throwing more
         // exceptions.
         log.warn(
-          LOG,
           `Discarding ${event} while in ${ConnectionState.DISCONNECTED_FOREVER}`
         )
         return
@@ -358,7 +355,7 @@ export class WebsocketConnection {
       throw new Error("Websocket already exists")
     }
 
-    log.info(LOG, "creating WebSocket")
+    log.info("creating WebSocket")
 
     // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
     // parameter to the WebSocket constructor) here in a slightly unfortunate
@@ -385,7 +382,7 @@ export class WebsocketConnection {
       if (checkWebsocket()) {
         this.handleMessage(event.data).catch(reason => {
           const err = `Failed to process a Websocket message (${reason})`
-          log.error(LOG, err)
+          log.error(err)
           this.stepFsm("FATAL_ERROR", err)
         })
       }
@@ -393,14 +390,14 @@ export class WebsocketConnection {
 
     this.websocket.addEventListener("open", () => {
       if (checkWebsocket()) {
-        log.info(LOG, "WebSocket onopen")
+        log.info("WebSocket onopen")
         this.stepFsm("CONNECTION_SUCCEEDED")
       }
     })
 
     this.websocket.addEventListener("close", () => {
       if (checkWebsocket()) {
-        log.warn(LOG, "WebSocket onclose")
+        log.warn("WebSocket onclose")
         this.closeConnection()
         this.stepFsm("CONNECTION_CLOSED")
       }
@@ -408,7 +405,7 @@ export class WebsocketConnection {
 
     this.websocket.addEventListener("error", () => {
       if (checkWebsocket()) {
-        log.error(LOG, "WebSocket onerror")
+        log.error("WebSocket onerror")
         this.closeConnection()
         this.stepFsm("CONNECTION_ERROR")
       }
@@ -431,7 +428,7 @@ export class WebsocketConnection {
 
       if (isNullOrUndefined(this.wsConnectionTimeoutId)) {
         // Sometimes the clearTimeout doesn't work. No idea why :-/
-        log.warn(LOG, "Timeout fired after cancellation")
+        log.warn("Timeout fired after cancellation")
         return
       }
 
@@ -445,12 +442,12 @@ export class WebsocketConnection {
       }
 
       if (this.websocket.readyState === 0 /* CONNECTING */) {
-        log.info(LOG, `${uri} timed out`)
+        log.info(`${uri} timed out`)
         this.closeConnection()
         this.stepFsm("CONNECTION_TIMED_OUT")
       }
     }, WEBSOCKET_TIMEOUT_MS)
-    log.info(LOG, `Set WS timeout ${this.wsConnectionTimeoutId}`)
+    log.info(`Set WS timeout ${this.wsConnectionTimeoutId}`)
   }
 
   private closeConnection(): void {
@@ -466,7 +463,7 @@ export class WebsocketConnection {
     }
 
     if (notNullOrUndefined(this.wsConnectionTimeoutId)) {
-      log.info(LOG, `Clearing WS timeout ${this.wsConnectionTimeoutId}`)
+      log.info(`Clearing WS timeout ${this.wsConnectionTimeoutId}`)
       window.clearTimeout(this.wsConnectionTimeoutId)
       this.wsConnectionTimeoutId = undefined
     }
@@ -520,13 +517,3 @@ export class WebsocketConnection {
     }
   }
 }
-
-export const StyledBashCode = styled.code(({ theme }) => ({
-  fontFamily: theme.genericFonts.codeFont,
-  fontSize: theme.fontSizes.sm,
-  "&::before": {
-    content: '"$"',
-    // eslint-disable-next-line streamlit-custom/no-hardcoded-theme-values
-    marginRight: "1ex",
-  },
-}))

--- a/frontend/app/src/connection/constants.ts
+++ b/frontend/app/src/connection/constants.ts
@@ -22,11 +22,6 @@ export const CORS_ERROR_MESSAGE_DOCUMENTATION_LINK =
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
 
 /**
- * Name of the logger.
- */
-export const LOG = "WebsocketConnection"
-
-/**
  * The path of the server's websocket endpoint.
  */
 export const WEBSOCKET_STREAM_PATH = "_stcore/stream"

--- a/frontend/app/src/connection/types.ts
+++ b/frontend/app/src/connection/types.ts
@@ -31,7 +31,7 @@ export type OnConnectionStateChange = (
 
 export type OnRetry = (
   totalTries: number,
-  errorNode: React.ReactNode,
+  errorMarkdown: string,
   retryTimeout: number
 ) => void
 


### PR DESCRIPTION
## Describe your changes

In the effort to decouple a connection package from @streamlit/lib, we are looking for easy ways to consolidate imports so that the dependency tree is simpler.

There's no real reason to have React be included in such a package. The right way to handle this is likely to use error codes, but a simple setup for now is to migrate to Markdown.

## Testing Plan

- Verified React components for errors are the same.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
