### PR TITLE
Enable better exception logging if `rich` is installed

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -490,8 +490,12 @@ def _logger_enable_rich() -> bool:
     try:
         import rich  # noqa: F401
 
+        # Rich is importable, activate rich logging.
         return True
     except Exception:
+        # We are extra broad in catching exceptions here because we don't want
+        # that this causes Streamlit to crash if there is any unexpected
+        # exception thrown by the import
         return False
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -469,22 +469,31 @@ def _logger_message_format() -> str:
         return "%(asctime)s %(message)s"
 
 
-_create_option(
+@_create_option(
     "logger.enableRich",
-    description="""
-        Controls whether uncaught app exceptions are logged via the rich library.
-
-        If True and if rich is installed, exception tracebacks will be logged with
-        syntax highlighting and formatting. Rich tracebacks are easier to read and
-        show more code than standard Python tracebacks.
-
-        If set to False, the default Python traceback formatting will be used.
-    """,
-    default_val=False,
     visibility="hidden",
     type_=bool,
     scriptable=True,
 )
+def _logger_enable_rich() -> bool:
+    """
+    Controls whether uncaught app exceptions are logged via the rich library.
+
+    If True and if rich is installed, exception tracebacks will be logged with
+    syntax highlighting and formatting. Rich tracebacks are easier to read and
+    show more code than standard Python tracebacks.
+
+    If set to False, the default Python traceback formatting will be used.
+
+    Defaults to True if rich is installed, False otherwise.
+    """
+    try:
+        import rich  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
 
 # Config Section: Client #
 


### PR DESCRIPTION
## Describe your changes

We recently removed rich as a required dependency in https://github.com/streamlit/streamlit/pull/10320.  This PR automatically enable better exception logging if `rich` is installed in the local environment, instead of also requiring the config option to be configured. This is mainly targeted for community cloud to simplify their configuration, but might also be useful for some users.

## Testing Plan

- Updated tests to validate that `rich` is activated if `rich` is installed (which is the case in our testing environment)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
