### PR TITLE
Remove MPAv1 code

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -78,7 +78,6 @@ import {
 
 import { showDevelopmentOptions } from "./showDevelopmentOptions"
 import { App, LOG, Props } from "./App"
-import { a } from "vitest/dist/chunks/suite.B2jumIFP"
 
 vi.mock("~lib/baseconsts", async () => {
   return {
@@ -1184,339 +1183,6 @@ describe("App", () => {
       expect(element).toBeInTheDocument()
     })
 
-    describe("page change URL handling", () => {
-      let pushStateSpy: any
-
-      beforeEach(() => {
-        window.history.pushState({}, "", "/")
-        pushStateSpy = vi.spyOn(window.history, "pushState")
-      })
-
-      afterEach(() => {
-        pushStateSpy.mockRestore()
-        window.history.pushState({}, "", "/")
-      })
-
-      it("can switch to the main page from a different page", () => {
-        renderApp(getProps())
-        window.history.replaceState({}, "", "/page2")
-
-        sendForwardMessage("newSession", NEW_SESSION_JSON)
-        sendForwardMessage("navigation", {
-          appPages: [
-            {
-              pageScriptHash: "page_script_hash",
-              pageName: "streamlit_app",
-              isDefault: true,
-            },
-          ],
-          pageScriptHash: "page_script_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
-      })
-
-      it("can switch to a non-main page", () => {
-        renderApp(getProps())
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "hash2",
-        })
-
-        sendForwardMessage("navigation", {
-          appPages: [
-            {
-              pageScriptHash: "page_script_hash",
-              pageName: "streamlit app",
-              urlPathname: "streamlit_app",
-              isDefault: true,
-            },
-            {
-              pageScriptHash: "hash2",
-              pageName: "page2",
-              urlPathname: "page2",
-            },
-          ],
-          pageScriptHash: "hash2",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).toHaveBeenLastCalledWith(
-          {},
-          "",
-          "/page2"
-        )
-      })
-
-      it("does not retain the query string without embed params", () => {
-        renderApp(getProps())
-        window.history.pushState({}, "", "/?foo=bar")
-
-        sendForwardMessage("newSession", NEW_SESSION_JSON)
-        sendForwardMessage("navigation", {
-          appPages: [
-            {
-              pageScriptHash: "page_script_hash",
-              pageName: "streamlit app",
-              urlPathname: "streamlit_app",
-              isDefault: true,
-            },
-            {
-              pageScriptHash: "hash2",
-              pageName: "page2",
-              urlPathname: "page2",
-            },
-          ],
-          pageScriptHash: "page_script_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).toHaveBeenLastCalledWith(
-          {},
-          "",
-          "/?foo=bar"
-        )
-      })
-
-      it("retains embed query params even if the page hash is different", () => {
-        const embedParams =
-          "embed=true&embed_options=disable_scrolling&embed_options=show_colored_line"
-        window.history.pushState({}, "", `/?${embedParams}`)
-
-        renderApp(getProps())
-
-        const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
-          HostCommunicationManager
-        )
-
-        const appPages = [
-          {
-            pageScriptHash: "toppage_hash",
-            pageName: "streamlit app",
-            urlPathname: "streamlit_app",
-            isDefault: true,
-          },
-          {
-            pageScriptHash: "subpage_hash",
-            pageName: "page2",
-            urlPathname: "page2",
-          },
-        ]
-
-        // Because the page URL is already "/" pointing to the main page, no new history is pushed.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "toppage_hash",
-        })
-
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "toppage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        const navLinks = screen.queryAllByTestId("stSidebarNavLink")
-        expect(navLinks).toHaveLength(2)
-
-        // TODO: Utilize user-event instead of fireEvent
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.click(navLinks[1])
-
-        const connectionManager = getMockConnectionManager()
-
-        expect(
-          // @ts-expect-error
-          connectionManager.sendMessage.mock.calls[0][0].rerunScript
-            .queryString
-        ).toBe(embedParams)
-
-        expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-          type: "SET_QUERY_PARAM",
-          queryParams: embedParams,
-        })
-      })
-
-      it("works with baseUrlPaths", () => {
-        renderApp(getProps())
-        vi.spyOn(
-          getMockConnectionManager(),
-          "getBaseUriParts"
-        ).mockReturnValue({
-          pathname: "/foo",
-          hostname: "",
-          port: "8501",
-        } as URL)
-
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "hash2",
-        })
-
-        sendForwardMessage("navigation", {
-          appPages: [
-            {
-              pageScriptHash: "page_script_hash",
-              pageName: "streamlit app",
-              urlPathname: "streamlit_app",
-              isDefault: true,
-            },
-            {
-              pageScriptHash: "hash2",
-              pageName: "page2",
-              urlPathname: "page2",
-            },
-          ],
-          pageScriptHash: "hash2",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).toHaveBeenLastCalledWith(
-          {},
-          "",
-          "/foo/page2"
-        )
-      })
-
-      it("doesn't push a new history when the same page URL is already set", () => {
-        renderApp(getProps())
-        history.replaceState({}, "", "/") // The URL is set to the main page from the beginning.
-
-        const appPages = [
-          {
-            pageScriptHash: "toppage_hash",
-            pageName: "streamlit app",
-            urlPathname: "streamlit_app",
-            isDefault: true,
-          },
-          {
-            pageScriptHash: "subpage_hash",
-            pageName: "page2",
-            urlPathname: "page2",
-          },
-        ]
-
-        // Because the page URL is already "/" pointing to the main page, no new history is pushed.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "toppage_hash",
-        })
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "toppage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).not.toHaveBeenCalled()
-        // @ts-expect-error
-        window.history.pushState.mockClear()
-
-        // When accessing a different page, a new history for that page is pushed.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "subpage_hash",
-        })
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "subpage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-        expect(window.history.pushState).toHaveBeenLastCalledWith(
-          {},
-          "",
-          "/page2"
-        )
-        // @ts-expect-error
-        window.history.pushState.mockClear()
-      })
-
-      it("doesn't push a duplicated history when rerunning", () => {
-        renderApp(getProps())
-        history.replaceState({}, "", "/page2") // Starting from a not main page.
-
-        const appPages = [
-          {
-            pageScriptHash: "toppage_hash",
-            pageName: "streamlit app",
-            urlPathname: "streamlit_app",
-            isDefault: true,
-          },
-          {
-            pageScriptHash: "subpage_hash",
-            pageName: "page2",
-            urlPathname: "page2",
-          },
-        ]
-
-        // Because the page URL is already "/" pointing to the main page, no new history is pushed.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "toppage_hash",
-        })
-
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "toppage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-
-        expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
-        // @ts-expect-error
-        window.history.pushState.mockClear()
-
-        // When running the same, e.g. clicking the "rerun" button,
-        // the history is not pushed again.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages: [],
-          pageScriptHash: "toppage_hash",
-        })
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "toppage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-        expect(window.history.pushState).not.toHaveBeenCalled()
-        // @ts-expect-error
-        window.history.pushState.mockClear()
-
-        // When accessing a different page, a new history for that page is pushed.
-        sendForwardMessage("newSession", {
-          ...NEW_SESSION_JSON,
-          appPages,
-          pageScriptHash: "subpage_hash",
-        })
-        sendForwardMessage("navigation", {
-          appPages,
-          pageScriptHash: "subpage_hash",
-          position: Navigation.Position.SIDEBAR,
-          sections: [],
-        })
-        expect(window.history.pushState).toHaveBeenLastCalledWith(
-          {},
-          "",
-          "/page2"
-        )
-        // @ts-expect-error
-        window.history.pushState.mockClear()
-      })
-    })
-
     it("resets document title if not fragment", () => {
       renderApp(getProps())
 
@@ -1655,6 +1321,7 @@ describe("App", () => {
           pageScriptHash: "top_hash",
           pageName: "streamlit app",
           urlPathname: "",
+          isDefault: true,
         },
         {
           pageScriptHash: "sub_hash",
@@ -1664,6 +1331,8 @@ describe("App", () => {
       ],
       pageScriptHash: "top_hash",
       fragmentIdsThisRun: [],
+      sections: [],
+      position: Navigation.Position.SIDEBAR,
     }
 
     beforeEach(() => {
@@ -2256,7 +1925,6 @@ describe("App", () => {
     it("redirects to the auth URL", () => {
       renderApp(getProps())
 
-      // A HACK to mock `window.location.reload`.
       // NOTE: The mocking must be done after mounting, but before `handleMessage` is called.
       // @ts-expect-error
       delete window.location
@@ -2267,13 +1935,14 @@ describe("App", () => {
 
       expect(window.location.href).toBe("https://example.com")
     })
+
     it("sends a message to the host when in child frame", () => {
       renderApp(getProps())
       // A HACK to mock a condition in `isInChildFrame` util function.
       // @ts-expect-error
       delete window.parent
       // @ts-expect-error
-      window.parent = undefined
+      window.parent = { postMessage: vi.fn() }
 
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
         HostCommunicationManager
@@ -2710,6 +2379,16 @@ describe("App", () => {
   })
 
   describe("showDevelopmentMenu", () => {
+    let prevWindowLocation: Location
+
+    beforeEach(() => {
+      prevWindowLocation = window.location
+    })
+
+    afterEach(() => {
+      window.location = prevWindowLocation
+    })
+
     it.each([
       // # Test cases for toolbarMode = Config.ToolbarMode.AUTO
       // Show developer menu only for localhost.
@@ -3421,87 +3100,100 @@ describe("App", () => {
       )
     })
 
-    it("shows hostMenuItems", () => {
-      // We need this to use the Main Menu Button
-      // eslint-disable-next-line testing-library/render-result-naming-convention
-      const app = renderApp(getProps())
+    describe("handleSetMenuItems", () => {
+      let prevWindowLocation: Location
 
-      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
-        HostCommunicationManager
-      )
-
-      hostCommunicationMgr.setAllowedOrigins({
-        allowedOrigins: ["https://devel.streamlit.test"],
-        useExternalAuthToken: false,
+      beforeEach(() => {
+        prevWindowLocation = window.location
       })
 
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
-      openMenu(screen)
-      let menuStructure = getMenuStructure(app)
-      expect(menuStructure).toEqual([
-        [
-          {
-            label: "Rerun",
-            type: "option",
-          },
-          {
-            label: "Settings",
-            type: "option",
-          },
-          {
-            type: "separator",
-          },
-          {
-            label: "Print",
-            type: "option",
-          },
-          {
-            type: "separator",
-          },
-          {
-            label: "About",
-            type: "option",
-          },
-        ],
-      ])
-
-      fireWindowPostMessage({
-        type: "SET_MENU_ITEMS",
-        items: [{ type: "option", label: "Fork this App", key: "fork" }],
+      afterEach(() => {
+        window.location = prevWindowLocation
       })
 
-      menuStructure = getMenuStructure(app)
+      it("shows hostMenuItems", () => {
+        mockWindowLocation("https://devel.streamlit.test")
+        // We need this to use the Main Menu Button
+        // eslint-disable-next-line testing-library/render-result-naming-convention
+        const app = renderApp(getProps())
 
-      expect(menuStructure).toEqual([
-        [
-          {
-            label: "Rerun",
-            type: "option",
-          },
-          {
-            label: "Settings",
-            type: "option",
-          },
-          {
-            type: "separator",
-          },
-          {
-            label: "Print",
-            type: "option",
-          },
-          {
-            type: "separator",
-          },
-          {
-            label: "Fork this App",
-            type: "option",
-          },
-          {
-            label: "About",
-            type: "option",
-          },
-        ],
-      ])
+        const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+          HostCommunicationManager
+        )
+
+        hostCommunicationMgr.setAllowedOrigins({
+          allowedOrigins: ["https://devel.streamlit.test"],
+          useExternalAuthToken: false,
+        })
+
+        sendForwardMessage("newSession", NEW_SESSION_JSON)
+        openMenu(screen)
+        let menuStructure = getMenuStructure(app)
+        expect(menuStructure).toEqual([
+          [
+            {
+              label: "Rerun",
+              type: "option",
+            },
+            {
+              label: "Settings",
+              type: "option",
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "Print",
+              type: "option",
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "About",
+              type: "option",
+            },
+          ],
+        ])
+
+        fireWindowPostMessage({
+          type: "SET_MENU_ITEMS",
+          items: [{ type: "option", label: "Fork this App", key: "fork" }],
+        })
+
+        menuStructure = getMenuStructure(app)
+
+        expect(menuStructure).toEqual([
+          [
+            {
+              label: "Rerun",
+              type: "option",
+            },
+            {
+              label: "Settings",
+              type: "option",
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "Print",
+              type: "option",
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "Fork this App",
+              type: "option",
+            },
+            {
+              label: "About",
+              type: "option",
+            },
+          ],
+        ])
+      })
     })
 
     it("shows hostToolbarItems", () => {
@@ -3658,6 +3350,335 @@ describe("App", () => {
 
       // Ensure rerun back message triggered
       expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe("page change URL handling", () => {
+    let pushStateSpy: any
+
+    beforeEach(() => {
+      window.history.pushState({}, "", "/")
+      pushStateSpy = vi.spyOn(window.history, "pushState")
+    })
+
+    afterEach(() => {
+      pushStateSpy.mockRestore()
+      window.history.pushState({}, "", "/")
+      window.localStorage.clear()
+    })
+
+    it("can switch to the main page from a different page", () => {
+      renderApp(getProps())
+      window.history.replaceState({}, "", "/page2")
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit_app",
+            isDefault: true,
+          },
+        ],
+        pageScriptHash: "page_script_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
+    })
+
+    it("can switch to a non-main page", () => {
+      renderApp(getProps())
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "hash2",
+      })
+
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+            isDefault: true,
+          },
+          {
+            pageScriptHash: "hash2",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
+        ],
+        pageScriptHash: "hash2",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/page2"
+      )
+    })
+
+    it("does not retain the query string without embed params", () => {
+      renderApp(getProps())
+      window.history.pushState({}, "", "/?foo=bar")
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+            isDefault: true,
+          },
+          {
+            pageScriptHash: "hash2",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
+        ],
+        pageScriptHash: "page_script_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/?foo=bar"
+      )
+    })
+
+    it("retains embed query params even if the page hash is different", () => {
+      const embedParams =
+        "embed=true&embed_options=disable_scrolling&embed_options=show_colored_line"
+      window.history.pushState({}, "", `/?${embedParams}`)
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+
+      const appPages = [
+        {
+          pageScriptHash: "toppage_hash",
+          pageName: "streamlit app",
+          urlPathname: "streamlit_app",
+          isDefault: true,
+        },
+        {
+          pageScriptHash: "subpage_hash",
+          pageName: "page2",
+          urlPathname: "page2",
+        },
+      ]
+
+      // Because the page URL is already "/" pointing to the main page, no new history is pushed.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "toppage_hash",
+      })
+
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "toppage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      const navLinks = screen.queryAllByTestId("stSidebarNavLink")
+      expect(navLinks).toHaveLength(2)
+
+      // TODO: Utilize user-event instead of fireEvent
+      // eslint-disable-next-line testing-library/prefer-user-event
+      fireEvent.click(navLinks[1])
+
+      const connectionManager = getMockConnectionManager()
+
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
+      ).toBe(embedParams)
+
+      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+        type: "SET_QUERY_PARAM",
+        queryParams: embedParams,
+      })
+    })
+
+    it("works with baseUrlPaths", () => {
+      renderApp(getProps())
+      vi.spyOn(getMockConnectionManager(), "getBaseUriParts").mockReturnValue({
+        pathname: "/foo",
+        hostname: "",
+        port: "8501",
+      } as URL)
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "hash2",
+      })
+
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+            isDefault: true,
+          },
+          {
+            pageScriptHash: "hash2",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
+        ],
+        pageScriptHash: "hash2",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/foo/page2"
+      )
+    })
+
+    it("doesn't push a new history when the same page URL is already set", () => {
+      renderApp(getProps())
+      history.replaceState({}, "", "/") // The URL is set to the main page from the beginning.
+
+      const appPages = [
+        {
+          pageScriptHash: "toppage_hash",
+          pageName: "streamlit app",
+          urlPathname: "streamlit_app",
+          isDefault: true,
+        },
+        {
+          pageScriptHash: "subpage_hash",
+          pageName: "page2",
+          urlPathname: "page2",
+        },
+      ]
+
+      // Because the page URL is already "/" pointing to the main page, no new history is pushed.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "toppage_hash",
+      })
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "toppage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).not.toHaveBeenCalled()
+      // @ts-expect-error
+      window.history.pushState.mockClear()
+
+      // When accessing a different page, a new history for that page is pushed.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "subpage_hash",
+      })
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "subpage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/page2"
+      )
+      // @ts-expect-error
+      window.history.pushState.mockClear()
+    })
+
+    it("doesn't push a duplicated history when rerunning", () => {
+      renderApp(getProps())
+      history.replaceState({}, "", "/page2") // Starting from a not main page.
+
+      const appPages = [
+        {
+          pageScriptHash: "toppage_hash",
+          pageName: "streamlit app",
+          urlPathname: "streamlit_app",
+          isDefault: true,
+        },
+        {
+          pageScriptHash: "subpage_hash",
+          pageName: "page2",
+          urlPathname: "page2",
+        },
+      ]
+
+      // Because the page URL is already "/" pointing to the main page, no new history is pushed.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "toppage_hash",
+      })
+
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "toppage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
+      // @ts-expect-error
+      window.history.pushState.mockClear()
+
+      // When running the same, e.g. clicking the "rerun" button,
+      // the history is not pushed again.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "toppage_hash",
+      })
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "toppage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+      expect(window.history.pushState).not.toHaveBeenCalled()
+      // @ts-expect-error
+      window.history.pushState.mockClear()
+
+      // When accessing a different page, a new history for that page is pushed.
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        appPages,
+        pageScriptHash: "subpage_hash",
+      })
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "subpage_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/page2"
+      )
+      // @ts-expect-error
+      window.history.pushState.mockClear()
     })
   })
 })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -60,6 +60,7 @@ import {
   IPageNotFound,
   IPagesChanged,
   IParentMessage,
+  Navigation,
   SessionEvent,
   SessionStatus,
   TextInput,
@@ -241,7 +242,7 @@ const NEW_SESSION_JSON: INewSession = {
     },
     sessionStatus: {
       runOnSave: false,
-      scriptIsRunning: false,
+      scriptIsRunning: true,
     },
     sessionId: "sessionId",
     isHello: false,
@@ -496,6 +497,7 @@ describe("App", () => {
           userInfo: {},
           sessionStatus: {},
         },
+        fragmentIdsThisRun: [],
       })
 
       expect(window.location.reload).not.toHaveBeenCalled()
