### PR TITLE
[Fix]: `st.altair_chart` selection interval showing `true` tooltip

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -89,6 +89,35 @@ if (
         "Scatter chart with selection_interval:", str(st.session_state.scatter_interval)
     )
 
+st.subheader("Scatter chart with selection_interval & tooltip")
+base = (
+    alt.Chart(cars)
+    .mark_point()
+    .encode(
+        x="Horsepower:Q",
+        y="Miles_per_Gallon:Q",
+        color=alt.condition(interval, "Origin:N", alt.value("lightgray")),
+        tooltip=["Horsepower", "Miles_per_Gallon"],
+    )
+)
+chart_interval = base.add_params(interval)
+# Set use_container_width=True for all charts so that the width is not dependent on Vega-lib updates.
+st.altair_chart(
+    chart_interval,
+    on_select="rerun",
+    key="scatter_interval_tooltip",
+    use_container_width=True,
+)
+if (
+    "scatter_interval_tooltip" in st.session_state
+    and len(st.session_state.scatter_interval_tooltip.selection) > 0
+):
+    st.write(
+        "Scatter chart with selection_interval & tooltip:",
+        str(st.session_state.scatter_interval_tooltip),
+    )
+
+
 # BAR CHART
 st.subheader("Bar chart with selection_point")
 source = pd.DataFrame(

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -262,8 +262,8 @@ def test_interval_selection_scatter_chart_no_tooltip_in_selection(app: Page):
     # get the tooltip
     tooltip = app.locator("#vg-tooltip-element")
 
-    # check the tooltip doesn't have "true" as content (Issue #10448)
-    expect(tooltip).not_to_have_text("true")
+    # check tooltip empty - doesn't have "true" as content (Issue #10448)
+    expect(tooltip).to_have_text("")
 
 
 def test_interval_selection_scatter_chart_tooltip_outside_selection(app: Page):

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -76,40 +76,44 @@ def _get_selection_interval_scatter_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(1)
 
 
-def _get_selection_point_bar_chart(app: Page) -> Locator:
+def _get_selection_interval_scatter_chart_tooltip(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(2)
 
 
-def _get_selection_interval_bar_chart(app: Page) -> Locator:
+def _get_selection_point_bar_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(3)
 
 
-def _get_selection_point_area_chart(app: Page) -> Locator:
+def _get_selection_interval_bar_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(4)
 
 
-def _get_selection_interval_area_chart(app: Page) -> Locator:
+def _get_selection_point_area_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(5)
 
 
-def _get_selection_point_histogram(app: Page) -> Locator:
+def _get_selection_interval_area_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(6)
 
 
-def _get_selection_interval_histogram(app: Page) -> Locator:
+def _get_selection_point_histogram(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(7)
 
 
-def _get_in_form_chart(app: Page) -> Locator:
+def _get_selection_interval_histogram(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(8)
 
 
-def _get_callback_chart(app: Page) -> Locator:
+def _get_in_form_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(9)
 
 
-def _get_in_fragment_chart(app: Page) -> Locator:
+def _get_callback_chart(app: Page) -> Locator:
     return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(10)
+
+
+def _get_in_fragment_chart(app: Page) -> Locator:
+    return app.get_by_test_id("stVegaLiteChart").locator("canvas").nth(11)
 
 
 def test_point_bar_chart_displays_selection_text(app: Page):
@@ -242,6 +246,43 @@ def test_interval_selection_scatter_chart_displays_selection_snapshot(
     expect_prefixed_markdown(app, expected_prefix, expected_selection)
 
     assert_snapshot(chart, name="st_altair_chart-scatter_interval_selection")
+
+
+def test_interval_selection_scatter_chart_no_tooltip_in_selection(app: Page):
+    chart = _get_selection_interval_scatter_chart_tooltip(app)
+
+    # create selection
+    _create_selection_rectangle(
+        app, chart, _MousePosition(260, 110), _MousePosition(433, 220)
+    )
+
+    # hover over a point in the selection
+    chart.hover(position={"x": 300, "y": 150})
+
+    # get the tooltip
+    tooltip = app.locator("#vg-tooltip-element")
+
+    # check the tooltip doesn't have "true" as content (Issue #10448)
+    expect(tooltip).not_to_have_text("true")
+
+
+def test_interval_selection_scatter_chart_tooltip_outside_selection(app: Page):
+    chart = _get_selection_interval_scatter_chart_tooltip(app)
+
+    # create selection
+    _create_selection_rectangle(
+        app, chart, _MousePosition(260, 110), _MousePosition(433, 220)
+    )
+
+    # hover over a point outside the selection
+    chart.hover(position={"x": 250, "y": 110})
+
+    # get the tooltip
+    tooltip = app.locator("#vg-tooltip-element")
+
+    # check the tooltip has expected content
+    expect(tooltip).to_contain_text("Horsepower")
+    expect(tooltip).to_contain_text("Miles_per_Gallon")
 
 
 def _test_shift_click_point_selection_scatter_chart_displays_selection(

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
@@ -121,7 +121,7 @@ export function applyStreamlitTheme(config: any, theme: EmotionTheme): any {
       columns: 1,
     },
     mark: {
-      tooltip: true,
+      tooltip: { content: "encoding" },
       color: getBlue80(theme),
     },
     bar: {


### PR DESCRIPTION
## Describe your changes
When adding a selection interval to an altair plot, the selection rectangle has a tooltip "true". There should not be a tooltip for the selection mark - it should be the same as vega behavior.

As noted in the vega docs [here](https://vega.github.io/vega-lite/docs/mark.html#mark-def) for `tooltip` property, setting tooltip to `true` or `{"content": "encoding"}` should exhibit the same behavior. 

**Vega editor when hovering over selection interval vs OUTSIDE selection:**
<img width="350" alt="Screenshot 2025-02-19 at 4 38 07 p m" src="https://github.com/user-attachments/assets/64dd52cc-c6a9-4efb-b6bd-0fd835fa24e4" /><img width="350" alt="Screenshot 2025-02-19 at 4 38 14 p m" src="https://github.com/user-attachments/assets/ae417d84-3685-4b6a-bdce-546148379182" />

**Current: Streamlit `st.altair_chart` when hovering over selection interval vs OUTSIDE**
<img width="350" alt="Screenshot 2025-02-19 at 4 42 11 p m" src="https://github.com/user-attachments/assets/161ffb9b-29ed-44da-b2c4-39f50028e0bc" /><img width="350" alt="Screenshot 2025-02-19 at 4 40 59 p m" src="https://github.com/user-attachments/assets/3f4da340-a336-459b-b614-ee7764ca3021" />

## GitHub Issue Link
Closes #10448

**Updated: hovering over selection interval**:
<img width="350" alt="Screenshot 2025-02-19 at 4 41 14 p m" src="https://github.com/user-attachments/assets/5391235f-60d6-4c51-9019-121a946d18b4" />

## Testing Plan
- E2E Tests: ✅  Added
- Manual Testing: ✅ 