### PR TITLE
[refactor] Remove per-element width prop

### DIFF
--- a/e2e_playwright/st_components_v1_test.py
+++ b/e2e_playwright/st_components_v1_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import re
 
 from playwright.sync_api import Page, expect
@@ -41,29 +42,41 @@ def test_components_iframe_rendering(
 
 
 def test_html_correctly_sets_attr(app: Page):
-    """Test that html correctly sets attributes."""
+    """Test that html correctly sets attributes and rendered size."""
 
     html_component = app.locator("iframe").nth(0)
 
     expect(html_component).to_have_attribute("srcDoc", "<h1>Hello, Streamlit!</h1>")
-    expect(html_component).to_have_attribute("width", "200")
-    expect(html_component).to_have_attribute("height", "500")
     expect(html_component).to_have_attribute("scrolling", "no")
+
+    # Check the actual rendered size
+    box = html_component.bounding_box()
+    if box is None:
+        raise AssertionError("Bounding box is None")
+
+    assert math.floor(box["width"]) == 200
+    assert math.floor(box["height"]) == 500
 
 
 def test_iframe_correctly_sets_attr(app: Page):
-    """Test that iframe correctly sets attributes."""
+    """Test that iframe correctly sets attributes and rendered size."""
 
     iframe_component = app.locator("iframe").nth(1)
 
     expect(iframe_component).to_have_attribute("src", "http://not.a.real.url")
-    expect(iframe_component).to_have_attribute("width", "200")
-    expect(iframe_component).to_have_attribute("height", "500")
     expect(iframe_component).to_have_attribute("scrolling", "auto")
+
+    # Check the actual rendered size
+    box = iframe_component.bounding_box()
+    if box is None:
+        raise AssertionError("Bounding box is None")
+
+    assert math.floor(box["width"]) == 200
+    assert math.floor(box["height"]) == 500
 
 
 def test_declare_component_correctly_sets_attr(app: Page):
-    """Test that components.declare_component correctly sets attributes."""
+    """Test that components.declare_component correctly sets attributes and rendered size."""
 
     declare_component = app.locator("iframe").nth(2)
 

--- a/e2e_playwright/st_dataframe_input_data_test.py
+++ b/e2e_playwright/st_dataframe_input_data_test.py
@@ -33,4 +33,5 @@ def test_dataframe_input_format_rendering(
 
         dataframe_element = app.get_by_test_id("stDataFrame")
         expect(dataframe_element).to_be_visible()
+        app.wait_for_selector("[data-testid='stDataFrame']", state="attached")
         assert_snapshot(dataframe_element, name=f"st_dataframe-input_data_{index}")

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -20,7 +20,6 @@ import React, {
   useContext,
   useEffect,
   useMemo,
-  useRef,
 } from "react"
 
 import classNames from "classnames"
@@ -38,6 +37,8 @@ import ChatMessage from "~lib/components/elements/ChatMessage"
 import Dialog from "~lib/components/elements/Dialog"
 import Expander from "~lib/components/elements/Expander"
 import { useScrollToBottom } from "~lib/hooks/useScrollToBottom"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useLayoutStyles } from "~lib/components/core/Layout/useLayoutStyles"
 
 import {
   assignDividerColor,
@@ -63,7 +64,7 @@ export interface BlockPropsWithoutWidth extends BaseBlockProps {
 
 interface BlockPropsWithWidth extends BaseBlockProps {
   node: BlockNode
-  width: number
+  width: React.CSSProperties["width"]
 }
 
 // Render BlockNodes (i.e. container nodes).
@@ -126,7 +127,6 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
       <Popover
         empty={node.isEmpty}
         element={node.deltaBlock.popover as BlockProto.Popover}
-        width={props.width}
       >
         {child}
       </Popover>
@@ -144,7 +144,6 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
         formId={formId}
         clearOnSubmit={clearOnSubmit}
         enterToSubmit={enterToSubmit}
-        width={props.width}
         hasSubmitButton={hasSubmitButton}
         scriptRunState={props.scriptRunState}
         widgetMgr={props.widgetMgr}
@@ -184,6 +183,16 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   }
 
   if (node.deltaBlock.tabContainer) {
+    // This is to get around a number of scrolling + mounting/unmounting issues
+    // in the Tabs component. Only render the Tabs if we have a calculated
+    // width. Often, the first render from VerticalBlock will have a width of 0,
+    // which causes an issue where the tabs can be unnecessarily horizontally
+    // scrolled in Webkit/Safari. Once we have an actual width, we can render
+    // the Tabs component and avoid this issue.
+    if (!childProps.width) {
+      return <div />
+    }
+
     const renderTabContent = (
       mappedChildProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
     ): ReactElement => {
@@ -288,51 +297,28 @@ function ScrollToBottomVerticalBlockWrapper(
 // Currently, only VerticalBlocks will ever contain leaf elements. But this is only enforced on the
 // Python side.
 const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
-  const wrapperElement = useRef<HTMLDivElement>(null)
-  const [width, setWidth] = React.useState(-1)
-
-  const observer = useMemo(
-    () =>
-      new ResizeObserver(([entry]) => {
-        // Since the setWidth will perform changes to the DOM,
-        // we need wrap it in a requestAnimationFrame to avoid this error:
-        // ResizeObserver loop completed with undelivered notifications.
-        window.requestAnimationFrame(() => {
-          // We need to determine the available width here to be able to set
-          // an explicit width for the `StyledVerticalBlock`.
-
-          // The width should never be set to 0 since it can cause
-          // flickering effects.
-          setWidth(entry.target.getBoundingClientRect().width || -1)
-        })
-      }),
-    [setWidth]
-  )
+  const {
+    values: [calculatedWidth],
+    elementRef: wrapperElement,
+    forceRecalculate,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   const border = props.node.deltaBlock.vertical?.border ?? false
   const height = props.node.deltaBlock.vertical?.height || undefined
 
   const activateScrollToBottom =
     height &&
-    props.node.children.find(node => {
+    props.node.children.some(node => {
       return (
         node instanceof BlockNode && node.deltaBlock.type === "chatMessage"
       )
-    }) !== undefined
+    })
 
+  // We need to update the observer whenever the scrolling is activated or deactivated
+  // Otherwise, it still tries to measure the width of the old wrapper element.
   useEffect(() => {
-    if (wrapperElement.current) {
-      observer.observe(wrapperElement.current)
-    }
-    return () => {
-      observer.disconnect()
-    }
-    // We need to update the observer whenever the scrolling is activated or deactivated
-    // Otherwise, it still tries to measure the width of the old wrapper element.
-    // TODO: Update to match React best practices
-    // eslint-disable-next-line react-compiler/react-compiler
-    /* eslint-disable react-hooks/exhaustive-deps */
-  }, [observer, activateScrollToBottom])
+    forceRecalculate()
+  }, [forceRecalculate, activateScrollToBottom])
 
   // Decide which wrapper to use based on whether we need to activate scrolling to bottom
   // This is done for performance reasons, to prevent the usage of useScrollToBottom
@@ -341,12 +327,17 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
     ? ScrollToBottomVerticalBlockWrapper
     : StyledVerticalBlockBorderWrapper
 
-  const propsWithNewWidth = {
-    ...props,
-    ...{ width },
-  }
   // Extract the user-specified key from the block ID (if provided):
   const userKey = getKeyFromId(props.node.deltaBlock.id)
+  const styles = useLayoutStyles({
+    width: calculatedWidth,
+    element: undefined,
+  })
+
+  const propsWithCalculatedWidth = {
+    ...props,
+    width: styles.width,
+  }
 
   // Widths of children autosizes to container width (and therefore window width).
   // StyledVerticalBlocks are the only things that calculate their own widths. They should never use
@@ -363,14 +354,14 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
     >
       <StyledVerticalBlockWrapper ref={wrapperElement}>
         <StyledVerticalBlock
-          width={width}
           className={classNames(
             "stVerticalBlock",
             convertKeyToClassName(userKey)
           )}
           data-testid="stVerticalBlock"
+          {...styles}
         >
-          <ChildRenderer {...propsWithNewWidth} />
+          <ChildRenderer {...propsWithCalculatedWidth} />
         </StyledVerticalBlock>
       </StyledVerticalBlockWrapper>
     </VerticalBlockBorderWrapper>

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -183,12 +183,10 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   }
 
   if (node.deltaBlock.tabContainer) {
-    // This is to get around a number of scrolling + mounting/unmounting issues
-    // in the Tabs component. Only render the Tabs if we have a calculated
-    // width. Often, the first render from VerticalBlock will have a width of 0,
-    // which causes an issue where the tabs can be unnecessarily horizontally
-    // scrolled in Webkit/Safari. Once we have an actual width, we can render
-    // the Tabs component and avoid this issue.
+    // Due to an issue with unnecessary unmounts/remounts, we see undesired
+    // horizontal scrolling in Webkit/Safari. We are planning a fix for the
+    // underlying issue, but, for now, only rendering the component when we have
+    // a width != 0 fixes the scrolling issue.
     if (!childProps.width) {
       return <div />
     }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -88,6 +88,7 @@ import { FormSubmitContent } from "~lib/components/widgets/Form"
 import Heading from "~lib/components/shared/StreamlitMarkdown/Heading"
 import { LibContext } from "~lib/components/core/LibContext"
 import { getElementId } from "~lib/util/utils"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import {
   BaseBlockProps,
@@ -96,7 +97,7 @@ import {
   isComponentStale,
   shouldComponentBeEnabled,
 } from "./utils"
-import { StyledElementContainer } from "./styled-components"
+import { StyledElementContainerLayoutWrapper } from "./StyledElementContainerLayoutWrapper"
 
 // Lazy-load elements.
 const Audio = React.lazy(() => import("~lib/components/elements/Audio"))
@@ -119,7 +120,9 @@ const BokehChart = React.lazy(
 
 // RTL ESLint triggers a false positive on this render function
 // eslint-disable-next-line testing-library/render-result-naming-convention
-const DebouncedBokehChart = debounceRender(BokehChart, 100)
+const DebouncedBokehChart = withCalculatedWidth(
+  debounceRender(BokehChart, 100)
+)
 
 const DeckGlJsonChart = React.lazy(
   () => import("~lib/components/elements/DeckGlJsonChart")
@@ -188,7 +191,7 @@ const StreamlitSyntaxHighlighter = React.lazy(
 
 export interface ElementNodeRendererProps extends BaseBlockProps {
   node: ElementNode
-  width: number
+  width: React.CSSProperties["width"]
 }
 
 interface RawElementNodeRendererProps extends ElementNodeRendererProps {
@@ -210,7 +213,6 @@ const RawElementNodeRenderer = (
   }
 
   const elementProps = {
-    width: props.width,
     disableFullscreenMode: props.disableFullscreenMode,
   }
 
@@ -721,9 +723,10 @@ const ElementNodeRenderer = (
   props: ElementNodeRendererProps
 ): ReactElement => {
   const { isFullScreen, fragmentIdsThisRun } = React.useContext(LibContext)
-  const { node, width } = props
+  const { node, width: propsWidth } = props
 
   const elementType = node.element.type || ""
+
   const enable = shouldComponentBeEnabled(elementType, props.scriptRunState)
   const isStale = isComponentStale(
     enable,
@@ -743,7 +746,7 @@ const ElementNodeRenderer = (
 
   return (
     <Maybe enable={enable}>
-      <StyledElementContainer
+      <StyledElementContainerLayoutWrapper
         className={classNames(
           "stElementContainer",
           "element-container",
@@ -754,10 +757,11 @@ const ElementNodeRenderer = (
         // Applying stale opacity in fullscreen mode
         // causes the fullscreen overlay to be transparent.
         isStale={isStale && !isFullScreen}
-        width={width}
+        width={propsWidth}
         elementType={elementType}
+        node={node}
       >
-        <ErrorBoundary width={width}>
+        <ErrorBoundary>
           <Suspense
             fallback={
               <Skeleton
@@ -770,7 +774,7 @@ const ElementNodeRenderer = (
             <RawElementNodeRenderer {...props} isStale={isStale} />
           </Suspense>
         </ErrorBoundary>
-      </StyledElementContainer>
+      </StyledElementContainerLayoutWrapper>
     </Maybe>
   )
 }

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from "react"
+
+import { useLayoutStyles } from "~lib/components/core/Layout/useLayoutStyles"
+import type { ElementNode } from "~lib/AppNode"
+
+import { StyledElementContainer } from "./styled-components"
+
+export const StyledElementContainerLayoutWrapper: FC<
+  Omit<Parameters<typeof StyledElementContainer>[0], "width"> & {
+    node: ElementNode
+    width: React.CSSProperties["width"]
+  }
+> = ({ width, node, ...rest }) => {
+  const styles = useLayoutStyles({
+    width,
+    element:
+      (node.element?.type && node.element[node.element.type]) || undefined,
+  })
+
+  return <StyledElementContainer {...rest} {...styles} />
+}

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -55,14 +55,16 @@ export const StyledHorizontalBlock = styled.div<StyledHorizontalBlockProps>(
 
 export interface StyledElementContainerProps {
   isStale: boolean
-  width: number
+  width: React.CSSProperties["width"]
+  maxWidth?: React.CSSProperties["maxWidth"]
   elementType: string
 }
 
 const GLOBAL_ELEMENTS = ["balloons", "snow"]
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
-  ({ theme, isStale, width, elementType }) => ({
+  ({ theme, isStale, width, elementType, maxWidth }) => ({
     width,
+    maxWidth,
     // Allows to have absolutely-positioned nodes inside app elements, like
     // floating buttons.
     position: "relative",
@@ -160,12 +162,14 @@ export const StyledColumn = styled.div<StyledColumnProps>(
 
 export interface StyledVerticalBlockProps {
   ref?: React.RefObject<any>
-  width?: number
+  width?: React.CSSProperties["width"]
+  maxWidth?: React.CSSProperties["maxWidth"]
 }
 
 export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
-  ({ width, theme }) => ({
+  ({ width, maxWidth, theme }) => ({
     width,
+    maxWidth,
     position: "relative", // Required for the automatic width computation.
     display: "flex",
     flex: 1,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -56,15 +56,13 @@ export const StyledHorizontalBlock = styled.div<StyledHorizontalBlockProps>(
 export interface StyledElementContainerProps {
   isStale: boolean
   width: React.CSSProperties["width"]
-  maxWidth?: React.CSSProperties["maxWidth"]
   elementType: string
 }
 
 const GLOBAL_ELEMENTS = ["balloons", "snow"]
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
-  ({ theme, isStale, width, elementType, maxWidth }) => ({
+  ({ theme, isStale, width, elementType }) => ({
     width,
-    maxWidth,
     // Allows to have absolutely-positioned nodes inside app elements, like
     // floating buttons.
     position: "relative",

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest"
+import { renderHook } from "@testing-library/react-hooks"
+
+import { useLayoutStyles } from "./useLayoutStyles"
+
+describe("#useLayoutStyles", () => {
+  describe("when rendering in the top-level container", () => {
+    describe("without an element", () => {
+      const element = undefined
+
+      it("should return default styles", () => {
+        const { result } = renderHook(() =>
+          useLayoutStyles({ width: 100, element })
+        )
+        expect(result.current).toEqual({
+          width: 100,
+        })
+      })
+    })
+  })
+
+  describe("with an element", () => {
+    describe("that has useContainerWidth set to a falsy value", () => {
+      const useContainerWidth = false
+
+      it.each([
+        [200, { width: 200, maxWidth: "100%" }],
+        [1000, { width: 700, maxWidth: "100%" }],
+        [undefined, { width: "auto", maxWidth: "100%" }],
+        [0, { width: "auto", maxWidth: "100%" }],
+        [-100, { width: "auto", maxWidth: "100%" }],
+        [NaN, { width: "auto", maxWidth: "100%" }],
+      ])("and with a width value of %s, returns %o", (width, expected) => {
+        const element = { width, useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ width: 700, element })
+        )
+        expect(result.current).toEqual(expected)
+      })
+    })
+
+    describe('that has useContainerWidth set to "true"', () => {
+      const useContainerWidth = true
+
+      it.each([
+        [200, { width: 700, maxWidth: "100%" }],
+        [1000, { width: 700, maxWidth: "100%" }],
+        [undefined, { width: 700, maxWidth: "100%" }],
+        [0, { width: 700, maxWidth: "100%" }],
+        [-100, { width: 700, maxWidth: "100%" }],
+        [NaN, { width: 700, maxWidth: "100%" }],
+      ])("and with a width value of %s, returns %o", (width, expected) => {
+        const element = { width, useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ width: 700, element })
+        )
+        expect(result.current).toEqual(expected)
+      })
+    })
+  })
+})

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -40,12 +40,12 @@ describe("#useLayoutStyles", () => {
       const useContainerWidth = false
 
       it.each([
-        [200, { width: 200, maxWidth: "100%" }],
-        [1000, { width: 700, maxWidth: "100%" }],
-        [undefined, { width: "auto", maxWidth: "100%" }],
-        [0, { width: "auto", maxWidth: "100%" }],
-        [-100, { width: "auto", maxWidth: "100%" }],
-        [NaN, { width: "auto", maxWidth: "100%" }],
+        [200, { width: 200 }],
+        [1000, { width: 700 }],
+        [undefined, { width: "auto" }],
+        [0, { width: "auto" }],
+        [-100, { width: "auto" }],
+        [NaN, { width: "auto" }],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = { width, useContainerWidth }
         const { result } = renderHook(() =>
@@ -59,12 +59,12 @@ describe("#useLayoutStyles", () => {
       const useContainerWidth = true
 
       it.each([
-        [200, { width: 700, maxWidth: "100%" }],
-        [1000, { width: 700, maxWidth: "100%" }],
-        [undefined, { width: 700, maxWidth: "100%" }],
-        [0, { width: 700, maxWidth: "100%" }],
-        [-100, { width: 700, maxWidth: "100%" }],
-        [NaN, { width: 700, maxWidth: "100%" }],
+        [200, { width: 700 }],
+        [1000, { width: 700 }],
+        [undefined, { width: 700 }],
+        [0, { width: 700 }],
+        [-100, { width: 700 }],
+        [NaN, { width: 700 }],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = { width, useContainerWidth }
         const { result } = renderHook(() =>

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react"
+
+export type UseLayoutStylesArgs<T> = {
+  width: React.CSSProperties["width"] | undefined
+  element:
+    | (T & { width?: number; useContainerWidth?: boolean | null })
+    | undefined
+}
+
+const isNonZeroPositiveNumber = (value: unknown): value is number =>
+  typeof value === "number" && value > 0 && !isNaN(value)
+
+export type UseLayoutStylesShape = {
+  width: React.CSSProperties["width"]
+  maxWidth?: React.CSSProperties["maxWidth"]
+}
+
+/**
+ * Returns the contextually-aware style values for an element container
+ */
+export const useLayoutStyles = <T>({
+  width: containerWidth,
+  element,
+}: UseLayoutStylesArgs<T>): UseLayoutStylesShape => {
+  /**
+   * The width set from the `st.<command>`
+   */
+  const commandWidth = element?.width
+  const useContainerWidth = element?.useContainerWidth
+
+  // Note: Consider rounding the width to the nearest pixel so we don't have
+  // subpixel widths, which leads to blurriness on screen
+
+  const layoutStyles = useMemo((): UseLayoutStylesShape => {
+    // If we don't have an element, we are rendering a root-level node, likely a
+    // `StyledAppViewBlockContainer`
+    if (!element) {
+      return {
+        width: containerWidth,
+      }
+    }
+
+    if ("imgs" in element) {
+      /**
+       * ImageList overrides its `width` param and handles its own width in the
+       * component. There should not be any element-specific carve-outs in this
+       * file, but given the long-standing behavior of ImageList, we have to
+       * make an exception here.
+       *
+       * @see WidthBehavior on the Backend
+       * @see the Image.proto file
+       */
+      return {
+        width: containerWidth,
+      }
+    }
+
+    let width =
+      useContainerWidth && isNonZeroPositiveNumber(containerWidth)
+        ? containerWidth
+        : commandWidth
+
+    if (width === 0) {
+      // An element with no width should be treated as if it has no width set
+      // This is likely from the proto, where the default value is 0
+      width = undefined
+    }
+
+    if (width && width < 0) {
+      width = undefined
+    }
+
+    if (width !== undefined && isNaN(width)) {
+      width = undefined
+    }
+
+    if (
+      width !== undefined &&
+      containerWidth !== undefined &&
+      typeof containerWidth === "number" &&
+      width > containerWidth
+    ) {
+      width = containerWidth
+    }
+
+    const widthWithFallback = width ?? "auto"
+
+    return {
+      width: widthWithFallback,
+      maxWidth: "100%",
+    }
+  }, [useContainerWidth, commandWidth, containerWidth, element])
+
+  return layoutStyles
+}

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -28,7 +28,6 @@ const isNonZeroPositiveNumber = (value: unknown): value is number =>
 
 export type UseLayoutStylesShape = {
   width: React.CSSProperties["width"]
-  maxWidth?: React.CSSProperties["maxWidth"]
 }
 
 /**
@@ -107,7 +106,6 @@ export const useLayoutStyles = <T>({
 
     return {
       width: widthWithFallback,
-      maxWidth: "100%",
     }
   }, [useContainerWidth, commandWidth, containerWidth, element])
 

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -83,10 +83,12 @@ export const useLayoutStyles = <T>({
     }
 
     if (width && width < 0) {
+      // If we have an invalid width, we should treat it as if it has no width set
       width = undefined
     }
 
     if (width !== undefined && isNaN(width)) {
+      // If we have an invalid width, we should treat it as if it has no width set
       width = undefined
     }
 
@@ -96,6 +98,8 @@ export const useLayoutStyles = <T>({
       typeof containerWidth === "number" &&
       width > containerWidth
     ) {
+      // If the width is greater than the container width, we should use the
+      // container width to prevent overflows
       width = containerWidth
     }
 

--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { ComponentType, useMemo } from "react"
+
+import hoistNonReactStatics from "hoist-non-react-statics"
+import { ReactElement } from "react-markdown/lib/react-markdown"
+
+import { Box } from "~lib/components/shared/Base/styled-components"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+
+/**
+ * HOC that wraps a component and passes its width as a prop. Should only be
+ * used in legacy components that require the width prop.
+ */
+export const withCalculatedWidth = <P extends { width?: number }>(
+  WrappedComponent: ComponentType<React.PropsWithChildren<P>>
+): ComponentType<Omit<P, "width">> => {
+  const EnhancedComponent = (props: Omit<P, "width">): ReactElement => {
+    const {
+      values: [width],
+      elementRef,
+    } = useResizeObserver(useMemo(() => ["width"], []))
+
+    return (
+      <Box ref={elementRef}>
+        {width ? <WrappedComponent {...(props as P)} width={width} /> : null}
+      </Box>
+    )
+  }
+  EnhancedComponent.displayName = `withCalculatedWidth(${
+    WrappedComponent.displayName || WrappedComponent.name
+  })`
+
+  // Static methods must be copied over
+  // https://en.reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
+  return hoistNonReactStatics(EnhancedComponent, WrappedComponent)
+}

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -31,7 +31,6 @@ const getProps = (
 ): AlertElementProps => ({
   body: "Something happened!",
   kind: Kind.INFO,
-  width: 100,
   ...elementProps,
 })
 

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -29,7 +29,6 @@ export interface AlertElementProps {
   body: string
   icon?: string
   kind: Kind
-  width: number
 }
 
 /**
@@ -39,7 +38,6 @@ function AlertElement({
   icon,
   body,
   kind,
-  width,
 }: Readonly<AlertElementProps>): ReactElement {
   const theme: EmotionTheme = useTheme()
   const markdownWidth = {
@@ -51,7 +49,7 @@ function AlertElement({
 
   return (
     <div className="stAlert" data-testid="stAlert">
-      <AlertContainer width={width} kind={kind}>
+      <AlertContainer kind={kind}>
         <StyledAlertContent>
           {icon && (
             <DynamicIcon

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -20,6 +20,7 @@ import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import ArrowVegaLiteChart, { Props } from "./ArrowVegaLiteChart"
 import { VegaLiteChartElement } from "./arrowUtils"
@@ -58,7 +59,6 @@ const getProps = (
     vegaLiteTheme: "streamlit",
     ...elementProps,
   },
-  width: 0,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
     formsDataChanged: vi.fn(),
@@ -67,6 +67,14 @@ const getProps = (
 })
 
 describe("ArrowVegaLiteChart", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
+  })
+
   it("renders without crashing", () => {
     render(<ArrowVegaLiteChart {...getProps()} />)
     const vegaLiteChart = screen.getByTestId("stVegaLiteChart")

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -36,7 +36,6 @@ import { useVegaEmbed } from "./useVegaEmbed"
 
 export interface Props {
   element: VegaLiteChartElement
-  width: number
   widgetMgr: WidgetStateManager
   fragmentId?: string
   disableFullscreenMode?: boolean

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -184,7 +184,7 @@ export const useVegaElementPreprocessor = (
         selectionMode,
         theme,
         isFullScreen,
-        width,
+        width || 0,
         height
       ),
     [

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -45,7 +45,6 @@ describe("Audio Element", () => {
       ...elementProps,
     }),
     endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
-    width: 0,
     elementMgr: elementMgrMock as unknown as ElementStateManager,
   })
 

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -25,7 +25,6 @@ import { StyledAudio, StyledAudioContainer } from "./styled-components"
 
 export interface AudioProps {
   endpoints: StreamlitEndpoints
-  width: number
   element: AudioProto
   elementMgr: ElementStateManager
 }

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -208,7 +208,6 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
     <StyledDeckGlChart
       className="stDeckGlJsonChart"
       data-testid="stDeckGlJsonChart"
-      width={width}
       height={height}
     >
       <Toolbar

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -19,15 +19,14 @@ import styled from "@emotion/styled"
 import { hasLightBackgroundColor } from "~lib/theme"
 
 export interface StyledDeckGlChartProps {
-  width: number | string
   height: number | string
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ width, height }) => ({
+  ({ height }) => ({
     position: "relative",
     height,
-    width,
+    width: "100%",
   })
 )
 

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/MapboxTokenError.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/MapboxTokenError.tsx
@@ -27,18 +27,12 @@ import {
 interface Props {
   error: Error | MapboxTokenFetchingError | MapboxTokenNotProvidedError
   deltaType: string
-  width: number
 }
 
-const MapboxTokenError = ({
-  error,
-  width,
-  deltaType,
-}: Props): ReactElement => {
+const MapboxTokenError = ({ error, deltaType }: Props): ReactElement => {
   if (error instanceof MapboxTokenNotProvidedError) {
     return (
       <ErrorElement
-        width={width}
         name="No Mapbox token provided"
         message={
           <>
@@ -77,7 +71,6 @@ const MapboxTokenError = ({
   if (error instanceof MapboxTokenFetchingError) {
     return (
       <ErrorElement
-        width={width}
         name="Error fetching Streamlit Mapbox token"
         message={
           <>
@@ -98,7 +91,6 @@ const MapboxTokenError = ({
 
   return (
     <ErrorElement
-      width={width}
       name="Error fetching Streamlit Mapbox token"
       message={error.message}
     />

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.test.tsx
@@ -88,7 +88,7 @@ describe("withMapboxToken", () => {
         data: { userMapboxToken: mockMapboxToken },
       }))
 
-      render(<WrappedComponent element={element} width={500} />)
+      render(<WrappedComponent element={element} />)
 
       const mockComponentText = screen.getByText(mockMapboxToken)
       expect(mockComponentText).toBeInTheDocument()
@@ -96,7 +96,7 @@ describe("withMapboxToken", () => {
 
     it("should render loading alert while fetching the token", () => {
       axios.get = vi.fn().mockReturnValue(new Promise(() => {}))
-      render(<WrappedComponent element={emptyElement} width={500} />)
+      render(<WrappedComponent element={emptyElement} />)
 
       expect(screen.getByTestId("stSkeleton")).toBeInTheDocument()
     })
@@ -106,7 +106,7 @@ describe("withMapboxToken", () => {
         .fn()
         .mockResolvedValue({ data: { mapbox: mockMapboxToken } })
 
-      render(<WrappedComponent element={emptyElement} width={500} />)
+      render(<WrappedComponent element={emptyElement} />)
 
       await waitFor(() => {
         expect(axios.get).toHaveBeenCalledWith(TOKENS_URL)
@@ -125,7 +125,6 @@ describe("withMapboxToken", () => {
             wrappedComponentInstance = ref
           }}
           element={emptyElement}
-          width={500}
         />
       )
 
@@ -140,12 +139,9 @@ describe("withMapboxToken", () => {
         data: { userMapboxToken: mockMapboxToken },
       }))
 
-      customRenderLibContext(
-        <WrappedComponent element={element} width={500} />,
-        {
-          libConfig: { mapboxToken: LIB_CONFIG_TOKEN },
-        }
-      )
+      customRenderLibContext(<WrappedComponent element={element} />, {
+        libConfig: { mapboxToken: LIB_CONFIG_TOKEN },
+      })
 
       await waitFor(() => {
         const element = screen.getByTestId("mock-component")
@@ -158,12 +154,9 @@ describe("withMapboxToken", () => {
         .fn()
         .mockResolvedValue({ data: { mapbox: mockMapboxToken } })
 
-      customRenderLibContext(
-        <WrappedComponent element={emptyElement} width={500} />,
-        {
-          libConfig: { mapboxToken: LIB_CONFIG_TOKEN },
-        }
-      )
+      customRenderLibContext(<WrappedComponent element={emptyElement} />, {
+        libConfig: { mapboxToken: LIB_CONFIG_TOKEN },
+      })
 
       await waitFor(() => {
         const element = screen.getByTestId("mock-component")

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.tsx
@@ -48,7 +48,6 @@ export type WrappedMapboxProps<P extends InjectedProps> = Omit<
   "mapboxToken"
 > & {
   element: DeckGlJsonChart
-  width: number
 }
 
 export class MapboxTokenNotProvidedError extends Error {}
@@ -144,16 +143,11 @@ const withMapboxToken =
 
       public render = (): ReactNode => {
         const { mapboxToken, mapboxTokenError, isFetching } = this.state
-        const { width } = this.props
 
         // We got an error when fetching our mapbox token: show the error.
         if (mapboxTokenError) {
           return (
-            <MapboxTokenError
-              width={width}
-              error={mapboxTokenError}
-              deltaType={deltaType}
-            />
+            <MapboxTokenError error={mapboxTokenError} deltaType={deltaType} />
           )
         }
 
@@ -176,7 +170,6 @@ const withMapboxToken =
           <WrappedComponent
             {...(this.props as unknown as P)}
             mapboxToken={mapboxToken}
-            width={width}
           />
         )
       }

--- a/frontend/lib/src/components/elements/DocString/DocString.test.tsx
+++ b/frontend/lib/src/components/elements/DocString/DocString.test.tsx
@@ -34,7 +34,6 @@ const getProps = (
     type: "method",
     ...elementProps,
   }),
-  width: 0,
 })
 
 describe("DocString Element", () => {

--- a/frontend/lib/src/components/elements/DocString/DocString.tsx
+++ b/frontend/lib/src/components/elements/DocString/DocString.tsx
@@ -33,19 +33,18 @@ import {
 } from "./styled-components"
 
 export interface DocStringProps {
-  width: number
   element: DocStringProto
 }
 
 /**
  * Functional element representing formatted text.
  */
-function DocString({ width, element }: DocStringProps): ReactElement {
+function DocString({ element }: DocStringProps): ReactElement {
   const { name, type, value, docString, members } = element
 
   // Put it all together into a nice little html view.
   return (
-    <StyledDocContainer className="stHelp" data-testid="stHelp" width={width}>
+    <StyledDocContainer className="stHelp" data-testid="stHelp">
       <StyledDocHeader>
         <StyledDocSummary>
           {name ? (

--- a/frontend/lib/src/components/elements/DocString/styled-components.ts
+++ b/frontend/lib/src/components/elements/DocString/styled-components.ts
@@ -33,20 +33,14 @@ export const StyledDocType = styled.span(({ theme }) => ({
 
 export const StyledDocValue = styled.span()
 
-export interface StyledDocContainerProps {
-  width: number
-}
-
-export const StyledDocContainer = styled.span<StyledDocContainerProps>(
-  ({ theme }) => ({
-    display: "flex",
-    flexDirection: "column",
-    borderRadius: theme.radii.default,
-    border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
-    fontFamily: theme.genericFonts.codeFont,
-    fontSize: theme.fontSizes.sm,
-  })
-)
+export const StyledDocContainer = styled.span(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  borderRadius: theme.radii.default,
+  border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
+  fontFamily: theme.genericFonts.codeFont,
+  fontSize: theme.fontSizes.sm,
+}))
 
 export const StyledDocHeader = styled.div(({ theme }) => ({
   padding: `${theme.spacing.sm} ${theme.spacing.lg}`,

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
@@ -34,7 +34,6 @@ const getProps = (
     messageIsMarkdown: false,
     ...elementProps,
   }),
-  width: 0,
 })
 
 describe("ExceptionElement Element", () => {

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
@@ -33,7 +33,6 @@ import {
 } from "./styled-components"
 
 export interface ExceptionElementProps {
-  width: number
   element: ExceptionProto
 }
 
@@ -108,14 +107,10 @@ function StackTrace({ stackTrace }: Readonly<StackTraceProps>): ReactElement {
  */
 function ExceptionElement({
   element,
-  width,
 }: Readonly<ExceptionElementProps>): ReactElement {
   return (
     <div className="stException" data-testid="stException">
-      <AlertContainer
-        kind={element.isWarning ? Kind.WARNING : Kind.ERROR}
-        width={width}
-      >
+      <AlertContainer kind={element.isWarning ? Kind.WARNING : Kind.ERROR}>
         <StyledExceptionMessage data-testid="stExceptionMessage">
           <ExceptionMessage
             type={element.type}

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -22,6 +22,7 @@ import { graphviz } from "d3-graphviz"
 
 import { GraphVizChart as GraphVizChartProto } from "@streamlit/protobuf"
 
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 
 import GraphVizChart, { GraphVizChartProps, log } from "./GraphVizChart"
@@ -50,7 +51,6 @@ const getProps = (
     elementId: "1",
     ...elementProps,
   }),
-  width: 700,
 })
 
 describe("GraphVizChart Element", () => {
@@ -58,6 +58,12 @@ describe("GraphVizChart Element", () => {
 
   beforeEach(() => {
     logErrorSpy = vi.spyOn(log, "error").mockImplementation(() => {})
+
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   afterEach(() => {

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -33,7 +33,6 @@ import { StyledGraphVizChart } from "./styled-components"
 
 export interface GraphVizChartProps {
   element: GraphVizChartProto
-  width: number
   disableFullscreenMode?: boolean
 }
 export const log = getLogger("GraphVizChart")
@@ -81,7 +80,7 @@ function GraphVizChart({
 
   return (
     <StyledToolbarElementContainer
-      width={width}
+      width={width ?? 0}
       height={height}
       useContainerWidth={isFullScreen || element.useContainerWidth}
     >

--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -29,7 +29,6 @@ const getProps = (elementProps: Partial<HtmlProto> = {}): HtmlProps => ({
     body: "<div>Test Html</div>",
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("HTML element", () => {
@@ -39,7 +38,6 @@ describe("HTML element", () => {
     const html = screen.getByTestId("stHtml")
     expect(html).toBeInTheDocument()
     expect(html).toHaveTextContent("Test Html")
-    expect(html).toHaveStyle("width: 100px")
     expect(html).toHaveClass("stHtml")
   })
 

--- a/frontend/lib/src/components/elements/Html/Html.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.tsx
@@ -21,7 +21,6 @@ import dompurify from "dompurify"
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
 export interface HtmlProps {
-  width: number
   element: HtmlProto
 }
 
@@ -60,7 +59,7 @@ const sanitizeString = (html: string): string => {
 /**
  * HTML code to insert into the page.
  */
-function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
+function Html({ element }: Readonly<HtmlProps>): ReactElement {
   const { body } = element
   const [sanitizedHtml, setSanitizedHtml] = useState(sanitizeString(body))
   const htmlRef = useRef<HTMLDivElement | null>(null)
@@ -91,7 +90,6 @@ function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
           className="stHtml"
           data-testid="stHtml"
           ref={htmlRef}
-          style={{ width }}
           dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
         />
       )}

--- a/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
@@ -32,7 +32,6 @@ const getProps = (elementProps: Partial<IFrameProto> = {}): IFrameProps => ({
   element: IFrameProto.create({
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("st.iframe", () => {
@@ -109,23 +108,6 @@ describe("st.iframe", () => {
         "sandbox",
         DEFAULT_IFRAME_SANDBOX_POLICY
       )
-    })
-  })
-
-  describe("Render iframe with specified width", () => {
-    const props = getProps({
-      hasWidth: true,
-      width: 200,
-    })
-    it("should set element width", () => {
-      render(<IFrame {...props} />)
-      expect(screen.getByTestId("stIFrame")).toHaveAttribute("width", "200")
-    })
-
-    it("should set app width", () => {
-      const props = getProps({})
-      render(<IFrame {...props} />)
-      expect(screen.getByTestId("stIFrame")).toHaveAttribute("width", "100")
     })
   })
 

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -37,15 +37,11 @@ function getNonEmptyString(
 
 export interface IFrameProps {
   element: IFrameProto
-  width: number
 }
 
 function IFrame({
   element,
-  width: propWidth,
 }: Readonly<IFrameProps>): ReactElement {
-  const width = element.hasWidth ? element.width : propWidth
-
   // Either 'src' or 'srcDoc' will be set in our element. If 'src'
   // is set, we're loading a remote URL in the iframe.
   const src = getNonEmptyString(element.src)
@@ -61,7 +57,6 @@ function IFrame({
       disableScrolling={!element.scrolling}
       src={src}
       srcDoc={srcDoc}
-      width={width}
       height={element.height}
       scrolling={element.scrolling ? "auto" : "no"}
       sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -39,9 +39,7 @@ export interface IFrameProps {
   element: IFrameProto
 }
 
-function IFrame({
-  element,
-}: Readonly<IFrameProps>): ReactElement {
+function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
   // Either 'src' or 'srcDoc' will be set in our element. If 'src'
   // is set, we're loading a remote URL in the iframe.
   const src = getNonEmptyString(element.src)

--- a/frontend/lib/src/components/elements/IFrame/styled-components.ts
+++ b/frontend/lib/src/components/elements/IFrame/styled-components.ts
@@ -22,6 +22,7 @@ interface StyledIframeProps {
 
 export const StyledIframe = styled.iframe<StyledIframeProps>(
   ({ theme, disableScrolling }) => ({
+    width: "100%",
     colorScheme: "normal",
     border: "none",
     padding: theme.spacing.none,

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -22,6 +22,7 @@ import { ImageList as ImageListProto } from "@streamlit/protobuf"
 
 import { render } from "~lib/test_util"
 import { mockEndpoints } from "~lib/mocks/mocks"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import ImageList, { ImageListProps } from "./ImageList"
 
@@ -40,7 +41,14 @@ describe("ImageList Element", () => {
       ...elementProps,
     }),
     endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
-    width: 0,
+  })
+
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   it("renders without crashing", () => {

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -22,13 +22,13 @@ import {
 } from "@streamlit/protobuf"
 
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
+import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
+import { withFullScreenWrapper } from "~lib/components/shared/FullScreenWrapper"
+import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import Toolbar, {
   StyledToolbarElementContainer,
 } from "~lib/components/shared/Toolbar"
-import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
-import { withFullScreenWrapper } from "~lib/components/shared/FullScreenWrapper"
-import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 
 import {
   StyledCaption,
@@ -38,7 +38,6 @@ import {
 
 export interface ImageListProps {
   endpoints: StreamlitEndpoints
-  width: number
   element: ImageListProto
   disableFullscreenMode?: boolean
 }
@@ -62,20 +61,19 @@ enum WidthBehavior {
  */
 function ImageList({
   element,
-  width,
   endpoints,
   disableFullscreenMode,
 }: Readonly<ImageListProps>): ReactElement {
   const {
     expanded: isFullScreen,
-    width: fullScreenWidth,
+    width,
     height,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
 
   // The width of the element is the width of the container, not necessarily the image.
-  const elementWidth: number = isFullScreen ? fullScreenWidth : width
+  const elementWidth = width || 0
   // The width field in the proto sets the image width, but has special
   // cases the values in the WidthBehavior enum.
   let imageWidth: number | undefined

--- a/frontend/lib/src/components/elements/Json/Json.test.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.test.tsx
@@ -33,7 +33,6 @@ const getProps = (elementProps: Partial<JsonProto> = {}): JsonProps => ({
       '  "json": "structure" }',
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("JSON element", () => {

--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -28,15 +28,15 @@ import { EmotionTheme, hasLightBackgroundColor } from "~lib/theme"
 import { ensureError } from "~lib/util/ErrorHandling"
 
 import { StyledJsonWrapper } from "./styled-components"
+
 export interface JsonProps {
-  width: number
   element: JsonProto
 }
 
 /**
  * Functional element representing JSON structured text.
  */
-function Json({ width, element }: Readonly<JsonProps>): ReactElement {
+function Json({ element }: Readonly<JsonProps>): ReactElement {
   const theme: EmotionTheme = useTheme()
 
   const elementRef = useRef<HTMLDivElement>(null)
@@ -74,7 +74,6 @@ function Json({ width, element }: Readonly<JsonProps>): ReactElement {
     <StyledJsonWrapper
       className="stJson"
       data-testid="stJson"
-      width={width}
       ref={elementRef}
     >
       <ReactJson

--- a/frontend/lib/src/components/elements/Json/styled-components.ts
+++ b/frontend/lib/src/components/elements/Json/styled-components.ts
@@ -16,19 +16,12 @@
 
 import styled from "@emotion/styled"
 
-interface StyledJsonWrapperProps {
-  width: number
-}
-
-export const StyledJsonWrapper = styled.div<StyledJsonWrapperProps>(
-  ({ theme, width }) => ({
-    width: width,
-    overflowY: "auto",
-    ".react-json-view .copy-icon svg": {
-      // Make the copy icon responsive to the root font size.
-      fontSize: `1em !important`,
-      marginRight: `${theme.spacing.threeXS} !important`,
-      verticalAlign: "middle !important",
-    },
-  })
-)
+export const StyledJsonWrapper = styled.div(({ theme }) => ({
+  overflowY: "auto",
+  ".react-json-view .copy-icon svg": {
+    // Make the copy icon responsive to the root font size.
+    fontSize: `1em !important`,
+    marginRight: `${theme.spacing.threeXS} !important`,
+    verticalAlign: "middle !important",
+  },
+}))

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -33,7 +33,6 @@ const getProps = (
     url: "https://streamlit.io",
     ...elementProps,
   }),
-  width: 250,
   disabled: false,
   ...widgetProps,
 })
@@ -47,14 +46,13 @@ describe("LinkButton widget", () => {
     expect(linkButton).toBeInTheDocument()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<LinkButton {...props} />)
 
     const linkButton = screen.getByTestId("stLinkButton")
 
     expect(linkButton).toHaveClass("stLinkButton")
-    expect(linkButton).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label within the button", () => {
@@ -85,38 +83,6 @@ describe("LinkButton widget", () => {
         const linkButton = screen.getByRole("link")
         expect(linkButton).toHaveAttribute("disabled")
       })
-    })
-
-    it("does not use container width by default", () => {
-      const props = getProps()
-      render(<LinkButton {...props}>Hello</LinkButton>)
-
-      const linkButton = screen.getByRole("link")
-      expect(linkButton).toHaveStyle("width: auto")
-    })
-
-    it("passes useContainerWidth property with help correctly", () => {
-      render(
-        <LinkButton
-          {...getProps({ useContainerWidth: true, help: "mockHelpText" })}
-        >
-          Hello
-        </LinkButton>
-      )
-
-      const linkButton = screen.getByRole("link")
-      expect(linkButton).toHaveStyle(`width: ${250}px`)
-    })
-
-    it("passes useContainerWidth property without help correctly", () => {
-      render(
-        <LinkButton {...getProps({ useContainerWidth: true })}>
-          Hello
-        </LinkButton>
-      )
-
-      const linkButton = screen.getByRole("link")
-      expect(linkButton).toHaveStyle("width: 100%")
     })
   })
 })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -24,18 +24,17 @@ import {
   BaseButtonTooltip,
   DynamicButtonLabel,
 } from "~lib/components/shared/BaseButton"
+import { Box } from "~lib/components/shared/Base/styled-components"
 
 import BaseLinkButton from "./BaseLinkButton"
 
 export interface Props {
   disabled: boolean
   element: LinkButtonProto
-  width: number
 }
 
 function LinkButton(props: Readonly<Props>): ReactElement {
-  const { disabled, element, width } = props
-  const style = { width }
+  const { disabled, element } = props
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -43,10 +42,6 @@ function LinkButton(props: Readonly<Props>): ReactElement {
   } else if (element.type === "tertiary") {
     kind = BaseButtonKind.TERTIARY
   }
-
-  // When useContainerWidth true & has help tooltip,
-  // we need to pass the container width down to the button
-  const fluidWidth = element.help ? width : true
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>): void => {
     // Prevent the link from being followed if the button is disabled.
@@ -56,7 +51,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
   }
 
   return (
-    <div className="stLinkButton" data-testid="stLinkButton" style={style}>
+    <Box className="stLinkButton" data-testid="stLinkButton">
       <BaseButtonTooltip help={element.help}>
         {/* We use separate BaseLinkButton instead of BaseButton here, because
         link behavior requires tag <a> instead of <button>.*/}
@@ -65,7 +60,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           size={BaseButtonSize.SMALL}
           disabled={disabled}
           onClick={handleClick}
-          fluidWidth={element.useContainerWidth ? fluidWidth : false}
+          fluidWidth={element.useContainerWidth || !!element.help}
           href={element.url}
           target="_blank"
           rel="noreferrer"
@@ -74,7 +69,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseLinkButton>
       </BaseButtonTooltip>
-    </div>
+    </Box>
   )
 }
 

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -34,8 +34,8 @@ export interface BaseLinkButtonProps {
     | BaseButtonKind.TERTIARY
   size?: BaseButtonSize
   disabled?: boolean
-  // If true or number, the button should take up container's full width
-  fluidWidth?: boolean | number
+  // If true, the button should take up container's full width
+  fluidWidth?: boolean
   children: ReactNode
   autoFocus?: boolean
   href: string
@@ -70,9 +70,6 @@ function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
 
 export const StyledBaseLinkButton = styled.a<RequiredBaseLinkButtonProps>(
   ({ fluidWidth, size, theme }) => {
-    const buttonWidth =
-      typeof fluidWidth == "number" ? `${fluidWidth}px` : "100%"
-
     return {
       display: "inline-flex",
       alignItems: "center",
@@ -85,7 +82,7 @@ export const StyledBaseLinkButton = styled.a<RequiredBaseLinkButtonProps>(
       lineHeight: theme.lineHeights.base,
       color: theme.colors.primary,
       textDecoration: "none",
-      width: fluidWidth ? buttonWidth : "auto",
+      width: fluidWidth ? "100%" : "auto",
       userSelect: "none",
       "&:visited": {
         color: theme.colors.primary,

--- a/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
+++ b/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
@@ -36,7 +36,6 @@ const getProps = (
     allowHtml: false,
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("Markdown element", () => {
@@ -46,7 +45,6 @@ describe("Markdown element", () => {
     const markdown = screen.getByTestId("stMarkdown")
     expect(markdown).toBeInTheDocument()
     expect(markdown).toHaveClass("stMarkdown")
-    expect(markdown).toHaveStyle("width: 100px")
   })
 })
 

--- a/frontend/lib/src/components/elements/Markdown/Markdown.tsx
+++ b/frontend/lib/src/components/elements/Markdown/Markdown.tsx
@@ -25,7 +25,6 @@ import {
 } from "~lib/components/shared/TooltipIcon"
 
 export interface MarkdownProps {
-  width: number
   help?: string
   element: MarkdownProto
 }
@@ -33,11 +32,9 @@ export interface MarkdownProps {
 /**
  * Functional element representing Markdown formatted text.
  */
-function Markdown({ width, element }: Readonly<MarkdownProps>): ReactElement {
-  const styleProp = { width }
-
+function Markdown({ element }: Readonly<MarkdownProps>): ReactElement {
   return (
-    <div className="stMarkdown" data-testid="stMarkdown" style={styleProp}>
+    <div className="stMarkdown" data-testid="stMarkdown">
       {element.help ? (
         <StyledLabelHelpWrapper
           isLatex={element.elementType === MarkdownProto.Type.LATEX}

--- a/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
@@ -22,7 +22,6 @@ import { userEvent } from "@testing-library/user-event"
 import { PageLink as PageLinkProto } from "@streamlit/protobuf"
 
 import { customRenderLibContext, render } from "~lib/test_util"
-import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 
 import PageLink, { Props } from "./PageLink"
 
@@ -37,7 +36,6 @@ const getProps = (
     useContainerWidth: null,
     ...elementProps,
   }),
-  width: 250,
   disabled: false,
   ...widgetProps,
 })
@@ -57,14 +55,13 @@ describe("PageLink", () => {
     expect(pageLink).toBeInTheDocument()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<PageLink {...props} />)
 
     const pageLink = screen.getByTestId("stPageLink")
 
     expect(pageLink).toHaveClass("stPageLink")
-    expect(pageLink).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label within the button", () => {
@@ -84,42 +81,6 @@ describe("PageLink", () => {
 
     const pageLink = screen.getByRole("link")
     expect(pageLink).toHaveAttribute("disabled")
-  })
-
-  it("follows useContainerWidth property if set to true", () => {
-    const props = getProps({ useContainerWidth: true })
-    render(<PageLink {...props} />)
-    const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    expect(pageNavLink).toHaveStyle("width: 250px")
-  })
-
-  it("follows useContainerWidth property if set to false", () => {
-    const props = getProps({ useContainerWidth: false })
-    render(<PageLink {...props} />)
-    const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    expect(pageNavLink).toHaveStyle("width: fit-content")
-  })
-
-  it("useContainerWidth true by default in the sidebar", () => {
-    const props = getProps()
-    render(
-      <IsSidebarContext.Provider value={true}>
-        <PageLink {...props} />
-      </IsSidebarContext.Provider>
-    )
-    const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    expect(pageNavLink).toHaveStyle("width: 250px")
-  })
-
-  it("useContainerWidth false by default in the main page", () => {
-    const props = getProps()
-    render(
-      <IsSidebarContext.Provider value={false}>
-        <PageLink {...props} />
-      </IsSidebarContext.Provider>
-    )
-    const pageNavLink = screen.getByTestId("stPageLink-NavLink")
-    expect(pageNavLink).toHaveStyle("width: fit-content")
   })
 
   it("triggers onPageChange with pageScriptHash when clicked", async () => {

--- a/frontend/lib/src/components/elements/PageLink/PageLink.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.tsx
@@ -37,7 +37,6 @@ import {
 export interface Props {
   disabled: boolean
   element: PageLinkProto
-  width: number
 }
 
 function shouldUseContainerWidth(
@@ -58,8 +57,7 @@ function PageLink(props: Readonly<Props>): ReactElement {
 
   const { colors }: EmotionTheme = useTheme()
 
-  const { disabled, element, width } = props
-  const style = { width }
+  const { disabled, element } = props
 
   const useContainerWidth = shouldUseContainerWidth(
     element.useContainerWidth,
@@ -84,14 +82,14 @@ function PageLink(props: Readonly<Props>): ReactElement {
   }
 
   return (
-    <div className="stPageLink" data-testid="stPageLink" style={style}>
+    <div className="stPageLink" data-testid="stPageLink">
       <BaseButtonTooltip help={element.help} placement={Placement.TOP_RIGHT}>
         <StyledNavLinkContainer>
           <StyledNavLink
             data-testid="stPageLink-NavLink"
             disabled={disabled}
             isCurrentPage={isCurrentPage}
-            fluidWidth={useContainerWidth ? width : false}
+            fluidWidth={useContainerWidth || !!element.help}
             href={element.page}
             target={element.external ? "_blank" : ""}
             rel="noreferrer"

--- a/frontend/lib/src/components/elements/PageLink/styled-components.ts
+++ b/frontend/lib/src/components/elements/PageLink/styled-components.ts
@@ -24,14 +24,14 @@ export const StyledNavLinkContainer = styled.div({
 export interface StyledNavLinkProps {
   disabled: boolean
   isCurrentPage: boolean
-  // If true or number, the button should take up container's full width
-  fluidWidth?: boolean | number
+  // If true, the button should take up container's full width
+  fluidWidth?: boolean
 }
 
 export const StyledNavLink = styled.a<StyledNavLinkProps>(
   ({ disabled, isCurrentPage, fluidWidth, theme }) => ({
     textDecoration: "none",
-    width: typeof fluidWidth == "number" ? `${fluidWidth}px` : "fit-content",
+    width: fluidWidth ? "100%" : "fit-content",
     display: "flex",
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, {
+  FC,
   memo,
   ReactElement,
   useCallback,
@@ -377,11 +378,12 @@ export function PlotlyChart({
   const theme: EmotionTheme = useTheme()
   const {
     expanded: isFullScreen,
-    width,
+    width: elWidth,
     height,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
+  const width = elWidth || 0
 
   // Load the initial figure spec from the element message
   const initialFigureSpec = useMemo<PlotlyFigureType>(() => {
@@ -592,7 +594,7 @@ export function PlotlyChart({
       : Math.max(
           element.useContainerWidth
             ? width
-            : Math.min(initialFigureSpec.layout.width ?? width, width),
+            : Math.min(initialFigureSpec.layout.width ?? width, width ?? 0),
           // Apply a min width to prevent the chart running into issues with negative
           // width values if the browser window is too small:
           MIN_WIDTH
@@ -790,4 +792,17 @@ export function PlotlyChart({
   )
 }
 
-export default memo(withFullScreenWrapper(PlotlyChart))
+const PlotlyChartWidthCheck: FC<Omit<PlotlyChartProps, "width">> = props => {
+  const { width } = useRequiredContext(ElementFullscreenContext)
+
+  // If the width is not defined yet, we don't want to render the chart because
+  // it can cause issues with Plotly's rendering where elements will be
+  // positioned incorrectly
+  if (!width) {
+    return null
+  }
+
+  return <PlotlyChart width={width} {...props} />
+}
+
+export default memo(withFullScreenWrapper(PlotlyChartWidthCheck))

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -37,7 +37,6 @@ const getProps = (
     ...elementProps,
   }),
   empty: false,
-  width: 100,
   ...props,
 })
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import React, { memo, ReactElement, useMemo } from "react"
 
 import { useTheme } from "@emotion/react"
 import { ExpandLess, ExpandMore } from "@emotion-icons/material-outlined"
@@ -31,19 +31,19 @@ import BaseButton, {
   DynamicButtonLabel,
 } from "~lib/components/shared/BaseButton"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { Box } from "~lib/components/shared/Base/styled-components"
 
 import { StyledPopoverButtonIcon } from "./styled-components"
 
 export interface PopoverProps {
   element: BlockProto.Popover
   empty: boolean
-  width: number
 }
 
 const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   element,
   empty,
-  width,
   children,
 }): ReactElement => {
   const [open, setOpen] = React.useState(false)
@@ -52,12 +52,13 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   const theme = useTheme()
   const lightBackground = hasLightBackgroundColor(theme)
 
-  // When useContainerWidth true & has help tooltip,
-  // we need to pass the container width down to the button
-  const fluidButtonWidth = element.help ? width : true
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   return (
-    <div data-testid="stPopover" className="stPopover">
+    <Box data-testid="stPopover" className="stPopover" ref={elementRef}>
       <UIPopover
         triggerType={TRIGGER_TYPE.click}
         placement={PLACEMENT.bottomLeft}
@@ -135,7 +136,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               kind={BaseButtonKind.SECONDARY}
               size={BaseButtonSize.SMALL}
               disabled={empty || element.disabled}
-              fluidWidth={element.useContainerWidth ? fluidButtonWidth : false}
+              fluidWidth={element.useContainerWidth || !!element.help}
               onClick={() => setOpen(!open)}
             >
               <DynamicButtonLabel icon={element.icon} label={element.label} />
@@ -153,7 +154,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
           </BaseButtonTooltip>
         </div>
       </UIPopover>
-    </div>
+    </Box>
   )
 }
 

--- a/frontend/lib/src/components/elements/Progress/Progress.test.tsx
+++ b/frontend/lib/src/components/elements/Progress/Progress.test.tsx
@@ -30,7 +30,6 @@ const getProps = (
   element: ProgressProto.create({
     value: 50,
   }),
-  width: 0,
   ...propOverrides,
 })
 
@@ -44,7 +43,7 @@ describe("Progress component", () => {
   })
 
   it("sets the value correctly", () => {
-    render(<Progress {...getProps({ width: 100 })} />)
+    render(<Progress {...getProps()} />)
 
     expect(screen.getByTestId("stProgress")).toBeInTheDocument()
     expect(screen.getByRole("progressbar")).toHaveAttribute(

--- a/frontend/lib/src/components/elements/Progress/Progress.tsx
+++ b/frontend/lib/src/components/elements/Progress/Progress.tsx
@@ -23,18 +23,17 @@ import { StyledProgressLabelContainer } from "~lib/components/elements/Progress/
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 
 export interface ProgressProps {
-  width: number
   element: ProgressProto
 }
 
-function Progress({ element, width }: Readonly<ProgressProps>): ReactElement {
+function Progress({ element }: Readonly<ProgressProps>): ReactElement {
   return (
     <div className="stProgress" data-testid="stProgress">
       <StyledProgressLabelContainer>
         <StreamlitMarkdown source={element.text} allowHTML={false} isLabel />
       </StyledProgressLabelContainer>
 
-      <ProgressBar value={element.value} width={width} />
+      <ProgressBar value={element.value} />
     </div>
   )
 }

--- a/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
@@ -33,7 +33,6 @@ const getProps = (
     text: "Loading...",
     ...elementOverrides,
   }),
-  width: 0,
   ...propOverrides,
 })
 
@@ -53,16 +52,12 @@ describe("Spinner component", () => {
   it("sets the text and width correctly", () => {
     render(
       <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({ width: 100 })} />
+        <Spinner {...getProps()} />
       </BaseProvider>
     )
 
     const markdownText = screen.getByText("Loading...")
     expect(markdownText).toBeInTheDocument()
-
-    // For the width, as it's a style attribute, we can test it this way:
-    const spinnerElement = screen.getByTestId("stSpinner")
-    expect(spinnerElement).toHaveStyle(`width: 100px`)
   })
 
   it("sets additional className/CSS for caching spinner", () => {

--- a/frontend/lib/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.tsx
@@ -30,7 +30,6 @@ import {
 } from "./styled-components"
 
 export interface SpinnerProps {
-  width: number
   element: SpinnerProto
 }
 
@@ -70,7 +69,7 @@ export const formatTime = (seconds: number): string => {
   return `(${hourText}${minText}${secText})`
 }
 
-function Spinner({ width, element }: Readonly<SpinnerProps>): ReactElement {
+function Spinner({ element }: Readonly<SpinnerProps>): ReactElement {
   const { cache, showTime } = element
   const [elapsedTime, setElapsedTime] = React.useState(0)
 
@@ -88,7 +87,6 @@ function Spinner({ width, element }: Readonly<SpinnerProps>): ReactElement {
     <StyledSpinner
       className={classNames({ stSpinner: true, stCacheSpinner: cache })}
       data-testid="stSpinner"
-      width={width}
       cache={cache}
     >
       <StyledSpinnerContainer>

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -37,13 +37,11 @@ export const ThemedStyledSpinner = styled(Spinner, {
 })
 
 interface StyledSpinnerProps {
-  width: number
   cache: boolean
 }
 
 export const StyledSpinner = styled.div<StyledSpinnerProps>(
-  ({ theme, width, cache }) => ({
-    width: width,
+  ({ theme, cache }) => ({
     ...(cache
       ? {
           paddingBottom: theme.spacing.lg,

--- a/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
+++ b/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
@@ -30,7 +30,6 @@ const getProps = (elementProps: Partial<TextProto> = {}): TextProps => ({
     body: "some plain text",
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("TextElement element", () => {

--- a/frontend/lib/src/components/elements/TextElement/TextElement.tsx
+++ b/frontend/lib/src/components/elements/TextElement/TextElement.tsx
@@ -26,21 +26,15 @@ import {
 import { StyledText } from "./styled-components"
 
 export interface TextProps {
-  width: number
   element: TextProto
 }
 
 /**
  * Functional element representing preformatted (plain) text.
  */
-function TextElement({ width, element }: Readonly<TextProps>): ReactElement {
-  const styleProp = { width }
+function TextElement({ element }: Readonly<TextProps>): ReactElement {
   return (
-    <StyledLabelHelpWrapper
-      style={styleProp}
-      className="stText"
-      data-testid="stText"
-    >
+    <StyledLabelHelpWrapper className="stText" data-testid="stText">
       <StyledText>{element.body}</StyledText>
       {element.help && <InlineTooltipIcon content={element.help} />}
     </StyledLabelHelpWrapper>

--- a/frontend/lib/src/components/elements/Toast/Toast.test.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.test.tsx
@@ -48,7 +48,6 @@ const createContainer = (): ReactElement => (
 const getProps = (elementProps: Partial<ToastProto> = {}): ToastProps => ({
   body: "This is a toast message",
   icon: "🐶",
-  width: 0,
   ...elementProps,
 })
 

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -41,7 +41,6 @@ import {
 export interface ToastProps {
   body: string
   icon?: string
-  width: number
 }
 
 function generateToastOverrides(theme: EmotionTheme): ToastOverrides {
@@ -112,7 +111,7 @@ export function shortenMessage(fullMessage: string): string {
   return fullMessage
 }
 
-function Toast({ body, icon, width }: Readonly<ToastProps>): ReactElement {
+function Toast({ body, icon }: Readonly<ToastProps>): ReactElement {
   const theme: EmotionTheme = useTheme()
   const displayMessage = shortenMessage(body)
   const shortened = body !== displayMessage
@@ -198,7 +197,6 @@ function Toast({ body, icon, width }: Readonly<ToastProps>): ReactElement {
       kind={Kind.ERROR}
       body="Streamlit API Error: `st.toast` cannot be called directly on the sidebar with `st.sidebar.toast`.
         See our `st.toast` API [docs](https://docs.streamlit.io/develop/api-reference/status/st.toast) for more information."
-      width={width}
     />
   )
   return (

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -23,6 +23,7 @@ import { Video as VideoProto } from "@streamlit/protobuf"
 import { render } from "~lib/test_util"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import Video, { VideoProps } from "./Video"
 
@@ -46,43 +47,40 @@ describe("Video Element", () => {
       ...elementProps,
     }),
     endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
-    width: 0,
+    width: 250,
     elementMgr: elementMgrMock as unknown as ElementStateManager,
   })
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
-  it("renders without crashing", () => {
+  it("renders without crashing", async () => {
     const props = getProps()
     render(<Video {...props} />)
 
-    const videoElement = screen.getByTestId("stVideo")
+    const videoElement = await screen.findByTestId("stVideo")
     expect(videoElement).toBeInTheDocument()
-    expect(videoElement).toHaveClass("stVideo")
+    expect(videoElement.classList).toContain("stVideo")
   })
 
-  it("has correct style", () => {
-    const props = getProps()
-    render(<Video {...props} />)
-    const video = screen.getByTestId("stVideo")
-
-    expect(video).toHaveAttribute("class", "stVideo")
-    expect(video).toHaveStyle("width: 0px; height: 528px;")
-  })
-
-  it("has controls", () => {
+  it("has controls", async () => {
     const props = getProps()
     render(<Video {...props} />)
 
-    expect(screen.getByTestId("stVideo")).toHaveAttribute("controls")
+    expect(await screen.findByTestId("stVideo")).toHaveAttribute("controls")
   })
 
-  it("creates its `src` attribute using buildMediaURL", () => {
+  it("creates its `src` attribute using buildMediaURL", async () => {
     render(<Video {...getProps({ url: "/media/mockVideoFile.mp4" })} />)
     expect(buildMediaURL).toHaveBeenCalledWith("/media/mockVideoFile.mp4")
-    expect(screen.getByTestId("stVideo")).toHaveAttribute(
+    expect(await screen.findByTestId("stVideo")).toHaveAttribute(
       "src",
       "https://mock.media.url"
     )
@@ -93,19 +91,19 @@ describe("Video Element", () => {
     mockGetElementState.mockReturnValue(false) // By default, assume autoplay is not prevented
   })
 
-  it("does not autoplay if preventAutoplay is set", () => {
+  it("does not autoplay if preventAutoplay is set", async () => {
     mockGetElementState.mockReturnValueOnce(true) // Autoplay should be prevented
     const props = getProps({ autoplay: true, id: "uniqueVideoId" })
     render(<Video {...props} />)
-    const audioElement = screen.getByTestId("stVideo")
+    const audioElement = await screen.findByTestId("stVideo")
     expect(audioElement).not.toHaveAttribute("autoPlay")
   })
 
-  it("autoplays if preventAutoplay is not set and autoplay is true", () => {
+  it("autoplays if preventAutoplay is not set and autoplay is true", async () => {
     mockGetElementState.mockReturnValueOnce(false) // Autoplay is not prevented
     const props = getProps({ autoplay: true, id: "uniqueVideoId" })
     render(<Video {...props} />)
-    const audioElement = screen.getByTestId("stVideo")
+    const audioElement = await screen.findByTestId("stVideo")
     expect(audioElement).toHaveAttribute("autoPlay")
   })
 
@@ -130,12 +128,12 @@ describe("Video Element", () => {
   })
 
   describe("YouTube", () => {
-    it("renders a youtube iframe", () => {
+    it("renders a youtube iframe", async () => {
       const props = getProps({
         type: VideoProto.Type.YOUTUBE_IFRAME,
       })
       render(<Video {...props} />)
-      const videoElement = screen.getByTestId("stVideo")
+      const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).toBeInstanceOf(HTMLIFrameElement)
       expect(videoElement).toHaveAttribute(
         "src",
@@ -143,13 +141,13 @@ describe("Video Element", () => {
       )
     })
 
-    it("renders a youtube iframe with an starting time", () => {
+    it("renders a youtube iframe with an starting time", async () => {
       const props = getProps({
         type: VideoProto.Type.YOUTUBE_IFRAME,
         startTime: 10,
       })
       render(<Video {...props} />)
-      const videoElement = screen.getByTestId("stVideo")
+      const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).toBeInstanceOf(HTMLIFrameElement)
       expect(videoElement).toHaveAttribute(
         "src",
@@ -161,15 +159,19 @@ describe("Video Element", () => {
   describe("updateTime", () => {
     const props = getProps()
 
-    it("sets the current time to startTime on render", () => {
+    it("sets the current time to startTime on render", async () => {
       render(<Video {...props} />)
-      const videoElement = screen.getByTestId("stVideo") as HTMLMediaElement
+      const videoElement = (await screen.findByTestId(
+        "stVideo"
+      )) as HTMLMediaElement
       expect(videoElement.currentTime).toBe(0)
     })
 
-    it("updates the current time when startTime is changed", () => {
+    it("updates the current time when startTime is changed", async () => {
       const { rerender } = render(<Video {...props} />)
-      const videoElement = screen.getByTestId("stVideo") as HTMLMediaElement
+      const videoElement = (await screen.findByTestId(
+        "stVideo"
+      )) as HTMLMediaElement
       expect(videoElement.currentTime).toBe(0)
 
       rerender(<Video {...getProps({ startTime: 10 })} />)

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -20,6 +20,7 @@ import { ISubtitleTrack, Video as VideoProto } from "@streamlit/protobuf"
 
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import { StyledVideoIframe } from "./styled-components"
 
@@ -235,4 +236,4 @@ function Video({
   )
 }
 
-export default memo(Video)
+export default withCalculatedWidth(memo(Video))

--- a/frontend/lib/src/components/shared/Base/styled-components.ts
+++ b/frontend/lib/src/components/shared/Base/styled-components.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CSSProperties } from "react"
+
+import styled from "@emotion/styled"
+
+export const Box = styled.div<{
+  width?: CSSProperties["width"]
+  height?: CSSProperties["height"]
+}>(({ width = "100%", height }) => ({
+  width,
+  height,
+}))

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
@@ -113,13 +113,4 @@ describe("Button element", () => {
     const buttonWidget = screen.getByRole("button")
     expect(buttonWidget).toHaveStyle("width: 100%")
   })
-
-  it("renders use container width buttons correctly when explicit width passed", () => {
-    // Fluid width is a number when the button has a help tooltip
-    // (need to pass explicit width down otherwise tooltip breaks use_container_width=True)
-    render(<BaseButton {...getProps({ fluidWidth: 250 })}>Hello</BaseButton>)
-
-    const buttonWidget = screen.getByRole("button")
-    expect(buttonWidget).toHaveStyle("width: 250px")
-  })
 })

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -55,8 +55,8 @@ export interface BaseButtonProps {
   size?: BaseButtonSize
   onClick?: (event: MouseEvent<HTMLButtonElement>) => any
   disabled?: boolean
-  // If true or number, the button should take up container's full width
-  fluidWidth?: boolean | number
+  // If true, the button should take up container's full width
+  fluidWidth?: boolean
   children: ReactNode
   autoFocus?: boolean
   "data-testid"?: string
@@ -89,9 +89,6 @@ function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
 
 export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
   ({ fluidWidth, size, theme }) => {
-    const buttonWidth =
-      typeof fluidWidth == "number" ? `${fluidWidth}px` : "100%"
-
     return {
       display: "inline-flex",
       alignItems: "center",
@@ -106,7 +103,7 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       fontSize: "inherit",
       fontFamily: "inherit",
       color: "inherit",
-      width: fluidWidth ? buttonWidth : "auto",
+      width: fluidWidth ? "100%" : "auto",
       cursor: "pointer",
       userSelect: "none",
       "&:focus": {
@@ -538,6 +535,7 @@ export const StyledElementToolbarButton = styled(
     minHeight: "unset",
     // line height should be the same as the icon size
     lineHeight: theme.iconSizes.md,
+    width: "auto",
 
     "&:focus": {
       outline: "none",

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
@@ -71,14 +71,6 @@ describe("ColorPicker widget", () => {
     expect(screen.getByTestId("stWidgetLabel")).toHaveStyle("display: none")
   })
 
-  it("should have correct style", () => {
-    const props = getProps()
-    render(<BaseColorPicker {...props} />)
-    const colorPicker = screen.getByTestId("stColorPicker")
-
-    expect(colorPicker).toHaveStyle(`width: ${props.width}px`)
-  })
-
   it("should render a default color in the preview and the color picker", async () => {
     const user = userEvent.setup()
     const props = getProps()

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -78,7 +78,6 @@ export interface BaseColorPickerProps {
 const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
   const {
     disabled,
-    width,
     value: propValue,
     showValue,
     label,
@@ -133,7 +132,6 @@ const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
     <StyledColorPicker
       className="stColorPicker"
       data-testid="stColorPicker"
-      width={width}
       disabled={disabled}
     >
       <WidgetLabel

--- a/frontend/lib/src/components/shared/BaseColorPicker/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseColorPicker/styled-components.ts
@@ -18,17 +18,15 @@ import styled from "@emotion/styled"
 
 export interface StyledColorPickerProps {
   disabled: boolean
-  width: number | undefined
 }
 
 export const StyledColorPicker = styled.div<StyledColorPickerProps>(
-  ({ disabled, width, theme }) => ({
+  ({ disabled, theme }) => ({
     fontFamily: theme.genericFonts.bodyFont,
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
     cursor: disabled ? "not-allowed" : "default",
-    width,
   })
 )
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -32,7 +32,6 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   value: 0,
   label: "Label",
   options: ["a", "b", "c"],
-  width: 0,
   disabled: false,
   onChange: vi.fn(),
   placeholder: "Select...",
@@ -56,11 +55,10 @@ describe("Selectbox widget", () => {
     expect(screen.getByRole("combobox")).toBeInTheDocument()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     render(<Selectbox {...props} />)
     const selectbox = screen.getByTestId("stSelectbox")
     expect(selectbox).toHaveClass("stSelectbox")
-    expect(selectbox).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -37,7 +37,6 @@ const NO_OPTIONS_MSG = "No options to select."
 
 export interface Props {
   disabled: boolean
-  width?: number
   value: number | null
   onChange: (value: number | null) => void
   options: any[]
@@ -76,7 +75,6 @@ export function fuzzyFilterSelectOptions(
 
 const Selectbox: React.FC<Props> = ({
   disabled,
-  width,
   value: propValue,
   onChange,
   options: propOptions,
@@ -148,7 +146,7 @@ const Selectbox: React.FC<Props> = ({
   const showKeyboardOnMobile = options.length > 10
 
   return (
-    <div className="stSelectbox" data-testid="stSelectbox" style={{ width }}>
+    <div className="stSelectbox" data-testid="stSelectbox">
       <WidgetLabel
         label={label}
         labelVisibility={labelVisibility}

--- a/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenContext.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenContext.tsx
@@ -17,7 +17,7 @@
 import { createContext } from "react"
 
 type ElementFullscreenContextShape = {
-  width: number
+  width: number | undefined
   height: number | undefined
   expanded: boolean
   expand: () => void

--- a/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
@@ -21,21 +21,25 @@ import { useTheme } from "@emotion/react"
 import { StyledFullScreenFrame } from "~lib/components/shared/FullScreenWrapper/styled-components"
 import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
 import { EmotionTheme } from "~lib/theme"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import { useFullscreen } from "./useFullscreen"
 
 type ElementFullscreenWrapperProps = PropsWithChildren<{
   height?: number
-  width: number
+  width?: number
 }>
 
 const ElementFullscreenWrapper: FC<ElementFullscreenWrapperProps> = ({
   children,
   height,
-  width,
 }) => {
   const theme: EmotionTheme = useTheme()
   const { expanded, fullHeight, fullWidth, zoomIn, zoomOut } = useFullscreen()
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   const fullscreenContextValue = useMemo(() => {
     return {
@@ -50,6 +54,7 @@ const ElementFullscreenWrapper: FC<ElementFullscreenWrapperProps> = ({
   return (
     <ElementFullscreenContext.Provider value={fullscreenContextValue}>
       <StyledFullScreenFrame
+        ref={elementRef}
         isExpanded={expanded}
         data-testid="stFullScreenFrame"
         theme={theme}

--- a/frontend/lib/src/components/shared/FullScreenWrapper/styled-components.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/styled-components.tsx
@@ -22,6 +22,7 @@ export interface StyledFullScreenFrameProps {
 
 export const StyledFullScreenFrame = styled.div<StyledFullScreenFrameProps>(
   ({ theme, isExpanded }) => ({
+    width: "100%",
     ...(isExpanded
       ? {
           position: "fixed",

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
@@ -19,6 +19,7 @@ import React, { PureComponent, ReactNode } from "react"
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import withFullScreenWrapper from "./withFullScreenWrapper"
 
@@ -54,6 +55,14 @@ const getProps = (props: Partial<TestProps> = {}): TestProps => ({
 const WrappedTestComponent = withFullScreenWrapper(TestComponent)
 
 describe("withFullScreenWrapper HOC", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
+  })
+
   it("renders without crashing", () => {
     render(<WrappedTestComponent {...getProps()} />)
 
@@ -64,18 +73,14 @@ describe("withFullScreenWrapper HOC", () => {
     const props = getProps()
     render(<WrappedTestComponent {...props} />)
 
-    expect(screen.getByTestId("stFullScreenFrame")).toHaveStyle(
-      `width: ${props.width}`
-    )
+    expect(screen.getByTestId("stFullScreenFrame")).toHaveStyle(`width: 100%`)
   })
 
   it("renders FullScreenWrapper with specified height", () => {
     const props = getProps({ width: 123, label: "label", height: 455 })
     render(<WrappedTestComponent {...props} />)
 
-    expect(screen.getByTestId("stFullScreenFrame")).toHaveStyle(
-      `width: ${props.width}`
-    )
+    expect(screen.getByTestId("stFullScreenFrame")).toHaveStyle(`width: 100%`)
     expect(screen.getByTestId("stFullScreenFrame")).toHaveStyle(
       `height: ${props.height}`
     )

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
@@ -20,12 +20,12 @@ import hoistNonReactStatics from "hoist-non-react-statics"
 
 import ElementFullscreenWrapper from "~lib/components/shared/ElementFullscreen/ElementFullscreenWrapper"
 
-function withFullScreenWrapper<P extends { width: number }>(
+function withFullScreenWrapper<P extends object>(
   WrappedComponent: ComponentType<React.PropsWithChildren<P>>
 ): ComponentType<React.PropsWithChildren<P>> {
   const ComponentWithFullScreenWrapper = (props: P): ReactElement => {
     return (
-      <ElementFullscreenWrapper width={props.width}>
+      <ElementFullscreenWrapper>
         <WrappedComponent {...(props as P)}></WrappedComponent>
       </ElementFullscreenWrapper>
     )

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.test.tsx
@@ -24,14 +24,14 @@ import ProgressBar from "./ProgressBar"
 
 describe("ProgressBar component", () => {
   it("renders without crashing", () => {
-    render(<ProgressBar value={50} width={100} />)
+    render(<ProgressBar value={50} />)
 
     const progressBarElement = screen.getByRole("progressbar")
     expect(progressBarElement).toBeInTheDocument()
   })
 
   it("sets the value correctly", () => {
-    render(<ProgressBar value={75} width={100} />)
+    render(<ProgressBar value={75} />)
     const progressBarElement = screen.getByRole("progressbar")
     expect(progressBarElement).toHaveAttribute("aria-valuenow", "75")
   })

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -35,7 +35,6 @@ export enum Size {
 }
 
 export interface ProgressBarProps {
-  width?: number
   value: number
   overrides?: Overrides<any>
   size?: Size
@@ -43,7 +42,6 @@ export interface ProgressBarProps {
 
 function ProgressBar({
   value,
-  width,
   size = Size.SMALL,
   overrides,
 }: ProgressBarProps): ReactElement {
@@ -66,7 +64,6 @@ function ProgressBar({
     },
     Bar: {
       style: ({ $theme }: { $theme: any }) => ({
-        width: width ? width.toString() : undefined,
         marginTop: theme.spacing.none,
         marginBottom: theme.spacing.none,
         marginRight: theme.spacing.none,

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -25,7 +25,6 @@ import { LabelVisibilityOptions } from "~lib/util/utils"
 import Radio, { Props } from "./Radio"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
-  width: 0,
   disabled: false,
   horizontal: false,
   value: 0,
@@ -77,13 +76,12 @@ describe("Radio widget", () => {
     expect(widgetLabel).not.toBeVisible()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<Radio {...props} />)
     const radioElement = screen.getByTestId("stRadio")
 
     expect(radioElement).toHaveClass("stRadio")
-    expect(radioElement).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -37,7 +37,6 @@ import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/Streamli
 export interface Props {
   disabled: boolean
   horizontal: boolean
-  width?: number
   value: number | null
   onChange: (selectedIndex: number) => any
   options: any[]
@@ -50,7 +49,6 @@ export interface Props {
 function Radio({
   disabled,
   horizontal,
-  width,
   value: defaultValue,
   onChange,
   options,
@@ -84,7 +82,6 @@ function Radio({
   )
 
   const theme = useTheme()
-  const style = { width }
   const hasCaptions = captions.length > 0
   const hasOptions = options.length > 0
   const cleanedOptions = hasOptions ? options : ["No options to select."]
@@ -100,7 +97,7 @@ function Radio({
   }
 
   return (
-    <div className="stRadio" data-testid="stRadio" style={style}>
+    <div className="stRadio" data-testid="stRadio">
       <WidgetLabel
         label={label}
         disabled={shouldDisable}

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -29,7 +29,6 @@ import Heading, { HeadingProtoProps } from "./Heading"
 const getHeadingProps = (
   elementProps: Partial<HeadingProto> = {}
 ): HeadingProtoProps => ({
-  width: 300,
   element: HeadingProto.create({
     anchor: "some-anchor",
     tag: "h1",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
@@ -33,7 +33,6 @@ import {
 } from "./StreamlitMarkdown"
 
 export interface HeadingProtoProps {
-  width: number
   element: HeadingProto
 }
 
@@ -55,7 +54,7 @@ function makeMarkdownHeading(tag: string, markdown: string): string {
 }
 
 function Heading(props: HeadingProtoProps): ReactElement {
-  const { width, element } = props
+  const { element } = props
   const { tag, anchor, body, help, hideAnchor, divider } = element
   const isInSidebar = React.useContext(IsSidebarContext)
   const isInDialog = React.useContext(IsDialogContext)
@@ -64,11 +63,10 @@ function Heading(props: HeadingProtoProps): ReactElement {
   const [heading, ...rest] = body.split("\n")
 
   return (
-    <div style={{ width }} className="stHeading" data-testid="stHeading">
+    <div className="stHeading" data-testid="stHeading">
       <StyledStreamlitMarkdown
         isCaption={Boolean(false)}
         isInSidebarOrDialog={isInSidebar || isInDialog}
-        style={{ width }}
         data-testid="stMarkdownContainer"
       >
         <HeadingWithActionElements

--- a/frontend/lib/src/components/shared/Toolbar/styled-components.ts
+++ b/frontend/lib/src/components/shared/Toolbar/styled-components.ts
@@ -66,7 +66,7 @@ export const StyledToolbar = styled.div(({ theme }) => ({
 }))
 
 export const StyledToolbarElementContainer = styled.div<{
-  width?: number
+  width?: number | string
   height?: number
   useContainerWidth: boolean
   topCentered?: boolean

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -170,6 +170,7 @@ function Tooltip({
           display: "flex",
           flexDirection: "row",
           justifyContent: inline ? "flex-end" : "",
+          width: "100%",
           ...style,
         }}
         data-testid="stTooltipHoverTarget"

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -39,7 +39,6 @@ const getProps = (
     label: "Label",
     ...elementProps,
   }),
-  width: 250,
   disabled: false,
   // @ts-expect-error
   widgetMgr: new WidgetStateManager(sendBackMsg),
@@ -62,7 +61,6 @@ describe("Button widget", () => {
     const stButtonDiv = screen.getByTestId("stButton")
 
     expect(stButtonDiv).toHaveClass("stButton")
-    expect(stButtonDiv).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("should render a label within the button", () => {
@@ -141,6 +139,6 @@ describe("Button widget", () => {
     )
 
     const buttonWidget = screen.getByRole("button")
-    expect(buttonWidget).toHaveStyle(`width: ${250}px`)
+    expect(buttonWidget).toHaveStyle(`width: 100%`)
   })
 })

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -25,18 +25,17 @@ import BaseButton, {
   DynamicButtonLabel,
 } from "~lib/components/shared/BaseButton"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import { Box } from "~lib/components/shared/Base/styled-components"
 
 export interface Props {
   disabled: boolean
   element: ButtonProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
 function Button(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, width, fragmentId } = props
-  const style = { width }
+  const { disabled, element, widgetMgr, fragmentId } = props
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -45,18 +44,14 @@ function Button(props: Props): ReactElement {
     kind = BaseButtonKind.TERTIARY
   }
 
-  // When useContainerWidth true & has help tooltip,
-  // we need to pass the container width down to the button
-  const fluidWidth = element.help ? width : true
-
   return (
-    <div className="stButton" data-testid="stButton" style={style}>
+    <Box className="stButton" data-testid="stButton">
       <BaseButtonTooltip help={element.help}>
         <BaseButton
           kind={kind}
           size={BaseButtonSize.SMALL}
           disabled={disabled}
-          fluidWidth={element.useContainerWidth ? fluidWidth : false}
+          fluidWidth={element.useContainerWidth || !!element.help}
           onClick={() =>
             widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
           }
@@ -64,7 +59,7 @@ function Button(props: Props): ReactElement {
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>
       </BaseButtonTooltip>
-    </div>
+    </Box>
   )
 }
 

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -25,6 +25,7 @@ import {
   LabelVisibilityMessage as LabelVisibilityMessageProto,
 } from "@streamlit/protobuf"
 
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -75,6 +76,15 @@ const getProps = (
 
 describe("CameraInput widget", () => {
   fetchMocker.enableMocks()
+
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
+  })
+
   it("renders without crashing", () => {
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setFileUploaderStateValue")

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -48,6 +48,7 @@ import {
   UploadFileInfo,
   UploadingStatus,
 } from "~lib/components/widgets/FileUploader/UploadFileInfo"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import CameraInputButton from "./CameraInputButton"
 import { FacingMode } from "./SwitchFacingModeButton"
@@ -593,4 +594,9 @@ function urltoFile(url: string, filename: string): Promise<File> {
     .then(buf => new File([buf], filename, { type: "image/jpeg" }))
 }
 
-export default CameraInput
+/**
+ * This component should be refactored to remove the width calculation from JS
+ * entirely and instead utilize width: 100%; height: 100%; aspect-ratio: 16 / 9;
+ * on the StyledBox CSS instead.
+ */
+export default withCalculatedWidth(CameraInput)

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -27,6 +27,7 @@ import {
 
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import ChatInput, { Props } from "./ChatInput"
 
@@ -81,6 +82,14 @@ const mockChatInputValue = (text: string): IChatInputValue => {
 describe("ChatInput widget", () => {
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   it("renders without crashing", () => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -20,6 +20,7 @@ import React, {
   memo,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -52,6 +53,7 @@ import {
 } from "~lib/components/widgets/FileUploader/UploadFileInfo"
 import { FileUploadClient } from "~lib/FileUploadClient"
 import { getAccept } from "~lib/components/widgets/FileUploader/FileDropzone"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import {
   StyledChatInput,
@@ -70,7 +72,6 @@ export interface Props {
   disabled: boolean
   element: ChatInputProto
   widgetMgr: WidgetStateManager
-  width: number
   uploadClient: FileUploadClient
   fragmentId?: string
 }
@@ -94,7 +95,6 @@ const getFile = (
 ): UploadFileInfo | undefined => currentFiles.find(f => f.id === localFileId)
 
 function ChatInput({
-  width,
   element,
   widgetMgr,
   fragmentId,
@@ -105,6 +105,11 @@ function ChatInput({
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
   const counterRef = useRef(0)
   const heightGuidance = useRef({ minHeight: 0, maxHeight: 0 })
+
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   // True if the user-specified state.value has not yet been synced to the WidgetStateManager.
   const [dirty, setDirty] = useState(false)
@@ -409,7 +414,7 @@ function ChatInput({
       <StyledChatInputContainer
         className="stChatInput"
         data-testid="stChatInput"
-        width={width}
+        ref={elementRef}
       >
         {showDropzone ? (
           <ChatFileUploadDropzone

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -17,17 +17,11 @@ import styled from "@emotion/styled"
 
 import { hasLightBackgroundColor } from "~lib/theme"
 
-export interface StyledChatInputContainerProps {
-  width: number
-}
-
-export const StyledChatInputContainer =
-  styled.div<StyledChatInputContainerProps>(({ width }) => ({
-    border: "none",
-    position: "relative",
-    display: "flex",
-    width: `${width}px`,
-  }))
+export const StyledChatInputContainer = styled.div`
+  border: none;
+  position: relative;
+  display: flex;
+`
 
 export interface StyledChatInputProps {
   extended: boolean

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -40,7 +40,6 @@ const getProps = (
     type: CheckboxProto.StyleType.DEFAULT,
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -71,13 +70,12 @@ describe("Checkbox widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<Checkbox {...props} />)
     const checkboxElement = screen.getByTestId("stCheckbox")
 
     expect(checkboxElement).toHaveClass("stCheckbox")
-    expect(checkboxElement).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -44,12 +44,10 @@ export interface Props {
   disabled: boolean
   element: CheckboxProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
 function Checkbox({
-  width,
   element,
   disabled,
   widgetMgr,
@@ -84,11 +82,7 @@ function Checkbox({
   const color = disabled ? colors.fadedText40 : colors.bodyText
 
   return (
-    <StyledCheckbox
-      className="row-widget stCheckbox"
-      data-testid="stCheckbox"
-      width={width}
-    >
+    <StyledCheckbox className="row-widget stCheckbox" data-testid="stCheckbox">
       <UICheckbox
         checked={value}
         disabled={disabled}

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -18,18 +18,11 @@ import styled from "@emotion/styled"
 
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
-export interface StyledCheckboxProps {
-  width: number
-}
-
-export const StyledCheckbox = styled.div<StyledCheckboxProps>(
-  ({ width, theme }) => ({
-    width,
-    display: "flex",
-    alignItems: "center",
-    minHeight: theme.sizes.smallElementHeight,
-  })
-)
+export const StyledCheckbox = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  minHeight: theme.sizes.smallElementHeight,
+}))
 
 export interface StyledContentProps {
   visibility?: LabelVisibilityOptions

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -36,7 +36,6 @@ const getProps = (
     default: "#000000",
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -30,7 +30,6 @@ export interface Props {
   disabled: boolean
   element: ColorPickerProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -77,7 +76,6 @@ const ColorPicker: FC<Props> = ({
   element,
   disabled,
   widgetMgr,
-  width,
   fragmentId,
 }) => {
   const [value, setValueWithSource] = useBasicWidgetState<
@@ -109,7 +107,6 @@ const ColorPicker: FC<Props> = ({
       help={element.help}
       onChange={handleColorClose}
       disabled={disabled}
-      width={width}
       value={value}
     />
   )

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -33,6 +33,7 @@ import { bgColorToBaseString, toExportedTheme } from "~lib/theme"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { mockTheme } from "~lib/mocks/mockTheme"
 import { render } from "~lib/test_util"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import ComponentInstance, {
   COMPONENT_READY_WARNING_TIME_MS,
@@ -79,6 +80,12 @@ describe("ComponentInstance", () => {
     logWarnSpy = vi
       .spyOn(componentUtilsLog, "warn")
       .mockImplementation(() => {})
+
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   it("registers a message listener on render", () => {
@@ -88,7 +95,6 @@ describe("ComponentInstance", () => {
       <ComponentInstance
         element={createElementProp()}
         registry={componentRegistry}
-        width={100}
         disabled={false}
         widgetMgr={
           new WidgetStateManager({
@@ -111,7 +117,6 @@ describe("ComponentInstance", () => {
       <ComponentInstance
         element={createElementProp()}
         registry={componentRegistry}
-        width={100}
         disabled={false}
         widgetMgr={
           new WidgetStateManager({
@@ -131,7 +136,6 @@ describe("ComponentInstance", () => {
       <ComponentInstance
         element={createElementProp()}
         registry={componentRegistry}
-        width={100}
         disabled={false}
         widgetMgr={
           new WidgetStateManager({
@@ -157,7 +161,6 @@ describe("ComponentInstance", () => {
       <ComponentInstance
         element={createElementProp()}
         registry={componentRegistry}
-        width={100}
         disabled={false}
         widgetMgr={
           new WidgetStateManager({
@@ -181,7 +184,6 @@ describe("ComponentInstance", () => {
       <ComponentInstance
         element={createElementProp({ height: 0 })}
         registry={componentRegistry}
-        width={100}
         disabled={false}
         widgetMgr={
           new WidgetStateManager({
@@ -205,7 +207,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -240,7 +241,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp()}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -277,7 +277,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -303,7 +302,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -352,7 +350,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -383,7 +380,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -398,14 +394,19 @@ describe("ComponentInstance", () => {
     })
 
     it("send render message when viewport changes", () => {
-      const jsonArgs = { foo: "string", bar: 5 }
       let width = 100
+      vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+        elementRef: React.createRef(),
+        forceRecalculate: vitest.fn(),
+        values: [width],
+      })
+
+      const jsonArgs = { foo: "string", bar: 5 }
       const componentRegistry = getComponentRegistry()
       const { rerender } = render(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={width}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -432,11 +433,18 @@ describe("ComponentInstance", () => {
         })
       )
       width = width + 1
+
+      // Update the spy to return the new width
+      vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+        elementRef: React.createRef(),
+        forceRecalculate: vitest.fn(),
+        values: [width],
+      })
+
       rerender(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={width}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -458,7 +466,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp(jsonArgs)}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -495,7 +502,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={element}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -516,7 +522,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={createElementProp()}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -549,7 +554,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={element}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -609,7 +613,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={element}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -677,7 +680,6 @@ describe("ComponentInstance", () => {
         <ComponentInstance
           element={element}
           registry={componentRegistry}
-          width={100}
           disabled={false}
           widgetMgr={
             new WidgetStateManager({
@@ -720,7 +722,6 @@ describe("ComponentInstance", () => {
           <ComponentInstance
             element={element}
             registry={componentRegistry}
-            width={100}
             disabled={false}
             widgetMgr={
               new WidgetStateManager({
@@ -778,7 +779,6 @@ describe("ComponentInstance", () => {
           <ComponentInstance
             element={element}
             registry={componentRegistry}
-            width={100}
             disabled={false}
             widgetMgr={
               new WidgetStateManager({

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -40,6 +40,7 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { COMMUNITY_URL, COMPONENT_DEVELOPER_URL } from "~lib/urls"
 import { ensureError } from "~lib/util/ErrorHandling"
 import { isNullOrUndefined, notNullOrUndefined } from "~lib/util/utils"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import { ComponentRegistry } from "./ComponentRegistry"
 import {
@@ -368,7 +369,6 @@ function ComponentInstance(props: Props): ReactElement {
     // eslint-disable-next-line react-compiler/react-compiler
     !isReadyRef.current && isReadyTimeout ? (
       <AlertElement
-        width={width}
         body={getWarnMessage(componentName, url)}
         kind={Kind.WARNING}
       />
@@ -412,4 +412,4 @@ function ComponentInstance(props: Props): ReactElement {
   )
 }
 
-export default memo(ComponentInstance)
+export default withCalculatedWidth(memo(ComponentInstance))

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -24,6 +24,7 @@ import { Arrow as ArrowProto } from "@streamlit/protobuf"
 import { TEN_BY_TEN } from "~lib/mocks/arrow"
 import { render } from "~lib/test_util"
 import { Quiver } from "~lib/dataframes/Quiver"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 vi.mock("@glideapps/glide-data-grid", async () => ({
   ...(await vi.importActual("@glideapps/glide-data-grid")),
@@ -50,7 +51,6 @@ const getProps = (
     editingMode,
   }),
   data,
-  width: 700,
   disabled: false,
   widgetMgr: {
     getStringValue: vi.fn(),
@@ -63,15 +63,11 @@ describe("DataFrame widget", () => {
   const props = getProps(new Quiver({ data: TEN_BY_TEN }))
 
   beforeEach(() => {
-    // Mocking ResizeObserver to prevent:
-    // TypeError: window.ResizeObserver is not a constructor
-    // @ts-expect-error
-    delete window.ResizeObserver
-    window.ResizeObserver = vi.fn().mockImplementation(() => ({
-      observe: vi.fn(),
-      unobserve: vi.fn(),
-      disconnect: vi.fn(),
-    }))
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   afterEach(() => {
@@ -90,24 +86,6 @@ describe("DataFrame widget", () => {
     const styledResizableContainer = screen.getByTestId("stDataFrame")
 
     expect(styledResizableContainer).toHaveClass("stDataFrame")
-  })
-
-  it("grid container should use full width when useContainerWidth is used", () => {
-    render(<DataFrame {...getProps(new Quiver({ data: TEN_BY_TEN }), true)} />)
-    const dfStyle = getComputedStyle(
-      screen.getByTestId("stDataFrameResizable")
-    )
-    expect(dfStyle.width).toBe("700px")
-    expect(dfStyle.height).toBe("400px")
-  })
-
-  it("grid container should render with specific size", () => {
-    render(<DataFrame {...props} />)
-    const dfStyle = getComputedStyle(
-      screen.getByTestId("stDataFrameResizable")
-    )
-    expect(dfStyle.width).toBe("400px")
-    expect(dfStyle.height).toBe("400px")
   })
 
   it("should have a toolbar", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -104,7 +104,6 @@ export interface DataFrameProps {
   widgetMgr: WidgetStateManager
   disableFullscreenMode?: boolean
   fragmentId?: string
-  width: number
   height?: number
 }
 
@@ -576,7 +575,7 @@ function DataFrame({
     gridTheme,
     numRows,
     usesGroupRow,
-    containerWidth,
+    containerWidth || 0,
     containerHeight,
     isFullScreen
   )
@@ -610,7 +609,7 @@ function DataFrame({
   const { pinColumn, unpinColumn, freezeColumns } = useColumnPinning(
     columns,
     isEmptyTable,
-    containerWidth,
+    containerWidth || 0,
     gridTheme.minColumnWidth,
     clearSelection,
     setColumnConfigMapping

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -45,7 +45,6 @@ const getProps = (
     format: "YYYY/MM/DD",
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -128,13 +127,12 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<DateInput {...props} />)
 
     const dateInput = screen.getByTestId("stDateInput")
     expect(dateInput).toHaveAttribute("class", "stDateInput")
-    expect(dateInput).toHaveStyle("width: 0px;")
   })
 
   it("renders a default value", () => {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -54,7 +54,6 @@ export interface Props {
   disabled: boolean
   element: DateInputProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -78,7 +77,6 @@ function DateInput({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Props): ReactElement {
   const theme: EmotionTheme = useTheme()
@@ -107,7 +105,6 @@ function DateInput({
   const { locale } = useContext(LibContext)
   const loadedLocale = useIntlLocale(locale)
 
-  const style = { width }
   const minDate = moment(element.min, DATE_FORMAT).toDate()
   const maxDate = getMaxDate(element)
   const clearable = element.default.length === 0 && !disabled
@@ -171,7 +168,7 @@ function DateInput({
   }, [isEmpty, element, setValueWithSource])
 
   return (
-    <div className="stDateInput" data-testid="stDateInput" style={style}>
+    <div className="stDateInput" data-testid="stDateInput">
       <WidgetLabel
         label={element.label}
         disabled={disabled}

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -40,7 +40,6 @@ const getProps = (
     url: "/media/mockDownloadURL",
     ...elementProps,
   }),
-  width: 250,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -59,14 +58,13 @@ describe("DownloadButton widget", () => {
     expect(downloadButton).toBeInTheDocument()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<DownloadButton {...props} />)
 
     const downloadButton = screen.getByTestId("stDownloadButton")
 
     expect(downloadButton).toHaveClass("stDownloadButton")
-    expect(downloadButton).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label within the button", () => {
@@ -138,38 +136,6 @@ describe("DownloadButton widget", () => {
 
       const downloadButton = screen.getByRole("button")
       expect(downloadButton).toBeDisabled()
-    })
-
-    it("does not use container width by default", () => {
-      const props = getProps()
-      render(<DownloadButton {...props}>Hello</DownloadButton>)
-
-      const downloadButton = screen.getByRole("button")
-      expect(downloadButton).toHaveStyle("width: auto")
-    })
-
-    it("passes useContainerWidth property with help correctly", () => {
-      render(
-        <DownloadButton
-          {...getProps({ useContainerWidth: true, help: "mockHelpText" })}
-        >
-          Hello
-        </DownloadButton>
-      )
-
-      const downloadButton = screen.getByRole("button")
-      expect(downloadButton).toHaveStyle(`width: ${250}px`)
-    })
-
-    it("passes useContainerWidth property without help correctly", () => {
-      render(
-        <DownloadButton {...getProps({ useContainerWidth: true })}>
-          Hello
-        </DownloadButton>
-      )
-
-      const downloadButton = screen.getByRole("button")
-      expect(downloadButton).toHaveStyle("width: 100%")
     })
   })
 })

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -34,7 +34,6 @@ export interface Props {
   disabled: boolean
   element: DownloadButtonProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -51,8 +50,8 @@ export function createDownloadLink(
 }
 
 function DownloadButton(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, width, endpoints, fragmentId } = props
-  const style = { width }
+  const { disabled, element, widgetMgr, endpoints, fragmentId } = props
+
   const {
     libConfig: { enforceDownloadInNewTab = false }, // Default to false, if no libConfig, e.g. for tests
   } = React.useContext(LibContext)
@@ -76,23 +75,15 @@ function DownloadButton(props: Props): ReactElement {
     link.click()
   }
 
-  // When useContainerWidth true & has help tooltip,
-  // we need to pass the container width down to the button
-  const fluidWidth = element.help ? width : true
-
   return (
-    <div
-      className="stDownloadButton"
-      data-testid="stDownloadButton"
-      style={style}
-    >
+    <div className="stDownloadButton" data-testid="stDownloadButton">
       <BaseButtonTooltip help={element.help}>
         <BaseButton
           kind={kind}
           size={BaseButtonSize.SMALL}
           disabled={disabled}
           onClick={handleDownloadClick}
-          fluidWidth={element.useContainerWidth ? fluidWidth : false}
+          fluidWidth={element.useContainerWidth || !!element.help}
         >
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -30,6 +30,7 @@ import {
 
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import FileUploader, { Props } from "./FileUploader"
 
@@ -66,7 +67,7 @@ const getProps = (
       maxUploadSizeMb: 50,
       ...elementProps,
     }),
-    width: 0,
+    width: 250,
     disabled: false,
     widgetMgr: new WidgetStateManager({
       sendRerunBackMsg: vi.fn(),
@@ -95,6 +96,14 @@ const getProps = (
 }
 
 describe("FileUploader widget tests", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
+  })
+
   it("renders without crashing", () => {
     const props = getProps()
     render(<FileUploader {...props} />)

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -43,20 +43,23 @@ import {
 } from "~lib/components/widgets/BaseWidget"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { Placement } from "~lib/components/shared/Tooltip"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import FileDropzone from "./FileDropzone"
 import { StyledFileUploader } from "./styled-components"
 import UploadedFiles from "./UploadedFiles"
 import { UploadedStatus, UploadFileInfo } from "./UploadFileInfo"
 
-export interface Props {
+interface InnerProps {
   disabled: boolean
   element: FileUploaderProto
   widgetMgr: WidgetStateManager
   uploadClient: FileUploadClient
-  width: number
   fragmentId?: string
+  width: number
 }
+
+export type Props = Omit<InnerProps, "width">
 
 type FileUploaderStatus =
   | "ready" // FileUploader can upload or delete files
@@ -70,7 +73,7 @@ export interface State {
   files: UploadFileInfo[]
 }
 
-class FileUploader extends React.PureComponent<Props, State> {
+class FileUploader extends React.PureComponent<InnerProps, State> {
   private readonly formClearHelper = new FormClearHelper()
 
   /**
@@ -91,7 +94,7 @@ class FileUploader extends React.PureComponent<Props, State> {
    */
   private forceUpdatingStatus = false
 
-  public constructor(props: Props) {
+  public constructor(props: InnerProps) {
     super(props)
     this.state = this.initialValue
   }
@@ -571,4 +574,4 @@ class FileUploader extends React.PureComponent<Props, State> {
   }
 }
 
-export default memo(FileUploader)
+export default withCalculatedWidth(memo(FileUploader))

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -28,7 +28,6 @@ describe("Form", () => {
   function getProps(props: Partial<Props> = {}): Props {
     return {
       formId: "mockFormId",
-      width: 100,
       hasSubmitButton: false,
       scriptRunState: ScriptRunState.RUNNING,
       clearOnSubmit: false,

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -33,7 +33,6 @@ export interface Props {
   formId: string
   clearOnSubmit: boolean
   enterToSubmit: boolean
-  width: number
   hasSubmitButton: boolean
   scriptRunState: ScriptRunState
   children?: ReactNode
@@ -55,7 +54,6 @@ function Form(props: Props): ReactElement {
     widgetMgr,
     hasSubmitButton,
     children,
-    width,
     scriptRunState,
     clearOnSubmit,
     enterToSubmit,
@@ -89,11 +87,7 @@ function Form(props: Props): ReactElement {
   if (showWarning) {
     submitWarning = (
       <StyledErrorContainer>
-        <AlertElement
-          body={MISSING_SUBMIT_BUTTON_WARNING}
-          kind={Kind.ERROR}
-          width={width}
-        />
+        <AlertElement body={MISSING_SUBMIT_BUTTON_WARNING} kind={Kind.ERROR} />
       </StyledErrorContainer>
     )
   }

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -62,7 +62,6 @@ describe("FormSubmitButton", () => {
       }),
       disabled: false,
       hasInProgressUpload: false,
-      width: 250,
       widgetMgr,
       ...props,
     }
@@ -73,14 +72,13 @@ describe("FormSubmitButton", () => {
     expect(screen.getByRole("button")).toBeInTheDocument()
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<FormSubmitButton {...props} />)
 
     const formSubmitButton = screen.getByTestId("stFormSubmitButton")
 
     expect(formSubmitButton).toHaveClass("stFormSubmitButton")
-    expect(formSubmitButton).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label within the button", () => {
@@ -172,30 +170,5 @@ describe("FormSubmitButton", () => {
     unmountView2()
 
     expect(formsData.submitButtons.get("mockFormId")?.length).toBe(0)
-  })
-
-  it("does not use container width by default", () => {
-    render(<FormSubmitButton {...getProps()} />)
-
-    const formSubmitButton = screen.getByRole("button")
-    expect(formSubmitButton).toHaveStyle("width: auto")
-  })
-
-  it("passes useContainerWidth property with help correctly", () => {
-    render(<FormSubmitButton {...getProps({}, { useContainerWidth: true })} />)
-
-    const formSubmitButton = screen.getByRole("button")
-    expect(formSubmitButton).toHaveStyle(`width: ${250}px`)
-  })
-
-  it("passes useContainerWidth property without help correctly", () => {
-    render(
-      <FormSubmitButton
-        {...getProps({}, { useContainerWidth: true, help: "" })}
-      />
-    )
-
-    const formSubmitButton = screen.getByRole("button")
-    expect(formSubmitButton).toHaveStyle("width: 100%")
   })
 })

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -18,6 +18,7 @@ import React, { ReactElement, useEffect } from "react"
 
 import { Button as ButtonProto } from "@streamlit/protobuf"
 
+import { Box } from "~lib/components/shared/Base/styled-components"
 import BaseButton, {
   BaseButtonKind,
   BaseButtonSize,
@@ -31,21 +32,13 @@ export interface Props {
   element: ButtonProto
   hasInProgressUpload: boolean
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
 export function FormSubmitButton(props: Props): ReactElement {
-  const {
-    disabled,
-    element,
-    widgetMgr,
-    hasInProgressUpload,
-    width,
-    fragmentId,
-  } = props
+  const { disabled, element, widgetMgr, hasInProgressUpload, fragmentId } =
+    props
   const { formId } = element
-  const style = { width }
 
   let kind = BaseButtonKind.SECONDARY_FORM_SUBMIT
   if (element.type === "primary") {
@@ -59,21 +52,13 @@ export function FormSubmitButton(props: Props): ReactElement {
     return () => widgetMgr.removeSubmitButton(formId, element)
   }, [widgetMgr, formId, element])
 
-  // When useContainerWidth true & has help tooltip,
-  // we need to pass the container width down to the button
-  const fluidWidth = element.help ? width : true
-
   return (
-    <div
-      className="stFormSubmitButton"
-      data-testid="stFormSubmitButton"
-      style={style}
-    >
+    <Box className="stFormSubmitButton" data-testid="stFormSubmitButton">
       <BaseButtonTooltip help={element.help}>
         <BaseButton
           kind={kind}
           size={BaseButtonSize.SMALL}
-          fluidWidth={element.useContainerWidth ? fluidWidth : false}
+          fluidWidth={element.useContainerWidth || !!element.help}
           disabled={disabled || hasInProgressUpload}
           onClick={() => {
             widgetMgr.submitForm(element.formId, fragmentId, element)
@@ -82,6 +67,6 @@ export function FormSubmitButton(props: Props): ReactElement {
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseButton>
       </BaseButtonTooltip>
-    </div>
+    </Box>
   )
 }

--- a/frontend/lib/src/components/widgets/Form/FormSubmitContent.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitContent.tsx
@@ -20,11 +20,8 @@ import { FormSubmitButton, Props } from "./FormSubmitButton"
 import { StyledFormSubmitContent } from "./styled-components"
 
 export function FormSubmitContent(props: Props): ReactElement {
-  const { width } = props
-  const style = { width }
-
   return (
-    <StyledFormSubmitContent style={style}>
+    <StyledFormSubmitContent>
       <FormSubmitButton {...props} />
     </StyledFormSubmitContent>
   )

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -43,7 +43,6 @@ const getProps = (
     placeholder: "Please select",
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -99,13 +98,12 @@ describe("Multiselect widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<Multiselect {...props} />)
     const multiSelect = screen.getByTestId("stMultiSelect")
 
     expect(multiSelect).toHaveClass("stMultiSelect")
-    expect(multiSelect).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -50,7 +50,6 @@ export interface Props {
   disabled: boolean
   element: MultiSelectProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -95,7 +94,7 @@ const updateWidgetMgrState = (
 }
 
 const Multiselect: FC<Props> = props => {
-  const { element, widgetMgr, width, fragmentId } = props
+  const { element, widgetMgr, fragmentId } = props
 
   const theme: EmotionTheme = useTheme()
   const [value, setValueWithSource] = useBasicWidgetState<
@@ -191,7 +190,6 @@ const Multiselect: FC<Props> = props => {
     [overMaxSelections, value]
   )
 
-  const style = { width }
   const { options } = element
   const disabled = options.length === 0 ? true : props.disabled
   const placeholder =
@@ -210,7 +208,7 @@ const Multiselect: FC<Props> = props => {
   const showKeyboardOnMobile = options.length > 10
 
   return (
-    <div className="stMultiSelect" data-testid="stMultiSelect" style={style}>
+    <div className="stMultiSelect" data-testid="stMultiSelect">
       <WidgetLabel
         label={element.label}
         disabled={disabled}

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -25,6 +25,7 @@ import {
 
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import NumberInput, {
   canDecrement,
@@ -41,7 +42,6 @@ const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
     hasMax: false,
     ...elementProps,
   }),
-  width: 300,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -72,6 +72,14 @@ const getFloatProps = (
 }
 
 describe("NumberInput widget", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
+  })
+
   it("renders without crashing", () => {
     const props = getIntProps()
     render(<NumberInput {...props} />)
@@ -606,8 +614,14 @@ describe("NumberInput widget", () => {
     })
 
     it("hides stepUp and stepDown buttons when width is smaller than 120px", () => {
+      vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+        elementRef: React.createRef(),
+        forceRecalculate: vitest.fn(),
+        values: [100],
+      })
+
       const props = getIntProps({ default: 1, step: 1, max: 2, hasMax: true })
-      render(<NumberInput {...props} width={100} />)
+      render(<NumberInput {...props} />)
 
       expect(
         screen.queryByTestId("stNumberInputStepUp")
@@ -619,16 +633,22 @@ describe("NumberInput widget", () => {
 
     it("shows stepUp and stepDown buttons when width is bigger than 120px", () => {
       const props = getIntProps({ default: 1, step: 1, max: 2, hasMax: true })
-      render(<NumberInput {...props} width={185} />)
+      render(<NumberInput {...props} />)
 
       expect(screen.getByTestId("stNumberInputStepUp")).toBeInTheDocument()
       expect(screen.getByTestId("stNumberInputStepDown")).toBeInTheDocument()
     })
 
     it("hides Please enter to apply text when width is smaller than 120px", async () => {
+      vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+        elementRef: React.createRef(),
+        forceRecalculate: vitest.fn(),
+        values: [100],
+      })
+
       const user = userEvent.setup()
       const props = getIntProps({ default: 1, step: 1, max: 20, hasMax: true })
-      render(<NumberInput {...props} width={100} />)
+      render(<NumberInput {...props} />)
       const numberInput = screen.getByTestId("stNumberInputField")
 
       // userEvent necessary to trigger dirty state
@@ -641,7 +661,7 @@ describe("NumberInput widget", () => {
     it("shows Please enter to apply text when width is bigger than 120px", async () => {
       const user = userEvent.setup()
       const props = getIntProps({ default: 1, step: 1, max: 20, hasMax: true })
-      render(<NumberInput {...props} width={185} />)
+      render(<NumberInput {...props} />)
       const numberInput = screen.getByTestId("stNumberInputField")
 
       // userEvent necessary to trigger dirty state

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -19,6 +19,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -49,6 +50,7 @@ import {
   WidgetLabel,
 } from "~lib/components/widgets/BaseWidget"
 import { EmotionTheme } from "~lib/theme"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import {
   StyledInputContainer,
@@ -167,7 +169,6 @@ export interface Props {
   disabled: boolean
   element: NumberInputProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -175,7 +176,6 @@ const NumberInput: React.FC<Props> = ({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Props): ReactElement => {
   const theme: EmotionTheme = useTheme()
@@ -189,6 +189,11 @@ const NumberInput: React.FC<Props> = ({
   } = element
   const min = element.hasMin ? element.min : -Infinity
   const max = element.hasMax ? element.max : +Infinity
+
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   const [step, setStep] = useState<number>(getStep(element))
   const initialValue = getInitialValue({ element, widgetMgr })
@@ -402,7 +407,7 @@ const NumberInput: React.FC<Props> = ({
     <div
       className="stNumberInput"
       data-testid="stNumberInput"
-      style={{ width }}
+      ref={elementRef}
     >
       <WidgetLabel
         label={element.label}

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -38,7 +38,6 @@ const getProps = (
     captions: [],
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -84,13 +83,12 @@ describe("Radio widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<Radio {...props} />)
     const radioElement = screen.getByTestId("stRadio")
 
     expect(radioElement).toHaveClass("stRadio")
-    expect(radioElement).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {

--- a/frontend/lib/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.tsx
@@ -30,7 +30,6 @@ export interface Props {
   disabled: boolean
   element: RadioProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -40,7 +39,6 @@ function Radio({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Readonly<Props>): ReactElement {
   const [value, setValueWithSource] = useBasicWidgetState<
@@ -72,7 +70,6 @@ function Radio({
       onChange={onChange}
       options={options}
       captions={captions}
-      width={width}
       disabled={disabled}
       horizontal={horizontal}
       labelVisibility={labelVisibilityProtoValueToEnum(labelVisibility?.value)}

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -38,7 +38,6 @@ const getProps = (
     options: ["a", "b", "c"],
     ...elementProps,
   }),
-  width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -33,7 +33,6 @@ export interface Props {
   disabled: boolean
   element: SelectboxProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -76,7 +75,6 @@ const Selectbox: FC<Props> = ({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }) => {
   const { options, help, label, labelVisibility, placeholder } = element
@@ -109,7 +107,6 @@ const Selectbox: FC<Props> = ({
       labelVisibility={labelVisibilityProtoValueToEnum(labelVisibility?.value)}
       options={options}
       disabled={disabled}
-      width={width}
       onChange={onChange}
       value={value}
       help={help}

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -44,7 +44,6 @@ const getProps = (
     options: [],
     ...elementProps,
   }),
-  width: 600,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -23,6 +23,7 @@ import {
   Slider as SliderProto,
 } from "@streamlit/protobuf"
 
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { withTimezones } from "~lib/util/withTimezones"
@@ -44,6 +45,7 @@ const getProps = (
     options: [],
     ...elementProps,
   }),
+  width: 600,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -71,6 +73,12 @@ describe("Slider widget", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.clearAllTimers()
+
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [250],
+    })
   })
 
   it("shows a label", () => {

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -57,7 +57,6 @@ export interface Props {
   disabled: boolean
   element: SliderProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -65,7 +64,6 @@ function Slider({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Props): ReactElement {
   const [value, setValueWithSource] = useBasicWidgetState<
@@ -95,7 +93,6 @@ function Slider({
   >([])
 
   const { colors, fonts, fontSizes, spacing } = useTheme()
-  const style = { width }
 
   const formattedValueArr = uiValue.map(v => formatValue(v, element))
   const formattedMinValue = formatValue(element.min, element)
@@ -240,12 +237,7 @@ function Slider({
   )
 
   return (
-    <div
-      ref={sliderRef}
-      className="stSlider"
-      data-testid="stSlider"
-      style={style}
-    >
+    <div ref={sliderRef} className="stSlider" data-testid="stSlider">
       <WidgetLabel
         label={element.label}
         disabled={disabled}

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -43,6 +43,7 @@ import {
 } from "~lib/components/widgets/BaseWidget"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { Placement } from "~lib/components/shared/Tooltip"
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import {
   StyledThumb,
@@ -57,6 +58,7 @@ export interface Props {
   disabled: boolean
   element: SliderProto
   widgetMgr: WidgetStateManager
+  width: number
   fragmentId?: string
 }
 
@@ -561,4 +563,9 @@ function fixLabelOverlap(
   }
 }
 
-export default memo(Slider)
+// Note: we shouldn't need `withCalculatedWidth` here, but there is some custom
+// ref measurement and style setting logic in this component used for fixing
+// overflows that is not properly within the React lifecycle. This leads to race
+// conditions in styles being applied outside of React's knowledge, which can
+// lead to visually incorrect labels in certain scenarios.
+export default withCalculatedWidth(memo(Slider))

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -24,6 +24,7 @@ import {
   TextArea as TextAreaProto,
 } from "@streamlit/protobuf"
 
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -40,7 +41,6 @@ const getProps = (
     placeholder: "Placeholder",
     ...elementProps,
   }),
-  width: 300,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -85,13 +85,12 @@ describe("TextArea widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<TextArea {...props} />)
     const textArea = screen.getByTestId("stTextArea")
 
     expect(textArea).toHaveClass("stTextArea")
-    expect(textArea).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("renders a label", () => {
@@ -227,7 +226,13 @@ describe("TextArea widget", () => {
 
   it("hides Please enter to apply text when width is smaller than 180px", async () => {
     const user = userEvent.setup()
-    const props = getProps({}, { width: 100 })
+    const props = getProps({}, {})
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [100],
+    })
+
     render(<TextArea {...props} />)
 
     const textArea = screen.getByRole("textbox")
@@ -237,8 +242,14 @@ describe("TextArea widget", () => {
   })
 
   it("shows Please enter to apply text when width is bigger than 180px", async () => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [190],
+    })
+
     const user = userEvent.setup()
-    const props = getProps({}, { width: 190 })
+    const props = getProps({}, {})
     render(<TextArea {...props} />)
 
     const textArea = screen.getByRole("textbox")

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback, useRef, useState } from "react"
+import React, { FC, memo, useCallback, useMemo, useRef, useState } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 import { useTheme } from "@emotion/react"
@@ -39,12 +39,12 @@ import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 export interface Props {
   disabled: boolean
   element: TextAreaProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -79,16 +79,15 @@ const updateWidgetMgrState = (
   )
 }
 
-const TextArea: FC<Props> = ({
-  disabled,
-  element,
-  widgetMgr,
-  fragmentId,
-  width,
-}) => {
+const TextArea: FC<Props> = ({ disabled, element, widgetMgr, fragmentId }) => {
   // TODO: Update to match React best practices
   // eslint-disable-next-line react-compiler/react-compiler
   const id = useRef(uniqueId("text_area_")).current
+
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   /**
    * True if the user-specified state.value has not yet been synced to the WidgetStateManager.
@@ -97,6 +96,7 @@ const TextArea: FC<Props> = ({
   /**
    * Whether the area is currently focused.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [focused, setFocused] = useState(false)
 
   /**
@@ -163,7 +163,6 @@ const TextArea: FC<Props> = ({
     true
   )
 
-  const style = { width }
   const { height, placeholder, formId } = element
 
   // Show "Please enter" instructions if in a form & allowed, or not in form and state is dirty.
@@ -176,7 +175,7 @@ const TextArea: FC<Props> = ({
     focused && width > theme.breakpoints.hideWidgetDetails
 
   return (
-    <div className="stTextArea" data-testid="stTextArea" style={style}>
+    <div className="stTextArea" data-testid="stTextArea" ref={elementRef}>
       <WidgetLabel
         label={element.label}
         disabled={disabled}

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -26,6 +26,7 @@ import {
 
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import TextInput, { Props } from "./TextInput"
 
@@ -40,7 +41,6 @@ const getProps = (
     type: TextInputProto.Type.DEFAULT,
     ...elementProps,
   }),
-  width: 300,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -50,6 +50,14 @@ const getProps = (
 })
 
 describe("TextInput widget", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [190],
+    })
+  })
+
   it("renders without crashing", () => {
     const props = getProps()
     render(<TextInput {...props} />)
@@ -162,13 +170,12 @@ describe("TextInput widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<TextInput {...props} />)
     const textInput = screen.getByTestId("stTextInput")
 
     expect(textInput).toHaveClass("stTextInput")
-    expect(textInput).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("can be disabled", () => {
@@ -446,8 +453,13 @@ describe("TextInput widget", () => {
   })
 
   it("hides Please enter to apply text when width is smaller than 180px", async () => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: React.createRef(),
+      forceRecalculate: vitest.fn(),
+      values: [100],
+    })
     const user = userEvent.setup()
-    const props = getProps({}, { width: 100 })
+    const props = getProps({}, {})
     render(<TextInput {...props} />)
 
     // Focus on input
@@ -459,7 +471,7 @@ describe("TextInput widget", () => {
 
   it("shows Please enter to apply text when width is bigger than 180px", async () => {
     const user = userEvent.setup()
-    const props = getProps({}, { width: 190 })
+    const props = getProps({}, {})
     render(<TextInput {...props} />)
 
     // Focus on input

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback, useState } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useCallback,
+  useMemo,
+  useState,
+} from "react"
 
 import uniqueId from "lodash/uniqueId"
 import { Input as UIInput } from "baseui/input"
@@ -38,6 +44,7 @@ import {
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { Placement } from "~lib/components/shared/Tooltip"
 import { isInForm, labelVisibilityProtoValueToEnum } from "~lib/util/utils"
+import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import { StyledTextInput } from "./styled-components"
 
@@ -45,7 +52,6 @@ export interface Props {
   disabled: boolean
   element: TextInputProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -53,7 +59,6 @@ function TextInput({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Props): ReactElement {
   /**
@@ -63,6 +68,11 @@ function TextInput({
   const [uiValue, setUiValue] = useState<string | null>(
     getStateFromWidgetMgr(widgetMgr, element) ?? null
   )
+
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver(useMemo(() => ["width"], []))
 
   /**
    * True if the user-specified state.value has not yet been synced to the WidgetStateManager.
@@ -144,7 +154,7 @@ function TextInput({
     <StyledTextInput
       className="stTextInput"
       data-testid="stTextInput"
-      width={width}
+      ref={elementRef}
     >
       <WidgetLabel
         label={element.label}

--- a/frontend/lib/src/components/widgets/TextInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/TextInput/styled-components.ts
@@ -16,13 +16,6 @@
 
 import styled from "@emotion/styled"
 
-export interface StyledTextInputProps {
-  width: number
-}
-
-export const StyledTextInput = styled.div<StyledTextInputProps>(
-  ({ width }) => ({
-    position: "relative",
-    width,
-  })
-)
+export const StyledTextInput = styled.div`
+  position: relative;
+`

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -40,7 +40,6 @@ const getProps = (
     step: 900,
     ...elementProps,
   }),
-  width: 0,
   disabled: disabled,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
@@ -116,13 +115,12 @@ describe("TimeInput widget", () => {
     )
   })
 
-  it("has correct className and style", () => {
+  it("has correct className", () => {
     const props = getProps()
     render(<TimeInput {...props} />)
 
     const timeInput = screen.getByTestId("stTimeInput")
     expect(timeInput).toHaveClass("stTimeInput")
-    expect(timeInput).toHaveStyle(`width: ${props.width}px`)
   })
 
   it("can be disabled", () => {

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -45,7 +45,6 @@ export interface Props {
   disabled: boolean
   element: TimeInputProto
   widgetMgr: WidgetStateManager
-  width: number
   fragmentId?: string
 }
 
@@ -53,7 +52,6 @@ function TimeInput({
   disabled,
   element,
   widgetMgr,
-  width,
   fragmentId,
 }: Props): ReactElement {
   const [value, setValueWithSource] = useBasicWidgetState<
@@ -70,7 +68,6 @@ function TimeInput({
   })
 
   const clearable = isNullOrUndefined(element.default) && !disabled
-  const style = { width }
   const theme = useTheme()
 
   const selectOverrides = {
@@ -179,7 +176,7 @@ function TimeInput({
   }, [handleChange])
 
   return (
-    <div className="stTimeInput" data-testid="stTimeInput" style={style}>
+    <div className="stTimeInput" data-testid="stTimeInput">
       <WidgetLabel
         label={element.label}
         disabled={disabled}

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+
+import { DOMRectKeys, useResizeObserver } from "./useResizeObserver"
+
+const mockDisconnect = vi.fn()
+const mockObserve = vi.fn()
+
+describe("useResizeObserver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Mock ResizeObserver with immediate callback execution
+    global.ResizeObserver = vi.fn().mockImplementation(callback => ({
+      observe: mockObserve.mockImplementation(() => {
+        callback([{ target: document.createElement("div") }])
+      }),
+      disconnect: mockDisconnect,
+    }))
+    // Mock requestAnimationFrame
+    global.requestAnimationFrame = vi.fn().mockImplementation(cb => {
+      cb()
+      return 1
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("should initialize with empty values", () => {
+    const properties: DOMRectKeys[] = ["width", "height"]
+    const { result } = renderHook(() => useResizeObserver(properties))
+
+    expect(result.current.values).toEqual([])
+    expect(result.current.elementRef.current).toBeNull()
+  })
+
+  it("should observe element changes", () => {
+    const properties: DOMRectKeys[] = ["width", "height"]
+    const { result } = renderHook(() => useResizeObserver(properties))
+
+    // Simulate element reference
+    const mockElement = document.createElement("div")
+    vi.spyOn(mockElement, "getBoundingClientRect").mockReturnValue({
+      width: 100,
+      height: 200,
+    } as DOMRect)
+
+    // Set the ref
+    result.current.elementRef.current = mockElement
+
+    // Trigger resize observation
+    const observer = new ResizeObserver(() => {})
+    observer.observe(mockElement)
+
+    expect(mockObserve).toHaveBeenCalledWith(mockElement)
+  })
+
+  it("should handle force recalculation", async () => {
+    const properties: DOMRectKeys[] = ["width", "height"]
+    const { result } = renderHook(() => useResizeObserver(properties))
+
+    // Simulate element reference
+    const mockElement = document.createElement("div")
+    vi.spyOn(mockElement, "getBoundingClientRect").mockReturnValue({
+      width: 100,
+      height: 200,
+    } as DOMRect)
+
+    // Set the ref and trigger initial calculation
+    act(() => {
+      result.current.elementRef.current = mockElement
+    })
+
+    // Force recalculation
+    await act(async () => {
+      result.current.forceRecalculate()
+    })
+
+    // Run any pending timers
+    vi.runAllTimers()
+
+    expect(result.current.values).toEqual([100, 200])
+  })
+})

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+export type DOMRectKeys =
+  | "bottom"
+  | "height"
+  | "left"
+  | "right"
+  | "top"
+  | "width"
+  | "x"
+  | "y"
+
+/**
+ * A hook that observes changes to the dimensions of a DOM element.
+ *
+ * @template T - The type of the HTML element being observed.
+ * @param {DOMRectKeys[]} properties - The list of DOMRect properties to observe.
+ * @returns {{
+ *   values: number[],
+ *   elementRef: MutableRefObject<T | null>,
+ *   forceRecalculate: () => void
+ *   }} An object containing the observed values, a ref to the observed element,
+ *   and a function to force recalculation.
+ */
+export const useResizeObserver = <T extends HTMLDivElement>(
+  properties: DOMRectKeys[]
+): {
+  values: number[]
+  elementRef: MutableRefObject<T | null>
+  forceRecalculate: () => void
+} => {
+  const elementRef = useRef<T | null>(null)
+  const [values, setValues] = useState<number[]>([])
+
+  /**
+   * Gets the current values of the specified DOMRect properties.
+   *
+   * @returns {DOMRectKeys[]} The current values of the specified properties.
+   */
+  const getValues = useCallback(() => {
+    if (!elementRef.current) {
+      return []
+    }
+
+    const rect = elementRef.current.getBoundingClientRect()
+
+    return properties.map(property => {
+      return rect[property]
+    })
+  }, [properties])
+
+  /**
+   * Forces a recalculation of the observed values. Using this shouldn't be
+   * necessary in a vast majority of cases!
+   */
+  const forceRecalculate = useCallback(() => {
+    setValues(getValues())
+  }, [getValues])
+
+  useEffect(() => {
+    if (!elementRef.current) {
+      return
+    }
+
+    setValues(getValues())
+
+    let frameId: number
+    const observer = new ResizeObserver(() => {
+      frameId = window.requestAnimationFrame(() => {
+        setValues(getValues())
+      })
+    })
+
+    observer.observe(elementRef.current)
+
+    return () => {
+      observer.disconnect()
+      if (frameId) {
+        cancelAnimationFrame(frameId)
+      }
+    }
+  }, [properties, getValues])
+
+  return { values, elementRef, forceRecalculate }
+}

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -72,8 +72,11 @@ export const useResizeObserver = <T extends HTMLDivElement>(
   }, [properties])
 
   /**
-   * Forces a recalculation of the observed values. Using this shouldn't be
-   * necessary in a vast majority of cases!
+   * Forces a recalculation of the observed values.
+   *
+   * This is included for backwards compatibility after the addition of
+   * useResizeObserver but we anticipate all new cases should be implemented
+   * without this.
    */
   const forceRecalculate = useCallback(() => {
     setValues(getValues())

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -107,7 +107,6 @@ describe("useWidgetManagerElementState hook", () => {
             formId={formId}
             clearOnSubmit={true}
             enterToSubmit={false}
-            width={0}
             hasSubmitButton={true}
             widgetMgr={widgetMgr}
             border={false}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -55,3 +55,9 @@ console.warn = (...args) => {
 Element.prototype.animate = vi
   .fn()
   .mockImplementation(() => ({ addEventListener: vi.fn() }))
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))


### PR DESCRIPTION
## Describe your changes

This pull request includes several changes to improve layout handling and simplify the codebase. The most important changes include refactoring width handling, introducing a new `useLayoutStyles` hook.

### Refactoring `width` handling:

* Updated `BlockPropsWithWidth` and `ElementNodeRendererProps` to use `React.CSSProperties["width"]` instead of `number` for width. This change affects multiple files, including `Block.tsx` and `ElementNodeRenderer.tsx`. [[1]](diffhunk://#diff-f54e8507113a9d3a258c5a1b9835d4dd7c850d2cbb071108f54f0ab69fe1e105R52-R67) [[2]](diffhunk://#diff-9f22876c600a7c0da7a5218b63c6c2745d4254c9187f6dff46eccdba1ddcd4e5L190-R190)
* Removed explicit width props from all Element components. Instead, elements should utilize `width: 100%` if necessary and not worry about explicit values of their width.
* Updates tests, and removes some legacy vitest tests that are unnecessary since they are testing against CSS evaluated properties, which is not actually supported in JSDOM.

### Introducing `useLayoutStyles` hook:

* Added a new `useLayoutStyles` hook to handle width and layout parent styles dynamically. This hook is used to calculate and apply styles based on the container and element properties. It centralizes logic for new props that will be added in upcoming Advanced Layouts work.
* Created a test file `useLayoutStyles.test.tsx` to ensure the new hook works correctly under different scenarios.

### Escape hatches for when a component requires a JS-evaluated `width` value

* There are 2 options: `withCalculatedWidth` and `useResizeObserver`. The former is a HOC that is good for older components that might have tighter coupling. The latter is more generic and can be used in any elements that need to size themselves.

### Updating component imports and usage:

* Introduced a new `StyledElementContainerLayoutWrapper` component to replace `StyledElementContainer` in `ElementNodeRenderer.tsx`, leveraging the new `useLayoutStyles` hook for dynamic styling. [[1]](diffhunk://#diff-aacca35a0bb47be90eb37d418404ed2ff4ea17af63984ffeba0c488d1c0ca3ccR1-R37) [[2]](diffhunk://#diff-9f22876c600a7c0da7a5218b63c6c2745d4254c9187f6dff46eccdba1ddcd4e5L745-R745)

These changes collectively improve the flexibility and maintainability of the codebase by centralizing layout logic and reducing redundancy.


## GitHub Issue Link (if applicable)

## Testing Plan

- Adds unit tests for new functionality
- Streamlines existing tests where necessary
- Lots of e2e tests will cover the visual aspect here

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
