### PR TITLE
Activate venv before pip install

### DIFF
--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -42,7 +42,9 @@ jobs:
         uses: ./.github/actions/make_init
 
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
 
       - name: Build Package
         timeout-minutes: 120

--- a/.github/workflows/ensure-relative-imports.yml
+++ b/.github/workflows/ensure-relative-imports.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
+
       - name: Run make protobuf
         run: make protobuf
       - name: Run make frontend-lib-prod

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
       - name: Run make protobuf
         run: make protobuf
       - name: Run make frontend-lib

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
+
       - name: Create tag
         id: create_tag
         run: |
@@ -159,7 +162,9 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
       - name: Verify git tag vs. version
         env:
           TAG: ${{ needs.create-nightly-tag.outputs.tag }}

--- a/.github/workflows/notify-about-new-emojis-material-icons.yml
+++ b/.github/workflows/notify-about-new-emojis-material-icons.yml
@@ -32,8 +32,9 @@ jobs:
         uses: ./.github/actions/make_init
 
       - name: Run make develop
-        run: make develop
-
+        run: |
+          source venv/bin/activate
+          make develop
       - name: Install newest version of emoji package
         run: pip install emoji --upgrade
 

--- a/.github/workflows/playwright-custom-components.yml
+++ b/.github/workflows/playwright-custom-components.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Run make frontend
         run: make frontend
       - name: Run make playwright-custom-components
-        run: make playwright-custom-components
+        run: |
+          source venv/bin/activate
+          make playwright-custom-components
       - name: Upload failed test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -74,6 +74,7 @@ jobs:
         # To create a consistent location for the release/demo whl file, we need a
         # stagnent version number (streamlit-11.11.11)
         run: |
+          source venv/bin/activate
           # Install awscli via pip/uv:
           uv pip install awscli==1.37.6
 

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -56,11 +56,15 @@ jobs:
         with:
           use_cached_venv: false
       - name: Install min dependencies (force reinstall)
-        run: uv pip install -r lib/min-constraints-gen.txt --force-reinstall
+        run: |
+          source venv/bin/activate
+          uv pip install -r lib/min-constraints-gen.txt --force-reinstall
       - name: Generate Protobufs
         run: make protobuf
       - name: Make local modules visible
-        run: uv pip install --editable ./lib --no-deps
+        run: |
+          source venv/bin/activate
+          uv pip install --editable ./lib --no-deps
       - name: Run Python Tests
         run: make pytest
       - name: CLI Smoke Tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
       - name: Run Linters
         run: make pylint
         env:
@@ -238,9 +240,13 @@ jobs:
           # which might cause some unexpected issues with dependencies.
           use_cached_venv: false
       - name: Run make develop
-        run: make develop
+        run: |
+          source venv/bin/activate
+          make develop
       - name: Install integration dependencies
-        run: uv pip install -r lib/integration-requirements.txt --force-reinstall
+        run: |
+          source venv/bin/activate
+          uv pip install -r lib/integration-requirements.txt --force-reinstall
       - name: Run Python integration tests
         run: make pytest-integration
         env:


### PR DESCRIPTION
## Describe your changes

Our Github actions fail because our venv is no longer being activated on its own? As a result, we need to make sure we activate the venv each time. I mapped out where we did that and source activate it to make sure it works.

## Testing Plan

- CI should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
