### PR TITLE
Use higher threshold for import test to minimize flakiness

### DIFF
--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -196,7 +196,7 @@ def test_importtime_median_under_threshold():
     # While its important to keep the import time low, you can
     # modify this threshold if it's really needed to add some new features.
     # But make sure that its justified and intended.
-    max_allowed_import_time_us = 500_000
+    max_allowed_import_time_us = 600_000
 
     import_times = []
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -196,7 +196,7 @@ def test_importtime_median_under_threshold():
     # While its important to keep the import time low, you can
     # modify this threshold if it's really needed to add some new features.
     # But make sure that its justified and intended.
-    max_allowed_import_time_us = 600_000
+    max_allowed_import_time_us = 700_000
 
     import_times = []
 


### PR DESCRIPTION
## Describe your changes

I have seen one unit test run fail with an import time slightly above 0.5 seconds. I am updating this threshold to 0.7 seconds to hopefully prevent any flakiness. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
