### PR TITLE
Use string path for page `__file__`

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -292,8 +292,8 @@ class StreamlitPage:
             else:
                 code = ctx.pages_manager.get_page_script_byte_code(str(self._page))
                 module = types.ModuleType("__main__")
-                # We want __file__ to be the path to the script
-                module.__dict__["__file__"] = self._page
+                # We want __file__ to be the string path to the script
+                module.__dict__["__file__"] = str(self._page)
                 exec(code, module.__dict__)
 
     @property


### PR DESCRIPTION
## Describe your changes

When running the tests locally via `make pytest`, I get this error: `AttributeError: 'PosixPath' object has no attribute 'endswith'` which is related to us setting the page module path to a `Path` object instead of a string path. Not sure why it works in our CI, but the `__file__` property is expected to be a string path in Python. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
