### PR TITLE
Raise an exception when provider name contains underscore

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -172,6 +172,12 @@ def validate_auth_credentials(provider: str) -> None:
 
     provider_section = auth_section.get(provider)
 
+    if "_" in provider:
+        raise StreamlitAuthError(
+            f'Auth provider name "{provider}" contains an underscore. '
+            f"Please use a provider name without underscores."
+        )
+
     if provider_section is None and provider == "default":
         provider_section = generate_default_provider_section(auth_section)
 

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -172,6 +172,8 @@ def validate_auth_credentials(provider: str) -> None:
 
     provider_section = auth_section.get(provider)
 
+    # TODO[kajarenc]: Revisit this check later when investigating the ability
+    # TODO[kajarenc] to add "_" to the provider name.
     if "_" in provider:
         raise StreamlitAuthError(
             f'Auth provider name "{provider}" contains an underscore. '

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -173,11 +173,21 @@ class UserInfoAuthTest(DeltaGeneratorTestCase):
     def test_user_login_with_invalid_provider(self):
         """Test that st.login raise exception for invalid provider."""
         with self.assertRaises(StreamlitAuthError) as ex:
-            st.login("invalid_provider")
+            st.login("invalid-provider")
 
         assert (
             "Authentication credentials in `.streamlit/secrets.toml` are missing for the "
-            'authentication provider "invalid_provider". Please check your configuration.'
+            'authentication provider "invalid-provider". Please check your configuration.'
+        ) == str(ex.exception)
+
+    def test_user_login_with_provider_with_underscore(self):
+        """Test that st.login raise exception for provider containing underscore."""
+        with self.assertRaises(StreamlitAuthError) as ex:
+            st.login("invalid_provider")
+
+        assert (
+            """Auth provider name "invalid_provider" contains an underscore. """
+            """Please use a provider name without underscores."""
         ) == str(ex.exception)
 
     def test_user_login_redirect_uri_missing(self):


### PR DESCRIPTION
## Describe your changes

## GitHub Issue Link (if applicable)

Closes #10356 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Done
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
