### PR TITLE
Allow user to choose whether to print error finding secrets 

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -450,3 +450,10 @@ class StreamlitBadTimeStringError(LocalizableStreamlitException):
             "`'1d2h34m'` or `2 days`, for example. Got: {time_string}",
             time_string=time_string,
         )
+
+
+class StreamlitSecretNotFoundError(LocalizableStreamlitException, FileNotFoundError):
+    """Exception raised when a secret cannot be found or parsed in the secrets.toml file."""
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -268,7 +268,7 @@ class Secrets(Mapping[str, Any]):
             # The TomlDecodeError constructor requires 3 arguments: message, doc, and pos
             # Extract doc and pos from the original exception
             doc = ex.doc if hasattr(ex, "doc") else ""
-            pos = ex.pos if hasattr(ex, "pos") else (0, 0)
+            pos = ex.pos if hasattr(ex, "pos") else 0
             raise toml.TomlDecodeError(msg, doc, pos) from ex
 
         return secrets, found_secrets_file

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -284,7 +284,6 @@ class Secrets(Mapping[str, Any]):
                 error_msg = secret_error_messages_singleton.get_subfolder_path_is_not_a_folder_message(
                     sub_folder_path
                 )
-                self._print_exception_if_not_suppressed(error_msg)
                 raise ValueError(error_msg)
             sub_secrets = {}
 
@@ -317,7 +316,6 @@ class Secrets(Mapping[str, Any]):
         error_msg = secret_error_messages_singleton.get_invalid_secret_path_message(
             path
         )
-        self._print_exception_if_not_suppressed(error_msg)
         raise ValueError(error_msg)
 
     def _parse(self) -> Mapping[str, Any]:

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -30,6 +30,7 @@ from blinker import Signal
 import streamlit as st
 import streamlit.watcher.path_watcher
 from streamlit import runtime
+from streamlit.errors import StreamlitSecretNotFoundError
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
@@ -216,7 +217,7 @@ class Secrets(Mapping[str, Any]):
             self._parse()
 
             return True
-        except FileNotFoundError:
+        except StreamlitSecretNotFoundError:
             # No secrets.toml files exist. That's fine.
             return False
 
@@ -252,24 +253,13 @@ class Secrets(Mapping[str, Any]):
             import toml
 
             secrets.update(toml.loads(secrets_file_str))
-        except TypeError as ex:
+        except (TypeError, toml.TomlDecodeError) as ex:
             msg = (
                 secret_error_messages_singleton.get_error_parsing_file_at_path_message(
                     path, ex
                 )
             )
-            raise TypeError(msg) from ex
-        except toml.TomlDecodeError as ex:
-            msg = (
-                secret_error_messages_singleton.get_error_parsing_file_at_path_message(
-                    path, ex
-                )
-            )
-            # The TomlDecodeError constructor requires 3 arguments: message, doc, and pos
-            # Extract doc and pos from the original exception
-            doc = ex.doc if hasattr(ex, "doc") else ""
-            pos = ex.pos if hasattr(ex, "pos") else 0
-            raise toml.TomlDecodeError(msg, doc, pos) from ex
+            raise StreamlitSecretNotFoundError(msg) from ex
 
         return secrets, found_secrets_file
 
@@ -328,7 +318,7 @@ class Secrets(Mapping[str, Any]):
         error_msg = secret_error_messages_singleton.get_invalid_secret_path_message(
             path
         )
-        raise ValueError(error_msg)
+        raise StreamlitSecretNotFoundError(error_msg)
 
     def _parse(self) -> Mapping[str, Any]:
         """Parse our secrets.toml files if they're not already parsed.
@@ -342,7 +332,7 @@ class Secrets(Mapping[str, Any]):
 
         Raises
         ------
-        FileNotFoundError
+            StreamlitSecretNotFoundError
             Raised if secrets.toml doesn't exist.
 
         """
@@ -371,7 +361,7 @@ class Secrets(Mapping[str, Any]):
                         file_paths
                     )
                 )
-                raise FileNotFoundError(error_msg)
+                raise StreamlitSecretNotFoundError(error_msg)
 
             for k, v in secrets.items():
                 self._maybe_set_environment_variable(k, v)

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -204,6 +204,12 @@ class Secrets(Mapping[str, Any]):
             doc="Emitted when a `secrets.toml` file has been changed."
         )
 
