### PR TITLE
Prevent update of remark-gfm in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
       - dependency-name: "react-dom"
         # Updating react will need some extra work.
         versions: [">=19.0.0"]
+      - dependency-name: "remark-gfm"
+        # Breaks our current markdown rendering logic.
+        versions: [">=4.0.0"]
 
   # Keep Pipfile up to date
   - package-ecosystem: "pip"


### PR DESCRIPTION
## Describe your changes

Dependabot tried to update `remark-gfm`, but the update seems to break our current markdown rendering logic: https://github.com/streamlit/streamlit/pull/10460

Adding remark-gfm to our dependabot ignore list temporarily.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
