### PR TITLE
Extend `host_config` endpoint with `blockErrorDialogs`

### DIFF
--- a/e2e_playwright/host_config.py
+++ b/e2e_playwright/host_config.py
@@ -17,6 +17,23 @@ import pandas as pd
 
 import streamlit as st
 
+
+def page2():
+    st.header("Page 2")
+
+
+def page3():
+    st.header("Page 3")
+
+
+# Make MPA to use for dialog blocking test
+st.navigation(
+    [
+        st.Page(page2, title="02_App_Page_2", default=True),
+        st.Page(page3, title="03_App_Page_3"),
+    ]
+)
+
 # always generate the same data
 np.random.seed(0)
 

--- a/e2e_playwright/host_config_test.py
+++ b/e2e_playwright/host_config_test.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Page, Route, expect
 from e2e_playwright.conftest import (
     ImageCompareFunction,
     wait_for_app_loaded,
+    wait_until,
 )
 
 
@@ -79,13 +80,15 @@ def test_block_error_dialogs(page: Page, app_port: int):
 
     # Navigate to a non-existent page to trigger page not found error
     page.goto(f"http://localhost:{app_port}/nonexistent_page")
-    page.wait_for_timeout(1000)
 
-    # Console includes 2 404 errors (health & host-config) + 1 error from page not found (last message)
-    last_message = messages.pop()
-    assert (
-        "The page that you have requested does not seem to exist. Running the app's main page."
-        in last_message.text
+    # Wait until the expected error is logged - console should include 2 404 errors (health & host-config) then the page not found error
+    wait_until(
+        page,
+        lambda: any(
+            "The page that you have requested does not seem to exist. Running the app's main page."
+            in message.text
+            for message in messages
+        ),
     )
 
     # Verify no error dialog is shown

--- a/e2e_playwright/host_config_test.py
+++ b/e2e_playwright/host_config_test.py
@@ -14,13 +14,17 @@
 
 from playwright.sync_api import Page, Route, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_loaded
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+)
 
 
-def handle_route_hostconfig_disable_fullscreen(route: Route) -> None:
+def handle_route_hostconfig_disable_fullscreen_and_error_dialogs(route: Route) -> None:
     response = route.fetch()
     body = response.json()
     body["disableFullscreenMode"] = True
+    body["blockErrorDialogs"] = True
     route.fulfill(
         # Pass all fields from the response.
         response=response,
@@ -33,7 +37,10 @@ def test_disable_fullscreen(
     page: Page, app_port: int, assert_snapshot: ImageCompareFunction
 ):
     """Test that fullscreen mode is disabled for elements when set via host-config."""
-    page.route("**/_stcore/host-config", handle_route_hostconfig_disable_fullscreen)
+    page.route(
+        "**/_stcore/host-config",
+        handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
+    )
     page.goto(f"http://localhost:{app_port}")
     wait_for_app_loaded(page)
 
@@ -52,3 +59,34 @@ def test_disable_fullscreen(
     assert_snapshot(
         dataframe_toolbar, name="host_config-dataframe_disabled_fullscreen_mode"
     )
+
+
+def test_block_error_dialogs(page: Page, app_port: int):
+    """Test that error dialogs are blocked and sent to host when set via host-config."""
+    # Need to be more specific about the route to allow for successful redirect
+    page.route(
+        f"http://localhost:{app_port}/_stcore/host-config",
+        handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
+    )
+
+    # Initial load of page
+    page.goto(f"http://localhost:{app_port}")
+    wait_for_app_loaded(page)
+
+    # Capture console messages
+    messages = []
+    page.on("console", lambda msg: messages.append(msg))
+
+    # Navigate to a non-existent page to trigger page not found error
+    page.goto(f"http://localhost:{app_port}/nonexistent_page")
+    page.wait_for_timeout(1000)
+
+    # Console includes 2 404 errors (health & host-config) + 1 error from page not found (last message)
+    last_message = messages.pop()
+    assert (
+        "The page that you have requested does not seem to exist. Running the app's main page."
+        in last_message.text
+    )
+
+    # # Verify no error dialog is shown
+    expect(page.get_by_role("dialog")).not_to_be_attached()

--- a/e2e_playwright/host_config_test.py
+++ b/e2e_playwright/host_config_test.py
@@ -88,5 +88,5 @@ def test_block_error_dialogs(page: Page, app_port: int):
         in last_message.text
     )
 
-    # # Verify no error dialog is shown
+    # Verify no error dialog is shown
     expect(page.get_by_role("dialog")).not_to_be_attached()

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2708,6 +2708,7 @@ describe("App", () => {
           enableCustomParentMessages: false,
           mapboxToken: "",
           metricsUrl: "test.streamlit.io",
+          blockErrorDialogs: false,
           ...options,
         })
       })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3432,7 +3432,7 @@ describe("App", () => {
         })
       })
 
