### PR TITLE
Fix react warning about wrong usage of `key` in dataframe component

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -436,15 +436,13 @@ const RawElementNodeRenderer = (
       widgetProps.disabled = widgetProps.disabled || arrowProto.disabled
       return (
         <ArrowDataFrame
-          element={arrowProto}
-          data={node.quiverElement as Quiver}
           // Arrow dataframe can be used as a widget (data_editor) or
           // an element (dataframe). We only want to set the key in case of
           // it being used as a widget. For the non-widget usage, the id will
           // be undefined.
-          {...(arrowProto.id && {
-            key: arrowProto.id,
-          })}
+          key={arrowProto.id || undefined}
+          element={arrowProto}
+          data={node.quiverElement as Quiver}
           {...widgetProps}
         />
       )


### PR DESCRIPTION
## Describe your changes

Fix a react warning of wrong usage of key with the dataframe component (when used as data editor):

![image](https://github.com/user-attachments/assets/2101f4cd-97ab-46b2-a0cc-b3c42ba9d5a9)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
