### PR TITLE
Misc docstrings for 1.42.0

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -108,14 +108,26 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
     **Example 2: Configuration with keyword arguments and external authentication**
 
-    You can configure your Snowflake connection with keyword arguments (with or
-    without ``secrets.toml``). For example, if your Snowflake account supports
-    SSO, you can set up a quick local connection for development using `browser-based SSO
+    You can configure your Snowflake connection with keyword arguments. The
+    keyword arguments are merged with (and take precedence over) the values in
+    ``secrets.toml``. However, if you name your connection ``"snowflake"`` and
+    don't have a ``[connections.snowflake]`` dictionary in your
+    ``secrets.toml`` file, Streamlit will ignore any keyword arguments and use
+    the default Snowflake connection as described in Example 5 and Example 6.
+    To configure your connection using only keyword arguments, declare a name
+    for the connection other than ``"snowflake"``.
+
+    For example, if your Snowflake account supports SSO, you can set up a quick
+    local connection for development using `browser-based SSO
     <https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works>`_.
+    Because there is nothing configured in ``secrets.toml``, the name is an
+    empty string and the type is set to ``"snowflake"``. This prevents
+    Streamlit from ignoring the keyword arguments and using a default
+    Snowflake connection.
 
     >>> import streamlit as st
     >>> conn = st.connection(
-    ...     connection_name,
+    ...     "",
     ...     type="snowflake",
     ...     account="xxx-xxx",
     ...     user="xxx",
@@ -164,12 +176,12 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     >>> conn = st.connection("snowflake")
     >>> df = conn.query("SELECT * FROM my_table")
 
-    **Snowflake Default Connection**
-    If you don't have Streamlit secret `[connections.snowflake]` and just use
-    `st.connection("snowflake")`, Streamlit will use the default connection behavior as documented in
-    https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
+    **Example 5: Default connection with an environment variable**
 
-    ***Example 5: Default connection with an environment variable***
+    If you don't have a ``[connections.snowflake]`` dictionary in your
+    ``secrets.toml`` file and use ``st.connection("snowflake")``, Streamlit
+    will use the default connection for the `Snowflake Python Connector
+    <https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection>`_.
 
     If you have a Snowflake configuration file with a connection named
     ``my_connection`` as in Example 3, you can set an environment variable to
@@ -183,7 +195,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     >>> conn = st.connection("snowflake")
     >>> df = conn.query("SELECT * FROM my_table")
 
-    ***Example 6: Default connection in Snowflake's connection configuration file***
+    **Example 6: Default connection in Snowflake's connection configuration file**
 
     If you have a Snowflake configuration file that defines your ``default``
     connection, Streamlit will automatically use it if no other connection is

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -38,7 +38,14 @@ class AlertMixin:
         Parameters
         ----------
         body : str
-            The error text to display.
+            The text to display as GitHub-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), no icon is displayed. If ``icon`` is a
@@ -82,7 +89,14 @@ class AlertMixin:
         Parameters
         ----------
         body : str
-            The warning text to display.
+            The text to display as GitHub-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), no icon is displayed. If ``icon`` is a
@@ -125,7 +139,14 @@ class AlertMixin:
         Parameters
         ----------
         body : str
-            The info text to display.
+            The text to display as GitHub-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), no icon is displayed. If ``icon`` is a
@@ -169,7 +190,14 @@ class AlertMixin:
         Parameters
         ----------
         body : str
-            The success text to display.
+            The text to display as GitHub-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), no icon is displayed. If ``icon`` is a

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -634,24 +634,30 @@ class ArrowMixin:
         """Display a static table.
 
         While ``st.dataframe`` is geared towards large datasets and interactive
-        data exploration, ``st.table`` is useful to display a small table without
-        scrolling – e.g. a confusion matrix or a leaderboard. For this reason, it also
-        supports Markdown formatting.
+        data exploration, ``st.table`` is useful for displaying small, styled
+        tables without sorting or scrolling. For example, ``st.table`` may be
+        the preferred way to display a confusion matrix or leaderboard.
+        Additionally, ``st.table`` supports Markdown.
 
         Parameters
         ----------
         data : Anything supported by st.dataframe
             The table data.
 
-            All cells including the index and column headers can optionally contain
-            GitHub-flavored Markdown. See the ``body`` parameter of
-            |st.markdown|_ for additional, supported Markdown directives.
+            All cells including the index and column headers can optionally
+            contain GitHub-flavored Markdown. Syntax information can be found
+            at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        Example
-        -------
+        Examples
+        --------
+        **Example 1: Display a simple dataframe as a static table**
+
         >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
@@ -666,19 +672,26 @@ class ArrowMixin:
            https://doc-table.streamlit.app/
            height: 480px
 
+        **Example 2: Display a table of Markdown strings**
 
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>>
         >>> df = pd.DataFrame(
         ...     {
         ...         "Command": ["**st.table**", "*st.dataframe*"],
         ...         "Type": ["`static`", "`interactive`"],
-        ...         "URL": ["[docs](https://docs.streamlit.io)", "🔗"],
+        ...         "Docs": [
+        ...             "[:rainbow[docs]](https://docs.streamlit.io/develop/api-reference/data/st.dataframe)",
+        ...             "[:book:](https://docs.streamlit.io/develop/api-reference/data/st.table)",
+        ...         ],
         ...     }
         ... )
         >>> st.table(df)
 
         .. output::
            https://doc-table-markdown.streamlit.app/
-           height: 480px
+           height: 200px
         """
 
         # Check if data is uncollected, and collect it but with 100 rows max, instead of

--- a/lib/streamlit/elements/code.py
+++ b/lib/streamlit/elements/code.py
@@ -62,9 +62,10 @@ class CodeMixin:
             to ``False``.
 
         height : int or None
-            Desired height of the code block expressed in pixels. If None (default) the
-            code block grows to fit its content. If a fixed height, scrolling is enabled
-            for long code.
+            Desired height of the code block expressed in pixels. If ``height``
+            is ``None`` (default), Streamlit sets the element's height to fit
+            its content. Vertical scrolling within the element is enabled when
+            the height does not accomodate all lines.
 
         Examples
         --------

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -216,11 +216,29 @@ class FormMixin:
         Parameters
         ----------
         label : str
-            A short label explaining to the user what this button is for.
-            Defaults to "Submit".
+            A short label explaining to the user what this button is for. This
+            defaults to ``"Submit"``. The label can optionally contain
+            GitHub-flavored Markdown of the following types: Bold, Italics,
+            Strikethroughs, Inline Code, Links, and Images. Images display like
+            icons, with a max height equal to the font height.
+
+            Unsupported Markdown elements are unwrapped so only their children
+            (text contents) render. Display unsupported elements as literal
+            characters by backslash-escaping them. E.g.,
+            ``"1\\. Not an ordered list"``.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         help : str or None
-            A tooltip that gets displayed when the button is hovered over.
-            Defaults to None.
+            A tooltip that gets displayed when the button is hovered over. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
         on_click : callable
             An optional callback invoked when this button is clicked.
         args : tuple

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -68,8 +68,13 @@ class HeadingMixin:
             in the URL. If omitted, it generates an anchor using the body.
             If False, the anchor is not shown in the UI.
 
-        help : str
-            An optional tooltip that gets displayed next to the header.
+        help : str or None
+            A tooltip that gets displayed next to the header. If this is
+            ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         divider : bool or “blue”, “green”, “orange”, “red”, “violet”, “gray”/"grey", or “rainbow”
             Shows a colored divider below the header. If True, successive
@@ -135,8 +140,13 @@ class HeadingMixin:
             in the URL. If omitted, it generates an anchor using the body.
             If False, the anchor is not shown in the UI.
 
-        help : str
-            An optional tooltip that gets displayed next to the subheader.
+        help : str or None
+            A tooltip that gets displayed next to the subheader. If this is
+            ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         divider : bool or “blue”, “green”, “orange”, “red”, “violet”, “gray”/"grey", or “rainbow”
             Shows a colored divider below the header. If True, successive
@@ -204,8 +214,13 @@ class HeadingMixin:
             in the URL. If omitted, it generates an anchor using the body.
             If False, the anchor is not shown in the UI.
 
-        help : str
-            An optional tooltip that gets displayed next to the title.
+        help : str or None
+            A tooltip that gets displayed next to the title. If this is
+            ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         Examples
         --------

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -83,7 +83,7 @@ class ImageMixin:
             must be a list of captions (one caption for each image) or
             ``None``.
 
-            Image captions are displayed as GitHub-flavored Markdown. Syntax
+            Captions can optionally contain GitHub-flavored Markdown. Syntax
             information can be found at: https://github.github.com/gfm.
 
             See the ``body`` parameter of |st.markdown|_ for additional,

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -79,9 +79,18 @@ class ImageMixin:
               row of images that overflow to additional rows as needed.
         caption : str or list of str
             Image caption(s). If this is ``None`` (default), no caption is
-            displayed. If ``image`` is a list of multiple images,
-            ``caption`` must be a list of captions (one caption for each
-            image) or ``None``.
+            displayed. If ``image`` is a list of multiple images, ``caption``
+            must be a list of captions (one caption for each image) or
+            ``None``.
+
+            Image captions are displayed as GitHub-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
+
+            See the ``body`` parameter of |st.markdown|_ for additional,
+            supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
         width : int or None
             Image width. If this is ``None`` (default), Streamlit will use the
             image's native width, up to the width of the parent container.

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -647,9 +647,13 @@ class LayoutsMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        help : str
-            An optional tooltip that gets displayed when the popover button is
-            hovered over.
+        help : str or None
+            A tooltip that gets displayed when the popover button is hovered
+            over. If this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         icon : str
             An optional emoji or icon to display next to the button label. If ``icon``

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -152,8 +152,12 @@ class ColumnConfig(TypedDict, total=False):
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -252,8 +256,12 @@ def Column(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -354,8 +362,12 @@ def NumberColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -493,8 +505,12 @@ def TextColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -613,8 +629,12 @@ def LinkColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -766,8 +786,12 @@ def CheckboxColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -872,8 +896,12 @@ def SelectboxColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -993,8 +1021,12 @@ def BarChartColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     pinned: bool or None
         Whether the column is pinned. A pinned column will stay visible on the
@@ -1087,8 +1119,12 @@ def LineChartColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     pinned: bool or None
         Whether the column is pinned. A pinned column will stay visible on the
@@ -1182,8 +1218,12 @@ def AreaChartColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     pinned: bool or None
         Whether the column is pinned. A pinned column will stay visible on the
@@ -1283,8 +1323,12 @@ def ImageColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     pinned: bool or None
         Whether the column is pinned. A pinned column will stay visible on the
@@ -1363,8 +1407,12 @@ def ListColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     pinned: bool or None
         Whether the column is pinned. A pinned column will stay visible on the
@@ -1454,8 +1502,12 @@ def DatetimeColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -1601,8 +1653,12 @@ def TimeColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -1743,8 +1799,12 @@ def DateColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     disabled: bool or None
         Whether editing should be disabled for this column. If this is ``None``
@@ -1880,8 +1940,12 @@ def ProgressColumn(
         - ``"large"``: 400px wide
 
     help: str or None
-        An optional tooltip that gets displayed when hovering over the column
-        label. If this is ``None`` (default), no tooltip is displayed.
+        A tooltip that gets displayed when hovering over the column label. If
+        this is ``None`` (default), no tooltip is displayed.
+
+        The tooltip can optionally contain GitHub-flavored Markdown, including
+        the Markdown directives described in the ``body`` parameter of
+        ``st.markdown``.
 
     format: str or None
         A printf-style format string controlling how numbers are displayed.

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -93,8 +93,13 @@ class MarkdownMixin:
                 If you only want to insert HTML or CSS without Markdown text,
                 we recommend using ``st.html`` instead.
 
-        help : str
-            An optional tooltip that gets displayed next to the Markdown.
+        help : str or None
+            A tooltip that gets displayed next to the Markdown. If this is
+            ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         Examples
         --------
@@ -205,8 +210,13 @@ class MarkdownMixin:
                 If you only want to insert HTML or CSS without Markdown text,
                 we recommend using ``st.html`` instead.
 
-        help : str
-            An optional tooltip that gets displayed next to the caption.
+        help : str or None
+            A tooltip that gets displayed next to the caption. If this is
+            ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         Examples
         --------
@@ -246,9 +256,13 @@ class MarkdownMixin:
             a good idea to use raw Python strings since LaTeX uses backslashes
             a lot.
 
-        help : str
-            An optional tooltip that gets displayed next to the LaTeX expression.
+        help : str or None
+            A tooltip that gets displayed next to the LaTeX expression. If
+            this is ``None`` (default), no tooltip is displayed.
 
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         Example
         -------

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -102,10 +102,14 @@ class MetricMixin:
              good, e.g. if cost decreased. If "off", delta is  shown in gray
              regardless of its value.
 
-        help : str
-            An optional tooltip that gets displayed next to the metric label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the metric label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. The default is ``"visible"``. If this

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -36,6 +36,16 @@ def spinner(
     text : str
         The text to display next to the spinner. This defaults to
         ``"In progress..."``.
+
+        The text can optionally contain GitHub-flavored Markdown. Syntax
+        information can be found at: https://github.github.com/gfm.
+
+        See the ``body`` parameter of |st.markdown|_ for additional, supported
+        Markdown directives.
+
+        .. |st.markdown| replace:: ``st.markdown``
+        .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
     show_time : bool
         Whether to show the elapsed time next to the spinner text. If this is
         ``False`` (default), no time is displayed. If this is ``True``,

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -34,9 +34,13 @@ def spinner(
     Parameters
     ----------
     text : str
-        The text to display next to the spinner. Defaults to "In progress...".
+        The text to display next to the spinner. This defaults to
+        ``"In progress..."``.
     show_time : bool
-        Whether to show the elapsed time next to the spinner text. Defaults to False.
+        Whether to show the elapsed time next to the spinner text. If this is
+        ``False`` (default), no time is displayed. If this is ``True``,
+        elapsed time is displayed with a precision of 0.1 seconds. The time
+        format is not configurable.
 
     Example
     -------
@@ -46,6 +50,11 @@ def spinner(
     >>> with st.spinner("Wait for it...", show_time=True):
     >>>     time.sleep(5)
     >>> st.success("Done!")
+    >>> st.button("Rerun")
+
+    .. output ::
+        https://doc-spinner.streamlit.app/
+        height: 210px
 
     """
     from streamlit.proto.Spinner_pb2 import Spinner as SpinnerProto

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -45,8 +45,13 @@ class TextMixin:
         body : str
             The string to display.
 
-        help : str
-            An optional tooltip that gets displayed next to the text.
+        help : str or None
+            A tooltip that gets displayed next to the text. If this is ``None``
+            (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         Example
         -------

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1523,16 +1523,18 @@ class VegaChartsMixin:
             descriptions.
 
         use_container_width : bool or None
-            Whether to override the figure's native width with the width of
-            the parent container. If ``use_container_width`` is None (default),
-            Streamlit will set it to True for all charts except for facet,
-            horizontal concatenation, and repeat charts (note that for these chart
-            types, ``use_container_width=True`` doesn't work properly). If
-            ``use_container_width`` is ``True``, Streamlit sets the width of the
-            figure to match the width of the parent container. If ``use_container_width``
-            is ``False``, Streamlit sets the width of the chart to fit its contents
-            according to the plotting library, up to the width of the parent
-            container.
+            Whether to override the chart's native width with the width of
+            the parent container. This can be one of the following:
+
+            - ``None`` (default): Streamlit will use the parent container's
+              width for all charts except those with known incompatibility
+              (``altair.Facet``, ``altair.HConcatChart``, and
+              ``altair.RepeatChart``).
+            - ``True``: Streamlit sets the width of the chart to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the chart to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
 
         theme : "streamlit" or None
             The theme of the chart. If ``theme`` is ``"streamlit"`` (default),
@@ -1689,16 +1691,18 @@ class VegaChartsMixin:
             https://vega.github.io/vega-lite/docs/ for more info.
 
         use_container_width : bool or None
-            Whether to override the figure's native width with the width of
-            the parent container. If ``use_container_width`` is None (default),
-            Streamlit will set it to True for all charts except for facet,
-            horizontal concatenation, and repeat charts (note that for these chart
-            types, ``use_container_width=True`` doesn't work properly). If
-            ``use_container_width`` is ``True``, Streamlit sets the width of the
-            figure to match the width of the parent container. If ``use_container_width``
-            is ``False``, Streamlit sets the width of the chart to fit its contents
-            according to the plotting library, up to the width of the parent
-            container.
+            Whether to override the chart's native width with the width of
+            the parent container. This can be one of the following:
+
+            - ``None`` (default): Streamlit will use the parent container's
+              width for all charts except those with known incompatibility
+              (``altair.Facet``, ``altair.HConcatChart``, and
+              ``altair.RepeatChart``).
+            - ``True``: Streamlit sets the width of the chart to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the chart to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
 
         theme : "streamlit" or None
             The theme of the chart. If ``theme`` is ``"streamlit"`` (default),

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -131,10 +131,14 @@ class AudioInputMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this audio input's value

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -125,9 +125,14 @@ class ButtonMixin:
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
-        help : str
-            An optional tooltip that gets displayed when the button is
-            hovered over.
+
+        help : str or None
+            A tooltip that gets displayed when the button is hovered over. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_click : callable
             An optional callback invoked when this button is clicked.
@@ -321,9 +326,13 @@ class ButtonMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed when the button is
-            hovered over.
+        help : str or None
+            A tooltip that gets displayed when the button is hovered over. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_click : callable
             An optional callback invoked when this button is clicked.
@@ -498,9 +507,13 @@ class ButtonMixin:
         url : str
             The url to be opened on user click
 
-        help : str
-            An optional tooltip that gets displayed when the button is
-            hovered over.
+        help : str or None
+            A tooltip that gets displayed when the button is hovered over. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         type : "primary", "secondary", or "tertiary"
             An optional string that specifies the button type. This can be one
@@ -634,9 +647,13 @@ class ButtonMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
-        help : str
-            An optional tooltip that gets displayed when the link is
-            hovered over.
+        help : str or None
+            A tooltip that gets displayed when the link is hovered over. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         disabled : bool
             An optional boolean that disables the page link if set to ``True``.

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -471,7 +471,9 @@ class ButtonGroupMixin:
             Labels for the select options in an ``Iterable``. This can be a
             ``list``, ``set``, or anything supported by ``st.dataframe``. If
             ``options`` is dataframe-like, the first column will be used. Each
-            label will be cast to ``str`` internally by default.
+            label will be cast to ``str`` internally by default and can
+            optionally contain GitHub-flavored Markdown, including the Markdown
+            directives described in the ``body`` parameter of ``st.markdown``.
 
         selection_mode: "single" or "multi"
             The selection mode for the widget. If this is ``"single"``
@@ -488,7 +490,9 @@ class ButtonGroupMixin:
             Function to modify the display of the options. It receives
             the raw option as an argument and should output the label to be
             shown for that option. This has no impact on the return value of
-            the command.
+            the command. The output can optionally contain GitHub-flavored
+            Markdown, including the Markdown directives described in the
+            ``body`` parameter of ``st.markdown``.
 
         key: str or int
             An optional string or integer to use as the unique key for the widget.
@@ -496,10 +500,14 @@ class ButtonGroupMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
 
-        help: str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help: str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change: callable
             An optional callback invoked when this widget's value changes.
@@ -673,7 +681,9 @@ class ButtonGroupMixin:
             Labels for the select options in an ``Iterable``. This can be a
             ``list``, ``set``, or anything supported by ``st.dataframe``. If
             ``options`` is dataframe-like, the first column will be used. Each
-            label will be cast to ``str`` internally by default.
+            label will be cast to ``str`` internally by default and can
+            optionally contain GitHub-flavored Markdown, including the Markdown
+            directives described in the ``body`` parameter of ``st.markdown``.
 
         selection_mode: "single" or "multi"
             The selection mode for the widget. If this is ``"single"``
@@ -690,7 +700,9 @@ class ButtonGroupMixin:
             Function to modify the display of the options. It receives
             the raw option as an argument and should output the label to be
             shown for that option. This has no impact on the return value of
-            the command.
+            the command. The output can optionally contain GitHub-flavored
+            Markdown, including the Markdown directives described in the
+            ``body`` parameter of ``st.markdown``.
 
         key: str or int
             An optional string or integer to use as the unique key for the widget.
@@ -698,10 +710,14 @@ class ButtonGroupMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
 
-        help: str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help: str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change: callable
             An optional callback invoked when this widget's value changes.

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -127,10 +127,14 @@ class CameraInputMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this camera_input's value

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -105,10 +105,14 @@ class CheckboxMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this checkbox's value changes.
@@ -212,10 +216,14 @@ class CheckboxMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this toggle's value changes.

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -107,10 +107,14 @@ class ColorPickerMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this color_picker's value

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -276,10 +276,14 @@ class FileUploaderMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this file_uploader's value

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -167,10 +167,14 @@ class MultiSelectMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help: str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help: str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change: callable
             An optional callback invoked when this widget's value changes.

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -251,10 +251,14 @@ class NumberInputMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this number_input's value changes.

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -188,10 +188,14 @@ class RadioMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this radio's value changes.

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -230,10 +230,14 @@ class SelectSliderMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this select_slider's value changes.

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -175,10 +175,14 @@ class SelectboxMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this selectbox's value changes.

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -426,10 +426,14 @@ class SliderMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this slider's value changes.

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -176,10 +176,14 @@ class TextWidgetsMixin:
             a regular text input), or "password" (for a text input that
             masks the user's typed value). Defaults to "default".
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         autocomplete : str
             An optional value that will be passed to the <input> element's
@@ -450,10 +454,14 @@ class TextWidgetsMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this text_area's value changes.

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -406,10 +406,14 @@ class TimeWidgetsMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this time_input's value changes.
@@ -716,10 +720,14 @@ class TimeWidgetsMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help : str
-            An optional tooltip that gets displayed next to the widget label.
-            Streamlit only displays the tooltip when
-            ``label_visibility="visible"``.
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``. If
+            this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
 
         on_change : callable
             An optional callback invoked when this date_input's value changes.

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -251,48 +251,59 @@ class WriteMixin:
 
     @gather_metrics("write")
     def write(self, *args: Any, unsafe_allow_html: bool = False, **kwargs) -> None:
-        """Write arguments to the app.
+        """Displays arguments in the app.
 
         This is the Swiss Army knife of Streamlit commands: it does different
-        things depending on what you throw at it. Unlike other Streamlit commands,
-        write() has some unique properties:
+        things depending on what you throw at it. Unlike other Streamlit
+        commands, ``st.write()`` has some unique properties:
 
-        1. You can pass in multiple arguments, all of which will be written.
-        2. Its behavior depends on the input types as follows.
-        3. It returns None, so its "slot" in the App cannot be reused.
+        - You can pass in multiple arguments, all of which will be displayed.
+        - Its behavior depends on the input type(s).
 
         Parameters
         ----------
         *args : any
-            One or many objects to print to the App.
+            One or many objects to display in the app.
 
-            Arguments are handled as follows:
+            .. list-table:: Each type of argument is handled as follows:
+                :header-rows: 1
 
-            - write(string)         : Prints the formatted Markdown string, with
-                support for LaTeX expression, emoji shortcodes, and colored text.
-                See docs for st.markdown for more.
-            - write(dataframe)      : Displays any dataframe-like object in an interactive table.
-            - write(dict)           : Displays dict-like in an interactive viewer.
-            - write(list)           : Displays list-like in an interactive viewer.
-            - write(error)          : Prints an exception specially.
-            - write(func)           : Displays information about a function.
-            - write(module)         : Displays information about a module.
-            - write(class)          : Displays information about a class.
-            - write(DeltaGenerator) : Displays information about a DeltaGenerator.
-            - write(mpl_fig)        : Displays a Matplotlib figure.
-            - write(generator)      : Streams the output of a generator.
-            - write(openai.Stream)  : Streams the output of an OpenAI stream.
-            - write(altair)         : Displays an Altair chart.
-            - write(PIL.Image)      : Displays an image.
-            - write(keras)          : Displays a Keras model.
-            - write(graphviz)       : Displays a Graphviz graph.
-            - write(plotly_fig)     : Displays a Plotly figure.
-            - write(bokeh_fig)      : Displays a Bokeh figure.
-            - write(sympy_expr)     : Prints SymPy expression using LaTeX.
-            - write(htmlable)       : Prints _repr_html_() for the object if available.
-            - write(db_cursor)      : Displays DB API 2.0 cursor results in a table.
-            - write(obj)            : Prints str(obj) if otherwise unknown.
-
+                * - Type
+                  - Handling
+                * - ``str``
+                  - Uses ``st.markdown()``.
+                * - dataframe-like, ``dict``, or ``list``
+                  - Uses ``st.dataframe()``.
+                * - ``Exception``
+                  - Uses ``st.exception()``.
+                * - function, module, or class
+                  - Uses ``st.help()``.
+                * - ``DeltaGenerator``
+                  - Uses ``st.help()``.
+                * - Altair chart
+                  - Uses ``st.altair_chart()``.
+                * - Bokeh figure
+                  - Uses ``st.bokeh_chart()``.
+                * - Graphviz graph
+                  - Uses ``st.graphviz_chart()``.
+                * - Keras model
+                  - Converts model and uses ``st.graphviz_chart()``.
+                * - Matplotlib figure
+                  - Uses ``st.pyplot()``.
+                * - Plotly figure
+                  - Uses ``st.plotly_chart()``.
+                * - ``PIL.Image``
+                  - Uses ``st.image()``.
+                * - generator or stream (like ``openai.Stream``)
+                  - Uses ``st.write_stream()``.
+                * - SymPy expression
+                  - Uses ``st.latex()``.
+                * - An object with ``._repr_html()``
+                  - Uses ``st.html()``.
+                * - Database cursor
+                  - Displays DB API 2.0 cursor results in a table.
+                * - Any
+                  - Displays ``str(arg)`` as inline code.
 
         unsafe_allow_html : bool
             Whether to render HTML within ``*args``. This only applies to
@@ -316,9 +327,12 @@ class WriteMixin:
             Use other, more specific Streamlit commands to pass additional
             keyword arguments.
 
-
-        Example
+        Returns
         -------
+        None
+
+        Examples
+        --------
 
         Its basic use case is to draw Markdown-formatted text, whenever the
         input is a string:

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -370,7 +370,7 @@ def _get_user_info() -> UserInfo:
 
 class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
     """
-    A read-only, dict-like object for accessing information about the current
+    A read-only, dict-like object for accessing information about the current\
     user.
 
     ``st.experimental_user`` is dependent on the host platform running your


### PR DESCRIPTION
## Describe your changes
Additional docstring edits for Streamlit version 1.42.0
- Markdown for tables
- Elapsed time for spinners
- st.write passing to st.html (and reformatting of st.write docstring)
- Chart default widths
- Code block height
- Markdown in image captions
- Default connection handling in SnowflakeConnection

## Testing Plan
n/a docstrings only.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
