### PR TITLE
Prevent showing tooltips on trailing dataframe row

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -534,6 +534,8 @@ function DataFrame({
     getCellContent,
     // If dynamic editing is enabled, we need to ignore the last row (trailing row)
     // because it would result in some undesired errors in the tooltips.
+    // The index are 0-based -> therefore, numRows will point to the trailing row
+    // (which is not part of the actual data).
     isDynamicAndEditable ? [numRows] : []
   )
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -201,6 +201,9 @@ function DataFrame({
   const isSortingEnabled =
     !isLargeTable && !isEmptyTable && element.editingMode !== DYNAMIC
 
+  const isDynamicAndEditable =
+    !isEmptyTable && element.editingMode === DYNAMIC && !disabled
+
   const editingState = React.useRef<EditingState>(
     new EditingState(originalNumRows)
   )
@@ -526,7 +529,13 @@ function DataFrame({
     tooltip,
     clearTooltip,
     onItemHovered: handleTooltips,
-  } = useTooltips(columns, getCellContent)
+  } = useTooltips(
+    columns,
+    getCellContent,
+    // If dynamic editing is enabled, we need to ignore the last row (trailing row)
+    // because it would result in some undesired errors in the tooltips otherwise
+    isDynamicAndEditable ? [numRows] : []
+  )
 
   const { drawCell, customRenderers } = useCustomRenderer(columns)
 
@@ -595,9 +604,6 @@ function DataFrame({
   }, [resetEditingState, clearSelection])
 
   useFormClearHelper({ element, widgetMgr, onFormCleared })
-
-  const isDynamicAndEditable =
-    !isEmptyTable && element.editingMode === DYNAMIC && !disabled
 
   const { pinColumn, unpinColumn, freezeColumns } = useColumnPinning(
     columns,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -533,7 +533,7 @@ function DataFrame({
     columns,
     getCellContent,
     // If dynamic editing is enabled, we need to ignore the last row (trailing row)
-    // because it would result in some undesired errors in the tooltips otherwise
+    // because it would result in some undesired errors in the tooltips.
     isDynamicAndEditable ? [numRows] : []
   )
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.test.ts
@@ -206,4 +206,23 @@ describe("useTooltips hook", () => {
 
     expect(result.current.tooltip).toBeUndefined()
   })
+
+  it("does not render a tooltip when hovering a cell in an ignored row", () => {
+    const { result } = renderHook(() => {
+      return useTooltips(MOCK_COLUMNS, getCellContentMock, [1])
+    })
+
+    act(() => {
+      // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+      result.current.onItemHovered!({
+        kind: "cell",
+        location: [0, 1], // This is row index 1, which is ignored
+        bounds: { x: 0, y: 30, width: 100, height: 30 },
+      } as object as GridMouseEventArgs)
+
+      vi.advanceTimersByTime(DEBOUNCE_TIME_MS)
+    })
+
+    expect(result.current.tooltip).toBeUndefined()
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
@@ -51,14 +51,14 @@ export type TooltipsReturn = {
  *
  * @param columns columns of the datagrid
  * @param getCellContent function that returns the cell content for a given cell position
- * @param ignoredRowIdx array of row indices to ignore when showing tooltips.
+ * @param ignoredRowIndices array of row indices to ignore when showing tooltips.
  * @returns the tooltip to show (if any), a callback to clear the tooltip, and the
  * onItemHovered callback to pass to the datagrid
  */
 function useTooltips(
   columns: BaseColumn[],
   getCellContent: ([col, row]: readonly [number, number]) => GridCell,
-  ignoredRowIdx: number[] = []
+  ignoredRowIndices: number[] = []
 ): TooltipsReturn {
   const [tooltip, setTooltip] = React.useState<
     { content: string; left: number; top: number } | undefined
@@ -83,8 +83,8 @@ function useTooltips(
           return
         }
 
-        if (ignoredRowIdx.includes(rowIdx)) {
-          // Ignore the row if it is in the configured ignoredRowIdx array.
+        if (ignoredRowIndices.includes(rowIdx)) {
+          // Ignore the row if it is in the configured ignoredRowIndices array.
           return
         }
 
@@ -122,7 +122,7 @@ function useTooltips(
         }
       }
     },
-    [columns, getCellContent, setTooltip, timeoutRef, ignoredRowIdx]
+    [columns, getCellContent, setTooltip, timeoutRef, ignoredRowIndices]
   )
 
   const clearTooltip = React.useCallback(() => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
@@ -51,12 +51,14 @@ export type TooltipsReturn = {
  *
  * @param columns columns of the datagrid
  * @param getCellContent function that returns the cell content for a given cell position
+ * @param ignoredRowIdx array of row indices to ignore when showing tooltips.
  * @returns the tooltip to show (if any), a callback to clear the tooltip, and the
  * onItemHovered callback to pass to the datagrid
  */
 function useTooltips(
   columns: BaseColumn[],
-  getCellContent: ([col, row]: readonly [number, number]) => GridCell
+  getCellContent: ([col, row]: readonly [number, number]) => GridCell,
+  ignoredRowIdx: number[] = []
 ): TooltipsReturn {
   const [tooltip, setTooltip] = React.useState<
     { content: string; left: number; top: number } | undefined
@@ -81,13 +83,16 @@ function useTooltips(
           return
         }
 
+        if (ignoredRowIdx.includes(rowIdx)) {
+          // Ignore the row if it is in the configured ignoredRowIdx array.
+          return
+        }
+
         const column = columns[colIdx]
 
         if (args.kind === "header" && notNullOrUndefined(column)) {
           tooltipContent = column.help
         } else if (args.kind === "cell") {
-          // TODO(lukasmasuch): Ignore the last row if num_rows=dynamic (trailing row).
-
           const cell = getCellContent([colIdx, rowIdx])
 
           if (isErrorCell(cell)) {
@@ -117,7 +122,7 @@ function useTooltips(
         }
       }
     },
-    [columns, getCellContent, setTooltip, timeoutRef]
+    [columns, getCellContent, setTooltip, timeoutRef, ignoredRowIdx]
   )
 
   const clearTooltip = React.useCallback(() => {


### PR DESCRIPTION
## Describe your changes

Small bugfix to prevent showing tooltips on the trailing row which is used for add row actions when num_rows="dynamic".

![image](https://github.com/user-attachments/assets/8ea5b3c1-5924-4fbc-8b3f-649ecd140fc5)

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