+    def set_suppress_print_error_on_exception(
+        self, suppress_print_error_on_exception: bool
+    ) -> None:
+        """This is left in place for compatibility with integrations until integration code can be updated."""
+        pass
+
     def load_if_toml_exists(self) -> bool:
         """Load secrets.toml files from disk if they exists. If none exist,
         no exception will be raised. (If a file exists but is malformed,

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -204,12 +204,6 @@ class Secrets(Mapping[str, Any]):
             doc="Emitted when a `secrets.toml` file has been changed."
         )
 
-    def set_suppress_print_error_on_exception(
-        self, suppress_print_error_on_exception: bool
-    ) -> None:
-        """This is left in place for compatibility with integrations until integration code can be updated."""
-        pass
-
     def load_if_toml_exists(self) -> bool:
         """Load secrets.toml files from disk if they exists. If none exist,
         no exception will be raised. (If a file exists but is malformed,
@@ -226,6 +220,12 @@ class Secrets(Mapping[str, Any]):
         except StreamlitSecretNotFoundError:
             # No secrets.toml files exist. That's fine.
             return False
+
+    def set_suppress_print_error_on_exception(
+        self, suppress_print_error_on_exception: bool
+    ) -> None:
+        """This is left in place for compatibility with integrations until integration code can be updated."""
+        pass
 
     def _reset(self) -> None:
         """Clear the secrets dictionary and remove any secrets that were

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -292,7 +292,7 @@ class Secrets(Mapping[str, Any]):
                 error_msg = secret_error_messages_singleton.get_subfolder_path_is_not_a_folder_message(
                     sub_folder_path
                 )
-                raise ValueError(error_msg)
+                raise StreamlitSecretNotFoundError(error_msg)
             sub_secrets = {}
 
             for filename in os.listdir(sub_folder_path):

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -29,7 +29,7 @@ from streamlit.connections import (
     SnowparkConnection,
     SQLConnection,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitSecretNotFoundError
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
     _create_connection,
@@ -102,7 +102,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         [
             # No type is specified, and there's no config file to find one
             # in.
-            (None, FileNotFoundError, "No secrets found"),
+            (None, StreamlitSecretNotFoundError, "No secrets found"),
             # Nonexistent module.
             (
                 "nonexistent.module.SomeConnection",

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -267,10 +267,6 @@ class MultipleSecretsFilesTest(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 secrets.get("no_such_secret", None)
 
-            # mock_st_error.assert_called_once_with(
-            #     "No secrets found. Valid paths for a secrets.toml file or secret directories are: /mock1/secrets.toml, /mock2/secrets.toml"
-            # )
-
     @patch("streamlit.runtime.secrets._LOGGER")
     def test_only_one_secrets_file_fine(self, patched_logger):
         with os.fdopen(self._fd1, "w") as tmp:

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -25,8 +25,8 @@ from collections.abc import MutableMapping as MutableMappingABC
 from unittest.mock import MagicMock, mock_open, patch
 
 from parameterized import parameterized
-from toml import TomlDecodeError
 
+from streamlit.errors import StreamlitSecretNotFoundError
 from streamlit.runtime.secrets import (
     AttrDict,
     SecretErrorMessages,
@@ -145,14 +145,14 @@ class SecretsTest(unittest.TestCase):
         with patch("builtins.open", mock_open()) as mock_file:
             mock_file.side_effect = FileNotFoundError()
 
-            with self.assertRaises(FileNotFoundError):
+            with self.assertRaises(StreamlitSecretNotFoundError):
                 self.secrets.get("no_such_secret", None)
 
     @patch("builtins.open", new_callable=mock_open, read_data="invalid_toml")
     @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
     def test_malformed_toml_error(self, mock_get_option, _):
         """Secrets access raises an error if secrets.toml is malformed."""
-        with self.assertRaises(TomlDecodeError):
+        with self.assertRaises(StreamlitSecretNotFoundError):
             self.secrets.get("no_such_secret", None)
 
     @patch("streamlit.watcher.path_watcher.watch_file")
@@ -264,7 +264,7 @@ class MultipleSecretsFilesTest(unittest.TestCase):
         with patch("streamlit.config.get_option", new=mock_get_option):
             secrets = Secrets()
 
-            with self.assertRaises(FileNotFoundError):
+            with self.assertRaises(StreamlitSecretNotFoundError):
                 secrets.get("no_such_secret", None)
 
     @patch("streamlit.runtime.secrets._LOGGER")

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -26,6 +26,8 @@ from unittest.mock import MagicMock, mock_open, patch
 
 from parameterized import parameterized
 
+import streamlit as st
+from streamlit import config
 from streamlit.errors import StreamlitSecretNotFoundError
 from streamlit.runtime.secrets import (
     AttrDict,
@@ -33,6 +35,7 @@ from streamlit.runtime.secrets import (
     Secrets,
 )
 from tests import testutil
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import call_on_threads
 
 MOCK_TOML = """
@@ -457,3 +460,113 @@ class AttrDictTest(unittest.TestCase):
         attr_dict.to_dict()["x"]["y"] = "zed"
         assert attr_dict.x.y == "z"
         assert d["x"]["y"] == "z"
+
+
+class SecretsFallbackTest(DeltaGeneratorTestCase):
+    """Test that secrets falls back gracefully in various error scenarios."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._orig_environ = dict(os.environ)
+        st.secrets._reset()
+
+        # Keep track of the original config
+        self._orig_secrets_files = config.get_option("secrets.files")
+
+        # Define mock paths we'll use
+        self.mock_path = "/mock/path/secrets.toml"
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        os.environ.clear()
+        os.environ.update(self._orig_environ)
+        st.secrets._reset()
+
+        # Restore the original config
+        config._set_option("secrets.files", self._orig_secrets_files, "test")
+
+    def test_nonexistent_file_fallback_no_error(self):
+        """Test fallback when no secrets file exists."""
+        # Point to a non-existent path
+        config._set_option(
+            "secrets.files", ["/definitely/not/a/real/path/secrets.toml"], "test"
+        )
+
+        # Test the fallback pattern
+        self._run_token_fallback_test()
+
+    @patch("os.path.exists", return_value=True)  # Make it think the file exists
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="""
+        # This TOML file has secrets but not the one we're looking for
+        db_username = "Jane"
+        db_password = "12345qwerty"
+
+        [subsection]
+        email = "eng@streamlit.io"
+        """,
+    )
+    def test_missing_key_fallback_no_error(self, mock_open, mock_exists):
+        """Test fallback when the secrets file exists but doesn't have the target key."""
+        # Point to our mock path
+        config._set_option("secrets.files", [self.mock_path], "test")
+
+        # Test the fallback pattern
+        self._run_token_fallback_test()
+
+    @patch("os.path.exists", return_value=True)  # Make it think the file exists
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="This is not valid TOML syntax",
+    )
+    def test_invalid_toml_fallback_no_error(self, mock_open, mock_exists):
+        """Test fallback when the secrets file has invalid TOML syntax."""
+        # Point to our mock path
+        config._set_option("secrets.files", [self.mock_path], "test")
+
+        # Test the fallback pattern
+        self._run_token_fallback_test()
+
+    def _run_token_fallback_test(self):
+        """Helper that runs the token fallback pattern and verifies UI behavior."""
+        # The key we'll try to access that doesn't exist
+        TARGET_KEY = "TOKEN"
+
+        # Run the pattern from the example
+        token = None
+
+        try:
+            if TARGET_KEY in st.secrets:
+                token = st.secrets[TARGET_KEY]
+        except StreamlitSecretNotFoundError:
+            pass
+
+        if not token:
+            token = st.text_input("Pass in your token!", type="password")
+
+        # Check that a text_input was created (this confirms the fallback worked)
+        text_input_proto = self.get_delta_from_queue().new_element.text_input
+        self.assertEqual(text_input_proto.label, "Pass in your token!")
+
+        # In the protocol buffer, password type is represented by enum value 1
+        self.assertEqual(text_input_proto.type, 1)  # 1 corresponds to "password" type
+
+        # Verify no error messages were sent to the UI
+        deltas = self.get_all_deltas_from_queue()
+
+        # Check for error messages in a way that's compatible with the Delta structure
+        for delta in deltas:
+            # Check if this is an error message delta
+            if delta.HasField("new_element"):
+                element = delta.new_element
+                # Check if the element has an exception field
+                self.assertFalse(element.HasField("exception"))
+                # Also check for markdown elements that might contain error messages
+                if element.HasField("markdown"):
+                    markdown_text = element.markdown.body
+                    self.assertFalse(
+                        "Error" in markdown_text or "error" in markdown_text
+                    )


### PR DESCRIPTION
## Describe your changes

Currently, we both raise an error and print the error in the app when there is a problem loading the secrets from the toml file. 

This change removes the printing so that the app developer can decide whether to display the error to the end user. The Streamlit customized message for the error is added to the raised exception for debugability.

Image with no error handling in the app code:

![Screenshot 2025-02-25 at 4 11 11 PM](https://github.com/user-attachments/assets/69881787-ba0b-4cf3-b1b3-4247d5564b80)

 

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/8559

## Testing Plan

Existing tests cover this change and are updated. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
