### PR TITLE
fix warning for custom streamlit mime type

### DIFF
--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -253,9 +253,6 @@ def test_uploads_and_deletes_single_file(
         file_chooser = fc_info.value
         file_chooser.set_files(files=[file1])
 
-    wait_for_app_run(app, wait_delay=1000)
-    assert_snapshot(app, name="st_chat_input-single_file_button_tooltip")
-
     # take away hover focus of button
     app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
     wait_for_app_run(app)

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -253,6 +253,9 @@ def test_uploads_and_deletes_single_file(
         file_chooser = fc_info.value
         file_chooser.set_files(files=[file1])
 
+    wait_for_app_run(app, wait_delay=1000)
+    assert_snapshot(app, name="st_chat_input-single_file_button_tooltip")
+
     # take away hover focus of button
     app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
     wait_for_app_run(app)

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -20,7 +20,7 @@ import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 
-import FileDropzone, { Props } from "./FileDropzone"
+import FileDropzone, { Props, STREAMLIT_MIME_TYPE } from "./FileDropzone"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   disabled: false,
@@ -57,6 +57,6 @@ describe("FileDropzone widget", () => {
     render(<FileDropzone {...props} />)
     expect(
       screen.queryByTestId("stFileUploaderDropzoneInput")
-    ).toHaveAttribute("accept", ".jpg")
+    ).toHaveAttribute("accept", [STREAMLIT_MIME_TYPE, ".jpg"].join(","))
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -35,14 +35,12 @@ export interface Props {
   label: string
 }
 
-// Before we support official MIME types, using the custom "application/streamlit" as a wild card
-// to allow file types defined in acceptedExtensions.
-export const STREAMLIT_MIME_TYPE = "application/streamlit"
-
 export function getAccept(acceptedExtensions: string[]): Accept | undefined {
-  // Remove mimetype when this component moves to functional
+  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
+  // to allow file types defined in acceptedExtensions.
+  // Also, remove mimetype when this component moves to functional.
   return acceptedExtensions.length
-    ? { STREAMLIT_MIME_TYPE: acceptedExtensions }
+    ? { "application/streamlit": acceptedExtensions }
     : undefined
 }
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -35,13 +35,16 @@ export interface Props {
   label: string
 }
 
+// Before we support official MIME types, using the custom "application/streamlit" as a wild card
+// to allow file types defined in acceptedExtensions.
+export const STREAMLIT_MIME_TYPE = "application/streamlit"
+
+// Remove mimetype when this component moves to functional
 export function getAccept(acceptedExtensions: string[]): Accept | undefined {
-  // Before we support official MIME types, using the custom "application/streamlit" as a wild card
-  // to allow file types defined in acceptedExtensions.
-  // Also, remove mimetype when this component moves to functional.
-  return acceptedExtensions.length
-    ? { "application/streamlit": acceptedExtensions }
-    : undefined
+  const accept: Accept = {}
+  accept[STREAMLIT_MIME_TYPE] = acceptedExtensions
+
+  return acceptedExtensions.length ? accept : undefined
 }
 
 const FileDropzone = ({


### PR DESCRIPTION
## Describe your changes

When we introduced the custom `STREAMLIT_MIME_TYPE`, the key wasn't set properly to the `Accept` object.
Hence, we're seeing this following warning:
![image](https://github.com/user-attachments/assets/c7f35960-6f96-451d-a571-654ce6603f99)

In this PR the key assignment was fixed.
<img width="1713" alt="Screenshot 2025-02-14 at 12 41 49 PM" src="https://github.com/user-attachments/assets/251d1f61-9fbb-4ec0-8045-3c52c2fad16d" />


## GitHub Issue Link (if applicable)

## Testing Plan

- n/a

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
