### PR TITLE
[fix] HTML in tabs content render fixes

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -46,3 +46,9 @@ st.tabs(
         ":material/check_circle: Icon",
     ]
 )
+
+
+tabs = st.tabs(["HTML Tab 1", "HTML Tab 2", "HTML Tab 3"])
+
+for i, tab in enumerate(tabs):
+    tab.html(f"<h1>Hello</h1><p>This is HTML tab {i + 1}</p>")

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -20,7 +20,7 @@ from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
 
 def test_tabs_render_correctly(themed_app: Page, assert_snapshot: ImageCompareFunction):
     st_tabs = themed_app.get_by_test_id("stTabs")
-    expect(st_tabs).to_have_count(4)
+    expect(st_tabs).to_have_count(5)
 
     assert_snapshot(st_tabs.nth(0), name="st_tabs-sidebar")
     assert_snapshot(st_tabs.nth(1), name="st_tabs-text_input")
@@ -43,3 +43,15 @@ def test_contains_all_tabs_when_overflowing(app: Page):
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stTabs")
+
+
+def test_tabs_with_html(app: Page):
+    tabs = app.get_by_test_id("stTabs").nth(4)
+
+    expect(app.get_by_text("This is HTML tab 1")).to_be_visible()
+    tabs.get_by_role("tab", name="HTML Tab 2").click()
+    expect(app.get_by_text("This is HTML tab 2")).to_be_visible()
+    tabs.get_by_role("tab", name="HTML Tab 3").click()
+    expect(app.get_by_text("This is HTML tab 3")).to_be_visible()
+    tabs.get_by_role("tab", name="HTML Tab 1").click()
+    expect(app.get_by_text("This is HTML tab 1")).to_be_visible()

--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -30,7 +30,6 @@ const getProps = (elementProps: Partial<HtmlProto> = {}): HtmlProps => ({
     body: "<div>Test Html</div>",
     ...elementProps,
   }),
