### PR TITLE
unhide new custom theme options

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1148,7 +1148,6 @@ _create_theme_options(
         file_uploader, etc).
     """,
     type_=bool,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1168,7 +1167,6 @@ _create_theme_options(
         Whether to show a vertical separator between the sidebar and the main content.
     """,
     type_=bool,
-    visibility="hidden",
 )
 
 # Config Section: Secrets #

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -318,13 +318,13 @@ def _create_theme_options(
             f"{section}.{name}",
             description=description,
             default_val=default_val,
-            scriptable=False,
             visibility=visibility,
+            type_=type_,
+            scriptable=False,
             deprecated=False,
             deprecation_text=None,
             expiration_date=None,
             replaced_by=None,
-            type_=type_,
             sensitive=False,
         )
 
@@ -1084,7 +1084,6 @@ _create_theme_options(
     "linkColor",
     categories=["theme", CustomThemeCategories.SIDEBAR],
     description="Color used for all links.",
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1104,7 +1103,6 @@ _create_theme_options(
         The font family to use for code (monospace) in the app.
         To use a custom font, it needs to be added via [theme.fontFaces].
     """,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1114,7 +1112,6 @@ _create_theme_options(
         The font family to use for headings in the app.
         To use a custom font, it needs to be added via [theme.fontFaces].
     """,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1123,7 +1120,6 @@ _create_theme_options(
     description="""
     Configure a list of font faces that you can use for the app & code fonts.
 """,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1134,7 +1130,6 @@ _create_theme_options(
         "none", "small", "medium", "large", "full", or the number in pixel or rem.
         For example: "10px", "0.5rem", "1.2rem", "2rem".
     """,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1143,7 +1138,6 @@ _create_theme_options(
     description="""
         The color of the border around elements.
     """,
-    visibility="hidden",
 )
 
 _create_theme_options(
@@ -1165,7 +1159,6 @@ _create_theme_options(
         scale of text and UI elements. The default base font size is 16.
     """,
     type_=int,
-    visibility="hidden",
 )
 
 _create_theme_options(


### PR DESCRIPTION
## Describe your changes

Make visible the remaining advanced custom theme options. They were available to be set in the config and will be, but will be shown as available options in the `streamlit config show` command.

## Testing Plan

New options revealed with `streamlit config show` for both `[theme]` and `[theme.sidebar]`
```
[theme]

# The preset Streamlit theme that your custom theme inherits from.
# One of "light" or "dark".
# base =

# Primary accent color for interactive elements.
# The value below was set in /Users/pchiu/snowflake/streamlit/.streamlit/config.toml
primaryColor = "4747D4"

# Background color for the main content area.
# backgroundColor =

# Background color used for the sidebar and most interactive widgets.
# secondaryBackgroundColor =

# Color used for almost all text.
# textColor =

# Color used for all links.
# linkColor =

# The font family for all text in the app, except code blocks. One of "sans serif",
# "serif", or "monospace".
# To use a custom font, it needs to be added via [theme.fontFaces].
# font =

# The font family to use for code (monospace) in the app.
# To use a custom font, it needs to be added via [theme.fontFaces].
# codeFont =

# The font family to use for headings in the app.
# To use a custom font, it needs to be added via [theme.fontFaces].
# headingFont =

# Configure a list of font faces that you can use for the app & code fonts.
# fontFaces =

# The radius used as basis for the corners of most UI elements. Can be:
# "none", "small", "medium", "large", "full", or the number in pixel or rem.
# For example: "10px", "0.5rem", "1.2rem", "2rem".
# The value below was set in /Users/pchiu/snowflake/streamlit/.streamlit/config.toml
baseRadius = "full"

# The color of the border around elements.
# borderColor =

# Whether to show a border around input widgets (e.g. text_input, number_input,
# file_uploader, etc).
# showWidgetBorder =

# Sets the root font size (in pixels) for the app, which determines the overall
# scale of text and UI elements. The default base font size is 16.
# baseFontSize =

# Whether to show a vertical separator between the sidebar and the main content.
# showSidebarBorder =


[theme.sidebar]

# Primary accent color for interactive elements.
# The value below was set in /Users/pchiu/snowflake/streamlit/.streamlit/config.toml
primaryColor = "#bb5a38"

# Background color for the main content area.
# backgroundColor =

# Background color used for the sidebar and most interactive widgets.
# secondaryBackgroundColor =

# Color used for almost all text.
# textColor =

# Color used for all links.
# linkColor =

# The font family for all text in the app, except code blocks. One of "sans serif",
# "serif", or "monospace".
# To use a custom font, it needs to be added via [theme.fontFaces].
# font =

# The font family to use for code (monospace) in the app.
# To use a custom font, it needs to be added via [theme.fontFaces].
# codeFont =

# The font family to use for headings in the app.
# To use a custom font, it needs to be added via [theme.fontFaces].
# headingFont =

# The radius used as basis for the corners of most UI elements. Can be:
# "none", "small", "medium", "large", "full", or the number in pixel or rem.
# For example: "10px", "0.5rem", "1.2rem", "2rem".
# The value below was set in /Users/pchiu/snowflake/streamlit/.streamlit/config.toml
baseRadius = "none"

# The color of the border around elements.
# borderColor =

# Whether to show a border around input widgets (e.g. text_input, number_input,
# file_uploader, etc).
# showWidgetBorder =
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
