### PR TITLE
Fix `font` theme config not being passed to custom components

### DIFF
--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -819,6 +819,8 @@ describe("ComponentInstance", () => {
     disabled = false,
     theme = {
       ...toExportedTheme(mockTheme.emotion),
+      // Fills in the deprecated font property for backwards compatibility
+      font: mockTheme.emotion.genericFonts.bodyFont,
       base: bgColorToBaseString(mockTheme.emotion.colors.bgColor),
     }
   ): any {

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@streamlit/protobuf"
 
 import { mockTheme } from "~lib/mocks/mockTheme"
+import { toExportedTheme } from "~lib/theme"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
@@ -162,7 +163,10 @@ describe("test componentUtils", () => {
           args,
           dfs: dataframeArgs,
           disabled,
-          theme: expect.any(Object),
+          theme: {
+            ...toExportedTheme(mockTheme.emotion),
+            font: mockTheme.emotion.genericFonts.bodyFont,
+          },
         },
         "*"
       )

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -165,6 +165,7 @@ describe("test componentUtils", () => {
           disabled,
           theme: {
             ...toExportedTheme(mockTheme.emotion),
+            // Should fill in the deprecated font property for backwards compatibility
             font: mockTheme.emotion.genericFonts.bodyFont,
           },
         },

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -262,7 +262,12 @@ export function sendRenderMessage(
       args: currentArgs,
       dfs: currentDataframeArgs,
       disabled: disabled,
-      theme: toExportedTheme(theme),
+      theme: {
+        ...toExportedTheme(theme),
+        // TODO(lukasmasuch): adds backwards compatibility for the deprecated font
+        // property. Should be cleaned-up at some point when we revamp custom components.
+        font: theme.genericFonts.bodyFont,
+      },
     },
     "*"
   )

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -176,6 +176,7 @@ describe("Cached theme helpers", () => {
         backgroundColor: "orange",
         secondaryBackgroundColor: "yellow",
         textColor: "green",
+        bodyFont: '"Source Sans Pro", sans-serif',
       }
 
       const customTheme = createTheme(CUSTOM_THEME_NAME, themeInput)
@@ -220,6 +221,7 @@ describe("Cached theme helpers", () => {
       backgroundColor: "orange",
       secondaryBackgroundColor: "yellow",
       textColor: "green",
+      bodyFont: '"Source Sans Pro", sans-serif',
     }
     const customTheme = createTheme(CUSTOM_THEME_NAME, themeInput)
 
@@ -693,6 +695,7 @@ describe("toThemeInput", () => {
     const { colors } = lightTheme.emotion
     expect(toThemeInput(lightTheme.emotion)).toEqual({
       primaryColor: colors.primary,
+      bodyFont: `"Source Sans Pro", sans-serif`,
       backgroundColor: colors.bgColor,
       secondaryBackgroundColor: colors.secondaryBg,
       textColor: colors.bodyText,

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -310,6 +310,7 @@ export const toThemeInput = (
     backgroundColor: colors.bgColor,
     secondaryBackgroundColor: colors.secondaryBg,
     textColor: colors.bodyText,
+    bodyFont: theme.genericFonts.bodyFont,
   }
 }
 
@@ -319,6 +320,7 @@ export type ExportedTheme = {
   backgroundColor: string
   secondaryBackgroundColor: string
   textColor: string
+  bodyFont: string
 } & DerivedColors
 
 export const toExportedTheme = (theme: EmotionTheme): ExportedTheme => {
@@ -333,7 +335,7 @@ export const toExportedTheme = (theme: EmotionTheme): ExportedTheme => {
     backgroundColor: themeInput.backgroundColor as string,
     secondaryBackgroundColor: themeInput.secondaryBackgroundColor as string,
     textColor: themeInput.textColor as string,
-
+    bodyFont: themeInput.bodyFont as string,
     base: bgColorToBaseString(themeInput.backgroundColor),
 
     ...computeDerivedColors(colors),

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -30,6 +30,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import dataframe_util
+from streamlit.type_util import get_fqn_type
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_mocks.snowpandas_mocks import DataFrame as SnowpandasDataFrame
 from tests.streamlit.data_mocks.snowpandas_mocks import Index as SnowpandasIndex
@@ -577,21 +578,27 @@ class DataframeUtilTest(unittest.TestCase):
 
         dask_df = dask.datasets.timeseries()
 
-        assert dataframe_util.is_dask_object(dask_df) is True
+        assert dataframe_util.is_dask_object(dask_df) is True, (
+            f"Failed to detect dask dataframe with type {get_fqn_type(dask_df)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_df),
             pd.DataFrame,
         )
 
         dask_series = dask_df["x"]
-        assert dataframe_util.is_dask_object(dask_series) is True
+        assert dataframe_util.is_dask_object(dask_series) is True, (
+            f"Failed to detect dask series with type {get_fqn_type(dask_series)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_series),
             pd.DataFrame,
         )
 
         dask_index = dask_df.index
-        assert dataframe_util.is_dask_object(dask_index) is True
+        assert dataframe_util.is_dask_object(dask_index) is True, (
+            f"Failed to detect dask index with type {get_fqn_type(dask_index)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_index),
             pd.DataFrame,

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -30,7 +30,6 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import dataframe_util
-from streamlit.type_util import get_fqn_type
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_mocks.snowpandas_mocks import DataFrame as SnowpandasDataFrame
 from tests.streamlit.data_mocks.snowpandas_mocks import Index as SnowpandasIndex
@@ -578,27 +577,21 @@ class DataframeUtilTest(unittest.TestCase):
 
         dask_df = dask.datasets.timeseries()
 
-        assert dataframe_util.is_dask_object(dask_df) is True, (
-            f"Failed to detect dask dataframe with type {get_fqn_type(dask_df)}"
-        )
+        assert dataframe_util.is_dask_object(dask_df) is True
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_df),
             pd.DataFrame,
         )
 
         dask_series = dask_df["x"]
-        assert dataframe_util.is_dask_object(dask_series) is True, (
-            f"Failed to detect dask series with type {get_fqn_type(dask_series)}"
-        )
+        assert dataframe_util.is_dask_object(dask_series) is True
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_series),
             pd.DataFrame,
         )
 
         dask_index = dask_df.index
-        assert dataframe_util.is_dask_object(dask_index) is True, (
-            f"Failed to detect dask index with type {get_fqn_type(dask_index)}"
-        )
+        assert dataframe_util.is_dask_object(dask_index) is True
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_index),
             pd.DataFrame,


### PR DESCRIPTION
## Describe your changes

We deprecated the enum-based `font` property in our internal theme in 1.43. This also caused the `font` property to not be passed to custom components that rely on `font` being filled. This PR fixes the regression by passing in the new `bodyFont` property to the `font` property so that it stays backwards compatible to existing custom components.

## Github Issues

- Closes https://github.com/streamlit/streamlit/issues/10660

## Testing Plan

- Update unit tests.
- Manually verified the fix with the ant component.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
