### PR TITLE
Add docs for chat input file uploader

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -447,7 +447,7 @@ class ChatMixin:
               rerun, the widget returns a dict-like object with two attributes,
               ``text`` and ``files``.
 
-            When the widget is confugired to accept files and the user submits
+            When the widget is configured to accept files and the user submits
             something in the last rerun, you can access the user's submission
             with key or attribute notation from the dict-like object. This is
             shown in Example 3 below.
@@ -457,7 +457,7 @@ class ChatMixin:
             files.
 
             The ``files`` attribute holds a list of UploadedFile objects.
-            The list is empty if the user only subitted a message. Unlike
+            The list is empty if the user only submitted a message. Unlike
             ``st.file_uploader``, this attribute always returns a list, even
             when the widget is configured to accept only one file at a time.
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -374,9 +374,9 @@ class ChatMixin:
         Parameters
         ----------
         placeholder : str
-            A placeholder text shown when the chat input is empty. Defaults to
-            "Your message". For accessibility reasons, you should not use an
-            empty string.
+            A placeholder text shown when the chat input is empty. This
+            defaults to ``"Your message"``. For accessibility reasons, you
+            should not use an empty string.
 
         key : str or int
             An optional string or integer to use as the unique key for the widget.
@@ -384,19 +384,44 @@ class ChatMixin:
             its content. No two widgets may have the same key.
 
         max_chars : int or None
-            The maximum number of characters that can be entered. If ``None``
-            (default), there will be no maximum.
+            The maximum number of characters that can be entered. If this is
+            ``None`` (default), there will be no maximum.
 
-        accept_file : bool | str
-            Whether the chat input should accept files. ``True`` to accept a single
-            file, ``"multiple"`` to accept multiple files.
+        accept_file : bool or str
+            Whether the chat input should accept files. This can be one of the
+            following values:
+
+            - ``False`` (default): No files are accepted and the user can only
+              submit a message.
+            - ``True``: The user can add a single file to their submission.
+            - ``"multiple"``: The user can add multiple files to their
+              submission.
+
+            When the widget is configured to accept files, the accepted file
+            types can be configured with the ``file_type`` parameter.
+
+            By default, uploaded files are limited to 200 MB each. You can
+            configure this using the ``server.maxUploadSize`` config option.
+            For more information on how to set config options, see
+            |config.toml|_.
+
+            .. |config.toml| replace:: ``config.toml``
+            .. _config.toml: https://docs.streamlit.io/develop/api-reference/configuration/config.toml
+
+        file_type : str, Sequence[str], or None
+            The allowed file extension(s) for uploaded files. This can be one
+            of the following types:
+
+            - ``None`` (default): All file extensions are allowed.
+            - A string: A single file extension is allowed. For example, to
+              only accept CSV files, use ``"csv"``.
+            - A sequence of strings: Multiple file extensions are allowed. For
+              example, to only accept JPG/JPEG and PNG files, use
+              ``["jpg", "jpeg", "png"]``.
 
         disabled : bool
-            Whether the chat input should be disabled. Defaults to ``False``.
-
-        file_type : str or list[str] or None
-            Array of allowed extensions. ['png', 'jpg']
-            The default is None, which means all extensions are allowed.
+            Whether the chat input should be disabled. This defaults to
+            ``False``.
 
         on_submit : callable
             An optional callback invoked when the chat input's value is submitted.
@@ -409,12 +434,41 @@ class ChatMixin:
 
         Returns
         -------
-        str or None
-            The current (non-empty) value of the text input widget on the last
-            run of the app. Otherwise, ``None``.
+        None, str, or dict-like
+            The user's submission. This is one of the following types:
+
+            - ``None``: If the user didn't submit a message or file in the last
+              rerun, the widget returns ``None``.
+            - A string: When the widget is not configured to accept files and
+              the user submitted a message in the last rerun, the widget
+              returns the user's message as a string.
+            - A dict-like object: When the widget is configured to accept files
+              and the user submitted a message and/or file(s) in the last
+              rerun, the widget returns a dict-like object with two attributes,
+              ``text`` and ``files``.
+
+            When the widget is confugired to accept files and the user submits
+            something in the last rerun, you can access the user's submission
+            with key or attribute notation from the dict-like object. This is
+            shown in the examples below.
+
+            The ``text`` attribute holds a string, which is the user's message.
+            This is an empty string if the user only submitted one or more
+            files.
+
+            The ``files`` attribute holds a list of UploadedFile objects.
+            The list can be empty if the user only subitted a message. Unlike
+            ``st.file_uploader``, this attribute always returns a list, even
+            when the widget is configured to accept only one file at a time.
+
+            The UploadedFile class is a subclass of BytesIO, and therefore is
+            "file-like". This means you can pass an instance of it anywhere a
+            file is expected.
 
         Examples
         --------
