### PR TITLE
request script rerun when host explicitly requests reconnect

### DIFF
--- a/e2e_playwright/hostframe_app_test.py
+++ b/e2e_playwright/hostframe_app_test.py
@@ -247,9 +247,10 @@ def test_handles_host_terminate_and_restart_websocket_connection_messages(
     assert statuses[1] == "CONNECTING"
     assert statuses[2] == "CONNECTED"
 
-    # Check that the script state of the app indicates not running.
+    # Check that the connection state change triggers a rerun of the app.
+    expect(frame_locator.get_by_test_id("stStatusWidget")).to_be_visible()
     expect(frame_locator.get_by_test_id("stApp")).to_have_attribute(
-        "data-test-script-state", "notRunning"
+        "data-test-script-state", "running"
     )
 
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -79,7 +79,7 @@ import {
 import { showDevelopmentOptions } from "./showDevelopmentOptions"
 import { App, LOG, Props } from "./App"
 
-type viMock = ReturnType<typeof vi.fn>
+type ViMock = ReturnType<typeof vi.fn>
 
 vi.mock("~lib/baseconsts", async () => {
   return {
@@ -2615,7 +2615,7 @@ describe("App", () => {
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as viMock
+        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       sendUpdateWidgetsMessageMock.mockReset()
       act(() => {
@@ -2631,7 +2631,7 @@ describe("App", () => {
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as viMock
+        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -2661,7 +2661,7 @@ describe("App", () => {
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as viMock
+        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -2673,6 +2673,7 @@ describe("App", () => {
 
       // trigger a state transition to RERUN_REQUESTED
       getMockConnectionManager(true)
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(document.body, {
         key: "r",
         which: 82,
@@ -3359,7 +3360,7 @@ describe("App", () => {
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
       const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as viMock
+        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2617,6 +2617,105 @@ describe("App", () => {
         "sendUpdateWidgetsMessage"
       )
 
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Confirm previous session info does not exist
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      expect(sessionInfo.last).toBeFalsy()
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
+    })
+
+    it("requests script rerun if script run was interrupted", () => {
+      renderApp(getProps())
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // trigger a state transition to RUNNING
+      getMockConnectionManager(true)
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: false,
+        scriptIsRunning: true,
+      })
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.DISCONNECTED_FOREVER
+        )
+      })
+
+      // Ensure sessionInfo.last exists so check based on lastRunWasInterrupted
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      expect(sessionInfo.last).toBeTruthy()
+
+      // Initialize spy here to verify triggered from handleConnectionStateChanged
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        widgetStateManager,
+        "sendUpdateWidgetsMessage"
+      )
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
+    })
+
+    it("requests script rerun if wasRerunRequested is true", () => {
+      renderApp(getProps())
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // trigger a state transition to RERUN_REQUESTED
+      getMockConnectionManager(true)
+      // eslint-disable-next-line testing-library/prefer-user-event
+      fireEvent.keyDown(document.body, {
+        key: "r",
+        which: 82,
+      })
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.DISCONNECTED_FOREVER
+        )
+      })
+
+      // Ensure sessionInfo.last exists
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      expect(sessionInfo.last).toBeTruthy()
+
+      // Initialize spy here to verify triggered from handleConnectionStateChanged
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        widgetStateManager,
+        "sendUpdateWidgetsMessage"
+      )
+
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
           ConnectionState.CONNECTED
@@ -2655,47 +2754,6 @@ describe("App", () => {
         )
       })
       expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
-    })
-
-    it("requests script rerun if script was interrupted", () => {
-      renderApp(getProps())
-      const widgetStateManager =
-        getStoredValue<WidgetStateManager>(WidgetStateManager)
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
-
-      // trigger a state transition to RERUN_REQUESTED
-      getMockConnectionManager(true)
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.keyDown(document.body, {
-        key: "r",
-        which: 82,
-      })
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.DISCONNECTED_FOREVER
-        )
-      })
-
-      // Initialize spy here to verify triggered from handleConnectionStateChanged
-      const sendUpdateWidgetsMessageSpy = vi.spyOn(
-        widgetStateManager,
-        "sendUpdateWidgetsMessage"
-      )
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
   })
 
@@ -3340,23 +3398,45 @@ describe("App", () => {
       })
     })
 
-    it("properly handles TERMINATE_WEBSOCKET_CONNECTION and RESTART_WEBSOCKET_CONNECTION messages", () => {
+    it("properly handles TERMINATE_WEBSOCKET_CONNECTION & RESTART_WEBSOCKET_CONNECTION messages", () => {
       prepareHostCommunicationManager()
-
-      const originalConnectionManager = getMockConnectionManager()
+      const connectionMgr = getMockConnectionManager()
 
       fireWindowPostMessage({
         type: "TERMINATE_WEBSOCKET_CONNECTION",
       })
 
-      expect(originalConnectionManager.disconnect).toHaveBeenCalled()
+      expect(connectionMgr.disconnect).toHaveBeenCalled()
 
       fireWindowPostMessage({
         type: "RESTART_WEBSOCKET_CONNECTION",
       })
 
       const newConnectionManager = getMockConnectionManager()
-      expect(newConnectionManager).not.toBe(originalConnectionManager)
+      expect(newConnectionManager).not.toBe(connectionMgr)
+
+      // Ensure sessionInfo.last exists so check based on scriptRunState (wasRerunRequested)
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      expect(sessionInfo.current).toBeTruthy()
+      sessionInfo.setCurrent(mockSessionInfoProps())
+      expect(sessionInfo.last).toBeTruthy()
+
+      // Set up spy to verify triggered from handleConnectionStateChanged
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        getStoredValue<WidgetStateManager>(WidgetStateManager),
+        "sendUpdateWidgetsMessage"
+      )
+
+      // Mock the connection manager's state change
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // Ensure rerun back message triggered
+      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -79,8 +79,6 @@ import {
 import { showDevelopmentOptions } from "./showDevelopmentOptions"
 import { App, LOG, Props } from "./App"
 
-type ViMock = ReturnType<typeof vi.fn>
-
 vi.mock("~lib/baseconsts", async () => {
   return {
     ...(await vi.importActual("~lib/baseconsts")),
@@ -2614,24 +2612,23 @@ describe("App", () => {
       renderApp(getProps())
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
-      const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as ViMock
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        widgetStateManager,
+        "sendUpdateWidgetsMessage"
+      )
 
-      sendUpdateWidgetsMessageMock.mockReset()
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
           ConnectionState.CONNECTED
         )
       })
-      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
+      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
 
-    it("does not request script rerun by default for second run", () => {
+    it("does not request script rerun by default for subsequent run", () => {
       renderApp(getProps())
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
-      const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -2646,22 +2643,24 @@ describe("App", () => {
           ConnectionState.DISCONNECTED_FOREVER
         )
       })
+      // Initialize spy here to verify triggered from handleConnectionStateChanged
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        widgetStateManager,
+        "sendUpdateWidgetsMessage"
+      )
 
-      sendUpdateWidgetsMessageMock.mockReset()
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
           ConnectionState.CONNECTED
         )
       })
-      expect(sendUpdateWidgetsMessageMock).not.toHaveBeenCalled()
+      expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
     })
 
     it("requests script rerun if script was interrupted", () => {
       renderApp(getProps())
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
-      const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as ViMock
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -2685,13 +2684,18 @@ describe("App", () => {
         )
       })
 
-      sendUpdateWidgetsMessageMock.mockReset()
+      // Initialize spy here to verify triggered from handleConnectionStateChanged
+      const sendUpdateWidgetsMessageSpy = vi.spyOn(
+        widgetStateManager,
+        "sendUpdateWidgetsMessage"
+      )
+
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
           ConnectionState.CONNECTED
         )
       })
-      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
+      expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
   })
 
