### PR TITLE
Adjustments to NumberInput to follow the react-refresh linter rule. 

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -27,12 +27,7 @@ import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
-import NumberInput, {
-  canDecrement,
-  canIncrement,
-  formatValue,
-  Props,
-} from "./NumberInput"
+import NumberInput, { Props } from "./NumberInput"
 
 const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   element: NumberInputProto.create({
@@ -702,84 +697,5 @@ describe("NumberInput widget", () => {
     const forId2 = numberInputLabel2.getAttribute("for")
 
     expect(forId2).toBe(forId1)
-  })
-
-  describe("utilities", () => {
-    describe("canDecrement function", () => {
-      it("returns true if decrementing stays above min", () => {
-        expect(canDecrement(5, 1, 0)).toBe(true)
-      })
-
-      it("returns false if decrementing goes below min", () => {
-        expect(canDecrement(0, 1, 0)).toBe(false)
-      })
-    })
-
-    describe("canIncrement function", () => {
-      it("returns true if incrementing stays below max", () => {
-        expect(canIncrement(5, 1, 10)).toBe(true)
-      })
-
-      it("returns false if incrementing goes above max", () => {
-        expect(canIncrement(10, 1, 10)).toBe(false)
-      })
-    })
-
-    describe("formatValue function", () => {
-      it("returns null for null value", () => {
-        expect(
-          formatValue({
-            value: null,
-            format: null,
-            step: 1,
-            dataType: NumberInputProto.DataType.INT,
-          })
-        ).toBeNull()
-      })
-
-      it("formats integer without specified format", () => {
-        expect(
-          formatValue({
-            value: 123,
-            format: null,
-            step: 1,
-            dataType: NumberInputProto.DataType.INT,
-          })
-        ).toBe("123")
-      })
-
-      it("formats float without specified format, considering step for precision", () => {
-        expect(
-          formatValue({
-            value: 123.456,
-            format: null,
-            step: 0.01,
-            dataType: NumberInputProto.DataType.FLOAT,
-          })
-        ).toBe("123.46")
-      })
-
-      it("respects format string for integers", () => {
-        expect(
-          formatValue({
-            value: 123,
-            format: "%04d",
-            step: 1,
-            dataType: NumberInputProto.DataType.INT,
-          })
-        ).toBe("0123")
-      })
-
-      it("respects format string for floats", () => {
-        expect(
-          formatValue({
-            value: 123.456,
-            format: "%.2f",
-            step: 0.01,
-            dataType: NumberInputProto.DataType.FLOAT,
-          })
-        ).toBe("123.46")
-      })
-    })
   })
 })

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -26,10 +26,8 @@ import React, {
 
 import { Minus, Plus } from "@emotion-icons/open-iconic"
 import { useTheme } from "@emotion/react"
-import { sprintf } from "sprintf-js"
 import { Input as UIInput } from "baseui/input"
 import uniqueId from "lodash/uniqueId"
-import { getLogger } from "loglevel"
 
 import { NumberInput as NumberInputProto } from "@streamlit/protobuf"
 
@@ -53,117 +51,18 @@ import { EmotionTheme } from "~lib/theme"
 import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import {
+  formatValue,
+  canDecrement,
+  canIncrement,
+  getInitialValue,
+  getStep,
+} from "./utils"
+import {
   StyledInputContainer,
   StyledInputControl,
   StyledInputControls,
   StyledInstructionsContainer,
 } from "./styled-components"
-
-const LOG = getLogger("NumberInput")
-
-/**
- * Return a string property from an element. If the string is
- * null or empty, return undefined instead.
- */
-function getNonEmptyString(
-  value: string | null | undefined
-): string | undefined {
-  return isNullOrUndefined(value) || value === "" ? undefined : value
-}
-
-/**
- * This function returns the initial value for the NumberInput widget
- * via the widget manager.
- */
-const getInitialValue = (
-  props: Pick<Props, "element" | "widgetMgr">
-): number | null => {
-  const isIntData = props.element.dataType === NumberInputProto.DataType.INT
-  const storedValue = isIntData
-    ? props.widgetMgr.getIntValue(props.element)
-    : props.widgetMgr.getDoubleValue(props.element)
-  return storedValue ?? props.element.default ?? null
-}
-
-const getStep = ({
-  step,
-  dataType,
-}: Pick<NumberInputProto, "step" | "dataType">): number => {
-  if (step) {
-    return step
-  }
-  if (dataType === NumberInputProto.DataType.INT) {
-    return 1
-  }
-  return 0.01
-}
-
-/**
- * Utilizes the sprintf library to format a number value
- * according to a given format string.
- */
-export const formatValue = ({
-  value,
-  format,
-  step,
-  dataType,
-}: {
-  value: number | null
-  format?: string | null
-  step?: number
-  dataType: NumberInputProto.DataType
-}): string | null => {
-  if (isNullOrUndefined(value)) {
-    return null
-  }
-
-  let formatString = getNonEmptyString(format)
-
-  if (isNullOrUndefined(formatString) && notNullOrUndefined(step)) {
-    const strStep = step.toString()
-    if (
-      dataType === NumberInputProto.DataType.FLOAT &&
-      step !== 0 &&
-      strStep.includes(".")
-    ) {
-      const decimalPlaces = strStep.split(".")[1].length
-      formatString = `%0.${decimalPlaces}f`
-    }
-  }
-
-  if (isNullOrUndefined(formatString)) {
-    return value.toString()
-  }
-
-  try {
-    return sprintf(formatString, value)
-  } catch (e) {
-    LOG.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
-    return String(value)
-  }
-}
-
-export const canDecrement = (
-  value: number | null,
-  step: number,
-  min: number
-): boolean => {
-  if (isNullOrUndefined(value)) {
-    return false
-  }
-  return value - step >= min
-}
-
-export const canIncrement = (
-  value: number | null,
-  step: number,
-  max: number
-): boolean => {
-  if (isNullOrUndefined(value)) {
-    return false
-  }
-  return value + step <= max
-}
 
 export interface Props {
   disabled: boolean

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -51,9 +51,9 @@ import { EmotionTheme } from "~lib/theme"
 import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import {
-  formatValue,
   canDecrement,
   canIncrement,
+  formatValue,
   getInitialValue,
   getStep,
 } from "./utils"

--- a/frontend/lib/src/components/widgets/NumberInput/utils.test.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/utils.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NumberInput as NumberInputProto } from "@streamlit/protobuf"
+
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import {
+  canDecrement,
+  canIncrement,
+  formatValue,
+  getStep,
+  getInitialValue,
+} from "./utils"
+
+describe("canDecrement function", () => {
+  it("returns true if decrementing stays above min", () => {
+    expect(canDecrement(5, 1, 0)).toBe(true)
+  })
+
+  it("returns true if decrementing equals min", () => {
+    expect(canDecrement(1, 1, 0)).toBe(true)
+  })
+
+  it("returns false if decrementing goes below min", () => {
+    expect(canDecrement(0, 1, 0)).toBe(false)
+  })
+})
+
+describe("canIncrement function", () => {
+  it("returns true if incrementing stays below max", () => {
+    expect(canIncrement(5, 1, 10)).toBe(true)
+  })
+
+  it("returns true if incrementing equals max", () => {
+    expect(canIncrement(5, 5, 10)).toBe(true)
+  })
+
+  it("returns false if incrementing goes above max", () => {
+    expect(canIncrement(10, 1, 10)).toBe(false)
+  })
+})
+
+describe("formatValue function", () => {
+  it("returns null for null value", () => {
+    expect(
+      formatValue({
+        value: null,
+        format: null,
+        step: 1,
+        dataType: NumberInputProto.DataType.INT,
+      })
+    ).toBeNull()
+  })
+
+  it("returns formatted value when step is undefined", () => {
+    expect(
+      formatValue({
+        value: 123,
+        format: null,
+        dataType: NumberInputProto.DataType.INT,
+      })
+    ).toBe("123")
+  })
+
+  it("formats integer without specified format", () => {
+    expect(
+      formatValue({
+        value: 123,
+        format: null,
+        step: 1,
+        dataType: NumberInputProto.DataType.INT,
+      })
+    ).toBe("123")
+  })
+
+  it("formats float without specified format, considering step for precision", () => {
+    expect(
+      formatValue({
+        value: 123.456,
+        format: null,
+        step: 0.01,
+        dataType: NumberInputProto.DataType.FLOAT,
+      })
+    ).toBe("123.46")
+  })
+
+  it("respects format string for integers", () => {
+    expect(
+      formatValue({
+        value: 123,
+        format: "%04d",
+        step: 1,
+        dataType: NumberInputProto.DataType.INT,
+      })
+    ).toBe("0123")
+  })
+
+  it("respects format string for integers when step not included", () => {
+    expect(
+      formatValue({
+        value: 123,
+        format: "%04d",
+        dataType: NumberInputProto.DataType.INT,
+      })
+    ).toBe("0123")
+  })
+
+  it("respects format string for floats", () => {
+    expect(
+      formatValue({
+        value: 123.456,
+        format: "%.2f",
+        step: 0.01,
+        dataType: NumberInputProto.DataType.FLOAT,
+      })
+    ).toBe("123.46")
+  })
+})
+
+describe("getStep function", () => {
+  it("returns step when provided ", () => {
+    const element = NumberInputProto.create({
+      label: "Label",
+      step: 3,
+      dataType: NumberInputProto.DataType.INT,
+    })
+    expect(getStep(element)).toBe(3)
+  })
+
+  it("returns default INT value", () => {
+    const element = NumberInputProto.create({
+      label: "Label",
+      dataType: NumberInputProto.DataType.INT,
+    })
+    expect(getStep(element)).toBe(1)
+  })
+
+  it("returns default float value", () => {
+    const element = NumberInputProto.create({
+      label: "Label",
+      dataType: NumberInputProto.DataType.FLOAT,
+    })
+    expect(getStep(element)).toBe(0.01)
+  })
+})
+
+describe("getInitialValue function", () => {
+  it("returns widget value when dataType is INT and the widget has a value ", () => {
+    const props = {
+      element: NumberInputProto.create({
+        label: "Label",
+        dataType: NumberInputProto.DataType.INT,
+      }),
+      widgetMgr: new WidgetStateManager({
+        sendRerunBackMsg: vi.fn(),
+        formsDataChanged: vi.fn(),
+      }),
+    }
+    vi.spyOn(props.widgetMgr, "getIntValue").mockReturnValue(3)
+    expect(getInitialValue(props)).toBe(3)
+  })
+
+  it("returns widget value when the dataType is FLOAT and the widget has a value ", () => {
+    const props = {
+      element: NumberInputProto.create({
+        label: "Label",
+        dataType: NumberInputProto.DataType.FLOAT,
+      }),
+      widgetMgr: new WidgetStateManager({
+        sendRerunBackMsg: vi.fn(),
+        formsDataChanged: vi.fn(),
+      }),
+    }
+    vi.spyOn(props.widgetMgr, "getDoubleValue").mockReturnValue(0.03)
+    expect(getInitialValue(props)).toBe(0.03)
+  })
+
+  it("returns default value when widget has no value ", () => {
+    const props = {
+      element: NumberInputProto.create({
+        label: "Label",
+        dataType: NumberInputProto.DataType.FLOAT,
+        default: 0.01,
+      }),
+      widgetMgr: new WidgetStateManager({
+        sendRerunBackMsg: vi.fn(),
+        formsDataChanged: vi.fn(),
+      }),
+    }
+    expect(getInitialValue(props)).toBe(0.01)
+  })
+
+  it("returns null when widget has no value and no default is provided ", () => {
+    const props = {
+      element: NumberInputProto.create({
+        label: "Label",
+        dataType: NumberInputProto.DataType.FLOAT,
+      }),
+      widgetMgr: new WidgetStateManager({
+        sendRerunBackMsg: vi.fn(),
+        formsDataChanged: vi.fn(),
+      }),
+    }
+    expect(getInitialValue(props)).toBe(null)
+  })
+})

--- a/frontend/lib/src/components/widgets/NumberInput/utils.test.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/utils.test.ts
@@ -21,8 +21,8 @@ import {
   canDecrement,
   canIncrement,
   formatValue,
-  getStep,
   getInitialValue,
+  getStep,
 } from "./utils"
 
 describe("canDecrement function", () => {
@@ -131,7 +131,7 @@ describe("formatValue function", () => {
 })
 
 describe("getStep function", () => {
-  it("returns step when provided ", () => {
+  it("returns step when provided", () => {
     const element = NumberInputProto.create({
       label: "Label",
       step: 3,
@@ -158,7 +158,7 @@ describe("getStep function", () => {
 })
 
 describe("getInitialValue function", () => {
-  it("returns widget value when dataType is INT and the widget has a value ", () => {
+  it("returns widget value when dataType is INT and the widget has a value", () => {
     const props = {
       element: NumberInputProto.create({
         label: "Label",
@@ -173,7 +173,7 @@ describe("getInitialValue function", () => {
     expect(getInitialValue(props)).toBe(3)
   })
 
-  it("returns widget value when the dataType is FLOAT and the widget has a value ", () => {
+  it("returns widget value when the dataType is FLOAT and the widget has a value", () => {
     const props = {
       element: NumberInputProto.create({
         label: "Label",
@@ -188,7 +188,7 @@ describe("getInitialValue function", () => {
     expect(getInitialValue(props)).toBe(0.03)
   })
 
-  it("returns default value when widget has no value ", () => {
+  it("returns default value when widget has no value", () => {
     const props = {
       element: NumberInputProto.create({
         label: "Label",
@@ -203,7 +203,7 @@ describe("getInitialValue function", () => {
     expect(getInitialValue(props)).toBe(0.01)
   })
 
-  it("returns null when widget has no value and no default is provided ", () => {
+  it("returns null when widget has no value and no default is provided", () => {
     const props = {
       element: NumberInputProto.create({
         label: "Label",

--- a/frontend/lib/src/components/widgets/NumberInput/utils.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/utils.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { sprintf } from "sprintf-js"
+import { getLogger } from "loglevel"
+
+import { NumberInput as NumberInputProto } from "@streamlit/protobuf"
+
+import { isNullOrUndefined, notNullOrUndefined } from "~lib/util/utils"
+
+import { Props } from "./NumberInput"
+
+const log = getLogger("NumberInput")
+
+/**
+ * Return a string property from an element. If the string is
+ * null or empty, return undefined instead.
+ */
+function getNonEmptyString(
+  value: string | null | undefined
+): string | undefined {
+  return isNullOrUndefined(value) || value === "" ? undefined : value
+}
+
+/**
+ * Utilizes the sprintf library to format a number value
+ * according to a given format string.
+ */
+export const formatValue = ({
+  value,
+  format,
+  step,
+  dataType,
+}: {
+  value: number | null
+  format?: string | null
+  step?: number
+  dataType: NumberInputProto.DataType
+}): string | null => {
+  if (isNullOrUndefined(value)) {
+    return null
+  }
+
+  let formatString = getNonEmptyString(format)
+
+  if (isNullOrUndefined(formatString) && notNullOrUndefined(step)) {
+    const strStep = step.toString()
+    if (
+      dataType === NumberInputProto.DataType.FLOAT &&
+      step !== 0 &&
+      strStep.includes(".")
+    ) {
+      const decimalPlaces = strStep.split(".")[1].length
+      formatString = `%0.${decimalPlaces}f`
+    }
+  }
+
+  if (isNullOrUndefined(formatString)) {
+    return value.toString()
+  }
+
+  try {
+    return sprintf(formatString, value)
+  } catch (e) {
+    log.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
+    return String(value)
+  }
+}
+
+export const canDecrement = (
+  value: number | null,
+  step: number,
+  min: number
+): boolean => {
+  if (isNullOrUndefined(value)) {
+    return false
+  }
+  return value - step >= min
+}
+
+export const canIncrement = (
+  value: number | null,
+  step: number,
+  max: number
+): boolean => {
+  if (isNullOrUndefined(value)) {
+    return false
+  }
+  return value + step <= max
+}
+
+/**
+ * This function returns the initial value for the NumberInput widget
+ * via the widget manager.
+ */
+export const getInitialValue = (
+  props: Pick<Props, "element" | "widgetMgr">
+): number | null => {
+  const isIntData = props.element.dataType === NumberInputProto.DataType.INT
+  const storedValue = isIntData
+    ? props.widgetMgr.getIntValue(props.element)
+    : props.widgetMgr.getDoubleValue(props.element)
+  return storedValue ?? props.element.default ?? null
+}
+
+export const getStep = ({
+  step,
+  dataType,
+}: Pick<NumberInputProto, "step" | "dataType">): number => {
+  if (step) {
+    return step
+  }
+  if (dataType === NumberInputProto.DataType.INT) {
+    return 1
+  }
+  return 0.01
+}

--- a/frontend/lib/src/components/widgets/NumberInput/utils.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/utils.ts
@@ -22,7 +22,7 @@ import { isNullOrUndefined, notNullOrUndefined } from "~lib/util/utils"
 
 import { Props } from "./NumberInput"
 
-const log = getLogger("NumberInput")
+const LOG = getLogger("NumberInput")
 
 /**
  * Return a string property from an element. If the string is
@@ -74,7 +74,7 @@ export const formatValue = ({
   try {
     return sprintf(formatString, value)
   } catch (e) {
-    log.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
+    LOG.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
     return String(value)
   }
 }


### PR DESCRIPTION
## Describe your changes

Part of some ongoing work to fix all violations of [react-refresh rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) which will be followed by adding this eslint rule.

Also adds some test cases for `canDecrement`, `canIncrement`, `formatValue`, `getStep` and `getInitialValue` util functions. 

## GitHub Issue Link (if applicable)

## Testing Plan

No functional changes, but some new test cases added opportunistically. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
