### PR TITLE
Adjustments to FileUploader to support react-refresh linter rule

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -52,7 +52,7 @@ import {
   UploadFileInfo,
 } from "~lib/components/widgets/FileUploader/UploadFileInfo"
 import { FileUploadClient } from "~lib/FileUploadClient"
-import { getAccept } from "~lib/components/widgets/FileUploader/FileDropzone"
+import { getAccept } from "~lib/components/widgets/FileUploader/utils"
 import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 
 import {

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -20,7 +20,8 @@ import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 
-import FileDropzone, { Props, STREAMLIT_MIME_TYPE } from "./FileDropzone"
+import FileDropzone, { Props } from "./FileDropzone"
+import { STREAMLIT_MIME_TYPE } from "./utils"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   disabled: false,

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import Dropzone, { Accept, FileRejection } from "react-dropzone"
+import Dropzone, { FileRejection } from "react-dropzone"
 
 import BaseButton, {
   BaseButtonKind,
@@ -25,6 +25,7 @@ import BaseButton, {
 
 import { StyledFileDropzoneSection } from "./styled-components"
 import FileDropzoneInstructions from "./FileDropzoneInstructions"
+import { getAccept } from "./utils"
 
 export interface Props {
   disabled: boolean
@@ -33,18 +34,6 @@ export interface Props {
   acceptedExtensions: string[]
   maxSizeBytes: number
   label: string
-}
-
-// Before we support official MIME types, using the custom "application/streamlit" as a wild card
-// to allow file types defined in acceptedExtensions.
-export const STREAMLIT_MIME_TYPE = "application/streamlit"
-
-// Remove mimetype when this component moves to functional
-export function getAccept(acceptedExtensions: string[]): Accept | undefined {
-  const accept: Accept = {}
-  accept[STREAMLIT_MIME_TYPE] = acceptedExtensions
-
-  return acceptedExtensions.length ? accept : undefined
 }
 
 const FileDropzone = ({

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -574,4 +574,5 @@ class FileUploader extends React.PureComponent<InnerProps, State> {
   }
 }
 
-export default withCalculatedWidth(memo(FileUploader))
+const FileUploaderWithCalculatedWidth = withCalculatedWidth(memo(FileUploader))
+export default FileUploaderWithCalculatedWidth

--- a/frontend/lib/src/components/widgets/FileUploader/utils.test.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/utils.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getAccept, STREAMLIT_MIME_TYPE } from "./utils"
+
+describe("FileUploader utils", () => {
+  describe("getAccept", () => {
+    it("returns undefined when no extensions provided", () => {
+      expect(getAccept([])).toBeUndefined()
+    })
+
+    it("returns accept object with MIME type when extensions provided", () => {
+      const extensions = [".jpg", ".png"]
+      const result = getAccept(extensions)
+
+      expect(result).toEqual({
+        [STREAMLIT_MIME_TYPE]: extensions,
+      })
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/FileUploader/utils.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Accept } from "react-dropzone"
+
+// Before we support official MIME types, using the custom "application/streamlit" as a wild card
+// to allow file types defined in acceptedExtensions.
+export const STREAMLIT_MIME_TYPE = "application/streamlit"
+
+export function getAccept(acceptedExtensions: string[]): Accept | undefined {
+  const accept: Accept = {}
+  accept[STREAMLIT_MIME_TYPE] = acceptedExtensions
+
+  return acceptedExtensions.length ? accept : undefined
+}


### PR DESCRIPTION
## Describe your changes

Part of some ongoing work to fix all violations of [react-refresh rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) which will be followed by adding this eslint rule.

Also adds tests for the `getAccept` function.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
