### PR TITLE
Update mypy and ruff target-version to Python 3.9 and use ruff 0.9.4

### DIFF
--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -173,7 +173,7 @@ def check_if_pr_has_label(label: str, action: str) -> bool:
         pr_labels = get_current_pr_labels()
         if label in pr_labels:
             print(f"PR has the following labels: {pr_labels}")
-            print(f"{action}, because PR has {label !r} label.")
+            print(f"{action}, because PR has {label!r} label.")
             return True
     return False
 
@@ -293,11 +293,12 @@ def save_output_variables(variables: dict[str, str]) -> None:
     Saves build variables
     """
     print("Saving output variables")
-    with open(
-        os.environ.get(GITHUB_ENV_ENV_VAR, "/dev/null"), "w+"
-    ) as github_env_file, open(
-        os.environ.get(GITHUB_OUTPUT_ENV_VAR, "/dev/null"), "w+"
-    ) as github_output_file:
+    with (
+        open(os.environ.get(GITHUB_ENV_ENV_VAR, "/dev/null"), "w+") as github_env_file,
+        open(
+            os.environ.get(GITHUB_OUTPUT_ENV_VAR, "/dev/null"), "w+"
+        ) as github_output_file,
+    ):
         for target_file in [sys.stdout, github_env_file, github_output_file]:
             for name, value in variables.items():
                 target_file.write(f"{name}={value}\n")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.0
+    rev: v0.9.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@
 # because the files were linted after trying to do the first commit.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
+    # We fix ruff to a version to be in sync with the dev-requirements:
     rev: v0.9.4
     hooks:
       # Run the linter.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -20,7 +20,7 @@ include = [
   "e2e_playwright/**/*.py",
   "scripts/**/*.py",
 ]
-target-version = 'py38'
+target-version = 'py39'
 line-length = 88
 
 [format]

--- a/e2e_playwright/auth_test.py
+++ b/e2e_playwright/auth_test.py
@@ -15,8 +15,8 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Generator
 from tempfile import NamedTemporaryFile
-from typing import Generator
 
 import pytest
 from playwright.sync_api import Page, expect

--- a/e2e_playwright/auth_test.py
+++ b/e2e_playwright/auth_test.py
@@ -15,8 +15,8 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Generator
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -27,6 +27,9 @@ from e2e_playwright.conftest import (
     wait_for_app_run,
 )
 from e2e_playwright.shared.app_utils import get_button, get_markdown
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 AUTH_SECRETS_TEMPLATE = """
 [auth]

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -28,12 +28,13 @@ import socket
 import subprocess
 import sys
 import time
+from collections.abc import Generator
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from random import randint
 from tempfile import TemporaryFile
-from typing import TYPE_CHECKING, Any, Callable, Generator, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 from urllib import parse
 
 import pytest
@@ -397,9 +398,11 @@ def iframed_app(page: Page, app_port: int) -> IframedPage:
                 <body style="height: 100%;">
                     <iframe
                         src={src}
-                        id={_iframe_element_attrs.element_id
-                            if _iframe_element_attrs.element_id
-                            else ""}
+                        id={
+                _iframe_element_attrs.element_id
+                if _iframe_element_attrs.element_id
+                else ""
+            }
                         title="Iframed Streamlit App"
                         allow="clipboard-write; microphone;"
                         sandbox="allow-popups allow-same-origin allow-scripts allow-downloads"
@@ -754,7 +757,7 @@ def assert_snapshot(
 
         test_failure_messages.append(
             f"Snapshot mismatch for {snapshot_file_name} ({mismatch} pixels difference;"
-            f" {mismatch/total_pixels * 100:.2f}%)"
+            f" {mismatch / total_pixels * 100:.2f}%)"
         )
 
     yield compare

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -28,7 +28,6 @@ import socket
 import subprocess
 import sys
 import time
-from collections.abc import Generator
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -58,6 +57,7 @@ from e2e_playwright.shared.performance import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from types import ModuleType
 
 

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import platform
 import re
-from typing import Literal, Pattern
+from re import Pattern
+from typing import Literal
 
 from playwright.sync_api import Frame, Locator, Page, expect
 

--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,6 +1,6 @@
 pre-commit
 # We fix ruff to a version to be in sync with the pre-commit hook:
-ruff==0.8.*
+ruff==0.9.4
 # as soon as the error reported in https://github.com/python/mypy/issues/17604
 # is released for mypy, we can update to version 1.11
 mypy>=1.4, <1.11

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 cache_dir = .mypy_cache
 
 # TODO(nate): Additional strictness checks to work towards.

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Mapping, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from streamlit import config
 from streamlit.errors import StreamlitAuthError

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -19,7 +19,8 @@ import contextlib
 import re
 import textwrap
 import traceback
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from streamlit.runtime.metrics_util import gather_metrics
 

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -19,10 +19,12 @@ import contextlib
 import re
 import textwrap
 import traceback
-from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from streamlit.runtime.metrics_util import gather_metrics
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 _SPACES_RE = re.compile("\\s*")
 _EMPTY_LINE_RE = re.compile("\\s*\n")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -94,7 +94,9 @@ def _new_fragment_id_queue(
             new_queue := list(
                 dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue)
             )
-        ), "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+        ), (
+            "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+        )
 
         return new_queue
 

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -15,9 +15,10 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Mapping
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Final, Literal, Mapping, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, Union, cast
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -215,9 +215,9 @@ def get_options_for_section(section: str) -> dict[str, Any]:
 
 def _create_section(section: str, description: str) -> None:
     """Create a config section and store it globally in this module."""
-    assert (
-        section not in _section_descriptions
-    ), f'Cannot define section "{section}" twice.'
+    assert section not in _section_descriptions, (
+        f'Cannot define section "{section}" twice.'
+    )
     _section_descriptions[section] = description
 
 
@@ -282,11 +282,11 @@ def _create_option(
         type_=type_,
         sensitive=sensitive,
     )
