### PR TITLE
[fix] Update tooltip positioning logic + test fixes with createRoot

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -58,6 +58,7 @@ def test_can_switch_between_pages_and_edit_widgets(app: Page):
 
     app.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
     wait_for_app_run(app, wait_delay=1000)
+    expect(app.get_by_role("heading", name="Page 3")).to_be_visible()
 
     expect(app.get_by_test_id("stHeading")).to_contain_text("Page 3")
     expect(app.get_by_test_id("stMarkdown")).to_contain_text("x is 0")
@@ -212,6 +213,8 @@ def test_widget_state_reset_on_page_switch(app: Page):
     # Page 3
     app.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
 
+    expect(app.get_by_role("heading", name="Page 3")).to_be_visible()
+
     slider = app.locator('.stSlider [role="slider"]')
     slider.click()
     slider.press("ArrowRight")
@@ -220,6 +223,8 @@ def test_widget_state_reset_on_page_switch(app: Page):
 
     # Switch to the slow page
     app.get_by_test_id("stSidebarNav").locator("a").nth(7).click()
+
+    expect(app.get_by_role("heading", name="slow page")).to_be_visible()
 
     # Wait for the view container and main menu to appear (like in wait_for_app_loaded),
     # but don't wait for the script to finish running.
@@ -230,6 +235,7 @@ def test_widget_state_reset_on_page_switch(app: Page):
 
     # Back to page 3
     app.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
+    expect(app.get_by_role("heading", name="Page 3")).to_be_visible()
     wait_for_app_run(app, wait_delay=500)
 
     # Slider reset
@@ -270,6 +276,8 @@ def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     app.get_by_test_id("stSidebarNav").locator("a").nth(8).click()
     wait_for_app_loaded(app)
 
+    expect(app.get_by_role("heading", name="Logo page")).to_be_visible()
+
     # Sidebar logo
     expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(
         "href", "https://www.example.com"
@@ -297,6 +305,8 @@ def test_renders_small_logos(app: Page, assert_snapshot: ImageCompareFunction):
     app.get_by_test_id("stSidebarNav").locator("a").nth(9).click()
     wait_for_app_loaded(app)
 
+    expect(app.get_by_role("heading", name="Logo page")).to_be_visible()
+
     # Sidebar logo
     expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(
         "href", "https://www.example.com"
@@ -323,6 +333,8 @@ def test_renders_large_logos(app: Page, assert_snapshot: ImageCompareFunction):
     # Go to large logo page & wait short moment for logo to appear
     app.get_by_test_id("stSidebarNav").locator("a").nth(10).click()
     wait_for_app_loaded(app)
+
+    expect(app.get_by_role("heading", name="Logo page")).to_be_visible()
 
     # Sidebar logo
     expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -30,7 +30,9 @@ def file_upload_helper(app: Page, chat_input: Locator, files: list[FilePayload])
         file_chooser.set_files(files=files)
 
     # take away hover focus of button
-    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
+    app.keyboard.press("Escape")
+    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0}, force=True)
+
     wait_for_app_run(app, 500)
 
 
