### PR TITLE
Modernize pathlib watcher

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -732,7 +732,7 @@ const ElementNodeRenderer = (
   const elementId = getElementId(node.element)
   const userKey = getKeyFromId(elementId)
 
-  // TODO: If would be great if we could return an empty fragment if isHidden is true, to keep the
+  // TODO: It would be great if we could return an empty fragment if isHidden is true, to keep the
   // DOM clean. But this would require the keys passed to ElementNodeRenderer at Block.tsx to be a
   // stable hash of some sort.
 

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Callable, Final
 
 from streamlit.logger import get_logger
@@ -59,7 +60,7 @@ class PollingPathWatcher:
         retains references to all active instances.)
         """
         # TODO(vdonato): Modernize this by switching to pathlib.
-        self._path = path
+        self._path = Path(path)  # Changed to pathlib.Path
         self._on_changed = on_changed
 
         self._glob_pattern = glob_pattern
@@ -68,10 +69,10 @@ class PollingPathWatcher:
         self._active = True
 
         self._modification_time = util.path_modification_time(
-            self._path, self._allow_nonexistent
+            str(self._path), self._allow_nonexistent
         )
         self._md5 = util.calc_md5_with_blocking_retries(
-            self._path,
+            str(self._path),
             glob_pattern=self._glob_pattern,
             allow_nonexistent=self._allow_nonexistent,
         )
@@ -93,7 +94,7 @@ class PollingPathWatcher:
             return
 
         modification_time = util.path_modification_time(
-            self._path, self._allow_nonexistent
+            str(self._path), self._allow_nonexistent
         )
         # We add modification_time != 0.0 check since on some file systems (s3fs/fuse)
         # modification_time is always 0.0 because of file system limitations.
@@ -104,7 +105,7 @@ class PollingPathWatcher:
         self._modification_time = modification_time
 
         md5 = util.calc_md5_with_blocking_retries(
-            self._path,
+            str(self._path),
             glob_pattern=self._glob_pattern,
             allow_nonexistent=self._allow_nonexistent,
         )
@@ -115,7 +116,7 @@ class PollingPathWatcher:
         self._md5 = md5
 
         _LOGGER.debug("Change detected: %s", self._path)
-        self._on_changed(self._path)
+        self._on_changed(str(self._path))
 
         self._schedule()
 


### PR DESCRIPTION
## Describe your changes  
- Refactored `PollingPathWatcher` to use `pathlib.Path` instead of string-based path handling for improved readability and reliability.  
- Fixed a typo in `streamlit/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx`.  

## GitHub Issue Link (if applicable)  
N/A  

## Testing Plan  
- No additional tests needed as functionality remains unchanged.  
- Existing unit tests should cover path handling behavior.  
- Manually tested file watching to ensure expected behavior.  

---

### **Code change for `pathlib` refactor**  

Replace:  
```
self._path = path
```
With:
```
from pathlib import Path
self._path = Path(path)
```
And ensure all path usages are converted with ```str(self._path)``` where necessary (e.g., when calling ```util.path_modification_time```

