### PR TITLE
Fix deprecation with `fillna` pandas method

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1264,7 +1264,9 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
 
     # Replace all recognized nulls (np.nan, pd.NA, NaT) with None
     # then infer objects without creating a separate copy:
-    return df.replace([pd.NA, pd.NaT, np.nan], None).infer_objects(copy=False)
+    # For performance reasons, we could use copy=False here.
+    # However, this is only available in pandas >=2.
+    return df.replace([pd.NA, pd.NaT, np.nan], None).infer_objects()
 
 
 def _pandas_df_to_series(df: DataFrame) -> Series[Any]:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1260,8 +1260,11 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
     which is the only missing value type that is supported by all data
     """
     import numpy as np
+    import pandas as pd
 
-    return df.fillna(np.nan).replace([np.nan], [None]).infer_objects()
+    # Replace all recognized nulls (np.nan, pd.NA, NaT) with None
+    # then infer objects without creating a separate copy:
+    return df.replace([pd.NA, pd.NaT, np.nan], None).infer_objects(copy=False)
 
 
 def _pandas_df_to_series(df: DataFrame) -> Series[Any]:


### PR DESCRIPTION
## Describe your changes

The way we use `fillna` is deprecated resulting in the following deprecation warning: 
Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set pd.set_option('future.no_silent_downcasting', True)

This PR replaces the logic with a simple replace which should be equivalent and probably also a bit more efficient.

## Testing Plan

- No logical changes, existing tests should cover this well.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