-      it("blocks connection error dialog  ", () => {
+      it("blocks connection error dialog", () => {
         const hostCommunicationMgr = prepareHostCommunicationManager({
           blockErrorDialogs: true,
         })
@@ -3452,9 +3452,8 @@ describe("App", () => {
         })
       })
 
-      it("blocks deploy error dialog", () => {
-        // TODO: First verify that the deploy button exists in SIS
-      })
+      // TODO (mayagbarnes): First verify that the deploy button exists in SIS
+      // If so, add test for deploy error dialog
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -48,6 +48,7 @@ import {
   CustomThemeConfig,
   Delta,
   Element,
+  Exception,
   ForwardMsg,
   ForwardMsgMetadata,
   IAuthRedirect,
@@ -3374,6 +3375,86 @@ describe("App", () => {
 
       // Ensure rerun back message triggered
       expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
+    })
+
+    describe("blocks error dialogs when the host config option is set", () => {
+      it("blocks script compile error dialog", () => {
+        const hostCommunicationMgr = prepareHostCommunicationManager({
+          blockErrorDialogs: true,
+        })
+
+        // send a session event forward message with a script compile error
+        const sessionEvent = SessionEvent.create({
+          scriptCompilationException: Exception.create({
+            message: "random string",
+          }),
+        })
+        sendForwardMessage("sessionEvent", sessionEvent)
+
+        expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
+          type: "CLIENT_ERROR",
+          dialog: true,
+          error: "scriptCompileError",
+          message: "random string",
+        })
+      })
+
+      it("block bad message format dialog", () => {
+        const hostCommunicationMgr = prepareHostCommunicationManager({
+          blockErrorDialogs: true,
+        })
+
+        // @ts-expect-error - send an unknown type of forward message
+        sendForwardMessage("randomMessage", {})
+
+        expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
+          type: "CLIENT_ERROR",
+          dialog: true,
+          error: "Bad message format",
+          message: 'Cannot handle type "undefined".',
+        })
+      })
+
+      it("blocks page not found dialog", () => {
+        const hostCommunicationMgr = prepareHostCommunicationManager({
+          blockErrorDialogs: true,
+        })
+
+        // send a page not found forward message
+        sendForwardMessage("pageNotFound", { pageName: "random page" })
+
+        expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
+          type: "CLIENT_ERROR",
+          dialog: true,
+          error: "Page not found",
+          message:
+            "You have requested page /random page, but no corresponding file was found in the app's pages/ directory. Running the app's main page.",
+        })
+      })
+
+      it("blocks connection error dialog  ", () => {
+        const hostCommunicationMgr = prepareHostCommunicationManager({
+          blockErrorDialogs: true,
+        })
+
+        // Trigger a connection error dialog
+        act(() => {
+          getMockConnectionManagerProp("onConnectionError")(
+            "Connection error message."
+          )
+        })
+
+        expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
+          type: "CLIENT_ERROR",
+          dialog: true,
+          error: "Connection error",
+          message: "Connection error message.",
+        })
+      })
+
+      it("blocks deploy error dialog", () => {
+        // TODO: First verify that the deploy button exists in SIS
+      })
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3447,9 +3447,6 @@ describe("App", () => {
           message: "Connection error message.",
         })
       })
-
-      // TODO (mayagbarnes): First verify that the deploy button exists in SIS
-      // If so, add test for deploy error dialog
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3392,8 +3392,7 @@ describe("App", () => {
         sendForwardMessage("sessionEvent", sessionEvent)
 
         expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
-          type: "CLIENT_ERROR",
-          dialog: true,
+          type: "CLIENT_ERROR_DIALOG",
           error: "scriptCompileError",
           message: "random string",
         })
