### PR TITLE
[fix] add correct hours handling in formatTime

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.test.ts
@@ -31,5 +31,9 @@ withTimezones(() => {
     it('should format 90000 milliseconds as "01:30"', () => {
       expect(formatTime(90000)).toBe("01:30")
     })
+
+    it('should format 3660000 milliseconds as "01:01:00"', () => {
+      expect(formatTime(3660000)).toBe("01:01:00")
+    })
   })
 })

--- a/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/formatTime.ts
@@ -15,13 +15,14 @@
  */
 
 const formatTime = (timeMs: number): string => {
-  const date = new Date(timeMs)
+  const hours = Math.floor(timeMs / 3600000);
+  const minutes = Math.floor((timeMs % 3600000) / 60000);
+  const seconds = Math.floor((timeMs % 60000) / 1000);
 
-  return date.toLocaleTimeString(undefined, {
-    minute: "2-digit",
-    second: "2-digit",
-    timeZone: "UTC",
-  })
-}
+  const mm = minutes < 10 ? `0${minutes}` : `${minutes}`;
+  const ss = seconds < 10 ? `0${seconds}` : `${seconds}`;
+
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+};
 
 export default formatTime


### PR DESCRIPTION
## Describe your changes

To resolve the timer overflow issue when recording exceeds one hour, we need to correctly format the duration to include hours.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/10373

## Testing Plan

- Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
