### PR TITLE
[refactor] Reduce unnecessary Dialog re-renders

### DIFF
--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -71,7 +71,7 @@ describe("Dialog container", () => {
       </Dialog>
     )
 
-    expect(() => screen.getByText("test")).toThrow()
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
   })
 
   it("should close when dismissible", async () => {
@@ -86,7 +86,7 @@ describe("Dialog container", () => {
     expect(screen.getByText("test")).toBeVisible()
     await user.click(screen.getByLabelText("Close"))
     // dialog should be closed by clicking outside and, thus, the content should be gone
-    expect(() => screen.getByText("test")).toThrow()
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
   })
 
   it("should not close when not dismissible", () => {
@@ -99,6 +99,203 @@ describe("Dialog container", () => {
 
     expect(screen.getByText("test")).toBeVisible()
     // close button - and hence dismiss - does not exist
-    expect(() => screen.getByLabelText("Close")).toThrow()
+    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument()
+  })
+
+  it("should reopen dialog when deltaMsgReceivedAt changes even if isOpen hasn't changed", async () => {
+    // Initial render with dialog open
+    const initialProps = getProps()
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    expect(screen.getByText("test")).toBeVisible()
+
+    // User closes the dialog
+    await userEvent.click(screen.getByLabelText("Close"))
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+
+    // New message arrives with same isOpen=true but different deltaMsgReceivedAt
+    const newProps = getProps({}, { deltaMsgReceivedAt: Date.now() })
+    rerender(
+      <Dialog {...newProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible again
+    expect(screen.getByText("test")).toBeVisible()
+  })
+
+  it("should reset dialog state when isOpen prop changes", () => {
+    // Initial render with dialog closed
+    const initialProps = getProps({ isOpen: false })
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be closed
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+
+    // Change isOpen to true
+    const newProps = getProps({ isOpen: true })
+    rerender(
+      <Dialog {...newProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible
+    expect(screen.getByText("test")).toBeVisible()
+  })
+
+  it("should maintain closed state when only title changes", async () => {
+    // Initial render with dialog open
+    const initialProps = getProps()
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible
+    expect(screen.getByText("test")).toBeVisible()
+
+    // User closes the dialog
+    await userEvent.click(screen.getByLabelText("Close"))
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+
+    // Only title changes
+    const newProps = getProps({ title: "New Title" })
+    rerender(
+      <Dialog {...newProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should remain closed
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+  })
+
+  it("should handle null initialIsOpen correctly", () => {
+    // Create props with undefined isOpen
+    const element = BlockProto.Dialog.create({
+      title: "StreamlitDialog",
+      dismissible: true,
+      isOpen: null,
+    })
+    const props = { element }
+
+    render(
+      <Dialog {...props}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be closed by default when isOpen is null
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+  })
+
+  it("should handle multiple deltaMsgReceivedAt changes", async () => {
+    // Initial render with dialog open
+    const initialProps = getProps()
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    expect(screen.getByText("test")).toBeVisible()
+
+    // User closes the dialog
+    await userEvent.click(screen.getByLabelText("Close"))
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+
+    // First message arrives
+    const firstMsgProps = getProps({}, { deltaMsgReceivedAt: Date.now() })
+    rerender(
+      <Dialog {...firstMsgProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible again
+    expect(screen.getByText("test")).toBeVisible()
+
+    // User closes the dialog again
+    await userEvent.click(screen.getByLabelText("Close"))
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+
+    // Second message arrives
+    const secondMsgProps = getProps(
+      {},
+      { deltaMsgReceivedAt: Date.now() + 1000 }
+    )
+    rerender(
+      <Dialog {...secondMsgProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible again
+    expect(screen.getByText("test")).toBeVisible()
+  })
+
+  it("should handle isOpen changing from true to false", () => {
+    // Initial render with dialog open
+    const initialProps = getProps({ isOpen: true })
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be visible
+    expect(screen.getByText("test")).toBeVisible()
+
+    // Change isOpen to false
+    const newProps = getProps({ isOpen: false })
+    rerender(
+      <Dialog {...newProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Dialog should be closed
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+  })
+
+  it("should update title when it changes while dialog is open", () => {
+    // Initial render with dialog open and initial title
+    const initialTitle = "Initial Title"
+    const initialProps = getProps({ title: initialTitle })
+    const { rerender } = render(
+      <Dialog {...initialProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // Initial title should be visible
+    expect(screen.getByText(initialTitle)).toBeVisible()
+
+    // Change title while dialog remains open
+    const newTitle = "Updated Title"
+    const newProps = getProps({ title: newTitle })
+    rerender(
+      <Dialog {...newProps}>
+        <div>test</div>
+      </Dialog>
+    )
+
+    // New title should be visible
+    expect(screen.getByText(newTitle)).toBeVisible()
+    // Old title should no longer be present
+    expect(screen.queryByText(initialTitle)).not.toBeInTheDocument()
+    // Dialog content should still be visible
+    expect(screen.getByText("test")).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -103,6 +103,7 @@ describe("Dialog container", () => {
   })
 
   it("should reopen dialog when deltaMsgReceivedAt changes even if isOpen hasn't changed", async () => {
+    const user = userEvent.setup()
     // Initial render with dialog open
     const initialProps = getProps()
     const { rerender } = render(
@@ -114,7 +115,7 @@ describe("Dialog container", () => {
     expect(screen.getByText("test")).toBeVisible()
 
     // User closes the dialog
-    await userEvent.click(screen.getByLabelText("Close"))
+    await user.click(screen.getByLabelText("Close"))
     expect(screen.queryByText("test")).not.toBeInTheDocument()
 
     // New message arrives with same isOpen=true but different deltaMsgReceivedAt
@@ -154,6 +155,7 @@ describe("Dialog container", () => {
   })
 
   it("should maintain closed state when only title changes", async () => {
+    const user = userEvent.setup()
     // Initial render with dialog open
     const initialProps = getProps()
     const { rerender } = render(
@@ -166,7 +168,7 @@ describe("Dialog container", () => {
     expect(screen.getByText("test")).toBeVisible()
 
     // User closes the dialog
-    await userEvent.click(screen.getByLabelText("Close"))
+    await user.click(screen.getByLabelText("Close"))
     expect(screen.queryByText("test")).not.toBeInTheDocument()
 
     // Only title changes
@@ -201,6 +203,7 @@ describe("Dialog container", () => {
   })
 
   it("should handle multiple deltaMsgReceivedAt changes", async () => {
+    const user = userEvent.setup()
     // Initial render with dialog open
     const initialProps = getProps()
     const { rerender } = render(
@@ -212,7 +215,7 @@ describe("Dialog container", () => {
     expect(screen.getByText("test")).toBeVisible()
 
     // User closes the dialog
-    await userEvent.click(screen.getByLabelText("Close"))
+    await user.click(screen.getByLabelText("Close"))
     expect(screen.queryByText("test")).not.toBeInTheDocument()
 
     // First message arrives
@@ -227,7 +230,7 @@ describe("Dialog container", () => {
     expect(screen.getByText("test")).toBeVisible()
 
     // User closes the dialog again
-    await userEvent.click(screen.getByLabelText("Close"))
+    await user.click(screen.getByLabelText("Close"))
     expect(screen.queryByText("test")).not.toBeInTheDocument()
 
     // Second message arrives

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useState } from "react"
+import React, { memo, ReactElement, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
@@ -29,22 +29,13 @@ export interface Props {
 
 const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
   element,
-  deltaMsgReceivedAt,
   children,
 }): ReactElement => {
   const { title, dismissible, width, isOpen: initialIsOpen } = element
-  const [isOpen, setIsOpen] = useState<boolean>(false)
-
-  useEffect(() => {
-    // Only apply the open state if it was actually set in the proto.
-    if (notNullOrUndefined(initialIsOpen)) {
-      setIsOpen(initialIsOpen)
-    }
-
-    // when the deltaMsgReceivedAt changes, we might want to open the dialog again.
-    // since dismissing is a UI-only action, the initialIsOpen prop might not have
-    // changed which would lead to the dialog not opening again.
-  }, [initialIsOpen, deltaMsgReceivedAt])
+  // Initialize state directly from props since component will be recreated with new key when props change
+  const [isOpen, setIsOpen] = useState<boolean>(() =>
+    notNullOrUndefined(initialIsOpen) ? initialIsOpen : false
+  )
 
   // don't use the Modal's isOpen prop as it feels laggy when using it
   if (!isOpen) {
@@ -67,9 +58,13 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
 function DialogWithProvider(
   props: React.PropsWithChildren<Props>
 ): ReactElement {
+  // Create a key based on the element and deltaMsgReceivedAt to reset state when they change
+  const { element, deltaMsgReceivedAt } = props
+  const dialogKey = `${element.isOpen}-${deltaMsgReceivedAt}`
+
   return (
     <IsDialogContext.Provider value={true}>
-      <Dialog {...props} />
+      <Dialog key={dialogKey} {...props} />
     </IsDialogContext.Provider>
   )
 }


### PR DESCRIPTION
## Describe your changes

- Leveraging the guidance from [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes), this replaces an unnecessary `useEffect` call with a localized React Key
- Adds a number of unit tests
  - Confirmed locally that these tests work with both the prior and the current implementation

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
