### PR TITLE
[refactor] Remove flushSync from deckgl

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -226,38 +226,42 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
           />
         )}
       </Toolbar>
-      <DeckGL
-        viewState={viewState}
-        onViewStateChange={onViewStateChange}
-        height={height}
-        width={width}
-        layers={isInitialized ? deck.layers : EMPTY_LAYERS}
-        getTooltip={createTooltip}
-        // @ts-expect-error There is a type mismatch due to our versions of the libraries
-        ContextProvider={MapContext.Provider}
-        controller
-        onClick={
-          isSelectionModeActivated && !disabled ? handleClick : undefined
-        }
-      >
-        <StaticMap
+      {/* Only render the DeckGL component if the viewState is not null,
+      or else we'll get a runtime assertion error from deck.gl and the map will not render. */}
+      {viewState && (
+        <DeckGL
+          viewState={viewState}
+          onViewStateChange={onViewStateChange}
           height={height}
           width={width}
-          mapStyle={
-            deck.mapStyle &&
-            (typeof deck.mapStyle === "string"
-              ? deck.mapStyle
-              : deck.mapStyle[0])
+          layers={isInitialized ? deck.layers : EMPTY_LAYERS}
+          getTooltip={createTooltip}
+          // @ts-expect-error There is a type mismatch due to our versions of the libraries
+          ContextProvider={MapContext.Provider}
+          controller
+          onClick={
+            isSelectionModeActivated && !disabled ? handleClick : undefined
           }
-          mapboxApiAccessToken={elementMapboxToken || propsMapboxToken}
-        />
-        <StyledNavigationControlContainer>
-          <NavigationControl
-            data-testid="stDeckGlJsonChartZoomButton"
-            showCompass={false}
+        >
+          <StaticMap
+            height={height}
+            width={width}
+            mapStyle={
+              deck.mapStyle &&
+              (typeof deck.mapStyle === "string"
+                ? deck.mapStyle
+                : deck.mapStyle[0])
+            }
+            mapboxApiAccessToken={elementMapboxToken || propsMapboxToken}
           />
-        </StyledNavigationControlContainer>
-      </DeckGL>
+          <StyledNavigationControlContainer>
+            <NavigationControl
+              data-testid="stDeckGlJsonChartZoomButton"
+              showCompass={false}
+            />
+          </StyledNavigationControlContainer>
+        </DeckGL>
+      )}
     </StyledDeckGlChart>
   )
 }

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -21,7 +21,6 @@ import { PickingInfo, ViewStateChangeParameters } from "@deck.gl/core"
 import { TooltipContent } from "@deck.gl/core/dist/lib/tooltip"
 import isEqual from "lodash/isEqual"
 import { parseToRgba } from "color2k"
-import { flushSync } from "react-dom"
 
 import { DeckGlJsonChart as DeckGlJsonChartProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -60,7 +60,7 @@ type UseDeckGlShape = {
   setSelection: React.Dispatch<
     React.SetStateAction<ValueWithSource<DeckGlElementState> | null>
   >
-  viewState: Record<string, unknown>
+  viewState: Record<string, unknown> | null
   width: number | string
 }
 
@@ -181,11 +181,9 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
     fragmentId,
   })
 
-  const [viewState, setViewState] = useState<Record<string, unknown>>({
-    bearing: 0,
-    pitch: 0,
-    zoom: 11,
-  })
+  const [viewState, setViewState] = useState<Record<string, unknown> | null>(
+    null
+  )
 
   const { height, width } = useStWidthHeight({
     element,
@@ -193,13 +191,14 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
     shouldUseContainerWidth,
     container: { height: propsHeight, width: propsWidth },
     heightFallback:
-      (viewState.initialViewState as { height: number } | undefined)?.height ||
-      theme.sizes.defaultMapHeight,
+      (viewState?.initialViewState as { height: number } | undefined)
+        ?.height || theme.sizes.defaultMapHeight,
   })
 
-  const [initialViewState, setInitialViewState] = useState<
-    Record<string, unknown>
-  >({})
+  const [initialViewState, setInitialViewState] = useState<Record<
+    string,
+    unknown
+  > | null>(null)
 
   /**
    * Our proto for selectionMode is an array in order to support future-looking
@@ -350,7 +349,7 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
       const diff = Object.keys(deck.initialViewState).reduce(
         (diff, key): any => {
           // @ts-expect-error
-          if (deck.initialViewState[key] === initialViewState[key]) {
+          if (deck.initialViewState[key] === initialViewState?.[key]) {
             return diff
           }
 
@@ -363,14 +362,8 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
         {}
       )
 
-      // Note: `flushSync` is required since we are interfacing with a 3rd party
-      // library that is handling updates to its own canvas element. This is an
-      // expected usage of `flushSync`:
-      // https://react.dev/reference/react-dom/flushSync#flushing-updates-for-third-party-integrations
-      flushSync(() => {
-        setViewState({ ...viewState, ...diff })
-        setInitialViewState(deck.initialViewState)
-      })
+      setViewState(existing => ({ ...existing, ...diff }))
+      setInitialViewState(deck.initialViewState)
     }
   }, [deck.initialViewState, initialViewState, viewState])
 
@@ -395,13 +388,7 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
 
   const onViewStateChange = useCallback(
     ({ viewState }: ViewStateChangeParameters) => {
-      // Note: `flushSync` is required since we are interfacing with a 3rd party
-      // library that is handling updates to its own canvas element. This is an
-      // expected usage of `flushSync`:
-      // https://react.dev/reference/react-dom/flushSync#flushing-updates-for-third-party-integrations
-      flushSync(() => {
-        setViewState(viewState)
-      })
+      setViewState(viewState)
     },
     [setViewState]
   )


### PR DESCRIPTION
## Describe your changes

- Removes `flushSync` from deck.gl codepaths by changing the rendering order such that we only render the deck.gl component once we actually have a `viewState` to render.
  - This removes the timing issue that was previously requiring the `flushSync`

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ existing e2e tests cover this
- ✅ manually tested

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
