### PR TITLE
[fix] File uploader state management with createRoot

### DIFF
--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -18,12 +18,22 @@ from e2e_playwright.conftest import ImageCompareFunction, rerun_app, wait_for_ap
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 
 
+def _assert_file_uploaders_rendered(app: Page):
+    """
+    Assert that the all the file uploaders are rendered to prevent accessing
+    things out of order.
+    """
+    file_uploaders = app.get_by_test_id("stFileUploader")
+    expect(file_uploaders).to_have_count(10)
+
+    return file_uploaders
+
+
 def test_file_uploader_render_correctly(
     themed_app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test that the file uploader render as expected via screenshot matching."""
-    file_uploaders = themed_app.get_by_test_id("stFileUploader")
-    expect(file_uploaders).to_have_count(10)
+    file_uploaders = _assert_file_uploaders_rendered(themed_app)
 
     assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
     assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
@@ -42,6 +52,7 @@ def test_file_uploader_error_message_disallowed_files(
     file_name1 = "example.json"
     file_content1 = b"{}"
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 0
 
     with app.expect_file_chooser() as fc_info:
@@ -81,6 +92,7 @@ def test_uploads_and_deletes_single_file_only(
     file_name2 = "file2.txt"
     file_content2 = b"file2content"
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 0
 
     with app.expect_file_chooser() as fc_info:
@@ -169,6 +181,7 @@ def test_uploads_and_deletes_multiple_files(
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -230,6 +243,7 @@ def test_uploads_multiple_files_one_by_one_quickly(app: Page):
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -302,6 +316,7 @@ def test_uploads_multiple_files_one_by_one_slowly(app: Page):
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -365,6 +380,7 @@ def test_does_not_call_callback_when_not_changed(app: Page):
     file_name1 = "example5.txt"
     file_content1 = b"Hello world!"
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 6
 
     # Script contains counter variable stored in session_state with
@@ -408,6 +424,7 @@ def test_works_inside_form(app: Page):
     file_name1 = "form_file1.txt"
     file_content1 = b"form_file1content"
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 3
 
     with app.expect_file_chooser() as fc_info:
@@ -473,6 +490,7 @@ def test_file_uploader_works_with_fragments(app: Page):
     expect(app.get_by_text("Runs: 1")).to_be_visible()
     expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
 
+    _assert_file_uploaders_rendered(app)
     uploader_index = 7
 
     with app.expect_file_chooser() as fc_info:

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -18,22 +18,12 @@ from e2e_playwright.conftest import ImageCompareFunction, rerun_app, wait_for_ap
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 
 
-def _assert_file_uploaders_rendered(app: Page):
-    """
-    Assert that the all the file uploaders are rendered to prevent accessing
-    things out of order.
-    """
-    file_uploaders = app.get_by_test_id("stFileUploader")
-    expect(file_uploaders).to_have_count(10)
-
-    return file_uploaders
-
-
 def test_file_uploader_render_correctly(
     themed_app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test that the file uploader render as expected via screenshot matching."""
-    file_uploaders = _assert_file_uploaders_rendered(themed_app)
+    file_uploaders = themed_app.get_by_test_id("stFileUploader")
+    expect(file_uploaders).to_have_count(10)
 
     assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
     assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
@@ -52,7 +42,6 @@ def test_file_uploader_error_message_disallowed_files(
     file_name1 = "example.json"
     file_content1 = b"{}"
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 0
 
     with app.expect_file_chooser() as fc_info:
@@ -92,7 +81,6 @@ def test_uploads_and_deletes_single_file_only(
     file_name2 = "file2.txt"
     file_content2 = b"file2content"
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 0
 
     with app.expect_file_chooser() as fc_info:
@@ -181,7 +169,6 @@ def test_uploads_and_deletes_multiple_files(
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -243,7 +230,6 @@ def test_uploads_multiple_files_one_by_one_quickly(app: Page):
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -316,7 +302,6 @@ def test_uploads_multiple_files_one_by_one_slowly(app: Page):
         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
     ]
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 2
 
     with app.expect_file_chooser() as fc_info:
@@ -380,7 +365,6 @@ def test_does_not_call_callback_when_not_changed(app: Page):
     file_name1 = "example5.txt"
     file_content1 = b"Hello world!"
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 6
 
     # Script contains counter variable stored in session_state with
@@ -424,7 +408,6 @@ def test_works_inside_form(app: Page):
     file_name1 = "form_file1.txt"
     file_content1 = b"form_file1content"
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 3
 
     with app.expect_file_chooser() as fc_info:
@@ -490,7 +473,6 @@ def test_file_uploader_works_with_fragments(app: Page):
     expect(app.get_by_text("Runs: 1")).to_be_visible()
     expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
 
-    _assert_file_uploaders_rendered(app)
     uploader_index = 7
 
     with app.expect_file_chooser() as fc_info:

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -507,21 +507,21 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
     // Using flushSync here because we need the state to be immediately updated
     // before any subsequent file upload operations occur.
     flushSync(() => {
-      this.setState({ files: [] })
+      this.setState({ files: [] }, () => {
+        const newWidgetValue = this.createWidgetValue()
+        if (isNullOrUndefined(newWidgetValue)) {
+          return
+        }
+
+        const { widgetMgr, element, fragmentId } = this.props
+        widgetMgr.setFileUploaderStateValue(
+          element,
+          newWidgetValue,
+          { fromUi: true },
+          fragmentId
+        )
+      })
     })
-
-    const newWidgetValue = this.createWidgetValue()
-    if (isNullOrUndefined(newWidgetValue)) {
-      return
-    }
-
-    const { widgetMgr, element, fragmentId } = this.props
-    widgetMgr.setFileUploaderStateValue(
-      element,
-      newWidgetValue,
-      { fromUi: true },
-      fragmentId
-    )
   }
 
   public render(): React.ReactNode {

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -72,16 +72,6 @@ export interface State {
    * rejected files that will not be updated.
    */
   files: UploadFileInfo[]
-  /**
-   * A flag to handle the case where a file uploader that only accepts one file
-   * at a time has its file replaced, which we want to treat as a single change
-   * rather than the deletion of a file followed by the upload of another.
-   * Doing this ensures that the script (and thus callbacks, etc) is only run a
-   * single time when replacing a file.  Note that deleting a file and uploading
-   * a new one with two interactions (clicking the 'X', then dragging a file
-   * into the file uploader) will still cause the script to execute twice.
-   */
-  isUpdating: boolean
 }
 
 class FileUploader extends React.PureComponent<InnerProps, State> {
@@ -111,7 +101,7 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
   }
 
   get initialValue(): State {
-    const emptyState = { files: [], isUpdating: false }
+    const emptyState = { files: [] }
     const { widgetMgr, element } = this.props
 
     const widgetValue = widgetMgr.getFileUploaderStateValue(element)
@@ -138,7 +128,6 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
           fileUrls,
         })
       }),
