### PR TITLE
Fix typo in set_page_config doc string

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -172,7 +172,7 @@ def set_page_config(
           format ``":material/icon_name:"`` where "icon_name" is the name
           of the icon in snake case.
 
-          For example, ``icon=":material/thumb_up:"`` will display the
+          For example, ``page_icon=":material/thumb_up:"`` will display the
           Thumb Up icon. Find additional icons in the `Material Symbols \
           <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
           font library.


### PR DESCRIPTION
## Describe your changes

Fix typo in `set_page_config` docstring.

## GitHub Issue Link (if applicable)

## Testing Plan

- No testing plan - this is just a docstring modification.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
