### PR TITLE
[fix] Run all RTL hook tests in createRoot mode

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -61,7 +61,6 @@
     "@swc/plugin-emotion": "^3.0.9",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.1.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/hoist-non-react-statics": "^3.3.6",
     "@types/lodash": "^4.17.13",

--- a/frontend/app/src/util/useThemeManager.test.ts
+++ b/frontend/app/src/util/useThemeManager.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import {
   AUTO_THEME_NAME,

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -136,7 +136,6 @@
     "@swc/plugin-emotion": "^3.0.9",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.1.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/d3": "^7.4.3",
     "@types/d3-color": "^3.1.3",

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { useLayoutStyles } from "./useLayoutStyles"
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -16,7 +16,7 @@
 
 import { createRef } from "react"
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { View as VegaView } from "vega"
 import embed from "vega-embed"
 import { expressionInterpreter } from "vega-interpreter"

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
@@ -16,7 +16,7 @@
 
 import { Mock, Mocked } from "vitest"
 import { View as VegaView } from "vega"
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { debounce } from "~lib/util/utils"

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -401,7 +401,7 @@ describe("#useDeckGl", () => {
         })
       })
 
-      rerender()
+      rerender(initialProps)
 
       expect(result.current.hasActiveSelection).toBe(true)
     })

--- a/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
@@ -21,7 +21,7 @@ import { RenderOptions, RenderResult } from "@testing-library/react"
 import {
   renderHook as reactTestingLibraryRenderHook,
   RenderHookOptions,
-} from "@testing-library/react-hooks"
+} from "@testing-library/react"
 
 import ElementFullscreenWrapper from "~lib/components/shared/ElementFullscreen/ElementFullscreenWrapper"
 import { TestAppWrapper, render as testUtilRender } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
