### PR TITLE
[Fix] Reuse event loop logic

### DIFF
--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -340,10 +340,14 @@ def run(
     async def main():
         await run_server()
 
-    # Check if we're already in an event loop
-    if asyncio.get_event_loop().is_running():
-        # Use `asyncio.create_task` if we're in an async context
-        asyncio.create_task(main())
-    else:
-        # Otherwise, use `asyncio.run`
+    try:
+        # Check if we're already in an event loop
+        if asyncio.get_running_loop().is_running():
+            # Use `asyncio.create_task` if we're in an async context
+            asyncio.create_task(main())
+        else:
+            # Otherwise, use `asyncio.run`
+            asyncio.run(main())
+    except RuntimeError:
+        # get_running_loop throws RuntimeError if no running event loop
         asyncio.run(main())

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -441,3 +441,12 @@ class BootstrapRunTest(IsolatedAsyncioTestCase):
                 bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)
 
             event_loop.run_until_complete(_run())
+
+    def test_bootstrap_run_without_existing_event_loop(self):
+        import asyncio
+
+        # Remove the existing event loop
+        asyncio.set_event_loop(None)
+
+        with testutil.patch_config_options({"server.headless": True}):
+            bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)


### PR DESCRIPTION
## Describe your changes
`asyncio.get_running_loop()` throws a `RuntimeError: There is no current event loop in thread 'MainThread'` when this is no current event loop.

Resolves issue introduced in #10164.

## GitHub Issue Link (if applicable)
Closes #10452

## Testing Plan
- Unit Tests (JS and/or Python): Added ✅ 
- Manual Testing: ✅ 