@@ -3408,8 +3407,7 @@ describe("App", () => {
         sendForwardMessage("randomMessage", {})
 
         expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
-          type: "CLIENT_ERROR",
-          dialog: true,
+          type: "CLIENT_ERROR_DIALOG",
           error: "Bad message format",
           message: 'Cannot handle type "undefined".',
         })
@@ -3424,8 +3422,7 @@ describe("App", () => {
         sendForwardMessage("pageNotFound", { pageName: "random page" })
 
         expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
-          type: "CLIENT_ERROR",
-          dialog: true,
+          type: "CLIENT_ERROR_DIALOG",
           error: "Page not found",
           message:
             "You have requested page /random page, but no corresponding file was found in the app's pages/ directory. Running the app's main page.",
@@ -3445,8 +3442,7 @@ describe("App", () => {
         })
 
         expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
-          type: "CLIENT_ERROR",
-          dialog: true,
+          type: "CLIENT_ERROR_DIALOG",
           error: "Connection error",
           message: "Connection error message.",
         })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -82,7 +82,6 @@ import {
   GitInfo,
   IAppPage,
   ICustomThemeConfig,
-  IException,
   IGitInfo,
   Initialize,
   Logo,
@@ -109,8 +108,8 @@ import ToolbarActions from "@streamlit/app/src/components/ToolbarActions"
 import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"
 import {
-  DialogProps,
   DeployErrorProps,
+  DialogProps,
   ScriptCompileErrorProps,
   StreamlitDialog,
   WarningProps,
@@ -562,7 +561,7 @@ export class App extends PureComponent<Props, State> {
    */
   maybeShowErrorDialog(
     newDialog: WarningProps | DeployErrorProps | ScriptCompileErrorProps,
-    errorMsg: string | IException | null = ""
+    errorMsg: string
   ): void {
     const { blockErrorDialogs } = this.state.appConfig
 
@@ -570,27 +569,21 @@ export class App extends PureComponent<Props, State> {
       // Show dialog as normal
       this.openDialog(newDialog)
     } else {
-      // @ts-expect-error - script compile error has exception property instead of title
       const {
+        // @ts-expect-error - script compile error has exception instead of title
         title: dialogTitle,
         type: dialogType,
-        exception: dialogException,
       } = newDialog
       const isScriptCompileError =
         dialogType === DialogType.SCRIPT_COMPILE_ERROR
       const error = isScriptCompileError ? dialogType : dialogTitle
-      const message =
-        isScriptCompileError && dialogException?.message
-          ? dialogException.message
-          : errorMsg
 
       // Send error info to host via postMessage instead
       this.hostCommunicationMgr.sendMessageToHost({
         type: "CLIENT_ERROR",
         dialog: true,
         error,
-        // @ts-expect-error - case where errorMsg is an exception handled above
-        message: message ?? "",
+        message: errorMsg,
       })
     }
   }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -82,6 +82,7 @@ import {
   GitInfo,
   IAppPage,
   ICustomThemeConfig,
+  IException,
   IGitInfo,
   Initialize,
   Logo,
@@ -109,7 +110,10 @@ import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"
 import {
   DialogProps,
+  DeployErrorProps,
+  ScriptCompileErrorProps,
   StreamlitDialog,
+  WarningProps,
 } from "@streamlit/app/src/components/StreamlitDialog"
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {
@@ -552,6 +556,45 @@ export class App extends PureComponent<Props, State> {
     window.removeEventListener("popstate", this.onHistoryChange, false)
   }
 
+  /**
+   * Checks whether to show error dialog or send error info
+   * to be handled by the host.
+   */
+  maybeShowErrorDialog(
+    newDialog: WarningProps | DeployErrorProps | ScriptCompileErrorProps,
+    errorMsg: string | IException | null = ""
+  ): void {
+    const { blockErrorDialogs } = this.state.appConfig
+
+    if (!blockErrorDialogs) {
+      // Show dialog as normal
+      this.openDialog(newDialog)
+    } else {
+      // @ts-expect-error - script compile error has exception property instead of title
+      const {
+        title: dialogTitle,
+        type: dialogType,
+        exception: dialogException,
+      } = newDialog
+      const isScriptCompileError =
+        dialogType === DialogType.SCRIPT_COMPILE_ERROR
+      const error = isScriptCompileError ? dialogType : dialogTitle
+      const message =
+        isScriptCompileError && dialogException?.message
+          ? dialogException.message
+          : errorMsg
+
+      // Send error info to host via postMessage instead
+      this.hostCommunicationMgr.sendMessageToHost({
+        type: "CLIENT_ERROR",
+        dialog: true,
+        error,
+        // @ts-expect-error - case where errorMsg is an exception handled above
+        message: message ?? "",
+      })
+    }
+  }
+
   showError(title: string, errorMarkdown: string): void {
     LOG.error(errorMarkdown)
     const newDialog: DialogProps = {
@@ -560,22 +603,24 @@ export class App extends PureComponent<Props, State> {
       msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
       onClose: () => {},
     }
-    this.openDialog(newDialog)
+    this.maybeShowErrorDialog(newDialog, errorMarkdown)
   }
 
   showDeployError = (
     title: string,
     errorNode: ReactNode,
+    errorMsg: string,
     onContinue?: () => void
   ): void => {
-    this.openDialog({
+    const newDialog: DialogProps = {
       type: DialogType.DEPLOY_ERROR,
       title,
       msg: errorNode,
       onContinue,
       onClose: () => {},
       onTryAgain: this.sendLoadGitInfoBackMsg,
-    })
+    }
+    this.maybeShowErrorDialog(newDialog, errorMsg)
   }
 
   /**
@@ -958,7 +1003,10 @@ export class App extends PureComponent<Props, State> {
         exception: sessionEvent.scriptCompilationException,
         onClose: () => {},
       }
-      this.openDialog(newDialog)
+      this.maybeShowErrorDialog(
+        newDialog,
+        sessionEvent.scriptCompilationException?.message ?? ""
+      )
     }
   }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -424,12 +424,14 @@ export class App extends PureComponent<Props, State> {
           mapboxToken,
           enforceDownloadInNewTab,
           metricsUrl,
+          blockErrorDialogs,
         } = response
 
         const appConfig: AppConfig = {
           allowedOrigins,
           useExternalAuthToken,
           enableCustomParentMessages,
+          blockErrorDialogs,
         }
         const libConfig: LibConfig = {
           mapboxToken,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -108,7 +108,6 @@ import ToolbarActions from "@streamlit/app/src/components/ToolbarActions"
 import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"
 import {
-  DeployErrorProps,
   DialogProps,
   ScriptCompileErrorProps,
   StreamlitDialog,
@@ -560,7 +559,7 @@ export class App extends PureComponent<Props, State> {
    * to be handled by the host.
    */
   maybeShowErrorDialog(
-    newDialog: WarningProps | DeployErrorProps | ScriptCompileErrorProps,
+    newDialog: WarningProps | ScriptCompileErrorProps,
     errorMsg: string
   ): void {
     // Show dialog only if blockErrorDialogs host config is false
@@ -596,7 +595,6 @@ export class App extends PureComponent<Props, State> {
   showDeployError = (
     title: string,
     errorNode: ReactNode,
-    errorMsg: string,
     onContinue?: () => void
   ): void => {
     const newDialog: DialogProps = {
@@ -607,7 +605,7 @@ export class App extends PureComponent<Props, State> {
       onClose: () => {},
       onTryAgain: this.sendLoadGitInfoBackMsg,
     }
-    this.maybeShowErrorDialog(newDialog, errorMsg)
+    this.openDialog(newDialog)
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -563,29 +563,23 @@ export class App extends PureComponent<Props, State> {
     newDialog: WarningProps | DeployErrorProps | ScriptCompileErrorProps,
     errorMsg: string
   ): void {
+    // Show dialog only if blockErrorDialogs host config is false
     const { blockErrorDialogs } = this.state.appConfig
-
     if (!blockErrorDialogs) {
-      // Show dialog as normal
       this.openDialog(newDialog)
-    } else {
-      const {
-        // @ts-expect-error - script compile error has exception instead of title
-        title: dialogTitle,
-        type: dialogType,
-      } = newDialog
-      const isScriptCompileError =
-        dialogType === DialogType.SCRIPT_COMPILE_ERROR
-      const error = isScriptCompileError ? dialogType : dialogTitle
-
-      // Send error info to host via postMessage instead
-      this.hostCommunicationMgr.sendMessageToHost({
-        type: "CLIENT_ERROR",
-        dialog: true,
-        error,
-        message: errorMsg,
-      })
     }
+
+    const isScriptCompileError =
+      newDialog.type === DialogType.SCRIPT_COMPILE_ERROR
+    // script compile error has no title
+    const error = isScriptCompileError ? newDialog.type : newDialog.title
+
+    // Send error info to host via postMessage
+    this.hostCommunicationMgr.sendMessageToHost({
+      type: "CLIENT_ERROR_DIALOG",
+      error,
+      message: errorMsg,
+    })
   }
 
   showError(title: string, errorMarkdown: string): void {
@@ -998,7 +992,7 @@ export class App extends PureComponent<Props, State> {
       }
       this.maybeShowErrorDialog(
         newDialog,
-        sessionEvent.scriptCompilationException?.message ?? ""
+        sessionEvent.scriptCompilationException?.message ?? "No message"
       )
     }
   }

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -78,6 +78,7 @@ export interface DeployDialogProps {
   showDeployError: (
     title: string,
     errorNode: ReactNode,
+    errorMsg: string,
     onContinue?: () => void
   ) => void
   isDeployErrorModalOpen: boolean
@@ -99,7 +100,7 @@ export function DeployDialog(
     if (!gitInfo) {
       const dialog = NoRepositoryDetected()
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, "No repository detected")
 
       return
     }
@@ -116,7 +117,7 @@ export function DeployDialog(
     if (hasMissingGitInfo && gitState === GitStates.DEFAULT) {
       const dialog = NoRepositoryDetected()
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, "No repository detected")
 
       return
     }
@@ -124,7 +125,7 @@ export function DeployDialog(
     if (gitState === GitStates.HEAD_DETACHED) {
       const dialog = DetachedHead()
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, "Detached head")
 
       return
     }
@@ -132,7 +133,7 @@ export function DeployDialog(
     if (module && untrackedFiles?.includes(module)) {
       const dialog = ModuleIsNotAdded(module)
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, "Module not added")
 
       return
     }

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -78,7 +78,6 @@ export interface DeployDialogProps {
   showDeployError: (
     title: string,
     errorNode: ReactNode,
-    errorMsg: string,
     onContinue?: () => void
   ) => void
   isDeployErrorModalOpen: boolean
@@ -100,7 +99,7 @@ export function DeployDialog(
     if (!gitInfo) {
       const dialog = NoRepositoryDetected()
 
-      showDeployError(dialog.title, dialog.body, "No repository detected")
+      showDeployError(dialog.title, dialog.body)
 
       return
     }
@@ -117,7 +116,7 @@ export function DeployDialog(
     if (hasMissingGitInfo && gitState === GitStates.DEFAULT) {
       const dialog = NoRepositoryDetected()
 
-      showDeployError(dialog.title, dialog.body, "No repository detected")
+      showDeployError(dialog.title, dialog.body)
 
       return
     }
@@ -125,7 +124,7 @@ export function DeployDialog(
     if (gitState === GitStates.HEAD_DETACHED) {
       const dialog = DetachedHead()
 
-      showDeployError(dialog.title, dialog.body, "Detached head")
+      showDeployError(dialog.title, dialog.body)
 
       return
     }
@@ -133,7 +132,7 @@ export function DeployDialog(
     if (module && untrackedFiles?.includes(module)) {
       const dialog = ModuleIsNotAdded(module)
 
-      showDeployError(dialog.title, dialog.body, "Module not added")
+      showDeployError(dialog.title, dialog.body)
 
       return
     }

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -208,7 +208,7 @@ function clearCacheDialog(props: ClearCacheProps): ReactElement {
   )
 }
 
-interface ScriptCompileErrorProps {
+export interface ScriptCompileErrorProps {
   type: DialogType.SCRIPT_COMPILE_ERROR
   exception: IException | null | undefined
   onClose: PlainEventHandler
@@ -241,7 +241,7 @@ function settingsDialog(props: SettingsProps): ReactElement {
   return <SettingsDialog {...props} />
 }
 
-interface WarningProps {
+export interface WarningProps {
   type: DialogType.WARNING
   title: string
   msg: ReactNode
@@ -260,7 +260,7 @@ function warningDialog(props: WarningProps): ReactElement {
   )
 }
 
-interface DeployErrorProps {
+export interface DeployErrorProps {
   type: DialogType.DEPLOY_ERROR
   title: string
   msg: ReactNode

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -260,7 +260,7 @@ function warningDialog(props: WarningProps): ReactElement {
   )
 }
 
-export interface DeployErrorProps {
+interface DeployErrorProps {
   type: DialogType.DEPLOY_ERROR
   title: string
   msg: ReactNode

--- a/frontend/app/src/components/StreamlitDialog/index.ts
+++ b/frontend/app/src/components/StreamlitDialog/index.ts
@@ -14,4 +14,10 @@
  * limitations under the License.
  */
 export { StreamlitDialog } from "./StreamlitDialog"
-export type { DialogProps, PlainEventHandler } from "./StreamlitDialog"
+export type {
+  DialogProps,
+  PlainEventHandler,
+  ScriptCompileErrorProps,
+  WarningProps,
+  DeployErrorProps,
+} from "./StreamlitDialog"

--- a/frontend/app/src/components/StreamlitDialog/index.ts
+++ b/frontend/app/src/components/StreamlitDialog/index.ts
@@ -19,5 +19,4 @@ export type {
   PlainEventHandler,
   ScriptCompileErrorProps,
   WarningProps,
-  DeployErrorProps,
 } from "./StreamlitDialog"

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -187,6 +187,11 @@ export type AppConfig = {
    * Enables custom string messages to be sent to the host
    */
   enableCustomParentMessages?: boolean
+  /**
+   * Whether host wants to block error dialogs. If true, blocks error dialogs
+   * from being shown to the user, sends error info to host via postMessage
+   */
+  blockErrorDialogs?: boolean
 }
 
 export type MetricsConfig = {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -234,6 +234,12 @@ export type IGuestToHostMessage =
       eventName: string
       data: MetricsEvent
     }
+  | {
+      type: "CLIENT_ERROR"
+      dialog: boolean
+      error: string
+      message?: string
+    }
 
 export type VersionedMessage<Message> = {
   stCommVersion: number

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -50,6 +50,11 @@ export type AppConfig = {
    * Enables custom string messages to be sent to the host
    */
   enableCustomParentMessages?: boolean
+  /**
+   * Whether host wants to block error dialogs. If true, blocks error dialogs
+   * from being shown to the user, sends error info to host via postMessage
+   */
+  blockErrorDialogs?: boolean
 }
 
 export type DeployedAppMetadata = {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -235,8 +235,7 @@ export type IGuestToHostMessage =
       data: MetricsEvent
     }
   | {
-      type: "CLIENT_ERROR"
-      dialog: boolean
+      type: "CLIENT_ERROR_DIALOG"
       error: string
       message?: string
     }

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -236,6 +236,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
+                "blockErrorDialogs": False,
             }
         )
         self.set_status(200)

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -305,6 +305,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
+                "blockErrorDialogs": False,
             },
             response_body,
         )


### PR DESCRIPTION
## Describe your changes
**Part 1 of sending client errors to host: PR going into feature branch** 
* Add a config to the `host_config` endpoint - `blockErrorDialogs` - which is plumbed to the `appConfig` slice of state in `App.tsx`. Config is `False` by default - does not change existing behavior.
* Adds new Guest -> Host message `"CLIENT_ERROR_DIALOG"` to send error information to the host whenever these error dialogs are encountered for their metrics
* When set to `True`, config blocks App error dialogs, as follows:
    *  Page not found
    * Bad message format 
    * Connection error
    * Script Compile Error

## Testing Plan
- JS & Python Unit Tests: ✅ 
- E2E Tests: ✅ 
- Manual Testing: ✅ 