### PR TITLE
[fix] Stabilize Arrow Vega Lite Chart with createRoot

### DIFF
--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useEffect, useRef } from "react"
+import React, { FC, useEffect, useLayoutEffect, useRef } from "react"
 
 import { Global } from "@emotion/react"
 
@@ -76,7 +76,9 @@ const ArrowVegaLiteChart: FC<Props> = ({
 
   // Create the view once the container is ready and re-create
   // if the spec changes or the dimensions change.
-  useEffect(() => {
+  // We utilize useLayoutEffect to ensure that the view is created
+  // after the container is mounted to avoid layout shift.
+  useLayoutEffect(() => {
     if (containerRef.current !== null) {
       createView(containerRef, spec)
     }


### PR DESCRIPTION
## Describe your changes

Note: This is a PR into the long-running feature branch `feature/react-create-root`, not `develop`! Failing tests are expected while we work through the long tail of issues.

- Utilizes `useLayoutEffect` in `ArrowVegaLiteChart` to prevent unnecessary layout shifting.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Covered by existing e2e snapshot tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
