### PR TITLE
Fix codeql error for needing type string

### DIFF
--- a/frontend/app/src/connection/promiseWithResolversPolyfill.ts
+++ b/frontend/app/src/connection/promiseWithResolversPolyfill.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-if (typeof Promise.withResolvers === undefined) {
+if (typeof Promise.withResolvers === "undefined") {
   Promise.withResolvers = <T>() => {
     let promiseResolve: PromiseWithResolvers<T>["resolve"]
     let promiseReject: PromiseWithResolvers<T>["reject"]


### PR DESCRIPTION
## Describe your changes

Fixed a valid codeql issue where the type should be a string.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
