### PR TITLE
Remove `rich` from required dependencies

### DIFF
--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -11,7 +11,6 @@ protobuf==3.20
 pyarrow==7.0
 pydeck==0.8.0b4
 requests==2.27
-rich==10.14.0
 tenacity==8.1.0
 toml==0.10.1
 tornado==6.0.3

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -46,7 +46,6 @@ INSTALL_REQUIRES = [
     # upper bound on it.
     "pyarrow>=7.0",
     "requests>=2.27, <3",
-    "rich>=10.14.0, <14",
     "tenacity>=8.1.0, <10",
     "toml>=0.10.1, <2",
     "typing-extensions>=4.4.0, <5",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -474,8 +474,9 @@ _create_option(
     description="""
         Controls whether uncaught app exceptions are logged via the rich library.
 
-        If True and if rich is installed, exception tracebacks will be logged with syntax highlighting and formatting.
-        Rich tracebacks are easier to read and show more code than standard Python tracebacks.
+        If True and if rich is installed, exception tracebacks will be logged with
+        syntax highlighting and formatting. Rich tracebacks are easier to read and
+        show more code than standard Python tracebacks.
 
         If set to False, the default Python traceback formatting will be used.
     """,

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,6 +8,10 @@ matplotlib>=3.3.4
 plotly>=5.3.1
 seaborn>=0.11.2
 watchdog>=2.1.5
+# Optional dependency used for improved exception formatting
+# in Community Cloud:
+rich>=10.14.0
+
 # We still need numpy < 2 for our bokeh tests since
 # bokeh 2.4.3 is incompatible with numpy 2.x:
 numpy<2


### PR DESCRIPTION
## Describe your changes

We have a Python dependency in Streamlit - `rich` - that is almost exclusively used in Community Cloud to get nicer formatting for exceptions in the log viewer. However, it is currently installed for all Streamlit installs, which is suboptimal. The dependency is already implemented in Streamlit in a way that it is optional (only used if installed). We have recently changed that `rich` gets auto-installed on Community Cloud, therefore, we can remove it from Streamlit's required dependencies. 

In a follow-up after the release, we also plan to deprecate and eventually remove the `logger.enableRich` config option and always use `rich` if installed.

## Testing Plan

- No logical changes. Rich is already an optional dependency in the code logic.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
