### PR TITLE
Increase number of automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
     # Allow one update PR at a time:
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
 
     labels:
       - "change:chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
     # Allow a limited number of update PRs at a time
-    # to keep the number of parallel dependency updates manageable. 
+    # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
 
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-    # Allow a limited number of update PRs at a time:
+    # Allow a limited number of update PRs at a time
+    # to keep the number of parallel dependency updates manageable. 
     open-pull-requests-limit: 3
 
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-    # Allow one update PR at a time:
+    # Allow a limited number of update PR's at a time:
     open-pull-requests-limit: 3
 
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-    # Allow a limited number of update PR's at a time:
+    # Allow a limited number of update PRs at a time:
     open-pull-requests-limit: 3
 
     labels:


### PR DESCRIPTION
## Describe your changes

Just allowing a single dependency PR also leads to only a single dependabot update PR per day since the workflow is only running daily. This PR increases this number to 3 to speed up dependency updates a bit without flooding our PRs. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