@@ -339,9 +341,7 @@ def test_file_upload_error_message_disallowed_files(
     expect(app.get_by_text("json files are not allowed.")).to_be_visible()
 
 
-def test_file_upload_error_message_file_too_large(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
+def test_file_upload_error_message_file_too_large(app: Page):
     """Test that shows error message for files exceeding max size limit."""
     app.set_viewport_size({"width": 750, "height": 2000})
 
@@ -352,7 +352,11 @@ def test_file_upload_error_message_file_too_large(
         buffer=b"x" * (2 * 1024 * 1024),  # 2MB
     )
 
+    expect(app.get_by_text(file_name1)).not_to_be_attached()
+
     file_upload_helper(app, app.get_by_test_id("stChatInput").nth(3), [file1])
+
+    expect(app.get_by_text(file_name1)).to_be_visible()
 
     uploaded_files = app.get_by_test_id("stChatUploadedFiles").nth(1)
     uploaded_files.get_by_test_id("stTooltipHoverTarget").nth(0).hover()

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -19,7 +19,6 @@ import React, {
   ReactElement,
   ReactNode,
   useCallback,
-  useLayoutEffect,
   useState,
 } from "react"
 
@@ -34,6 +33,7 @@ import {
 import { EmotionTheme, hasLightBackgroundColor } from "~lib/theme"
 
 import { StyledTooltipContentWrapper } from "./styled-components"
+import { useTooltipMeasurementSideEffect } from "./useTooltipMeasurementSideEffect"
 
 export enum Placement {
   AUTO = "auto",
@@ -86,46 +86,7 @@ function Tooltip({
     setIsOpen(false)
   }, [])
 
-  useLayoutEffect(() => {
-    const parentElement = tooltipElement?.parentElement
-    if (!parentElement) {
-      return
-    }
-
-    const handleMeasurement = async (): Promise<void> => {
-      await new Promise(resolve => setTimeout(resolve, 10))
-      // if the tooltip is offscreen to the left, move it to the right by the same amount of pixels
-      // use a timeout to that parentElement.getBoundingClientRect returns the correct value; otherwise
-      // I have observed it to be "0".
-      const boundingClientRect = parentElement.getBoundingClientRect()
-      const xCoordinate = boundingClientRect.x
-
-      const overflowRight =
-        xCoordinate + boundingClientRect.width - window.innerWidth
-
-      // this is the out-of-tree Basweb DOM structure. For the right overflow,
-      // this is the element that has the transform-style property set that needs
-      // to be modified.
-      const parentsParentElement = parentElement.parentElement
-
-      if (overflowRight > 0 && parentsParentElement) {
-        // Baseweb uses a transform to position the tooltip, so we need to adjust the transform instead
-        // of the left / right property, otherwise it looks weird when the tooltip overflows the right side
-        const transformStyleMatrix = new DOMMatrix(
-          window.getComputedStyle(parentsParentElement)?.transform
-        )
-        parentsParentElement.style.transform = `translate3d(${
-          transformStyleMatrix.e - overflowRight
-        }px, ${transformStyleMatrix.f}px, 0px)`
-      }
-
-      if (xCoordinate < 0) {
-        parentElement.style.left = `${-xCoordinate}px`
-      }
-    }
-
-    handleMeasurement()
-  }, [tooltipElement, isOpen])
+  useTooltipMeasurementSideEffect(tooltipElement, isOpen)
 
   return (
     <StatefulTooltip

--- a/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react"
+import { MockInstance } from "vitest"
+
+import { useTooltipMeasurementSideEffect } from "./useTooltipMeasurementSideEffect"
+
+const MOCK_INNER_WIDTH = 1000
+const MOCK_TRANSFORM = "matrix(1, 0, 0, 1, 900, 10)"
+
+class MockDOMMatrix {
+  e: number
+
+  f: number
+
+  constructor(transform: string | null) {
+    // Default to identity matrix values
+    this.e = 0
+    this.f = 0
+
+    if (transform) {
+      const values = transform.match(/-?\d+(\.\d+)?/g)
+      if (values && values.length >= 6) {
+        this.e = parseFloat(values[4]) // 5th value is e (translateX)
+        this.f = parseFloat(values[5]) // 6th value is f (translateY)
+      }
+    }
+  }
+}
+
+vi.stubGlobal("DOMMatrix", MockDOMMatrix)
+
+describe("useTooltipMeasurementSideEffect", () => {
+  let requestAnimationFrameSpy: MockInstance
+  let getComputedStyleSpy: MockInstance
+  let innerWidthSpy: MockInstance
+
+  /** Helper function to create DOM elements for testing */
+  const createTooltipElements = (): {
+    parentElement: HTMLDivElement
+    tooltipElement: HTMLDivElement
+  } => {
+    const parentElement = document.createElement("div")
+    const tooltipElement = document.createElement("div")
+    parentElement.appendChild(tooltipElement)
+    document.body.appendChild(parentElement)
+
+    return { parentElement, tooltipElement }
+  }
+
+  /** Helper function to create DOM elements with grandparent for transform tests */
+  const createTooltipElementsWithGrandparent = (): {
+    grandparentElement: HTMLDivElement
+    parentElement: HTMLDivElement
+    tooltipElement: HTMLDivElement
+  } => {
+    const grandparentElement = document.createElement("div")
+    const parentElement = document.createElement("div")
+    const tooltipElement = document.createElement("div")
+
+    parentElement.appendChild(tooltipElement)
+    grandparentElement.appendChild(parentElement)
+    document.body.appendChild(grandparentElement)
+
+    return { grandparentElement, parentElement, tooltipElement }
+  }
+
+  /** Helper function to create a mock DOMRect */
+  const createMockDOMRect = (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): DOMRect => ({
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    left: x,
+    toJSON: () => ({}),
+  })
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation(
+        cb => setTimeout(() => cb(0), 0) as unknown as number
+      )
+
+    getComputedStyleSpy = vi
+      .spyOn(window, "getComputedStyle")
+      .mockImplementation(
+        () =>
+          ({
+            transform: MOCK_TRANSFORM,
+            getPropertyValue: (prop: string) =>
+              prop === "transform" ? MOCK_TRANSFORM : "",
+          } as unknown as CSSStyleDeclaration)
+      )
+
+    innerWidthSpy = vi
+      .spyOn(window, "innerWidth", "get")
+      .mockReturnValue(MOCK_INNER_WIDTH)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+
+    vi.restoreAllMocks()
+  })
+
+  it("does nothing when tooltipElement is null", () => {
+    renderHook(() => useTooltipMeasurementSideEffect(null, true))
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+  })
+
+  it("handles tooltip positioning with valid coordinates", async () => {
+    const { parentElement, tooltipElement } = createTooltipElements()
+
+    const getBoundingClientRectSpy = vi
+      .spyOn(parentElement, "getBoundingClientRect")
+      .mockReturnValue(createMockDOMRect(10, 10, 100, 50))
+
+    renderHook(() => useTooltipMeasurementSideEffect(tooltipElement, true))
+
+    await waitFor(() => {
+      expect(getBoundingClientRectSpy).toHaveBeenCalled()
+    })
+  })
+
+  it("handles right overflow correctly", async () => {
+    const { parentElement, tooltipElement } =
+      createTooltipElementsWithGrandparent()
+
+    // Mock getBoundingClientRect for parent element - this will cause overflow
+    vi.spyOn(parentElement, "getBoundingClientRect").mockReturnValue(
+      createMockDOMRect(900, 10, 200, 50)
+    )
+
+    renderHook(() => useTooltipMeasurementSideEffect(tooltipElement, true))
+
+    // Wait for the position to be adjusted and verify
+    await waitFor(() => {
+      // The overflow is 100 (900 + 200 - 1000), so the transform should adjust X by -100
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(parentElement.parentElement?.style.transform).toBe(
+        "translate3d(800px, 10px, 0px)"
+      )
+    })
+  })
+
+  it("handles left overflow correctly", async () => {
+    const { parentElement, tooltipElement } = createTooltipElements()
+
+    // Mock getBoundingClientRect to simulate left overflow
+    vi.spyOn(parentElement, "getBoundingClientRect").mockReturnValue(
+      createMockDOMRect(-20, 10, 100, 50)
+    )
+
+    renderHook(() => useTooltipMeasurementSideEffect(tooltipElement, true))
+
+    await waitFor(() => {
+      expect(parentElement.style.left).toBe("20px")
+    })
+  })
+
+  it("retries measurements when initial coordinates are invalid", async () => {
+    const { parentElement, tooltipElement } = createTooltipElements()
+
+    // Mock getBoundingClientRect to first return invalid coordinates, then valid ones
+    const getBoundingClientRectSpy = vi
+      .spyOn(parentElement, "getBoundingClientRect")
+      .mockReturnValueOnce(createMockDOMRect(0, 0, 100, 50))
+      .mockReturnValueOnce(createMockDOMRect(10, 10, 100, 50))
+
+    renderHook(() => useTooltipMeasurementSideEffect(tooltipElement, true))
+
+    await waitFor(() => {
+      expect(requestAnimationFrameSpy).toHaveBeenCalled()
+    })
+
+    await waitFor(() =>
+      expect(getBoundingClientRectSpy).toHaveBeenCalledTimes(2)
+    )
+  })
+
+  it("uses window APIs for positioning calculations", async () => {
+    const { parentElement, tooltipElement } =
+      createTooltipElementsWithGrandparent()
+
+    // Mock getBoundingClientRect to simulate right overflow
+    vi.spyOn(parentElement, "getBoundingClientRect").mockReturnValue(
+      createMockDOMRect(900, 10, 200, 50)
+    )
+
+    renderHook(() => useTooltipMeasurementSideEffect(tooltipElement, true))
+
+    await waitFor(() => {
+      expect(getComputedStyleSpy).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(innerWidthSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.ts
+++ b/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from "react"
+
+/**
+ * A hook that handles tooltip positioning and measurement with retry logic to
+ * ensure proper positioning even when initial measurements are invalid.
+ *
+ * This is a side effect of the Tooltip component, so it's not a hook that
+ * should be used in any other place. This hook exists due to the race
+ * conditions in the BaseWeb Tooltip and the need to ensure that the tooltip is
+ * always positioned correctly.
+ *
+ * When we move off of BaseWeb we should delete this hook!
+ *
+ * @param tooltipElement The tooltip element ref
+ * @param isOpen Whether the tooltip is currently open
+ */
+export function useTooltipMeasurementSideEffect(
+  tooltipElement: HTMLDivElement | null,
+  isOpen: boolean
+): void {
+  useEffect(() => {
+    const parentElement = tooltipElement?.parentElement
+    if (!parentElement) {
+      return
+    }
+
+    const handleMeasurement = async (): Promise<void> => {
+      // Implement a retry mechanism to ensure we get valid coordinates
+      const getMeasurements = (): DOMRect | null => {
+        const rect = parentElement.getBoundingClientRect()
+        // Check if we have valid non-zero coordinates
+        if (rect.x !== 0 || rect.y !== 0) {
+          return rect
+        }
+        return null
+      }
+
+      // Try to get valid measurements with retries
+      let boundingClientRect: DOMRect | null = null
+      let attempts = 0
+      const maxAttempts = 5
+
+      while (!boundingClientRect && attempts < maxAttempts) {
+        boundingClientRect = getMeasurements()
+        if (!boundingClientRect) {
+          attempts++
+          // Wait for next frame before trying again
+          await new Promise(resolve => requestAnimationFrame(resolve))
+        }
+      }
+
+      // If we still don't have valid measurements after all attempts, use what we have
+      if (!boundingClientRect) {
+        boundingClientRect = parentElement.getBoundingClientRect()
+      }
+
+      const xCoordinate = boundingClientRect.x
+
+      const overflowRight =
+        xCoordinate + boundingClientRect.width - window.innerWidth
+
+      // this is the out-of-tree Basweb DOM structure. For the right overflow,
+      // this is the element that has the transform-style property set that needs
+      // to be modified.
+      const parentsParentElement = parentElement.parentElement
+
+      if (overflowRight > 0 && parentsParentElement) {
+        // Baseweb uses a transform to position the tooltip, so we need to adjust the transform instead
+        // of the left / right property, otherwise it looks weird when the tooltip overflows the right side
+        const transformStyleMatrix = new DOMMatrix(
+          window.getComputedStyle(parentsParentElement)?.transform
+        )
+        parentsParentElement.style.transform = `translate3d(${
+          transformStyleMatrix.e - overflowRight
+        }px, ${transformStyleMatrix.f}px, 0px)`
+      }
+
+      if (xCoordinate < 0) {
+        parentElement.style.left = `${-xCoordinate}px`
+      }
+    }
+
+    handleMeasurement()
+  }, [tooltipElement, isOpen])
+}

--- a/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.ts
+++ b/frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.ts
@@ -29,6 +29,9 @@ import { useEffect } from "react"
  *
  * @param tooltipElement The tooltip element ref
  * @param isOpen Whether the tooltip is currently open
+ *
+ * @deprecated This is not a pattern we should use. Only here so until we move
+ * off of BaseWeb.
  */
 export function useTooltipMeasurementSideEffect(
   tooltipElement: HTMLDivElement | null,


### PR DESCRIPTION
## Describe your changes

Note: this is a PR into the `feature/react-create-root` feature branch!

### End-to-End Test Improvements:

* [`e2e_playwright/multipage_apps/mpa_basics_test.py`](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR61): Added visibility checks for page headings in various tests to ensure the correct page is displayed before proceeding with further actions. [[1]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR61) [[2]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR216-R217) [[3]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR227-R228) [[4]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR238) [[5]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR279-R280) [[6]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR308-R309) [[7]](diffhunk://#diff-24ecc937a117bfd88cfd3a8cbfe878c86efb5b42eea1753af7c42405908574dfR337-R338)
* [`e2e_playwright/st_chat_input_test.py`](diffhunk://#diff-91c04b9fe23d134b720135a67bd5b3ecc30f6af9629a7a5c4ece1de63ef19777L33-R35): Improved the file upload helper by adding a keyboard escape press and forcing a click to remove hover focus. [[1]](diffhunk://#diff-91c04b9fe23d134b720135a67bd5b3ecc30f6af9629a7a5c4ece1de63ef19777L33-R35) [[2]](diffhunk://#diff-91c04b9fe23d134b720135a67bd5b3ecc30f6af9629a7a5c4ece1de63ef19777L342-R344) [[3]](diffhunk://#diff-91c04b9fe23d134b720135a67bd5b3ecc30f6af9629a7a5c4ece1de63ef19777R355-R360)

### Tooltip Side Effect Refactor:

* [`frontend/lib/src/components/shared/Tooltip/Tooltip.tsx`](diffhunk://#diff-9c1459f9e01a40718ca2da673c5c1caab54c1be3e91c17f597d3bb2af657cd10L22): Moved the inline tooltip positioning logic into its own `useTooltipMeasurementSideEffect` hook. [[1]](diffhunk://#diff-9c1459f9e01a40718ca2da673c5c1caab54c1be3e91c17f597d3bb2af657cd10L22) [[2]](diffhunk://#diff-9c1459f9e01a40718ca2da673c5c1caab54c1be3e91c17f597d3bb2af657cd10R36) [[3]](diffhunk://#diff-9c1459f9e01a40718ca2da673c5c1caab54c1be3e91c17f597d3bb2af657cd10L89-R89)
* [`frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.ts`](diffhunk://#diff-053a09a573084c04b7682e234a28bc26af583bfdc4692d7c92fdfd17a1601c9bR1-R101): This is the standalone hook to handle tooltip positioning and measurement with retry logic to ensure proper positioning even when initial measurements are invalid.
* [`frontend/lib/src/components/shared/Tooltip/useTooltipMeasurementSideEffect.test.tsx`](diffhunk://#diff-28497bcde1594bcc2c520240f4699c59cb3b8ebdaaa131d8ef3c9133d166c6c5R1-R223): Added tests for the new `useTooltipMeasurementSideEffect` hook to verify its behavior in various scenarios, including handling right and left overflow and retrying measurements.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Covered by existing e2e test
- ✅ Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
