### PR TITLE
[Fix] Disable scroll within `st.number_input`

### DIFF
--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -205,6 +205,24 @@ def test_empty_number_input_behaves_correctly(
     )
 
 
+def test_number_input_does_not_allow_wheel_events(app: Page):
+    """Test that st.number_input does not allow wheel events."""
+    number_input = app.locator(".stNumberInput input[type='number']").nth(1)
+
+    # Click/focus needed to bring mouse to center of input
+    number_input.click()
+    # Scroll a little at a time to see the effect of a wheel event
+    # Negative y delta scrolls up, would increase value if wheel event was allowed
+    app.mouse.wheel(0, -50)
+    number_input.focus()
+    app.mouse.wheel(0, -50)
+    number_input.focus()
+    app.mouse.wheel(0, -50)
+    number_input.press("Enter")
+
+    expect(number_input).to_have_value("1")
+
+
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
     expect(get_element_by_key(app, "number_input_9")).to_be_visible()

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -204,6 +204,17 @@ const NumberInput: React.FC<Props> = ({
       commitValue({ value, source: { fromUi: false } })
     }
 
+    const numberInput = inputRef.current
+    if (numberInput) {
+      // Issue #8867: Disable wheel events on the input to avoid accidental changes
+      // caused by scrolling.
+      numberInput.addEventListener("wheel", e => e.preventDefault())
+
+      return () => {
+        numberInput.removeEventListener("wheel", e => e.preventDefault())
+      }
+    }
+
     // I don't want to run this effect on every render, only on mount.
     // Additionally, it's okay if commitValue changes, because we only call
     // it once in the beginning anyways.


### PR DESCRIPTION
## Describe your changes
Disables the `"wheel"` event on number inputs to avoid accidental modification of `st.number_input` value while scrolling

## GitHub Issue Link (if applicable)
Closes #8867 

## Testing Plan
- E2E Tests: ✅  Added
- Manual Testing: ✅ 
