### PR TITLE
Fix usage of "sans serife" as font

### DIFF
--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -817,7 +817,7 @@ describe("parseFont", () => {
     ["SANS-SERIF", '"Source Sans Pro", sans-serif'], // All caps
     ["sans serif", '"Source Sans Pro", sans-serif'], // With space
     ["serif", '"Source Serif Pro", serif'],
-    ["monospace", '"Source Code Pro", monospac'],
+    ["monospace", '"Source Code Pro", monospace'],
 
     // Test fonts that aren't in the map (should return as-is)
     ["Arial", "Arial"],

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -42,6 +42,7 @@ import {
   getSystemTheme,
   isColor,
   isPresetTheme,
+  parseFont,
   removeCachedTheme,
   setCachedTheme,
   toThemeInput,
@@ -805,5 +806,26 @@ describe("theme overrides", () => {
     const module = await import("./utils")
     expect(module.getMergedLightTheme()).toEqual(lightTheme)
     expect(module.getMergedDarkTheme()).toEqual(darkTheme)
+  })
+})
+
+describe("parseFont", () => {
+  it.each([
+    // Test standard font mappings
+    ["sans-serif", '"Source Sans Pro", sans-serif'],
+    ["Sans-Serif", '"Source Sans Pro", sans-serif'], // Case insensitive
+    ["SANS-SERIF", '"Source Sans Pro", sans-serif'], // All caps
+    ["sans serif", '"Source Sans Pro", sans-serif'], // With space
+    ["serif", '"Source Serif Pro", serif'],
+    ["monospace", '"IBM Plex Mono", monospace'],
+
+    // Test fonts that aren't in the map (should return as-is)
+    ["Arial", "Arial"],
+    ["Helvetica", "Helvetica"],
+    ["Times New Roman", "Times New Roman"],
+    ["Comic Sans MS", "Comic Sans MS"],
+    ["", ""],
+  ])("correctly maps '%s' to '%s'", (input, expected) => {
+    expect(parseFont(input)).toBe(expected)
   })
 })

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -817,7 +817,7 @@ describe("parseFont", () => {
     ["SANS-SERIF", '"Source Sans Pro", sans-serif'], // All caps
     ["sans serif", '"Source Sans Pro", sans-serif'], // With space
     ["serif", '"Source Serif Pro", serif'],
-    ["monospace", '"IBM Plex Mono", monospace'],
+    ["monospace", '"Source Code Pro", monospac'],
 
     // Test fonts that aren't in the map (should return as-is)
     ["Arial", "Arial"],

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -129,7 +129,7 @@ export const isColor = (strColor: string): boolean => {
   return s.color !== ""
 }
 
-const parseFont = (font: string): string => {
+export const parseFont = (font: string): string => {
   // Try to map a short font family to our default
   // font families
   const fontMap: Record<string, string> = {
@@ -137,9 +137,12 @@ const parseFont = (font: string): string => {
     serif: fonts.serif,
     monospace: fonts.monospace,
   }
+  // The old font config supported "sans serif" as a font family, but this
+  // isn't a valid font family, so we need to support it by converting it to
+  // "sans-serif".
   const fontKey = font.toLowerCase().replaceAll(" ", "-")
   if (fontKey in fontMap) {
-    return fontMap[font]
+    return fontMap[fontKey]
   }
 
   // If the font is not in the map, return the font as is:


### PR DESCRIPTION
## Describe your changes

Our old `font` property allowed configuring the font family to `sans serif`. This isn't a valid CSS font family, but we still want to support it for backwards compatibility reasons. This PR fixes the mapping that we apply to map to our font family we defined for `sans-serif`.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10786

## Testing Plan

- Added unit test to cover this.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