@@ -3353,40 +3357,6 @@ describe("App", () => {
 
       const newConnectionManager = getMockConnectionManager()
       expect(newConnectionManager).not.toBe(originalConnectionManager)
-    })
-
-    it("requests script rerun if host is explicitly reconnecting", () => {
-      prepareHostCommunicationManager()
-      const widgetStateManager =
-        getStoredValue<WidgetStateManager>(WidgetStateManager)
-      const sendUpdateWidgetsMessageMock =
-        widgetStateManager.sendUpdateWidgetsMessage as ViMock
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.DISCONNECTED_FOREVER
-        )
-      })
-
-      fireWindowPostMessage({
-        type: "RESTART_WEBSOCKET_CONNECTION",
-      })
-
-      sendUpdateWidgetsMessageMock.mockReset()
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -79,6 +79,8 @@ import {
 import { showDevelopmentOptions } from "./showDevelopmentOptions"
 import { App, LOG, Props } from "./App"
 
+type viMock = ReturnType<typeof vi.fn>
+
 vi.mock("~lib/baseconsts", async () => {
   return {
     ...(await vi.importActual("~lib/baseconsts")),
@@ -2512,7 +2514,7 @@ describe("App", () => {
   })
 
   describe("App.handleConnectionStateChanged", () => {
-    it("Sends WEBSOCKET_CONNECTED and WEBSOCKET_DISCONNECTED messages", () => {
+    it("sends WEBSOCKET_CONNECTED and WEBSOCKET_DISCONNECTED messages", () => {
       renderApp(getProps())
 
       const connectionManager = getMockConnectionManager(false)
@@ -2545,7 +2547,7 @@ describe("App", () => {
       })
     })
 
-    it("Correctly sets the data-test-connection-state attribute", () => {
+    it("correctly sets the data-test-connection-state attribute", () => {
       renderApp(getProps())
 
       const connectionManager = getMockConnectionManager(false)
@@ -2578,7 +2580,7 @@ describe("App", () => {
       )
     })
 
-    it("Sets attemptingToReconnect to false if DISCONNECTED_FOREVER", () => {
+    it("sets attemptingToReconnect to false if DISCONNECTED_FOREVER", () => {
       renderApp(getProps())
 
       const connectionManager = getMockConnectionManager(false)
@@ -2606,6 +2608,89 @@ describe("App", () => {
         type: "WEBSOCKET_DISCONNECTED",
         attemptingToReconnect: false,
       })
+    })
+
+    it("requests script rerun if this is the first time we've connected", () => {
+      renderApp(getProps())
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const sendUpdateWidgetsMessageMock =
+        widgetStateManager.sendUpdateWidgetsMessage as viMock
+
+      sendUpdateWidgetsMessageMock.mockReset()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
+    })
+
+    it("does not request script rerun by default for second run", () => {
+      renderApp(getProps())
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const sendUpdateWidgetsMessageMock =
+        widgetStateManager.sendUpdateWidgetsMessage as viMock
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.DISCONNECTED_FOREVER
+        )
+      })
+
+      sendUpdateWidgetsMessageMock.mockReset()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageMock).not.toHaveBeenCalled()
+    })
+
+    it("requests script rerun if script was interrupted", () => {
+      renderApp(getProps())
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const sendUpdateWidgetsMessageMock =
+        widgetStateManager.sendUpdateWidgetsMessage as viMock
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // trigger a state transition to RERUN_REQUESTED
+      getMockConnectionManager(true)
+      fireEvent.keyDown(document.body, {
+        key: "r",
+        which: 82,
+      })
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.DISCONNECTED_FOREVER
+        )
+      })
+
+      sendUpdateWidgetsMessageMock.mockReset()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
     })
   })
 
@@ -3267,6 +3352,40 @@ describe("App", () => {
 
       const newConnectionManager = getMockConnectionManager()
       expect(newConnectionManager).not.toBe(originalConnectionManager)
+    })
+
+    it("requests script rerun if host is explicitly reconnecting", () => {
+      prepareHostCommunicationManager()
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const sendUpdateWidgetsMessageMock =
+        widgetStateManager.sendUpdateWidgetsMessage as viMock
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.DISCONNECTED_FOREVER
+        )
+      })
+
+      fireWindowPostMessage({
+        type: "RESTART_WEBSOCKET_CONNECTION",
+      })
+
+      sendUpdateWidgetsMessageMock.mockReset()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+      expect(sendUpdateWidgetsMessageMock).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -371,6 +371,7 @@ export class App extends PureComponent<Props, State> {
       },
       restartWebsocketConnection: () => {
         if (!this.connectionManager) {
+          this.setState({ scriptRunState: ScriptRunState.RERUN_REQUESTED })
           this.initializeConnectionManager()
         }
       },
@@ -633,19 +634,23 @@ export class App extends PureComponent<Props, State> {
 
     if (newState === ConnectionState.CONNECTED) {
       LOG.info("Reconnected to server.")
-
-      const lastRunWasInterrupted =
-        this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED ||
-        this.state.scriptRunState === ScriptRunState.RUNNING
-
       // We request a script rerun if:
       //   1. this is the first time we establish a websocket connection to the
       //      server, or
       //   2. our last script run attempt was interrupted by the websocket
       //      connection dropping, or
-      //   3. the host explicitly requested a reconnect
-      if (!this.sessionInfo.last || lastRunWasInterrupted) {
-        log.info("Requesting a script run.")
+      //   3. the host explicitly requested a reconnect (we trigger scriptRunState to be RERUN_REQUESTED)
+      const lastRunWasInterrupted =
+        this.state.scriptRunState === ScriptRunState.RUNNING
+      const wasRerunRequested =
+        this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
+
+      if (
+        !this.sessionInfo.last ||
+        lastRunWasInterrupted ||
+        wasRerunRequested
+      ) {
+        LOG.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
         this.setState({ dialog: null })
       }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -192,7 +192,6 @@ interface State {
   appConfig: AppConfig
   autoReruns: NodeJS.Timeout[]
   inputsDisabled: boolean
-  reconnectRequested: boolean
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -321,7 +320,6 @@ export class App extends PureComponent<Props, State> {
       appConfig: {},
       autoReruns: [],
       inputsDisabled: false,
-      reconnectRequested: false,
     }
 
     this.connectionManager = null
@@ -372,7 +370,6 @@ export class App extends PureComponent<Props, State> {
         this.setState({ deployedAppMetadata })
       },
       restartWebsocketConnection: () => {
-        this.setState({ reconnectRequested: true })
         if (!this.connectionManager) {
           this.initializeConnectionManager()
         }
@@ -647,14 +644,10 @@ export class App extends PureComponent<Props, State> {
       //   2. our last script run attempt was interrupted by the websocket
       //      connection dropping, or
       //   3. the host explicitly requested a reconnect
-      if (
-        !this.sessionInfo.last ||
-        lastRunWasInterrupted ||
-        this.state.reconnectRequested
-      ) {
+      if (!this.sessionInfo.last || lastRunWasInterrupted) {
         log.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
-        this.setState({ dialog: null, reconnectRequested: false })
+        this.setState({ dialog: null })
       }
 
       this.hostCommunicationMgr.sendMessageToHost({

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -371,6 +371,8 @@ export class App extends PureComponent<Props, State> {
       },
       restartWebsocketConnection: () => {
         if (!this.connectionManager) {
+          // Performing an intentional restart - we want the script to rerun on load
+          // so setting RERUN_REQUESTED so handleConnectionStateChanged triggers it
           this.setState({ scriptRunState: ScriptRunState.RERUN_REQUESTED })
           this.initializeConnectionManager()
         }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -192,6 +192,7 @@ interface State {
   appConfig: AppConfig
   autoReruns: NodeJS.Timeout[]
   inputsDisabled: boolean
+  reconnectRequested: boolean
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -320,6 +321,7 @@ export class App extends PureComponent<Props, State> {
       appConfig: {},
       autoReruns: [],
       inputsDisabled: false,
+      reconnectRequested: false,
     }
 
     this.connectionManager = null
@@ -370,6 +372,7 @@ export class App extends PureComponent<Props, State> {
         this.setState({ deployedAppMetadata })
       },
       restartWebsocketConnection: () => {
+        this.setState({ reconnectRequested: true })
         if (!this.connectionManager) {
           this.initializeConnectionManager()
         }
@@ -642,11 +645,16 @@ export class App extends PureComponent<Props, State> {
       //   1. this is the first time we establish a websocket connection to the
       //      server, or
       //   2. our last script run attempt was interrupted by the websocket
-      //      connection dropping.
-      if (!this.sessionInfo.last || lastRunWasInterrupted) {
-        LOG.info("Requesting a script run.")
+      //      connection dropping, or
+      //   3. the host explicitly requested a reconnect
+      if (
+        !this.sessionInfo.last ||
+        lastRunWasInterrupted ||
+        this.state.reconnectRequested
+      ) {
+        log.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
-        this.setState({ dialog: null })
+        this.setState({ dialog: null, reconnectRequested: false })
       }
 
       this.hostCommunicationMgr.sendMessageToHost({


### PR DESCRIPTION
## Describe your changes
- request script rerun when host explicitly requests reconnect
- PR https://github.com/streamlit/streamlit/pull/9083 causes a regression in SiS with the connection button (I missed this when I reviewed the change) which we see with the streamlit 1.39 upgrade. Now when `RESTART_WEBSOCKET_CONNECTION` gets sent the websocket gets recreated but no initialization BackMsg gets sent, and thus the script never reruns. When `RESTART_WEBSOCKET_CONNECTION` gets sent the host in this case is assumed to not have an active session to reconnect to - the client should send the initialization message to sync widget state and request a script rerun.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python): ✅ Added
- E2E Tests - ✅ Updated
- Manual Testing - ✅ with `hostframe

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
