### PR TITLE
Add test execution time to e2e performance tracking

### DIFF
--- a/e2e_playwright/shared/performance.py
+++ b/e2e_playwright/shared/performance.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime
 import json
 import os
+import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -112,8 +113,14 @@ def measure_performance(
 
         client.send("Performance.enable")
 
+        # Start timing
+        start_time = time.time()
+
         # Run the test
         yield
+
+        # Calculate execution time
+        execution_time = time.time() - start_time
 
         metrics_response = client.send("Performance.getMetrics")
         captured_traces_result = client.send(
@@ -137,7 +144,8 @@ def measure_performance(
         ) as f:
             json.dump(
                 {
-                    "metrics": metrics_response["metrics"],
+                    "metrics": metrics_response["metrics"]
+                    + [{"name": "TestExecutionTime", "value": execution_time}],
                     "capturedTraces": parsed_captured_traces,
                 },
                 f,

--- a/e2e_playwright/shared/performance.py
+++ b/e2e_playwright/shared/performance.py
@@ -122,6 +122,10 @@ def measure_performance(
         # Calculate execution time
         execution_time = time.time() - start_time
 
+        # Add custom metric for test execution time
+        custom_metrics = [{"name": "TestExecutionTime", "value": execution_time}]
+
+        # Get metrics from Chrome DevTools Protocol
         metrics_response = client.send("Performance.getMetrics")
         captured_traces_result = client.send(
             "Runtime.evaluate",
@@ -144,8 +148,7 @@ def measure_performance(
         ) as f:
             json.dump(
                 {
-                    "metrics": metrics_response["metrics"]
-                    + [{"name": "TestExecutionTime", "value": execution_time}],
+                    "metrics": metrics_response["metrics"] + custom_metrics,
                     "capturedTraces": parsed_captured_traces,
                 },
                 f,


### PR DESCRIPTION
## Describe your changes

Adds a custom metric to our performance tracking that captures the total execution time of the test logic. While it doesn't perfectly fit in with the existing browser based metrics, it seems like the easiest way to track this execution number for some of our tests.

This is mainly relevant for some follow-up performance tracking related to the forward message cache: https://github.com/streamlit/streamlit/pull/10638

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
