### PR TITLE
Replace third-party github action in community voting workflow

### DIFF
--- a/.github/workflows/community-voting.yml
+++ b/.github/workflows/community-voting.yml
@@ -24,10 +24,16 @@ jobs:
 
             ![Visits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&title=visits&edge_flat=false)
       - name: Upvote issue
-        uses: aidan-mundy/react-to-issue@b2a9194cf1ea483d633bc2834ed6c4c41c2a45f0
+        uses: actions/github-script@v7
         with:
-          issue-number: ${{ github.event.issue.number }}
-          reactions: "+1"
+          script: |
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: '+1'
+            });
+            console.log(`Added +1 reaction to issue #${context.issue.number}`);
   add-bug-comment:
     if: github.event.label.name == 'type:bug'
     runs-on: ubuntu-latest
@@ -45,7 +51,13 @@ jobs:
 
             ![Visits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&title=visits&edge_flat=false)
       - name: Upvote issue
-        uses: aidan-mundy/react-to-issue@b2a9194cf1ea483d633bc2834ed6c4c41c2a45f0
+        uses: actions/github-script@v7
         with:
-          issue-number: ${{ github.event.issue.number }}
-          reactions: "+1"
+          script: |
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: '+1'
+            });
+            console.log(`Added +1 reaction to issue #${context.issue.number}`);


### PR DESCRIPTION
## Describe your changes

Replaces `aidan-mundy/react-to-issue` action with custom `actions/github-script` logic to auto-comment on new issues and upvote.

Will need some testing once it is merged.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
