### PR TITLE
Add `autofix` command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,3 +463,18 @@ run-e2e-test:
 		echo "You can find test-results in ./e2e_playwright/test-results"; \
 		exit 1 \
 	)
+
+.PHONY: autofix
+# Autofix linting and formatting errors.
+autofix:
+	# Python fixes:
+	make pyformat
+	ruff check --fix
+	# JS fixes:
+	make react-init
+	make jsformat
+	cd frontend/ ; yarn workspaces foreach --all run lint --fix
+	# Other fixes:
+	make notices
+	# Run all pre-commit fixes but not fail if any of them don't work.
+	pre-commit run --all-files --hook-stage manual || true


### PR DESCRIPTION
## Describe your changes

Adds a `make autofix` command to the Makefile that automatically fixes linting and formatting issues and generates the notices + adds license headers.

Next step: Add a CI workflow that allows applying the auto fixes directly to a PR branch.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
