### PR TITLE
Fix: `st.logo` unmounts with use of `st.fragment`

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1210,6 +1210,18 @@ export class App extends PureComponent<Props, State> {
         status ===
           ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
       ) {
+        const { scriptRunId, fragmentIdsThisRun } = this.state
+
+        // If we are running a fragment, we need to update the scriptRunId
+        // associated with logo to ensure it isn't cleared (Issue #10350)
+        if (
+          status ===
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        ) {
+          this.pendingElementsBuffer =
+            this.pendingElementsBuffer.updateLogoScriptRunId(scriptRunId)
+        }
+
         // Clear any stale elements left over from the previous run.
         // We only do that for completed runs, not for runs that were finished early
         // due to reruns; this is to avoid flickering of elements where they disappear for
@@ -1218,13 +1230,13 @@ export class App extends PureComponent<Props, State> {
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
         this.setState(
-          ({ scriptRunId, fragmentIdsThisRun }) => ({
+          {
             // Apply any pending elements that haven't been applied.
             elements: this.pendingElementsBuffer.clearStaleNodes(
               scriptRunId,
               fragmentIdsThisRun
             ),
-          }),
+          },
           () => {
             this.pendingElementsBuffer = this.state.elements
           }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1213,7 +1213,7 @@ export class App extends PureComponent<Props, State> {
         const { scriptRunId, fragmentIdsThisRun } = this.state
 
         // If we are running a fragment, we need to update the scriptRunId
-        // associated with logo to ensure it isn't cleared (Issue #10350)
+        // associated with logo to ensure it isn't cleared (Issue #10350/#10382)
         if (
           status ===
           ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1210,18 +1210,6 @@ export class App extends PureComponent<Props, State> {
         status ===
           ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
       ) {
-        const { scriptRunId, fragmentIdsThisRun } = this.state
-
-        // If we are running a fragment, we need to update the scriptRunId
-        // associated with logo to ensure it isn't cleared (Issue #10350/#10382)
-        if (
-          status ===
-          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
-        ) {
-          this.pendingElementsBuffer =
-            this.pendingElementsBuffer.updateLogoScriptRunId(scriptRunId)
-        }
-
         // Clear any stale elements left over from the previous run.
         // We only do that for completed runs, not for runs that were finished early
         // due to reruns; this is to avoid flickering of elements where they disappear for
@@ -1230,13 +1218,13 @@ export class App extends PureComponent<Props, State> {
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
         this.setState(
-          {
+          ({ scriptRunId, fragmentIdsThisRun }) => ({
             // Apply any pending elements that haven't been applied.
             elements: this.pendingElementsBuffer.clearStaleNodes(
               scriptRunId,
               fragmentIdsThisRun
             ),
-          },
+          }),
           () => {
             this.pendingElementsBuffer = this.state.elements
           }

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -879,6 +879,23 @@ describe("AppRoot.clearStaleNodes", () => {
     expect(newNewRoot.logo).toBeNull()
   })
 
+  it("does not clear logo on fragment run", () => {
+    const logo = LogoProto.create({
+      image:
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png",
+    })
+    const newRoot = ROOT.appRootWithLogo(logo, {
+      activeScriptHash: "hash",
+      scriptRunId: "script_run_id",
+    })
+    expect(newRoot.logo).not.toBeNull()
+
+    const newNewRoot = newRoot.clearStaleNodes("new_script_run_id", [
+      "my_fragment_id",
+    ])
+    expect(newNewRoot.logo).not.toBeNull()
+  })
+
   it("handles currentFragmentId correctly", () => {
     const tabContainerProto = makeProto(DeltaProto, {
       addBlock: { tabContainer: {}, allowEmpty: false },

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -714,17 +714,6 @@ export class AppRoot {
     })
   }
 
-  public updateLogoScriptRunId(scriptRunId: string): AppRoot {
-    if (!this.appLogo) {
-      return this
-    }
-
-    return new AppRoot(this.mainScriptHash, this.root, {
-      ...this.appLogo,
-      scriptRunId,
-    })
-  }
-
   public applyDelta(
     scriptRunId: string,
     delta: Delta,

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -571,7 +571,8 @@ export class AppRoot {
   /* The hash of the main script that creates this AppRoot. */
   readonly mainScriptHash: string
 
-  readonly appLogo: AppLogo | null
+  /* The app logo, if it exists. */
+  private appLogo: AppLogo | null
 
   /**
    * Create an empty AppRoot with a placeholder "skeleton" element.
@@ -710,6 +711,17 @@ export class AppRoot {
     return new AppRoot(this.mainScriptHash, this.root, {
       logo,
       ...metadata,
+    })
+  }
+
+  public updateLogoScriptRunId(scriptRunId: string): AppRoot {
+    if (!this.appLogo) {
+      return this
+    }
+
+    return new AppRoot(this.mainScriptHash, this.root, {
+      ...this.appLogo,
+      scriptRunId,
     })
   }
 

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -833,8 +833,12 @@ export class AppRoot {
       this.bottom.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
       new BlockNode(this.mainScriptHash)
 
+    // Check if we're running a fragment, ensure logo isn't cleared as stale (Issue #10350/#10382)
+    const isFragmentRun = fragmentIdsThisRun && fragmentIdsThisRun.length > 0
     const appLogo =
-      this.appLogo?.scriptRunId === currentScriptRunId ? this.appLogo : null
+      isFragmentRun || this.appLogo?.scriptRunId === currentScriptRunId
+        ? this.appLogo
+        : null
 
     return new AppRoot(
       this.mainScriptHash,


### PR DESCRIPTION
## Describe your changes
`st.fragment` generates a new `scriptRunId`, causing `st.logo` to be cleaned up as stale in `clearStaleNodes` (which checks that the `scriptRunId` attached to the app's logo matches the current `scriptRunId`).
This also impact use of logo with `st.dialog`.

This PR resolves the bugs by checking in `clearStaleNodes` if a fragment triggered the re-run - if so, `st.logo` is not cleared as stale.

## GitHub Issue Link
Closes #10350 
Closes #10382 

## Testing Plan
- JS Unit Tests: Added ✅ 
- Manual Testing: ✅ 
