### PR TITLE
Using LOG instead of log

### DIFF
--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -30,7 +30,7 @@ import { getCookie, localStorageAvailable } from "@streamlit/utils"
 
 // Default metrics config fetched when none provided by host config endpoint
 export const DEFAULT_METRICS_CONFIG = "https://data.streamlit.io/metrics.json"
-const log = getLogger("MetricsManager")
+const LOG = getLogger("MetricsManager")
 
 type EventName = "viewReport" | "updateReport" | "pageProfile" | "menuClick"
 type Event = [EventName, Partial<IMetricsEvent>]
@@ -99,7 +99,7 @@ export class MetricsManager {
 
       // If metricsUrl still undefined, deactivate metrics
       if (!this.metricsUrl) {
-        log.error("Undefined metrics config - deactivating metrics tracking.")
+        LOG.error("Undefined metrics config - deactivating metrics tracking.")
         this.actuallySendMetrics = false
       }
     }
@@ -108,7 +108,7 @@ export class MetricsManager {
       this.sendPendingEvents()
     }
 
-    log.info("Gather usage stats: ", this.actuallySendMetrics)
+    LOG.info("Gather usage stats: ", this.actuallySendMetrics)
     this.initialized = true
   }
 
@@ -167,7 +167,7 @@ export class MetricsManager {
 
       if (!response.ok) {
         this.metricsUrl = undefined
-        log.error("Failed to fetch metrics config: ", response.status)
+        LOG.error("Failed to fetch metrics config: ", response.status)
       } else {
         const data = await response.json()
         this.metricsUrl = data.url ?? undefined
@@ -176,7 +176,7 @@ export class MetricsManager {
         }
       }
     } catch (err) {
-      log.error("Failed to fetch metrics config:", err)
+      LOG.error("Failed to fetch metrics config:", err)
     }
   }
 
