### PR TITLE
Move instructions to set up ubuntu environment into makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ ensure-relative-imports:
 	./scripts/ensure_relative_imports.sh
 
 .PHONY: performance-lighthouse
-# Run Lighthouse performance tests
+# Run Lighthouse performance tests.
 performance-lighthouse:
 	cd frontend/app; \
 	yarn run lighthouse:run

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,9 @@ conditional-ubuntu-init:
 		libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
 		xz-utils tk-dev libffi-dev liblzma-dev python3-openssl mysql-client libmysqlclient-dev unixodbc-dev ; \
 		curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash ; \
-		#: "Avoid pyenv 'Restart your shell for the changes to take effect.' error by re-sourcing." ; \
-		#source ~/.bashrc ; \
+		: "Take pyenv's 'Restart your shell for the changes to take effect.' advice." ; \
+		: "It is unclear to me if this is actually necessary." ; \
+		source ~/.bashrc ; \
 		: 'Install some other deps, incl. Pip, Protobuf.' ; \
 		sudo apt install -y graphviz pre-commit python3-pip protobuf-compiler  ; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,54 @@ build-deps: mini-init develop
 
 .PHONY: init
 # Install all Python and JS dependencies.
-init: python-init-all react-init protobuf
+init: conditional-ubuntu-init python-init-all react-init protobuf
 
 .PHONY: mini-init
 # Install minimal Python and JS dependencies for development.
-mini-init: python-init-dev-only react-init protobuf
+mini-init: conditional-ubuntu-init python-init-dev-only react-init protobuf
+
+.PHONY: conditional-ubuntu-init
+# If we detect we're on an Ubuntu system, install most of the Ubuntu pre-requisites (otherwise do nothing).
+conditional-ubuntu-init:
+	@# : is used to comment code in the below because it is difficult to combine comments and multi-line strings otherwise.
+	@if grep "ubuntu" /etc/os-release --quiet ; then \
+		echo "Apparently an Ubuntu system, therefore I will install Ubuntu requirements..." 1>&2 ; \
+		: There are ways to run this script as root without having sudo installed, but most people won't, so let's ignore the nigh-inevitable error. ; \
+		apt-get install -y sudo 2>/dev/null ; \
+		: Install some essentials. ; \
+		: Again, including make, even though you need it to run this make script itself, so this is probably pointless. ; \
+		sudo apt-get install -y make curl git unzip ; \
+		: Set up the Yarn repo ; \
+		node_version_major=`node -v | tr -d 'v' | cut -d'.' -f1` ; \
+		node_version_minor=`node -v | tr -d 'v' | cut -d'.' -f2` ; \
+		: : If node -v shows a version less than 16.10, OR if there is no node or the parsed version numbers are not integers; \
+		if ( [ "$$node_version_major" -lt 16 ] && [ "$$node_version_minor" -lt 10 ] ) || ( ! node -v || [ -z "$${node_version_major//[0-9]}" ] || [ -z "$${node_version_minor//[0-9]}" ] ) ; then \
+			curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash ; \
+			source ~/.bashrc ; \
+			: '=> Close and reopen your terminal to start using nvm or run the following to use it now:' ; \
+			: "I don't know why we seem to need to run the following commands to make nvm work, considering they end up in the bashrc we just re-sourced, but it didn't seem to work without this." ;\
+			export NVM_DIR="$$HOME/.nvm" ; \
+			[ -s "$$NVM_DIR/nvm.sh" ] && \. "$$NVM_DIR/nvm.sh" ; \
+			[ -s "$$NVM_DIR/bash_completion" ] && \. "$$NVM_DIR/bash_completion" ; \
+			nvm install node ; \
+			source ~/.bashrc ; \
+		fi ; \
+		: I, Wyatt, do not know why we do this one, but it is in the instructions I am porting here. ; \
+		sudo apt-get update ; \
+		: Install Pyenv for testing multiple Python versions ; \
+		sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+		libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+		xz-utils tk-dev libffi-dev liblzma-dev python3-openssl mysql-client libmysqlclient-dev unixodbc-dev ; \
+		curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash ; \
+		#: "Avoid pyenv 'Restart your shell for the changes to take effect.' error by re-sourcing." ; \
+		#source ~/.bashrc ; \
+		: 'Install some other deps (python3-distutils has been removed from this list).' ; \
+		sudo apt install -y graphviz pre-commit ; \
+		: 'Install pip, Protobuf, npm (libgconf-2-4 is no longer on this list as Cypress (which we use for our e2e tests) no longer requires it; cf https://github.com/cypress-io/cypress/issues/27972).' ; \
+		sudo apt install -y python3-pip protobuf-compiler  ; \
+	else \
+		echo "Apparently not on Ubuntu." 1>&2 ; \
+	fi ; \
 
 .PHONY: frontend
 # Build frontend into static files.

