### PR TITLE
[fix] Tooltip positioning logic with createRoot

### DIFF
--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useRef } from "react"
+import React, {
+  memo,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react"
 
 import { useTheme } from "@emotion/react"
 import {
@@ -66,52 +73,68 @@ function Tooltip({
   const theme: EmotionTheme = useTheme()
   const { colors, fontSizes, radii, fontWeights } = theme
 
-  const tooltipRef = useRef<HTMLDivElement>(null)
+  // This section of code is to work around a timing issue with BaseWeb's Tooltip component
+  const [tooltipRef, setTooltipRef] = useState<HTMLDivElement | null>(null)
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  useEffect(() => {
+    const parentElement = tooltipRef?.parentElement
+    if (!parentElement) {
+      return
+    }
+
+    const handleMeasurement = async (): Promise<void> => {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      // if the tooltip is offscreen to the left, move it to the right by the same amount of pixels
+      // use a timeout to that parentElement.getBoundingClientRect returns the correct value; otherwise
+      // I have observed it to be "0".
+      const boundingClientRect = parentElement.getBoundingClientRect()
+      const xCoordinate = boundingClientRect.x
+
+      const overflowRight =
+        xCoordinate + boundingClientRect.width - window.innerWidth
+
+      // this is the out-of-tree Basweb DOM structure. For the right overflow,
+      // this is the element that has the transform-style property set that needs
+      // to be modified.
+      const parentsParentElement = parentElement.parentElement
+
+      if (overflowRight > 0 && parentsParentElement) {
+        // Baseweb uses a transform to position the tooltip, so we need to adjust the transform instead
+        // of the left / right property, otherwise it looks weird when the tooltip overflows the right side
+        const transformStyleMatrix = new DOMMatrix(
+          window.getComputedStyle(parentsParentElement)?.transform
+        )
+        parentsParentElement.style.transform = `translate3d(${
+          transformStyleMatrix.e - overflowRight
+        }px, ${transformStyleMatrix.f}px, 0px)`
+      }
+
+      if (xCoordinate < 0) {
+        parentElement.style.left = `${-xCoordinate}px`
+      }
+    }
+
+    handleMeasurement()
+  }, [tooltipRef, isOpen])
 
   return (
     <StatefulTooltip
-      onOpen={() => {
-        const parentElement = tooltipRef.current?.parentElement
-        if (!parentElement) {
-          return
-        }
-        // if the tooltip is offscreen to the left, move it to the right by the same amount of pixels
-        // use a timeout to that parentElement.getBoundingClientRect returns the correct value; otherwise
-        // I have observed it to be "0".
-        setTimeout(() => {
-          const boundingClientRect = parentElement.getBoundingClientRect()
-          const xCoordinate = boundingClientRect.x
-
-          const overflowRight =
-            xCoordinate + boundingClientRect.width - window.innerWidth
-
-          // this is the out-of-tree Basweb DOM structure. For the right overflow,
-          // this is the element that has the transform-style property set that needs
-          // to be modified.
-          const parentsParentElement = parentElement.parentElement
-
-          if (overflowRight > 0 && parentsParentElement) {
-            // Baseweb uses a transform to position the tooltip, so we need to adjust the transform instead
-            // of the left / right property, otherwise it looks weird when the tooltip overflows the right side
-            const transformStyleMatrix = new DOMMatrix(
-              window.getComputedStyle(parentsParentElement)?.transform
-            )
-            parentsParentElement.style.transform = `translate3d(${
-              transformStyleMatrix.e - overflowRight
-            }px, ${transformStyleMatrix.f}px, 0px)`
-          }
-
-          if (xCoordinate < 0) {
-            parentElement.style.left = `${-xCoordinate}px`
-          }
-        }, 0)
-      }}
+      onOpen={handleOpen}
+      onClose={handleClose}
       content={
         content ? (
           <StyledTooltipContentWrapper
             className="stTooltipContent"
             data-testid="stTooltipContent"
-            ref={tooltipRef}
+            ref={setTooltipRef}
           >
             {content}
           </StyledTooltipContentWrapper>
@@ -181,4 +204,4 @@ function Tooltip({
   )
 }
 
-export default Tooltip
+export default memo(Tooltip)

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -74,7 +74,9 @@ function Tooltip({
   const { colors, fontSizes, radii, fontWeights } = theme
 
   // This section of code is to work around a timing issue with BaseWeb's Tooltip component
-  const [tooltipRef, setTooltipRef] = useState<HTMLDivElement | null>(null)
+  const [tooltipElement, setTooltipElement] = useState<HTMLDivElement | null>(
+    null
+  )
   const [isOpen, setIsOpen] = useState(false)
 
   const handleOpen = useCallback(() => {
@@ -85,7 +87,7 @@ function Tooltip({
   }, [])
 
   useEffect(() => {
-    const parentElement = tooltipRef?.parentElement
+    const parentElement = tooltipElement?.parentElement
     if (!parentElement) {
       return
     }
@@ -123,7 +125,7 @@ function Tooltip({
     }
 
     handleMeasurement()
-  }, [tooltipRef, isOpen])
+  }, [tooltipElement, isOpen])
 
   return (
     <StatefulTooltip
@@ -134,7 +136,7 @@ function Tooltip({
           <StyledTooltipContentWrapper
             className="stTooltipContent"
             data-testid="stTooltipContent"
-            ref={setTooltipRef}
+            ref={setTooltipElement}
           >
             {content}
           </StyledTooltipContentWrapper>


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Fixes an issue where the Tooltip would appear visually incorrect when rendering in `createRoot`
  - Due to the new batching rendering logic, there was a timing issue when attempting to measure position of elements. To fix this, we keep some local state for the Tooltip's state and defer its measurement into a `useEffect`

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This fixes e2e tests that were previously failing for Tooltip

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
