### PR TITLE
Fix: Windows Ctrl+C handling without browser tab

### DIFF
--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -41,7 +41,12 @@ def _set_up_signal_handler(server: Server) -> None:
 
     def signal_handler(signal_number, stack_frame):
         # The server will shut down its threads and exit its loop.
+        _LOGGER.debug(f"Received signal {signal_number}")
         server.stop()
+        # On Windows, force exit after server stop
+        if sys.platform == "win32":
+            import os
+            os._exit(0)
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -46,6 +46,7 @@ def _set_up_signal_handler(server: Server) -> None:
         # On Windows, force exit after server stop
         if sys.platform == "win32":
             import os
+
             os._exit(0)
 
     signal.signal(signal.SIGTERM, signal_handler)

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -18,6 +18,7 @@ import asyncio
 import os
 import signal
 import sys
+import threading
 from typing import Any, Final
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
@@ -42,11 +43,21 @@ def _set_up_signal_handler(server: Server) -> None:
     def signal_handler(signal_number, stack_frame):
         # The server will shut down its threads and exit its loop.
         _LOGGER.debug(f"Received signal {signal_number}")
-        server.stop()
-        # On Windows, force exit after server stop
-        if sys.platform == "win32":
-            import os
+        try:
+            server.stop()
+        except SystemExit:
+            # Normal exit path
+            raise
+        except Exception:
+            _LOGGER.exception("Error during server shutdown")
 
+        # On Windows, if we're not in the main thread and server.stop() didn't exit,
+        # we need to force an exit as a last resort
+        if (
+            sys.platform == "win32"
+            and threading.current_thread() is not threading.main_thread()
+        ):
+            _LOGGER.warning("Forcing Windows process termination from non-main thread")
             os._exit(0)
 
     signal.signal(signal.SIGTERM, signal_handler)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -471,7 +471,7 @@ class Server:
         """
         cli_util.print_to_cli("  Stopping...", fg="blue")
         self._runtime.stop()
-        
+
         # Force immediate shutdown on Windows
         if sys.platform == "win32":
             sys.exit(0)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -18,7 +18,9 @@ import errno
 import logging
 import mimetypes
 import os
+import signal
 import sys
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
@@ -484,3 +486,35 @@ def _set_tornado_log_levels() -> None:
         logging.getLogger("tornado.access").setLevel(logging.ERROR)
         logging.getLogger("tornado.application").setLevel(logging.ERROR)
         logging.getLogger("tornado.general").setLevel(logging.ERROR)
+
+
+def _set_up_signal_handler(server: Server) -> None:
+    _LOGGER.debug("Setting up signal handler")
+
+    def signal_handler(signal_number, stack_frame):
+        _LOGGER.debug(f"Received signal {signal_number}")
+
+        # The server will shut down its threads and exit its loop.
+        try:
+            server.stop()
+        except SystemExit:
+            # Normal exit path
+            raise
+        except Exception:
+            _LOGGER.exception("Error during server shutdown")
+
+        # On Windows, if we're not in the main thread and server.stop() didn't exit,
+        # we need to force an exit as a last resort
+        if (
+            sys.platform == "win32"
+            and threading.current_thread() is not threading.main_thread()
+        ):
+            _LOGGER.warning("Forcing Windows process termination from non-main thread")
+            os._exit(0)
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    if sys.platform == "win32":
+        signal.signal(signal.SIGBREAK, signal_handler)
+    else:
+        signal.signal(signal.SIGQUIT, signal_handler)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -466,8 +466,15 @@ class Server:
         return self._main_script_path == streamlit_app.__file__
 
     def stop(self) -> None:
+        """Request that the Server shut down. The actual shutdown may be delayed
+        if the Server is currently handling a request.
+        """
         cli_util.print_to_cli("  Stopping...", fg="blue")
         self._runtime.stop()
+        
+        # Force immediate shutdown on Windows
+        if sys.platform == "win32":
+            sys.exit(0)
 
 
 def _set_tornado_log_levels() -> None:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -18,9 +18,7 @@ import errno
 import logging
 import mimetypes
 import os
-import signal
 import sys
-import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
@@ -486,35 +484,3 @@ def _set_tornado_log_levels() -> None:
         logging.getLogger("tornado.access").setLevel(logging.ERROR)
         logging.getLogger("tornado.application").setLevel(logging.ERROR)
         logging.getLogger("tornado.general").setLevel(logging.ERROR)
-
-
-def _set_up_signal_handler(server: Server) -> None:
-    _LOGGER.debug("Setting up signal handler")
-
-    def signal_handler(signal_number, stack_frame):
-        _LOGGER.debug(f"Received signal {signal_number}")
-
-        # The server will shut down its threads and exit its loop.
-        try:
-            server.stop()
-        except SystemExit:
-            # Normal exit path
-            raise
-        except Exception:
-            _LOGGER.exception("Error during server shutdown")
-
-        # On Windows, if we're not in the main thread and server.stop() didn't exit,
-        # we need to force an exit as a last resort
-        if (
-            sys.platform == "win32"
-            and threading.current_thread() is not threading.main_thread()
-        ):
-            _LOGGER.warning("Forcing Windows process termination from non-main thread")
-            os._exit(0)
-
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
-    if sys.platform == "win32":
-        signal.signal(signal.SIGBREAK, signal_handler)
-    else:
-        signal.signal(signal.SIGQUIT, signal_handler)


### PR DESCRIPTION
## 🐛 Bug Fix: Windows Ctrl+C handling without browser tab

Fixes #6855

### Problem
When running a Streamlit app on Windows without opening a browser tab (e.g., with `--server.headless=true`), the Ctrl+C signal is not properly handled, making it impossible to gracefully terminate the process from the command line.

### Root Cause
Windows handles console signals differently than Unix-based systems. The current implementation doesn't properly force process termination on Windows after the server stop is requested, causing the process to hang.

### Solution
1. Enhanced the signal handler to force process termination on Windows using `os._exit(0)`
2. Added Windows-specific handling in the server's stop method using `sys.exit(0)`
3. Improved signal handling logging for better debugging

### Changes
- Modified `_set_up_signal_handler` in `bootstrap.py` to force exit on Windows
- Updated `stop` method in `server.py` to handle Windows-specific termination
- Added debug logging for signal handling

### Testing Done
Tested the following scenarios on Windows:
- [x] Ctrl+C with `--server.headless=true`
- [x] Ctrl+C with browser tab open
- [x] Normal termination scenarios
- [x] Verified no impact on Unix-based systems

### Notes
- This fix specifically targets Windows systems while maintaining existing behavior on other platforms
- Uses `os._exit(0)` as a last resort to ensure clean process termination on Windows

/label bug
/label impact/minor
/label security/none