+        **Example 1: Pin the the chat input widget to the bottom of your app**
+
         When ``st.chat_input`` is used in the main body of an app, it will be
         pinned to the bottom of the page.
 
@@ -428,9 +482,11 @@ class ChatMixin:
             https://doc-chat-input.streamlit.app/
             height: 350px
 
+        **Example 2: Use the chat input widget inline**
+
         The chat input can also be used inline by nesting it inside any layout
         container (container, columns, tabs, sidebar, etc) or fragment. Create
-        chat interfaces embedded next to other content or have multiple
+        chat interfaces embedded next to other content, or have multiple
         chatbots!
 
         >>> import streamlit as st
@@ -444,6 +500,32 @@ class ChatMixin:
         .. output ::
             https://doc-chat-input-inline.streamlit.app/
             height: 350px
+
+        **Example 3: Let users upload files**
+
+        When you configure your chat input widget to allow file attachments, it
+        will return a dict-like object when the user sends a submission. You
+        can access the user's message through the ``text`` attribute of this
+        dictionary. You can access a list of the user's submitted file(s)
+        through the ``files`` attribute. Similar to ``st.session_state``, you
+        can use key or attribute notation.
+
+        >>> import streamlit as st
+        >>>
+        >>> prompt = st.chat_input(
+        >>>     "Say something and/or attach an image",
+        >>>     accept_file=True,
+        >>>     file_type=["jpg", "jpeg", "png"],
+        >>> )
+        >>> if prompt and prompt.text:
+        >>>     st.markdown(prompt.text)
+        >>> if prompt and prompt["files"]:
+        >>>     st.image(prompt["files"][0])
+
+        .. output ::
+            https://doc-chat-input-file-uploader.streamlit.app/
+            height: 350px
+
         """
         # We default to an empty string here and disallow user choice intentionally
         default = ""

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -450,14 +450,14 @@ class ChatMixin:
             When the widget is confugired to accept files and the user submits
             something in the last rerun, you can access the user's submission
             with key or attribute notation from the dict-like object. This is
-            shown in the examples below.
+            shown in Example 3 below.
 
             The ``text`` attribute holds a string, which is the user's message.
             This is an empty string if the user only submitted one or more
             files.
 
             The ``files`` attribute holds a list of UploadedFile objects.
-            The list can be empty if the user only subitted a message. Unlike
+            The list is empty if the user only subitted a message. Unlike
             ``st.file_uploader``, this attribute always returns a list, even
             when the widget is configured to accept only one file at a time.
 

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -235,10 +235,12 @@ class FileUploaderMixin:
         label_visibility: LabelVisibility = "visible",
     ) -> UploadedFile | list[UploadedFile] | None:
         r"""Display a file uploader widget.
-        By default, uploaded files are limited to 200MB. You can configure
-        this using the ``server.maxUploadSize`` config option. For more info
-        on how to set config options, see
-        https://docs.streamlit.io/develop/api-reference/configuration/config.toml
+        By default, uploaded files are limited to 200 MB each. You can
+        configure this using the ``server.maxUploadSize`` config option. For
+        more information on how to set config options, see |config.toml|_.
+
+        .. |config.toml| replace:: ``config.toml``
+        .. _config.toml: https://docs.streamlit.io/develop/api-reference/configuration/config.toml
 
         Parameters
         ----------
@@ -265,13 +267,21 @@ class FileUploaderMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         type : str or list of str or None
-            Array of allowed extensions. ['png', 'jpg']
-            The default is None, which means all extensions are allowed.
+            The allowed file extension(s) for uploaded files. This can be one
+            of the following types:
+
+            - ``None`` (default): All file extensions are allowed.
+            - A string: A single file extension is allowed. For example, to
+              only accept CSV files, use ``"csv"``.
+            - A sequence of strings: Multiple file extensions are allowed. For
+              example, to only accept JPG/JPEG and PNG files, use
+              ``["jpg", "jpeg", "png"]``.
 
         accept_multiple_files : bool
-            If True, allows the user to upload multiple files at the same time,
-            in which case the return value will be a list of files.
-            Default: False
+            Whether to accept more than one file in a submission. If this is
+            ``False`` (default), the user can only submit one file at a time.
+            If this is ``True``, the user can upload multiple files at the same
+            time, in which case the return value will be a list of files.
 
         key : str or int
             An optional string or integer to use as the unique key for the widget.
@@ -309,7 +319,7 @@ class FileUploaderMixin:
 
         Returns
         -------
-        None or UploadedFile or list of UploadedFile
+        None, UploadedFile, or list of UploadedFile
             - If accept_multiple_files is False, returns either None or
               an UploadedFile object.
             - If accept_multiple_files is True, returns a list with the


### PR DESCRIPTION
## Describe your changes
Update docstring for the `chat_input` for new file uploading capabilities. Also update docstring for `file_uploader` for clarity and style.

Docs only/no testing.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
