### PR TITLE
Make test get_min_versions script works with nightly builds

### DIFF
--- a/scripts/get_min_versions.py
+++ b/scripts/get_min_versions.py
@@ -29,7 +29,7 @@ if package is None:
 
 oldest_dependencies = []
 
-for requirement in package.requires():  # type: ignore
+for requirement in package.requires():
     dependency = requirement.project_name
     if requirement.extras:
         dependency += "[" + ",".join(requirement.extras) + "]"

--- a/scripts/get_min_versions.py
+++ b/scripts/get_min_versions.py
@@ -20,6 +20,12 @@
 import pkg_resources
 
 package = pkg_resources.working_set.find(pkg_resources.Requirement.parse("streamlit"))
+if package is None:
+    package = pkg_resources.working_set.find(
+        pkg_resources.Requirement.parse("streamlit-nightly")
+    )
+if package is None:
+    raise ValueError("streamlit package not found")
 
 oldest_dependencies = []
 

--- a/scripts/get_min_versions.py
+++ b/scripts/get_min_versions.py
@@ -25,7 +25,7 @@ if package is None:
         pkg_resources.Requirement.parse("streamlit-nightly")
     )
 if package is None:
-    raise ValueError("streamlit package not found")
+    raise ValueError("streamlit/streamlit-nightly packages not found")
 
 oldest_dependencies = []
 


### PR DESCRIPTION
## Describe your changes

This script only looks for the `streamlit` package, but now that we are using it in the nightly build pipeline we should also look for the `streamlit-nightly` package if we can't find the `streamlit` pacakge. 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