--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,12 @@ mini-init: conditional-ubuntu-init python-init-dev-only react-init protobuf
 .PHONY: conditional-ubuntu-init
 # If we detect we're on an Ubuntu system, install most of the Ubuntu pre-requisites (otherwise do nothing).
 conditional-ubuntu-init:
-	@# : is used to comment code in the below because it is difficult to combine comments and multi-line strings otherwise.
+	@# : is used to comment code in the below because it is difficult to combine comments and line-continuation otherwise.
 	@if grep "ubuntu" /etc/os-release --quiet ; then \
 		echo "Apparently an Ubuntu system, therefore I will install Ubuntu requirements..." 1>&2 ; \
 		: There are ways to run this script as root without having sudo installed, but most people won't, so let's ignore the nigh-inevitable error. ; \
 		apt-get install -y sudo 2>/dev/null ; \
-		: Install some essentials. ; \
-		: Again, including make, even though you need it to run this make script itself, so this is probably pointless. ; \
+		: 'Install some essentials (including make, even though you need it to run this make script itself, so this is probably pointless).' ; \
 		sudo apt-get install -y make curl git unzip ; \
 		: Set up the Yarn repo ; \
 		node_version_major=`node -v | tr -d 'v' | cut -d'.' -f1` ; \

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ protobuf: check-protoc
 .PHONY: react-init
 # React init.
 react-init:
-	cd frontend/ ; yarn install --immutable
+	cd frontend/ ; corepack enable ; corepack install ; yarn install --immutable
 
 .PHONY: react-build
 # React build.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ GITHUB_REPOSITORY ?= streamlit/streamlit
 CONSTRAINTS_BRANCH ?= constraints-develop
 CONSTRAINTS_URL ?= https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${CONSTRAINTS_BRANCH}/constraints-${PYTHON_VERSION}.txt
 
-# Black magic to get module directories
+# Black magic to get module directories.
+# (Should the quoting use bash ${parameter@Q} instead? (https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) In what way, exactly?)
 PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), "$(realpath $(dir $(initpy)))")
 
 # Check if Python is installed and can be executed, otherwise show an error message in red (but continue)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CONSTRAINTS_BRANCH ?= constraints-develop
 CONSTRAINTS_URL ?= https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${CONSTRAINTS_BRANCH}/constraints-${PYTHON_VERSION}.txt
 
 # Black magic to get module directories
-PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), $(realpath $(dir $(initpy))))
+PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), "$(realpath $(dir $(initpy)))")
 
 # Check if Python is installed and can be executed, otherwise show an error message in red (but continue)
 ifeq ($(PYTHON_VERSION),)

--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,8 @@ conditional-ubuntu-init:
 		curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash ; \
 		#: "Avoid pyenv 'Restart your shell for the changes to take effect.' error by re-sourcing." ; \
 		#source ~/.bashrc ; \
-		: 'Install some other deps (python3-distutils has been removed from this list).' ; \
-		sudo apt install -y graphviz pre-commit ; \
-		: 'Install pip, Protobuf, npm (libgconf-2-4 is no longer on this list as Cypress (which we use for our e2e tests) no longer requires it; cf https://github.com/cypress-io/cypress/issues/27972).' ; \
-		sudo apt install -y python3-pip protobuf-compiler  ; \
+		: 'Install some other deps, incl. Pip, Protobuf.' ; \
+		sudo apt install -y graphviz pre-commit python3-pip protobuf-compiler  ; \
 	else \
 		echo "Apparently not on Ubuntu." 1>&2 ; \
 	fi ; \

