### PR TITLE
Fix console error when using rem in svg width & height attributes

### DIFF
--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -20,7 +20,7 @@ import Clipboard from "clipboard"
 import { Copy as CopyIcon } from "react-feather"
 import { useTheme } from "@emotion/react"
 
-import { EmotionTheme } from "~lib/theme"
+import { convertRemToPx, EmotionTheme } from "~lib/theme"
 
 import { StyledCopyButton } from "./styled-components"
 
@@ -62,7 +62,8 @@ const CopyButton: React.FC<Props> = ({ text }) => {
         right: 0,
       }}
     >
-      <CopyIcon size={theme.iconSizes.base} />
+      {/* Convert size to px because using rem works but logs a console error (at least on webkit) */}
+      <CopyIcon size={convertRemToPx(theme.iconSizes.base)} />
     </StyledCopyButton>
   )
 }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -51,6 +51,7 @@ import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import ErrorBoundary from "~lib/components/shared/ErrorBoundary"
 import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon"
 import {
+  convertRemToPx,
   EmotionTheme,
   getMarkdownBgColors,
   getMarkdownTextColors,
@@ -169,7 +170,8 @@ const HeaderActionElements: FunctionComponent<HeadingActionElements> = ({
       {help && <InlineTooltipIcon content={help} />}
       {elementId && !hideAnchor && (
         <StyledLinkIcon href={`#${elementId}`}>
-          <LinkIcon size={theme.iconSizes.base} />
+          {/* Convert size to px because using rem works but logs a console error (at least on webkit) */}
+          <LinkIcon size={convertRemToPx(theme.iconSizes.base)} />
         </StyledLinkIcon>
       )}
     </StyledHeadingActionElements>

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
@@ -23,7 +23,7 @@ import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
 import StreamlitMarkdown, {
   StreamlitMarkdownProps,
 } from "~lib/components/shared/StreamlitMarkdown"
-import { EmotionTheme } from "~lib/theme"
+import { convertRemToPx, EmotionTheme } from "~lib/theme"
 
 import {
   StyledLabelHelpInline,
@@ -68,7 +68,11 @@ function TooltipIcon({
         inline
       >
         {children || (
-          <HelpCircleIcon className="icon" size={theme.iconSizes.base} />
+          <HelpCircleIcon
+            className="icon"
+            /* Convert size to px because using rem works but logs a console error (at least on webkit) */
+            size={convertRemToPx(theme.iconSizes.base)}
+          />
         )}
       </Tooltip>
     </StyledTooltipIconWrapper>


### PR DESCRIPTION
## Describe your changes

The heading copy-link icon uses a `rem` size, which shows the following error in the console:

![Screenshot 2025-02-19 at 11 00 19](https://github.com/user-attachments/assets/024cddaa-19a0-40ae-b5ab-7286bbefc742)

This PR transforms the `rem` to `px` in order to get rid of the error warning.

## GitHub Issue Link (if applicable)

## Testing Plan

- No visual changes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
