### PR TITLE
Log script compilation error via error log level

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -550,7 +550,7 @@ class ScriptRunner:
 
             except Exception as ex:
                 # We got a compile error. Send an error event and bail immediately.
-                _LOGGER.debug("Fatal script error", exc_info=ex)
+                _LOGGER.exception("Script compilation error", exc_info=ex)
                 self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = False
                 self.on_event.send(
                     self,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -827,8 +827,8 @@ class ScriptRunnerTest(AsyncTestCase):
     def test_dg_stack_preserved_for_fragment_rerun(self):
         """Tests that the dg_stack and cursor are preserved for a fragment rerun.
 
-        Having a fragment rerun that is interrupted by a RerunException triggered by a
-        nother fragment run simulates what we have seen in the issue where the main app
+        Having a fragment rerun that is interrupted by a RerunException triggered by
+        another fragment run simulates what we have seen in the issue where the main app
         was rendered inside of a dialog when two fragment-related reruns were handled
         in the same ScriptRunner thread.
         """

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -404,7 +404,8 @@ class ScriptRunnerTest(AsyncTestCase):
         ex = patched_handle_exception.call_args[0][0]
         assert isinstance(ex, KeyError)
 
-    def test_compile_error(self):
+    @patch("streamlit.runtime.scriptrunner.script_runner._LOGGER.exception")
+    def test_compile_error(self, patched_logger_exception):
         """Tests that we get an exception event when a script can't compile."""
         scriptrunner = TestScriptRunner("compile_error.py.txt")
         scriptrunner.request_rerun(RerunData())
@@ -421,6 +422,15 @@ class ScriptRunnerTest(AsyncTestCase):
             ],
         )
         self._assert_text_deltas(scriptrunner, [])
+
+        # Verify that the exception was logged
+        patched_logger_exception.assert_called_once()
+        # Verify the logger was called with the correct message
+        self.assertEqual(
+            patched_logger_exception.call_args[0][0], "Script compilation error"
+        )
+        # Ensure that exc_info parameter was passed (contains the actual exception)
+        self.assertIn("exc_info", patched_logger_exception.call_args[1])
 
     @patch("streamlit.runtime.state.session_state.SessionState._call_callbacks")
     def test_calls_widget_callbacks(self, patched_call_callbacks):
@@ -796,7 +806,9 @@ class ScriptRunnerTest(AsyncTestCase):
         self._assert_text_deltas(scriptrunner, [text_utf])
 
     def test_remove_nonexistent_elements(self):
-        """Tests that nonexistent elements are removed from widget cache after script run."""
+        """Tests that nonexistent elements are removed from widget cache after
+        script run.
+        """
 
         widget_id = "nonexistent_widget_id"
 
@@ -815,13 +827,15 @@ class ScriptRunnerTest(AsyncTestCase):
     def test_dg_stack_preserved_for_fragment_rerun(self):
         """Tests that the dg_stack and cursor are preserved for a fragment rerun.
 
-        Having a fragment rerun that is interrupted by a RerunException triggered by another fragment run
-        simulates what we have seen in the issue where the main app was rendered inside of a dialog when
-        two fragment-related reruns were handled in the same ScriptRunner thread.
+        Having a fragment rerun that is interrupted by a RerunException triggered by a
+        nother fragment run simulates what we have seen in the issue where the main app
+        was rendered inside of a dialog when two fragment-related reruns were handled
+        in the same ScriptRunner thread.
         """
         scriptrunner = TestScriptRunner("good_script.py")
 
-        # set the dg_stack from the fragment to simulate a populated dg_stack of a real app
+        # set the dg_stack from the fragment to simulate a populated dg_stack of
+        # a real app
         dg_stack_set_by_fragment = (
             DeltaGenerator(),
             DeltaGenerator(),
@@ -833,13 +847,16 @@ class ScriptRunnerTest(AsyncTestCase):
             lambda: context_dg_stack.set(dg_stack_set_by_fragment),
         )
 
-        # trigger a run with fragment_id to avoid clearing the fragment_storage in the script runner
+        # trigger a run with fragment_id to avoid clearing the fragment_storage in the
+        # script runner
         scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
 
-        # yielding a rerun request will raise a RerunException in the script runner with the provided RerunData
+        # yielding a rerun request will raise a RerunException in the script runner
+        # with the provided RerunData
         on_scriptrunner_yield_mock = MagicMock()
         on_scriptrunner_yield_mock.side_effect = [
-            # the original_dg_stack will be set to the dg_stack populated by the first requested_rerun of the fragment
+            # the original_dg_stack will be set to the dg_stack populated by the first
+            # requested_rerun of the fragment
             ScriptRequest(
                 ScriptRequestType.RERUN, RerunData(fragment_id_queue=["my_fragment1"])
             ),
@@ -871,10 +888,12 @@ class ScriptRunnerTest(AsyncTestCase):
             lambda: context_dg_stack.set(dg_stack_set_by_fragment),
         )
 
-        # trigger a run with fragment_id to avoid clearing the fragment_storage in the script runner
+        # trigger a run with fragment_id to avoid clearing the fragment_storage
+        # in the script runner
         scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment1"]))
 
-        # yielding a rerun request will raise a RerunException in the script runner with the provided RerunData
+        # yielding a rerun request will raise a RerunException in the script runner
+        # with the provided RerunData
         on_scriptrunner_yield_mock = MagicMock()
         on_scriptrunner_yield_mock.side_effect = [
             # raise RerunException for full app run


### PR DESCRIPTION
## Describe your changes

Currently, we only log script compilation errors via the `debug` log level. This PR changes it to log it as an `exception` / `error` log level instead. This simplifies usage in AI dev tools that access the logging output. 

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
