### PR TITLE
Don't set imported theme if font faces is empty

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1717,6 +1717,45 @@ describe("App", () => {
     })
   })
 
+  describe("App.processThemeInput", () => {
+    it("calls setImportedTheme when fontFaces are provided", () => {
+      const fontFaces = [{ url: "test-url" }]
+      const themeInput = new CustomThemeConfig({
+        primaryColor: "blue",
+        fontFaces,
+      })
+
+      const props = getProps()
+      renderApp(props)
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: themeInput,
+      })
+
+      // Should have called setImportedTheme
+      expect(props.theme.setImportedTheme).toHaveBeenCalledWith(themeInput)
+    })
+
+    it("doesn't call setImportedTheme when fontFaces is empty", () => {
+      const themeInput = new CustomThemeConfig({
+        primaryColor: "blue",
+        fontFaces: [],
+      })
+
+      const props = getProps()
+      renderApp(props)
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: themeInput,
+      })
+
+      // Should not have called setImportedTheme
+      expect(props.theme.setImportedTheme).not.toHaveBeenCalled()
+    })
+  })
+
   describe("App.handleScriptFinished", () => {
     it("will not increment cache count if session info is not set", () => {
       renderApp(getProps())

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1194,7 +1194,7 @@ export class App extends PureComponent<Props, State> {
       }
     }
 
-    if (themeInput?.fontFaces) {
+    if (themeInput?.fontFaces && themeInput.fontFaces.length > 0) {
       // If font faces are provided, we need to set the imported theme with the theme
       // manager to make the font faces available.
       this.props.theme.setImportedTheme(themeInput)


### PR DESCRIPTION
## Describe your changes

It looks like when `fontFaces` config is not provided, it defaults to an empty array which would pass the current check to trigger `setImportedTheme`

In this PR:
* [`frontend/app/src/App.tsx`](diffhunk://#diff-1b95d4e0dda1e5928f99c8303599bd811f140fdd40e028fcfca3077f802d6210L1197-R1197): Updated the `App` component to check if `fontFaces` is non-empty before calling `setImportedTheme`.
* [`frontend/app/src/App.test.tsx`](diffhunk://#diff-dfcf6ed685bcc5a501a25d24d90c4a44789cc7a08aa9201b62719001f3e3f229R1720-R1758): Added new test cases to ensure `setImportedTheme` is called only when `fontFaces` are provided and non-empty.


## GitHub Issue Link (if applicable)

## Testing Plan

JS test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
