### PR TITLE
Send `postMessage` on websocket connection errors

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -433,6 +433,19 @@ export class App extends PureComponent<Props, State> {
       connectionStateChanged: this.handleConnectionStateChanged,
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
+      sendClientError: (
+        error: string | number,
+        message: string,
+        source: string
+      ) => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "CLIENT_ERROR",
+          component: "Websocket Connection",
+          error,
+          message,
+          source,
+        })
+      },
       onHostConfigResp: (response: IHostConfigResponse) => {
         const {
           allowedOrigins,

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -70,6 +70,16 @@ interface Props {
   resetHostAuthToken: () => void
 
   /**
+   * Sends message to host when websocket connection errors encountered to
+   * inform where/why the error occurred.
+   */
+  sendClientError: (
+    error: string | number,
+    message: string,
+    source: string
+  ) => void
+
+  /**
    * Function to set the host config for this app (if in a relevant deployment
    * scenario).
    */
@@ -168,7 +178,12 @@ export class ConnectionManager {
         this.websocketConnection = await this.connectToRunningServer()
       } catch (e) {
         const err = e instanceof Error ? e : new Error(`${e}`)
-        LOG.error(err.message)
+        LOG.error(`Client Error: Websocket connection - ${err.message}`)
+        this.props.sendClientError(
+          "Failed to establish websocket connection",
+          err.message,
+          "Connection Manager"
+        )
         this.setConnectionState(
           ConnectionState.DISCONNECTED_FOREVER,
           err.message
@@ -220,6 +235,7 @@ export class ConnectionManager {
       onRetry: this.showRetryError,
       claimHostAuthToken: this.props.claimHostAuthToken,
       resetHostAuthToken: this.props.resetHostAuthToken,
+      sendClientError: this.props.sendClientError,
       onHostConfigResp: this.props.onHostConfigResp,
     })
   }

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -41,6 +41,11 @@ export function doInitPings(
   minimumTimeoutMs: number,
   maximumTimeoutMs: number,
   retryCallback: OnRetry,
+  sendClientError: (
+    error: string | number,
+    message: string,
+    source: string
+  ) => void,
   onHostConfigResp: (resp: IHostConfigResponse) => void
 ): Promise<number> {
   const { promise, resolve } = Promise.withResolvers<number>()
@@ -128,7 +133,30 @@ If you are trying to access a Streamlit app running on another server, this coul
         resolve(uriNumber)
       })
       .catch(error => {
+        // If its our 6th try (retry count at which we show connection error dialog), send a client error
+        // to inform the host of connection error
+        const shouldSendClientError = totalTries === 6
+
+        // Handle retrieving the source URL from the error (health or host-config endpoint)
+        // Fallback to "DoInitPings" if we can't retrieve the source url from the error
+        let source = "DoInitPings"
+        if (error.config?.url) {
+          source = new URL(error.config.url).pathname
+        } else if (error.response?.config?.url) {
+          source = new URL(error.response.config.url).pathname
+        } else if (error.request?.path) {
+          source = new URL(error.request.path).pathname
+        }
+
         if (error.code === "ECONNABORTED") {
+          if (shouldSendClientError) {
+            LOG.error("Client error: DoInitPings timed out")
+            sendClientError(
+              "DoInitPings timed out",
+              "Connection timed out - ECONNABORTED",
+              source
+            )
+          }
           return retry("Connection timed out.")
         }
 
@@ -136,13 +164,37 @@ If you are trying to access a Streamlit app running on another server, this coul
           // The request was made and the server responded with a status code
           // that falls out of the range of 2xx
 
-          const { data, status } = error.response
+          const { data, status, statusText } = error.response
 
           if (status === /* NO RESPONSE */ 0) {
+            if (shouldSendClientError) {
+              LOG.error(
+                `Client Error: response received with status ${status} when attempting to reach ${source}`
+              )
+              sendClientError(
+                `Response received with status ${status}`,
+                statusText,
+                source
+              )
+            }
             return retryWhenTheresNoResponse()
           }
+
           if (status === 403) {
+            if (shouldSendClientError) {
+              LOG.error(
+                `Client Error: response received with status ${status} when attempting to reach ${source}`
+              )
+              sendClientError(status, statusText, source)
+            }
             return retryWhenIsForbidden()
+          }
+
+          if (shouldSendClientError) {
+            LOG.error(
+              `Client Error: response received with status ${status} when attempting to reach ${source}`
+            )
+            sendClientError(status, statusText, source)
           }
           return retry(
             `Connection failed with status ${status}, ` +
@@ -153,9 +205,30 @@ If you are trying to access a Streamlit app running on another server, this coul
           // The request was made but no response was received
           // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
           // http.ClientRequest in node.js
+
+          if (shouldSendClientError) {
+            LOG.error(
+              `Client Error in reaching server endpoint - No response received when attempting to reach ${source}`
+            )
+            sendClientError(
+              "No response received from server",
+              error.request,
+              source
+            )
+          }
           return retryWhenTheresNoResponse()
         }
         // Something happened in setting up the request that triggered an Error
+        if (shouldSendClientError) {
+          LOG.error(
+            `Client Error in reaching server endpoint - error in setting up request when attempting to reach ${source}`
+          )
+          sendClientError(
+            "Error setting up request to server",
+            error.message,
+            source
+          )
+        }
         return retry(error.message)
       })
   }

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -107,6 +107,21 @@ If you are trying to access a Streamlit app running on another server, this coul
     retry(forbiddenMessage)
   }
 