-      isUpdating: false,
     }
   }
 
@@ -162,7 +151,7 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
     const isFileUpdating = (file: UploadFileInfo): boolean =>
       file.status.type === "uploading"
 
-    if (this.state.files.some(isFileUpdating) || this.state.isUpdating) {
+    if (this.state.files.some(isFileUpdating) || this.forceUpdatingStatus) {
       return "updating"
     }
 
@@ -273,15 +262,9 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
             f => f.status.type !== "error"
           )
           if (existingFile) {
-            flushSync(() => {
-              this.setState({ isUpdating: true })
-            })
-
+            this.forceUpdatingStatus = true
             this.deleteFile(existingFile.id)
-
-            flushSync(() => {
-              this.setState({ isUpdating: false })
-            })
+            this.forceUpdatingStatus = false
           }
         }
 
@@ -439,6 +422,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Append the given file to `state.files`. */
   private addFile = (file: UploadFileInfo): void => {
+    // Using flushSync here because we need the state to be immediately updated
+    // before any subsequent file upload operations occur.
     flushSync(() => {
       this.setState(state => ({ files: [...state.files, file] }))
     })
@@ -446,6 +431,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Append the given files to `state.files`. */
   private addFiles = (files: UploadFileInfo[]): void => {
+    // Using flushSync here because we need the state to be immediately updated
+    // before any subsequent file upload operations occur.
     flushSync(() => {
       this.setState(state => ({ files: [...state.files, ...files] }))
     })
@@ -453,6 +440,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Remove the file with the given ID from `state.files`. */
   private removeFile = (idToRemove: number): void => {
+    // Using flushSync here because we need the state to be immediately updated
+    // before any subsequent file upload operations occur.
     flushSync(() => {
       this.setState(state => ({
         files: state.files.filter(file => file.id !== idToRemove),
@@ -469,6 +458,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Replace the file with the given id in `state.files`. */
   private updateFile = (curFileId: number, newFile: UploadFileInfo): void => {
+    // Using flushSync here because we need the state to be immediately updated
+    // before any subsequent file upload operations occur.
     flushSync(() => {
       this.setState(curState => {
         return {
@@ -511,6 +502,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
    * form is submitted. Restore our default value and update the WidgetManager.
    */
   private onFormCleared = (): void => {
+    // Using flushSync here because we need the state to be immediately updated
+    // before any subsequent file upload operations occur.
     flushSync(() => {
       this.setState({ files: [] })
     })

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -151,6 +151,8 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
     const isFileUpdating = (file: UploadFileInfo): boolean =>
       file.status.type === "uploading"
 
+    // If any of our files is Uploading or Deleting, then we're currently
+    // updating.
     if (this.state.files.some(isFileUpdating) || this.forceUpdatingStatus) {
       return "updating"
     }

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -20,6 +20,7 @@ import axios from "axios"
 import isEqual from "lodash/isEqual"
 import zip from "lodash/zip"
 import { FileRejection } from "react-dropzone"
+import { flushSync } from "react-dom"
 
 import {
   FileUploader as FileUploaderProto,
@@ -71,6 +72,16 @@ export interface State {
    * rejected files that will not be updated.
    */
   files: UploadFileInfo[]
+  /**
+   * A flag to handle the case where a file uploader that only accepts one file
+   * at a time has its file replaced, which we want to treat as a single change
+   * rather than the deletion of a file followed by the upload of another.
+   * Doing this ensures that the script (and thus callbacks, etc) is only run a
+   * single time when replacing a file.  Note that deleting a file and uploading
+   * a new one with two interactions (clicking the 'X', then dragging a file
+   * into the file uploader) will still cause the script to execute twice.
+   */
+  isUpdating: boolean
 }
 
 class FileUploader extends React.PureComponent<InnerProps, State> {
@@ -100,7 +111,7 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
   }
 
   get initialValue(): State {
-    const emptyState = { files: [], newestServerFileId: 0 }
+    const emptyState = { files: [], isUpdating: false }
     const { widgetMgr, element } = this.props
 
     const widgetValue = widgetMgr.getFileUploaderStateValue(element)
@@ -127,6 +138,7 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
           fileUrls,
         })
       }),
+      isUpdating: false,
     }
   }
 
@@ -150,9 +162,7 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
     const isFileUpdating = (file: UploadFileInfo): boolean =>
       file.status.type === "uploading"
 
-    // If any of our files is Uploading or Deleting, then we're currently
-    // updating.
-    if (this.state.files.some(isFileUpdating) || this.forceUpdatingStatus) {
+    if (this.state.files.some(isFileUpdating) || this.state.isUpdating) {
       return "updating"
     }
 
@@ -220,13 +230,6 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
   }
 
   /**
-   * Clear files and errors, and reset the widget to its READY state.
-   */
-  private reset = (): void => {
-    this.setState({ files: [] })
-  }
-
-  /**
    * Called by react-dropzone when files and drag-and-dropped onto the widget.
    *
    * @param acceptedFiles an array of files.
@@ -270,9 +273,15 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
             f => f.status.type !== "error"
           )
           if (existingFile) {
-            this.forceUpdatingStatus = true
+            flushSync(() => {
+              this.setState({ isUpdating: true })
+            })
+
             this.deleteFile(existingFile.id)
-            this.forceUpdatingStatus = false
+
+            flushSync(() => {
+              this.setState({ isUpdating: false })
+            })
           }
         }
 
@@ -430,19 +439,25 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Append the given file to `state.files`. */
   private addFile = (file: UploadFileInfo): void => {
-    this.setState(state => ({ files: [...state.files, file] }))
+    flushSync(() => {
+      this.setState(state => ({ files: [...state.files, file] }))
+    })
   }
 
   /** Append the given files to `state.files`. */
   private addFiles = (files: UploadFileInfo[]): void => {
-    this.setState(state => ({ files: [...state.files, ...files] }))
+    flushSync(() => {
+      this.setState(state => ({ files: [...state.files, ...files] }))
+    })
   }
 
   /** Remove the file with the given ID from `state.files`. */
   private removeFile = (idToRemove: number): void => {
-    this.setState(state => ({
-      files: state.files.filter(file => file.id !== idToRemove),
-    }))
+    flushSync(() => {
+      this.setState(state => ({
+        files: state.files.filter(file => file.id !== idToRemove),
+      }))
+    })
   }
 
   /**
@@ -454,12 +469,14 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
 
   /** Replace the file with the given id in `state.files`. */
   private updateFile = (curFileId: number, newFile: UploadFileInfo): void => {
-    this.setState(curState => {
-      return {
-        files: curState.files.map(file =>
-          file.id === curFileId ? newFile : file
-        ),
-      }
+    flushSync(() => {
+      this.setState(curState => {
+        return {
+          files: curState.files.map(file =>
+            file.id === curFileId ? newFile : file
+          ),
+        }
+      })
     })
   }
 
@@ -494,20 +511,22 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
    * form is submitted. Restore our default value and update the WidgetManager.
    */
   private onFormCleared = (): void => {
-    this.setState({ files: [] }, () => {
-      const newWidgetValue = this.createWidgetValue()
-      if (isNullOrUndefined(newWidgetValue)) {
-        return
-      }
-
-      const { widgetMgr, element, fragmentId } = this.props
-      widgetMgr.setFileUploaderStateValue(
-        element,
-        newWidgetValue,
-        { fromUi: true },
-        fragmentId
-      )
+    flushSync(() => {
+      this.setState({ files: [] })
     })
+
+    const newWidgetValue = this.createWidgetValue()
+    if (isNullOrUndefined(newWidgetValue)) {
+      return
+    }
+
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setFileUploaderStateValue(
+      element,
+      newWidgetValue,
+      { fromUi: true },
+      fragmentId
+    )
   }
 
   public render(): React.ReactNode {


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Fixes state race conditions when using file uploader in `createRoot` API
  - Leverages `flushState` since we are dealing with browser APIs
  - Removes a piece of unused state + unused function
- Result: all file uploader tests in CI now pass!

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This fixes e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