-    assert (
-        option.section in _section_descriptions
-    ), 'Section "{}" must be one of {}.'.format(
-        option.section,
-        ", ".join(_section_descriptions.keys()),
+    assert option.section in _section_descriptions, (
+        'Section "{}" must be one of {}.'.format(
+            option.section,
+            ", ".join(_section_descriptions.keys()),
+        )
     )
     assert key not in _config_options_template, f'Cannot define option "{key}" twice.'
     _config_options_template[key] = option
@@ -300,9 +300,9 @@ def _delete_option(key: str) -> None:
     """
     try:
         del _config_options_template[key]
-        assert (
-            _config_options is not None
-        ), "_config_options should always be populated here."
+        assert _config_options is not None, (
+            "_config_options should always be populated here."
+        )
         del _config_options[key]
     except Exception:
         # We don't care if the option already doesn't exist.
@@ -1115,9 +1115,9 @@ def is_manually_set(option_name: str) -> bool:
 def show_config() -> None:
     """Print all config options to the terminal."""
     with _config_lock:
-        assert (
-            _config_options is not None
-        ), "_config_options should always be populated here."
+        assert _config_options is not None, (
+            "_config_options should always be populated here."
+        )
         config_util.show_config(_section_descriptions, _config_options)
 
 
@@ -1140,9 +1140,9 @@ def _set_option(key: str, value: Any, where_defined: str) -> None:
         Tells the config system where this was set.
 
     """
-    assert (
-        _config_options is not None
-    ), "_config_options should always be populated here."
+    assert _config_options is not None, (
+        "_config_options should always be populated here."
+    )
     if key not in _config_options:
         # Import logger locally to prevent circular references
         from streamlit.logger import get_logger
@@ -1346,13 +1346,13 @@ def _check_conflicts() -> None:
     LOGGER = get_logger(__name__)
 
     if get_option("global.developmentMode"):
-        assert _is_unset(
-            "server.port"
-        ), "server.port does not work when global.developmentMode is true."
+        assert _is_unset("server.port"), (
+            "server.port does not work when global.developmentMode is true."
+        )
 
-        assert _is_unset(
-            "browser.serverPort"
-        ), "browser.serverPort does not work when global.developmentMode is true."
+        assert _is_unset("browser.serverPort"), (
+            "browser.serverPort does not work when global.developmentMode is true."
+        )
 
     # XSRF conflicts
     if get_option("server.enableXsrfProtection"):

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -215,9 +215,9 @@ class ConfigOption:
             Returns self, which makes testing easier. See config_test.py.
 
         """
-        assert (
-            get_val_func.__doc__
-        ), "Complex config options require doc strings for their description."
+        assert get_val_func.__doc__, (
+            "Complex config options require doc strings for their description."
+        )
         self.description = get_val_func.__doc__
         self._get_val_func = get_val_func
         return self

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 import threading
 from collections import ChainMap
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, cast
+from typing import TYPE_CHECKING, cast
 
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import (

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import threading
 from collections import ChainMap
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, cast
 
@@ -36,6 +35,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from datetime import timedelta
 
     from pandas import DataFrame

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -21,8 +21,10 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Collection
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 SNOWSQL_CONNECTION_FILE = "~/.snowsql/config"
 

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -21,7 +21,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Collection, cast
+from collections.abc import Collection
+from typing import Any, cast
 
 SNOWSQL_CONNECTION_FILE = "~/.snowsql/config"
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -29,7 +29,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    List,
     Protocol,
     TypeVar,
     Union,
@@ -944,7 +943,7 @@ def convert_anything_to_list(obj: OptionSequence[V_co]) -> list[V_co]:
         return (
             []
             if data_df.empty
-            else cast(List[V_co], list(data_df.iloc[:, 0].to_list()))
+            else cast(list[V_co], list(data_df.iloc[:, 0].to_list()))
         )
     except errors.StreamlitAPIException:
         # Wrap the object into a list

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -22,18 +22,15 @@ import inspect
 import math
 import re
 from collections import ChainMap, UserDict, UserList, deque
-from collections.abc import ItemsView
+from collections.abc import ItemsView, Iterable, Mapping, Sequence
 from enum import Enum, EnumMeta, auto
 from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    Iterable,
     List,
-    Mapping,
     Protocol,
-    Sequence,
     TypeVar,
     Union,
     cast,
@@ -1279,8 +1276,7 @@ def _pandas_df_to_series(df: DataFrame) -> Series[Any]:
     # Select first column in dataframe and create a new series based on the values
     if len(df.columns) != 1:
         raise ValueError(
-            "DataFrame is expected to have a single column but "
-            f"has {len(df.columns)}."
+            f"DataFrame is expected to have a single column but has {len(df.columns)}."
         )
     return df[df.columns[0]]
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -17,13 +17,13 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Final,
-    Iterable,
     Literal,
     NoReturn,
     TypeVar,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Hashable, Iterable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -54,6 +53,8 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 from streamlit.runtime.state import WidgetCallback, register_widget
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable
+
     from numpy import typing as npt
     from pandas import DataFrame
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -15,13 +15,12 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Hashable, Iterable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    Hashable,
-    Iterable,
     Literal,
     TypedDict,
     cast,
@@ -921,9 +920,9 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
     if dataframe_util.is_pandas_styler(data):
         # default_uuid is a string only if the data is a `Styler`,
         # and `None` otherwise.
-        assert isinstance(
-            default_uuid, str
-        ), "Default UUID must be a string for Styler data."
+        assert isinstance(default_uuid, str), (
+            "Default UUID must be a string for Styler data."
+        )
         marshall_styler(proto, data, default_uuid)
 
     proto.data = dataframe_util.convert_anything_to_arrow_bytes(data)

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -15,15 +15,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
     Final,
-    Iterable,
     Literal,
-    Mapping,
     TypedDict,
     cast,
     overload,

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -15,12 +15,10 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Final,
     Literal,
     TypedDict,
@@ -45,6 +43,8 @@ from streamlit.runtime.state import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from pydeck import Deck
 
     from streamlit.delta_generator import DeltaGenerator
@@ -541,6 +541,6 @@ def _get_pydeck_tooltip(pydeck_obj: Deck | None) -> dict[str, str] | None:
     # For details, see: https://github.com/visgl/deck.gl/pull/7125/files
     tooltip = getattr(pydeck_obj, "_tooltip", None)
     if tooltip is not None and isinstance(tooltip, dict):
-        return cast(Dict[str, str], tooltip)
+        return cast(dict[str, str], tooltip)
 
     return None

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Sequence, Union, cast
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal, Union, cast
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -16,17 +16,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Hashable, Sequence
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
-    Collection,
     Final,
-    Hashable,
     Literal,
-    Sequence,
     TypedDict,
     cast,
 )

--- a/lib/streamlit/elements/lib/color_util.py
+++ b/lib/streamlit/elements/lib/color_util.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import Any, Callable, Tuple, Union, cast
+from typing import Any, Callable, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -23,17 +23,17 @@ from streamlit.errors import StreamlitInvalidColorError
 
 # components go from 0.0 to 1.0
 # Supported by Pillow and pretty common.
-FloatRGBColorTuple: TypeAlias = Tuple[float, float, float]
-FloatRGBAColorTuple: TypeAlias = Tuple[float, float, float, float]
+FloatRGBColorTuple: TypeAlias = tuple[float, float, float]
+FloatRGBAColorTuple: TypeAlias = tuple[float, float, float, float]
 
 # components go from 0 to 255
 # DeckGL uses these.
-IntRGBColorTuple: TypeAlias = Tuple[int, int, int]
-IntRGBAColorTuple: TypeAlias = Tuple[int, int, int, int]
+IntRGBColorTuple: TypeAlias = tuple[int, int, int]
+IntRGBAColorTuple: TypeAlias = tuple[int, int, int, int]
 
 # components go from 0 to 255, except alpha goes from 0.0 to 1.0
 # CSS uses these.
-MixedRGBAColorTuple: TypeAlias = Tuple[int, int, int, float]
+MixedRGBAColorTuple: TypeAlias = tuple[int, int, int, float]
 
 Color4Tuple: TypeAlias = Union[
     FloatRGBAColorTuple,

--- a/lib/streamlit/elements/lib/color_util.py
+++ b/lib/streamlit/elements/lib/color_util.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Tuple, Union, cast
+from collections.abc import Collection
+from typing import Any, Callable, Tuple, Union, cast
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -18,7 +18,7 @@ import copy
 import json
 from collections.abc import Mapping
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Final, Literal, Union
+from typing import TYPE_CHECKING, Final, Literal, Union
 
 from typing_extensions import TypeAlias
 
@@ -68,7 +68,7 @@ class ColumnDataKind(str, Enum):
 # The dataframe schema is a mapping from the name of the column
 # in the underlying dataframe to the column data kind.
 # The index column uses `_index` as name.
-DataframeSchema: TypeAlias = Dict[str, ColumnDataKind]
+DataframeSchema: TypeAlias = dict[str, ColumnDataKind]
 
 # This mapping contains all editable column types mapped to the data kinds
 # that the column type is compatible for editing.
@@ -397,7 +397,7 @@ def determine_dataframe_schema(
 
 
 # A mapping of column names/IDs to column configs.
-ColumnConfigMapping: TypeAlias = Dict[Union[IndexIdentifierType, str], ColumnConfig]
+ColumnConfigMapping: TypeAlias = dict[Union[IndexIdentifierType, str], ColumnConfig]
 ColumnConfigMappingInput: TypeAlias = Mapping[
     Union[IndexIdentifierType, str],
     Union[ColumnConfig, None, str],

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import copy
 import json
+from collections.abc import Mapping
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Final, Literal, Mapping, Union
+from typing import TYPE_CHECKING, Dict, Final, Literal, Union
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -15,12 +15,14 @@
 from __future__ import annotations
 
 import datetime
-from collections.abc import Iterable
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 from typing_extensions import NotRequired, TypeAlias
 
 from streamlit.runtime.metrics_util import gather_metrics
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 ColumnWidth: TypeAlias = Literal["small", "medium", "large"]
 

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import datetime
-from typing import Iterable, Literal, TypedDict
+from collections.abc import Iterable
+from typing import Literal, TypedDict
 
 from typing_extensions import NotRequired, TypeAlias
 

--- a/lib/streamlit/elements/lib/dicttools.py
+++ b/lib/streamlit/elements/lib/dicttools.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 
 def _unflatten_single_dict(flat_dict: dict[Any, Any]) -> dict[Any, Any]:

--- a/lib/streamlit/elements/lib/dicttools.py
+++ b/lib/streamlit/elements/lib/dicttools.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def _unflatten_single_dict(flat_dict: dict[Any, Any]) -> dict[Any, Any]:

--- a/lib/streamlit/elements/lib/event_utils.py
+++ b/lib/streamlit/elements/lib/event_utils.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any
 
 
-class AttributeDictionary(Dict[Any, Any]):
+class AttributeDictionary(dict[Any, Any]):
     """
     A dictionary subclass that supports attribute-style access.
 

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -14,7 +14,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 TYPE_PAIRS = [
     (".jpg", ".jpeg"),

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 TYPE_PAIRS = [
     (".jpg", ".jpeg"),

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import io
 import os
 import re
+from collections.abc import Sequence
 from enum import IntEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, Literal, Sequence, Union, cast
+from typing import TYPE_CHECKING, Final, Literal, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -416,9 +417,9 @@ def marshall_images(
     else:
         captions = [str(caption)]
 
-    assert isinstance(
-        captions, list
-    ), "If image is a list then caption should be as well"
+    assert isinstance(captions, list), (
+        "If image is a list then caption should be as well"
+    )
     assert len(captions) == len(images), "Cannot pair %d captions with %d images." % (
         len(captions),
         len(images),

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from enum import Enum, EnumMeta
-from typing import Any, Final, Iterable, Sequence, TypeVar, overload
+from typing import Any, Final, TypeVar, overload
 
 from streamlit import config, logger
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -14,9 +14,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from enum import Enum, EnumMeta
-from typing import Any, Final, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Final, TypeVar, overload
 
 from streamlit import config, logger
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
@@ -26,6 +25,9 @@ from streamlit.type_util import (
     T,
     check_python_comparable,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
 _LOGGER: Final = logger.get_logger(__name__)
 

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from streamlit import dataframe_util
 from streamlit.errors import StreamlitAPIException

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final
 
 from streamlit import config, errors, logger, runtime
@@ -32,6 +31,8 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 from streamlit.runtime.state import WidgetCallback, get_session_state
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.delta_generator import DeltaGenerator
 
 

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Final
 
 from streamlit import config, errors, logger, runtime
 from streamlit.elements.lib.form_utils import is_in_form

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -45,6 +44,7 @@ from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
     from builtins import ellipsis
+    from collections.abc import Iterable
 
 
 Key: TypeAlias = Union[str, int]

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -15,11 +15,11 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterable,
     Literal,
     Union,
     overload,

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import TYPE_CHECKING, Any, Collection, Final, cast
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit import config, dataframe_util

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import copy
 import json
-from collections.abc import Collection
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
@@ -34,6 +33,8 @@ from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonCha
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from pandas import DataFrame
 
     from streamlit.dataframe_util import Data

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -162,7 +162,7 @@ class MarkdownMixin:
 
         """
         code_proto = MarkdownProto()
-        markdown = f'```{language or ""}\n{body}\n```'
+        markdown = f"```{language or ''}\n{body}\n```"
         code_proto.body = clean_text(markdown)
         code_proto.element_type = MarkdownProto.Type.CODE
         return self.dg._enqueue("markdown", code_proto)

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -18,7 +18,7 @@ import io
 import re
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Final, Union, cast
+from typing import TYPE_CHECKING, Final, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -54,7 +54,7 @@ MediaData: TypeAlias = Union[
 ]
 
 SubtitleData: TypeAlias = Union[
-    str, Path, bytes, io.BytesIO, Dict[str, Union[str, Path, bytes, io.BytesIO]], None
+    str, Path, bytes, io.BytesIO, dict[str, Union[str, Path, bytes, io.BytesIO]], None
 ]
 
 MediaTime: TypeAlias = Union[int, float, timedelta, str]

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -17,13 +17,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
     Final,
-    Iterable,
     List,
     Literal,
     TypedDict,

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -17,14 +17,11 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Final,
-    List,
     Literal,
     TypedDict,
     Union,
@@ -50,6 +47,8 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_r
 from streamlit.runtime.state import WidgetCallback, register_widget
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import matplotlib
     import plotly.graph_objs as go
     from plotly.basedatatypes import BaseFigure
@@ -65,11 +64,11 @@ _AtomicFigureOrData: TypeAlias = Union[
 ]
 FigureOrData: TypeAlias = Union[
     _AtomicFigureOrData,
-    List[_AtomicFigureOrData],
+    list[_AtomicFigureOrData],
     # It is kind of hard to figure out exactly what kind of dict is supported
     # here, as plotly hasn't embraced typing yet. This version is chosen to
     # align with the docstring.
-    Dict[str, _AtomicFigureOrData],
+    dict[str, _AtomicFigureOrData],
     "BaseFigure",
     "matplotlib.figure.Figure",
 ]

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from typing import Iterator
+from collections.abc import Iterator
 
 import streamlit as st
 from streamlit.runtime.scriptrunner import add_script_run_ctx

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import streamlit as st
 from streamlit.runtime.scriptrunner import add_script_run_ctx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @contextlib.contextmanager

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -19,15 +19,14 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Iterable, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    Iterable,
     Literal,
-    Sequence,
     TypedDict,
     Union,
     cast,

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from collections.abc import Iterable, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import (
@@ -58,6 +57,8 @@ from streamlit.runtime.state import WidgetCallback, register_widget
 from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     import altair as alt
 
     from streamlit.dataframe_util import Data

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,7 +22,6 @@ from typing import (
     Final,
     Generic,
     Literal,
-    Sequence,
     TypeVar,
     cast,
     overload,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -14,15 +14,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, MutableMapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterator,
     Literal,
-    MutableMapping,
-    Sequence,
     cast,
     overload,
 )

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import (
@@ -22,10 +23,8 @@ from typing import (
     Any,
     Dict,
     Final,
-    Iterable,
     List,
     Literal,
-    Mapping,
     Set,
     Tuple,
     TypedDict,

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -15,18 +15,13 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Final,
-    List,
     Literal,
-    Set,
-    Tuple,
     TypedDict,
     TypeVar,
     Union,
@@ -69,6 +64,8 @@ from streamlit.type_util import is_type
 from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import numpy as np
     import pandas as pd
     import pyarrow as pa
@@ -84,10 +81,10 @@ EditableData = TypeVar(
     "EditableData",
     bound=Union[
         dataframe_util.DataFrameGenericAlias[Any],  # covers DataFrame and Series
-        Tuple[Any],
-        List[Any],
-        Set[Any],
-        Dict[str, Any],
+        tuple[Any],
+        list[Any],
+        set[Any],
+        dict[str, Any],
         # TODO(lukasmasuch): Add support for np.ndarray
         # but it is not possible with np.ndarray.
         # NDArray[Any] works, but is only available in numpy>1.20.
@@ -105,10 +102,10 @@ DataTypes: TypeAlias = Union[
     "Styler",
     "pa.Table",
     "np.ndarray[Any, np.dtype[np.float64]]",
-    Tuple[Any],
-    List[Any],
-    Set[Any],
-    Dict[str, Any],
+    tuple[Any],
+    list[Any],
+    set[Any],
+    dict[str, Any],
 ]
 
 

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -14,10 +14,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, List, Literal, Union, cast, overload
+from typing import TYPE_CHECKING, Literal, Union, cast, overload
 
 from typing_extensions import TypeAlias
 
@@ -49,12 +48,14 @@ from streamlit.runtime.state import (
 from streamlit.runtime.uploaded_file_manager import DeletedFile, UploadedFile
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.delta_generator import DeltaGenerator
 
 SomeUploadedFiles: TypeAlias = Union[
     UploadedFile,
     DeletedFile,
-    List[Union[UploadedFile, DeletedFile]],
+    list[Union[UploadedFile, DeletedFile]],
     None,
 ]
 

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -14,9 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, List, Literal, Sequence, Union, cast, overload
+from typing import TYPE_CHECKING, List, Literal, Union, cast, overload
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -14,9 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Generic, cast
 
 from streamlit.dataframe_util import OptionSequence
 from streamlit.elements.lib.form_utils import current_form_id

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
@@ -51,6 +50,8 @@ from streamlit.type_util import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.delta_generator import DeltaGenerator
 
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -14,9 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
 from streamlit.elements.lib.form_utils import current_form_id

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import (
@@ -21,7 +22,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Sequence,
     Tuple,
     cast,
     overload,

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import (
@@ -22,7 +21,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Tuple,
     cast,
     overload,
 )
@@ -64,6 +62,8 @@ from streamlit.runtime.state.common import (
 from streamlit.type_util import T, check_python_comparable
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.delta_generator import DeltaGenerator
 
 
@@ -91,7 +91,7 @@ class SelectSliderSerde(Generic[T]):
 
         # The widget always returns floats, so convert to ints before indexing
         return_value: tuple[T, T] = cast(
-            Tuple[T, T],
+            tuple[T, T],
             tuple(self.options[int(x)] for x in ui_value),
         )
 
@@ -412,7 +412,7 @@ class SelectSliderMixin:
         )
         if isinstance(widget_state.value, tuple):
             widget_state = maybe_coerce_enum_sequence(
-                cast(RegisterWidgetResult[Tuple[T, T]], widget_state), options, opt
+                cast(RegisterWidgetResult[tuple[T, T]], widget_state), options, opt
             )
         else:
             widget_state = maybe_coerce_enum(widget_state, options, opt)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
 from streamlit.elements.lib.form_utils import current_form_id

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
@@ -50,6 +49,8 @@ from streamlit.type_util import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.delta_generator import DeltaGenerator
 
 

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from numbers import Integral, Real
@@ -23,7 +24,6 @@ from typing import (
     Any,
     Final,
     List,
-    Sequence,
     Tuple,
     TypeVar,
     Union,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -23,8 +23,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    List,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -65,16 +63,16 @@ SliderNumericT = TypeVar("SliderNumericT", int, float)
 SliderDatelikeT = TypeVar("SliderDatelikeT", date, time, datetime)
 
 SliderNumericSpanT: TypeAlias = Union[
-    List[SliderNumericT],
-    Tuple[()],
-    Tuple[SliderNumericT],
-    Tuple[SliderNumericT, SliderNumericT],
+    list[SliderNumericT],
+    tuple[()],
+    tuple[SliderNumericT],
+    tuple[SliderNumericT, SliderNumericT],
 ]
 SliderDatelikeSpanT: TypeAlias = Union[
-    List[SliderDatelikeT],
-    Tuple[()],
-    Tuple[SliderDatelikeT],
-    Tuple[SliderDatelikeT, SliderDatelikeT],
+    list[SliderDatelikeT],
+    tuple[()],
+    tuple[SliderDatelikeT],
+    tuple[SliderDatelikeT, SliderDatelikeT],
 ]
 
 StepNumericT: TypeAlias = SliderNumericT
@@ -96,8 +94,8 @@ SliderValue: TypeAlias = Union[
 ]
 SliderReturnGeneric: TypeAlias = Union[
     SliderValueT,
-    Tuple[SliderValueT],
-    Tuple[SliderValueT, SliderValueT],
+    tuple[SliderValueT],
+    tuple[SliderValueT, SliderValueT],
 ]
 SliderReturn: TypeAlias = Union[
     SliderReturnGeneric[int],

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from textwrap import dedent
@@ -23,7 +24,6 @@ from typing import (
     Final,
     List,
     Literal,
-    Sequence,
     Tuple,
     Union,
     cast,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -22,9 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    List,
     Literal,
-    Tuple,
     Union,
     cast,
     overload,
@@ -72,9 +70,9 @@ DateValue: TypeAlias = Union[NullableScalarDateValue, Sequence[NullableScalarDat
 
 # The return value of st.date_input.
 DateWidgetRangeReturn: TypeAlias = Union[
-    Tuple[()],
-    Tuple[date],
-    Tuple[date, date],
+    tuple[()],
+    tuple[date],
+    tuple[date, date],
 ]
 DateWidgetReturn: TypeAlias = Union[date, DateWidgetRangeReturn, None]
 
@@ -229,7 +227,7 @@ class _DateInputValues:
         )
 
         if value == "today":
-            v = cast(List[date], parsed_value)[0]
+            v = cast(list[date], parsed_value)[0]
             if v < parsed_min:
                 parsed_value = [parsed_min]
             if v > parsed_max:

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -18,16 +18,20 @@ import dataclasses
 import inspect
 import types
 from collections import ChainMap, UserDict, UserList
-from collections.abc import ItemsView, KeysView, ValuesView
+from collections.abc import (
+    AsyncGenerator,
+    Generator,
+    ItemsView,
+    Iterable,
+    KeysView,
+    ValuesView,
+)
 from io import StringIO
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
     Callable,
     Final,
-    Generator,
-    Iterable,
     List,
     cast,
 )

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -32,7 +32,6 @@ from typing import (
     Any,
     Callable,
     Final,
-    List,
     cast,
 )
 
@@ -62,7 +61,7 @@ _LOGGER: Final = get_logger(__name__)
 _TEXT_CURSOR: Final = " ▏"
 
 
-class StreamingOutput(List[Any]):
+class StreamingOutput(list[Any]):
     pass
 
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -154,8 +154,7 @@ class StreamlitModuleNotFoundError(StreamlitAPIWarning):
 
     def __init__(self, module_name, *args):
         message = (
-            f'This Streamlit command requires module "{module_name}" '
-            "to be installed."
+            f'This Streamlit command requires module "{module_name}" to be installed.'
         )
         super().__init__(message, *args)
 

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -246,9 +246,9 @@ class LLMThought:
     def complete(self, final_label: str | None = None) -> None:
         """Finish the thought."""
         if final_label is None and self._state == LLMThoughtState.RUNNING_TOOL:
-            assert (
-                self._last_tool is not None
-            ), "_last_tool should never be null when _state == RUNNING_TOOL"
+            assert self._last_tool is not None, (
+                "_last_tool should never be null when _state == RUNNING_TOOL"
+            )
             final_label = self._labeler.get_tool_label(
                 self._last_tool, is_complete=True
             )

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -579,9 +579,9 @@ class AppSession:
             browser. Set only for the SCRIPT_STARTED event.
         """
 
-        assert (
-            self._event_loop == asyncio.get_running_loop()
-        ), "This function must only be called on the eventloop thread the AppSession was created on."
+        assert self._event_loop == asyncio.get_running_loop(), (
+            "This function must only be called on the eventloop thread the AppSession was created on."
+        )
 
         if sender is not self._scriptrunner:
             # This event was sent by a non-current ScriptRunner; ignore it.
@@ -597,9 +597,9 @@ class AppSession:
         if event == ScriptRunnerEvent.SCRIPT_STARTED:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
-            assert (
-                page_script_hash is not None
-            ), "page_script_hash must be set for the SCRIPT_STARTED event"
+            assert page_script_hash is not None, (
+                "page_script_hash must be set for the SCRIPT_STARTED event"
+            )
 
             # Update the client state with the new page_script_hash if
             # necessary. This handles an edge case where a script is never
@@ -647,9 +647,9 @@ class AppSession:
             else:
                 # The script didn't complete successfully: send the exception
                 # to the frontend.
-                assert (
-                    exception is not None
-                ), "exception must be set for the SCRIPT_STOPPED_WITH_COMPILE_ERROR event"
+                assert exception is not None, (
+                    "exception must be set for the SCRIPT_STOPPED_WITH_COMPILE_ERROR event"
+                )
                 msg = ForwardMsg()
                 exception_utils.marshall(
                     msg.session_event.script_compilation_exception, exception
@@ -667,9 +667,9 @@ class AppSession:
                 self._local_sources_watcher.update_watched_modules()
 
         elif event == ScriptRunnerEvent.SHUTDOWN:
-            assert (
-                client_state is not None
-            ), "client_state must be set for the SHUTDOWN event"
+            assert client_state is not None, (
+                "client_state must be set for the SHUTDOWN event"
+            )
 
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
@@ -680,9 +680,9 @@ class AppSession:
             self._scriptrunner = None
 
         elif event == ScriptRunnerEvent.ENQUEUE_FORWARD_MSG:
-            assert (
-                forward_msg is not None
-            ), "null forward_msg in ENQUEUE_FORWARD_MSG event"
+            assert forward_msg is not None, (
+                "null forward_msg in ENQUEUE_FORWARD_MSG event"
+            )
             self._enqueue_forward_msg(forward_msg)
 
         # Send a message if our run state changed

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import contextlib
 import threading
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 import streamlit as st
 from streamlit import runtime, util

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Union
 
@@ -29,6 +28,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from types import FunctionType
 
     from google.protobuf.message import Message

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -34,7 +34,7 @@ import weakref
 from enum import Enum
 from re import Pattern
 from types import MappingProxyType
-from typing import Any, Callable, Dict, Final, Type, Union, cast
+from typing import Any, Callable, Final, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -53,7 +53,7 @@ _PANDAS_SAMPLE_SIZE: Final = 10000
 _NP_SIZE_LARGE: Final = 1000000
 _NP_SAMPLE_SIZE: Final = 100000
 
-HashFuncsDict: TypeAlias = Dict[Union[str, Type[Any]], Callable[[Any], Any]]
+HashFuncsDict: TypeAlias = dict[Union[str, type[Any]], Callable[[Any], Any]]
 
 # Arbitrary item to denote where we found a cycle in a hashed object.
 # This allows us to hash self-referencing lists, dictionaries, etc.

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -32,8 +32,9 @@ import threading
 import uuid
 import weakref
 from enum import Enum
+from re import Pattern
 from types import MappingProxyType
-from typing import Any, Callable, Dict, Final, Pattern, Type, Union, cast
+from typing import Any, Callable, Dict, Final, Type, Union, cast
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -14,9 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Mapping
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from streamlit import runtime
 from streamlit.runtime.metrics_util import gather_metrics

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Final
 from weakref import WeakKeyDictionary
 
@@ -26,6 +25,8 @@ from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     from streamlit.runtime.app_session import AppSession
 
 _LOGGER: Final = get_logger(__name__)

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Final, MutableMapping
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Final
 from weakref import WeakKeyDictionary
 
 from streamlit import config, util

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -14,11 +14,14 @@
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping
+from typing import TYPE_CHECKING
 
 from cachetools import TTLCache
 
 from streamlit.runtime.session_manager import SessionInfo, SessionStorage
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
 
 
 class MemorySessionStorage(SessionStorage):

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from collections.abc import MutableMapping
 
 from cachetools import TTLCache
 

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from streamlit import util
 from streamlit.runtime.stats import CacheStat, group_stats
@@ -25,6 +25,9 @@ from streamlit.runtime.uploaded_file_manager import (
     UploadedFileRec,
     UploadFileUrlInfo,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class MemoryUploadedFileManager(UploadedFileManager):

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from typing import Sequence
+from collections.abc import Sequence
 
 from streamlit import util
 from streamlit.runtime.stats import CacheStat, group_stats

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import time
 import traceback
-from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Final, NamedTuple
@@ -59,6 +58,8 @@ from streamlit.runtime.stats import StatsManager
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from streamlit.components.types.base_component_registry import BaseComponentRegistry
     from streamlit.proto.BackMsg_pb2 import BackMsg
     from streamlit.runtime.caching.storage import CacheStorageManager

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import asyncio
 import time
 import traceback
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Awaitable, Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 from streamlit import config
 from streamlit.components.lib.local_component_registry import LocalComponentRegistry
@@ -385,9 +386,9 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        assert not (
-            existing_session_id and session_id_override
-        ), "Only one of existing_session_id and session_id_override should be set!"
+        assert not (existing_session_id and session_id_override), (
+            "Only one of existing_session_id and session_id_override should be set!"
+        )
 
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeStoppedError(f"Can't connect_session (state={self._state})")

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -535,9 +535,10 @@ class ScriptRunner:
             module.__dict__["__file__"] = script_path
 
             def code_to_exec(code=code, module=module, ctx=ctx, rerun_data=rerun_data):
-                with modified_sys_path(
-                    self._main_script_path
-                ), self._set_execing_flag():
+                with (
+                    modified_sys_path(self._main_script_path),
+                    self._set_execing_flag(),
+                ):
                     # Run callbacks for widgets whose values have changed.
                     if rerun_data.widget_states is not None:
                         self._session_state.on_script_will_rerun(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     Final,
     Union,
 )
@@ -51,7 +50,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 _LOGGER: Final = get_logger(__name__)
 
-UserInfo: TypeAlias = Dict[str, Union[str, bool, None]]
+UserInfo: TypeAlias = dict[str, Union[str, bool, None]]
 
 
 # If true, it indicates that we are in a cached function that disallows the usage of

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -18,11 +18,11 @@ import collections
 import contextlib
 import contextvars
 import threading
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Counter,
     Dict,
     Final,
     Union,

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -16,17 +16,13 @@ from __future__ import annotations
 
 import os
 import threading
+from collections.abc import ItemsView, Iterator, KeysView, Mapping, ValuesView
 from copy import deepcopy
 from typing import (
     Any,
     Callable,
     Final,
-    ItemsView,
-    Iterator,
-    KeysView,
-    Mapping,
     NoReturn,
-    ValuesView,
 )
 
 from blinker import Signal

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -20,11 +20,9 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     Callable,
-    Dict,
     Final,
     Generic,
     Literal,
-    Tuple,
     TypeVar,
     cast,
     get_args,
@@ -45,8 +43,8 @@ T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
 
-WidgetArgs: TypeAlias = Tuple[Any, ...]
-WidgetKwargs: TypeAlias = Dict[str, Any]
+WidgetArgs: TypeAlias = tuple[Any, ...]
+WidgetKwargs: TypeAlias = dict[str, Any]
 WidgetCallback: TypeAlias = Callable[..., None]
 
 # A deserializer receives the value from whatever field is set on the

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Final, Iterable, Iterator, MutableMapping
+from typing import TYPE_CHECKING, Final
 from urllib import parse
 
 from streamlit.errors import StreamlitAPIException

--- a/lib/streamlit/runtime/state/query_params_proxy.py
+++ b/lib/streamlit/runtime/state/query_params_proxy.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Iterator, MutableMapping, overload
+from collections.abc import Iterable, Iterator, MutableMapping
+from typing import TYPE_CHECKING, overload
 
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.state.session_state_proxy import get_session_state

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
     from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
     from streamlit.runtime.state.common import RegisterWidgetResult, T, WidgetMetadata

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -15,8 +15,9 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -16,16 +16,14 @@ from __future__ import annotations
 
 import json
 import pickle
+from collections.abc import Iterator, KeysView, MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    Iterator,
-    KeysView,
     List,
-    MutableMapping,
     Union,
     cast,
 )

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -23,7 +23,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
-    List,
     Union,
     cast,
 )
@@ -253,7 +252,7 @@ class WStates(MutableMapping[str, Any]):
             for widget_id in self.states.keys()
             if self.get_serialized(widget_id)
         ]
-        states = cast(List[WidgetStateProto], states)
+        states = cast(list[WidgetStateProto], states)
         return states
 
     def call_callback(self, widget_id: str) -> None:

--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Final, Iterator, MutableMapping
+from collections.abc import Iterator, MutableMapping
+from typing import Any, Final
 
 from streamlit import logger as _logger
 from streamlit import runtime

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 import io
 from abc import abstractmethod
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from streamlit import util
 from streamlit.runtime.stats import CacheStatsProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 
 

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import io
 from abc import abstractmethod
-from typing import TYPE_CHECKING, NamedTuple, Protocol, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from streamlit import util
 from streamlit.runtime.stats import CacheStatsProvider

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Final, List, cast
+from typing import TYPE_CHECKING, Callable, Final, cast
 
 from streamlit.logger import get_logger
 from streamlit.runtime.app_session import AppSession
@@ -162,6 +162,6 @@ class WebsocketSessionManager(SessionManager):
 
     def list_sessions(self) -> list[SessionInfo]:
         return (
-            cast(List[SessionInfo], self.list_active_sessions())
+            cast(list[SessionInfo], self.list_active_sessions())
             + self._session_storage.list()
         )

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -67,9 +67,9 @@ class WebsocketSessionManager(SessionManager):
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
-        assert not (
-            existing_session_id and session_id_override
-        ), "Only one of existing_session_id and session_id_override should be truthy"
+        assert not (existing_session_id and session_id_override), (
+            "Only one of existing_session_id and session_id_override should be truthy"
+        )
 
         if existing_session_id in self._active_session_info_by_id:
             _LOGGER.warning(
@@ -109,9 +109,9 @@ class WebsocketSessionManager(SessionManager):
             "Created new session for client %s. Session ID: %s", id(client), session.id
         )
 
-        assert (
-            session.id not in self._active_session_info_by_id
-        ), f"session.id '{session.id}' registered multiple times!"
+        assert session.id not in self._active_session_info_by_id, (
+            f"session.id '{session.id}' registered multiple times!"
+        )
 
         self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
         return session.id

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -18,8 +18,9 @@ import inspect
 import tempfile
 import textwrap
 import traceback
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import MagicMock
 from urllib import parse
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -18,7 +18,6 @@ import inspect
 import tempfile
 import textwrap
 import traceback
-from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import MagicMock
@@ -89,6 +88,8 @@ from streamlit.testing.v1.util import patch_config_options
 from streamlit.util import HASHLIB_KWARGS, calc_md5
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.proto.WidgetStates_pb2 import WidgetStates
 
 TMP_DIR = tempfile.TemporaryDirectory()

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import textwrap
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import date, datetime, time, timedelta
 from typing import (
@@ -23,7 +24,6 @@ from typing import (
     Callable,
     Generic,
     List,
-    Sequence,
     TypeVar,
     Union,
     cast,

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -23,7 +23,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    List,
     TypeVar,
     Union,
     cast,
@@ -728,7 +727,7 @@ class ButtonGroup(Widget, Generic[T]):
         else:
             state = self.root.session_state
             assert state
-            return cast(List[T], state[self.id])
+            return cast(list[T], state[self.id])
 
     @property
     def indices(self) -> Sequence[int]:
@@ -816,7 +815,7 @@ class Multiselect(Widget, Generic[T]):
         else:
             state = self.root.session_state
             assert state
-            return cast(List[T], state[self.id])
+            return cast(list[T], state[self.id])
 
     @property
     def indices(self) -> Sequence[int]:

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -77,9 +77,9 @@ class LocalScriptRunner(ScriptRunner):
         ) -> None:
             # Assert that we're not getting unexpected `sender` params
             # from ScriptRunner.on_event
-            assert (
-                sender is None or sender == self
-            ), "Unexpected ScriptRunnerEvent sender!"
+            assert sender is None or sender == self, (
+                "Unexpected ScriptRunnerEvent sender!"
+            )
 
             self.events.append(event)
             self.event_data.append(kwargs)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -20,20 +20,24 @@ import dataclasses
 import re
 import types
 from collections import UserList, deque
-from collections.abc import ItemsView, KeysView, ValuesView
+from collections.abc import (
+    AsyncGenerator,
+    Generator,
+    ItemsView,
+    Iterable,
+    KeysView,
+    Mapping,
+    Sequence,
+    ValuesView,
+)
 from enum import EnumMeta
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
     Final,
-    Generator,
-    Iterable,
     Literal,
-    Mapping,
     NamedTuple,
     Protocol,
-    Sequence,
     Tuple,
     TypeVar,
     Union,

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -38,7 +38,6 @@ from typing import (
     Literal,
     NamedTuple,
     Protocol,
-    Tuple,
     TypeVar,
     Union,
     overload,
@@ -60,7 +59,7 @@ T = TypeVar("T")
 
 # we define our own type here because mypy doesn't seem to support the shape type and
 # reports unreachable code. When mypy supports it, we can remove this custom type.
-NumpyShape: TypeAlias = Tuple[int, ...]
+NumpyShape: TypeAlias = tuple[int, ...]
 
 
 class SupportsStr(Protocol):

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -14,11 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from typing import (
     TYPE_CHECKING,
     Final,
-    Iterator,
-    Mapping,
     NoReturn,
     Union,
 )

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-from typing import Callable, Type, Union
+from typing import Callable, Union
 
 import streamlit.watcher
 from streamlit import cli_util, config, env_util
@@ -46,9 +46,9 @@ class NoOpPathWatcher:
 # implementation if its import failed (due to missing watchdog module),
 # so we can't reference it directly in this type.
 PathWatcherType = Union[
-    Type["streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher"],
-    Type[PollingPathWatcher],
-    Type[NoOpPathWatcher],
+    type["streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher"],
+    type[PollingPathWatcher],
+    type[NoOpPathWatcher],
 ]
 
 

--- a/lib/streamlit/web/server/authlib_tornado_integration.py
+++ b/lib/streamlit/web/server/authlib_tornado_integration.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from authlib.integrations.base_client import (  # type: ignore[import-untyped]
     FrameworkIntegration,

--- a/lib/streamlit/web/server/authlib_tornado_integration.py
+++ b/lib/streamlit/web/server/authlib_tornado_integration.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from authlib.integrations.base_client import (  # type: ignore[import-untyped]
@@ -24,6 +23,8 @@ from authlib.integrations.base_client import (  # type: ignore[import-untyped]
 from streamlit.runtime.secrets import AttrDict
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.web.server.oidc_mixin import TornadoOAuth
 
 

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import hmac
 import json
-from typing import TYPE_CHECKING, Any, Awaitable, Final
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
 import tornado.concurrent

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import hmac
 import json
-from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
@@ -40,6 +39,8 @@ from streamlit.web.server.server_util import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 _LOGGER: Final = get_logger(__name__)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import os
-from typing import Final, Sequence
+from collections.abc import Sequence
+from typing import Final
 
 import tornado.web
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import tornado.web
 
@@ -27,6 +26,9 @@ from streamlit.web.server.server_util import (
     emit_endpoint_deprecation_notice,
     is_xsrf_enabled,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -19,8 +19,9 @@ import logging
 import mimetypes
 import os
 import sys
+from collections.abc import Awaitable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import tornado.concurrent
 import tornado.locks

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -19,7 +19,6 @@ import logging
 import mimetypes
 import os
 import sys
-from collections.abc import Awaitable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
@@ -64,6 +63,7 @@ from streamlit.web.server.stats_request_handler import StatsRequestHandler
 from streamlit.web.server.upload_file_request_handler import UploadFileRequestHandler
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from ssl import SSLContext
 
 _LOGGER: Final = get_logger(__name__)

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -49,9 +49,9 @@ with (
     import streamlit as st  # noqa: F401
     from streamlit import config, file_util, source_util
 
-    assert (
-        not config._config_options
-    ), "config.get_option() should not be called on file import!"
+    assert not config._config_options, (
+        "config.get_option() should not be called on file import!"
+    )
 
     config_path = file_util.get_streamlit_file_path("config.toml")
     path_exists.side_effect = lambda path: path == config_path

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -36,9 +36,12 @@ unitTest = true
 gatherUsageStats = false
 """
 
-with patch(
-    "streamlit.config.open", mock_open(read_data=CONFIG_FILE_CONTENTS), create=True
-), patch("streamlit.config.os.path.exists") as path_exists:
+with (
+    patch(
+        "streamlit.config.open", mock_open(read_data=CONFIG_FILE_CONTENTS), create=True
+    ),
+    patch("streamlit.config.os.path.exists") as path_exists,
+):
     # Import streamlit even if we don't do anything with it below as we want to
     # be sure to catch any instances of calling config.get_option() when
     # first importing a file. We disallow this because doing so means that we

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -624,11 +624,11 @@ class ConfigTest(unittest.TestCase):
 
         mock_callback = MagicMock(return_value=None)
 
-        with patch.object(config, "_config_options", new=config_options), patch.object(
-            config._on_config_parsed, "connect"
-        ) as patched_connect, patch.object(
-            config._on_config_parsed, "disconnect"
-        ) as patched_disconnect:
+        with (
+            patch.object(config, "_config_options", new=config_options),
+            patch.object(config._on_config_parsed, "connect") as patched_connect,
+            patch.object(config._on_config_parsed, "disconnect") as patched_disconnect,
+        ):
             mock_callback.reset_mock()
             disconnect_callback = config.on_config_parsed(mock_callback, connect_signal)
 

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -210,15 +210,15 @@ class ConfigUtilTest(unittest.TestCase):
             "# This option's description starts from third line."
         )
 
-        assert (
-            description_index > 1
-        ), "Description should not be at the start of the output"
-        assert (
-            lines[description_index - 1].strip() == ""
-        ), "Preceding line should be empty (this line separates config options)"
-        assert (
-            lines[description_index - 2].strip() != ""
-        ), "The line before the preceding line should not be empty (this is the section header)"
+        assert description_index > 1, (
+            "Description should not be at the start of the output"
+        )
+        assert lines[description_index - 1].strip() == "", (
+            "Preceding line should be empty (this line separates config options)"
+        )
+        assert lines[description_index - 2].strip() != "", (
+            "The line before the preceding line should not be empty (this is the section header)"
+        )
 
     @patch("click.secho")
     def test_description_appears_before_option(self, patched_echo):

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -122,11 +122,16 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
     def test_on_secrets_changed(self):
         conn = MockConnection("my_mock_connection")
 
-        with patch(
-            "streamlit.connections.base_connection.BaseConnection.reset"
-        ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection._secrets",
-            PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
+        with (
+            patch(
+                "streamlit.connections.base_connection.BaseConnection.reset"
+            ) as patched_reset,
+            patch(
+                "streamlit.connections.base_connection.BaseConnection._secrets",
+                PropertyMock(
+                    return_value=AttrDict({"mock_connection": {"new": "secret"}})
+                ),
+            ),
         ):
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_called_once()

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -19,8 +19,9 @@ from __future__ import annotations
 import datetime
 import json
 import unittest
+from collections.abc import Mapping
 from decimal import Decimal
-from typing import Any, Mapping
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -19,9 +19,8 @@ from __future__ import annotations
 import datetime
 import json
 import unittest
-from collections.abc import Mapping
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -53,6 +52,9 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_test_cases import SHARED_TEST_CASES, CaseMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def _get_arrow_schema(df: pd.DataFrame) -> pa.Schema:

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -282,9 +282,12 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         and not image_to_url - to throw an error.)
         """
         # Mock out save_image_data to avoid polluting the cache for later tests
-        with mock.patch(
-            "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_media_data"):
+        with (
+            mock.patch(
+                "streamlit.runtime.media_file_manager.MediaFileManager.add"
+            ) as mock_mfm_add,
+            mock.patch("streamlit.runtime.caching.save_media_data"),
+        ):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             result = image_to_url(

--- a/lib/tests/streamlit/elements/media_test.py
+++ b/lib/tests/streamlit/elements/media_test.py
@@ -59,9 +59,12 @@ class MediaTest(DeltaGeneratorTestCase):
         """st.audio + st.video should register bytes and filenames with the
         MediaFileManager. URL-based media does not go through the MediaFileManager.
         """
-        with mock.patch(
-            "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_media_data"):
+        with (
+            mock.patch(
+                "streamlit.runtime.media_file_manager.MediaFileManager.add"
+            ) as mock_mfm_add,
+            mock.patch("streamlit.runtime.caching.save_media_data"),
+        ):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             if media_kind is MockMediaKind.AUDIO:

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -150,7 +150,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f'{hashlib.md5(b"default").hexdigest()}.vtt',
+            filename=f"{hashlib.md5(b'default').hexdigest()}.vtt",
         )
         self.assertIn(expected_subtitle_url, el.video.subtitles[0].url)
 
@@ -173,12 +173,12 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_empty_subtitle_url = _calculate_file_id(
             b"",
             "text/vtt",
-            filename=f'{hashlib.md5(b"").hexdigest()}.vtt',
+            filename=f"{hashlib.md5(b'').hexdigest()}.vtt",
         )
         expected_english_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f'{hashlib.md5(b"English").hexdigest()}.vtt',
+            filename=f"{hashlib.md5(b'English').hexdigest()}.vtt",
         )
         self.assertIn(expected_empty_subtitle_url, el.video.subtitles[0].url)
         self.assertIn(expected_english_subtitle_url, el.video.subtitles[1].url)
@@ -197,7 +197,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_english_subtitle_url = _calculate_file_id(
             fake_sub_content,
             "text/vtt",
-            filename=f'{hashlib.md5(b"default").hexdigest()}.vtt',
+            filename=f"{hashlib.md5(b'default').hexdigest()}.vtt",
         )
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -14,11 +14,14 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from parameterized import parameterized
 
 from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class FileUploaderUtilsTest(unittest.TestCase):

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import Sequence
+from collections.abc import Sequence
 
 from parameterized import parameterized
 

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -67,9 +67,11 @@ class FileUtilTest(unittest.TestCase):
 
         dirname = os.path.dirname(file_util.get_streamlit_file_path(FILENAME))
         # patch streamlit.*.os.makedirs instead of os.makedirs for py35 compat
-        with patch("streamlit.file_util.open", mock_open()) as open, patch(
-            "streamlit.file_util.os.makedirs"
-        ) as makedirs, file_util.streamlit_write(FILENAME) as output:
+        with (
+            patch("streamlit.file_util.open", mock_open()) as open,
+            patch("streamlit.file_util.os.makedirs") as makedirs,
+            file_util.streamlit_write(FILENAME) as output,
+        ):
             output.write("some data")
             open().write.assert_called_once_with("some data")
             makedirs.assert_called_once_with(dirname, exist_ok=True)
@@ -78,13 +80,15 @@ class FileUtilTest(unittest.TestCase):
     @patch("streamlit.env_util.IS_DARWIN", True)
     def test_streamlit_write_exception(self):
         """Test streamlitfile_util.streamlit_write."""
-        with patch("streamlit.file_util.open", mock_open()) as p, patch(
-            "streamlit.file_util.os.makedirs"
+        with (
+            patch("streamlit.file_util.open", mock_open()) as p,
+            patch("streamlit.file_util.os.makedirs"),
         ):
             p.side_effect = OSError(errno.EINVAL, "[Errno 22] Invalid argument")
-            with pytest.raises(errors.Error) as e, file_util.streamlit_write(
-                FILENAME
-            ) as output:
+            with (
+                pytest.raises(errors.Error) as e,
+                file_util.streamlit_write(FILENAME) as output,
+            ):
                 output.write("some data")
             error_msg = (
                 "Unable to write file: /some/cache/file\n"

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -53,8 +53,9 @@ class GitUtilTest(unittest.TestCase):
         prompt the user for credentials. We don't want to do this, so
         repo.is_valid() returns False for old gits.
         """
-        with patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock, patch(
-            "streamlit.git_util.os"
+        with (
+            patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock,
+            patch("streamlit.git_util.os"),
         ):
             git_mock.return_value.version_info = (1, 6, 4)  # An old git version
             repo = GitRepo(".")
@@ -62,8 +63,9 @@ class GitUtilTest(unittest.TestCase):
             self.assertEqual((1, 6, 4), repo.git_version)
 
     def test_git_repo_valid(self):
-        with patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock, patch(
-            "streamlit.git_util.os"
+        with (
+            patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock,
+            patch("streamlit.git_util.os"),
         ):
             git_mock.return_value.version_info = (2, 20, 3)  # A recent git version
             repo = GitRepo(".")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -73,12 +73,15 @@ def _create_test_session(
     if event_loop is None:
         event_loop = MagicMock()
 
-    with patch(
-        "streamlit.runtime.app_session.asyncio.get_running_loop",
-        return_value=event_loop,
-    ), patch(
-        "streamlit.runtime.app_session.LocalSourcesWatcher",
-        MagicMock(spec=LocalSourcesWatcher),
+    with (
+        patch(
+            "streamlit.runtime.app_session.asyncio.get_running_loop",
+            return_value=event_loop,
+        ),
+        patch(
+            "streamlit.runtime.app_session.LocalSourcesWatcher",
+            MagicMock(spec=LocalSourcesWatcher),
+        ),
     ):
         return AppSession(
             script_data=ScriptData("/fake/script_path.py", is_hello=False),
@@ -568,13 +571,17 @@ class AppSessionTest(unittest.TestCase):
     def test_disconnect_file_watchers(self, patched_secrets_disconnect):
         session = _create_test_session()
 
-        with patch.object(
-            session._local_sources_watcher, "close"
-        ) as patched_close_local_sources_watcher, patch.object(
-            session, "_stop_config_listener"
-        ) as patched_stop_config_listener, patch.object(
-            session, "_stop_pages_listener"
-        ) as patched_stop_pages_listener:
+        with (
+            patch.object(
+                session._local_sources_watcher, "close"
+            ) as patched_close_local_sources_watcher,
+            patch.object(
+                session, "_stop_config_listener"
+            ) as patched_stop_config_listener,
+            patch.object(
+                session, "_stop_pages_listener"
+            ) as patched_stop_pages_listener,
+        ):
             session.disconnect_file_watchers()
 
             patched_close_local_sources_watcher.assert_called_once()
@@ -983,11 +990,14 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         handle_backmsg_exception.
         """
         session = _create_test_session(asyncio.get_running_loop())
-        with patch.object(
-            session, "handle_backmsg_exception"
-        ) as handle_backmsg_exception, patch.object(
-            session, "_handle_clear_cache_request"
-        ) as handle_clear_cache_request:
+        with (
+            patch.object(
+                session, "handle_backmsg_exception"
+            ) as handle_backmsg_exception,
+            patch.object(
+                session, "_handle_clear_cache_request"
+            ) as handle_clear_cache_request,
+        ):
             error = Exception("explode!")
             handle_clear_cache_request.side_effect = error
 
@@ -1010,11 +1020,14 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
     @patch("streamlit.runtime.app_session._LOGGER")
     async def test_handles_app_heartbeat_backmsg(self, patched_logger):
         session = _create_test_session(asyncio.get_running_loop())
-        with patch.object(
-            session, "handle_backmsg_exception"
-        ) as handle_backmsg_exception, patch.object(
-            session, "_handle_app_heartbeat_request"
-        ) as handle_app_heartbeat_request:
+        with (
+            patch.object(
+                session, "handle_backmsg_exception"
+            ) as handle_backmsg_exception,
+            patch.object(
+                session, "_handle_app_heartbeat_request"
+            ) as handle_app_heartbeat_request,
+        ):
             msg = BackMsg()
             msg.app_heartbeat = True
             session.handle_backmsg(msg)

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -435,9 +435,10 @@ class CacheDataPersistTest(DeltaGeneratorTestCase):
 
         mock_os_remove.assert_not_called()
 
-        with patch(
-            "os.listdir", MagicMock(return_value=created_files_base_names)
-        ), patch("os.path.isdir", MagicMock(return_value=True)):
+        with (
+            patch("os.listdir", MagicMock(return_value=created_files_base_names)),
+            patch("os.path.isdir", MagicMock(return_value=True)),
+        ):
             # Clear foo's cache
             foo.clear()
 
@@ -632,9 +633,12 @@ class CacheDataValidateParamsTest(DeltaGeneratorTestCase):
         Runtime._instance = mock_runtime
 
     def test_error_logged_and_raised_on_improperly_configured_cache_data(self):
-        with self.assertRaises(InvalidCacheStorageContext) as e, self.assertLogs(
-            "streamlit.runtime.caching.cache_data_api", level=logging.ERROR
-        ) as logs:
+        with (
+            self.assertRaises(InvalidCacheStorageContext) as e,
+            self.assertLogs(
+                "streamlit.runtime.caching.cache_data_api", level=logging.ERROR
+            ) as logs,
+        ):
 
             @st.cache_data(persist="disk")
             def foo():

--- a/lib/tests/streamlit/runtime/credentials_test.py
+++ b/lib/tests/streamlit/runtime/credentials_test.py
@@ -197,9 +197,10 @@ class CredentialsClassTest(unittest.TestCase):
         """Test Credentials.check_activated() has an error."""
         c = Credentials.get_current()
         c.activation = _Activation("some_email", True)
-        with patch.object(c, "load", side_effect=Exception("Some error")), patch(
-            "streamlit.runtime.credentials._exit"
-        ) as p:
+        with (
+            patch.object(c, "load", side_effect=Exception("Some error")),
+            patch("streamlit.runtime.credentials._exit") as p,
+        ):
             c._check_activated(auto_resolve=False)
             p.assert_called_once_with("Some error")
 
@@ -222,9 +223,12 @@ class CredentialsClassTest(unittest.TestCase):
         )
 
         # patch streamlit.*.os.makedirs instead of os.makedirs for py35 compat
-        with patch(
-            "streamlit.runtime.credentials.open", mock_open(), create=True
-        ) as open, patch("streamlit.runtime.credentials.os.makedirs") as make_dirs:
+        with (
+            patch(
+                "streamlit.runtime.credentials.open", mock_open(), create=True
+            ) as open,
+            patch("streamlit.runtime.credentials.os.makedirs") as make_dirs,
+        ):
             c.save()
 
             make_dirs.assert_called_once_with(streamlit_root_path, exist_ok=True)
@@ -266,9 +270,11 @@ class CredentialsClassTest(unittest.TestCase):
         c = Credentials.get_current()
         c.activation = None
 
-        with patch.object(
-            c, "load", side_effect=RuntimeError("Some error")
-        ), patch.object(c, "save") as patched_save, patch(PROMPT) as patched_prompt:
+        with (
+            patch.object(c, "load", side_effect=RuntimeError("Some error")),
+            patch.object(c, "save") as patched_save,
+            patch(PROMPT) as patched_prompt,
+        ):
             patched_prompt.side_effect = ["user@domain.com"]
             c.activate()
             patched_save.assert_called_once()
@@ -294,9 +300,13 @@ class CredentialsClassTest(unittest.TestCase):
     )
     def test_Credentials_reset_error(self):
         """Test Credentials.reset() with error."""
-        with patch(
-            "streamlit.runtime.credentials.os.remove", side_effect=OSError("some error")
-        ), patch("streamlit.runtime.credentials._LOGGER") as p:
+        with (
+            patch(
+                "streamlit.runtime.credentials.os.remove",
+                side_effect=OSError("some error"),
+            ),
+            patch("streamlit.runtime.credentials._LOGGER") as p,
+        ):
             Credentials.reset()
             p.exception.assert_called_once_with("Error removing credentials file.")
 

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import Callable, Tuple
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -569,7 +569,7 @@ inside_container_writing_apps: list[APP_FUNCTION] = [
     _run_fragment_writes_to_nested_inside_container_app,
 ]
 
-TEST_TUPLE = Tuple[str, APP_FUNCTION, ELEMENT_PRODUCER]
+TEST_TUPLE = tuple[str, APP_FUNCTION, ELEMENT_PRODUCER]
 
 
 def get_test_tuples(

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -51,15 +51,17 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /etc"""
         file_data = "etc"
 
-        with patch(
-            "streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
-            "streamlit.runtime.metrics_util.open",
-            mock_open(read_data=file_data),
-            create=True,
-        ), patch(
-            "streamlit.runtime.metrics_util.os.path.isfile",
-            side_effect=lambda path: path == "/etc/machine-id",
+        with (
+            patch("streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC),
+            patch(
+                "streamlit.runtime.metrics_util.open",
+                mock_open(read_data=file_data),
+                create=True,
+            ),
+            patch(
+                "streamlit.runtime.metrics_util.os.path.isfile",
+                side_effect=lambda path: path == "/etc/machine-id",
+            ),
         ):
             machine_id = metrics_util._get_machine_id_v3()
         assert machine_id == file_data
@@ -68,15 +70,17 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /var/lib/dbus"""
         file_data = "dbus"
 
-        with patch(
-            "streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
-            "streamlit.runtime.metrics_util.open",
-            mock_open(read_data=file_data),
-            create=True,
-        ), patch(
-            "streamlit.runtime.metrics_util.os.path.isfile",
-            side_effect=lambda path: path == "/var/lib/dbus/machine-id",
+        with (
+            patch("streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC),
+            patch(
+                "streamlit.runtime.metrics_util.open",
+                mock_open(read_data=file_data),
+                create=True,
+            ),
+            patch(
+                "streamlit.runtime.metrics_util.os.path.isfile",
+                side_effect=lambda path: path == "/var/lib/dbus/machine-id",
+            ),
         ):
             machine_id = metrics_util._get_machine_id_v3()
         assert machine_id == file_data
@@ -84,9 +88,10 @@ class MetricsUtilTest(unittest.TestCase):
     def test_machine_id_v3_from_node(self):
         """Test getting the machine id as the mac address"""
 
-        with patch(
-            "streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC
-        ), patch("streamlit.runtime.metrics_util.os.path.isfile", return_value=False):
+        with (
+            patch("streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC),
+            patch("streamlit.runtime.metrics_util.os.path.isfile", return_value=False),
+        ):
             machine_id = metrics_util._get_machine_id_v3()
         assert machine_id == MAC
 

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -232,13 +232,17 @@ class RuntimeTest(RuntimeTestCase):
         )
         session = self.runtime._session_mgr.get_session_info(session_id).session
 
-        with patch.object(
-            self.runtime._session_mgr, "disconnect_session", new=MagicMock()
-        ) as patched_disconnect_session, patch.object(
-            self.runtime, "_on_session_disconnected", new=MagicMock()
-        ) as patched_on_session_disconnected, patch.object(
-            self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
-        ) as patched_remove_refs_for_session:
+        with (
+            patch.object(
+                self.runtime._session_mgr, "disconnect_session", new=MagicMock()
+            ) as patched_disconnect_session,
+            patch.object(
+                self.runtime, "_on_session_disconnected", new=MagicMock()
+            ) as patched_on_session_disconnected,
+            patch.object(
+                self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
+            ) as patched_remove_refs_for_session,
+        ):
             self.runtime.disconnect_session(session_id)
             patched_disconnect_session.assert_called_once_with(session_id)
             patched_on_session_disconnected.assert_called_once()
@@ -252,13 +256,17 @@ class RuntimeTest(RuntimeTestCase):
         )
         session = self.runtime._session_mgr.get_session_info(session_id).session
 
-        with patch.object(
-            self.runtime._session_mgr, "close_session", new=MagicMock()
-        ) as patched_close_session, patch.object(
-            self.runtime, "_on_session_disconnected", new=MagicMock()
-        ) as patched_on_session_disconnected, patch.object(
-            self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
-        ) as patched_remove_refs_for_session:
+        with (
+            patch.object(
+                self.runtime._session_mgr, "close_session", new=MagicMock()
+            ) as patched_close_session,
+            patch.object(
+                self.runtime, "_on_session_disconnected", new=MagicMock()
+            ) as patched_on_session_disconnected,
+            patch.object(
+                self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
+            ) as patched_remove_refs_for_session,
+        ):
             self.runtime.close_session(session_id)
             patched_close_session.assert_called_once_with(session_id)
             patched_on_session_disconnected.assert_called_once()

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -87,9 +87,9 @@ class MockSessionManager(SessionManager):
                 session_id_override=session_id_override,
             )
 
-        assert (
-            session.id not in self._session_info_by_id
-        ), f"session.id '{session.id}' registered multiple times!"
+        assert session.id not in self._session_info_by_id, (
+            f"session.id '{session.id}' registered multiple times!"
+        )
 
         self._session_info_by_id[session.id] = SessionInfo(client, session)
         return session.id

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -70,10 +70,13 @@ class MockSessionManager(SessionManager):
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
-        with mock.patch(
-            "streamlit.runtime.scriptrunner.ScriptRunner", new=mock.MagicMock()
-        ), mock.patch.object(
-            PagesManager, "get_pages", mock.MagicMock(return_value={})
+        with (
+            mock.patch(
+                "streamlit.runtime.scriptrunner.ScriptRunner", new=mock.MagicMock()
+            ),
+            mock.patch.object(
+                PagesManager, "get_pages", mock.MagicMock(return_value={})
+            ),
         ):
             session = AppSession(
                 script_data=script_data,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -269,7 +269,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             os.path.realpath(scriptrunner._main_script_path),
             os.path.realpath(sys.modules["__main__"].__file__),
-            (" ScriptRunner should set the __main__.__file__attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__ attribute correctly"),
         )
 
         Runtime._instance.media_file_mgr.clear_session_refs.assert_called_once()
@@ -994,7 +994,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             os.path.join(os.path.dirname(__file__), "test_data", "good_script2.py"),
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__ attribute correctly"),
         )
 
         shutdown_data = scriptrunner.event_data[-1]
@@ -1033,7 +1033,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__ attribute correctly"),
         )
 
     @patch(
@@ -1073,7 +1073,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__ attribute correctly"),
         )
 
     def _assert_no_exceptions(self, scriptrunner: TestScriptRunner) -> None:

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -269,7 +269,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             os.path.realpath(scriptrunner._main_script_path),
             os.path.realpath(sys.modules["__main__"].__file__),
-            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__attribute correctly"),
         )
 
         Runtime._instance.media_file_mgr.clear_session_refs.assert_called_once()
@@ -994,7 +994,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             os.path.join(os.path.dirname(__file__), "test_data", "good_script2.py"),
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__attribute correctly"),
         )
 
         shutdown_data = scriptrunner.event_data[-1]
@@ -1033,7 +1033,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__attribute correctly"),
         )
 
     @patch(
@@ -1073,7 +1073,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(
             scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
-            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+            (" ScriptRunner should set the __main__.__file__attribute correctly"),
         )
 
     def _assert_no_exceptions(self, scriptrunner: TestScriptRunner) -> None:
@@ -1175,9 +1175,9 @@ class TestScriptRunner(ScriptRunner):
         ) -> None:
             # Assert that we're not getting unexpected `sender` params
             # from ScriptRunner.on_event
-            assert (
-                sender is None or sender == self
-            ), "Unexpected ScriptRunnerEvent sender!"
+            assert sender is None or sender == self, (
+                "Unexpected ScriptRunnerEvent sender!"
+            )
 
             self.events.append(event)
             self.event_data.append(kwargs)

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from collections.abc import Mapping, MutableMapping
 from collections.abc import Mapping as MappingABC
 from collections.abc import MutableMapping as MutableMappingABC
-from typing import Mapping, MutableMapping
 from unittest.mock import MagicMock, mock_open, patch
 
 from parameterized import parameterized

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -435,15 +435,15 @@ class ComputeElementIdTests(DeltaGeneratorTestCase):
 
         # Get call kwargs from patched_compute_element_id
         call_kwargs = patched_compute_element_id.call_args[1]
-        assert (
-            "active_script_hash" in call_kwargs
-        ), "active_script_hash is expected to always be included "
+        assert "active_script_hash" in call_kwargs, (
+            "active_script_hash is expected to always be included "
+        )
         "in element ID calculation."
 
         # Elements that don't set a form ID
-        assert (
-            call_kwargs.get("form_id") == expected_form_id
-        ), "form_id is expected to be included in element ID calculation."
+        assert call_kwargs.get("form_id") == expected_form_id, (
+            "form_id is expected to be included in element ID calculation."
+        )
 
     @parameterized.expand(WIDGET_ELEMENTS)
     def test_triggers_duplicate_id_error(self, _element_name: str, widget_func):

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -32,12 +32,14 @@ from tests.testutil import patch_config_options
 class FileWatcherTest(unittest.TestCase):
     @patch_config_options({"server.fileWatcherType": "watchdog"})
     def test_report_watchdog_availability_mac(self):
-        with patch(
-            "streamlit.watcher.path_watcher._is_watchdog_available",
-            return_value=False,
-        ), patch("streamlit.env_util.IS_DARWIN", new=True), patch(
-            "click.secho"
-        ) as mock_echo:
+        with (
+            patch(
+                "streamlit.watcher.path_watcher._is_watchdog_available",
+                return_value=False,
+            ),
+            patch("streamlit.env_util.IS_DARWIN", new=True),
+            patch("click.secho") as mock_echo,
+        ):
             streamlit.watcher.path_watcher.report_watchdog_availability()
 
         msg = "\n  $ xcode-select --install"
@@ -58,30 +60,39 @@ class FileWatcherTest(unittest.TestCase):
 
     @patch_config_options({"server.fileWatcherType": "poll"})
     def test_no_watchdog_suggestion_for_poll_type(self):
-        with patch(
-            "streamlit.watcher.path_watcher._is_watchdog_available", return_value=False
-        ), patch("streamlit.env_util.IS_DARWIN", new=False), patch(
-            "click.secho"
-        ) as mock_echo:
+        with (
+            patch(
+                "streamlit.watcher.path_watcher._is_watchdog_available",
+                return_value=False,
+            ),
+            patch("streamlit.env_util.IS_DARWIN", new=False),
+            patch("click.secho") as mock_echo,
+        ):
             streamlit.watcher.path_watcher.report_watchdog_availability()
         mock_echo.assert_not_called()
 
     @patch_config_options({"server.fileWatcherType": "none"})
     def test_no_watchdog_suggestion_for_none_type(self):
-        with patch(
-            "streamlit.watcher.path_watcher._is_watchdog_available", return_value=False
-        ), patch("streamlit.env_util.IS_DARWIN", new=False), patch(
-            "click.secho"
-        ) as mock_echo:
+        with (
+            patch(
+                "streamlit.watcher.path_watcher._is_watchdog_available",
+                return_value=False,
+            ),
+            patch("streamlit.env_util.IS_DARWIN", new=False),
+            patch("click.secho") as mock_echo,
+        ):
             streamlit.watcher.path_watcher.report_watchdog_availability()
         mock_echo.assert_not_called()
 
     def test_report_watchdog_availability_nonmac(self):
-        with patch(
-            "streamlit.watcher.path_watcher._is_watchdog_available", return_value=False
-        ), patch("streamlit.env_util.IS_DARWIN", new=False), patch(
-            "click.secho"
-        ) as mock_echo:
+        with (
+            patch(
+                "streamlit.watcher.path_watcher._is_watchdog_available",
+                return_value=False,
+            ),
+            patch("streamlit.env_util.IS_DARWIN", new=False),
+            patch("click.secho") as mock_echo,
+        ):
             streamlit.watcher.path_watcher.report_watchdog_availability()
 
         msg = ""
@@ -120,11 +131,12 @@ class FileWatcherTest(unittest.TestCase):
         for watcher_config, watchdog_available, path_watcher_class in subtest_params:
             test_name = f"config.fileWatcherType={watcher_config}, watcher_available={watchdog_available}"
             with self.subTest(test_name):
-                with patch_config_options(
-                    {"server.fileWatcherType": watcher_config}
-                ), patch(
-                    "streamlit.watcher.path_watcher._is_watchdog_available",
-                    return_value=watchdog_available,
+                with (
+                    patch_config_options({"server.fileWatcherType": watcher_config}),
+                    patch(
+                        "streamlit.watcher.path_watcher._is_watchdog_available",
+                        return_value=watchdog_available,
+                    ),
                 ):
                     # Test get_default_path_watcher_class() result
                     self.assertEqual(

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -50,8 +50,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             {"browser.serverAddress": "the-address"}
         )
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(True)
 
@@ -67,8 +68,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             {"browser.serverAddress": "the-address"}
         )
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -89,8 +91,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         mock_get_internal_ip.return_value = "internal-ip"
         mock_get_external_ip.return_value = "external-ip"
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -114,8 +117,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         mock_get_internal_ip.return_value = "internal-ip"
         mock_get_external_ip.return_value = None
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -139,8 +143,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         mock_get_internal_ip.return_value = None
         mock_get_external_ip.return_value = "external-ip"
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -160,8 +165,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
         mock_get_internal_ip.return_value = "internal-ip"
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -184,8 +190,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
         mock_get_internal_ip.return_value = "internal-ip"
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -209,8 +216,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
         mock_get_internal_ip.return_value = "internal-ip"
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -234,8 +242,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
         mock_get_internal_ip.return_value = None
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -272,8 +281,9 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             }
         )
 
-        with patch.object(config, "get_option", new=mock_get_option), patch.object(
-            config, "is_manually_set", new=mock_is_manually_set
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
         ):
             bootstrap._print_url(False)
 
@@ -325,9 +335,10 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         folder total size is too large.
         """
 
-        with testutil.patch_config_options(
-            {"server.enableStaticServing": True}
-        ), patch.object(config, "set_option") as mock_set_option:
+        with (
+            testutil.patch_config_options({"server.enableStaticServing": True}),
+            patch.object(config, "set_option") as mock_set_option,
+        ):
             bootstrap._maybe_print_static_folder_warning("app_root/main_script_path")
             mock_echo.assert_called_once_with(
                 "WARNING: Static folder size is larger than 1GB. "

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -78,18 +78,22 @@ class CliTest(unittest.TestCase):
 
     def test_run_existing_file_argument(self):
         """streamlit run succeeds if an existing file is passed."""
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertEqual(0, result.exit_code)
 
     def test_run_non_existing_file_argument(self):
         """streamlit run should fail if a non existing file is passed."""
 
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=False):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=False),
+        ):
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertNotEqual(0, result.exit_code)
         self.assertIn("File does not exist", result.output)
@@ -108,9 +112,11 @@ class CliTest(unittest.TestCase):
     def test_run_valid_url(self, temp_dir):
         """streamlit run succeeds if an existing url is passed."""
 
-        with patch("streamlit.url_util.is_url", return_value=True), patch(
-            "streamlit.web.cli._main_run"
-        ), requests_mock.mock() as m:
+        with (
+            patch("streamlit.url_util.is_url", return_value=True),
+            patch("streamlit.web.cli._main_run"),
+            requests_mock.mock() as m,
+        ):
             file_content = b"content"
             m.get("http://url/app.py", content=file_content)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
@@ -127,9 +133,11 @@ class CliTest(unittest.TestCase):
         url is passed.
         """
 
-        with patch("streamlit.url_util.is_url", return_value=True), patch(
-            "streamlit.web.cli._main_run"
-        ), requests_mock.mock() as m:
+        with (
+            patch("streamlit.url_util.is_url", return_value=True),
+            patch("streamlit.web.cli._main_run"),
+            requests_mock.mock() as m,
+        ):
             m.get("http://url/app.py", exc=requests.exceptions.RequestException)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
@@ -140,8 +148,9 @@ class CliTest(unittest.TestCase):
 
     def test_run_arguments(self):
         """The correct command line should be passed downstream."""
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "os.path.exists", return_value=True
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("os.path.exists", return_value=True),
         ):
             with patch("streamlit.web.cli._main_run") as mock_main_run:
                 result = self.runner.invoke(
@@ -163,9 +172,11 @@ class CliTest(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_run_command_with_flag_config_options(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(
                 cli, ["run", "file_name.py", "--server.port=8502"]
             )
@@ -176,9 +187,11 @@ class CliTest(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_run_command_with_multiple_secrets_path_single_value(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(
                 cli, ["run", "file_name.py", "--secrets.files=secrets1.toml"]
             )
@@ -189,9 +202,11 @@ class CliTest(unittest.TestCase):
         assert result.exit_code == 0
 
     def test_run_command_with_multiple_secrets_path_multiple_value(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(
                 cli,
                 [
@@ -212,9 +227,11 @@ class CliTest(unittest.TestCase):
 
     @parameterized.expand(["mapbox.token", "server.cookieSecret"])
     def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(
                 cli, ["run", "file_name.py", f"--{sensitive_option}=TESTSECRET"]
             )
@@ -285,11 +302,14 @@ class CliTest(unittest.TestCase):
         """If headless mode and no config is present,
         activation should be None."""
         with testutil.patch_config_options({"server.headless": True}):
-            with patch("streamlit.url_util.is_url", return_value=False), patch(
-                "streamlit.web.bootstrap.run"
-            ), patch("os.path.exists", return_value=True), patch(
-                "streamlit.runtime.credentials._check_credential_file_exists",
-                return_value=False,
+            with (
+                patch("streamlit.url_util.is_url", return_value=False),
+                patch("streamlit.web.bootstrap.run"),
+                patch("os.path.exists", return_value=True),
+                patch(
+                    "streamlit.runtime.credentials._check_credential_file_exists",
+                    return_value=False,
+                ),
             ):
                 result = self.runner.invoke(cli, ["run", "some script.py"])
             from streamlit.runtime.credentials import Credentials
@@ -305,13 +325,17 @@ class CliTest(unittest.TestCase):
         So we call `_check_activated`.
         """
         with testutil.patch_config_options({"server.headless": headless_mode}):
-            with patch("streamlit.url_util.is_url", return_value=False), patch(
-                "streamlit.web.bootstrap.run"
-            ), patch("os.path.exists", return_value=True), mock.patch(
-                "streamlit.runtime.credentials.Credentials._check_activated"
-            ) as mock_check, patch(
-                "streamlit.runtime.credentials._check_credential_file_exists",
-                return_value=True,
+            with (
+                patch("streamlit.url_util.is_url", return_value=False),
+                patch("streamlit.web.bootstrap.run"),
+                patch("os.path.exists", return_value=True),
+                mock.patch(
+                    "streamlit.runtime.credentials.Credentials._check_activated"
+                ) as mock_check,
+                patch(
+                    "streamlit.runtime.credentials._check_credential_file_exists",
+                    return_value=True,
+                ),
             ):
                 result = self.runner.invoke(cli, ["run", "some script.py"])
             self.assertTrue(mock_check.called)
@@ -322,11 +346,14 @@ class CliTest(unittest.TestCase):
         """If headless mode, show a message about usage metrics gathering."""
 
         with testutil.patch_config_options({"server.headless": headless_mode}):
-            with patch("streamlit.url_util.is_url", return_value=False), patch(
-                "os.path.exists", return_value=True
-            ), patch("streamlit.config.is_manually_set", return_value=False), patch(
-                "streamlit.runtime.credentials._check_credential_file_exists",
-                return_value=False,
+            with (
+                patch("streamlit.url_util.is_url", return_value=False),
+                patch("os.path.exists", return_value=True),
+                patch("streamlit.config.is_manually_set", return_value=False),
+                patch(
+                    "streamlit.runtime.credentials._check_credential_file_exists",
+                    return_value=False,
+                ),
             ):
                 result = self.runner.invoke(cli, ["run", "file_name.py"])
 
@@ -376,9 +403,11 @@ class CliTest(unittest.TestCase):
             mock_logger.warning.assert_called_once()
 
     def test_hello_command_with_flag_config_options(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(cli, ["hello", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()
@@ -395,9 +424,11 @@ class CliTest(unittest.TestCase):
             mock_config.assert_called()
 
     def test_config_show_command_with_flag_config_options(self):
-        with patch("streamlit.url_util.is_url", return_value=False), patch(
-            "streamlit.web.cli._main_run"
-        ), patch("os.path.exists", return_value=True):
+        with (
+            patch("streamlit.url_util.is_url", return_value=False),
+            patch("streamlit.web.cli._main_run"),
+            patch("os.path.exists", return_value=True),
+        ):
             result = self.runner.invoke(cli, ["config", "show", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -36,9 +36,12 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_connect_with_no_session_id(self):
-        with self._patch_app_session(), patch.object(
-            self.server._runtime, "connect_session"
-        ) as patched_connect_session:
+        with (
+            self._patch_app_session(),
+            patch.object(
+                self.server._runtime, "connect_session"
+            ) as patched_connect_session,
+        ):
             await self.server.start()
             await self.ws_connect()
 
@@ -50,9 +53,12 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_connect_with_session_id(self):
-        with self._patch_app_session(), patch.object(
-            self.server._runtime, "connect_session"
-        ) as patched_connect_session:
+        with (
+            self._patch_app_session(),
+            patch.object(
+                self.server._runtime, "connect_session"
+            ) as patched_connect_session,
+        ):
             await self.server.start()
             await self.ws_connect(existing_session_id="session_id")
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -239,11 +239,12 @@ class ServerTest(ServerTestCase):
             # Get the server's socket and session for this client
             session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
 
-            with patch.object(
-                session_info.session, "flush_browser_queue"
-            ) as flush_browser_queue, patch.object(
-                session_info.client, "write_message"
-            ) as ws_write_message:
+            with (
+                patch.object(
+                    session_info.session, "flush_browser_queue"
+                ) as flush_browser_queue,
+                patch.object(session_info.client, "write_message") as ws_write_message,
+            ):
                 # Patch flush_browser_queue to simulate a pending message.
                 flush_browser_queue.return_value = [create_dataframe_msg([1, 2, 3])]
 
@@ -350,9 +351,11 @@ class SslServerTest(unittest.TestCase):
         The test checks the behavior whenever one of the two required configuration
         option is set.
         """
-        with patch_config_options({option_name: "/tmp/file"}), pytest.raises(
-            SystemExit
-        ), self.assertLogs("streamlit.web.server.server") as logs:
+        with (
+            patch_config_options({option_name: "/tmp/file"}),
+            pytest.raises(SystemExit),
+            self.assertLogs("streamlit.web.server.server") as logs,
+        ):
             start_listening(mock.MagicMock())
         self.assertEqual(
             logs.output,
@@ -480,12 +483,12 @@ class UnixSocketTest(unittest.TestCase):
         some_socket = object()
 
         mock_server = self.get_httpserver()
-        with patch(
-            "streamlit.web.server.server.HTTPServer", return_value=mock_server
-        ), patch.object(
-            tornado.netutil, "bind_unix_socket", return_value=some_socket
-        ) as bind_unix_socket, patch.dict(
-            os.environ, {"HOME": "/home/superfakehomedir"}
+        with (
+            patch("streamlit.web.server.server.HTTPServer", return_value=mock_server),
+            patch.object(
+                tornado.netutil, "bind_unix_socket", return_value=some_socket
+            ) as bind_unix_socket,
+            patch.dict(os.environ, {"HOME": "/home/superfakehomedir"}),
         ):
             start_listening(app)
 

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -38,12 +38,15 @@ class ServerUtilTest(unittest.TestCase):
             self.assertTrue(server_util.is_url_from_allowed_origins("does not matter"))
 
     def test_is_url_from_allowed_origins_browser_serverAddress(self):
-        with patch(
-            "streamlit.web.server.server_util.config.is_manually_set",
-            side_effect=[True],
-        ), patch(
-            "streamlit.web.server.server_util.config.get_option",
-            side_effect=[True, "browser.server.address"],
+        with (
+            patch(
+                "streamlit.web.server.server_util.config.is_manually_set",
+                side_effect=[True],
+            ),
+            patch(
+                "streamlit.web.server.server_util.config.get_option",
+                side_effect=[True, "browser.server.address"],
+            ),
         ):
             self.assertTrue(
                 server_util.is_url_from_allowed_origins("browser.server.address")

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -89,9 +89,10 @@ class StreamlitWriteTest(unittest.TestCase):
             def _repr_html_(self):
                 return "hello **world**"
 
-        with patch("streamlit.delta_generator.DeltaGenerator.html") as p1, patch(
-            "streamlit.delta_generator.DeltaGenerator.help"
-        ) as p2:
+        with (
+            patch("streamlit.delta_generator.DeltaGenerator.html") as p1,
+            patch("streamlit.delta_generator.DeltaGenerator.help") as p2,
+        ):
             obj = FakeHTMLable()
             st.write(obj)
 
@@ -396,9 +397,12 @@ class StreamlitWriteTest(unittest.TestCase):
         # We patch streamlit.exception to observe it, but we also make sure
         # it's still called (via side_effect). This ensures that it's called
         # with the proper arguments.
-        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as m, patch(
-            "streamlit.delta_generator.DeltaGenerator.exception",
-            side_effect=handle_uncaught_app_exception,
+        with (
+            patch("streamlit.delta_generator.DeltaGenerator.markdown") as m,
+            patch(
+                "streamlit.delta_generator.DeltaGenerator.exception",
+                side_effect=handle_uncaught_app_exception,
+            ),
         ):
             m.side_effect = Exception("some exception")
 
@@ -425,9 +429,10 @@ class StreamlitWriteTest(unittest.TestCase):
 
     def test_sidebar(self):
         """Test st.write in the sidebar."""
-        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as m, patch(
-            "streamlit.delta_generator.DeltaGenerator.help"
-        ) as h:
+        with (
+            patch("streamlit.delta_generator.DeltaGenerator.markdown") as m,
+            patch("streamlit.delta_generator.DeltaGenerator.help") as h,
+        ):
             st.sidebar.write("markdown", st.help)
 
             m.assert_called_once()

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -154,12 +154,12 @@ class TestCLIRegressions:
         reason="Skip version verification when `SKIP_VERSION_CHECK` env var is set",
     )
     def test_streamlit_version(self):
-        assert (
-            STREAMLIT_RELEASE_VERSION != None and STREAMLIT_RELEASE_VERSION != ""
-        ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
-        assert (
-            STREAMLIT_RELEASE_VERSION in self.run_command("streamlit version")
-        ), f"Package version does not match the desired version of {STREAMLIT_RELEASE_VERSION}"
+        assert STREAMLIT_RELEASE_VERSION != None and STREAMLIT_RELEASE_VERSION != "", (
+            "You must set the $STREAMLIT_RELEASE_VERSION env variable"
+        )
+        assert STREAMLIT_RELEASE_VERSION in self.run_command("streamlit version"), (
+            f"Package version does not match the desired version of {STREAMLIT_RELEASE_VERSION}"
+        )
 
     def test_streamlit_activate(self):
         process = subprocess.Popen(
@@ -170,9 +170,9 @@ class TestCLIRegressions:
         process.communicate()
 
         with open(CREDENTIALS_FILE_PATH) as f:
-            assert (
-                "regressiontest@streamlit.io" in f.read()
-            ), "Email address was not found in the credentials file"
+            assert "regressiontest@streamlit.io" in f.read(), (
+                "Email address was not found in the credentials file"
+            )
 
     def test_port_reassigned(self):
         """When starting a new Streamlit session, it will run on port 8501 by default. If 8501 is
@@ -194,9 +194,9 @@ class TestCLIRegressions:
         )
 
         assert ":8501" in out_one, f"Incorrect port. See output:\n{out_one}"
-        assert (
-            "Port 8501 is already in use" in out_two
-        ), f"Incorrect conflict. See output:\n{out_one}"
+        assert "Port 8501 is already in use" in out_two, (
+            f"Incorrect conflict. See output:\n{out_one}"
+        )
 
     def test_cli_defined_port(self):
         out = self.run_single_proc(

--- a/scripts/run_bare_execution_tests.py
+++ b/scripts/run_bare_execution_tests.py
@@ -110,7 +110,7 @@ def main():
         click.secho(
             "\n".join(_command_to_string(command) for command in failed), fg="red"
         )
-        click.secho(f"\n{ len(failed)} failed scripts", fg="red", bold=True)
+        click.secho(f"\n{len(failed)} failed scripts", fg="red", bold=True)
         sys.exit(-1)
 
 


### PR DESCRIPTION
## Describe your changes

In https://github.com/streamlit/streamlit/pull/9919 we set the min Python version to 3.9, so it's time to update the ruff format target version also to Python 3.9. Also, we bump the ruff version from `0.8.6` to `0.9.4`. We also bump the min Python version used by `mypy` from `3.8` to `3.9`.

Fixes:
- [UP035] Import from `collections.abc` instead: `Sequence`, `typing.Tuple` is deprecated, use `tuple` instead
- [UP006] Use `tuple` instead of `Tuple` for type annotation
- [TC003] Move standard library import `collections.abc.*` into a type-checking block

## GitHub Issue Link (if applicable)

## Testing Plan

- No test updates because this is formatting only. Existing tests should catch any issues.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