+  // Handle retrieving the source URL, otherwise fallback to "DoInitPings"
+  const determineUrlSource = (url: string | undefined): string => {
+    let source = "DoInitPings"
+
+    if (url) {
+      try {
+        source = new URL(url).pathname
+      } catch (e) {
+        LOG.error(`unrecognized url: ${url}`)
+      }
+    }
+
+    return source
+  }
+
   connect = () => {
     const uriParts = uriPartsList[uriNumber]
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
@@ -142,9 +157,7 @@ If you are trying to access a Streamlit app running on another server, this coul
         if (error.code === "ECONNABORTED") {
           if (shouldSendClientError) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
-            const source = error.config?.url
-              ? new URL(error.config.url).pathname
-              : "DoInitPings"
+            const source = determineUrlSource(error.config?.url)
             LOG.error("Client error: DoInitPings timed out")
             sendClientError(
               "DoInitPings timed out",
@@ -161,9 +174,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 
           const { data, status, statusText } = error.response
           // Handle retrieving the source URL from the error (health or host-config endpoint)
-          const source = error.response.config?.url
-            ? new URL(error.response.config.url).pathname
-            : "DoInitPings"
+          const source = determineUrlSource(error.response.config?.url)
 
           if (status === /* NO RESPONSE */ 0) {
             if (shouldSendClientError) {
@@ -207,9 +218,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 
           if (shouldSendClientError) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
-            const source = error.request.path
-              ? new URL(error.request.path).pathname
-              : "DoInitPings"
+            const source = determineUrlSource(error.request.path)
             LOG.error(
               `Client Error in reaching server endpoint - No response received when attempting to reach ${source}`
             )
@@ -224,9 +233,7 @@ If you are trying to access a Streamlit app running on another server, this coul
         // Something happened in setting up the request that triggered an Error
         if (shouldSendClientError) {
           // Handle retrieving the source URL from the error (health or host-config endpoint)
-          const source = error.config?.url
-            ? new URL(error.config.url).pathname
-            : "DoInitPings"
+          const source = determineUrlSource(error.config?.url)
           LOG.error(
             `Client Error in reaching server endpoint - error in setting up request when attempting to reach ${source}`
           )

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -35,6 +35,7 @@ import {
 import { IHostConfigResponse, OnRetry } from "./types"
 
 const LOG = getLogger("DoInitPings")
+export const THRESHOLD_FOR_CONNECTION_ERROR_DIALOG = 6
 
 export function doInitPings(
   uriPartsList: URL[],
@@ -135,21 +136,15 @@ If you are trying to access a Streamlit app running on another server, this coul
       .catch(error => {
         // If its our 6th try (retry count at which we show connection error dialog), send a client error
         // to inform the host of connection error
-        const shouldSendClientError = totalTries === 6
-
-        // Handle retrieving the source URL from the error (health or host-config endpoint)
-        // Fallback to "DoInitPings" if we can't retrieve the source url from the error
-        let source = "DoInitPings"
-        if (error.config?.url) {
-          source = new URL(error.config.url).pathname
-        } else if (error.response?.config?.url) {
-          source = new URL(error.response.config.url).pathname
-        } else if (error.request?.path) {
-          source = new URL(error.request.path).pathname
-        }
+        const shouldSendClientError =
+          totalTries === THRESHOLD_FOR_CONNECTION_ERROR_DIALOG
 
         if (error.code === "ECONNABORTED") {
           if (shouldSendClientError) {
+            // Handle retrieving the source URL from the error (health or host-config endpoint)
+            const source = error.config?.url
+              ? new URL(error.config.url).pathname
+              : "DoInitPings"
             LOG.error("Client error: DoInitPings timed out")
             sendClientError(
               "DoInitPings timed out",
@@ -165,6 +160,10 @@ If you are trying to access a Streamlit app running on another server, this coul
           // that falls out of the range of 2xx
 
           const { data, status, statusText } = error.response
+          // Handle retrieving the source URL from the error (health or host-config endpoint)
+          const source = error.response.config?.url
+            ? new URL(error.response.config.url).pathname
+            : "DoInitPings"
 
           if (status === /* NO RESPONSE */ 0) {
             if (shouldSendClientError) {
@@ -207,6 +206,10 @@ If you are trying to access a Streamlit app running on another server, this coul
           // http.ClientRequest in node.js
 
           if (shouldSendClientError) {
+            // Handle retrieving the source URL from the error (health or host-config endpoint)
+            const source = error.request.path
+              ? new URL(error.request.path).pathname
+              : "DoInitPings"
             LOG.error(
               `Client Error in reaching server endpoint - No response received when attempting to reach ${source}`
             )
@@ -220,6 +223,10 @@ If you are trying to access a Streamlit app running on another server, this coul
         }
         // Something happened in setting up the request that triggered an Error
         if (shouldSendClientError) {
+          // Handle retrieving the source URL from the error (health or host-config endpoint)
+          const source = error.config?.url
+            ? new URL(error.config.url).pathname
+            : "DoInitPings"
           LOG.error(
             `Client Error in reaching server endpoint - error in setting up request when attempting to reach ${source}`
           )

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -212,7 +212,7 @@ If you are trying to access a Streamlit app running on another server, this coul
             )
             sendClientError(
               "No response received from server",
-              error.request,
+              error.request.status,
               source
             )
           }
@@ -225,7 +225,7 @@ If you are trying to access a Streamlit app running on another server, this coul
           )
           sendClientError(
             "Error setting up request to server",
-            error.message,
+            error.message ?? "",
             source
           )
         }

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -23,7 +23,10 @@ import { BackMsg } from "@streamlit/protobuf"
 import { ConnectionState } from "./ConnectionState"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
 import { CORS_ERROR_MESSAGE_DOCUMENTATION_LINK } from "./constants"
-import { doInitPings } from "./DoInitPings"
+import {
+  doInitPings,
+  THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+} from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
 
 const MOCK_ALLOWED_ORIGINS_CONFIG = {
@@ -36,6 +39,31 @@ const MOCK_HOST_CONFIG_RESPONSE = {
 }
 
 const MOCK_HEALTH_RESPONSE = { status: "ok" }
+
+// Sets up axios get mock to fail a specific number of times before succeeding
+function setupAxiosMockWithFailures(
+  retryCount: number,
+  errorObj: any
+): ReturnType<typeof vi.fn> {
+  const mockImplementation = vi.fn()
+  axios.get = mockImplementation
+
+  // Each "totalTries" increment involves cycling through all URIs
+  // Each URI requires 2 axios calls (health + config)
+  // So total failed calls needed = retryCount * numUris * 2
+  const totalFailedCalls = retryCount * 2 * 2
+
+  // Setup all the rejected calls
+  for (let i = 0; i < totalFailedCalls; i++) {
+    mockImplementation.mockRejectedValueOnce(errorObj)
+  }
+
+  // Add final successful calls to break the loop
+  mockImplementation.mockResolvedValueOnce("") // healthzUri success
+  mockImplementation.mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE) // hostConfigUri success
+
+  return mockImplementation
+}
 
 /** Create mock WebsocketConnection arguments */
 function createMockArgs(overrides?: Partial<Args>): Args {
@@ -596,6 +624,137 @@ If you are trying to access a Streamlit app running on another server, this coul
     expect(timeouts[0]).toEqual(10)
     expect(timeouts[1]).toBeGreaterThan(timeouts[0])
     expect(timeouts2[0]).toEqual(10)
+  })
+
+  describe("calls sendClientError when we've reached connection error threshold", () => {
+    it("with status = 0 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 0,
+            statusText: "No response",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      // Verify that sendClientError was called with the expected arguments
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        "Response received with status 0",
+        "No response",
+        "/health"
+      )
+    })
+
+    it("with status = 403 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 403,
+            statusText: "Forbidden",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        403,
+        "Forbidden",
+        "/health"
+      )
+    })
+
+    it("with status = 500 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 500,
+            statusText: "Internal Server Error",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        500,
+        "Internal Server Error",
+        "/health"
+      )
+    })
+
+    it("with request error", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          request: {
+            path: "https://example.com/health",
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        "No response received from server",
+        undefined,
+        "/health"
+      )
+    })
   })
 })
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -54,6 +54,7 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     onRetry: vi.fn(),
     claimHostAuthToken: () => Promise.resolve(undefined),
     resetHostAuthToken: vi.fn(),
+    sendClientError: vi.fn(),
     onHostConfigResp: vi.fn(),
     ...overrides,
   }
@@ -68,6 +69,7 @@ describe("doInitPings", () => {
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: vi.fn(),
+    sendClientError: vi.fn(),
     setAllowedOrigins: vi.fn(),
   }
 
@@ -94,6 +96,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(0)
@@ -113,6 +116,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(0)
@@ -136,6 +140,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(1)
@@ -161,6 +166,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -188,6 +194,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -219,6 +226,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -248,6 +256,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -287,6 +296,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -322,6 +332,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -354,6 +365,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -393,6 +405,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -443,6 +456,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -496,6 +510,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -550,6 +565,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -573,6 +589,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -242,7 +242,7 @@ export type IGuestToHostMessage =
   | {
       type: "CLIENT_ERROR"
       component: string
-      customComponentName: string
+      customComponentName?: string
       error: string | number
       message: string
       source: string


### PR DESCRIPTION
## Describe your changes
**Part 3 of sending client errors to host: PR going into feature branch**

The `CLIENT_ERROR_DIALOG` message is already fired to the host from App's `onConnectionError`, but this does not generally provide sufficient context on the source/error. This PR adds `CLIENT_ERROR` messages at the points of failure for our websocket connection. Added as follows:
* `ConnectionManager` when the establishment of a websocket connection fails
* `WebsocketConnection` when `FATAL_ERROR` event is received and the connection state is not already `DISCONNECTED_FOREVER` (currently triggers the Connection Error dialog), when `onerror` event is fired, and when the connection times out
* `DoInitPings` when pings to `health` or `host-config` endpoints fails - server responded & not successful (currently triggers the Connection Error dialog after 6 failed attempts).

**Context - when the Connection Error dialog is shown:**
`App` passes down `onConnectionError` (triggers Connection Error dialog) to the `ConnectionManager`, which is called by:
* `setConnectionState` when a second arg `errMsg` is passed to it
    * This happens in `WebsocketConnection`'s function `stepFsm` when a `FATAL_ERROR` event is received and the connection state is not already `DISCONNECTED_FOREVER`
* `showRetryError` when `totalRetries` hits 6
    *  This happens in the `DoInitPings` function `retry` which is fired directly/indirectly in the `catch` of the axios requests to the `health` and `host-config` endpoints

## Testing Plan
- JS Unit Tests: ✅ 
- Manual Testing: ✅ 