### PR TITLE
Build Streamlit wheel file only for Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ cli-regression-tests: install
 distribution:
 	# Get rid of the old build and dist folders to make sure that we clean old js and css.
 	rm -rfv lib/build lib/dist
-	cd lib ; python3 setup.py bdist_wheel --universal sdist
+	cd lib ; python3 setup.py bdist_wheel sdist
 
 .PHONY: package
 # Build lib and frontend, and then run 'distribution'.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1974,7 +1974,7 @@ export class App extends PureComponent<Props, State> {
               }
               data-test-connection-state={connectionState}
             >
-              {/* The tabindex below is required for testing. */}
+              {/* The tabindex below is required for testing */}
               <Header>
                 {!hideTopBar && (
                   <>

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1974,7 +1974,7 @@ export class App extends PureComponent<Props, State> {
               }
               data-test-connection-state={connectionState}
             >
-              {/* The tabindex below is required for testing */}
+              {/* The tabindex below is required for testing. */}
               <Header>
                 {!hideTopBar && (
                   <>


### PR DESCRIPTION
## Describe your changes

Remove the `--universal` flag to produce wheel file only for Python3

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
