### PR TITLE
Remove remaining widget background color theme

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/styled-components.ts
@@ -43,8 +43,7 @@ export const StyledChatFileUploadDropzoneLabel =
     border: `${theme.sizes.borderWidth} solid`,
     borderColor: theme.colors.primary,
     borderRadius: theme.radii.chatInput,
-    backgroundColor:
-      theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
+    backgroundColor: theme.colors.secondaryBg,
     color: theme.colors.primary,
     display: "flex",
     alignItems: "center",

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -30,10 +30,9 @@ export interface StyledChatInputProps {
 export const StyledChatInput = styled.div<StyledChatInputProps>(
   ({ theme, extended }) => ({
     border: `${theme.sizes.borderWidth} solid`,
-    borderColor: theme.colors.widgetBorderColor ?? theme.colors.transparent,
+    borderColor: theme.colors.transparent,
     borderRadius: theme.radii.chatInput,
-    backgroundColor:
-      theme.colors.widgetBackgroundColor ?? theme.colors.secondaryBg,
+    backgroundColor: theme.colors.secondaryBg,
     position: "relative",
     flexGrow: 1,
     display: "flex",


### PR DESCRIPTION
## Describe your changes

`widgetBackgroundColor` is now deprecated

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