@@ -55,7 +55,6 @@ export function renderHook<Props, Result>(
   options: Omit<RenderHookOptions<Props>, "wrapper"> | undefined
 ) {
   return reactTestingLibraryRenderHook(hook, {
-    // @ts-expect-error This works but TS is being weird about it
     wrapper: FullscreenHarness,
     ...options,
   })

--- a/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
@@ -17,10 +17,11 @@
 import React, { FC, PropsWithChildren, ReactElement } from "react"
 
 /* eslint-disable import/no-extraneous-dependencies */
-import { RenderOptions, RenderResult } from "@testing-library/react"
 import {
   renderHook as reactTestingLibraryRenderHook,
   RenderHookOptions,
+  RenderOptions,
+  RenderResult,
 } from "@testing-library/react"
 
 import ElementFullscreenWrapper from "~lib/components/shared/ElementFullscreen/ElementFullscreenWrapper"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnReordering.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnReordering.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnSizer.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnSizer.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { GridColumn, SizedGridColumn } from "@glideapps/glide-data-grid"
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import useColumnSizer from "./useColumnSizer"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnSort.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnSort.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { GridCell, NumberCell } from "@glideapps/glide-data-grid"
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomEditors.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomEditors.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { GridCellKind, NumberCell, TextCell } from "@glideapps/glide-data-grid"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { JsonTextCellEditor } from "~lib/components/widgets/DataFrame/columns/cells/JsonCell"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomRenderer.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomRenderer.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
@@ -19,7 +19,7 @@ import {
   GridSelection,
   TextCell,
 } from "@glideapps/glide-data-grid"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 import { showSaveFilePicker } from "native-file-system-adapter"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
@@ -17,7 +17,7 @@
 import React from "react"
 
 import { GridCellKind } from "@glideapps/glide-data-grid"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 import { Field, Utf8 } from "apache-arrow"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import { CustomGridTheme } from "./useCustomTheme"
 import useRowHover from "./useRowHover"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { CompactSelection } from "@glideapps/glide-data-grid"
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { Field, Utf8 } from "apache-arrow"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { GridMouseEventArgs } from "@glideapps/glide-data-grid"
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
 import {

--- a/frontend/lib/src/hooks/useDebouncedCallback.test.ts
+++ b/frontend/lib/src/hooks/useDebouncedCallback.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { useDebouncedCallback } from "./useDebouncedCallback"
 

--- a/frontend/lib/src/hooks/useOnInputChange.test.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import useOnInPutChange from "./useOnInputChange"
 

--- a/frontend/lib/src/hooks/useOnInputChange.test.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 
 import useOnInPutChange from "./useOnInputChange"
 

--- a/frontend/lib/src/hooks/useScrollAnimation.test.ts
+++ b/frontend/lib/src/hooks/useScrollAnimation.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import useScrollAnimation from "./useScrollAnimation"
 

--- a/frontend/lib/src/hooks/useScrollSpy.test.ts
+++ b/frontend/lib/src/hooks/useScrollSpy.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import useScrollSpy, { debounce } from "./useScrollSpy"
 

--- a/frontend/lib/src/hooks/useScrollToBottom.test.ts
+++ b/frontend/lib/src/hooks/useScrollToBottom.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { MockedFunction } from "vitest"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { useScrollToBottom } from "./useScrollToBottom"
 import useStateRef from "./useStateRef"

--- a/frontend/lib/src/hooks/useStWidthHeight.test.ts
+++ b/frontend/lib/src/hooks/useStWidthHeight.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { useStWidthHeight } from "./useStWidthHeight"
 

--- a/frontend/lib/src/hooks/useStateRef.test.ts
+++ b/frontend/lib/src/hooks/useStateRef.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 
 import useStateRef from "./useStateRef" // import the hook
 

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 

--- a/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
+++ b/frontend/lib/src/hooks/useSubmitFormViaEnterKey.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 

--- a/frontend/lib/src/hooks/useTimeout.test.ts
+++ b/frontend/lib/src/hooks/useTimeout.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import useTimeout from "./useTimeout"
 

--- a/frontend/lib/src/hooks/useTimeout.test.ts
+++ b/frontend/lib/src/hooks/useTimeout.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 
 import useTimeout from "./useTimeout"
 

--- a/frontend/lib/src/hooks/useUpdateUiValue.test.ts
+++ b/frontend/lib/src/hooks/useUpdateUiValue.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react"
 
 import useUpdateUiValue from "./useUpdateUiValue"
 

--- a/frontend/lib/src/hooks/useUpdateUiValue.test.ts
+++ b/frontend/lib/src/hooks/useUpdateUiValue.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/react"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 
 import useUpdateUiValue from "./useUpdateUiValue"
 

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC } from "react"
 
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react"
 import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -16,8 +16,7 @@
 
 import React, { FC } from "react"
 
-import { act, renderHook } from "@testing-library/react"
-import { render, screen } from "@testing-library/react"
+import { act, render, renderHook, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { WidgetStateManager } from "~lib/WidgetStateManager"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2757,7 +2757,6 @@ __metadata:
     "@swc/plugin-emotion": "npm:^3.0.9"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^14.1.2"
-    "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/user-event": "npm:^14.4.3"
     "@types/hoist-non-react-statics": "npm:^3.3.6"
     "@types/lodash": "npm:^4.17.13"
@@ -2888,7 +2887,6 @@ __metadata:
     "@swc/plugin-emotion": "npm:^3.0.9"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^14.1.2"
-    "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/user-event": "npm:^14.4.3"
     "@types/d3": "npm:^7.4.3"
     "@types/d3-color": "npm:^3.1.3"
@@ -3328,28 +3326,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     redent: "npm:^3.0.0"
   checksum: 10c0/5566b6c0b7b0709bc244aec3aa3dc9e5f4663e8fb2b99d8cd456fc07279e59db6076cbf798f9d3099a98fca7ef4cd50e4e1f4c4dec5a60a8fad8d24a638a5bf6
-  languageName: node
-  linkType: hard
-
-"@testing-library/react-hooks@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@testing-library/react-hooks@npm:8.0.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-    react-error-boundary: "npm:^3.1.0"
-  peerDependencies:
-    "@types/react": ^16.9.0 || ^17.0.0
-    react: ^16.9.0 || ^17.0.0
-    react-dom: ^16.9.0 || ^17.0.0
-    react-test-renderer: ^16.9.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    react-dom:
-      optional: true
-    react-test-renderer:
-      optional: true
-  checksum: 10c0/83bef2d4c437b84143213b5275ef00ef14e5bcd344f9ded12b162d253dc3c799138ead4428026b9c725e5a38dbebf611f2898aa43f3e43432bcaccbd7bf413e5
   languageName: node
   linkType: hard
 
@@ -15305,17 +15281,6 @@ __metadata:
   dependencies:
     prop-types: "npm:^15.5.8"
   checksum: 10c0/f1831df379dfb5074b546de48f42db270bc1e97367342d07bb3fce07f4799a8d33d5e5a605b1b12243087d0eb0ab0fecc1fa0ade49c487b8504217824f3f2ad0
-  languageName: node
-  linkType: hard
-
-"react-error-boundary@npm:^3.1.0":
-  version: 3.1.4
-  resolution: "react-error-boundary@npm:3.1.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-  peerDependencies:
-    react: ">=16.13.1"
-  checksum: 10c0/f977ca61823e43de2381d53dd7aa8b4d79ff6a984c9afdc88dc44f9973b99de7fd382d2f0f91f2688e24bb987c0185bf45d0b004f22afaaab0f990a830253bfb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Ensures that anything that uses [React Hooks Testing Library](https://github.com/testing-library/react-hooks-testing-library) leverages the new import import path so that they are run in `createRoot` mode
  - Note that this is following [this part in their docs](https://github.com/testing-library/react-hooks-testing-library?tab=readme-ov-file#a-note-about-react-18-support).
- Impact: Removes any `ReactDOM.render is no longer supported in React 18.` logs in the test output by ensuring we are actually running the hooks in `createRoot` mode!

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This is a test infrastructure change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