@@ -188,7 +188,7 @@ export class MetricsManager {
 
     // Don't actually track events when in dev mode, just print them instead.
     if (IS_DEV_ENV) {
-      log.info("[Dev mode] Not tracking stat datapoint: ", evName, data)
+      LOG.info("[Dev mode] Not tracking stat datapoint: ", evName, data)
     } else if (this.metricsUrl === "postMessage") {
       this.postMessageEvent(evName, data)
     } else {

--- a/frontend/app/src/hocs/withScreencast/withScreencast.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.tsx
@@ -57,7 +57,7 @@ interface InjectedProps {
 
 type WrappedProps<P extends InjectedProps> = Omit<P, "screenCast">
 
-const log = getLogger("withScreencast")
+const LOG = getLogger("withScreencast")
 
 function withScreencast<P extends InjectedProps>(
   WrappedComponent: ComponentType<PropsWithChildren<P>>
@@ -116,7 +116,7 @@ function withScreencast<P extends InjectedProps>(
         recordAudio,
         onErrorOrStop: () => {
           stopRecording().catch(err =>
-            log.warn(`withScreencast.stopRecording threw an error: ${err}`)
+            LOG.warn(`withScreencast.stopRecording threw an error: ${err}`)
           )
         },
       })
@@ -124,7 +124,7 @@ function withScreencast<P extends InjectedProps>(
       try {
         await recorderRef.current.initialize()
       } catch (e) {
-        log.warn(`ScreenCastRecorder.initialize error: ${e}`)
+        LOG.warn(`ScreenCastRecorder.initialize error: ${e}`)
         setCurrentState("UNSUPPORTED")
         return
       }
@@ -147,7 +147,7 @@ function withScreencast<P extends InjectedProps>(
 
         // If we are currently in any other state, stop any ongoing recording
         stopRecording().catch(err =>
-          log.warn(`withScreencast.stopRecording threw an error: ${err}`)
+          LOG.warn(`withScreencast.stopRecording threw an error: ${err}`)
         )
       },
       [currentState, stopRecording]
@@ -164,7 +164,7 @@ function withScreencast<P extends InjectedProps>(
         setCurrentState("RECORDING")
       } else {
         stopRecording().catch(err =>
-          log.warn(`withScreencast.stopRecording threw an error: ${err}`)
+          LOG.warn(`withScreencast.stopRecording threw an error: ${err}`)
         )
       }
     }, [stopRecording])

--- a/frontend/app/src/util/ScreenCastRecorder.ts
+++ b/frontend/app/src/util/ScreenCastRecorder.ts
@@ -19,7 +19,7 @@ import { getLogger } from "loglevel"
 import { notNullOrUndefined } from "@streamlit/utils"
 
 const BLOB_TYPE = "video/webm"
-const log = getLogger("ScreenCastRecorder")
+const LOG = getLogger("ScreenCastRecorder")
 
 interface ScreenCastRecorderOptions {
   recordAudio: boolean
@@ -108,12 +108,12 @@ class ScreenCastRecorder {
    */
   public start(): boolean {
     if (!this.mediaRecorder) {
-      log.warn(`ScreenCastRecorder.start: mediaRecorder is null`)
+      LOG.warn(`ScreenCastRecorder.start: mediaRecorder is null`)
       return false
     }
 
     const logRecorderError = (e: any): void => {
-      log.warn(`mediaRecorder.start threw an error: ${e}`)
+      LOG.warn(`mediaRecorder.start threw an error: ${e}`)
     }
 
     this.mediaRecorder.onerror = (e: any): void => {

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -32,7 +32,7 @@ import { WebsocketConnection } from "./WebsocketConnection"
  * due to jitter).
  */
 const RETRY_COUNT_FOR_WARNING = 6
-const log = getLogger("ConnectionManager")
+const LOG = getLogger("ConnectionManager")
 
 interface Props {
   /** The app's SessionInfo instance */
@@ -119,7 +119,7 @@ export class ConnectionManager {
       this.websocketConnection.sendMessage(obj)
     } else {
       // Don't need to make a big deal out of this. Just print to console.
-      log.error(`Cannot send message when server is disconnected: ${obj}`)
+      LOG.error(`Cannot send message when server is disconnected: ${obj}`)
     }
   }
 
@@ -168,7 +168,7 @@ export class ConnectionManager {
         this.websocketConnection = await this.connectToRunningServer()
       } catch (e) {
         const err = e instanceof Error ? e : new Error(`${e}`)
-        log.error(err.message)
+        LOG.error(err.message)
         this.setConnectionState(
           ConnectionState.DISCONNECTED_FOREVER,
           err.message

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -34,7 +34,7 @@ import {
 } from "./constants"
 import { IHostConfigResponse, OnRetry } from "./types"
 
-const log = getLogger("DoInitPings")
+const LOG = getLogger("DoInitPings")
 
 export function doInitPings(
   uriPartsList: URL[],
@@ -106,7 +106,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
     const hostConfigUri = buildHttpUri(uriParts, HOST_CONFIG_PATH)
 
-    log.info(`Attempting to connect to ${healthzUri}.`)
+    LOG.info(`Attempting to connect to ${healthzUri}.`)
 
     if (uriNumber === 0) {
       totalTries++

--- a/frontend/connection/src/ForwardMessageCache.ts
+++ b/frontend/connection/src/ForwardMessageCache.ts
@@ -21,7 +21,7 @@ import { isNullOrUndefined, notNullOrUndefined } from "@streamlit/utils"
 
 import { StreamlitEndpoints } from "./types"
 
-const log = getLogger("ForwardMessageCache")
+const LOG = getLogger("ForwardMessageCache")
 
 class CacheEntry {
   public readonly encodedMsg: Uint8Array
@@ -73,7 +73,7 @@ export class ForwardMsgCache {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach#Description
     this.messages.forEach((entry, hash) => {
       if (entry.getAge(this.scriptRunCount) > maxMessageAge) {
-        log.info(`Removing expired ForwardMsg [hash=${hash}]`)
+        LOG.info(`Removing expired ForwardMsg [hash=${hash}]`)
         this.messages.delete(hash)
       }
     })
@@ -102,10 +102,10 @@ export class ForwardMsgCache {
 
     let newMsg = this.getCachedMessage(msg.refHash as string, true)
     if (notNullOrUndefined(newMsg)) {
-      log.info(`Cached ForwardMsg HIT [hash=${msg.refHash}]`)
+      LOG.info(`Cached ForwardMsg HIT [hash=${msg.refHash}]`)
     } else {
       // Cache miss: fetch from the server
-      log.info(`Cached ForwardMsg MISS [hash=${msg.refHash}]`)
+      LOG.info(`Cached ForwardMsg MISS [hash=${msg.refHash}]`)
       const encodedNewMsg = await this.endpoints.fetchCachedForwardMsg(
         msg.refHash as string
       )
@@ -155,7 +155,7 @@ export class ForwardMsgCache {
       return
     }
 
-    log.info(`Caching ForwardMsg [hash=${msg.hash}]`)
+    LOG.info(`Caching ForwardMsg [hash=${msg.hash}]`)
     this.messages.set(
       msg.hash,
       new CacheEntry(encodedMsg, this.scriptRunCount)

--- a/frontend/connection/src/StaticConnection.test.tsx
+++ b/frontend/connection/src/StaticConnection.test.tsx
@@ -42,7 +42,7 @@ describe("StaticConnection", () => {
   })
 
   beforeEach(() => {
-    logErrorSpy = vi.spyOn(log, "error").mockImplementation(() => {})
+    logErrorSpy = vi.spyOn(LOG, "error").mockImplementation(() => {})
   })
 
   afterEach(() => {

--- a/frontend/connection/src/StaticConnection.test.tsx
+++ b/frontend/connection/src/StaticConnection.test.tsx
@@ -25,7 +25,7 @@ import {
   establishStaticConnection,
   getProtoResponse,
   getStaticConfig,
-  log,
+  LOG,
 } from "./StaticConnection"
 
 describe("StaticConnection", () => {

--- a/frontend/connection/src/StaticConnection.tsx
+++ b/frontend/connection/src/StaticConnection.tsx
@@ -25,7 +25,7 @@ import { StreamlitEndpoints } from "./types"
 // TODO: Change this to a stable location and eventually make it configurable
 // Holds url for static asset location
 export const STATIC_ASSET_CONFIG = "https://data.streamlit.io/static.json"
-export const log = getLogger("StaticConnection")
+export const LOG = getLogger("StaticConnection")
 
 type OnMessage = (ForwardMsg: any) => void
 type OnConnectionStateChange = (
@@ -54,7 +54,7 @@ export async function getStaticConfig(): Promise<string> {
     })
 
     if (!response.ok) {
-      log.error("Failed to fetch static config url: ", response.status)
+      LOG.error("Failed to fetch static config url: ", response.status)
     } else {
       const config = await response.json()
       staticConfigUrl = config.static_url ?? undefined
@@ -65,7 +65,7 @@ export async function getStaticConfig(): Promise<string> {
       }
     }
   } catch (err) {
-    log.error("Failed to fetch static config url:", err)
+    LOG.error("Failed to fetch static config url:", err)
   }
 
   return staticConfigUrl
@@ -85,7 +85,7 @@ export async function getProtoResponse(
   })
 
   if (!response.ok) {
-    log.error(
+    LOG.error(
       `Failed to fetch static app protos for id: ${staticAppId}`,
       response.status
     )
@@ -107,7 +107,7 @@ export async function dispatchAppForwardMessages(
   const arrayBuffer = await getProtoResponse(staticAppId, staticConfigUrl)
 
   if (!arrayBuffer) {
-    log.error("Failed to retrieve static app protos")
+    LOG.error("Failed to retrieve static app protos")
     onConnectionError(
       `Failed to retrieve static app protos. Please confirm the id is correct and try again. Given static app id: ${staticAppId}`
     )

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -95,7 +95,7 @@ interface MessageQueue {
   [index: number]: any
 }
 
-const log = getLogger("WebsocketConnection")
+const LOG = getLogger("WebsocketConnection")
 
 /**
  * Events of the WebsocketConnection state machine. Here's what the FSM looks
@@ -195,7 +195,7 @@ export class WebsocketConnection {
 
   // This should only be called inside stepFsm().
   private setFsmState(state: ConnectionState, errMsg?: string): void {
-    log.info(`New state: ${state}`)
+    LOG.info(`New state: ${state}`)
     this.state = state
 
     // Perform pre-callback actions when entering certain states.
@@ -234,7 +234,7 @@ export class WebsocketConnection {
    * will be displayed to the user in a "Connection Error" dialog.
    */
   private stepFsm(event: Event, errMsg?: string): void {
-    log.info(`State: ${this.state}; Event: ${event}`)
+    LOG.info(`State: ${this.state}; Event: ${event}`)
 
     if (
       event === "FATAL_ERROR" &&
@@ -291,7 +291,7 @@ export class WebsocketConnection {
         // process any events, and it's possible we're in this state because
         // of a fatal error. Just log these events rather than throwing more
         // exceptions.
-        log.warn(
+        LOG.warn(
           `Discarding ${event} while in ${ConnectionState.DISCONNECTED_FOREVER}`
         )
         return
@@ -356,7 +356,7 @@ export class WebsocketConnection {
       throw new Error("Websocket already exists")
     }
 
-    log.info("creating WebSocket")
+    LOG.info("creating WebSocket")
 
     // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
     // parameter to the WebSocket constructor) here in a slightly unfortunate
@@ -383,7 +383,7 @@ export class WebsocketConnection {
       if (checkWebsocket()) {
         this.handleMessage(event.data).catch(reason => {
           const err = `Failed to process a Websocket message (${reason})`
-          log.error(err)
+          LOG.error(err)
           this.stepFsm("FATAL_ERROR", err)
         })
       }
@@ -391,14 +391,14 @@ export class WebsocketConnection {
 
     this.websocket.addEventListener("open", () => {
       if (checkWebsocket()) {
-        log.info("WebSocket onopen")
+        LOG.info("WebSocket onopen")
         this.stepFsm("CONNECTION_SUCCEEDED")
       }
     })
 
     this.websocket.addEventListener("close", () => {
       if (checkWebsocket()) {
-        log.warn("WebSocket onclose")
+        LOG.warn("WebSocket onclose")
         this.closeConnection()
         this.stepFsm("CONNECTION_CLOSED")
       }
@@ -406,7 +406,7 @@ export class WebsocketConnection {
 
     this.websocket.addEventListener("error", () => {
       if (checkWebsocket()) {
-        log.error("WebSocket onerror")
+        LOG.error("WebSocket onerror")
         this.closeConnection()
         this.stepFsm("CONNECTION_ERROR")
       }
@@ -429,7 +429,7 @@ export class WebsocketConnection {
 
       if (isNullOrUndefined(this.wsConnectionTimeoutId)) {
         // Sometimes the clearTimeout doesn't work. No idea why :-/
-        log.warn("Timeout fired after cancellation")
+        LOG.warn("Timeout fired after cancellation")
         return
       }
 
@@ -443,12 +443,12 @@ export class WebsocketConnection {
       }
 
       if (this.websocket.readyState === 0 /* CONNECTING */) {
-        log.info(`${uri} timed out`)
+        LOG.info(`${uri} timed out`)
         this.closeConnection()
         this.stepFsm("CONNECTION_TIMED_OUT")
       }
     }, WEBSOCKET_TIMEOUT_MS)
-    log.info(`Set WS timeout ${this.wsConnectionTimeoutId}`)
+    LOG.info(`Set WS timeout ${this.wsConnectionTimeoutId}`)
   }
 
   private closeConnection(): void {
@@ -464,7 +464,7 @@ export class WebsocketConnection {
     }
 
     if (notNullOrUndefined(this.wsConnectionTimeoutId)) {
-      log.info(`Clearing WS timeout ${this.wsConnectionTimeoutId}`)
+      LOG.info(`Clearing WS timeout ${this.wsConnectionTimeoutId}`)
       window.clearTimeout(this.wsConnectionTimeoutId)
       this.wsConnectionTimeoutId = undefined
     }

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -39,7 +39,7 @@ interface Props {
   requestFileURLs?: (requestId: string, files: File[]) => void
 }
 
-const log = getLogger("FileUploadClient")
+const LOG = getLogger("FileUploadClient")
 
 /**
  * Handles operations related to the widgets that require file uploading.
@@ -173,7 +173,7 @@ export class FileUploadClient {
       }
       this.pendingFileURLsRequests.delete(id)
     } else {
-      log.warn("fileURLsResponse received for nonexistent request, ignoring.")
+      LOG.warn("fileURLsResponse received for nonexistent request, ignoring.")
     }
   }
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -36,7 +36,7 @@ import {
 import { useVegaLiteSelections } from "./useVegaLiteSelections"
 
 const DEFAULT_DATA_NAME = "source"
-const log = getLogger("useVegaEmbed")
+const LOG = getLogger("useVegaEmbed")
 
 interface UseVegaEmbedOutput {
   createView: (
@@ -194,7 +194,7 @@ export function useVegaEmbed(
       if (data.hash !== prevData.hash) {
         // Clean the dataset and insert from scratch.
         view.data(name, getDataArray(data))
-        log.info(
+        LOG.info(
           `Had to clear the ${name} dataset before inserting data through Vega view.`
         )
       }

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
@@ -44,7 +44,7 @@ export interface UseVegaLiteSelectionsOutput {
   onFormCleared: () => void
 }
 
-const log = getLogger("useVegaLiteSelections")
+const LOG = getLogger("useVegaLiteSelections")
 
 /**
  * Hook that returns a function that can be used to configure the selection
@@ -142,7 +142,7 @@ export const useVegaLiteSelections = (
         try {
           return vegaView.setState(viewState)
         } catch (e) {
-          log.warn("Failed to restore view state", e)
+          LOG.warn("Failed to restore view state", e)
         }
       }
 

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -25,7 +25,7 @@ import { GraphVizChart as GraphVizChartProto } from "@streamlit/protobuf"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 
-import GraphVizChart, { GraphVizChartProps, log } from "./GraphVizChart"
+import GraphVizChart, { GraphVizChartProps, LOG } from "./GraphVizChart"
 
 vi.mock("d3-graphviz", () => ({
   graphviz: vi.fn().mockReturnValue({
@@ -57,7 +57,7 @@ describe("GraphVizChart Element", () => {
   let logErrorSpy: MockInstance
 
   beforeEach(() => {
-    logErrorSpy = vi.spyOn(log, "error").mockImplementation(() => {})
+    logErrorSpy = vi.spyOn(LOG, "error").mockImplementation(() => {})
 
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: React.createRef(),

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -35,7 +35,7 @@ export interface GraphVizChartProps {
   element: GraphVizChartProto
   disableFullscreenMode?: boolean
 }
-export const log = getLogger("GraphVizChart")
+export const LOG = getLogger("GraphVizChart")
 
 function GraphVizChart({
   element,
@@ -68,7 +68,7 @@ function GraphVizChart({
         node.removeAttribute("height")
       }
     } catch (error) {
-      log.error(error)
+      LOG.error(error)
     }
   }, [
     chartId,

--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
@@ -32,7 +32,7 @@ import {
 } from "~lib/theme"
 import { ensureError } from "~lib/util/ErrorHandling"
 
-const log = getLogger("PlotlyChart:CustomTheme")
+const LOG = getLogger("PlotlyChart:CustomTheme")
 /**
  * This applies general layout changes to things such as x axis,
  * y axis, legends, titles, grid changes, background, etc.
@@ -409,7 +409,7 @@ export function applyStreamlitTheme(spec: any, theme: EmotionTheme): void {
     applyStreamlitThemeTemplateLayout(spec.layout.template.layout, theme)
   } catch (e) {
     const err = ensureError(e)
-    log.error(err)
+    LOG.error(err)
   }
   if ("title" in spec.layout) {
     spec.layout.title = merge(spec.layout.title, {

--- a/frontend/lib/src/components/shared/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/lib/src/components/shared/ErrorBoundary/ErrorBoundary.tsx
@@ -29,7 +29,7 @@ export interface State {
   error?: Error | null
 }
 
-const log = getLogger("ErrorBoundary")
+const LOG = getLogger("ErrorBoundary")
 
 /**
  * A component that catches errors that take place when React is asynchronously
@@ -51,7 +51,7 @@ class ErrorBoundary extends React.PureComponent<
   }
 
   public componentDidCatch = (error: Error): void => {
-    log.error(`${error.name}: ${error.message}\n${error.stack}`)
+    LOG.error(`${error.name}: ${error.message}\n${error.stack}`)
   }
 
   public render(): React.ReactNode {

--- a/frontend/lib/src/components/widgets/AudioInput/convertAudioToWav.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/convertAudioToWav.ts
@@ -17,7 +17,7 @@
 
 import { getLogger } from "loglevel"
 
-const log = getLogger("convertAudioToWav")
+const LOG = getLogger("convertAudioToWav")
 
 /**
  * Converts a file Blob (audio/video) to a WAV Blob.
@@ -32,7 +32,7 @@ async function convertFileToWav(fileBlob: Blob): Promise<Blob | undefined> {
   try {
     audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
   } catch (error) {
-    log.error(error)
+    LOG.error(error)
     return undefined // Return undefined if decoding fails
   }
 

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -105,7 +105,7 @@ export interface State {
 }
 
 const MIN_SHUTTER_EFFECT_TIME_MS = 150
-const log = getLogger("CameraInput")
+const LOG = getLogger("CameraInput")
 
 class CameraInput extends React.PureComponent<Props, State> {
   private localFileIdCounter = 1
@@ -179,7 +179,7 @@ class CameraInput extends React.PureComponent<Props, State> {
         })
       })
       .catch(err => {
-        log.error(err)
+        LOG.error(err)
       })
   }
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -39,7 +39,7 @@ import ComponentInstance, {
   COMPONENT_READY_WARNING_TIME_MS,
 } from "./ComponentInstance"
 import {
-  log as componentUtilsLog,
+  LOG as componentUtilsLog,
   CUSTOM_COMPONENT_API_VERSION,
 } from "./componentUtils"
 import { ComponentRegistry } from "./ComponentRegistry"

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -53,7 +53,7 @@ import {
 } from "./componentUtils"
 import { StyledComponentIframe } from "./styled-components"
 
-const log = getLogger("ComponentInstance")
+const LOG = getLogger("ComponentInstance")
 /**
  * If we haven't received a COMPONENT_READY message this many seconds
  * after the component has been created, explain to the user that there
@@ -221,7 +221,7 @@ function ComponentInstance(props: Props): ReactElement {
 
   // Show a log in the console as a soft-warning to the developer before showing the more disrupting warning element
   const clearTimeoutLog = useTimeout(
-    () => log.warn(getWarnMessage(componentName, url)),
+    () => LOG.warn(getWarnMessage(componentName, url)),
     COMPONENT_READY_WARNING_TIME_MS / 4
   )
   const clearTimeoutWarningElement = useTimeout(
@@ -247,7 +247,7 @@ function ComponentInstance(props: Props): ReactElement {
   useEffect(() => {
     const handleSetFrameHeight = (height: number | undefined): void => {
       if (height === undefined) {
-        log.warn(`handleSetFrameHeight: missing 'height' prop`)
+        LOG.warn(`handleSetFrameHeight: missing 'height' prop`)
         return
       }
 
@@ -258,7 +258,7 @@ function ComponentInstance(props: Props): ReactElement {
 
       if (isNullOrUndefined(iframeRef.current)) {
         // This should not be possible.
-        log.warn(`handleSetFrameHeight: missing our iframeRef!`)
+        LOG.warn(`handleSetFrameHeight: missing our iframeRef!`)
         return
       }
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -25,7 +25,7 @@ export type ComponentMessageListener = (
   data: any
 ) => void
 
-const log = getLogger("ComponentRegistry")
+const LOG = getLogger("ComponentRegistry")
 
 /**
  * Dispatches iframe messages to ComponentInstances.
@@ -51,7 +51,7 @@ export class ComponentRegistry {
     listener: ComponentMessageListener
   ): void => {
     if (this.msgListeners.has(source)) {
-      log.warn(`MessageEventSource registered multiple times!`, source)
+      LOG.warn(`MessageEventSource registered multiple times!`, source)
     }
 
     this.msgListeners.set(source, listener)
@@ -60,7 +60,7 @@ export class ComponentRegistry {
   public deregisterListener = (source: MessageEventSource): void => {
     const removed = this.msgListeners.delete(source)
     if (!removed) {
-      log.warn(`Could not deregister unregistered MessageEventSource!`)
+      LOG.warn(`Could not deregister unregistered MessageEventSource!`)
     }
   }
 
@@ -80,14 +80,14 @@ export class ComponentRegistry {
 
     if (isNullOrUndefined(event.source)) {
       // This should not be possible.
-      log.warn(`Received component message with no eventSource!`, event.data)
+      LOG.warn(`Received component message with no eventSource!`, event.data)
       return
     }
 
     // Get the ComponentInstance associated with the event
     const listener = this.msgListeners.get(event.source)
     if (isNullOrUndefined(listener) || typeof listener !== "function") {
-      log.warn(
+      LOG.warn(
         `Received component message for unregistered ComponentInstance!`,
         event.data
       )
@@ -96,7 +96,7 @@ export class ComponentRegistry {
 
     const { type } = event.data
     if (isNullOrUndefined(type)) {
-      log.warn(`Received Streamlit message with no type!`, event.data)
+      LOG.warn(`Received Streamlit message with no type!`, event.data)
       return
     }
 

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -77,7 +77,7 @@ export interface DataframeArg {
  * version in the COMPONENT_READY call.
  */
 export const CUSTOM_COMPONENT_API_VERSION = 1
-export const log = getLogger("componentUtils")
+export const LOG = getLogger("componentUtils")
 
 /**
  * Create a callback to be passed to  {@link ComponentRegistry#registerListener}.
@@ -134,7 +134,7 @@ export function createIframeMessageHandler(
 
       case ComponentMessageType.SET_COMPONENT_VALUE:
         if (!isReady) {
-          log.warn(
+          LOG.warn(
             `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
           )
         } else {
@@ -151,7 +151,7 @@ export function createIframeMessageHandler(
 
       case ComponentMessageType.SET_FRAME_HEIGHT:
         if (!isReady) {
-          log.warn(
+          LOG.warn(
             `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
           )
         } else {
@@ -162,7 +162,7 @@ export function createIframeMessageHandler(
         break
 
       default:
-        log.warn(`Unrecognized ComponentBackMsgType: ${type}`)
+        LOG.warn(`Unrecognized ComponentBackMsgType: ${type}`)
     }
   }
 }
@@ -243,13 +243,13 @@ export function sendRenderMessage(
 ): void {
   if (!iframe) {
     // This should never happen!
-    log.warn("Can't send ForwardMsg; missing our iframe!")
+    LOG.warn("Can't send ForwardMsg; missing our iframe!")
     return
   }
 
   if (isNullOrUndefined(iframe.contentWindow)) {
     // Nor should this!
-    log.warn("Can't send ForwardMsg; iframe has no contentWindow!")
+    LOG.warn("Can't send ForwardMsg; iframe has no contentWindow!")
     return
   }
 
@@ -286,7 +286,7 @@ function handleSetComponentValue(
   fragmentId?: string
 ): void {
   if (value === undefined) {
-    log.warn(`handleSetComponentValue: missing 'value' prop`)
+    LOG.warn(`handleSetComponentValue: missing 'value' prop`)
     return
   }
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -52,7 +52,7 @@ export const COLUMN_WIDTH_MAPPING = {
   large: 400,
 }
 
-const log = getLogger("useColumnLoader")
+const LOG = getLogger("useColumnLoader")
 
 /**
  * Options to configure columns.
@@ -217,7 +217,7 @@ export function getColumnConfig(configJson: string): Map<string, any> {
   } catch (error) {
     // This is not expected to happen, but if it does, we'll return an empty map
     // and log the error to the console.
-    log.error(error)
+    LOG.error(error)
     return new Map()
   }
 }
@@ -244,7 +244,7 @@ export function getColumnType(column: BaseColumnProps): ColumnCreator {
     if (ColumnTypes.has(customType)) {
       ColumnType = ColumnTypes.get(customType)
     } else {
-      log.warn(
+      LOG.warn(
         `Unknown column type configured in column configuration: ${customType}`
       )
     }

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.ts
@@ -41,7 +41,7 @@ type DataEditorReturn = Pick<
   "onCellEdited" | "onPaste" | "onRowAppended" | "onDelete" | "validateCell"
 >
 
-const log = getLogger("useDataEditor")
+const LOG = getLogger("useDataEditor")
 
 /**
  * Custom hook to handle all aspects related to data editing. This includes editing cells,
@@ -112,7 +112,7 @@ function useDataEditor(
 
         syncEditState()
       } else {
-        log.warn(
+        LOG.warn(
           `Not applying the cell edit since it causes this error:\n ${newCell.data}`
         )
       }

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -40,7 +40,7 @@ const CSV_UTF8_BOM = "\ufeff"
 const CSV_SPECIAL_CHARS_REGEX = new RegExp(
   `[${[CSV_DELIMITER, CSV_QUOTE_CHAR, CSV_ROW_DELIMITER].join("")}]`
 )
-const log = getLogger("useDataExporter")
+const LOG = getLogger("useDataExporter")
 
 export function toCsvRow(rowValues: any[]): string {
   return (
@@ -160,7 +160,7 @@ function useDataExporter(
       }
 
       try {
-        log.warn(
+        LOG.warn(
           "Failed to export data as CSV with FileSystem API, trying fallback method",
           error
         )
@@ -200,7 +200,7 @@ function useDataExporter(
         document.body.removeChild(link) // Clean up
         URL.revokeObjectURL(url) // Free up memory
       } catch (error) {
-        log.error("Failed to export data as CSV", error)
+        LOG.error("Failed to export data as CSV", error)
       }
     }
   }, [columns, numRows, getCellContent, enforceDownloadInNewTab])

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -59,7 +59,7 @@ import {
   StyledInstructionsContainer,
 } from "./styled-components"
 
-const log = getLogger("NumberInput")
+const LOG = getLogger("NumberInput")
 
 /**
  * Return a string property from an element. If the string is
@@ -138,7 +138,7 @@ export const formatValue = ({
   try {
     return sprintf(formatString, value)
   } catch (e) {
-    log.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
+    LOG.warn(`Error in sprintf(${formatString}, ${value}): ${e}`)
     return String(value)
   }
 }

--- a/frontend/lib/src/dataframes/arrowFormatUtils.ts
+++ b/frontend/lib/src/dataframes/arrowFormatUtils.ts
@@ -79,7 +79,7 @@ type PandasPeriodFrequency =
   | SupportedPandasOffsetType
   | `${SupportedPandasOffsetType}-${string}`
 
-const log = getLogger("arrowFormatUtils")
+const LOG = getLogger("arrowFormatUtils")
 const WEEKDAY_SHORT = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
 const formatMs = (duration: number): string =>
   moment("19700101", "YYYYMMDD")
@@ -265,7 +265,7 @@ function formatDate(date: number | Date): string {
       (typeof date === "number" && Number.isFinite(date))
     )
   ) {
-    log.warn(`Unsupported date value: ${date}`)
+    LOG.warn(`Unsupported date value: ${date}`)
     return String(date)
   }
 
@@ -287,7 +287,7 @@ function formatDatetime(date: number | Date, field?: Field): string {
       (typeof date === "number" && Number.isFinite(date))
     )
   ) {
-    log.warn(`Unsupported datetime value: ${date}`)
+    LOG.warn(`Unsupported datetime value: ${date}`)
     return String(date)
   }
 
@@ -384,12 +384,12 @@ export function formatPeriodFromFreq(
   const momentConverter =
     PERIOD_TYPE_FORMATTERS[freqName as SupportedPandasOffsetType]
   if (!momentConverter) {
-    log.warn(`Unsupported period frequency: ${freq}`)
+    LOG.warn(`Unsupported period frequency: ${freq}`)
     return String(duration)
   }
   const durationNumber = Number(duration)
   if (!Number.isSafeInteger(durationNumber)) {
-    log.warn(
+    LOG.warn(
       `Unsupported value: ${duration}. Supported values: [${Number.MIN_SAFE_INTEGER}-${Number.MAX_SAFE_INTEGER}]`
     )
     return String(duration)
@@ -401,7 +401,7 @@ function formatPeriod(duration: number | bigint, field?: Field): string {
   // Serialization for pandas.Period is provided by Arrow extensions
   // https://github.com/pandas-dev/pandas/blob/70bb855cbbc75b52adcb127c84e0a35d2cd796a9/pandas/core/arrays/arrow/extension_types.py#L26
   if (isNullOrUndefined(field)) {
-    log.warn("Field information is missing")
+    LOG.warn("Field information is missing")
     return String(duration)
   }
 
@@ -412,12 +412,12 @@ function formatPeriod(duration: number | bigint, field?: Field): string {
     isNullOrUndefined(extensionName) ||
     isNullOrUndefined(extensionMetadata)
   ) {
-    log.warn("Arrow extension metadata is missing")
+    LOG.warn("Arrow extension metadata is missing")
     return String(duration)
   }
 
   if (extensionName !== "pandas.period") {
-    log.warn(`Unsupported extension name for period type: ${extensionName}`)
+    LOG.warn(`Unsupported extension name for period type: ${extensionName}`)
     return String(duration)
   }
 

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -71,7 +71,7 @@ declare global {
     >
   }
 }
-const log = getLogger("theme:utils")
+const LOG = getLogger("theme:utils")
 
 function mergeTheme(
   theme: ThemeConfig,
@@ -487,7 +487,7 @@ export function computeSpacingStyle(
       }
 
       if (!(marginValue in theme.spacing)) {
-        log.error(`Invalid spacing value: ${marginValue}`)
+        LOG.error(`Invalid spacing value: ${marginValue}`)
         return theme.spacing.none
       }
 


### PR DESCRIPTION
## Describe your changes

Part of some ongoing work to fix all violations of [react-refresh rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) which will be followed by adding this eslint rule.

In some places we used `log` instead of `LOG` for the const. This updates it to `LOG` so that it won't trigger the linting rule. Not all are in `.tsx` files but I have just updated it everywhere for consistency. 

## GitHub Issue Link (if applicable)

## Testing Plan

Just renaming. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
