### PR TITLE
CVE-2025-1685: Insecure Deserialization in Cache API

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from .safe_pickle import SafeUnpickler
 import pickle
 import threading
 import types
@@ -634,15 +635,19 @@ class DataCache(Cache):
             raise CacheError(str(e)) from e
 
         try:
-            entry = pickle.loads(pickled_entry)
+            entry = SafeUnpickler.loads(pickled_entry)
+
             if not isinstance(entry, CachedResult):
                 # Loaded an old cache file format, remove it and let the caller
                 # rerun the function.
                 self.storage.delete(key)
                 raise CacheKeyNotFoundError()
+            
             return entry
+        
         except pickle.UnpicklingError as exc:
-            raise CacheError(f"Failed to unpickle {key}") from exc
+            self.storage.delete(key)
+            raise CacheKeyNotFoundError(f"Cache entry {key} was corrupted and removed.") from exc
 
     @gather_metrics("_cache_data_object")
     def write_result(self, key: str, value: Any, messages: list[MsgData]) -> None:
@@ -653,7 +658,7 @@ class DataCache(Cache):
             main_id = st._main.id
             sidebar_id = st.sidebar.id
             entry = CachedResult(value, messages, main_id, sidebar_id)
-            pickled_entry = pickle.dumps(entry)
+            pickled_entry = pickle.dumps(entry, protocol=pickle.HIGHEST_PROTOCOL)
         except (pickle.PicklingError, TypeError) as exc:
             raise CacheError(f"Failed to pickle {key}") from exc
         self.storage.set(key, pickled_entry)

--- a/lib/streamlit/runtime/caching/safe_pickle.py
+++ b/lib/streamlit/runtime/caching/safe_pickle.py
@@ -1,0 +1,27 @@
+import pickle
+import io
+
+class SafeUnpickler(pickle.Unpickler):
+    SAFE_BUILTINS = {
+        "builtins.list",
+        "builtins.dict",
+        "builtins.set",
+        "builtins.str",
+        "builtins.int",
+        "builtins.float",
+        "builtins.bool",
+        "builtins.tuple",
+        "streamlit.runtime.caching.cache_data_api.CachedResult",
+    }
+
+    def find_class(self, module, name):
+        """Only allow deserialization of safe built-in types."""
+        full_name = f"{module}.{name}"
+        if full_name not in self.SAFE_BUILTINS:
+            raise pickle.UnpicklingError(f"Blocked unsafe deserialization: {full_name}")
+        return super().find_class(module, name)
+
+    @staticmethod
+    def loads(data):
+        """Use the restricted unpickler."""
+        return SafeUnpickler(io.BytesIO(data)).load()


### PR DESCRIPTION
## Describe your changes
This PR addresses an insecure deserialization vulnerability in Streamlit’s caching system (st.cache_data and st.cache_resource).

The caching mechanism loads cached objects using pickle.loads(), which is significantly unsafe because it can execute arbitrary code if an attacker controls the cached file content.

### Exploitation Chain (Chained with PR #10509)
This vulnerability can be exploited in combination with the file upload bypass fixed in the mentioned PR, allowing an attacker to achieve remote code execution:
1. Use #10509's File Upload Bypass
* The attacker exploits the file type validation bypass in st.file_uploader to upload a malicious .memo file containing a serialized payload.
* This payload is crafted to execute arbitrary system commands when deserialized.

2. Create a Streamlit application vulnerable to Path Traversal via the upload directory
* The attacker abuses path traversal to place the malicious .memo file inside Streamlit’s cache folder (~/.streamlit/cache/).
* This, however, can also be achieved by manually placing the malicious .memo file inside the cache directory (if there's access to the server hosting Streamlit)

3. Trigger Insecure Deserialization
* When the vulnerable Streamlit app reloads cache data, it calls pickle.loads(malicious.memo), executing the attacker’s arbitrary code.
* This can lead to full system compromise if Streamlit is running with elevated privileges.

Below is a video that provides a proof of concept:

https://github.com/user-attachments/assets/7d7fb0cc-fee6-4147-a6ca-dd7855c43e46

### Fixes Implemented
* Replaced pickle.loads() with a restricted unpickler (SafeUnpickler) to limit deserialization to trusted objects.
* Ensured only expected cache objects (CachedResult) can be deserialized.
* Ensured cache corruption or tampering does not crash the app.
* Removed outdated cache files that fail integrity checks.


## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed
* The fix does not change the caching functionality, it only restricts deserialization to safe objects.
* Existing tests already cover cache loading and error handling.


- Unit Tests (JS and/or Python)
- E2E Tests

- Any manual testing needed?
* Uploaded valid files and confirmed they worked normally.
* Placed a manipulated .memo file in the cache folder and ensured RCE wasn't achieved.

---

## References

Vulnerable app code:

```
import streamlit as st
import pandas as pd
import numpy as np
import sqlite3
import os
import time

os.environ["STREAMLIT_CACHE_DIR"] = os.path.expanduser("~/.streamlit/cache")

@st.cache_data(persist="disk")
def load_data(nrows):
    time.sleep(2)
    df = pd.DataFrame(np.random.randn(nrows, 4), columns=list("ABCD"))
    return df

@st.cache_resource
def get_db_connection():
    st.write("Initializing database connection (persistent manually)...")
    db_path = os.path.expanduser("~/.streamlit/cache/cached_db.sqlite")
    conn = sqlite3.connect(db_path)
    return conn

st.title("Streamlit Cache Test")

st.write("### Cached Data")
rows = st.slider("Number of rows to load", 100, 5000, 1000)

data = load_data(rows)

UPLOAD_FOLDER = os.path.expanduser("~/.streamlit/uploads")

os.makedirs(UPLOAD_FOLDER, exist_ok=True)

st.title("Upload a File")

uploaded_file = st.file_uploader("Choose a file to upload. PDFs Only!", type=["pdf"])

if uploaded_file:
    file_path = os.path.join(UPLOAD_FOLDER, uploaded_file.name)

    # Save uploaded file to disk
    with open(file_path, "wb") as f:
        f.write(uploaded_file.getbuffer())

    st.success(f"File successfully uploaded: {file_path}")
    st.write("Now check the upload directory:", UPLOAD_FOLDER)
```


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
