### PR TITLE
Add .xml to the list of allowed static file extensions

### DIFF
--- a/lib/streamlit/web/server/app_static_file_handler.py
+++ b/lib/streamlit/web/server/app_static_file_handler.py
@@ -30,7 +30,17 @@ _LOGGER: Final = get_logger(__name__)
 MAX_APP_STATIC_FILE_SIZE = 200 * 1024 * 1024  # 200 MB
 # The list of file extensions that we serve with the corresponding Content-Type header.
 # All files with other extensions will be served with Content-Type: text/plain
-SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".pdf", ".gif", ".webp")
+SAFE_APP_STATIC_FILE_EXTENSIONS = (
+    # Common image types:
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    # Other types:
+    ".pdf",
+    ".xml",
+)
 
 
 class AppStaticFileHandler(tornado.web.StaticFileHandler):

--- a/lib/tests/streamlit/web/server/app_static_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/app_static_file_handler_test.py
@@ -56,6 +56,11 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmp_webp_image_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="image.webp", delete=False
         )
+
+        self._tmp_xml_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="file.xml", delete=False
+        )
+
         self._tmp_dir_inside_static_folder = tempfile.TemporaryDirectory(
             dir=self._tmpdir.name
         )
@@ -77,6 +82,7 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._png_image_filename = os.path.basename(self._tmp_png_image_file.name)
         self._pdf_document_filename = os.path.basename(self._tmp_pdf_document_file.name)
         self._webp_image_filename = os.path.basename(self._tmp_webp_image_file.name)
+        self._xml_filename = os.path.basename(self._tmp_xml_file.name)
 
         super().setUp()
 
@@ -145,6 +151,17 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 200
         assert response.headers["Content-Type"] == "application/pdf"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    def test_static_xml_file_200(self):
+        """Files with extensions listed in app_static_file_handler.py
+        `SAFE_APP_STATIC_FILE_EXTENSIONS` (e.g. xml) should have the
+        `Content-Type` header based on their extension.
+        """
+        response = self.fetch(f"/app/static/{self._xml_filename}")
+
+        assert response.code == 200
+        assert response.headers["Content-Type"] == "application/xml"
         assert response.headers["X-Content-Type-Options"] == "nosniff"
 
     @patch("os.path.getsize", MagicMock(return_value=MAX_APP_STATIC_FILE_SIZE + 1))


### PR DESCRIPTION
## Describe your changes

Add .xml to the list of allowed static file extensions

## GitHub Issue Link (if applicable)
Closes #10302
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