--- a/frontend/protobuf/scripts/generate-proto.js
+++ b/frontend/protobuf/scripts/generate-proto.js
@@ -29,7 +29,7 @@ const outputJsFile = "proto.js"
 const outputDtsFile = "proto.d.ts"
 
 // Commands to run
-const pbjsCommand = `yarn run --silent pbjs ${protoGlob} --path ${protoDir} -t static-module --wrap es6`
+const pbjsCommand = `yarn run --silent pbjs "${protoGlob}" --path "${protoDir}" -t static-module --wrap es6`
 const pbtsCommand = `yarn run --silent pbts proto.js`
 const TEMPLATE = "/* eslint-disable */\n\n"
 


### PR DESCRIPTION
## Describe your changes

In this PR, I have moved almost all of the steps to set up an Ubuntu environment from https://github.com/streamlit/streamlit/wiki/Contributing into the makefile, in a target called ubuntu-conditional-init. I would have made a macos-conditional-init as well, but as I do not have MacOS, troubleshooting that would have been difficult. (I would have made a wsl-conditional-init as well, but the prospect just seemed too annoying and byzantine to me.)

I also fixed some additional incidental problems along the way, including several quoting problems I discovered because my directory path has a space in it.

I also moved the "corepack enable; corepack install" steps to react-init, which allows it to be run at the proper time with no additional hassle.

The part of the setup that deals with venv is a little untidy still, and could be improved, but I did not do so at this time. (Example untidiness: I keep running the make script only for it to error, and then I remember I have to run it in the venv. This is not really mentioned on the right part of the documentation page. But it's only a small problem, anyway — and there are several ways the user could elect to use a venv or not.)

## Documentation fixes

I cannot edit the Contribution documentation directly to reflect my changes, because it is a "wiki" page I don't have edit access to instead of living directly in https://github.com/streamlit/streamlit/blob/develop/CONTRIBUTING.md — this confuses me, but no matter; here are some changes I think should be made:

• https://github.com/streamlit/streamlit/wiki/Contributing#ubuntu should be replaced with:
  1. If you are on Ubuntu 22.04.5 LTS or earlier, then you will only have access to libprotoc 3.12.4, which is lower than the minimum required version 3.20. Therefore, you will have to `do-release-upgrade`.
  2. Make sure you have sudo installed. This comes with Ubuntu by default; but if you somehow lack it, you can become root using `su -` and then install sudo with `apt-get install -y sudo`.
  3. Make sure you have make installed. This does *not* come with Ubuntu by default, and can be installed using `sudo apt-get install -y make` or `sudo apt-get install -y build-essentials`

• https://github.com/streamlit/streamlit/wiki/Contributing#windows should have its python version(?) increased to something we actually support(?), possibly python [3.9.0](https://github.com/streamlit/streamlit/blob/develop/lib/setup.py#L127), if setup.py is to be believed.
• Since node doesn't support WSL1, a note in the WSL section should be made that WSL1 won't work (but most WSLs are WSL2 by default) (TODO(me): I am testing if this is still true or an archaic restriction)
  ◦ Oddly, on my WSL1 system, on the `uv pip install --editable ./lib --requirement lib/dev-requirements.txt --requirement lib/test-requirements.txt` I got a weird "not permitted error" until I ran `sudo make all-devel` instead. Might be worth mentioning. (Might be WSL1-related, or just a random foible of my particular system configuration.)

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/10754

## Testing Plan

- Given that this process was not automated before, it seems unlikely that there are any automated tests for it for me to edit or expand upon.
- I thought perhaps this script would be used in the CI/CD scripts to set up the environment, but they seem to do some other process to achieve the same results?
  - A new github action could perhaps be created just to verify that this make file sets up the environment in a way that does not crash, but I didn't go that far at this time.
    - Maybe I should!
- I manually tested this on WSL2 Ubuntu 24.04.2 LTS
- Some of my small fixes will be encountered in the current CI/CD scripts, thus verifying that they will work.

## Flagged as potentially worrisome
- This make target now includes a couple `curl | bash` install steps, which fills me with trepidation. But as far as I can tell this is fine and expected.
- I can't figure out if (and if so, where) we use pyenv in this project. `rg "pyenv"` doesn't reveal any actual usages. Perhaps we don't, and the installing pyenv step should be removed entirely?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
