### PR TITLE
Update "click immediately with onBlur" test to reduce flakiness

### DIFF
--- a/e2e_playwright/widget_state.py
+++ b/e2e_playwright/widget_state.py
@@ -16,6 +16,17 @@ import time
 
 import streamlit as st
 
+# we use session_state to store the callback function value
+# instead of using st.write directly in the button callback,
+# because we have observed that the button-click is sometimes not
+# dispatched correctly when the rerun from the textArea's onBlur event
+# is too fast which leads to a changing number of elements per rerun (because the
+# callback's write would disappear briefly).
+if "btn_callback" not in st.session_state:
+    st.session_state.btn_callback = "Input: "
+
+st.write(st.session_state.btn_callback)
+
 st.header("Widget State - Heavy Usage Test")
 # Test for https://github.com/streamlit/streamlit/issues/4836
 
@@ -40,8 +51,9 @@ st.header("Test for input change & button click in one motion")
 
 
 def btn_callback():
-    st.write("Input: " + st.session_state["key1"])
+    st.session_state.btn_callback = f"Input: {st.session_state['key1']}"
 
 
-st.text_area("Type something into the text area", key="key1")
+txt = st.text_area("Type something into the text area", key="key1")
 st.button("Submit text_area", on_click=btn_callback)
+st.write(f"Res: {txt}")

--- a/e2e_playwright/widget_state.py
+++ b/e2e_playwright/widget_state.py
@@ -22,10 +22,13 @@ import streamlit as st
 # dispatched correctly when the rerun from the textArea's onBlur event
 # is too fast which leads to a changing number of elements per rerun (because the
 # callback's write would disappear briefly).
+default_input = "Input: "
 if "btn_callback" not in st.session_state:
-    st.session_state.btn_callback = "Input: "
+    st.session_state.btn_callback = default_input
 
 st.write(st.session_state.btn_callback)
+# reset to harden the test against reruns
+st.session_state.btn_callback = default_input
 
 st.header("Widget State - Heavy Usage Test")
 # Test for https://github.com/streamlit/streamlit/issues/4836

--- a/e2e_playwright/widget_state_test.py
+++ b/e2e_playwright/widget_state_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.shared.app_utils import (
@@ -76,6 +77,10 @@ def test_doesnt_save_widget_state_on_redisplay_with_keyed_widget(app: Page):
     expect(markdown_el).not_to_be_attached()
 
 
+# Skip webkit since the test is flaky there. It seems like the setTimeout wrapper for
+# trigger-values in WidgetStateManager.ts is not working correctly; but I cannot
+# reproduce it manually in Safari.
+@pytest.mark.skip_browser("webkit")
 def test_click_button_after_input_change_without_losing_focus_first(app: Page):
     """Test that the input value is correctly updated when clicking a button
     right after changing the input value without losing focus first.

--- a/e2e_playwright/widget_state_test.py
+++ b/e2e_playwright/widget_state_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.shared.app_utils import (
@@ -77,18 +76,13 @@ def test_doesnt_save_widget_state_on_redisplay_with_keyed_widget(app: Page):
     expect(markdown_el).not_to_be_attached()
 
 
-# Skip webkit since the test is flaky there. Based on our investigation,
-# it seems like sometimes the button click event is not dispatched, perhaps
-# because the click is registered on the VerticalBlock component, probably due to
-# rerendering the component. Manually I can also reproduce the issue by clicking
-# in Chrome, but the test seems to be stable. The hypothesis is that the test clicks
-# so fast that the text area rerun message and re-rendering has not happened yet.
-@pytest.mark.skip_browser("webkit")
 def test_click_button_after_input_change_without_losing_focus_first(app: Page):
     """Test that the input value is correctly updated when clicking a button
     right after changing the input value without losing focus first.
 
     Related to: https://github.com/streamlit/streamlit/issues/10007"""
+
+    expect_markdown(app, "Input: ")
 
     text_area = app.get_by_test_id("stTextArea")
     text_area_field = text_area.locator("textarea").first

--- a/e2e_playwright/widget_state_test.py
+++ b/e2e_playwright/widget_state_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.shared.app_utils import (
@@ -76,6 +77,13 @@ def test_doesnt_save_widget_state_on_redisplay_with_keyed_widget(app: Page):
     expect(markdown_el).not_to_be_attached()
 
 
+# Skip webkit since the test is flaky there. Based on our investigation,
+# it seems like sometimes the button click event is not dispatched, perhaps
+# because the click is registered on the VerticalBlock component, probably due to
+# rerendering the component. Manually I can also reproduce the issue by clicking
+# in Chrome, but the test seems to be stable. The hypothesis is that the test clicks
+# so fast that the text area rerun message and re-rendering has not happened yet.
+@pytest.mark.skip_browser("webkit")
 def test_click_button_after_input_change_without_losing_focus_first(app: Page):
     """Test that the input value is correctly updated when clicking a button
     right after changing the input value without losing focus first.


### PR DESCRIPTION
## Describe your changes

We have observed that doing the `st.write` in the callback _can_ lead to flakiness for the following reason:
- the textArea's `onBlur` event triggers a rerun message and a rerun
- the rerun changes the number of rendered elements, because the rerun triggered by the `textArea` does not include the button's callback `write`
- the `click` event on the button is not dispatched by the browser, because the click target changed

Now, the callback updates the session state and the `st.write` happens outside of it, so that the number of elements per rerun is always the same.
This still tests the original intention based on https://github.com/streamlit/streamlit/issues/10007, because the reported issue used a `print` statement and the issue was that the trigger event happened before the text area rerun trigger.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
  - Updated e2e test to not be flaky
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
