### PR TITLE
Fix support for dask data objects

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -67,9 +67,14 @@ _MAX_UNEVALUATED_DF_ROWS = 10000
 
 _PANDAS_DATA_OBJECT_TYPE_RE: Final = re.compile(r"^pandas.*$")
 
-_DASK_DATAFRAME: Final = "dask.dataframe.core.DataFrame"
-_DASK_INDEX: Final = "dask.dataframe.core.Index"
-_DASK_SERIES: Final = "dask.dataframe.core.Series"
+_DASK_DATAFRAME: Final = "dask.dataframe.dask_expr._collection.DataFrame"
+_DASK_SERIES: Final = "dask.dataframe.dask_expr._collection.Series"
+_DASK_INDEX: Final = "dask.dataframe.dask_expr._collection.Index"
+# Dask removed the old legacy types, to support older and newer versions
+# we are still supporting the old an new types.
+_DASK_DATAFRAME_LEGACY: Final = "dask.dataframe.core.DataFrame"
+_DASK_SERIES_LEGACY: Final = "dask.dataframe.core.Series"
+_DASK_INDEX_LEGACY: Final = "dask.dataframe.core.Index"
 _DUCKDB_RELATION: Final = "duckdb.duckdb.DuckDBPyRelation"
 _MODIN_DF_TYPE_STR: Final = "modin.pandas.dataframe.DataFrame"
 _MODIN_SERIES_TYPE_STR: Final = "modin.pandas.series.Series"
@@ -377,8 +382,11 @@ def is_dask_object(obj: object) -> bool:
     """True if obj is a Dask DataFrame, Series, or Index."""
     return (
         is_type(obj, _DASK_DATAFRAME)
+        or is_type(obj, _DASK_DATAFRAME_LEGACY)
         or is_type(obj, _DASK_SERIES)
+        or is_type(obj, _DASK_SERIES_LEGACY)
         or is_type(obj, _DASK_INDEX)
+        or is_type(obj, _DASK_INDEX_LEGACY)
     )
 
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -30,6 +30,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import dataframe_util
+from streamlit.type_util import get_fqn_type
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_mocks.snowpandas_mocks import DataFrame as SnowpandasDataFrame
 from tests.streamlit.data_mocks.snowpandas_mocks import Index as SnowpandasIndex
@@ -577,21 +578,27 @@ class DataframeUtilTest(unittest.TestCase):
 
         dask_df = dask.datasets.timeseries()
 
-        assert dataframe_util.is_dask_object(dask_df) is True
+        assert dataframe_util.is_dask_object(dask_df) is True, (
+            f"Failed to detect dask dataframe with type {get_fqn_type(dask_df)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_df),
             pd.DataFrame,
         )
 
         dask_series = dask_df["x"]
-        assert dataframe_util.is_dask_object(dask_series) is True
+        assert dataframe_util.is_dask_object(dask_series) is True, (
+            f"Failed to detect dask series with type {get_fqn_type(dask_series)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_series),
             pd.DataFrame,
         )
 
         dask_index = dask_df.index
-        assert dataframe_util.is_dask_object(dask_index) is True
+        assert dataframe_util.is_dask_object(dask_index) is True, (
+            f"Failed to detect dask index with type {get_fqn_type(dask_index)}"
+        )
         assert isinstance(
             dataframe_util.convert_anything_to_pandas_df(dask_index),
             pd.DataFrame,


### PR DESCRIPTION
## Describe your changes

Dask recently removed the legacy types for dataframe, series, and object. This broke our support for dask objects and caused our integration tests to fail. This PR adds support for the new types.

## Testing Plan

- Existing tests should cover the new types. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
