### PR TITLE
[fix] Fix width flickering in some components

### DIFF
--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ComponentType, useMemo } from "react"
+import React, { ComponentType } from "react"
 
 import hoistNonReactStatics from "hoist-non-react-statics"
 import { ReactElement } from "react-markdown/lib/react-markdown"
 
 import { Box } from "~lib/components/shared/Base/styled-components"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 /**
  * HOC that wraps a component and passes its width as a prop. Should only be
@@ -29,14 +29,11 @@ export const withCalculatedWidth = <P extends { width?: number }>(
   WrappedComponent: ComponentType<React.PropsWithChildren<P>>
 ): ComponentType<Omit<P, "width">> => {
   const EnhancedComponent = (props: Omit<P, "width">): ReactElement => {
-    const {
-      values: [width],
-      elementRef,
-    } = useResizeObserver(useMemo(() => ["width"], []))
+    const [width, elementRef] = useCalculatedWidth()
 
     return (
       <Box ref={elementRef}>
-        <WrappedComponent {...(props as P)} width={width || -1} />
+        <WrappedComponent {...(props as P)} width={width} />
       </Box>
     )
   }

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useMemo } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { useTheme } from "@emotion/react"
 import { ExpandLess, ExpandMore } from "@emotion-icons/material-outlined"
@@ -31,8 +31,8 @@ import BaseButton, {
   DynamicButtonLabel,
 } from "~lib/components/shared/BaseButton"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 import { Box } from "~lib/components/shared/Base/styled-components"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 import { StyledPopoverButtonIcon } from "./styled-components"
 
@@ -52,10 +52,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   const theme = useTheme()
   const lightBackground = hasLightBackgroundColor(theme)
 
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   return (
     <Box data-testid="stPopover" className="stPopover" ref={elementRef}>

--- a/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
@@ -21,7 +21,7 @@ import { useTheme } from "@emotion/react"
 import { StyledFullScreenFrame } from "~lib/components/shared/FullScreenWrapper/styled-components"
 import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
 import { EmotionTheme } from "~lib/theme"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 import { useFullscreen } from "./useFullscreen"
 
@@ -36,10 +36,7 @@ const ElementFullscreenWrapper: FC<ElementFullscreenWrapperProps> = ({
 }) => {
   const theme: EmotionTheme = useTheme()
   const { expanded, fullHeight, fullWidth, zoomIn, zoomOut } = useFullscreen()
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   const fullscreenContextValue = useMemo(() => {
     return {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -21,7 +21,6 @@ import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react"
@@ -54,8 +53,8 @@ import {
 } from "~lib/components/widgets/FileUploader/UploadFileInfo"
 import { FileUploadClient } from "~lib/FileUploadClient"
 import { getAccept } from "~lib/components/widgets/FileUploader/utils"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
 import { FileSize, sizeConverter } from "~lib/util/FileHelper"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 import {
   StyledChatInput,
@@ -109,10 +108,7 @@ function ChatInput({
   const counterRef = useRef(0)
   const heightGuidance = useRef({ minHeight: 0, maxHeight: 0 })
 
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   // True if the user-specified state.value has not yet been synced to the WidgetStateManager.
   const [dirty, setDirty] = useState(false)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -19,7 +19,6 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react"
@@ -48,7 +47,7 @@ import {
   WidgetLabel,
 } from "~lib/components/widgets/BaseWidget"
 import { EmotionTheme } from "~lib/theme"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 import {
   canDecrement,
@@ -89,10 +88,7 @@ const NumberInput: React.FC<Props> = ({
   const min = element.hasMin ? element.min : -Infinity
   const max = element.hasMax ? element.max : +Infinity
 
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   const [step, setStep] = useState<number>(getStep(element))
   const initialValue = getInitialValue({ element, widgetMgr })

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback, useMemo, useRef, useState } from "react"
+import React, { FC, memo, useCallback, useRef, useState } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 import { useTheme } from "@emotion/react"
@@ -39,7 +39,7 @@ import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 export interface Props {
   disabled: boolean
@@ -84,10 +84,7 @@ const TextArea: FC<Props> = ({ disabled, element, widgetMgr, fragmentId }) => {
   // eslint-disable-next-line react-compiler/react-compiler
   const id = useRef(uniqueId("text_area_")).current
 
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   /**
    * True if the user-specified state.value has not yet been synced to the WidgetStateManager.

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  useCallback,
-  useMemo,
-  useState,
-} from "react"
+import React, { memo, ReactElement, useCallback, useState } from "react"
 
 import uniqueId from "lodash/uniqueId"
 import { Input as UIInput } from "baseui/input"
@@ -44,7 +38,7 @@ import {
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { Placement } from "~lib/components/shared/Tooltip"
 import { isInForm, labelVisibilityProtoValueToEnum } from "~lib/util/utils"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 import { StyledTextInput } from "./styled-components"
 
@@ -69,10 +63,7 @@ function TextInput({
     getStateFromWidgetMgr(widgetMgr, element) ?? null
   )
 
-  const {
-    values: [width],
-    elementRef,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  const [width, elementRef] = useCalculatedWidth()
 
   /**
    * True if the user-specified state.value has not yet been synced to the WidgetStateManager.

--- a/frontend/lib/src/hooks/useCalculatedWidth.test.ts
+++ b/frontend/lib/src/hooks/useCalculatedWidth.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+
+import * as useResizeObserver from "./useResizeObserver"
+import { useCalculatedWidth } from "./useCalculatedWidth"
+
+describe("useCalculatedWidth", () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    { width: -100, expected: -100 },
+    { width: -1, expected: -1 },
+    { width: -0, expected: -1 },
+    { width: 0, expected: -1 },
+    { width: 1, expected: 1 },
+    { width: 100, expected: 100 },
+  ])(
+    "with an observed width of $width should return $expected",
+    ({ width, expected }) => {
+      vi.spyOn(useResizeObserver, "useResizeObserver").mockImplementation(
+        () => ({
+          values: [width],
+          elementRef: { current: null },
+          forceRecalculate: vi.fn(),
+        })
+      )
+
+      const { result } = renderHook(() => useCalculatedWidth())
+      expect(result.current[0]).toBe(expected)
+    }
+  )
+})

--- a/frontend/lib/src/hooks/useCalculatedWidth.ts
+++ b/frontend/lib/src/hooks/useCalculatedWidth.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MutableRefObject, useMemo } from "react"
+
+import { useResizeObserver } from "./useResizeObserver"
+
+/**
+ * A React hook that observes and returns the width of a DOM element.
+ *
+ * This hook uses a ResizeObserver to track changes to an element's width in real-time.
+ * It returns -1 instead of 0 when no width is detected to prevent visual flickering
+ * that might occur during initial rendering or when elements are temporarily hidden.
+ *
+ * @template T - The type of HTML element being observed (defaults to HTMLDivElement)
+ *
+ * @returns A tuple containing:
+ *   - The current width of the observed element in pixels (or -1 if width is 0)
+ *   - A ref object that should be attached to the element you want to observe
+ *
+ * @example
+ * ```tsx
+ * const MyComponent = () => {
+ *   const [width, ref] = useCalculatedWidth();
+ *
+ *   return (
+ *     <div ref={ref}>
+ *       Current width: {width === -1 ? 'calculating...' : `${width}px`}
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
+export const useCalculatedWidth = <T extends HTMLDivElement>(): [
+  number,
+  MutableRefObject<T | null>
+] => {
+  const {
+    values: [width],
+    elementRef,
+  } = useResizeObserver<T>(useMemo(() => ["width"], []))
+
+  return [width || -1, elementRef]
+}


### PR DESCRIPTION
## Describe your changes

- Refactors all usages of `useResizeObserver` for their widths into a single shared `useCalculatedWidth` hook
- Matches the previous behavior of setting width to `-1` instead of `0` uniformly across all components that read their own width. 
- Writes unit tests

## GitHub Issue Link (if applicable)

## Testing Plan

- Manually tested
- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
