### PR TITLE
[fix] Chat Input measurement with createRoot

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -20,6 +20,7 @@ import React, {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -341,7 +342,10 @@ function ChatInput({
     }
   }, [element])
 
-  useEffect(() => {
+  // Use a Layout Effect since we are dealing with measurements and we want to
+  // avoid flickering.
+  // @see https://react.dev/reference/react/useLayoutEffect#usage
+  useLayoutEffect(() => {
     if (chatInputRef.current) {
       const { offsetHeight } = chatInputRef.current
       heightGuidance.current.minHeight = offsetHeight
@@ -393,7 +397,10 @@ function ChatInput({
     }
   }, [fileDragged])
 
-  useEffect(() => {
+  // Use a Layout Effect since we are dealing with measurements and we want to
+  // avoid flickering.
+  // @see https://react.dev/reference/react/useLayoutEffect#usage
+  useLayoutEffect(() => {
     const { minHeight } = heightGuidance.current
     setIsInputExtended(
       scrollHeight > 0 && chatInputRef.current


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Adheres to React best practices for dealing with measurements by leveraging `useLayoutEffect` for places in ChatInput that deal with measurements
- Impact: Fixes the e2e snapshot tests for ChatInput that were failing with `createRoot`

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Stabilizes e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