-  width: 100,
 })
 
 describe("HTML element", () => {

--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -29,6 +29,7 @@ const getProps = (elementProps: Partial<HtmlProto> = {}): HtmlProps => ({
     body: "<div>Test Html</div>",
     ...elementProps,
   }),
+  width: 100,
 })
 
 describe("HTML element", () => {
@@ -38,6 +39,7 @@ describe("HTML element", () => {
     const html = screen.getByTestId("stHtml")
     expect(html).toBeInTheDocument()
     expect(html).toHaveTextContent("Test Html")
+    expect(html).toHaveStyle("width: 100px")
     expect(html).toHaveClass("stHtml")
   })
 

--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -21,6 +21,7 @@ import { screen } from "@testing-library/react"
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
 import { render } from "~lib/test_util"
+import * as UseCalculatedWidth from "~lib/hooks/useCalculatedWidth"
 
 import Html, { HtmlProps } from "./Html"
 
@@ -33,6 +34,13 @@ const getProps = (elementProps: Partial<HtmlProto> = {}): HtmlProps => ({
 })
 
 describe("HTML element", () => {
+  beforeEach(() => {
+    vi.spyOn(UseCalculatedWidth, "useCalculatedWidth").mockReturnValue([
+      100,
+      { current: null },
+    ])
+  })
+
   it("renders the element as expected", () => {
     const props = getProps()
     render(<Html {...props} />)

--- a/frontend/lib/src/components/elements/Html/Html.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.tsx
@@ -20,8 +20,11 @@ import dompurify from "dompurify"
 
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
+import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
+
 export interface HtmlProps {
   element: HtmlProto
+  width: number
 }
 
 // preserve target=_blank and set security attributes (see https://github.com/cure53/DOMPurify/issues/317)
@@ -59,7 +62,7 @@ const sanitizeString = (html: string): string => {
 /**
  * HTML code to insert into the page.
  */
-function Html({ element }: Readonly<HtmlProps>): ReactElement {
+function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
   const { body } = element
   const htmlRef = useRef<HTMLDivElement | null>(null)
 
@@ -82,6 +85,7 @@ function Html({ element }: Readonly<HtmlProps>): ReactElement {
           className="stHtml"
           data-testid="stHtml"
           ref={htmlRef}
+          style={{ width }}
           // TODO: Update to match React best practices
           // eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
           dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
@@ -91,4 +95,4 @@ function Html({ element }: Readonly<HtmlProps>): ReactElement {
   )
 }
 
-export default memo(Html)
+export default withCalculatedWidth(memo(Html))

--- a/frontend/lib/src/components/elements/Html/Html.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.tsx
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
+import React, { memo, ReactElement, useEffect, useMemo } from "react"
 
 import dompurify from "dompurify"
 
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
-import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
+import { useCalculatedWidth } from "~lib/hooks/useCalculatedWidth"
 
 export interface HtmlProps {
   element: HtmlProto
-  width: number
 }
 
 // preserve target=_blank and set security attributes (see https://github.com/cure53/DOMPurify/issues/317)
@@ -62,9 +61,9 @@ const sanitizeString = (html: string): string => {
 /**
  * HTML code to insert into the page.
  */
-function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
+function Html({ element }: Readonly<HtmlProps>): ReactElement {
   const { body } = element
-  const htmlRef = useRef<HTMLDivElement | null>(null)
+  const [width, htmlRef] = useCalculatedWidth()
 
   const sanitizedHtml = useMemo(() => sanitizeString(body), [body])
 
@@ -74,23 +73,15 @@ function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
     // `StyledElementContainerLayoutWrapper`.
     // If the DOM structure changes, this will break.
 
-    /**
-     * Parent element is the `Box` rendered by the `withCalculatedWidth` HOC
-     */
-    const parent = htmlRef.current?.parentElement
-    /**
-     * Grandparent element is the `StyledElementContainer` rendered by the
-     * `StyledElementContainerLayoutWrapper`
-     */
-    const grandparent = parent?.parentElement
-
     if (
       htmlRef.current?.clientHeight === 0 &&
-      parent?.childElementCount === 1 &&
-      grandparent?.childElementCount === 1
+      // Ensure that the element content has been sized, this will be -1 if the
+      // element width is still being evaluated
+      width >= 0 &&
+      htmlRef.current.parentElement?.childElementCount === 1
     ) {
       // div has no rendered content - hide to avoid unnecessary spacing
-      grandparent.classList.add("stHtml-empty")
+      htmlRef.current.parentElement.classList.add("stHtml-empty")
     }
   })
 
@@ -111,4 +102,4 @@ function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
   )
 }
 
-export default withCalculatedWidth(memo(Html))
+export default memo(Html)

--- a/frontend/lib/src/components/elements/Html/Html.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.tsx
@@ -69,12 +69,28 @@ function Html({ element, width }: Readonly<HtmlProps>): ReactElement {
   const sanitizedHtml = useMemo(() => sanitizeString(body), [body])
 
   useEffect(() => {
+    // Side-effect to hide the element if it has no rendered content.
+    // This is a hack to avoid rendering empty children in the
+    // `StyledElementContainerLayoutWrapper`.
+    // If the DOM structure changes, this will break.
+
+    /**
+     * Parent element is the `Box` rendered by the `withCalculatedWidth` HOC
+     */
+    const parent = htmlRef.current?.parentElement
+    /**
+     * Grandparent element is the `StyledElementContainer` rendered by the
+     * `StyledElementContainerLayoutWrapper`
+     */
+    const grandparent = parent?.parentElement
+
     if (
       htmlRef.current?.clientHeight === 0 &&
-      htmlRef.current.parentElement?.childElementCount === 1
+      parent?.childElementCount === 1 &&
+      grandparent?.childElementCount === 1
     ) {
       // div has no rendered content - hide to avoid unnecessary spacing
-      htmlRef.current.parentElement.classList.add("stHtml-empty")
+      grandparent.classList.add("stHtml-empty")
     }
   })
 


### PR DESCRIPTION
## Describe your changes

- Adds explicitly defined `width` back to the `st.html` element to fix an issue where it wasn't rendering properly within `st.tabs`

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/10815

## Testing Plan

- ✅ Adds e2e tests
- ✅ Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
