### PR TITLE
Update hashlib usage for FIPS compliance

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -48,6 +48,7 @@ select = [
   "TID",    # Helps you write tidier imports.
   "UP",     # pyupgrade
   "W",      # pycodestyle warnings
+  "S324",   # Check usage of insecure hashlib functions
 ]
 ignore = [
   "B008",    # Checks for function calls in default function arguments.

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -16,14 +16,13 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from typing import TYPE_CHECKING, Final, cast
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.BokehChart_pb2 import BokehChart as BokehChartProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.util import HASHLIB_KWARGS
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     from bokeh.plotting.figure import Figure
@@ -97,7 +96,7 @@ class BokehMixin:
         # Generate element ID from delta path
         delta_path = self.dg._get_delta_path_str()
 
-        element_id = hashlib.md5(delta_path.encode(), **HASHLIB_KWARGS).hexdigest()
+        element_id = calc_md5(delta_path.encode())
         bokeh_chart_proto = BokehChartProto()
         marshall(bokeh_chart_proto, figure, use_container_width, element_id)
         return self.dg._enqueue("bokeh_chart", bokeh_chart_proto)

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from typing import TYPE_CHECKING, Union, cast
 
 from typing_extensions import TypeAlias
@@ -25,7 +24,7 @@ from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.GraphVizChart_pb2 import GraphVizChart as GraphVizChartProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.util import HASHLIB_KWARGS
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     import graphviz
@@ -110,7 +109,7 @@ class GraphvizMixin:
         """
         # Generate element ID from delta path
         delta_path = self.dg._get_delta_path_str()
-        element_id = hashlib.md5(delta_path.encode(), **HASHLIB_KWARGS).hexdigest()
+        element_id = calc_md5(delta_path.encode())
 
         graphviz_chart_proto = GraphVizChartProto()
 

--- a/lib/streamlit/elements/lib/subtitle_utils.py
+++ b/lib/streamlit/elements/lib/subtitle_utils.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import io
 import os
 import re
@@ -22,6 +21,7 @@ from pathlib import Path
 
 from streamlit import runtime
 from streamlit.runtime import caching
+from streamlit.util import calc_md5
 
 # Regular expression to match the SRT timestamp format
 # It matches the
@@ -161,7 +161,7 @@ def process_subtitle_data(
         raise TypeError(f"Invalid binary data format for subtitle: {type(data)}.")
 
     if runtime.exists():
-        filename = hashlib.md5(label.encode()).hexdigest()
+        filename = calc_md5(label.encode())
         # Save the processed data and return the file URL
         file_url = runtime.get_instance().media_file_mgr.add(
             path_or_data=subtitle_data,

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -164,7 +164,7 @@ def _compute_element_id(
     use it to be distinct. The element ID includes an easily identified prefix, and the
     user_key as a suffix, to make it easy to identify it and know if a key maps to it.
     """
-    h = hashlib.new("md5", **HASHLIB_KWARGS)
+    h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
     h.update(element_type.encode("utf-8"))
     if user_key:
         # Adding this to the hash isn't necessary for uniqueness since the

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -40,7 +40,6 @@ from streamlit.runtime.state.common import (
     TESTING_KEY,
     user_key_from_element_id,
 )
-from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
     from builtins import ellipsis
@@ -164,7 +163,7 @@ def _compute_element_id(
     use it to be distinct. The element ID includes an easily identified prefix, and the
     user_key as a suffix, to make it easy to identify it and know if a key maps to it.
     """
-    h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+    h = hashlib.new("md5", usedforsecurity=False)
     h.update(element_type.encode("utf-8"))
     if user_key:
         # Adding this to the hash isn't necessary for uniqueness since the

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 from contextlib import nullcontext
@@ -54,7 +53,7 @@ from streamlit.proto.ArrowVegaLiteChart_pb2 import (
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import WidgetCallback, register_widget
-from streamlit.util import HASHLIB_KWARGS
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -355,9 +354,7 @@ def _convert_altair_to_vega_lite_spec(
         # dataset name:
         data_bytes = dataframe_util.convert_anything_to_arrow_bytes(data)
         # Use the md5 hash of the data as the name:
-        h = hashlib.new("md5", **HASHLIB_KWARGS)
-        h.update(str(data_bytes).encode("utf-8"))
-        name = h.hexdigest()
+        name = calc_md5(str(data_bytes))
 
         datasets[name] = data_bytes
         return {"name": name}

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -430,7 +430,7 @@ def _make_value_key(
     # Create the hash from each arg value, except for those args whose name
     # starts with "_". (Underscore-prefixed args are deliberately excluded from
     # hashing.)
-    args_hasher = hashlib.new("md5", **HASHLIB_KWARGS)
+    args_hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
     for arg_name, arg_value in arg_pairs:
         if arg_name is not None and arg_name.startswith("_"):
             _LOGGER.debug("Not hashing %s because it starts with _", arg_name)
@@ -468,7 +468,7 @@ def _make_function_key(cache_type: CacheType, func: FunctionType) -> str:
     A function's key is stable across reruns of the app, and changes when
     the function's source code changes.
     """
-    func_hasher = hashlib.new("md5", **HASHLIB_KWARGS)
+    func_hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
 
     # Include the function's __module__ and __qualname__ strings in the hash.
     # This means that two identical functions in different modules

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -49,7 +49,6 @@ from streamlit.runtime.caching.hashing import HashFuncsDict, update_hash
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     in_cached_function,
 )
-from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
     from types import FunctionType
@@ -430,7 +429,7 @@ def _make_value_key(
     # Create the hash from each arg value, except for those args whose name
     # starts with "_". (Underscore-prefixed args are deliberately excluded from
     # hashing.)
-    args_hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+    args_hasher = hashlib.new("md5", usedforsecurity=False)
     for arg_name, arg_value in arg_pairs:
         if arg_name is not None and arg_name.startswith("_"):
             _LOGGER.debug("Not hashing %s because it starts with _", arg_name)
@@ -468,7 +467,7 @@ def _make_function_key(cache_type: CacheType, func: FunctionType) -> str:
     A function's key is stable across reruns of the app, and changes when
     the function's source code changes.
     """
-    func_hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+    func_hasher = hashlib.new("md5", usedforsecurity=False)
 
     # Include the function's __module__ and __qualname__ strings in the hash.
     # This means that two identical functions in different modules

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -43,7 +43,6 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.uploaded_file_manager import UploadedFile
-from streamlit.util import HASHLIB_KWARGS
 
 # If a dataframe has more than this many rows, we consider it large and hash a sample.
 _PANDAS_ROWS_LARGE: Final = 100000
@@ -351,7 +350,7 @@ class _CacheFuncHasher:
         runs.
         """
 
-        h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+        h = hashlib.new("md5", usedforsecurity=False)
 
         if type_util.is_type(obj, "unittest.mock.Mock") or type_util.is_type(
             obj, "unittest.mock.MagicMock"

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -351,7 +351,7 @@ class _CacheFuncHasher:
         runs.
         """
 
-        h = hashlib.new("md5", **HASHLIB_KWARGS)
+        h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
 
         if type_util.is_type(obj, "unittest.mock.Mock") or type_util.is_type(
             obj, "unittest.mock.MagicMock"

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from typing import TYPE_CHECKING, Final
 from weakref import WeakKeyDictionary
 
@@ -22,7 +21,6 @@ from streamlit import config, util
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
-from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -56,9 +54,7 @@ def populate_hash_if_needed(msg: ForwardMsg) -> str:
         msg.ClearField("metadata")
 
         # MD5 is good enough for what we need, which is uniqueness.
-        hasher = hashlib.md5(**HASHLIB_KWARGS)
-        hasher.update(msg.SerializeToString())
-        msg.hash = hasher.hexdigest()
+        msg.hash = util.calc_md5(msg.SerializeToString())
 
         # Restore metadata.
         msg.metadata.CopyFrom(metadata)

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import contextlib
-import hashlib
 import inspect
 from abc import abstractmethod
 from copy import deepcopy
@@ -36,6 +35,7 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.time_util import time_to_seconds
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -167,11 +167,9 @@ def _fragment(
 
         cursors_snapshot = deepcopy(ctx.cursors)
         dg_stack_snapshot = deepcopy(context_dg_stack.get())
-        h = hashlib.new("md5")
-        h.update(
-            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}".encode()
+        fragment_id = calc_md5(
+            f"{non_optional_func.__module__}.{non_optional_func.__qualname__}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}"
         )
-        fragment_id = h.hexdigest()
 
         # We intentionally want to capture the active script hash here to ensure
         # that the fragment is associated with the correct script running.

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -29,7 +29,6 @@ from streamlit.runtime.media_file_storage import (
     MediaFileStorageError,
 )
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
-from streamlit.util import HASHLIB_KWARGS
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -55,7 +54,7 @@ def _calculate_file_id(data: bytes, mimetype: str, filename: str | None = None) 
     filename
         Any string. Will be converted to bytes and used to compute a hash.
     """
-    filehash = hashlib.new("sha224", **HASHLIB_KWARGS)
+    filehash = hashlib.new("sha224", usedforsecurity=False)
     filehash.update(data)
     filehash.update(bytes(mimetype.encode()))
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import hashlib
 import inspect
 import tempfile
 import textwrap
@@ -85,7 +84,7 @@ from streamlit.testing.v1.element_tree import (
 )
 from streamlit.testing.v1.local_script_runner import LocalScriptRunner
 from streamlit.testing.v1.util import patch_config_options
-from streamlit.util import HASHLIB_KWARGS, calc_md5
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -208,8 +207,7 @@ class AppTest:
     def _from_string(
         cls, script: str, *, default_timeout: float = 3, args=None, kwargs=None
     ) -> AppTest:
-        hasher = hashlib.md5(bytes(script, "utf-8"), **HASHLIB_KWARGS)
-        script_name = hasher.hexdigest()
+        script_name = calc_md5(bytes(script, "utf-8"))
 
         path = Path(TMP_DIR.name, script_name)
         aligned_script = textwrap.dedent(script)

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -66,8 +66,11 @@ def repr_(self: Any) -> str:
 
 
 def calc_md5(s: bytes | str) -> str:
-    """Return the md5 hash of the given string."""
-    h = hashlib.new("md5", **HASHLIB_KWARGS)
+    """Return the md5 hash of the given string.
+
+    This should not be used for security-related purposes.
+    """
+    h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
 
     b = s.encode("utf-8") if isinstance(s, str) else s
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -19,14 +19,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import hashlib
-import sys
 from typing import Any, Callable
-
-# Due to security issue in md5 and sha1, usedforsecurity
-# argument is added to hashlib for python versions higher than 3.8
-HASHLIB_KWARGS: dict[str, Any] = (
-    {"usedforsecurity": False} if sys.version_info >= (3, 9) else {}
-)
 
 
 def memoize(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -70,7 +63,8 @@ def calc_md5(s: bytes | str) -> str:
 
     This should not be used for security-related purposes.
     """
-    h = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+    # Due to security issue in md5 and sha1, usedforsecurity
+    h = hashlib.new("md5", usedforsecurity=False)
 
     b = s.encode("utf-8") if isinstance(s, str) else s
 

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -20,14 +20,13 @@ functions that use streamlit.config can go here to avoid a dependency cycle.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import time
 from pathlib import Path
 from typing import Callable, TypeVar
 
 from streamlit.errors import Error
-from streamlit.util import HASHLIB_KWARGS
+from streamlit.util import calc_md5
 
 # How many times to try to grab the MD5 hash.
 _MAX_RETRIES = 5
@@ -67,11 +66,7 @@ def calc_md5_with_blocking_retries(
             path,
         )
 
-    md5 = hashlib.md5(**HASHLIB_KWARGS)
-    md5.update(content)
-
-    # Use hexdigest() instead of digest(), so it's easier to debug.
-    return md5.hexdigest()
+    return calc_md5(content)
 
 
 def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -14,7 +14,6 @@
 
 """st.video unit tests"""
 
-import hashlib
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -25,6 +24,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.media_file_storage import MediaFileStorageError
 from streamlit.runtime.memory_media_file_storage import _calculate_file_id
+from streamlit.util import calc_md5
 from streamlit.web.server.server import MEDIA_ENDPOINT
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -150,7 +150,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f"{hashlib.md5(b'default').hexdigest()}.vtt",
+            filename=f"{calc_md5(b'default')}.vtt",
         )
         self.assertIn(expected_subtitle_url, el.video.subtitles[0].url)
 
@@ -173,12 +173,12 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_empty_subtitle_url = _calculate_file_id(
             b"",
             "text/vtt",
-            filename=f"{hashlib.md5(b'').hexdigest()}.vtt",
+            filename=f"{calc_md5(b'')}.vtt",
         )
         expected_english_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f"{hashlib.md5(b'English').hexdigest()}.vtt",
+            filename=f"{calc_md5(b'English')}.vtt",
         )
         self.assertIn(expected_empty_subtitle_url, el.video.subtitles[0].url)
         self.assertIn(expected_english_subtitle_url, el.video.subtitles[1].url)
@@ -197,7 +197,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_english_subtitle_url = _calculate_file_id(
             fake_sub_content,
             "text/vtt",
-            filename=f"{hashlib.md5(b'default').hexdigest()}.vtt",
+            filename=f"{calc_md5(b'default')}.vtt",
         )
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -54,7 +54,7 @@ get_main_script_director = MagicMock(return_value=os.getcwd())
 
 
 def get_hash(value, hash_funcs=None, cache_type=None):
-    hasher = hashlib.new("md5", **HASHLIB_KWARGS)
+    hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
     update_hash(
         value, hasher, cache_type=cache_type or MagicMock(), hash_funcs=hash_funcs
     )

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -48,13 +48,12 @@ from streamlit.runtime.caching.hashing import (
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 from streamlit.type_util import is_type
-from streamlit.util import HASHLIB_KWARGS
 
 get_main_script_director = MagicMock(return_value=os.getcwd())
 
 
 def get_hash(value, hash_funcs=None, cache_type=None):
-    hasher = hashlib.new("md5", **HASHLIB_KWARGS)  # noqa: S324
+    hasher = hashlib.new("md5", usedforsecurity=False)
     update_hash(
         value, hasher, cache_type=cache_type or MagicMock(), hash_funcs=hash_funcs
     )


### PR DESCRIPTION
## Describe your changes

- Updates all our hashlib uses to either use `calc_md5` or explicitly set `usedforsecurity=False` to comply with FIPS. All our uses in Streamlit are not security-related.
- Adds a ruff rule to check for insecure usage of hashlib.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10412

## Testing Plan

- No logical changes -> no tests required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
