### PR TITLE
[fix] Websocket connection state with createRoot

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -22,6 +22,7 @@ import { enableAllPlugins as enableImmerPlugins } from "immer"
 import classNames from "classnames"
 import without from "lodash/without"
 import { getLogger } from "loglevel"
+import { flushSync } from "react-dom"
 
 import {
   AppRoot,
@@ -663,7 +664,9 @@ export class App extends PureComponent<Props, State> {
       }
     }
 
-    this.setState({ connectionState: newState })
+    flushSync(() => {
+      this.setState({ connectionState: newState })
+    })
   }
 
   handleGitInfoChanged = (gitInfo: IGitInfo): void => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -664,6 +664,11 @@ export class App extends PureComponent<Props, State> {
       }
     }
 
+    // We are using `flushSync` here because there is code that expects every
+    // state to be observed. With React batched updates, it is possible that
+    // multiple `connectionState` changes are applied in 1 render cycle, leading
+    // to the last state change being the only one observed. Utilizing
+    // `flushSync` ensures that we apply every state change.
     flushSync(() => {
       this.setState({ connectionState: newState })
     })


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Fixes an issue where connectionState updates must all applied in an expected order. `createRoot` would sometimes batch these changes, leading to "skipped" states
- Result: All websocket e2e tests are now passing

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This fixes e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
