### PR TITLE
[feat] Add Dockerfile for better e2e testing locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Version control
+# .git
+# .gitignore
+# .github
+
+# Node.js
+node_modules
+**/node_modules
+frontend/node_modules
+v8-compile-cache-0
+node-compile-cache
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.coverage
+htmlcov/
+.hypothesis/
+.benchmarks/
+
+# Docker
+Dockerfile
+.dockerignore
+docker-e2e-README.md
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+.DS_Store
+.cursor
+
+# Frontend
+.swc
+.swc-cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,6 +164,20 @@ repos:
           /vendor/
           |^vendor/
           |^component-lib/declarations/apache-arrow
+      - id: insert-license
+        name: Add license for all Dockerfile files
+        files: Dockerfile$
+        args:
+          - --comment-style
+          - "|#|"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/e2e_playwright/Dockerfile
+++ b/e2e_playwright/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.13-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    rsync \
+    nodejs \
+    npm \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs
+
+# Set working directory
+WORKDIR /app
+
+# Copy the repository (filtered by .dockerignore)
+COPY . .
+
+# Install dependencies and set up the development environment
+RUN corepack enable && cd frontend && corepack install && cd .. && make all-devel
+
+# Build the frontend for e2e testing
+RUN make frontend-build-with-profiler
+
+# Default command
+CMD ["/bin/bash"]

--- a/e2e_playwright/docker-e2e-README.md
+++ b/e2e_playwright/docker-e2e-README.md
@@ -1,0 +1,84 @@
+# Docker Environment for E2E Testing
+
+This Dockerfile creates a Linux-based environment for running and debugging Streamlit's end-to-end tests.
+
+**Note:** Snapshot testing will yield different results on different machines. Therefore, this container is not suitable for getting consistent snapshot results. We should still rely on CI results for snapshot testing.
+
+## Overview
+
+The Docker build uses a `.dockerignore` file to exclude non-git tracked files such as `node_modules` directories and build artifacts.
+
+## Dependencies
+
+The container includes:
+
+- Python 3.13
+- Node.js (current LTS)
+- Protocol Buffers compiler (`protoc`)
+- All dependency setup from `make all-devel`
+
+## Quick Start
+
+### Building the Image
+
+```bash
+docker build -t streamlit-e2e-test -f ./e2e_playwright/Dockerfile .
+```
+
+### Running the Container
+
+```bash
+docker run -it --rm -p 8501:8501 streamlit-e2e-test
+```
+
+### Running E2E Tests
+
+Once inside the container:
+
+```bash
+cd /e2e_playwright
+pytest ./<file_name>.py
+```
+
+#### Tips:
+
+- It is worthwhile to to run pytest with parallelism in order to get similar runtime characteristics as CI:
+  ```bash
+  pytest -n auto ./<file_name>.py
+  ```
+
+## Development Workflow
+
+### Mounting Local Code
+
+For faster development, mount your local code into the container:
+
+```bash
+docker run -it --rm -p 8501:8501 \
+  -v $(pwd)/.git:/app/.git \
+  -v $(pwd)/lib:/app/lib \
+  -v $(pwd)/frontend/app/src:/app/frontend/app/src \
+  -v $(pwd)/frontend/app/package.json:/app/frontend/app/package.json \
+  -v $(pwd)/frontend/lib/src:/app/frontend/lib/src \
+  -v $(pwd)/frontend/lib/package.json:/app/frontend/lib/package.json \
+  -v $(pwd)/e2e_playwright:/app/e2e_playwright \
+  -e GIT_DISCOVERY_ACROSS_FILESYSTEM=true \
+  streamlit-e2e-test
+```
+
+> **Note:** Volume mounts bypass the `.dockerignore` file. The targeted approach above:
+>
+> - Mounts only necessary directories
+> - Avoids dependency conflicts
+> - Preserves the container's optimized environment
+> - Improves performance
+>
+> You can customize directory mounts based on your needs.
+
+### After Frontend Changes
+
+If you modify frontend code, rebuild the frontend in the container before re-running your tests:
+
+```bash
+make frontend-build-with-profiler
+```

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -9,7 +9,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "vite",
     "build": "env NODE_OPTIONS=--max_old_space_size=8192 vite build",
-    "buildWithProfiler": "env IS_PROFILER_BUILD=1 vite build",
+    "buildWithProfiler": "env NODE_OPTIONS=--max_old_space_size=8192 env IS_PROFILER_BUILD=1 vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "testWatch": "vitest",


### PR DESCRIPTION
## Describe your changes

- Adds a `e2e_playwright/Dockerfile` with the intention of making e2e failures in a linux environment easier to reproduce
- Adds documentation on how to use the Dockerfile along with instructions for things like local file system mounting

## GitHub Issue Link (if applicable)

## Testing Plan

- Tested locally

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
