### PR TITLE
Temporarly skipping more dataframe firefox tests to lower flakiness

### DIFF
--- a/e2e_playwright/st_dataframe_interactions_test.py
+++ b/e2e_playwright/st_dataframe_interactions_test.py
@@ -152,6 +152,8 @@ def test_data_editor_delete_row_via_hotkey(app: Page):
     expect(data_editor_element).to_have_css("height", "212px")
 
 
+# The snapshots are flaky on Firefox in CI.
+@pytest.mark.skip_browser("firefox")
 def test_data_editor_add_row_via_toolbar(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
@@ -280,6 +282,8 @@ def test_open_search_via_hotkey(app: Page):
     expect(app.locator(".gdg-search-bar-inner")).to_be_visible()
 
 
+# The snapshots are flaky on Firefox in CI.
+@pytest.mark.skip_browser("firefox")
 def test_clicking_on_fullscreen_toolbar_button(
     app: Page, assert_snapshot: ImageCompareFunction
 ):


### PR DESCRIPTION
## Describe your changes

Temporarily skipping some dataframe interaction e2e tests for firefox to remove some annoying flakiness. I will look at this again at a later point to get these tests running again. I verified it locally with Firefox that it's working as expected.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