@@ -580,6 +582,7 @@ describe("App", () => {
           userInfo: {},
           sessionStatus: {},
         },
+        fragmentIdsThisRun: [],
       })
 
       expect(window.location.reload).not.toHaveBeenCalled()
@@ -634,15 +637,36 @@ describe("App", () => {
 
   describe("App.handleNewSession", () => {
     const makeAppWithElements = async (): Promise<void> => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
       renderApp(getProps())
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
 
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
       // Add an element to the screen
       // Need to set the script to running
       sendForwardMessage("sessionStatusChanged", {
         runOnSave: false,
         scriptIsRunning: true,
       })
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "hash1",
+            pageName: "page1",
+            urlPathname: "page1",
+            isDefault: true,
+          },
+        ],
+        pageScriptHash: "hash1",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+
       sendForwardMessage(
         "delta",
         {
@@ -1029,24 +1053,36 @@ describe("App", () => {
       expect(window.prerenderReady).toBe(true)
     })
 
-    it.skip("plumbs appPages and currentPageScriptHash to the AppView component", () => {
+    it("plumbs appPages and currentPageScriptHash to the AppView component", () => {
       renderApp(getProps())
+      const appPages = [
+        {
+          pageScriptHash: "hash1",
+          pageName: "page1",
+          urlPathname: "page1",
+          isDefault: true,
+        },
+        {
+          pageScriptHash: "hash2",
+          pageName: "page2",
+          urlPathname: "page2",
+          sectionHeader: "",
+        },
+      ]
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        pageScriptHash: "hash1",
+      })
+
+      sendForwardMessage("navigation", {
+        appPages,
+        pageScriptHash: "hash1",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
         HostCommunicationManager
       )
-
-      expect(screen.queryByTestId("stSidebarNav")).not.toBeInTheDocument()
-
-      const appPages = [
-        { pageScriptHash: "hash1", pageName: "page1", urlPathname: "page1" },
-        { pageScriptHash: "hash2", pageName: "page2", urlPathname: "page2" },
-      ]
-
-      sendForwardMessage("newSession", {
-        ...NEW_SESSION_JSON,
-        appPages,
-        pageScriptHash: "hash1",
-      })
 
       expect(screen.getByTestId("stSidebarNav")).toBeInTheDocument()
       const navLinks = screen.queryAllByTestId("stSidebarNavLink")
@@ -1135,7 +1171,7 @@ describe("App", () => {
       expect(element).toBeInTheDocument()
     })
 
-    describe.skip("page change URL handling", () => {
+    describe("page change URL handling", () => {
       let pushStateSpy: any
 
       beforeEach(() => {
@@ -1153,6 +1189,18 @@ describe("App", () => {
         window.history.replaceState({}, "", "/page2")
 
         sendForwardMessage("newSession", NEW_SESSION_JSON)
+        sendForwardMessage("navigation", {
+          appPages: [
+            {
+              pageScriptHash: "page_script_hash",
+              pageName: "streamlit_app",
+              isDefault: true,
+            },
+          ],
+          pageScriptHash: "page_script_hash",
+          position: 1,
+          sections: [],
+        })
 
         expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
       })
@@ -1161,11 +1209,17 @@ describe("App", () => {
         renderApp(getProps())
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "hash2",
+        })
+
+        sendForwardMessage("navigation", {
           appPages: [
             {
               pageScriptHash: "page_script_hash",
               pageName: "streamlit app",
               urlPathname: "streamlit_app",
+              isDefault: true,
             },
             {
               pageScriptHash: "hash2",
@@ -1174,6 +1228,8 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "hash2",
+          position: 1,
+          sections: [],
         })
 
         expect(window.history.pushState).toHaveBeenLastCalledWith(
@@ -1188,6 +1244,24 @@ describe("App", () => {
         window.history.pushState({}, "", "/?foo=bar")
 
         sendForwardMessage("newSession", NEW_SESSION_JSON)
+        sendForwardMessage("navigation", {
+          appPages: [
+            {
+              pageScriptHash: "page_script_hash",
+              pageName: "streamlit app",
+              urlPathname: "streamlit_app",
+              isDefault: true,
+            },
+            {
+              pageScriptHash: "hash2",
+              pageName: "page2",
+              urlPathname: "page2",
+            },
+          ],
+          pageScriptHash: "page_script_hash",
+          position: 1,
+          sections: [],
+        })
 
         expect(window.history.pushState).toHaveBeenLastCalledWith(
           {},
@@ -1212,6 +1286,7 @@ describe("App", () => {
             pageScriptHash: "toppage_hash",
             pageName: "streamlit app",
             urlPathname: "streamlit_app",
+            isDefault: true,
           },
           {
             pageScriptHash: "subpage_hash",
@@ -1223,8 +1298,15 @@ describe("App", () => {
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "toppage_hash",
+        })
+
+        sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
+          position: 1,
+          sections: [],
         })
 
         const navLinks = screen.queryAllByTestId("stSidebarNavLink")
@@ -1261,11 +1343,17 @@ describe("App", () => {
 
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "hash2",
+        })
+
+        sendForwardMessage("navigation", {
           appPages: [
             {
               pageScriptHash: "page_script_hash",
               pageName: "streamlit app",
               urlPathname: "streamlit_app",
+              isDefault: true,
             },
             {
               pageScriptHash: "hash2",
@@ -1274,6 +1362,8 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "hash2",
+          position: 1,
+          sections: [],
         })
 
         expect(window.history.pushState).toHaveBeenLastCalledWith(
@@ -1292,6 +1382,7 @@ describe("App", () => {
             pageScriptHash: "toppage_hash",
             pageName: "streamlit app",
             urlPathname: "streamlit_app",
+            isDefault: true,
           },
           {
             pageScriptHash: "subpage_hash",
@@ -1303,8 +1394,14 @@ describe("App", () => {
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "toppage_hash",
+        })
+        sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
+          position: 1,
+          sections: [],
         })
 
         expect(window.history.pushState).not.toHaveBeenCalled()
@@ -1314,8 +1411,14 @@ describe("App", () => {
         // When accessing a different page, a new history for that page is pushed.
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "subpage_hash",
+        })
+        sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "subpage_hash",
+          position: 1,
+          sections: [],
         })
         expect(window.history.pushState).toHaveBeenLastCalledWith(
           {},
@@ -1335,6 +1438,7 @@ describe("App", () => {
             pageScriptHash: "toppage_hash",
             pageName: "streamlit app",
             urlPathname: "streamlit_app",
+            isDefault: true,
           },
           {
             pageScriptHash: "subpage_hash",
@@ -1346,8 +1450,15 @@ describe("App", () => {
         // Because the page URL is already "/" pointing to the main page, no new history is pushed.
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "toppage_hash",
+        })
+
+        sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
+          position: 1,
+          sections: [],
         })
 
         expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
@@ -1358,8 +1469,14 @@ describe("App", () => {
         // the history is not pushed again.
         sendForwardMessage("newSession", {
           ...NEW_SESSION_JSON,
+          appPages: [],
+          pageScriptHash: "toppage_hash",
+        })
+        sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
+          position: 1,
+          sections: [],
         })
         expect(window.history.pushState).not.toHaveBeenCalled()
         // @ts-expect-error
@@ -1371,6 +1488,12 @@ describe("App", () => {
           appPages,
           pageScriptHash: "subpage_hash",
         })
+        sendForwardMessage("navigation", {
+          appPages,
+          pageScriptHash: "subpage_hash",
+          position: 1,
+          sections: [],
+        })
         expect(window.history.pushState).toHaveBeenLastCalledWith(
           {},
           "",
@@ -1381,7 +1504,7 @@ describe("App", () => {
       })
     })
 
-    it.skip("resets document title if not fragment", () => {
+    it("resets document title if not fragment", () => {
       renderApp(getProps())
 
       document.title = "some title"
@@ -1390,8 +1513,26 @@ describe("App", () => {
         ...NEW_SESSION_JSON,
         fragmentIdsThisRun: [],
       })
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+            isDefault: true,
+          },
+          {
+            pageScriptHash: "hash2",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
+        ],
+        pageScriptHash: "page_script_hash",
+        position: 1,
+        sections: [],
+      })
 
-      expect(document.title).toBe("streamlit_app")
+      expect(document.title).toBe("streamlit app")
     })
 
     it("does *not* reset document title if fragment", () => {
@@ -2758,6 +2899,10 @@ describe("App", () => {
       })
 
       sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: false,
+        scriptIsRunning: false,
+      })
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -78,6 +78,7 @@ import {
 
 import { showDevelopmentOptions } from "./showDevelopmentOptions"
 import { App, LOG, Props } from "./App"
+import { a } from "vitest/dist/chunks/suite.B2jumIFP"
 
 vi.mock("~lib/baseconsts", async () => {
   return {
@@ -259,6 +260,20 @@ const NEW_SESSION_JSON: INewSession = {
   mainScriptHash: "page_hash",
   scriptRunId: "script_run_id",
   fragmentIdsThisRun: [],
+}
+
+const NAVIGATION_JSON: INavigation = {
+  appPages: [
+    {
+      pageScriptHash: "page_script_hash",
+      pageName: "streamlit app",
+      urlPathname: "streamlit_app",
+      isDefault: true,
+    },
+  ],
+  pageScriptHash: "page_script_hash",
+  position: Navigation.Position.SIDEBAR,
+  sections: [],
 }
 
 // Prevent "moment-timezone requires moment" exception when mocking "moment".
@@ -656,13 +671,13 @@ describe("App", () => {
       sendForwardMessage("navigation", {
         appPages: [
           {
-            pageScriptHash: "hash1",
-            pageName: "page1",
-            urlPathname: "page1",
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
             isDefault: true,
           },
         ],
-        pageScriptHash: "hash1",
+        pageScriptHash: "page_script_hash",
         position: Navigation.Position.SIDEBAR,
         sections: [],
       })
@@ -679,7 +694,7 @@ describe("App", () => {
             },
           },
         },
-        { deltaPath: [0, 0] }
+        { deltaPath: [0, 0], activeScriptHash: "hash1" }
       )
 
       sendForwardMessage(
@@ -694,7 +709,7 @@ describe("App", () => {
             },
           },
         },
-        { deltaPath: [0, 1] }
+        { deltaPath: [0, 1], activeScriptHash: "hash1" }
       )
 
       // Delta Messages handle on a timer, so we make it async
@@ -1160,7 +1175,7 @@ describe("App", () => {
       ).not.toBeInTheDocument()
     })
 
-    it.skip("doesn't clear app elements if currentPageScriptHash doesn't change", async () => {
+    it("doesn't clear app elements if currentPageScriptHash doesn't change", async () => {
       await waitFor(() => {
         makeAppWithElements()
       })
@@ -1198,7 +1213,7 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "page_script_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1228,7 +1243,7 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "hash2",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1259,7 +1274,7 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "page_script_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1305,7 +1320,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1362,7 +1377,7 @@ describe("App", () => {
             },
           ],
           pageScriptHash: "hash2",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1400,7 +1415,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1417,7 +1432,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "subpage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
         expect(window.history.pushState).toHaveBeenLastCalledWith(
@@ -1457,7 +1472,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
 
@@ -1475,7 +1490,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "toppage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
         expect(window.history.pushState).not.toHaveBeenCalled()
@@ -1491,7 +1506,7 @@ describe("App", () => {
         sendForwardMessage("navigation", {
           appPages,
           pageScriptHash: "subpage_hash",
-          position: 1,
+          position: Navigation.Position.SIDEBAR,
           sections: [],
         })
         expect(window.history.pushState).toHaveBeenLastCalledWith(
@@ -1528,7 +1543,7 @@ describe("App", () => {
           },
         ],
         pageScriptHash: "page_script_hash",
-        position: 1,
+        position: Navigation.Position.SIDEBAR,
         sections: [],
       })
 
@@ -1603,7 +1618,7 @@ describe("App", () => {
     })
   })
 
-  describe.skip("App.onHistoryChange", () => {
+  describe("App.onHistoryChange", () => {
     const NEW_SESSION_JSON = {
       config: {
         gatherUsageStats: false,
@@ -1632,6 +1647,11 @@ describe("App", () => {
         sessionId: "sessionId",
         isHello: false,
       },
+      appPages: [],
+      pageScriptHash: "top_hash",
+      fragmentIdsThisRun: [],
+    }
+    const NAVIGATION_JSON = {
       appPages: [
         {
           pageScriptHash: "top_hash",
@@ -1659,14 +1679,26 @@ describe("App", () => {
         ...NEW_SESSION_JSON,
         pageScriptHash: "sub_hash",
       })
+      sendForwardMessage("navigation", {
+        ...NAVIGATION_JSON,
+        pageScriptHash: "sub_hash",
+      })
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
         pageScriptHash: "top_hash",
       })
+      sendForwardMessage("navigation", {
+        ...NAVIGATION_JSON,
+        pageScriptHash: "top_hash",
+      })
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
+        pageScriptHash: "sub_hash",
+      })
+      sendForwardMessage("navigation", {
+        ...NAVIGATION_JSON,
         pageScriptHash: "sub_hash",
       })
 
@@ -1719,6 +1751,10 @@ describe("App", () => {
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
+        pageScriptHash: "sub_hash",
+      })
+      sendForwardMessage("navigation", {
+        ...NAVIGATION_JSON,
         pageScriptHash: "sub_hash",
       })
       window.history.back()
@@ -1835,13 +1871,31 @@ describe("App", () => {
       window.history.pushState({}, "", "/")
     })
 
-    it.skip("sends the currentPageScriptHash if no pageScriptHash is given", () => {
+    it("sends the currentPageScriptHash if no pageScriptHash is given", () => {
       renderApp(getProps())
 
       // Set initial pageScriptHash
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
         pageScriptHash: "some_other_page_hash",
+      })
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "top_hash",
+            pageName: "streamlit app",
+            urlPathname: "",
+            isDefault: true,
+          },
+          {
+            pageScriptHash: "some_other_page_hash",
+            pageName: "page2",
+            urlPathname: "page2",
+          },
+        ],
+        pageScriptHash: "some_other_page_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
       })
 
       const widgetStateManager =
@@ -1932,7 +1986,7 @@ describe("App", () => {
       ).toBe("baz")
     })
 
-    it.skip("sets queryString to an empty string if the page hash is different", () => {
+    it("sets queryString to an empty string if the page hash is different", () => {
       renderApp(getProps())
 
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
@@ -1944,6 +1998,7 @@ describe("App", () => {
           pageScriptHash: "toppage_hash",
           pageName: "streamlit app",
           urlPathname: "streamlit_app",
+          isDefault: true,
         },
         {
           pageScriptHash: "subpage_hash",
@@ -1955,8 +2010,14 @@ describe("App", () => {
       // Because the page URL is already "/" pointing to the main page, no new history is pushed.
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "toppage_hash",
+      })
+      sendForwardMessage("navigation", {
         appPages,
         pageScriptHash: "toppage_hash",
+        sections: [],
+        position: Navigation.Position.SIDEBAR,
       })
       sendForwardMessage("pageInfoChanged", {
         queryString: "foo=bar",
@@ -2038,14 +2099,15 @@ describe("App", () => {
       expect(connectionManager.incrementMessageCacheRunCount).toBeCalled()
     })
 
-    it.skip("will clear stale nodes if finished successfully", async () => {
+    it("will clear stale nodes if finished successfully", async () => {
       renderApp(getProps())
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
       // Run the script with one new element
       sendForwardMessage("sessionStatusChanged", {
         runOnSave: false,
         scriptIsRunning: true,
       })
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", NAVIGATION_JSON)
       // this message now belongs to this^ session
       sendForwardMessage(
         "delta",
@@ -2082,9 +2144,10 @@ describe("App", () => {
       })
     })
 
-    it.skip("will not clear stale nodes if finished with rerun", async () => {
+    it("will not clear stale nodes if finished with rerun", async () => {
       renderApp(getProps())
       sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", NAVIGATION_JSON)
       // Run the script with one new element
       sendForwardMessage("sessionStatusChanged", {
         runOnSave: false,
@@ -2261,7 +2324,7 @@ describe("App", () => {
           { pageScriptHash: "other_page_script_hash", pageName: "Page 1" },
         ],
         pageScriptHash: "other_page_script_hash",
-        position: 0,
+        position: Navigation.Position.HIDDEN,
       })
 
       // Logo outside common script
@@ -2322,11 +2385,24 @@ describe("App", () => {
       })
     })
 
-    it.skip("will not clear logo as stale on fragment re-run", async () => {
+    it("will not clear logo as stale on fragment re-run", async () => {
       renderApp(getProps())
 
       // Initial script run, creates logo
       sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("navigation", {
+        appPages: [
+          {
+            pageScriptHash: "page_script_hash",
+            pageName: "streamlit app",
+            urlPathname: "streamlit_app",
+            isDefault: true,
+          },
+        ],
+        pageScriptHash: "page_script_hash",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
       sendForwardMessage(
         "logo",
         {
@@ -2515,7 +2591,7 @@ describe("App", () => {
       expect(clearInterval).toHaveBeenCalled()
     })
 
-    it.skip("triggers rerunScript with is_auto_rerun set to true", () => {
+    it("triggers rerunScript with is_auto_rerun set to true", () => {
       renderApp(getProps())
 
       const connectionManager = getMockConnectionManager()
@@ -3036,7 +3112,7 @@ describe("App", () => {
       openCacheModal()
     })
 
-    it.skip("changes scriptRunState and triggers stopScript when STOP_SCRIPT message has been received", () => {
+    it("changes scriptRunState and triggers stopScript when STOP_SCRIPT message has been received", () => {
       const hostCommunicationMgr = prepareHostCommunicationManager()
 
       const connectionManager = getMockConnectionManager(true)
@@ -3064,7 +3140,7 @@ describe("App", () => {
       })
     })
 
-    it.skip("changes scriptRunState and triggers rerunScript when scriptRerunRequested message has been received", () => {
+    it("changes scriptRunState and triggers rerunScript when scriptRerunRequested message has been received", () => {
       const hostCommunicationMgr = prepareHostCommunicationManager()
 
       const connectionManager = getMockConnectionManager(true)
@@ -3452,20 +3528,31 @@ describe("App", () => {
       expect(screen.getByTestId("stToolbarActionButton")).toBeInTheDocument()
     })
 
-    it.skip("sets hideSidebarNav based on the server config option and host setting", () => {
+    it("sets hideSidebarNav based on the server config option and host setting", () => {
       prepareHostCommunicationManager()
 
       expect(screen.queryByTestId("stSidebarNav")).not.toBeInTheDocument()
 
       const appPages = [
-        { pageScriptHash: "hash1", pageName: "page1", urlPathname: "page1" },
+        {
+          pageScriptHash: "hash1",
+          pageName: "page1",
+          urlPathname: "page1",
+          isDefault: true,
+        },
         { pageScriptHash: "hash2", pageName: "page2", urlPathname: "page2" },
       ]
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
+        appPages: [],
+        pageScriptHash: "hash1",
+      })
+      sendForwardMessage("navigation", {
         appPages,
         pageScriptHash: "hash1",
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
       })
 
       expect(screen.getByTestId("stSidebarNav")).toBeInTheDocument()

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1176,9 +1176,7 @@ describe("App", () => {
     })
 
     it("doesn't clear app elements if currentPageScriptHash doesn't change", async () => {
-      await waitFor(() => {
-        makeAppWithElements()
-      })
+      await makeAppWithElements()
 
       sendForwardMessage("newSession", NEW_SESSION_JSON)
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -647,6 +647,9 @@ export class App extends PureComponent<Props, State> {
       const wasRerunRequested =
         this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
 
+      console.log("HELLO")
+      console.log(lastRunWasInterrupted)
+      console.log(wasRerunRequested)
       if (
         !this.sessionInfo.last ||
         lastRunWasInterrupted ||

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -647,9 +647,6 @@ export class App extends PureComponent<Props, State> {
       const wasRerunRequested =
         this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
 
-      console.log("HELLO")
-      console.log(lastRunWasInterrupted)
-      console.log(wasRerunRequested)
       if (
         !this.sessionInfo.last ||
         lastRunWasInterrupted ||

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -729,8 +729,8 @@ export class App extends PureComponent<Props, State> {
           this.handlePageConfigChanged(pageConfig),
         pageInfoChanged: (pageInfo: PageInfo) =>
           this.handlePageInfoChanged(pageInfo),
-        pagesChanged: (pagesChangedMsg: PagesChanged) =>
-          this.handlePagesChanged(pagesChangedMsg),
+        // Deprecated protobuf option as navigation will always inform us of pages
+        pagesChanged: (_pagesChangedMsg: PagesChanged) => {},
         pageNotFound: (pageNotFound: PageNotFound) =>
           this.handlePageNotFound(pageNotFound),
         gitInfoChanged: (gitInfo: GitInfo) =>
@@ -854,10 +854,6 @@ export class App extends PureComponent<Props, State> {
       this.hostCommunicationMgr.sendMessageToHost,
       this.endpoints
     )
-  }
-
-  handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
-    this.maybeSetState(this.appNavigation.handlePagesChanged(pagesChangedMsg))
   }
 
   handleNavigation = (navigationMsg: Navigation): void => {
@@ -1281,10 +1277,6 @@ export class App extends PureComponent<Props, State> {
     scriptName: string,
     mainScriptHash: string
   ): void {
-    const { hideSidebarNav, elements } = this.state
-    // Handle hideSidebarNav = true -> retain sidebar elements to avoid flicker
-    const sidebarElements = (hideSidebarNav && elements.sidebar) || undefined
-
     this.setState(
       {
         scriptRunId,
@@ -1292,8 +1284,7 @@ export class App extends PureComponent<Props, State> {
         appHash,
         elements: this.appNavigation.clearPageElements(
           this.pendingElementsBuffer,
-          mainScriptHash,
-          sidebarElements
+          mainScriptHash
         ),
       },
       () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -845,7 +845,8 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
-    this.maybeSetState(this.appNavigation.handlePageNotFound(pageNotFound))
+    const { pageName } = pageNotFound
+    this.maybeSetState(this.appNavigation.handlePageNotFound(pageName))
   }
 
   onPageIconChanged = (iconUrl: string): void => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1476,8 +1476,7 @@ export class App extends PureComponent<Props, State> {
     // from the common script
     const nextPageElements = this.appNavigation.clearPageElements(
       elements,
-      mainScriptHash,
-      undefined
+      mainScriptHash
     )
     const activeWidgetIds = new Set(
       Array.from(nextPageElements.getElements())

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -24,7 +24,6 @@ import {
   NewSession,
   PageConfig,
   PageNotFound,
-  PagesChanged,
 } from "@streamlit/protobuf"
 
 import {
@@ -127,518 +126,331 @@ describe("AppNavigation", () => {
     )
   })
 
-  describe("MPA v1", () => {
-    beforeEach(() => {
-      appNavigation.strategy = new StrategyV1(appNavigation)
-    })
+  it("continues to set hideSidebarNav on new session", () => {
+    const cleanAppNavigation = new AppNavigation(
+      hostCommunicationMgr,
+      onUpdatePageUrl,
+      onPageNotFound,
+      onPageIconChange
+    )
 
-    it("sets appPages on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession())
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.appPages).toEqual([
-        {
-          pageScriptHash: "page_script_hash",
-          pageName: "streamlit app",
-          urlPathname: "streamlit_app",
-        },
-      ])
-    })
-
-    it("sets currentPageScriptHash on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession())
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("page_script_hash")
-    })
-
-    it("calls host communication on new session", () => {
-      const maybeState = appNavigation.handleNewSession(generateNewSession({}))
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
+    cleanAppNavigation.handleNavigation(
+      new Navigation({
+        sections: ["section1", "section2"],
         appPages: [
-          {
+          new AppPage({
+            pageName: "streamlit_app",
             pageScriptHash: "page_script_hash",
-            pageName: "streamlit app",
-            urlPathname: "streamlit_app",
-          },
+            isDefault: true,
+            sectionHeader: "section1",
+          }),
+          new AppPage({
+            pageName: "streamlit_app2",
+            pageScriptHash: "page_script_hash2",
+            isDefault: false,
+            sectionHeader: "section2",
+          }),
         ],
+        position: Navigation.Position.HIDDEN,
+        pageScriptHash: "page_script_hash",
+        expanded: false,
       })
+    )
 
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
-    })
+    const maybeState = cleanAppNavigation.handleNewSession(
+      generateNewSession()
+    )
+    expect(maybeState).not.toBeUndefined()
 
-    it("calls onUpdatePageUrl with the right information", () => {
-      appNavigation.handleNewSession(generateNewSession())
-      expect(onUpdatePageUrl).toHaveBeenCalledWith(
-        "streamlit_app",
-        "streamlit_app",
-        true
-      )
-    })
-
-    it("sets appPages on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.appPages).toEqual([
-        {
-          pageScriptHash: "other_page_script_hash",
-          pageName: "foo bar",
-          urlPathname: "foo_bar",
-        },
-      ])
-    })
-
-    it("calls host communication on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
-        appPages: [
-          {
-            pageScriptHash: "other_page_script_hash",
-            pageName: "foo bar",
-            urlPathname: "foo_bar",
-          },
-        ],
-      })
-    })
-
-    it("sets currentPageScriptHash on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "foo" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("page_script_hash")
-    })
-
-    it("calls host communication on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "foo" })
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
-    })
-
-    it("calls onPageNotFound when page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      appNavigation.handlePageNotFound(new PageNotFound({ pageName: "foo" }))
-      expect(onPageNotFound).toHaveBeenCalledWith("foo")
-    })
-
-    it("finds url by path when path is valid", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const page = appNavigation.findPageByUrlPath("/streamlit_app")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
-    })
-
-    it("returns default url by path when path is invalid", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const page = appNavigation.findPageByUrlPath("foo")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      hideSidebarNav: true,
     })
   })
 
-  describe("MPA v2", () => {
-    it("continues to set hideSidebarNav on new session", () => {
-      const cleanAppNavigation = new AppNavigation(
-        hostCommunicationMgr,
-        onUpdatePageUrl,
-        onPageNotFound,
-        onPageIconChange
-      )
+  it("sets currentPageScriptHash on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "" })
+    )
+    expect(maybeState).not.toBeUndefined()
 
-      cleanAppNavigation.handleNavigation(
-        new Navigation({
-          sections: ["section1", "section2"],
-          appPages: [
-            new AppPage({
-              pageName: "streamlit_app",
-              pageScriptHash: "page_script_hash",
-              isDefault: true,
-              sectionHeader: "section1",
-            }),
-            new AppPage({
-              pageName: "streamlit_app2",
-              pageScriptHash: "page_script_hash2",
-              isDefault: false,
-              sectionHeader: "section2",
-            }),
-          ],
-          position: Navigation.Position.HIDDEN,
+    const [newState] = maybeState!
+    expect(newState.currentPageScriptHash).toEqual("main_script_hash")
+  })
+
+  it("calls host communication on page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    const maybeState = appNavigation.handlePageNotFound(
+      new PageNotFound({ pageName: "" })
+    )
+    expect(maybeState).not.toBeUndefined()
+
+    const callback = maybeState![1]
+
+    callback()
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "main_script_hash",
+    })
+  })
+
+  it("calls onPageNotFound when page not found", () => {
+    // Initialize navigation from the new session proto
+    appNavigation.handleNewSession(generateNewSession())
+    appNavigation.handlePageNotFound(new PageNotFound({ pageName: "" }))
+    expect(onPageNotFound).toHaveBeenCalledWith("")
+  })
+
+  it("calls onUpdatePageUrl with the right information", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
           pageScriptHash: "page_script_hash",
-          expanded: false,
-        })
-      )
-
-      const maybeState = cleanAppNavigation.handleNewSession(
-        generateNewSession()
-      )
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        hideSidebarNav: true,
-      })
+          isDefault: true,
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash2",
+      expanded: false,
     })
+    appNavigation.handleNavigation(navigation)
+    expect(onUpdatePageUrl).toHaveBeenCalledWith(
+      "streamlit_app",
+      "streamlit_app2",
+      false
+    )
+  })
 
-    it("does not set anything on on pages changed", () => {
-      const maybeState = appNavigation.handlePagesChanged(
-        new PagesChanged({
-          appPages: [
-            {
-              pageScriptHash: "other_page_script_hash",
-              pageName: "foo bar",
-              urlPathname: "foo_bar",
-            },
-          ],
-        })
-      )
-      expect(maybeState).toBeUndefined()
+  it("finds url by path when path is valid", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
+          pageScriptHash: "page_script_hash",
+          isDefault: true,
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    appNavigation.handleNavigation(navigation)
+    const page = appNavigation.findPageByUrlPath("/streamlit_app2")
 
-    it("sets currentPageScriptHash on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "" })
-      )
-      expect(maybeState).not.toBeUndefined()
+    expect(page!.pageScriptHash).toEqual("page_script_hash2")
+    expect(page!.pageName).toEqual("streamlit app2")
+  })
 
-      const [newState] = maybeState!
-      expect(newState.currentPageScriptHash).toEqual("main_script_hash")
+  it("returns default url by path when path is invalid", () => {
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
+        new AppPage({
+          pageName: "streamlit app",
+          pageScriptHash: "page_script_hash",
+          isDefault: true,
+          sectionHeader: "section1",
+          urlPathname: "streamlit_app",
+        }),
+        new AppPage({
+          pageName: "streamlit app2",
+          pageScriptHash: "page_script_hash2",
+          isDefault: false,
+          sectionHeader: "section2",
+          urlPathname: "streamlit_app2",
+        }),
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    appNavigation.handleNavigation(navigation)
+    const page = appNavigation.findPageByUrlPath("foo")
 
-    it("calls host communication on page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      const maybeState = appNavigation.handlePageNotFound(
-        new PageNotFound({ pageName: "" })
-      )
-      expect(maybeState).not.toBeUndefined()
+    expect(page!.pageScriptHash).toEqual("page_script_hash")
+    expect(page!.pageName).toEqual("streamlit app")
+  })
 
-      const callback = maybeState![1]
-
-      callback()
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "main_script_hash",
-      })
-    })
-
-    it("calls onPageNotFound when page not found", () => {
-      // Initialize navigation from the new session proto
-      appNavigation.handleNewSession(generateNewSession())
-      appNavigation.handlePageNotFound(new PageNotFound({ pageName: "" }))
-      expect(onPageNotFound).toHaveBeenCalledWith("")
-    })
-
-    it("calls onUpdatePageUrl with the right information", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            urlPathname: "streamlit_app2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
+  it("sets navigation state to hidden on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
+        pageScriptHash: "page_script_hash",
+        isDefault: true,
+        sectionHeader: "section1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
         pageScriptHash: "page_script_hash2",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      expect(onUpdatePageUrl).toHaveBeenCalledWith(
-        "streamlit_app",
-        "streamlit_app2",
-        false
-      )
+        isDefault: false,
+        sectionHeader: "section2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-    it("finds url by path when path is valid", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            urlPathname: "streamlit_app2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      appPages,
+      hideSidebarNav: true,
+      expandSidebarNav: false,
+      currentPageScriptHash: "page_script_hash",
+      navSections: ["section1", "section2"],
+    })
+  })
+
+  it("sets navigation state to expanded on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
         pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const page = appNavigation.findPageByUrlPath("/streamlit_app2")
-
-      expect(page!.pageScriptHash).toEqual("page_script_hash2")
-      expect(page!.pageName).toEqual("streamlit app2")
+        isDefault: true,
+        sectionHeader: "section1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
+        pageScriptHash: "page_script_hash2",
+        isDefault: false,
+        sectionHeader: "section2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.SIDEBAR,
+      pageScriptHash: "page_script_hash",
+      expanded: true,
     })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-    it("returns default url by path when path is invalid", () => {
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            sectionHeader: "section1",
-            urlPathname: "streamlit_app",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            sectionHeader: "section2",
-            urlPathname: "streamlit_app2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      appPages,
+      hideSidebarNav: false,
+      expandSidebarNav: true,
+      currentPageScriptHash: "page_script_hash",
+      navSections: ["section1", "section2"],
+    })
+  })
+
+  it("calls host communication on navigation", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
         pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const page = appNavigation.findPageByUrlPath("foo")
+        isDefault: true,
+        sectionHeader: "section1",
+        icon: "icon1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
+        pageScriptHash: "page_script_hash2",
+        isDefault: false,
+        sectionHeader: "section2",
+        icon: "icon2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
+    })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
 
-      expect(page!.pageScriptHash).toEqual("page_script_hash")
-      expect(page!.pageName).toEqual("streamlit app")
+    const callback = maybeState![1]
+    callback()
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_PAGE_TITLE",
+      title: "streamlit_app",
     })
 
-    it("sets navigation state to hidden on navigation", () => {
-      const appPages = [
+    expect(onPageIconChange).toBeCalled()
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_APP_PAGES",
+      appPages,
+    })
+
+    expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "page_script_hash",
+    })
+  })
+
+  it("does not set the icon if set page config sets title or icon", () => {
+    // Clear the mock calls to avoid any confusion from setup
+    sendMessageToHost.mockClear()
+    appNavigation.handlePageConfigChanged(
+      new PageConfig({
+        title: "foo",
+        favicon: "bar",
+      })
+    )
+
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages: [
         new AppPage({
-          pageName: "streamlit_app",
+          pageName: "streamlit app",
           pageScriptHash: "page_script_hash",
           isDefault: true,
           sectionHeader: "section1",
-        }),
-        new AppPage({
-          pageName: "streamlit_app2",
-          pageScriptHash: "page_script_hash2",
-          isDefault: false,
-          sectionHeader: "section2",
-        }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        appPages,
-        hideSidebarNav: true,
-        expandSidebarNav: false,
-        currentPageScriptHash: "page_script_hash",
-        navSections: ["section1", "section2"],
-      })
-    })
-
-    it("sets navigation state to expanded on navigation", () => {
-      const appPages = [
-        new AppPage({
-          pageName: "streamlit_app",
-          pageScriptHash: "page_script_hash",
-          isDefault: true,
-          sectionHeader: "section1",
-        }),
-        new AppPage({
-          pageName: "streamlit_app2",
-          pageScriptHash: "page_script_hash2",
-          isDefault: false,
-          sectionHeader: "section2",
-        }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.SIDEBAR,
-        pageScriptHash: "page_script_hash",
-        expanded: true,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const [newState] = maybeState!
-      expect(newState).toEqual({
-        appPages,
-        hideSidebarNav: false,
-        expandSidebarNav: true,
-        currentPageScriptHash: "page_script_hash",
-        navSections: ["section1", "section2"],
-      })
-    })
-
-    it("calls host communication on navigation", () => {
-      const appPages = [
-        new AppPage({
-          pageName: "streamlit_app",
-          pageScriptHash: "page_script_hash",
-          isDefault: true,
-          sectionHeader: "section1",
+          urlPathname: "streamlit_app",
           icon: "icon1",
         }),
         new AppPage({
-          pageName: "streamlit_app2",
+          pageName: "streamlit app2",
           pageScriptHash: "page_script_hash2",
           isDefault: false,
           sectionHeader: "section2",
+          urlPathname: "streamlit_app2",
           icon: "icon2",
         }),
-      ]
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages,
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      const maybeState = appNavigation.handleNavigation(navigation)
-      expect(maybeState).not.toBeUndefined()
-
-      const callback = maybeState![1]
-      callback()
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_PAGE_TITLE",
-        title: "streamlit_app",
-      })
-
-      expect(onPageIconChange).toBeCalled()
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_APP_PAGES",
-        appPages,
-      })
-
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_CURRENT_PAGE_NAME",
-        currentPageName: "",
-        currentPageScriptHash: "page_script_hash",
-      })
+      ],
+      position: Navigation.Position.HIDDEN,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
     })
+    appNavigation.handleNavigation(navigation)
+    const hostCommCalls = sendMessageToHost.mock.calls
 
-    it("does not set the icon if set page config sets title or icon", () => {
-      // Clear the mock calls to avoid any confusion from setup
-      sendMessageToHost.mockClear()
-      appNavigation.handlePageConfigChanged(
-        new PageConfig({
-          title: "foo",
-          favicon: "bar",
-        })
-      )
-
-      const navigation = new Navigation({
-        sections: ["section1", "section2"],
-        appPages: [
-          new AppPage({
-            pageName: "streamlit app",
-            pageScriptHash: "page_script_hash",
-            isDefault: true,
-            sectionHeader: "section1",
-            urlPathname: "streamlit_app",
-            icon: "icon1",
-          }),
-          new AppPage({
-            pageName: "streamlit app2",
-            pageScriptHash: "page_script_hash2",
-            isDefault: false,
-            sectionHeader: "section2",
-            urlPathname: "streamlit_app2",
-            icon: "icon2",
-          }),
-        ],
-        position: Navigation.Position.HIDDEN,
-        pageScriptHash: "page_script_hash",
-        expanded: false,
-      })
-      appNavigation.handleNavigation(navigation)
-      const hostCommCalls = sendMessageToHost.mock.calls
-
-      expect(
-        hostCommCalls.some(call => call[0].type === "SET_PAGE_TITLE")
-      ).toBe(false)
-      expect(onPageIconChange).not.toBeCalled()
-    })
+    expect(hostCommCalls.some(call => call[0].type === "SET_PAGE_TITLE")).toBe(
+      false
+    )
+    expect(onPageIconChange).not.toBeCalled()
   })
 })

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -31,7 +31,6 @@ import {
   PageNotFoundCallback,
   PageUrlUpdateCallback,
   SetIconCallback,
-  StrategyV1,
 } from "./AppNavigation"
 
 function generateNewSession(changes = {}): NewSession {

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -23,7 +23,6 @@ import {
   Navigation,
   NewSession,
   PageConfig,
-  PageNotFound,
 } from "@streamlit/protobuf"
 
 import {
@@ -170,9 +169,7 @@ describe("AppNavigation", () => {
   it("sets currentPageScriptHash on page not found", () => {
     // Initialize navigation from the new session proto
     appNavigation.handleNewSession(generateNewSession())
-    const maybeState = appNavigation.handlePageNotFound(
-      new PageNotFound({ pageName: "" })
-    )
+    const maybeState = appNavigation.handlePageNotFound("")
     expect(maybeState).not.toBeUndefined()
 
     const [newState] = maybeState!
@@ -182,9 +179,7 @@ describe("AppNavigation", () => {
   it("calls host communication on page not found", () => {
     // Initialize navigation from the new session proto
     appNavigation.handleNewSession(generateNewSession())
-    const maybeState = appNavigation.handlePageNotFound(
-      new PageNotFound({ pageName: "" })
-    )
+    const maybeState = appNavigation.handlePageNotFound("")
     expect(maybeState).not.toBeUndefined()
 
     const callback = maybeState![1]
@@ -200,7 +195,7 @@ describe("AppNavigation", () => {
   it("calls onPageNotFound when page not found", () => {
     // Initialize navigation from the new session proto
     appNavigation.handleNewSession(generateNewSession())
-    appNavigation.handlePageNotFound(new PageNotFound({ pageName: "" }))
+    appNavigation.handlePageNotFound("")
     expect(onPageNotFound).toHaveBeenCalledWith("")
   })
 

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { AppRoot, BlockNode, HostCommunicationManager } from "@streamlit/lib"
+import { AppRoot, HostCommunicationManager } from "@streamlit/lib"
 import {
   IAppPage,
   Navigation,
   NewSession,
   PageConfig,
   PageNotFound,
-  PagesChanged,
 } from "@streamlit/protobuf"
 
 interface AppNavigationState {
@@ -51,127 +50,18 @@ function getTitle(pageName: string): string {
   return pageName
 }
 
-export class StrategyV1 {
-  private appPages: IAppPage[]
+export class AppNavigation {
+  readonly hostCommunicationMgr: HostCommunicationManager
 
-  private currentPageScriptHash: string | null
+  readonly onUpdatePageUrl: PageUrlUpdateCallback
 
-  private hideSidebarNav: boolean | null
+  readonly onPageNotFound: PageNotFoundCallback
 
-  private readonly appNav: AppNavigation
+  readonly onPageIconChange: SetIconCallback
 
-  constructor(appNav: AppNavigation) {
-    this.appNav = appNav
-    this.appPages = []
-    this.currentPageScriptHash = null
-    this.hideSidebarNav = null
-  }
+  isPageTitleSet: boolean
 
-  handleNewSession(newSession: NewSession): MaybeStateUpdate {
-    this.appPages = newSession.appPages
-    this.currentPageScriptHash = newSession.pageScriptHash
-    this.hideSidebarNav = newSession.config?.hideSidebarNav ?? false
-
-    // mainPage must be a string as we're guaranteed at this point that
-    // newSessionProto.appPages is nonempty and has a truthy pageName.
-    // Otherwise, we'd either have no main script or a nameless main script,
-    // neither of which can happen.
-    const mainPage = this.appPages[0] as IAppPage
-    const mainPageName = mainPage.urlPathname ?? ""
-    // We're similarly guaranteed that newPageName will be found / truthy
-    // here.
-    const newPageName =
-      this.appPages.find(
-        page => page.pageScriptHash === this.currentPageScriptHash
-      )?.urlPathname ?? ""
-
-    const isViewingMainPage =
-      mainPage.pageScriptHash === this.currentPageScriptHash
-    this.appNav.onUpdatePageUrl(mainPageName, newPageName, isViewingMainPage)
-
-    // Set the title to its default value
-    document.title = getTitle(newPageName ?? "")
-
-    return [
-      {
-        hideSidebarNav: this.hideSidebarNav,
-        appPages: this.appPages,
-        currentPageScriptHash: this.currentPageScriptHash,
-      },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_APP_PAGES",
-          appPages: this.appPages,
-        })
-
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: isViewingMainPage ? "" : newPageName,
-          currentPageScriptHash: this.currentPageScriptHash as string,
-        })
-      },
-    ]
-  }
-
-  handlePagesChanged(pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    const { appPages } = pagesChangedMsg
-    return [
-      { appPages },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_APP_PAGES",
-          appPages,
-        })
-      },
-    ]
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    const { pageName } = pageNotFound
-    this.appNav.onPageNotFound(pageName)
-    const currentPageScriptHash = this.appPages[0]?.pageScriptHash ?? ""
-    this.currentPageScriptHash = currentPageScriptHash
-
-    return [
-      { currentPageScriptHash },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: "",
-          currentPageScriptHash,
-        })
-      },
-    ]
-  }
-
-  handleNavigation(_navigationMsg: Navigation): MaybeStateUpdate {
-    // This message does not apply to V1
-    return undefined
-  }
-
-  findPageByUrlPath(pathname: string): IAppPage | null {
-    if (this.appPages.length === 0) {
-      return null
-    }
-
-    return (
-      this.appPages.find(appPage =>
-        pathname.endsWith("/" + appPage.urlPathname)
-      ) ?? this.appPages[0]
-    )
-  }
-
-  clearPageElements(
-    elements: AppRoot,
-    mainScriptHash: string,
-    sidebarElements: BlockNode | undefined
-  ): AppRoot {
-    return AppRoot.empty(mainScriptHash, false, sidebarElements, elements.logo)
-  }
-}
-
-export class StrategyV2 {
-  readonly appNav: AppNavigation
+  isPageIconSet: boolean
 
   mainScriptHash: string | null
 
@@ -181,8 +71,18 @@ export class StrategyV2 {
 
   hideSidebarNav: boolean | null
 
-  constructor(appNav: AppNavigation) {
-    this.appNav = appNav
+  constructor(
+    hostCommunicationMgr: HostCommunicationManager,
+    onUpdatePageUrl: PageUrlUpdateCallback,
+    onPageNotFound: PageNotFoundCallback,
+    onPageIconChange: SetIconCallback
+  ) {
+    this.hostCommunicationMgr = hostCommunicationMgr
+    this.onUpdatePageUrl = onUpdatePageUrl
+    this.onPageNotFound = onPageNotFound
+    this.onPageIconChange = onPageIconChange
+    this.isPageIconSet = false
+    this.isPageTitleSet = false
     this.mainScriptHash = null
     this.appPages = []
     this.mainPage = null
@@ -190,6 +90,9 @@ export class StrategyV2 {
   }
 
   handleNewSession(newSession: NewSession): MaybeStateUpdate {
+    this.isPageTitleSet = false
+    this.isPageIconSet = false
+
     this.mainScriptHash = newSession.mainScriptHash
     // Initialize to the config value if provided
     if (this.hideSidebarNav === null) {
@@ -200,27 +103,6 @@ export class StrategyV2 {
     document.title = getTitle("")
 
     return [{ hideSidebarNav: this.hideSidebarNav ?? false }, () => {}]
-  }
-
-  handlePagesChanged(_pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    // This message does not apply to V2
-    return undefined
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    const { pageName } = pageNotFound
-    this.appNav.onPageNotFound(pageName)
-
-    return [
-      { currentPageScriptHash: this.mainScriptHash ?? "" },
-      () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_CURRENT_PAGE_NAME",
-          currentPageName: "",
-          currentPageScriptHash: this.mainScriptHash ?? "",
-        })
-      },
-    ]
   }
 
   handleNavigation(navigationMsg: Navigation): MaybeStateUpdate {
@@ -237,20 +119,20 @@ export class StrategyV2 {
     this.mainPage = mainPage
     const currentPageName = currentPage.urlPathname as string
 
-    if (!this.appNav.isPageTitleSet) {
+    if (!this.isPageTitleSet) {
       const title = getTitle(currentPage.pageName as string)
       document.title = title
-      this.appNav.hostCommunicationMgr.sendMessageToHost({
+      this.hostCommunicationMgr.sendMessageToHost({
         type: "SET_PAGE_TITLE",
         title: currentPage.pageName ?? "",
       })
     }
 
-    if (!this.appNav.isPageIconSet && currentPage.icon) {
-      this.appNav.onPageIconChange(currentPage.icon)
+    if (!this.isPageIconSet && currentPage.icon) {
+      this.onPageIconChange(currentPage.icon)
     }
 
-    this.appNav.onUpdatePageUrl(
+    this.onUpdatePageUrl(
       mainPage.urlPathname ?? "",
       currentPageName,
       currentPage.isDefault ?? false
@@ -265,18 +147,34 @@ export class StrategyV2 {
         currentPageScriptHash,
       },
       () => {
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
+        this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_APP_PAGES",
           appPages,
         })
 
-        this.appNav.hostCommunicationMgr.sendMessageToHost({
+        this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_CURRENT_PAGE_NAME",
           // Make sure we don't send the official page name for the main page
           // This command is used to update the URL in the url bar, so the main page
           // should not have a page name in the URL.
           currentPageName: currentPage.isDefault ? "" : currentPageName,
           currentPageScriptHash,
+        })
+      },
+    ]
+  }
+
+  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
+    const { pageName } = pageNotFound
+    this.onPageNotFound(pageName)
+
+    return [
+      { currentPageScriptHash: this.mainScriptHash ?? "" },
+      () => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_CURRENT_PAGE_NAME",
+          currentPageName: "",
+          currentPageScriptHash: this.mainScriptHash ?? "",
         })
       },
     ]
@@ -292,91 +190,12 @@ export class StrategyV2 {
     )
   }
 
-  clearPageElements(
-    elements: AppRoot,
-    mainScriptHash: string,
-    _sidebarElements: BlockNode | undefined
-  ): AppRoot {
-    return elements.filterMainScriptElements(mainScriptHash)
-  }
-}
-
-export class AppNavigation {
-  readonly hostCommunicationMgr: HostCommunicationManager
-
-  readonly onUpdatePageUrl: PageUrlUpdateCallback
-
-  readonly onPageNotFound: PageNotFoundCallback
-
-  readonly onPageIconChange: SetIconCallback
-
-  isPageTitleSet: boolean
-
-  isPageIconSet: boolean
-
-  strategy: StrategyV1 | StrategyV2
-
-  constructor(
-    hostCommunicationMgr: HostCommunicationManager,
-    onUpdatePageUrl: PageUrlUpdateCallback,
-    onPageNotFound: PageNotFoundCallback,
-    onPageIconChange: SetIconCallback
-  ) {
-    this.hostCommunicationMgr = hostCommunicationMgr
-    this.onUpdatePageUrl = onUpdatePageUrl
-    this.onPageNotFound = onPageNotFound
-    this.onPageIconChange = onPageIconChange
-    this.isPageIconSet = false
-    this.isPageTitleSet = false
-
-    // Start with the V2 strategy
-    // Note: We never switch to V1, but we will remove that as a follow up
-    this.strategy = new StrategyV2(this)
-  }
-
-  handleNewSession(newSession: NewSession): MaybeStateUpdate {
-    this.isPageTitleSet = false
-    this.isPageIconSet = false
-
-    return this.strategy.handleNewSession(newSession)
-  }
-
-  handleNavigation(navigationMsg: Navigation): MaybeStateUpdate {
-    // Navigation call (through st.navigation) indicates we are using
-    // MPA v2. We can change strategy here. It will set the state properly
-    if (this.strategy instanceof StrategyV1) {
-      this.strategy = new StrategyV2(this)
-    }
-
-    return this.strategy.handleNavigation(navigationMsg)
-  }
-
-  handlePagesChanged(pagesChangedMsg: PagesChanged): MaybeStateUpdate {
-    return this.strategy.handlePagesChanged(pagesChangedMsg)
-  }
-
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    return this.strategy.handlePageNotFound(pageNotFound)
-  }
-
-  findPageByUrlPath(pathname: string): IAppPage | null {
-    return this.strategy.findPageByUrlPath(pathname)
-  }
-
   handlePageConfigChanged(pageConfig: PageConfig): void {
     this.isPageIconSet = Boolean(pageConfig.favicon)
     this.isPageTitleSet = Boolean(pageConfig.title)
   }
 
-  clearPageElements(
-    elements: AppRoot,
-    mainScriptHash: string,
-    sidebarElements: BlockNode | undefined
-  ): AppRoot {
-    return this.strategy.clearPageElements(
-      elements,
-      mainScriptHash,
-      sidebarElements
-    )
+  clearPageElements(elements: AppRoot, mainScriptHash: string): AppRoot {
+    return elements.filterMainScriptElements(mainScriptHash)
   }
 }

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -20,7 +20,6 @@ import {
   Navigation,
   NewSession,
   PageConfig,
-  PageNotFound,
 } from "@streamlit/protobuf"
 
 interface AppNavigationState {
@@ -164,8 +163,7 @@ export class AppNavigation {
     ]
   }
 
-  handlePageNotFound(pageNotFound: PageNotFound): MaybeStateUpdate {
-    const { pageName } = pageNotFound
+  handlePageNotFound(pageName: string): MaybeStateUpdate {
     this.onPageNotFound(pageName)
 
     return [

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -882,12 +882,7 @@ class ButtonMixin:
                     break
 
             if page_link_proto.page_script_hash == "":
-                is_mpa_v2 = (
-                    ctx.pages_manager is not None and ctx.pages_manager.mpa_version == 2
-                )
-
                 raise StreamlitPageNotFoundError(
-                    is_mpa_v2=is_mpa_v2,
                     page=page,
                     main_script_directory=main_script_directory,
                 )

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -52,6 +52,7 @@ from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonP
 from streamlit.proto.LinkButton_pb2 import LinkButton as LinkButtonProto
 from streamlit.proto.PageLink_pb2 import PageLink as PageLinkProto
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     WidgetArgs,
@@ -885,6 +886,7 @@ class ButtonMixin:
                 raise StreamlitPageNotFoundError(
                     page=page,
                     main_script_directory=main_script_directory,
+                    uses_pages_directory=bool(PagesManager.uses_pages_directory),
                 )
 
         return self.dg._enqueue("page_link", page_link_proto)

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -386,6 +386,15 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
             "allowed."
         )
 
+        from streamlit.runtime.pages_manager import PagesManager
+
+        if PagesManager.uses_pages_directory:
+            message = (
+                "Could not find page: `{page}`. You must provide a file path "
+                "relative to the entrypoint file (from the directory `{directory}`). "
+                "Only the entrypoint file and files in the `pages/` directory are supported."
+            )
+
         super().__init__(
             message,
             page=page,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -376,22 +376,15 @@ class StreamlitMissingPageLabelError(LocalizableStreamlitException):
 class StreamlitPageNotFoundError(LocalizableStreamlitException):
     """Exception raised the linked page can not be found."""
 
-    def __init__(self, page: str, main_script_directory: str, is_mpa_v2: bool):
+    def __init__(self, page: str, main_script_directory: str):
         directory = os.path.basename(main_script_directory)
 
         message = (
-            "Could not find page: `{page}`. You must provide a file path "
-            "relative to the entrypoint file (from the directory `{directory}`). "
-            "Only the entrypoint file and files in the `pages/` directory are supported."
+            "Could not find page: `{page}`. You must provide a `StreamlitPage` "
+            "object or file path relative to the entrypoint file. Only pages "
+            "previously defined by `st.Page` and passed to `st.navigation` are "
+            "allowed."
         )
-
-        if is_mpa_v2:
-            message = (
-                "Could not find page: `{page}`. You must provide a `StreamlitPage` "
-                "object or file path relative to the entrypoint file. Only pages "
-                "previously defined by `st.Page` and passed to `st.navigation` are "
-                "allowed."
-            )
 
         super().__init__(
             message,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -18,6 +18,7 @@ import os
 from typing import Any, Literal
 
 from streamlit import util
+from streamlit.runtime.pages_manager import PagesManager
 
 
 class Error(Exception):
@@ -385,8 +386,6 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
             "previously defined by `st.Page` and passed to `st.navigation` are "
             "allowed."
         )
-
-        from streamlit.runtime.pages_manager import PagesManager
 
         if PagesManager.uses_pages_directory:
             message = (

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -376,7 +376,9 @@ class StreamlitMissingPageLabelError(LocalizableStreamlitException):
 class StreamlitPageNotFoundError(LocalizableStreamlitException):
     """Exception raised the linked page can not be found."""
 
-    def __init__(self, page: str, main_script_directory: str):
+    def __init__(
+        self, page: str, main_script_directory: str, uses_pages_directory: bool
+    ):
         directory = os.path.basename(main_script_directory)
 
         message = (
@@ -386,9 +388,7 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
             "allowed."
         )
 
-        from streamlit.runtime.pages_manager import PagesManager
-
-        if PagesManager.uses_pages_directory:
+        if uses_pages_directory:
             message = (
                 "Could not find page: `{page}`. You must provide a file path "
                 "relative to the entrypoint file (from the directory `{directory}`). "

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -18,7 +18,6 @@ import os
 from typing import Any, Literal
 
 from streamlit import util
-from streamlit.runtime.pages_manager import PagesManager
 
 
 class Error(Exception):
@@ -386,6 +385,8 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
             "previously defined by `st.Page` and passed to `st.navigation` are "
             "allowed."
         )
+
+        from streamlit.runtime.pages_manager import PagesManager
 
         if PagesManager.uses_pages_directory:
             message = (

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -200,9 +200,6 @@ class AppSession:
         self._stop_config_listener = config.on_config_parsed(
             self._on_source_file_changed, force_connect=True
         )
-        self._stop_pages_listener = self._pages_manager.register_pages_changed_callback(
-            self._on_pages_changed
-        )
         secrets_singleton.file_change_listener.connect(self._on_secrets_file_changed)
 
     def disconnect_file_watchers(self) -> None:
@@ -488,14 +485,6 @@ class AppSession:
         # thus `_`), and introducing an unnecessary argument to
         # `_on_source_file_changed` just for this purpose sounded finicky.
         self._on_source_file_changed()
-
-    def _on_pages_changed(self, _) -> None:
-        msg = ForwardMsg()
-        self._populate_app_pages(msg.pages_changed, self._pages_manager.get_pages())
-        self._enqueue_forward_msg(msg)
-
-        if self._local_sources_watcher is not None:
-            self._local_sources_watcher.update_watched_pages()
 
     def _clear_queue(self, fragment_ids_this_run: list[str] | None = None) -> None:
         self._browser_queue.clear(

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -50,7 +50,6 @@ from streamlit.watcher import LocalSourcesWatcher
 
 if TYPE_CHECKING:
     from streamlit.proto.BackMsg_pb2 import BackMsg
-    from streamlit.proto.PagesChanged_pb2 import PagesChanged
     from streamlit.runtime.script_data import ScriptData
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.state import SessionState
@@ -870,7 +869,7 @@ class AppSession:
         self._enqueue_forward_msg(msg)
 
     def _populate_app_pages(
-        self, msg: NewSession | PagesChanged, pages: dict[PageHash, PageInfo]
+        self, msg: NewSession, pages: dict[PageHash, PageInfo]
     ) -> None:
         for page_script_hash, page_info in pages.items():
             page_proto = msg.app_pages.add()

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -14,15 +14,11 @@
 
 from __future__ import annotations
 
-import os
-import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Final
+from typing import TYPE_CHECKING, Any, Final
 
-from streamlit import source_util
 from streamlit.logger import get_logger
 from streamlit.util import calc_md5
-from streamlit.watcher import watch_dir
 
 if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
@@ -31,194 +27,16 @@ if TYPE_CHECKING:
 _LOGGER: Final = get_logger(__name__)
 
 
-class PagesStrategyV1:
-    """
-    Strategy for MPA v1. This strategy handles pages being set directly
-    by a call to `st.navigation`. The key differences here are:
-    - The pages are defined by the existence of a `pages` directory
-    - We will ensure one watcher is watching the scripts in the directory.
-    - Only one script runs for a full rerun.
-    - We know at the beginning the intended page script to run.
-
-    NOTE: Thread safety of the pages is handled by the source_util module
-    """
-
-    is_watching_pages_dir: bool = False
-    pages_watcher_lock = threading.Lock()
-
-    # This is a static method because we only want to watch the pages directory
-    # once on initial load.
-    @staticmethod
-    def watch_pages_dir(pages_manager: PagesManager):
-        with PagesStrategyV1.pages_watcher_lock:
-            if PagesStrategyV1.is_watching_pages_dir:
-                return
-
-            def _handle_page_changed(_path: str) -> None:
-                source_util.invalidate_pages_cache()
-
-            pages_dir = pages_manager.main_script_parent / "pages"
-            watch_dir(
-                str(pages_dir),
-                _handle_page_changed,
-                glob_pattern="*.py",
-                allow_nonexistent=True,
-            )
-            PagesStrategyV1.is_watching_pages_dir = True
-
-    def __init__(self, pages_manager: PagesManager, setup_watcher: bool = True):
-        self.pages_manager = pages_manager
-
-        if setup_watcher:
-            PagesStrategyV1.watch_pages_dir(pages_manager)
-
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_manager.current_page_script_hash
-
-    def get_initial_active_script(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> PageInfo | None:
-        pages = self.get_pages()
-
-        if page_script_hash:
-            return pages.get(page_script_hash, None)
-        elif not page_script_hash and page_name:
-            # If a user navigates directly to a non-main page of an app, we get
-            # the first script run request before the list of pages has been
-            # sent to the frontend. In this case, we choose the first script
-            # with a name matching the requested page name.
-            return next(
-                filter(
-                    # There seems to be this weird bug with mypy where it
-                    # thinks that p can be None (which is impossible given the
-                    # types of pages), so we add `p and` at the beginning of
-                    # the predicate to circumvent this.
-                    lambda p: p and (p["page_name"] == page_name),
-                    pages.values(),
-                ),
-                None,
-            )
-
-        # If no information about what page to run is given, default to
-        # running the main page.
-        # Safe because pages will at least contain the app's main page.
-        main_page_info = list(pages.values())[0]
-        return main_page_info
-
-    def get_pages(self) -> dict[PageHash, PageInfo]:
-        return source_util.get_pages(self.pages_manager.main_script_path)
-
-    def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
-    ) -> Callable[[], None]:
-        return source_util.register_pages_changed_callback(callback)
-
-    def set_pages(self, _pages: dict[PageHash, PageInfo]) -> None:
-        raise NotImplementedError("Unable to set pages in this V1 strategy")
-
-    def get_page_script(self, _fallback_page_hash: PageHash) -> PageInfo | None:
-        raise NotImplementedError("Unable to get page script in this V1 strategy")
-
-
-class PagesStrategyV2:
-    """
-    Strategy for MPA v2. This strategy handles pages being set directly
-    by a call to `st.navigation`. The key differences here are:
-    - The pages are set directly by the user
-    - The initial active script will always be the main script
-    - More than one script can run in a single app run (sequentially),
-      so we must keep track of the active script hash
-    - We rely on pages manager to retrieve the intended page script per run
-
-    NOTE: We don't provide any locks on the pages since the pages are not
-    shared across sessions. Only the user script thread can write to
-    pages and the event loop thread only reads
-    """
-
-    def __init__(self, pages_manager: PagesManager, **kwargs):
-        self.pages_manager = pages_manager
-        self._pages: dict[PageHash, PageInfo] | None = None
-
-    def get_initial_active_script(
-        self, page_script_hash: PageHash, page_name: PageName
-    ) -> PageInfo:
-        return {
-            # We always run the main script in V2 as it's the common code
-            "script_path": self.pages_manager.main_script_path,
-            "page_script_hash": page_script_hash
-            or self.pages_manager.main_script_hash,  # Default Hash
-        }
-
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_manager.main_script_hash
-
-    def get_page_script(self, fallback_page_hash: PageHash) -> PageInfo | None:
-        if self._pages is None:
-            return None
-
-        if self.pages_manager.intended_page_script_hash:
-            # We assume that if initial page hash is specified, that a page should
-            # exist, so we check out the page script hash or the default page hash
-            # as a backup
-            return self._pages.get(
-                self.pages_manager.intended_page_script_hash,
-                self._pages.get(fallback_page_hash, None),
-            )
-        elif self.pages_manager.intended_page_name:
-            # If a user navigates directly to a non-main page of an app, the
-            # the page name can identify the page script to run
-            return next(
-                filter(
-                    # There seems to be this weird bug with mypy where it
-                    # thinks that p can be None (which is impossible given the
-                    # types of pages), so we add `p and` at the beginning of
-                    # the predicate to circumvent this.
-                    lambda p: p
-                    and (p["url_pathname"] == self.pages_manager.intended_page_name),
-                    self._pages.values(),
-                ),
-                None,
-            )
-
-        return self._pages.get(fallback_page_hash, None)
-
-    def get_pages(self) -> dict[PageHash, PageInfo]:
-        # If pages are not set, provide the common page info where
-        # - the main script path is the executing script to start
-        # - the page script hash and name reflects the intended page requested
-        return self._pages or {
-            self.pages_manager.main_script_hash: {
-                "page_script_hash": self.pages_manager.intended_page_script_hash or "",
-                "page_name": self.pages_manager.intended_page_name or "",
-                "icon": "",
-                "script_path": self.pages_manager.main_script_path,
-            }
-        }
-
-    def set_pages(self, pages: dict[PageHash, PageInfo]) -> None:
-        self._pages = pages
-
-    def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
-    ) -> Callable[[], None]:
-        # V2 strategy does not handle any pages changed event
-        return lambda: None
-
-
 class PagesManager:
     """
-    PagesManager is responsible for managing the set of pages based on the
-    strategy. We default to MPA v2, and will remove v1 support since we found
-    a way to support most practical use cases with v2.
+    PagesManager is responsible for managing the set of pages that make up
+    the entire application. At the start we assume the main script is the
+    only page. As the script runs, the main script can call `st.navigation`
+    to set the set of pages that make up the app.
     """
 
-    DefaultStrategy: type[PagesStrategyV1 | PagesStrategyV2] = PagesStrategyV2
     uses_pages_directory: bool = False
-
+    
     def __init__(
         self,
         main_script_path: ScriptPath,
@@ -227,11 +45,11 @@ class PagesManager:
     ):
         self._main_script_path = main_script_path
         self._main_script_hash: PageHash = calc_md5(main_script_path)
-        self.pages_strategy = PagesManager.DefaultStrategy(self, **kwargs)
         self._script_cache = script_cache
         self._intended_page_script_hash: PageHash | None = None
         self._intended_page_name: PageName | None = None
         self._current_page_script_hash: PageHash = ""
+        self._pages: dict[PageHash, PageInfo] | None = None
         # A relic of v1 of Multipage apps, we performed special handling
         # for apps with a pages directory. We will keep this flag around
         # for now to maintain the behavior for apps that were created with
@@ -264,14 +82,6 @@ class PagesManager:
     def intended_page_script_hash(self) -> PageHash | None:
         return self._intended_page_script_hash
 
-    @property
-    def initial_active_script_hash(self) -> PageHash:
-        return self.pages_strategy.initial_active_script_hash
-
-    @property
-    def mpa_version(self) -> int:
-        return 2 if isinstance(self.pages_strategy, PagesStrategyV2) else 1
-
     def set_current_page_script_hash(self, page_script_hash: PageHash) -> None:
         self._current_page_script_hash = page_script_hash
 
@@ -290,45 +100,57 @@ class PagesManager:
     def get_initial_active_script(
         self, page_script_hash: PageHash, page_name: PageName
     ) -> PageInfo | None:
-        return self.pages_strategy.get_initial_active_script(
-            page_script_hash, page_name
-        )
+        return {
+            # We always run the main script in V2 as it's the common code
+            "script_path": self.main_script_path,
+            "page_script_hash": page_script_hash
+            or self.main_script_hash,  # Default Hash
+        }
 
     def get_pages(self) -> dict[PageHash, PageInfo]:
-        return self.pages_strategy.get_pages()
+        # If pages are not set, provide the common page info where
+        # - the main script path is the executing script to start
+        # - the page script hash and name reflects the intended page requested
+        return self._pages or {
+            self.main_script_hash: {
+                "page_script_hash": self.intended_page_script_hash or "",
+                "page_name": self.intended_page_name or "",
+                "icon": "",
+                "script_path": self.main_script_path,
+            }
+        }
 
     def set_pages(self, pages: dict[PageHash, PageInfo]) -> None:
-        # Manually setting the pages indicates we are using MPA v2.
-        if isinstance(self.pages_strategy, PagesStrategyV1):
-            if os.path.exists(self.main_script_parent / "pages"):
-                _LOGGER.warning(
-                    "st.navigation was called in an app with a pages/ directory. "
-                    "This may cause unusual app behavior. You may want to rename the "
-                    "pages/ directory."
-                )
-            PagesManager.DefaultStrategy = PagesStrategyV2
-            self.pages_strategy = PagesStrategyV2(self)
-
-        self.pages_strategy.set_pages(pages)
+        self._pages = pages
 
     def get_page_script(self, fallback_page_hash: PageHash = "") -> PageInfo | None:
-        # We assume the pages strategy is V2 cause this is used
-        # in the st.navigation call, but we just swallow the error
-        try:
-            return self.pages_strategy.get_page_script(fallback_page_hash)
-        except NotImplementedError:
+        if self._pages is None:
             return None
 
-    def register_pages_changed_callback(
-        self,
-        callback: Callable[[str], None],
-    ) -> Callable[[], None]:
-        """Register a callback to be called when the set of pages changes.
+        if self.intended_page_script_hash:
+            # We assume that if initial page hash is specified, that a page should
+            # exist, so we check out the page script hash or the default page hash
+            # as a backup
+            return self._pages.get(
+                self.intended_page_script_hash,
+                self._pages.get(fallback_page_hash, None),
+            )
+        elif self.intended_page_name:
+            # If a user navigates directly to a non-main page of an app, the
+            # the page name can identify the page script to run
+            return next(
+                filter(
+                    # There seems to be this weird bug with mypy where it
+                    # thinks that p can be None (which is impossible given the
+                    # types of pages), so we add `p and` at the beginning of
+                    # the predicate to circumvent this.
+                    lambda p: p and (p["url_pathname"] == self.intended_page_name),
+                    self._pages.values(),
+                ),
+                None,
+            )
 
-        The callback will be called with the path changed.
-        """
-
-        return self.pages_strategy.register_pages_changed_callback(callback)
+        return self._pages.get(fallback_page_hash, None)
 
     def get_page_script_byte_code(self, script_path: str) -> Any:
         if self._script_cache is None:

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -36,7 +36,7 @@ class PagesManager:
     """
 
     uses_pages_directory: bool = False
-    
+
     def __init__(
         self,
         main_script_path: ScriptPath,

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -35,7 +35,7 @@ class PagesManager:
     to set the set of pages that make up the app.
     """
 
-    uses_pages_directory: bool = False
+    uses_pages_directory: bool | None = None
 
     def __init__(
         self,
@@ -54,9 +54,14 @@ class PagesManager:
         # for apps with a pages directory. We will keep this flag around
         # for now to maintain the behavior for apps that were created with
         # the pages directory feature.
-        PagesManager.uses_pages_directory = Path(
-            self.main_script_parent / "pages"
-        ).exists()
+        #
+        # NOTE: we will update the feature if the flag has not been set
+        #       this means that if users use v2 behavior, the flag will
+        #       always be set to False
+        if PagesManager.uses_pages_directory is None:
+            PagesManager.uses_pages_directory = Path(
+                self.main_script_parent / "pages"
+            ).exists()
 
     @property
     def main_script_path(self) -> ScriptPath:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -145,7 +145,7 @@ class ScriptRunContext:
         self.form_ids_this_run = set()
         self.query_string = query_string
         self.pages_manager.set_current_page_script_hash(page_script_hash)
-        self._active_script_hash = self.pages_manager.initial_active_script_hash
+        self._active_script_hash = self.pages_manager.main_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -15,16 +15,15 @@
 from __future__ import annotations
 
 import re
-import threading
-from pathlib import Path
-from typing import Callable, Final, TypedDict
+from typing import TYPE_CHECKING, Final, TypedDict
 
-from blinker import Signal
 from typing_extensions import NotRequired, TypeAlias
 
 from streamlit.logger import get_logger
 from streamlit.string_util import extract_leading_emoji
-from streamlit.util import calc_md5
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -97,88 +96,3 @@ def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     ).strip() or extraction.group(1)
 
     return extract_leading_emoji(icon_and_name)
-
-
-_pages_cache_lock = threading.RLock()
-_cached_pages: dict[PageHash, PageInfo] | None = None
-_on_pages_changed = Signal(doc="Emitted when the pages directory is changed")
-
-
-def invalidate_pages_cache() -> None:
-    global _cached_pages
-
-    _LOGGER.debug("Pages directory changed")
-    with _pages_cache_lock:
-        _cached_pages = None
-
-    _on_pages_changed.send()
-
-
-def get_pages(main_script_path_str: ScriptPath) -> dict[PageHash, PageInfo]:
-    global _cached_pages
-
-    # Avoid taking the lock if the pages cache hasn't been invalidated.
-    precached_pages = _cached_pages
-    if precached_pages is not None:
-        return precached_pages
-
-    with _pages_cache_lock:
-        # The cache may have been repopulated while we were waiting to grab
-        # the lock.
-        if _cached_pages is not None:
-            return _cached_pages
-
-        main_script_path = Path(main_script_path_str)
-        main_page_icon, main_page_name = page_icon_and_name(main_script_path)
-        main_script_hash = calc_md5(main_script_path_str)
-
-        # NOTE: We include the script_hash in the dict even though it is
-        #       already used as the key because that occasionally makes things
-        #       easier for us when we need to iterate over pages.
-        pages: dict[PageHash, PageInfo] = {
-            main_script_hash: {
-                "page_script_hash": main_script_hash,
-                "page_name": main_page_name,
-                "icon": main_page_icon,
-                "script_path": str(main_script_path.resolve()),
-            }
-        }
-
-        pages_dir = main_script_path.parent / "pages"
-        page_scripts = sorted(
-            [
-                f
-                for f in pages_dir.glob("*.py")
-                if not f.name.startswith(".") and not f.name == "__init__.py"
-            ],
-            key=page_sort_key,
-        )
-
-        for script_path in page_scripts:
-            script_path_str = str(script_path.resolve())
-            pi, pn = page_icon_and_name(script_path)
-            psh = calc_md5(script_path_str)
-
-            pages[psh] = {
-                "page_script_hash": psh,
-                "page_name": pn,
-                "icon": pi,
-                "script_path": script_path_str,
-            }
-
-        _cached_pages = pages
-
-        return pages
-
-
-def register_pages_changed_callback(
-    callback: Callable[[str], None],
-) -> Callable[[], None]:
-    def disconnect():
-        _on_pages_changed.disconnect(callback)
-
-    # weak=False so that we have control of when the pages changed
-    # callback is deregistered.
-    _on_pages_changed.connect(callback, weak=False)
-
-    return disconnect

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -47,7 +47,7 @@ with (
     # first importing a file. We disallow this because doing so means that we
     # miss config options set via flag or environment variable.
     import streamlit as st  # noqa: F401
-    from streamlit import config, file_util, source_util
+    from streamlit import config, file_util
 
     assert not config._config_options, (
         "config.get_option() should not be called on file import!"
@@ -59,13 +59,6 @@ with (
     # Force a reparse of our config options with CONFIG_FILE_CONTENTS so the
     # result gets cached.
     config.get_config_options(force_reparse=True)
-
-    # Set source_util._cached_pages to the empty dict below so that
-    # source_util.get_pages' behavior is deterministic and doesn't depend on the
-    # filesystem of the machine tests are being run on. Tests that need
-    # source_util.get_pages to depend on the filesystem can patch this value
-    # back to None.
-    source_util._cached_pages = {}
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -96,11 +89,6 @@ def pytest_configure(config: pytest.Config):
 
 
 def pytest_runtest_setup(item: pytest.Item):
-    # Ensure Default Strategy is V2 to start
-    from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV2
-
-    PagesManager.DefaultStrategy = PagesStrategyV2
-
     is_require_integration = item.config.getoption(
         "--require-integration", default=False
     )

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -89,6 +89,11 @@ def pytest_configure(config: pytest.Config):
 
 
 def pytest_runtest_setup(item: pytest.Item):
+    from streamlit.runtime.pages_manager import PagesManager
+
+    # Ensure the pages directory feature is not set prior to the test
+    PagesManager.uses_pages_directory = None
+
     is_require_integration = item.config.getoption(
         "--require-integration", default=False
     )

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -21,7 +21,7 @@ import unittest
 from asyncio import AbstractEventLoop
 from typing import Any, Callable, cast
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import DEFAULT, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -468,48 +468,6 @@ class AppSessionTest(unittest.TestCase):
             }
         ),
     )
-    @patch("streamlit.runtime.app_session.AppSession._enqueue_forward_msg")
-    def test_on_pages_changed(self, mock_enqueue: MagicMock):
-        session = _create_test_session()
-        session._on_pages_changed("/foo/pages")
-
-        expected_msg = ForwardMsg()
-        expected_msg.pages_changed.app_pages.extend(
-            [
-                AppPage(
-                    page_script_hash="hash1",
-                    page_name="page 1",
-                    icon="",
-                    url_pathname="page_1",
-                ),
-                AppPage(
-                    page_script_hash="hash2",
-                    page_name="page 2",
-                    icon="🎉",
-                    url_pathname="page_2",
-                ),
-            ]
-        )
-
-        mock_enqueue.assert_called_once_with(expected_msg)
-
-    @patch.object(PagesManager, "register_pages_changed_callback")
-    def test_installs_pages_watcher_on_init(self, patched_register_callback):
-        session = _create_test_session()
-        patched_register_callback.assert_called_once_with(session._on_pages_changed)
-
-    def test_deregisters_pages_watcher_on_shutdown(self):
-        disconnect_mock = MagicMock()
-        with patch.object(
-            PagesManager,
-            "register_pages_changed_callback",
-            return_value=disconnect_mock,
-        ):
-            session = _create_test_session()
-            session.shutdown()
-
-            disconnect_mock.assert_called_once()
-
     def test_tags_fwd_msgs_with_last_backmsg_id_if_set(self):
         session = _create_test_session()
         session._debug_last_backmsg_id = "some backmsg id"
@@ -523,16 +481,15 @@ class AppSessionTest(unittest.TestCase):
     @patch(
         "streamlit.runtime.app_session.secrets_singleton.file_change_listener.connect"
     )
-    @patch.multiple(
+    @patch.object(
         PagesManager,
-        register_pages_changed_callback=DEFAULT,
-        get_pages=MagicMock(return_value={}),
+        "get_pages",
+        MagicMock(return_value={}),
     )
     def test_registers_file_watchers(
         self,
         patched_secrets_connect,
         patched_on_config_parsed,
-        register_pages_changed_callback,
     ):
         session = _create_test_session()
 
@@ -541,9 +498,6 @@ class AppSessionTest(unittest.TestCase):
         )
         patched_on_config_parsed.assert_called_once_with(
             session._on_source_file_changed, force_connect=True
-        )
-        register_pages_changed_callback.assert_called_once_with(
-            session._on_pages_changed
         )
         patched_secrets_connect.assert_called_once_with(
             session._on_secrets_file_changed
@@ -815,11 +769,6 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
     )
-    @patch.object(
-        PagesManager,
-        "register_pages_changed_callback",
-        MagicMock(return_value=lambda: None),
-    )
     async def test_new_session_message_includes_fragment_ids(self):
         session = _create_test_session(asyncio.get_running_loop())
 
@@ -934,11 +883,6 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
     @patch(
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
-    )
-    @patch.object(
-        PagesManager,
-        "register_pages_changed_callback",
-        MagicMock(return_value=lambda: None),
     )
     async def test_handle_backmsg_exception(self):
         """handle_backmsg_exception is a bit of a hack. Test that it does

--- a/lib/tests/streamlit/runtime/pages_manager_test.py
+++ b/lib/tests/streamlit/runtime/pages_manager_test.py
@@ -16,64 +16,12 @@
 
 from __future__ import annotations
 
-import os
 import unittest
-from unittest.mock import MagicMock, patch
 
-import streamlit.source_util as source_util
-from streamlit.runtime.pages_manager import PagesManager, PagesStrategyV1
-from streamlit.util import calc_md5
+from streamlit.runtime.pages_manager import PagesManager
 
 
 class PagesManagerTest(unittest.TestCase):
-    def test_register_pages_changed_callback(self):
-        """Test that the pages changed callback is correctly registered and unregistered"""
-        PagesManager.DefaultStrategy = PagesStrategyV1
-        pages_manager = PagesManager("main_script_path")
-        with patch.object(source_util, "_on_pages_changed", MagicMock()):
-
-            def callback():
-                return None
-
-            disconnect = pages_manager.register_pages_changed_callback(callback)
-
-            source_util._on_pages_changed.connect.assert_called_once_with(
-                callback, weak=False
-            )
-
-            disconnect()
-            source_util._on_pages_changed.disconnect.assert_called_once_with(callback)
-
-    @patch("streamlit.runtime.pages_manager.watch_dir")
-    @patch.object(source_util, "invalidate_pages_cache", MagicMock())
-    def test_install_pages_watcher(self, patched_watch_dir):
-        """Test that the pages watcher is correctly installed and uninstalled"""
-        PagesManager.DefaultStrategy = PagesStrategyV1
-        # Ensure PagesStrategyV1.is_watching_pages_dir is False to start
-        PagesStrategyV1.is_watching_pages_dir = False
-        PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
-
-        patched_watch_dir.assert_called_once()
-        args, _ = patched_watch_dir.call_args_list[0]
-        on_pages_changed = args[1]
-
-        patched_watch_dir.assert_called_once_with(
-            os.path.normpath("/foo/bar/pages"),
-            on_pages_changed,
-            glob_pattern="*.py",
-            allow_nonexistent=True,
-        )
-
-        patched_watch_dir.reset_mock()
-
-        _ = PagesManager(os.path.normpath("/foo/bar/streamlit_app.py"))
-        patched_watch_dir.assert_not_called()
-
-        on_pages_changed("/foo/bar/pages")
-        source_util.invalidate_pages_cache.assert_called_once()
-
-
-class PagesManagerV2Test(unittest.TestCase):
     def setUp(self):
         self.pages_manager = PagesManager("main_script_path")
 
@@ -144,53 +92,3 @@ class PagesManagerV2Test(unittest.TestCase):
             page_info,
             {"script_path": "main_script_path", "page_script_hash": "page_hash"},
         )
-
-
-# NOTE: We write this test function using pytest conventions (as opposed to
-# using unittest.TestCase like in the rest of the codebase) because the tmpdir
-# pytest fixture is so useful for writing this test it's worth having the
-# slight inconsistency.
-@patch("streamlit.source_util._cached_pages", new=None)
-def test_get_initial_active_script_v1(tmpdir):
-    PagesManager.DefaultStrategy = PagesStrategyV1
-    # Write an empty string to create a file.
-    tmpdir.join("streamlit_app.py").write("")
-
-    pages_dir = tmpdir.mkdir("pages")
-    pages = [
-        "03_other_page.py",
-        "04 last numbered page.py",
-        "01-page.py",
-    ]
-    for p in pages:
-        pages_dir.join(p).write("")
-
-    main_script_path = str(tmpdir / "streamlit_app.py")
-    pages_manager = PagesManager(main_script_path)
-
-    example_page_script_hash = calc_md5(str(pages_dir / "01-page.py"))
-
-    # positive case - get by hash
-    page = pages_manager.get_initial_active_script(example_page_script_hash, None)
-    assert page["page_script_hash"] == example_page_script_hash
-
-    # bad hash should not return a page
-    page = pages_manager.get_initial_active_script("random_hash", None)
-    assert page is None
-
-    # Even if the page name is specified, we detect via the hash only
-    page = pages_manager.get_initial_active_script("random_hash", "page")
-    assert page is None
-
-    # Find by page name works
-    page = pages_manager.get_initial_active_script("", "page")
-    assert page["page_script_hash"] == example_page_script_hash
-
-    # Try different page name
-    alternate_page_script_hash = calc_md5(str(pages_dir / "03_other_page.py"))
-    page = pages_manager.get_initial_active_script("", "other_page")
-    assert page["page_script_hash"] == alternate_page_script_hash
-
-    # Even if the valid page name is specified, we detect via the hash only
-    page = pages_manager.get_initial_active_script(alternate_page_script_hash, "page")
-    assert page["page_script_hash"] == alternate_page_script_hash

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -698,7 +698,6 @@ class RuntimeTest(RuntimeTestCase):
         self.assertIsInstance(self.runtime._get_async_objs(), AsyncObjects)
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptCheckTest(RuntimeTestCase):
     """Tests for Runtime.does_script_run_without_error"""
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -83,7 +83,6 @@ def _is_control_event(event: ScriptRunnerEvent) -> bool:
     return event != ScriptRunnerEvent.ENQUEUE_FORWARD_MSG
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -752,19 +751,6 @@ class ScriptRunnerTest(AsyncTestCase):
 
             self._assert_no_exceptions(scriptrunner)
 
-    @patch(
-        "streamlit.source_util.get_pages",
-        MagicMock(
-            return_value={
-                "hash1": {
-                    "page_script_hash": "hash1",
-                    "script_path": os.path.join(
-                        os.path.dirname(__file__), "test_data", "good_script.py"
-                    ),
-                },
-            },
-        ),
-    )
     def test_query_string_and_page_script_hash_saved(self):
         scriptrunner = TestScriptRunner("good_script.py")
         scriptrunner.request_rerun(

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -16,13 +16,11 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
 
 import streamlit.source_util as source_util
-from streamlit.util import calc_md5
 
 
 class PageHelperFunctionTests(unittest.TestCase):
@@ -94,90 +92,3 @@ class PageHelperFunctionTests(unittest.TestCase):
     )
     def test_page_icon_and_name(self, path_str, expected):
         assert source_util.page_icon_and_name(Path(path_str)) == expected
-
-    @patch("streamlit.source_util._on_pages_changed", MagicMock())
-    @patch("streamlit.source_util._cached_pages", new="Some pages")
-    def test_invalidate_pages_cache(self):
-        source_util.invalidate_pages_cache()
-
-        assert source_util._cached_pages is None
-        source_util._on_pages_changed.send.assert_called_once()
-
-    @patch("streamlit.source_util._on_pages_changed", MagicMock())
-    def test_register_pages_changed_callback(self):
-        def callback():
-            return None
-
-        disconnect = source_util.register_pages_changed_callback(callback)
-
-        source_util._on_pages_changed.connect.assert_called_once_with(
-            callback, weak=False
-        )
-
-        disconnect()
-        source_util._on_pages_changed.disconnect.assert_called_once_with(callback)
-
-
-# NOTE: We write this test function using pytest conventions (as opposed to
-# using unittest.TestCase like in the rest of the codebase) because the tmpdir
-# pytest fixture is so useful for writing this test it's worth having the
-# slight inconsistency.
-@patch("streamlit.source_util._cached_pages", new=None)
-def test_get_pages(tmpdir):
-    # Write an empty string to create a file.
-    tmpdir.join("streamlit_app.py").write("")
-
-    pages_dir = tmpdir.mkdir("pages")
-    pages = [
-        # These pages are out of order so that we can check that they're sorted
-        # in the assert below.
-        "03_other_page.py",
-        "04 last numbered page.py",
-        "01-page.py",
-        # This page should appear last since it doesn't have an integer prefix.
-        "page.py",
-        # This file shouldn't appear as a page because it's hidden.
-        ".hidden_file.py",
-        # This file shouldn't appear as a page because it's __init__.py, so also hidden.
-        "__init__.py",
-        # This shouldn't appear because it's not a Python file.
-        "not_a_page.rs",
-    ]
-    for p in pages:
-        pages_dir.join(p).write("")
-
-    main_script_path = str(tmpdir / "streamlit_app.py")
-
-    received_pages = source_util.get_pages(main_script_path)
-    assert received_pages == {
-        calc_md5(main_script_path): {
-            "page_script_hash": calc_md5(main_script_path),
-            "page_name": "streamlit_app",
-            "script_path": main_script_path,
-            "icon": "",
-        },
-        calc_md5(str(pages_dir / "01-page.py")): {
-            "page_script_hash": calc_md5(str(pages_dir / "01-page.py")),
-            "page_name": "page",
-            "script_path": str(pages_dir / "01-page.py"),
-            "icon": "",
-        },
-        calc_md5(str(pages_dir / "03_other_page.py")): {
-            "page_script_hash": calc_md5(str(pages_dir / "03_other_page.py")),
-            "page_name": "other_page",
-            "script_path": str(pages_dir / "03_other_page.py"),
-            "icon": "",
-        },
-        calc_md5(str(pages_dir / "04 last numbered page.py")): {
-            "page_script_hash": calc_md5(str(pages_dir / "04 last numbered page.py")),
-            "page_name": "last_numbered_page",
-            "script_path": str(pages_dir / "04 last numbered page.py"),
-            "icon": "",
-        },
-        calc_md5(str(pages_dir / "page.py")): {
-            "page_script_hash": calc_md5(str(pages_dir / "page.py")),
-            "page_name": "page",
-            "script_path": str(pages_dir / "page.py"),
-            "icon": "",
-        },
-    }

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -45,7 +45,6 @@ def NOOP_CALLBACK(_filepath):
     pass
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -77,7 +77,7 @@ message ForwardMsg {
     // Other messages.
     Navigation navigation = 23;
     PageNotFound page_not_found = 15;
-    PagesChanged pages_changed = 16;
+    PagesChanged pages_changed = 16 [deprecated = true];
     FileURLsResponse file_urls_response = 19;
     AutoRerun auto_rerun = 21;
 

--- a/proto/streamlit/proto/PagesChanged.proto
+++ b/proto/streamlit/proto/PagesChanged.proto
@@ -21,6 +21,7 @@ option java_outer_classname = "PagesChangedProto";
 
 import "streamlit/proto/AppPage.proto";
 
+// DEPRECATED - We don't use the proto anymore.
 // Message used to tell the client that the app's pages have changed.
 message PagesChanged {
   repeated AppPage app_pages = 1;


### PR DESCRIPTION
## Describe your changes

This PR strips all of the MPAv1 code away including the strategy pattern in both cases. It keeps AppNavigation in order to simplify code away from `App.tsx`.

## Testing Plan

- Python and JS unit tests updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
