### PR TITLE
Send `postMessage` on media load errors

### DIFF
--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -52,7 +52,7 @@ def test_component_source_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace source error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace source error"
             in message
             for message in messages
         ),
@@ -80,7 +80,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace fetch error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace fetch error"
             in message
             for message in messages
         ),
@@ -92,7 +92,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace timeout error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace timeout error"
             in message
             for message in messages
         ),

--- a/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
+++ b/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
@@ -17,8 +17,24 @@ import os
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import get_element_by_key
+
+
+def check_logo_source_errors(messages: list[str]):
+    """Check that both logo source error messages are logged."""
+    main_logo_error_count = 0
+    sidebar_logo_error_count = 0
+
+    # iterate over messages and check if both error messages are present
+    for message in messages:
+        if "Client Error: Logo source error" in message:
+            main_logo_error_count += 1
+        if "Client Error: Sidebar Logo source error" in message:
+            sidebar_logo_error_count += 1
+
+    assert main_logo_error_count == 1
+    assert sidebar_logo_error_count == 1
 
 
 @pytest.fixture(scope="module")
@@ -115,4 +131,28 @@ def test_logo_no_sidebar(app: Page, assert_snapshot: ImageCompareFunction):
     ).to_have_attribute("href", "https://www.example.com")
     assert_snapshot(
         app.get_by_test_id("stSidebarCollapsedControl"), name="logo-no-sidebar"
+    )
+
+
+def test_logo_source_errors(app: Page, app_port: int):
+    """Test that logo source errors are logged."""
+    app.route(
+        f"http://localhost:{app_port}/media/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    # for the logo in the main app area and the sidebar
+    wait_until(
+        app,
+        lambda: check_logo_source_errors(messages),
     )

--- a/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
+++ b/e2e_playwright/multipage_apps/mpa_configure_sidebar_test.py
@@ -17,24 +17,8 @@ import os
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import get_element_by_key
-
-
-def check_logo_source_errors(messages: list[str]):
-    """Check that both logo source error messages are logged."""
-    main_logo_error_count = 0
-    sidebar_logo_error_count = 0
-
-    # iterate over messages and check if both error messages are present
-    for message in messages:
-        if "Client Error: Logo source error" in message:
-            main_logo_error_count += 1
-        if "Client Error: Sidebar Logo source error" in message:
-            sidebar_logo_error_count += 1
-
-    assert main_logo_error_count == 1
-    assert sidebar_logo_error_count == 1
 
 
 @pytest.fixture(scope="module")
@@ -131,28 +115,4 @@ def test_logo_no_sidebar(app: Page, assert_snapshot: ImageCompareFunction):
     ).to_have_attribute("href", "https://www.example.com")
     assert_snapshot(
         app.get_by_test_id("stSidebarCollapsedControl"), name="logo-no-sidebar"
-    )
-
-
-def test_logo_source_errors(app: Page, app_port: int):
-    """Test that logo source errors are logged."""
-    app.route(
-        f"http://localhost:{app_port}/media/**",
-        lambda route: route.fulfill(
-            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
-        ),
-    )
-
-    # Capture console messages
-    messages = []
-    app.on("console", lambda msg: messages.append(msg.text))
-
-    # Navigate to the app
-    app.goto(f"http://localhost:{app_port}")
-
-    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
-    # for the logo in the main app area and the sidebar
-    wait_until(
-        app,
-        lambda: check_logo_source_errors(messages),
     )

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -75,22 +75,6 @@ def get_page_link(
     )
 
 
-def check_logo_source_errors(messages: list[str]):
-    """Check that both logo source error messages are logged."""
-    main_logo_error_count = 0
-    sidebar_logo_error_count = 0
-
-    # iterate over messages and check if both error messages are present
-    for message in messages:
-        if "Client Error: Logo source error" in message:
-            main_logo_error_count += 1
-        if "Client Error: Sidebar Logo source error" in message:
-            sidebar_logo_error_count += 1
-
-    assert main_logo_error_count == 1
-    assert sidebar_logo_error_count == 1
-
-
 def expect_page_order(app: Page, page_order: list[str] = expected_page_order):
     """Test that the page order is correct."""
     nav = app.get_by_test_id("stSidebarNav")
@@ -578,5 +562,13 @@ def test_logo_source_errors(app: Page, app_port: int):
     # for the logo in the main app area and the sidebar
     wait_until(
         app,
-        lambda: check_logo_source_errors(messages),
+        lambda: any(
+            "Client Error: Logo source error" in message for message in messages
+        ),
+    )
+    wait_until(
+        app,
+        lambda: any(
+            "Client Error: Sidebar Logo source error" in message for message in messages
+        ),
     )

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -20,6 +20,7 @@ from e2e_playwright.conftest import (
     ImageCompareFunction,
     wait_for_app_loaded,
     wait_for_app_run,
+    wait_until,
 )
 from e2e_playwright.shared.app_utils import (
     click_button,
@@ -72,6 +73,22 @@ def get_page_link(
     return (
         app.get_by_test_id("stSidebarNav").locator("a").nth(page_order.index(page_name))
     )
+
+
+def check_logo_source_errors(messages: list[str]):
+    """Check that both logo source error messages are logged."""
+    main_logo_error_count = 0
+    sidebar_logo_error_count = 0
+
+    # iterate over messages and check if both error messages are present
+    for message in messages:
+        if "Client Error: Logo source error" in message:
+            main_logo_error_count += 1
+        if "Client Error: Sidebar Logo source error" in message:
+            sidebar_logo_error_count += 1
+
+    assert main_logo_error_count == 1
+    assert sidebar_logo_error_count == 1
 
 
 def expect_page_order(app: Page, page_order: list[str] = expected_page_order):
@@ -539,3 +556,27 @@ def test_sidebar_interaction_performance(app: Page):
     options = sidebar.locator("li")
     for option in options.all():
         option.hover()
+
+
+def test_logo_source_errors(app: Page, app_port: int):
+    """Test that logo source errors are logged."""
+    app.route(
+        f"http://localhost:{app_port}/media/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    # for the logo in the main app area and the sidebar
+    wait_until(
+        app,
+        lambda: check_logo_source_errors(messages),
+    )

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -36,10 +37,19 @@ def check_audio_source_error_count(messages: list[str], expected_count: int):
                 if "Client Error: Audio source error" in message
             ]
         )
-        # when test run on webkit/firefox, it will sometimes log extra instances of the error
+        # when test run on webkit, it will sometimes log extra instances of the error
         # for the same source - so we use >= expected_count to avoid flakiness
         >= expected_count
     )
+
+
+def test_audio_has_correct_properties(app: Page):
+    """Test that `st.audio` renders correct properties."""
+    audio_elements = app.get_by_test_id("stAudio")
+    expect(audio_elements).to_have_count(6)
+    expect(audio_elements.nth(0)).to_be_visible()
+    expect(audio_elements.nth(0)).to_have_attribute("controls", "")
+    expect(audio_elements.nth(0)).to_have_attribute("src", re.compile(r".*media.*wav"))
 
 
 @pytest.mark.skip_browser("webkit")
@@ -134,6 +144,8 @@ def test_audio_uses_unified_height(
     assert_snapshot(audio_element, name="st_audio-unified_height")
 
 
+# TODO(mgbarnes): Figure out why this test is flaky on Firefox.
+@pytest.mark.skip_browser("firefox")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -159,6 +171,8 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
+# TODO(mgbarnes): Figure out why this test is flaky on Firefox.
+@pytest.mark.skip_browser("firefox")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -36,7 +36,9 @@ def check_audio_source_error_count(messages: list[str], expected_count: int):
                 if "Client Error: Audio source error" in message
             ]
         )
-        == expected_count
+        # when test run on webkit/firefox, it will sometimes log extra instances of the error
+        # for the same source - so we use >= expected_count to avoid flakiness
+        >= expected_count
     )
 
 

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import re
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -23,14 +22,22 @@ from e2e_playwright.shared.app_utils import (
     click_checkbox,
 )
 
+AUDIO_ELEMENTS_WITH_PATH = 3
+AUDIO_ELEMENTS_WITH_URL = 3
 
-def test_audio_has_correct_properties(app: Page):
-    """Test that `st.audio` renders correct properties."""
-    audio_elements = app.get_by_test_id("stAudio")
-    expect(audio_elements).to_have_count(6)
-    expect(audio_elements.nth(0)).to_be_visible()
-    expect(audio_elements.nth(0)).to_have_attribute("controls", "")
-    expect(audio_elements.nth(0)).to_have_attribute("src", re.compile(r".*media.*wav"))
+
+def check_audio_source_error_count(messages: list[str], expected_count: int):
+    """Check that the expected number of audio source error messages are logged."""
+    assert (
+        len(
+            [
+                message
+                for message in messages
+                if "Client Error: Audio source error" in message
+            ]
+        )
+        == expected_count
+    )
 
 
 @pytest.mark.skip_browser("webkit")
@@ -123,3 +130,53 @@ def test_audio_uses_unified_height(
     themed_app.wait_for_timeout(1000)
 
     assert_snapshot(audio_element, name="st_audio-unified_height")
+
+
+def test_audio_source_error_with_url(app: Page, app_port: int):
+    """Test `st.audio` source error when data is a url."""
+    # Ensure audio source request return a 404 status
+    app.route(
+        "https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/viper.mp3",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    # Should be 3 instances of the error, one for each audio element with url
+    wait_until(
+        app,
+        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_URL),
+    )
+
+
+def test_audio_source_error_with_path(app: Page, app_port: int):
+    """Test `st.audio` source error when data is path (media endpoint)."""
+    # Ensure audio source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/media/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
+    # Should be 3 instances of the error, one for each audio element with path
+    wait_until(
+        app,
+        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
+    )

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -12,77 +12,558 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import FilePayload, Page, expect
+from playwright.sync_api import FilePayload, Page, Route
 
-from e2e_playwright.conftest import ImageCompareFunction, rerun_app, wait_for_app_run
-from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
+from e2e_playwright.conftest import (
+    wait_for_app_run,
+    wait_until,
+)
+
+# def test_file_uploader_render_correctly(
+#     themed_app: Page, assert_snapshot: ImageCompareFunction
+# ):
+#     """Test that the file uploader render as expected via screenshot matching."""
+#     file_uploaders = themed_app.get_by_test_id("stFileUploader")
+#     expect(file_uploaders).to_have_count(10)
+
+#     assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
+#     assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
+#     assert_snapshot(file_uploaders.nth(2), name="st_file_uploader-multiple_files")
+#     assert_snapshot(file_uploaders.nth(4), name="st_file_uploader-hidden_label")
+#     assert_snapshot(file_uploaders.nth(5), name="st_file_uploader-collapsed_label")
+#     # The other file uploaders do not need to be snapshot tested.
+#     assert_snapshot(file_uploaders.nth(8), name="st_file_uploader-markdown_label")
+#     assert_snapshot(file_uploaders.nth(9), name="st_file_uploader-compact")
 
 
-def test_file_uploader_render_correctly(
-    themed_app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Test that the file uploader render as expected via screenshot matching."""
-    file_uploaders = themed_app.get_by_test_id("stFileUploader")
-    expect(file_uploaders).to_have_count(10)
+# def test_file_uploader_error_message_disallowed_files(
+#     app: Page, assert_snapshot: ImageCompareFunction
+# ):
+#     """Test that shows error message for disallowed files."""
+#     file_name1 = "example.json"
+#     file_content1 = b"{}"
 
-    assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
-    assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
-    assert_snapshot(file_uploaders.nth(2), name="st_file_uploader-multiple_files")
-    assert_snapshot(file_uploaders.nth(4), name="st_file_uploader-hidden_label")
-    assert_snapshot(file_uploaders.nth(5), name="st_file_uploader-collapsed_label")
-    # The other file uploaders do not need to be snapshot tested.
-    assert_snapshot(file_uploaders.nth(8), name="st_file_uploader-markdown_label")
-    assert_snapshot(file_uploaders.nth(9), name="st_file_uploader-compact")
+#     uploader_index = 0
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(
+#                 name=file_name1,
+#                 mimeType="application/json",
+#                 buffer=file_content1,
+#             )
+#         ]
+#     )
+
+#     wait_for_app_run(app)
+
+#     expect(
+#         app.get_by_test_id("stFileUploaderFileErrorMessage").nth(uploader_index)
+#     ).to_have_text("application/json files are not allowed.", use_inner_text=True)
+
+#     file_uploader_in_error_state = app.get_by_test_id("stFileUploader").nth(
+#         uploader_index
+#     )
+
+#     assert_snapshot(file_uploader_in_error_state, name="st_file_uploader-error")
 
 
-def test_file_uploader_error_message_disallowed_files(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Test that shows error message for disallowed files."""
-    file_name1 = "example.json"
-    file_content1 = b"{}"
+# def test_uploads_and_deletes_single_file_only(
+#     app: Page, assert_snapshot: ImageCompareFunction
+# ):
+#     """Test that uploading a file for single file uploader works as expected."""
+#     file_name1 = "file1.txt"
+#     file_content1 = b"file1content"
 
+#     file_name2 = "file2.txt"
+#     file_content2 = b"file2content"
+
+#     uploader_index = 0
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+#         ]
+#     )
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+#         file_name1, use_inner_text=True
+#     )
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         str(file_content1), use_inner_text=True
+#     )
+
+#     file_uploader_uploaded_state = app.get_by_test_id("stFileUploader").nth(
+#         uploader_index
+#     )
+
+#     assert_snapshot(
+#         file_uploader_uploaded_state, name="st_file_uploader-single_file_uploaded"
+#     )
+
+#     expect(
+#         app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
+#     ).to_have_text("True", use_inner_text=True)
+
+#     # Upload a second file. This one will replace the first.
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2)
+#         ]
+#     )
+
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+#         file_name2, use_inner_text=True
+#     )
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         str(file_content2), use_inner_text=True
+#     )
+
+#     expect(
+#         app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
+#     ).to_have_text("True", use_inner_text=True)
+
+#     rerun_app(app)
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         str(file_content2), use_inner_text=True
+#     )
+
+#     app.get_by_test_id("stFileUploaderDeleteBtn").nth(uploader_index).click()
+
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "No upload", use_inner_text=True
+#     )
+
+
+# def test_uploads_and_deletes_multiple_files(
+#     app: Page, assert_snapshot: ImageCompareFunction
+# ):
+#     """Test that uploading multiple files at once works correctly."""
+#     file_name1 = "file1.txt"
+#     file_content1 = b"file1content"
+
+#     file_name2 = "file2.txt"
+#     file_content2 = b"file2content"
+
+#     files = [
+#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+#     ]
+
+#     uploader_index = 2
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(files=files)
+
+#     wait_for_app_run(app, wait_delay=500)
+
+#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+
+#     # The widget should show the names of the uploaded files in reverse order
+#     file_names = [files[1]["name"], files[0]["name"]]
+
+#     for i, element in enumerate(uploaded_file_names.all()):
+#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+
+#     # The script should have printed the contents of the two files into a st.text.
+#     # This tests that the upload actually went through.
+#     content = "\n".join(
+#         [
+#             files[0]["buffer"].decode("utf-8"),
+#             files[1]["buffer"].decode("utf-8"),
+#         ]
+#     )
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         content, use_inner_text=True
+#     )
+
+#     file_uploader = app.get_by_test_id("stFileUploader").nth(uploader_index)
+#     assert_snapshot(file_uploader, name="st_file_uploader-multi_file_uploaded")
+
+#     #  Delete the second file. The second file is on top because it was
+#     #  most recently uploaded. The first file should still exist.
+#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
+#     )
+
+#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+#         "True", use_inner_text=True
+#     )
+
+
+# def test_uploads_multiple_files_one_by_one_quickly(app: Page):
+#     """Test that uploads and deletes multiple files quickly works correctly."""
+#     file_name1 = "file1.txt"
+#     file_content1 = b"file1content"
+
+#     file_name2 = "file2.txt"
+#     file_content2 = b"file2content"
+
+#     files = [
+#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+#     ]
+
+#     uploader_index = 2
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(files=files[0])
+
+#     # The widget should show the name of the uploaded file
+#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+#         file_name1, use_inner_text=True
+#     )
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+
+#     with app.expect_request("**/upload_file/**"):
+#         file_chooser.set_files(files=files[1])
+
+#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+
+#     # The widget should show the names of the uploaded files in reverse order
+#     file_names = [files[1]["name"], files[0]["name"]]
+
+#     for i, element in enumerate(uploaded_file_names.all()):
+#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+
+#     # The script should have printed the contents of the two files into a st.text.
+#     # This tests that the upload actually went through.
+#     content = "\n".join(
+#         [
+#             files[0]["buffer"].decode("utf-8"),
+#             files[1]["buffer"].decode("utf-8"),
+#         ]
+#     )
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         content, use_inner_text=True
+#     )
+
+#     #  Delete the second file. The second file is on top because it was
+#     #  most recently uploaded. The first file should still exist.
+#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
+#     )
+
+#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+#         "True", use_inner_text=True
+#     )
+
+
+# # NOTE: This test is essentially identical to the one above. The only
+# # difference is that we add a short delay to uploading the two files to
+# # ensure that two script runs happen separately (sufficiently rapid widget
+# # changes will often be batched into a single script run) to test for the
+# # failure mode in https://github.com/streamlit/streamlit/issues/3531.
+# def test_uploads_multiple_files_one_by_one_slowly(app: Page):
+#     """Test that uploads and deletes multiple files slowly works."""
+#     file_name1 = "file1.txt"
+#     file_content1 = b"file1content"
+
+#     file_name2 = "file2.txt"
+#     file_content2 = b"file2content"
+
+#     files = [
+#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+#     ]
+
+#     uploader_index = 2
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     # Here we wait for the first file to be uploaded before uploading the second
+#     with app.expect_request("**/upload_file/**"):
+#         file_chooser.set_files(files=files[0])
+
+#     # The widget should show the name of the uploaded file
+#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+#         file_name1, use_inner_text=True
+#     )
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+
+#     with app.expect_request("**/upload_file/**"):
+#         file_chooser.set_files(files=files[1])
+
+#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+
+#     # The widget should show the names of the uploaded files in reverse order
+#     file_names = [files[1]["name"], files[0]["name"]]
+
+#     for i, element in enumerate(uploaded_file_names.all()):
+#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+
+#     # The script should have printed the contents of the two files into a st.text.
+#     # This tests that the upload actually went through.
+#     content = "\n".join(
+#         [
+#             files[0]["buffer"].decode("utf-8"),
+#             files[1]["buffer"].decode("utf-8"),
+#         ]
+#     )
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         content, use_inner_text=True
+#     )
+
+#     #  Delete the second file. The second file is on top because it was
+#     #  most recently uploaded. The first file should still exist.
+#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
+#     )
+
+#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+#         "True", use_inner_text=True
+#     )
+
+
+# def test_does_not_call_callback_when_not_changed(app: Page):
+#     """Test that the file uploader does not call a callback when not changed."""
+#     file_name1 = "example5.txt"
+#     file_content1 = b"Hello world!"
+
+#     uploader_index = 6
+
+#     # Script contains counter variable stored in session_state with
+#     # default value 0. We increment counter inside file_uploader callback
+#     # Since callback did not called at this moment, counter value should
+#     # be equal 0
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "0", use_inner_text=True
+#     )
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(
+#                 name=file_name1,
+#                 mimeType="application/json",
+#                 buffer=file_content1,
+#             )
+#         ]
+#     )
+
+#     wait_for_app_run(app)
+
+#     # Make sure callback called
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "1", use_inner_text=True
+#     )
+#     rerun_app(app)
+
+#     # Counter should be still equal 1
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "1", use_inner_text=True
+#     )
+
+
+# def test_works_inside_form(app: Page):
+#     """Test that uploading a file inside form works as expected."""
+#     file_name1 = "form_file1.txt"
+#     file_content1 = b"form_file1content"
+
+#     uploader_index = 3
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+#         ]
+#     )
+#     wait_for_app_run(app)
+
+#     # We should be showing the uploaded file name
+#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+#         file_name1, use_inner_text=True
+#     )
+#     # But our uploaded text should contain nothing yet, as we haven't submitted.
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "No upload", use_inner_text=True
+#     )
+
+#     # Submit the form
+#     app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
+#     wait_for_app_run(app)
+
+#     # Now we should see the file's contents
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         str(file_content1), use_inner_text=True
+#     )
+
+#     # Press the delete button. Again, nothing should happen - we
+#     # should still see the file's contents.
+#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+#     wait_for_app_run(app)
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         str(file_content1), use_inner_text=True
+#     )
+
+#     # Submit again. Now the file should be gone.
+#     app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+#         "No upload", use_inner_text=True
+#     )
+
+
+# def test_check_top_level_class(app: Page):
+#     """Check that the top level class is correctly set."""
+#     check_top_level_class(app, "stFileUploader")
+
+
+# def test_custom_css_class_via_key(app: Page):
+#     """Test that the element can have a custom css class via the key argument."""
+#     expect(get_element_by_key(app, "single")).to_be_visible()
+
+
+# def test_file_uploader_works_with_fragments(app: Page):
+#     file_name1 = "form_file1.txt"
+#     file_content1 = b"form_file1content"
+
+#     expect(app.get_by_text("Runs: 1")).to_be_visible()
+#     expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
+
+#     uploader_index = 7
+
+#     with app.expect_file_chooser() as fc_info:
+#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+#     file_chooser = fc_info.value
+#     file_chooser.set_files(
+#         files=[
+#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+#         ]
+#     )
+#     wait_for_app_run(app)
+
+#     expect(app.get_by_text("File uploader in Fragment: True")).to_be_visible()
+#     expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+
+def test_file_uploader_upload_error(app: Page, app_port: int):
+    """Test that the file uploader upload error is correctly logged."""
+    # Ensure file upload source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
     uploader_index = 0
 
+    # Upload a file
     with app.expect_file_chooser() as fc_info:
         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
     file_chooser = fc_info.value
     file_chooser.set_files(
         files=[
-            FilePayload(
-                name=file_name1,
-                mimeType="application/json",
-                buffer=file_content1,
-            )
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
         ]
     )
-
     wait_for_app_run(app)
 
-    expect(
-        app.get_by_test_id("stFileUploaderFileErrorMessage").nth(uploader_index)
-    ).to_have_text("application/json files are not allowed.", use_inner_text=True)
-
-    file_uploader_in_error_state = app.get_by_test_id("stFileUploader").nth(
-        uploader_index
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: any(
+            "Client Error: File uploader error on file upload" in message
+            for message in messages
+        ),
     )
 
-    assert_snapshot(file_uploader_in_error_state, name="st_file_uploader-error")
 
+def test_file_uploader_delete_error(app: Page, app_port: int):
+    """Test that the file uploader delete error is correctly logged."""
 
-def test_uploads_and_deletes_single_file_only(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Test that uploading a file for single file uploader works as expected."""
+    # Allow GET requests to pass through, but block DELETE requests
+    def allow_file_upload_block_delete(route: Route):
+        if route.request.method == "DELETE":
+            route.fulfill(
+                status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+            )
+        else:
+            route.fallback()
+
+    # Ensure file upload source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        allow_file_upload_block_delete,
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
     file_name1 = "file1.txt"
     file_content1 = b"file1content"
-
-    file_name2 = "file2.txt"
-    file_content2 = b"file2content"
-
     uploader_index = 0
 
+    # Upload a file
     with app.expect_file_chooser() as fc_info:
         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
@@ -94,397 +575,15 @@ def test_uploads_and_deletes_single_file_only(
     )
     wait_for_app_run(app)
 
-    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-        file_name1, use_inner_text=True
-    )
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        str(file_content1), use_inner_text=True
-    )
-
-    file_uploader_uploaded_state = app.get_by_test_id("stFileUploader").nth(
-        uploader_index
-    )
-
-    assert_snapshot(
-        file_uploader_uploaded_state, name="st_file_uploader-single_file_uploaded"
-    )
-
-    expect(
-        app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
-    ).to_have_text("True", use_inner_text=True)
-
-    # Upload a second file. This one will replace the first.
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(
-        files=[
-            FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2)
-        ]
-    )
-
-    wait_for_app_run(app)
-
-    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-        file_name2, use_inner_text=True
-    )
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        str(file_content2), use_inner_text=True
-    )
-
-    expect(
-        app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
-    ).to_have_text("True", use_inner_text=True)
-
-    rerun_app(app)
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        str(file_content2), use_inner_text=True
-    )
-
-    app.get_by_test_id("stFileUploaderDeleteBtn").nth(uploader_index).click()
-
-    wait_for_app_run(app)
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "No upload", use_inner_text=True
-    )
-
-
-def test_uploads_and_deletes_multiple_files(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Test that uploading multiple files at once works correctly."""
-    file_name1 = "file1.txt"
-    file_content1 = b"file1content"
-
-    file_name2 = "file2.txt"
-    file_content2 = b"file2content"
-
-    files = [
-        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-    ]
-
-    uploader_index = 2
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(files=files)
-
-    wait_for_app_run(app, wait_delay=500)
-
-    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
-
-    # The widget should show the names of the uploaded files in reverse order
-    file_names = [files[1]["name"], files[0]["name"]]
-
-    for i, element in enumerate(uploaded_file_names.all()):
-        expect(element).to_have_text(file_names[i], use_inner_text=True)
-
-    # The script should have printed the contents of the two files into a st.text.
-    # This tests that the upload actually went through.
-    content = "\n".join(
-        [
-            files[0]["buffer"].decode("utf-8"),
-            files[1]["buffer"].decode("utf-8"),
-        ]
-    )
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        content, use_inner_text=True
-    )
-
-    file_uploader = app.get_by_test_id("stFileUploader").nth(uploader_index)
-    assert_snapshot(file_uploader, name="st_file_uploader-multi_file_uploaded")
-
-    #  Delete the second file. The second file is on top because it was
-    #  most recently uploaded. The first file should still exist.
-    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
-
-    wait_for_app_run(app)
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        files[0]["buffer"].decode("utf-8"), use_inner_text=True
-    )
-
-    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-        "True", use_inner_text=True
-    )
-
-
-def test_uploads_multiple_files_one_by_one_quickly(app: Page):
-    """Test that uploads and deletes multiple files quickly works correctly."""
-    file_name1 = "file1.txt"
-    file_content1 = b"file1content"
-
-    file_name2 = "file2.txt"
-    file_content2 = b"file2content"
-
-    files = [
-        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-    ]
-
-    uploader_index = 2
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(files=files[0])
-
-    # The widget should show the name of the uploaded file
-    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-        file_name1, use_inner_text=True
-    )
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-
-    with app.expect_request("**/upload_file/**"):
-        file_chooser.set_files(files=files[1])
-
-    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
-
-    # The widget should show the names of the uploaded files in reverse order
-    file_names = [files[1]["name"], files[0]["name"]]
-
-    for i, element in enumerate(uploaded_file_names.all()):
-        expect(element).to_have_text(file_names[i], use_inner_text=True)
-
-    # The script should have printed the contents of the two files into a st.text.
-    # This tests that the upload actually went through.
-    content = "\n".join(
-        [
-            files[0]["buffer"].decode("utf-8"),
-            files[1]["buffer"].decode("utf-8"),
-        ]
-    )
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        content, use_inner_text=True
-    )
-
-    #  Delete the second file. The second file is on top because it was
-    #  most recently uploaded. The first file should still exist.
-    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        files[0]["buffer"].decode("utf-8"), use_inner_text=True
-    )
-
-    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-        "True", use_inner_text=True
-    )
-
-
-# NOTE: This test is essentially identical to the one above. The only
-# difference is that we add a short delay to uploading the two files to
-# ensure that two script runs happen separately (sufficiently rapid widget
-# changes will often be batched into a single script run) to test for the
-# failure mode in https://github.com/streamlit/streamlit/issues/3531.
-def test_uploads_multiple_files_one_by_one_slowly(app: Page):
-    """Test that uploads and deletes multiple files slowly works."""
-    file_name1 = "file1.txt"
-    file_content1 = b"file1content"
-
-    file_name2 = "file2.txt"
-    file_content2 = b"file2content"
-
-    files = [
-        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-    ]
-
-    uploader_index = 2
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    # Here we wait for the first file to be uploaded before uploading the second
-    with app.expect_request("**/upload_file/**"):
-        file_chooser.set_files(files=files[0])
-
-    # The widget should show the name of the uploaded file
-    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-        file_name1, use_inner_text=True
-    )
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-
-    with app.expect_request("**/upload_file/**"):
-        file_chooser.set_files(files=files[1])
-
-    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
-
-    # The widget should show the names of the uploaded files in reverse order
-    file_names = [files[1]["name"], files[0]["name"]]
-
-    for i, element in enumerate(uploaded_file_names.all()):
-        expect(element).to_have_text(file_names[i], use_inner_text=True)
-
-    # The script should have printed the contents of the two files into a st.text.
-    # This tests that the upload actually went through.
-    content = "\n".join(
-        [
-            files[0]["buffer"].decode("utf-8"),
-            files[1]["buffer"].decode("utf-8"),
-        ]
-    )
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        content, use_inner_text=True
-    )
-
-    #  Delete the second file. The second file is on top because it was
-    #  most recently uploaded. The first file should still exist.
-    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
-
-    wait_for_app_run(app)
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        files[0]["buffer"].decode("utf-8"), use_inner_text=True
-    )
-
-    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-        "True", use_inner_text=True
-    )
-
-
-def test_does_not_call_callback_when_not_changed(app: Page):
-    """Test that the file uploader does not call a callback when not changed."""
-    file_name1 = "example5.txt"
-    file_content1 = b"Hello world!"
-
-    uploader_index = 6
-
-    # Script contains counter variable stored in session_state with
-    # default value 0. We increment counter inside file_uploader callback
-    # Since callback did not called at this moment, counter value should
-    # be equal 0
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "0", use_inner_text=True
-    )
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(
-        files=[
-            FilePayload(
-                name=file_name1,
-                mimeType="application/json",
-                buffer=file_content1,
-            )
-        ]
-    )
-
-    wait_for_app_run(app)
-
-    # Make sure callback called
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "1", use_inner_text=True
-    )
-    rerun_app(app)
-
-    # Counter should be still equal 1
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "1", use_inner_text=True
-    )
-
-
-def test_works_inside_form(app: Page):
-    """Test that uploading a file inside form works as expected."""
-    file_name1 = "form_file1.txt"
-    file_content1 = b"form_file1content"
-
-    uploader_index = 3
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(
-        files=[
-            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
-        ]
-    )
-    wait_for_app_run(app)
-
-    # We should be showing the uploaded file name
-    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-        file_name1, use_inner_text=True
-    )
-    # But our uploaded text should contain nothing yet, as we haven't submitted.
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "No upload", use_inner_text=True
-    )
-
-    # Submit the form
-    app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
-    wait_for_app_run(app)
-
-    # Now we should see the file's contents
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        str(file_content1), use_inner_text=True
-    )
-
-    # Press the delete button. Again, nothing should happen - we
-    # should still see the file's contents.
+    # Delete the file
     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
     wait_for_app_run(app)
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        str(file_content1), use_inner_text=True
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: any(
+            "Client Error: File uploader error on file delete" in message
+            for message in messages
+        ),
     )
-
-    # Submit again. Now the file should be gone.
-    app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
-    wait_for_app_run(app)
-
-    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-        "No upload", use_inner_text=True
-    )
-
-
-def test_check_top_level_class(app: Page):
-    """Check that the top level class is correctly set."""
-    check_top_level_class(app, "stFileUploader")
-
-
-def test_custom_css_class_via_key(app: Page):
-    """Test that the element can have a custom css class via the key argument."""
-    expect(get_element_by_key(app, "single")).to_be_visible()
-
-
-def test_file_uploader_works_with_fragments(app: Page):
-    file_name1 = "form_file1.txt"
-    file_content1 = b"form_file1content"
-
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
-    expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
-
-    uploader_index = 7
-
-    with app.expect_file_chooser() as fc_info:
-        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-    file_chooser = fc_info.value
-    file_chooser.set_files(
-        files=[
-            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
-        ]
-    )
-    wait_for_app_run(app)
-
-    expect(app.get_by_text("File uploader in Fragment: True")).to_be_visible()
-    expect(app.get_by_text("Runs: 1")).to_be_visible()

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -12,483 +12,487 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import FilePayload, Page, Route
+from playwright.sync_api import FilePayload, ImageCompareFunction, Page, Route, expect
 
 from e2e_playwright.conftest import (
+    check_top_level_class,
+    get_element_by_key,
+    rerun_app,
     wait_for_app_run,
     wait_until,
 )
 
-# def test_file_uploader_render_correctly(
-#     themed_app: Page, assert_snapshot: ImageCompareFunction
-# ):
-#     """Test that the file uploader render as expected via screenshot matching."""
-#     file_uploaders = themed_app.get_by_test_id("stFileUploader")
-#     expect(file_uploaders).to_have_count(10)
-
-#     assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
-#     assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
-#     assert_snapshot(file_uploaders.nth(2), name="st_file_uploader-multiple_files")
-#     assert_snapshot(file_uploaders.nth(4), name="st_file_uploader-hidden_label")
-#     assert_snapshot(file_uploaders.nth(5), name="st_file_uploader-collapsed_label")
-#     # The other file uploaders do not need to be snapshot tested.
-#     assert_snapshot(file_uploaders.nth(8), name="st_file_uploader-markdown_label")
-#     assert_snapshot(file_uploaders.nth(9), name="st_file_uploader-compact")
-
-
-# def test_file_uploader_error_message_disallowed_files(
-#     app: Page, assert_snapshot: ImageCompareFunction
-# ):
-#     """Test that shows error message for disallowed files."""
-#     file_name1 = "example.json"
-#     file_content1 = b"{}"
-
-#     uploader_index = 0
-
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
-
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(
-#                 name=file_name1,
-#                 mimeType="application/json",
-#                 buffer=file_content1,
-#             )
-#         ]
-#     )
-
-#     wait_for_app_run(app)
-
-#     expect(
-#         app.get_by_test_id("stFileUploaderFileErrorMessage").nth(uploader_index)
-#     ).to_have_text("application/json files are not allowed.", use_inner_text=True)
-
-#     file_uploader_in_error_state = app.get_by_test_id("stFileUploader").nth(
-#         uploader_index
-#     )
-
-#     assert_snapshot(file_uploader_in_error_state, name="st_file_uploader-error")
-
-
-# def test_uploads_and_deletes_single_file_only(
-#     app: Page, assert_snapshot: ImageCompareFunction
-# ):
-#     """Test that uploading a file for single file uploader works as expected."""
-#     file_name1 = "file1.txt"
-#     file_content1 = b"file1content"
 
-#     file_name2 = "file2.txt"
-#     file_content2 = b"file2content"
+def test_file_uploader_render_correctly(
+    themed_app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that the file uploader render as expected via screenshot matching."""
+    file_uploaders = themed_app.get_by_test_id("stFileUploader")
+    expect(file_uploaders).to_have_count(10)
+
+    assert_snapshot(file_uploaders.nth(0), name="st_file_uploader-single_file")
+    assert_snapshot(file_uploaders.nth(1), name="st_file_uploader-disabled")
+    assert_snapshot(file_uploaders.nth(2), name="st_file_uploader-multiple_files")
+    assert_snapshot(file_uploaders.nth(4), name="st_file_uploader-hidden_label")
+    assert_snapshot(file_uploaders.nth(5), name="st_file_uploader-collapsed_label")
+    # The other file uploaders do not need to be snapshot tested.
+    assert_snapshot(file_uploaders.nth(8), name="st_file_uploader-markdown_label")
+    assert_snapshot(file_uploaders.nth(9), name="st_file_uploader-compact")
+
+
+def test_file_uploader_error_message_disallowed_files(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that shows error message for disallowed files."""
+    file_name1 = "example.json"
+    file_content1 = b"{}"
+
+    uploader_index = 0
+
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(
+                name=file_name1,
+                mimeType="application/json",
+                buffer=file_content1,
+            )
+        ]
+    )
 
-#     uploader_index = 0
+    wait_for_app_run(app)
+
+    expect(
+        app.get_by_test_id("stFileUploaderFileErrorMessage").nth(uploader_index)
+    ).to_have_text("application/json files are not allowed.", use_inner_text=True)
+
+    file_uploader_in_error_state = app.get_by_test_id("stFileUploader").nth(
+        uploader_index
+    )
+
+    assert_snapshot(file_uploader_in_error_state, name="st_file_uploader-error")
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+def test_uploads_and_deletes_single_file_only(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that uploading a file for single file uploader works as expected."""
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
-#         ]
-#     )
-#     wait_for_app_run(app)
+    file_name2 = "file2.txt"
+    file_content2 = b"file2content"
 
-#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-#         file_name1, use_inner_text=True
-#     )
-
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         str(file_content1), use_inner_text=True
-#     )
-
-#     file_uploader_uploaded_state = app.get_by_test_id("stFileUploader").nth(
-#         uploader_index
-#     )
-
-#     assert_snapshot(
-#         file_uploader_uploaded_state, name="st_file_uploader-single_file_uploaded"
-#     )
+    uploader_index = 0
 
-#     expect(
-#         app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
-#     ).to_have_text("True", use_inner_text=True)
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     # Upload a second file. This one will replace the first.
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+        ]
+    )
+    wait_for_app_run(app)
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2)
-#         ]
-#     )
+    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+        file_name1, use_inner_text=True
+    )
 
-#     wait_for_app_run(app)
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        str(file_content1), use_inner_text=True
+    )
 
-#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-#         file_name2, use_inner_text=True
-#     )
+    file_uploader_uploaded_state = app.get_by_test_id("stFileUploader").nth(
+        uploader_index
+    )
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         str(file_content2), use_inner_text=True
-#     )
+    assert_snapshot(
+        file_uploader_uploaded_state, name="st_file_uploader-single_file_uploaded"
+    )
 
-#     expect(
-#         app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
-#     ).to_have_text("True", use_inner_text=True)
+    expect(
+        app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
+    ).to_have_text("True", use_inner_text=True)
 
-#     rerun_app(app)
+    # Upload a second file. This one will replace the first.
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         str(file_content2), use_inner_text=True
-#     )
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2)
+        ]
+    )
 
-#     app.get_by_test_id("stFileUploaderDeleteBtn").nth(uploader_index).click()
+    wait_for_app_run(app)
 
-#     wait_for_app_run(app)
+    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+        file_name2, use_inner_text=True
+    )
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "No upload", use_inner_text=True
-#     )
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        str(file_content2), use_inner_text=True
+    )
 
+    expect(
+        app.get_by_test_id("stMarkdownContainer").nth(uploader_index + 1)
+    ).to_have_text("True", use_inner_text=True)
 
-# def test_uploads_and_deletes_multiple_files(
-#     app: Page, assert_snapshot: ImageCompareFunction
-# ):
-#     """Test that uploading multiple files at once works correctly."""
-#     file_name1 = "file1.txt"
-#     file_content1 = b"file1content"
+    rerun_app(app)
 
-#     file_name2 = "file2.txt"
-#     file_content2 = b"file2content"
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        str(file_content2), use_inner_text=True
+    )
 
-#     files = [
-#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-#     ]
+    app.get_by_test_id("stFileUploaderDeleteBtn").nth(uploader_index).click()
 
-#     uploader_index = 2
+    wait_for_app_run(app)
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "No upload", use_inner_text=True
+    )
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(files=files)
 
-#     wait_for_app_run(app, wait_delay=500)
+def test_uploads_and_deletes_multiple_files(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that uploading multiple files at once works correctly."""
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
 
-#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+    file_name2 = "file2.txt"
+    file_content2 = b"file2content"
 
-#     # The widget should show the names of the uploaded files in reverse order
-#     file_names = [files[1]["name"], files[0]["name"]]
+    files = [
+        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+    ]
 
-#     for i, element in enumerate(uploaded_file_names.all()):
-#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+    uploader_index = 2
 
-#     # The script should have printed the contents of the two files into a st.text.
-#     # This tests that the upload actually went through.
-#     content = "\n".join(
-#         [
-#             files[0]["buffer"].decode("utf-8"),
-#             files[1]["buffer"].decode("utf-8"),
-#         ]
-#     )
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         content, use_inner_text=True
-#     )
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     file_uploader = app.get_by_test_id("stFileUploader").nth(uploader_index)
-#     assert_snapshot(file_uploader, name="st_file_uploader-multi_file_uploaded")
+    file_chooser = fc_info.value
+    file_chooser.set_files(files=files)
 
-#     #  Delete the second file. The second file is on top because it was
-#     #  most recently uploaded. The first file should still exist.
-#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+    wait_for_app_run(app, wait_delay=500)
 
-#     wait_for_app_run(app)
+    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
-#     )
+    # The widget should show the names of the uploaded files in reverse order
+    file_names = [files[1]["name"], files[0]["name"]]
 
-#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-#         "True", use_inner_text=True
-#     )
+    for i, element in enumerate(uploaded_file_names.all()):
+        expect(element).to_have_text(file_names[i], use_inner_text=True)
 
+    # The script should have printed the contents of the two files into a st.text.
+    # This tests that the upload actually went through.
+    content = "\n".join(
+        [
+            files[0]["buffer"].decode("utf-8"),
+            files[1]["buffer"].decode("utf-8"),
+        ]
+    )
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        content, use_inner_text=True
+    )
 
-# def test_uploads_multiple_files_one_by_one_quickly(app: Page):
-#     """Test that uploads and deletes multiple files quickly works correctly."""
-#     file_name1 = "file1.txt"
-#     file_content1 = b"file1content"
+    file_uploader = app.get_by_test_id("stFileUploader").nth(uploader_index)
+    assert_snapshot(file_uploader, name="st_file_uploader-multi_file_uploaded")
 
-#     file_name2 = "file2.txt"
-#     file_content2 = b"file2content"
+    #  Delete the second file. The second file is on top because it was
+    #  most recently uploaded. The first file should still exist.
+    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
 
-#     files = [
-#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-#     ]
+    wait_for_app_run(app)
 
-#     uploader_index = 2
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        files[0]["buffer"].decode("utf-8"), use_inner_text=True
+    )
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+        "True", use_inner_text=True
+    )
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(files=files[0])
 
-#     # The widget should show the name of the uploaded file
-#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-#         file_name1, use_inner_text=True
-#     )
+def test_uploads_multiple_files_one_by_one_quickly(app: Page):
+    """Test that uploads and deletes multiple files quickly works correctly."""
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    file_name2 = "file2.txt"
+    file_content2 = b"file2content"
 
-#     file_chooser = fc_info.value
+    files = [
+        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+    ]
 
-#     with app.expect_request("**/upload_file/**"):
-#         file_chooser.set_files(files=files[1])
+    uploader_index = 2
 
-#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     # The widget should show the names of the uploaded files in reverse order
-#     file_names = [files[1]["name"], files[0]["name"]]
+    file_chooser = fc_info.value
+    file_chooser.set_files(files=files[0])
 
-#     for i, element in enumerate(uploaded_file_names.all()):
-#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+    # The widget should show the name of the uploaded file
+    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+        file_name1, use_inner_text=True
+    )
 
-#     # The script should have printed the contents of the two files into a st.text.
-#     # This tests that the upload actually went through.
-#     content = "\n".join(
-#         [
-#             files[0]["buffer"].decode("utf-8"),
-#             files[1]["buffer"].decode("utf-8"),
-#         ]
-#     )
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         content, use_inner_text=True
-#     )
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     #  Delete the second file. The second file is on top because it was
-#     #  most recently uploaded. The first file should still exist.
-#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+    file_chooser = fc_info.value
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
-#     )
+    with app.expect_request("**/upload_file/**"):
+        file_chooser.set_files(files=files[1])
 
-#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-#         "True", use_inner_text=True
-#     )
+    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
 
+    # The widget should show the names of the uploaded files in reverse order
+    file_names = [files[1]["name"], files[0]["name"]]
 
-# # NOTE: This test is essentially identical to the one above. The only
-# # difference is that we add a short delay to uploading the two files to
-# # ensure that two script runs happen separately (sufficiently rapid widget
-# # changes will often be batched into a single script run) to test for the
-# # failure mode in https://github.com/streamlit/streamlit/issues/3531.
-# def test_uploads_multiple_files_one_by_one_slowly(app: Page):
-#     """Test that uploads and deletes multiple files slowly works."""
-#     file_name1 = "file1.txt"
-#     file_content1 = b"file1content"
+    for i, element in enumerate(uploaded_file_names.all()):
+        expect(element).to_have_text(file_names[i], use_inner_text=True)
 
-#     file_name2 = "file2.txt"
-#     file_content2 = b"file2content"
+    # The script should have printed the contents of the two files into a st.text.
+    # This tests that the upload actually went through.
+    content = "\n".join(
+        [
+            files[0]["buffer"].decode("utf-8"),
+            files[1]["buffer"].decode("utf-8"),
+        ]
+    )
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        content, use_inner_text=True
+    )
 
-#     files = [
-#         FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
-#         FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
-#     ]
+    #  Delete the second file. The second file is on top because it was
+    #  most recently uploaded. The first file should still exist.
+    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
 
-#     uploader_index = 2
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        files[0]["buffer"].decode("utf-8"), use_inner_text=True
+    )
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+        "True", use_inner_text=True
+    )
 
-#     file_chooser = fc_info.value
-#     # Here we wait for the first file to be uploaded before uploading the second
-#     with app.expect_request("**/upload_file/**"):
-#         file_chooser.set_files(files=files[0])
 
-#     # The widget should show the name of the uploaded file
-#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-#         file_name1, use_inner_text=True
-#     )
+# NOTE: This test is essentially identical to the one above. The only
+# difference is that we add a short delay to uploading the two files to
+# ensure that two script runs happen separately (sufficiently rapid widget
+# changes will often be batched into a single script run) to test for the
+# failure mode in https://github.com/streamlit/streamlit/issues/3531.
+def test_uploads_multiple_files_one_by_one_slowly(app: Page):
+    """Test that uploads and deletes multiple files slowly works."""
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    file_name2 = "file2.txt"
+    file_content2 = b"file2content"
 
-#     file_chooser = fc_info.value
+    files = [
+        FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1),
+        FilePayload(name=file_name2, mimeType="text/plain", buffer=file_content2),
+    ]
 
-#     with app.expect_request("**/upload_file/**"):
-#         file_chooser.set_files(files=files[1])
+    uploader_index = 2
 
-#     uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     # The widget should show the names of the uploaded files in reverse order
-#     file_names = [files[1]["name"], files[0]["name"]]
+    file_chooser = fc_info.value
+    # Here we wait for the first file to be uploaded before uploading the second
+    with app.expect_request("**/upload_file/**"):
+        file_chooser.set_files(files=files[0])
 
-#     for i, element in enumerate(uploaded_file_names.all()):
-#         expect(element).to_have_text(file_names[i], use_inner_text=True)
+    # The widget should show the name of the uploaded file
+    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+        file_name1, use_inner_text=True
+    )
 
-#     # The script should have printed the contents of the two files into a st.text.
-#     # This tests that the upload actually went through.
-#     content = "\n".join(
-#         [
-#             files[0]["buffer"].decode("utf-8"),
-#             files[1]["buffer"].decode("utf-8"),
-#         ]
-#     )
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         content, use_inner_text=True
-#     )
-
-#     #  Delete the second file. The second file is on top because it was
-#     #  most recently uploaded. The first file should still exist.
-#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
-
-#     wait_for_app_run(app)
-
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         files[0]["buffer"].decode("utf-8"), use_inner_text=True
-#     )
-
-#     expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
-#         "True", use_inner_text=True
-#     )
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-
-# def test_does_not_call_callback_when_not_changed(app: Page):
-#     """Test that the file uploader does not call a callback when not changed."""
-#     file_name1 = "example5.txt"
-#     file_content1 = b"Hello world!"
+    file_chooser = fc_info.value
 
-#     uploader_index = 6
+    with app.expect_request("**/upload_file/**"):
+        file_chooser.set_files(files=files[1])
 
-#     # Script contains counter variable stored in session_state with
-#     # default value 0. We increment counter inside file_uploader callback
-#     # Since callback did not called at this moment, counter value should
-#     # be equal 0
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "0", use_inner_text=True
-#     )
+    uploaded_file_names = app.get_by_test_id("stFileUploaderFileName")
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    # The widget should show the names of the uploaded files in reverse order
+    file_names = [files[1]["name"], files[0]["name"]]
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(
-#                 name=file_name1,
-#                 mimeType="application/json",
-#                 buffer=file_content1,
-#             )
-#         ]
-#     )
+    for i, element in enumerate(uploaded_file_names.all()):
+        expect(element).to_have_text(file_names[i], use_inner_text=True)
 
-#     wait_for_app_run(app)
+    # The script should have printed the contents of the two files into a st.text.
+    # This tests that the upload actually went through.
+    content = "\n".join(
+        [
+            files[0]["buffer"].decode("utf-8"),
+            files[1]["buffer"].decode("utf-8"),
+        ]
+    )
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        content, use_inner_text=True
+    )
 
-#     # Make sure callback called
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "1", use_inner_text=True
-#     )
-#     rerun_app(app)
+    #  Delete the second file. The second file is on top because it was
+    #  most recently uploaded. The first file should still exist.
+    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
 
-#     # Counter should be still equal 1
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "1", use_inner_text=True
-#     )
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        files[0]["buffer"].decode("utf-8"), use_inner_text=True
+    )
+
+    expect(app.get_by_test_id("stMarkdownContainer").nth(5)).to_have_text(
+        "True", use_inner_text=True
+    )
 
 
-# def test_works_inside_form(app: Page):
-#     """Test that uploading a file inside form works as expected."""
-#     file_name1 = "form_file1.txt"
-#     file_content1 = b"form_file1content"
+def test_does_not_call_callback_when_not_changed(app: Page):
+    """Test that the file uploader does not call a callback when not changed."""
+    file_name1 = "example5.txt"
+    file_content1 = b"Hello world!"
 
-#     uploader_index = 3
+    uploader_index = 6
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    # Script contains counter variable stored in session_state with
+    # default value 0. We increment counter inside file_uploader callback
+    # Since callback did not called at this moment, counter value should
+    # be equal 0
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "0", use_inner_text=True
+    )
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
-#         ]
-#     )
-#     wait_for_app_run(app)
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
-#     # We should be showing the uploaded file name
-#     expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
-#         file_name1, use_inner_text=True
-#     )
-#     # But our uploaded text should contain nothing yet, as we haven't submitted.
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "No upload", use_inner_text=True
-#     )
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(
+                name=file_name1,
+                mimeType="application/json",
+                buffer=file_content1,
+            )
+        ]
+    )
 
-#     # Submit the form
-#     app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
-#     wait_for_app_run(app)
+    wait_for_app_run(app)
 
-#     # Now we should see the file's contents
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         str(file_content1), use_inner_text=True
-#     )
+    # Make sure callback called
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "1", use_inner_text=True
+    )
+    rerun_app(app)
 
-#     # Press the delete button. Again, nothing should happen - we
-#     # should still see the file's contents.
-#     app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
-#     wait_for_app_run(app)
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         str(file_content1), use_inner_text=True
-#     )
+    # Counter should be still equal 1
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "1", use_inner_text=True
+    )
 
-#     # Submit again. Now the file should be gone.
-#     app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
-#     wait_for_app_run(app)
 
-#     expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
-#         "No upload", use_inner_text=True
-#     )
+def test_works_inside_form(app: Page):
+    """Test that uploading a file inside form works as expected."""
+    file_name1 = "form_file1.txt"
+    file_content1 = b"form_file1content"
 
+    uploader_index = 3
 
-# def test_check_top_level_class(app: Page):
-#     """Check that the top level class is correctly set."""
-#     check_top_level_class(app, "stFileUploader")
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
 
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+        ]
+    )
+    wait_for_app_run(app)
 
-# def test_custom_css_class_via_key(app: Page):
-#     """Test that the element can have a custom css class via the key argument."""
-#     expect(get_element_by_key(app, "single")).to_be_visible()
+    # We should be showing the uploaded file name
+    expect(app.get_by_test_id("stFileUploaderFileName")).to_have_text(
+        file_name1, use_inner_text=True
+    )
+    # But our uploaded text should contain nothing yet, as we haven't submitted.
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "No upload", use_inner_text=True
+    )
 
+    # Submit the form
+    app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
+    wait_for_app_run(app)
 
-# def test_file_uploader_works_with_fragments(app: Page):
-#     file_name1 = "form_file1.txt"
-#     file_content1 = b"form_file1content"
+    # Now we should see the file's contents
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        str(file_content1), use_inner_text=True
+    )
 
-#     expect(app.get_by_text("Runs: 1")).to_be_visible()
-#     expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
+    # Press the delete button. Again, nothing should happen - we
+    # should still see the file's contents.
+    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+    wait_for_app_run(app)
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        str(file_content1), use_inner_text=True
+    )
 
-#     uploader_index = 7
+    # Submit again. Now the file should be gone.
+    app.get_by_test_id("stFormSubmitButton").first.locator("button").click()
+    wait_for_app_run(app)
 
-#     with app.expect_file_chooser() as fc_info:
-#         app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+    expect(app.get_by_test_id("stText").nth(uploader_index)).to_have_text(
+        "No upload", use_inner_text=True
+    )
 
-#     file_chooser = fc_info.value
-#     file_chooser.set_files(
-#         files=[
-#             FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
-#         ]
-#     )
-#     wait_for_app_run(app)
 
-#     expect(app.get_by_text("File uploader in Fragment: True")).to_be_visible()
-#     expect(app.get_by_text("Runs: 1")).to_be_visible()
+def test_check_top_level_class(app: Page):
+    """Check that the top level class is correctly set."""
+    check_top_level_class(app, "stFileUploader")
+
+
+def test_custom_css_class_via_key(app: Page):
+    """Test that the element can have a custom css class via the key argument."""
+    expect(get_element_by_key(app, "single")).to_be_visible()
+
+
+def test_file_uploader_works_with_fragments(app: Page):
+    file_name1 = "form_file1.txt"
+    file_content1 = b"form_file1content"
+
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("File uploader in Fragment: False")).to_be_visible()
+
+    uploader_index = 7
+
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+        ]
+    )
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("File uploader in Fragment: True")).to_be_visible()
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
 
 
 def test_file_uploader_upload_error(app: Page, app_port: int):

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import FilePayload, ImageCompareFunction, Page, Route, expect
+from playwright.sync_api import FilePayload, Page, Route, expect
 
 from e2e_playwright.conftest import (
-    check_top_level_class,
-    get_element_by_key,
+    ImageCompareFunction,
     rerun_app,
     wait_for_app_run,
     wait_until,
 )
+from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 
 
 def test_file_uploader_render_correctly(

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -16,12 +16,28 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_until
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     get_element_by_key,
     get_image,
 )
+
+IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT = 37
+
+
+def check_image_source_error_count(messages: list[str], expected_count: int):
+    """Check that the expected number of image source error messages are logged."""
+    assert (
+        len(
+            [
+                message
+                for message in messages
+                if "Client Error: Image source error" in message
+            ]
+        )
+        == expected_count
+    )
 
 
 def test_image_display(app: Page):
@@ -215,3 +231,29 @@ def test_markdown_caption_support(app: Page, assert_snapshot: ImageCompareFuncti
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stImage")
+
+
+def test_image_source_error(app: Page, app_port: int):
+    """Test `st.image` source error."""
+    # Ensure image source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/media/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: check_image_source_error_count(
+            messages, IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT
+        ),
+    )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -378,18 +378,18 @@ export class App extends PureComponent<Props, State> {
       csrfEnabled: true,
       sendClientError: (
         component: string,
-        customComponentName: string,
         error: string | number,
         message: string,
-        source: string
+        source: string,
+        customComponentName?: string
       ) => {
         this.hostCommunicationMgr.sendMessageToHost({
           type: "CLIENT_ERROR",
           component,
           error,
           message,
-          customComponentName,
           source,
+          customComponentName,
         })
       },
     })

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -56,10 +56,10 @@ class Endpoints implements StreamlitEndpoints {
 
   public sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void {
     throw new Error("Unimplemented")
   }

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen, within } from "@testing-library/react"
+import { fireEvent, screen, within } from "@testing-library/react"
 
 import {
   AppRoot,
@@ -75,7 +75,12 @@ function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   }
 }
 
-const mockEndpointProp = mockEndpoints()
+const buildMediaURL = vi.fn((url: string) => url)
+const sendClientErrorToHost = vi.fn()
+const mockEndpointProp = mockEndpoints({
+  buildMediaURL,
+  sendClientErrorToHost,
+})
 
 function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
   const formsData = createFormsData()
@@ -492,6 +497,22 @@ describe("AppView element", () => {
     it("renders logo - large size when specified", () => {
       render(<AppView {...getProps({ appLogo: imageWithSize })} />)
       expect(screen.getByTestId("stLogo")).toHaveStyle({ height: "2rem" })
+    })
+
+    it("sends an CLIENT_ERROR message when the logo source fails to load", () => {
+      const props = getProps({ appLogo: imageOnly })
+      render(<AppView {...props} />)
+      const logoElement = screen.getByTestId("stLogo")
+      expect(logoElement).toBeInTheDocument()
+
+      fireEvent.error(logoElement)
+
+      expect(sendClientErrorToHost).toHaveBeenCalledWith(
+        "Logo",
+        "Logo source failed to load",
+        "onerror triggered",
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png"
+      )
     })
   })
 

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -16,6 +16,8 @@
 
 import React, { ReactElement } from "react"
 
+import { getLogger } from "loglevel"
+
 import { StreamlitEndpoints } from "@streamlit/connection"
 import {
   AppRoot,
@@ -54,6 +56,7 @@ import {
 } from "./styled-components"
 import ScrollToBottomContainer from "./ScrollToBottomContainer"
 
+const LOG = getLogger("AppView")
 export interface AppViewProps {
   elements: AppRoot
 
@@ -178,6 +181,21 @@ function AppView(props: AppViewProps): ReactElement {
     removeScriptFinishedHandler,
   ])
 
+  const handleLogoError = (
+    _: React.SyntheticEvent<HTMLImageElement>,
+    logoUrl: string
+  ): void => {
+    // StyledLogo does not retain the e.currentEvent.src like other onerror cases
+    // store and read from ref instead
+    LOG.error(`Client Error: Logo source error - ${logoUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Logo",
+      "Logo source failed to load",
+      "onerror triggered",
+      logoUrl
+    )
+  }
+
   const renderLogo = (appLogo: Logo): ReactElement => {
     const displayImage = appLogo.iconImage ? appLogo.iconImage : appLogo.image
     const source = endpoints.buildMediaURL(displayImage)
@@ -189,6 +207,8 @@ function AppView(props: AppViewProps): ReactElement {
         alt="Logo"
         className="stLogo"
         data-testid="stLogo"
+        // Save to logo's src to send on load error
+        onError={e => handleLogoError(e, source)}
       />
     )
 

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -181,10 +181,7 @@ function AppView(props: AppViewProps): ReactElement {
     removeScriptFinishedHandler,
   ])
 
-  const handleLogoError = (
-    _: React.SyntheticEvent<HTMLImageElement>,
-    logoUrl: string
-  ): void => {
+  const handleLogoError = (logoUrl: string): void => {
     // StyledLogo does not retain the e.currentEvent.src like other onerror cases
     // store and read from ref instead
     LOG.error(`Client Error: Logo source error - ${logoUrl}`)
@@ -208,7 +205,7 @@ function AppView(props: AppViewProps): ReactElement {
         className="stLogo"
         data-testid="stLogo"
         // Save to logo's src to send on load error
-        onError={e => handleLogoError(e, source)}
+        onError={_ => handleLogoError(source)}
       />
     )
 

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -34,7 +34,12 @@ vi.mock("~lib/util/Hooks", async () => ({
   useIsOverflowing: vi.fn(),
 }))
 
-const mockEndpointProp = mockEndpoints()
+const buildMediaURL = vi.fn((url: string) => url)
+const sendClientErrorToHost = vi.fn()
+const mockEndpointProp = mockEndpoints({
+  buildMediaURL,
+  sendClientErrorToHost,
+})
 
 function renderSidebar(props: Partial<SidebarProps> = {}): RenderResult {
   return render(
@@ -360,6 +365,23 @@ describe("Sidebar Component", () => {
       // L & R padding (twoXL) + R margin (sm) + collapse button (2.25rem)
       expect(sidebarLogo).toHaveStyle(
         `max-width: calc(${sidebarWidth} - 2 * 1.5rem - 0.5rem - 2.25rem)`
+      )
+    })
+
+    it("sends an CLIENT_ERROR message when the logo source fails to load", () => {
+      renderSidebar({ appLogo: fullAppLogo })
+      const sidebarLogo = within(
+        screen.getByTestId("stSidebarHeader")
+      ).getByTestId("stLogo")
+      expect(sidebarLogo).toBeInTheDocument()
+
+      fireEvent.error(sidebarLogo)
+
+      expect(sendClientErrorToHost).toHaveBeenCalledWith(
+        "Sidebar Logo",
+        "Logo source failed to load",
+        "onerror triggered",
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png"
       )
     })
   })

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -225,13 +225,15 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   const handleLogoError = (
     _: React.SyntheticEvent<HTMLImageElement>,
-    logoUrl: string
+    logoUrl: string,
+    collapsed: boolean
   ): void => {
     // StyledLogo does not retain the e.currentEvent.src like other onerror cases
     // store and read from ref instead
-    LOG.error(`Client Error: Logo source error - ${logoUrl}`)
+    const component = collapsed ? "Logo" : "Sidebar Logo"
+    LOG.error(`Client Error: ${component} source error - ${logoUrl}`)
     endpoints.sendClientErrorToHost(
-      "Sidebar Logo",
+      component,
       "Logo source failed to load",
       "onerror triggered",
       logoUrl
@@ -256,7 +258,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         className="stLogo"
         data-testid="stLogo"
         // Save to logo's src to send on load error
-        onError={e => handleLogoError(e, source)}
+        onError={e => handleLogoError(e, source, collapsed)}
       />
     )
 

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -24,6 +24,7 @@ import React, {
 
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 import { useTheme } from "@emotion/react"
+import { getLogger } from "loglevel"
 import { Resizable } from "re-resizable"
 
 import { StreamlitEndpoints } from "@streamlit/connection"
@@ -72,6 +73,8 @@ export interface SidebarProps {
 }
 
 const MIN_WIDTH = "336"
+
+const LOG = getLogger("Sidebar")
 
 function calculateMaxBreakpoint(value: string): number {
   // We subtract a margin of 0.02 to use as a max-width
@@ -220,6 +223,21 @@ const Sidebar: React.FC<SidebarProps> = ({
     setCollapsedSidebar(!collapsedSidebar)
   }, [collapsedSidebar])
 
+  const handleLogoError = (
+    _: React.SyntheticEvent<HTMLImageElement>,
+    logoUrl: string
+  ): void => {
+    // StyledLogo does not retain the e.currentEvent.src like other onerror cases
+    // store and read from ref instead
+    LOG.error(`Client Error: Logo source error - ${logoUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Sidebar Logo",
+      "Logo source failed to load",
+      "onerror triggered",
+      logoUrl
+    )
+  }
+
   function renderLogo(collapsed: boolean): ReactElement {
     if (!appLogo) {
       return <StyledNoLogoSpacer data-testid="stLogoSpacer" />
@@ -237,6 +255,8 @@ const Sidebar: React.FC<SidebarProps> = ({
         alt="Logo"
         className="stLogo"
         data-testid="stLogo"
+        // Save to logo's src to send on load error
+        onError={e => handleLogoError(e, source)}
       />
     )
 

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -223,11 +223,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     setCollapsedSidebar(!collapsedSidebar)
   }, [collapsedSidebar])
 
-  const handleLogoError = (
-    _: React.SyntheticEvent<HTMLImageElement>,
-    logoUrl: string,
-    collapsed: boolean
-  ): void => {
+  const handleLogoError = (logoUrl: string, collapsed: boolean): void => {
     // StyledLogo does not retain the e.currentEvent.src like other onerror cases
     // store and read from ref instead
     const component = collapsed ? "Logo" : "Sidebar Logo"
@@ -258,7 +254,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         className="stLogo"
         data-testid="stLogo"
         // Save to logo's src to send on load error
-        onError={e => handleLogoError(e, source, collapsed)}
+        onError={_ => handleLogoError(source, collapsed)}
       />
     )
 

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -344,7 +344,6 @@ describe("DefaultStreamlitEndpoints", () => {
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "File Uploader",
-        "",
         "Error uploading file",
         "Request failed with status code 400",
         "http://streamlit.mock:80/mock/base/path/_stcore/upload_file"
@@ -441,7 +440,6 @@ describe("DefaultStreamlitEndpoints", () => {
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "File Uploader",
-        "",
         "Error deleting file",
         "Request failed with status code 400",
         "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
@@ -502,7 +500,6 @@ describe("DefaultStreamlitEndpoints", () => {
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "Forward Message Cache",
-        "",
         "Error fetching cached forward message",
         "Request failed with status code 400",
         "http://streamlit.mock:80/mock/base/path/_stcore/message?hash=mockHash"
@@ -561,7 +558,7 @@ describe("DefaultStreamlitEndpoints", () => {
   })
 
   describe("checkSourceUrlResponse", () => {
-    it("calls the passed source - sends error to host if error on response", async () => {
+    it("sends error to host if error on response", async () => {
       // Mock fetch for checkSourceUrlResponse - response is not ok
       global.fetch = vi.fn(() =>
         Promise.resolve({
@@ -581,20 +578,24 @@ describe("DefaultStreamlitEndpoints", () => {
         endpoints,
         "sendClientErrorToHost"
       )
-      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+      await endpoints.checkSourceUrlResponse(
+        url,
+        "Custom Component",
+        "mockComponent"
+      )
 
       expect(fetch).toHaveBeenCalledWith(url)
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "Custom Component",
-        "mockComponent",
         404,
         "Not Found",
-        url
+        url,
+        "mockComponent"
       )
     })
 
-    it("calls the passed source - sends error to host if fetch fails", async () => {
+    it("sends error to host if fetch fails", async () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
@@ -609,16 +610,20 @@ describe("DefaultStreamlitEndpoints", () => {
         "sendClientErrorToHost"
       )
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
-      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+      await endpoints.checkSourceUrlResponse(
+        url,
+        "Custom Component",
+        "mockComponent"
+      )
 
       expect(fetch).toHaveBeenCalledWith(url)
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "Custom Component",
-        "mockComponent",
         "Error fetching source",
         "mockError",
-        url
+        url,
+        "mockComponent"
       )
     })
   })

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -329,6 +329,11 @@ describe("DefaultStreamlitEndpoints", () => {
         .onPut("http://streamlit.mock:80/mock/base/path/_stcore/upload_file")
         .reply(() => [400])
 
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
       await expect(
         endpoints.uploadFileUploaderFile(
           "/_stcore/upload_file",
@@ -336,6 +341,14 @@ describe("DefaultStreamlitEndpoints", () => {
           "mockSessionId"
         )
       ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "File Uploader",
+        "",
+        "Error uploading file",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/upload_file"
+      )
     })
   })
 
@@ -406,6 +419,34 @@ describe("DefaultStreamlitEndpoints", () => {
         data: { sessionId: "mockSessionId" },
       })
     })
+
+    it("errors on bad status", async () => {
+      axiosMock
+        .onDelete(
+          "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
+        )
+        .reply(() => [400])
+
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
+      await expect(
+        endpoints.deleteFileAtURL(
+          "/_stcore/upload_file/file_1",
+          "mockSessionId"
+        )
+      ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "File Uploader",
+        "",
+        "Error deleting file",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
+      )
+    })
   })
 
   describe("fetchCachedForwardMsg()", () => {
@@ -450,9 +491,22 @@ describe("DefaultStreamlitEndpoints", () => {
         )
         .reply(() => [400])
 
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
       await expect(
         endpoints.fetchCachedForwardMsg("mockHash")
       ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "Forward Message Cache",
+        "",
+        "Error fetching cached forward message",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/message?hash=mockHash"
+      )
     })
   })
 

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -254,7 +254,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
           error instanceof Error ? error.message : "Unknown Error"
         this.sendClientErrorToHost(
           "File Uploader",
-          "",
           "Error uploading file",
           message,
           uploadUrl
@@ -300,7 +299,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
           error instanceof Error ? error.message : "Unknown Error"
         this.sendClientErrorToHost(
           "File Uploader",
-          "",
           "Error deleting file",
           message,
           deleteUrl
@@ -328,7 +326,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       const message = error instanceof Error ? error.message : "Unknown Error"
       this.sendClientErrorToHost(
         "Forward Message Cache",
-        "",
         "Error fetching cached forward message",
         message,
         fetchUrl

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -34,10 +34,10 @@ interface Props {
   csrfEnabled: boolean
   sendClientError: (
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ) => void
 }
 
@@ -52,10 +52,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   private readonly sendClientError: (
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ) => void
 
   private readonly csrfEnabled: boolean
@@ -79,17 +79,17 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   public sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void {
     this.sendClientError(
       component,
-      customComponentName,
       error,
       message,
-      source
+      source,
+      customComponentName
     )
   }
 
@@ -99,36 +99,39 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
    */
   public async checkSourceUrlResponse(
     sourceUrl: string,
-    componentName: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void> {
+    const componentForError = customComponentName
+      ? `${componentName} ${customComponentName})`
+      : componentName
+
     try {
       const response = await fetch(sourceUrl)
       if (!response.ok) {
         // Send response info if unsuccessful
         LOG.error(
-          `Client Error: Custom component ${componentName} source error - ${response.status}`
+          `Client Error: ${componentForError} source error - ${response.status}`
         )
         this.sendClientErrorToHost(
-          "Custom Component",
           componentName,
           response.status,
           response.statusText,
-          sourceUrl
+          sourceUrl,
+          customComponentName
         )
       }
       // Don't send error info on success
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Unknown Error"
       // Send fetch error info on failure
-      LOG.error(
-        `Client Error: Custom component ${componentName} fetch error - ${message}`
-      )
+      LOG.error(`Client Error: ${componentForError} fetch error - ${message}`)
       this.sendClientErrorToHost(
-        "Custom Component",
         componentName,
         "Error fetching source",
         message,
-        sourceUrl
+        sourceUrl,
+        customComponentName
       )
     }
   }

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -231,14 +231,34 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
     const headers: Record<string, string> = this.getAdditionalHeaders()
 
-    return this.csrfRequest<number>(this.buildFileUploadURL(fileUploadUrl), {
+    const uploadUrl = this.buildFileUploadURL(fileUploadUrl)
+
+    return this.csrfRequest<number>(uploadUrl, {
       cancelToken,
       method: "PUT",
       data: form,
       responseType: "text",
       headers,
       onUploadProgress,
-    }).then(() => undefined) // If the request succeeds, we don't care about the response body
+    })
+      .then(() => undefined) // If the request succeeds, we don't care about the response body
+      .catch(error => {
+        // Send error info on failure
+        LOG.error(
+          `Client Error: File uploader error on file upload - ${error}`
+        )
+        const message =
+          error instanceof Error ? error.message : "Unknown Error"
+        this.sendClientErrorToHost(
+          "File Uploader",
+          "",
+          "Error uploading file",
+          message,
+          uploadUrl
+        )
+        // Reject the promise with the error after sending the error to the host
+        return Promise.reject(error)
+      })
   }
 
   private getAdditionalHeaders(): Record<string, string> {
@@ -261,25 +281,58 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     sessionId: string
   ): Promise<void> {
     const headers: Record<string, string> = this.getAdditionalHeaders()
-    return this.csrfRequest<number>(this.buildFileUploadURL(fileUrl), {
+    const deleteUrl = this.buildFileUploadURL(fileUrl)
+    return this.csrfRequest<number>(deleteUrl, {
       method: "DELETE",
       data: { sessionId },
       headers,
-    }).then(() => undefined) // If the request succeeds, we don't care about the response body
+    })
+      .then(() => undefined) // If the request succeeds, we don't care about the response body
+      .catch(error => {
+        // Send error info on failure
+        LOG.error(
+          `Client Error: File uploader error on file delete - ${error}`
+        )
+        const message =
+          error instanceof Error ? error.message : "Unknown Error"
+        this.sendClientErrorToHost(
+          "File Uploader",
+          "",
+          "Error deleting file",
+          message,
+          deleteUrl
+        )
+        // Reject the promise with the error after sending the error to the host
+        return Promise.reject(error)
+      })
   }
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
     const serverURI = this.requireServerUri()
-    const rsp = await axios.request({
-      url: buildHttpUri(
-        serverURI,
-        `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
-      ),
-      method: "GET",
-      responseType: "arraybuffer",
-    })
+    const fetchUrl = buildHttpUri(
+      serverURI,
+      `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
+    )
 
-    return new Uint8Array(rsp.data)
+    try {
+      const rsp = await axios.get(fetchUrl, { responseType: "arraybuffer" })
+      return new Uint8Array(rsp.data)
+    } catch (error) {
+      // Send error info on failure
+      LOG.error(
+        `Client Error: Cached forward message error on fetch - ${error}`
+      )
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "Forward Message Cache",
+        "",
+        "Error fetching cached forward message",
+        message,
+        fetchUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      return Promise.reject(error)
+    }
   }
 
   /**

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -236,7 +236,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
     const uploadUrl = this.buildFileUploadURL(fileUploadUrl)
 
-    return this.csrfRequest<number>(uploadUrl, {
+    const response = await this.csrfRequest<number>(uploadUrl, {
       cancelToken,
       method: "PUT",
       data: form,
@@ -259,8 +259,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
           uploadUrl
         )
         // Reject the promise with the error after sending the error to the host
-        return Promise.reject(error)
+        throw error
       })
+
+    return response
   }
 
   private getAdditionalHeaders(): Record<string, string> {
@@ -284,7 +286,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   ): Promise<void> {
     const headers: Record<string, string> = this.getAdditionalHeaders()
     const deleteUrl = this.buildFileUploadURL(fileUrl)
-    return this.csrfRequest<number>(deleteUrl, {
+    const response = await this.csrfRequest<number>(deleteUrl, {
       method: "DELETE",
       data: { sessionId },
       headers,
@@ -304,8 +306,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
           deleteUrl
         )
         // Reject the promise with the error after sending the error to the host
-        return Promise.reject(error)
+        throw error
       })
+
+    return response
   }
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -236,33 +236,29 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
     const uploadUrl = this.buildFileUploadURL(fileUploadUrl)
 
-    const response = await this.csrfRequest<number>(uploadUrl, {
-      cancelToken,
-      method: "PUT",
-      data: form,
-      responseType: "text",
-      headers,
-      onUploadProgress,
-    })
-      .then(() => undefined) // If the request succeeds, we don't care about the response body
-      .catch(error => {
-        // Send error info on failure
-        LOG.error(
-          `Client Error: File uploader error on file upload - ${error}`
-        )
-        const message =
-          error instanceof Error ? error.message : "Unknown Error"
-        this.sendClientErrorToHost(
-          "File Uploader",
-          "Error uploading file",
-          message,
-          uploadUrl
-        )
-        // Reject the promise with the error after sending the error to the host
-        throw error
+    try {
+      await this.csrfRequest<number>(uploadUrl, {
+        cancelToken,
+        method: "PUT",
+        data: form,
+        responseType: "text",
+        headers,
+        onUploadProgress,
       })
-
-    return response
+      // If the request succeeds, we don't care about the response body
+    } catch (error: unknown) {
+      // Send error info on failure
+      LOG.error(`Client Error: File uploader error on file upload - ${error}`)
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "File Uploader",
+        "Error uploading file",
+        message,
+        uploadUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      throw error
+    }
   }
 
   private getAdditionalHeaders(): Record<string, string> {
@@ -286,30 +282,27 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   ): Promise<void> {
     const headers: Record<string, string> = this.getAdditionalHeaders()
     const deleteUrl = this.buildFileUploadURL(fileUrl)
-    const response = await this.csrfRequest<number>(deleteUrl, {
-      method: "DELETE",
-      data: { sessionId },
-      headers,
-    })
-      .then(() => undefined) // If the request succeeds, we don't care about the response body
-      .catch(error => {
-        // Send error info on failure
-        LOG.error(
-          `Client Error: File uploader error on file delete - ${error}`
-        )
-        const message =
-          error instanceof Error ? error.message : "Unknown Error"
-        this.sendClientErrorToHost(
-          "File Uploader",
-          "Error deleting file",
-          message,
-          deleteUrl
-        )
-        // Reject the promise with the error after sending the error to the host
-        throw error
-      })
 
-    return response
+    try {
+      await this.csrfRequest<number>(deleteUrl, {
+        method: "DELETE",
+        data: { sessionId },
+        headers,
+      })
+      // If the request succeeds, we don't care about the response body
+    } catch (error: unknown) {
+      // Send error info on failure
+      LOG.error(`Client Error: File uploader error on file delete - ${error}`)
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "File Uploader",
+        "Error deleting file",
+        message,
+        deleteUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      throw error
+    }
   }
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -103,7 +103,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     customComponentName?: string
   ): Promise<void> {
     const componentForError = customComponentName
-      ? `${componentName} ${customComponentName})`
+      ? `${componentName} ${customComponentName}`
       : componentName
 
     try {

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -65,17 +65,17 @@ export interface StreamlitEndpoints {
   /**
    * Send postMessage to host with client errors
    * @param component component causing the error
-   * @param customComponentName if custom component, component's name
    * @param error error status code or message
    * @param message additional error info
    * @param source component src (url)
+   * @param customComponentName If custom component, the component's name causing the error.
    */
   sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void
 
   /**
@@ -83,10 +83,12 @@ export interface StreamlitEndpoints {
    * If not, sends CLIENT_ERROR message with error info.
    * @param sourceUrl The source to check.
    * @param componentName The component for which the source is being checked.
+   * @param customComponentName If custom component, the component's name for which the source is being checked.
    */
   checkSourceUrlResponse(
     sourceUrl: string,
-    componentName?: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void>
 
   /**

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -35,17 +35,17 @@ export interface StreamlitEndpoints {
   /**
    * Send postMessage to host with client errors
    * @param component component causing the error
-   * @param customComponentName if custom component, component's name
    * @param error error status code or message
    * @param message additional error info
    * @param source component src (url)
+   * @param customComponentName If custom component, the component's name causing the error.
    */
   sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void
 
   /**
@@ -53,10 +53,12 @@ export interface StreamlitEndpoints {
    * If not, sends CLIENT_ERROR message with error info.
    * @param sourceUrl The source to check.
    * @param componentName The component for which the source is being checked.
+   * @param customComponentName If custom component, the component's name for which the source is being checked.
    */
   checkSourceUrlResponse(
     sourceUrl: string,
-    componentName?: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void>
 
   /**

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -140,7 +140,6 @@ describe("Audio Element", () => {
 
     expect(sendClientErrorToHost).toHaveBeenCalledWith(
       "Audio",
-      "",
       "Audio source failed to load",
       "onerror triggered",
       "https://mock.media.url/"

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 
 import { Audio as AudioProto } from "@streamlit/protobuf"
 
@@ -28,6 +28,7 @@ import Audio, { AudioProps } from "./Audio"
 
 describe("Audio Element", () => {
   const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  const sendClientErrorToHost = vi.fn()
 
   const mockSetElementState = vi.fn()
   const mockGetElementState = vi.fn()
@@ -44,7 +45,10 @@ describe("Audio Element", () => {
       url: "/media/mockAudioFile.wav",
       ...elementProps,
     }),
-    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    endpoints: mockEndpoints({
+      buildMediaURL: buildMediaURL,
+      sendClientErrorToHost: sendClientErrorToHost,
+    }),
     elementMgr: elementMgrMock as unknown as ElementStateManager,
   })
 
@@ -124,5 +128,22 @@ describe("Audio Element", () => {
     audioElement = screen.getByTestId("stAudio") as HTMLAudioElement
 
     expect(audioElement.currentTime).toBe(10)
+  })
+
+  it("sends an CLIENT_ERROR message when the audio source fails to load", () => {
+    const props = getProps()
+    render(<Audio {...props} />)
+    const audioElement = screen.getByTestId("stAudio")
+    expect(audioElement).toBeInTheDocument()
+
+    fireEvent.error(audioElement)
+
+    expect(sendClientErrorToHost).toHaveBeenCalledWith(
+      "Audio",
+      "",
+      "Audio source failed to load",
+      "onerror triggered",
+      "https://mock.media.url/"
+    )
   })
 })

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -157,7 +157,6 @@ function Audio({
     LOG.error(`Client Error: Audio source error - ${audioUrl}`)
     endpoints.sendClientErrorToHost(
       "Audio",
-      "",
       "Audio source failed to load",
       "onerror triggered",
       audioUrl

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -16,6 +16,8 @@
 
 import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
 
+import { getLogger } from "loglevel"
+
 import { Audio as AudioProto } from "@streamlit/protobuf"
 
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
@@ -23,6 +25,7 @@ import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManag
 
 import { StyledAudio, StyledAudioContainer } from "./styled-components"
 
+const LOG = getLogger("Audio")
 export interface AudioProps {
   endpoints: StreamlitEndpoints
   element: AudioProto
@@ -147,6 +150,20 @@ function Audio({
 
   const uri = endpoints.buildMediaURL(element.url)
 
+  const handleAudioError = (
+    e: React.SyntheticEvent<HTMLAudioElement>
+  ): void => {
+    const audioUrl = e.currentTarget.src
+    LOG.error(`Client Error: Audio source error - ${audioUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Audio",
+      "",
+      "Audio source failed to load",
+      "onerror triggered",
+      audioUrl
+    )
+  }
+
   return (
     <StyledAudioContainer>
       <StyledAudio
@@ -156,6 +173,7 @@ function Audio({
         controls
         autoPlay={autoplay && !preventAutoplay}
         src={uri}
+        onError={handleAudioError}
       />
     </StyledAudioContainer>
   )

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -119,7 +119,6 @@ describe("ImageList Element", () => {
     // Verify the error was sent with correct parameters
     expect(sendClientErrorToHost).toHaveBeenCalledWith(
       "Image",
-      "",
       "Image source failed to load",
       "onerror triggered",
       "https://mock.media.url/"

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 
 import { ImageList as ImageListProto } from "@streamlit/protobuf"
 
@@ -28,6 +28,7 @@ import ImageList, { ImageListProps } from "./ImageList"
 
 describe("ImageList Element", () => {
   const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  const sendClientErrorToHost = vi.fn()
 
   const getProps = (
     elementProps: Partial<ImageListProto> = {}
@@ -40,7 +41,10 @@ describe("ImageList Element", () => {
       width: -1,
       ...elementProps,
     }),
-    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    endpoints: mockEndpoints({
+      buildMediaURL: buildMediaURL,
+      sendClientErrorToHost: sendClientErrorToHost,
+    }),
   })
 
   beforeEach(() => {
@@ -101,5 +105,24 @@ describe("ImageList Element", () => {
     captions.forEach(caption => {
       expect(caption).toHaveStyle("width: 300px")
     })
+  })
+
+  it("sends an CLIENT_ERROR message when the image source fails to load", () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(2)
+
+    // Trigger the error event on the first image using fireEvent
+    fireEvent.error(images[0])
+
+    // Verify the error was sent with correct parameters
+    expect(sendClientErrorToHost).toHaveBeenCalledWith(
+      "Image",
+      "",
+      "Image source failed to load",
+      "onerror triggered",
+      "https://mock.media.url/"
+    )
   })
 })

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -124,7 +124,6 @@ function ImageList({
     LOG.error(`Client Error: Image source error - ${imageUrl}`)
     endpoints.sendClientErrorToHost(
       "Image",
-      "",
       "Image source failed to load",
       "onerror triggered",
       imageUrl

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -16,6 +16,8 @@
 
 import React, { CSSProperties, memo, ReactElement } from "react"
 
+import { getLogger } from "loglevel"
+
 import {
   ImageList as ImageListProto,
   Image as ImageProto,
@@ -35,6 +37,8 @@ import {
   StyledImageContainer,
   StyledImageList,
 } from "./styled-components"
+
+const LOG = getLogger("ImageList")
 
 export interface ImageListProps {
   endpoints: StreamlitEndpoints
@@ -113,6 +117,20 @@ function ImageList({
     imgStyle.maxWidth = "100%"
   }
 
+  const handleImageError = (
+    e: React.SyntheticEvent<HTMLImageElement>
+  ): void => {
+    const imageUrl = e.currentTarget.src
+    LOG.error(`Client Error: Image source error - ${imageUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Image",
+      "",
+      "Image source failed to load",
+      "onerror triggered",
+      imageUrl
+    )
+  }
+
   return (
     <StyledToolbarElementContainer
       width={elementWidth}
@@ -138,6 +156,7 @@ function ImageList({
                 style={imgStyle}
                 src={endpoints.buildMediaURL(image.url)}
                 alt={idx.toString()}
+                onError={handleImageError}
               />
               {image.caption && (
                 <StyledCaption data-testid="stImageCaption" style={imgStyle}>

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -28,7 +28,8 @@ import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import Video, { VideoProps } from "./Video"
 
 describe("Video Element", () => {
-  const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  let buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  // const buildMediaURL = vi.fn((url: string) => url)
   const sendClientErrorToHost = vi.fn()
 
   const mockSetElementState = vi.fn()
@@ -99,7 +100,6 @@ describe("Video Element", () => {
 
     expect(sendClientErrorToHost).toHaveBeenCalledWith(
       "Video",
-      "",
       "Video source failed to load",
       "onerror triggered",
       "https://mock.media.url/"
@@ -196,6 +196,63 @@ describe("Video Element", () => {
 
       rerender(<Video {...getProps({ startTime: 10 })} />)
       expect(videoElement.currentTime).toBe(10)
+    })
+  })
+
+  describe("subtitles", () => {
+    it("renders subtitles properly", () => {
+      const props = getProps({
+        subtitles: [
+          { url: "https://mock.subtitle.url" },
+          { url: "https://mock.subtitle.url2" },
+        ],
+      })
+      props.endpoints.buildMediaURL = vi.fn(url => url)
+      render(<Video {...props} />)
+
+      // check that track elements are rendered
+      const trackElements = screen.getAllByTestId("stVideoSubtitle")
+      expect(trackElements).toHaveLength(2)
+
+      // check that the track element has the correct src
+      expect(trackElements[0]).toHaveAttribute(
+        "src",
+        "https://mock.subtitle.url"
+      )
+      expect(trackElements[1]).toHaveAttribute(
+        "src",
+        "https://mock.subtitle.url2"
+      )
+    })
+
+    it("checks the subtitles src url(s) on mount", () => {
+      buildMediaURL = vi.fn(url => url)
+      const props = getProps({
+        subtitles: [
+          { url: "https://mock.subtitle.url" },
+          { url: "https://mock.subtitle.url2" },
+        ],
+      })
+      props.endpoints.buildMediaURL = buildMediaURL
+      render(<Video {...props} />)
+
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledTimes(2)
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenNthCalledWith(
+        1,
+        "https://mock.subtitle.url",
+        "Video Subtitle"
+      )
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenNthCalledWith(
+        2,
+        "https://mock.subtitle.url2",
+        "Video Subtitle"
+      )
+    })
+
+    it("does not call checkSourceUrlResponse if there are no subtitles", () => {
+      const props = getProps()
+      render(<Video {...props} />)
+      expect(props.endpoints.checkSourceUrlResponse).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 
 import { Video as VideoProto } from "@streamlit/protobuf"
 
@@ -29,6 +29,7 @@ import Video, { VideoProps } from "./Video"
 
 describe("Video Element", () => {
   const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  const sendClientErrorToHost = vi.fn()
 
   const mockSetElementState = vi.fn()
   const mockGetElementState = vi.fn()
@@ -46,7 +47,10 @@ describe("Video Element", () => {
       startTime: 0,
       ...elementProps,
     }),
-    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    endpoints: mockEndpoints({
+      buildMediaURL: buildMediaURL,
+      sendClientErrorToHost: sendClientErrorToHost,
+    }),
     elementMgr: elementMgrMock as unknown as ElementStateManager,
   })
 
@@ -82,6 +86,23 @@ describe("Video Element", () => {
     expect(await screen.findByTestId("stVideo")).toHaveAttribute(
       "src",
       "https://mock.media.url"
+    )
+  })
+
+  it("sends an CLIENT_ERROR message when the video source fails to load", () => {
+    const props = getProps()
+    render(<Video {...props} />)
+    const videoElement = screen.getByTestId("stVideo")
+    expect(videoElement).toBeInTheDocument()
+
+    fireEvent.error(videoElement)
+
+    expect(sendClientErrorToHost).toHaveBeenCalledWith(
+      "Video",
+      "",
+      "Video source failed to load",
+      "onerror triggered",
+      "https://mock.media.url/"
     )
   })
 

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -29,7 +29,6 @@ import Video, { VideoProps } from "./Video"
 
 describe("Video Element", () => {
   let buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
-  // const buildMediaURL = vi.fn((url: string) => url)
   const sendClientErrorToHost = vi.fn()
 
   const mockSetElementState = vi.fn()

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -71,6 +71,18 @@ function Video({
     return preventAutoplay ?? false
   }, [element.id, elementMgr])
 
+  // Check the video's subtitles for load errors
+  useEffect(() => {
+    // Since there is no onerror event for track elements, we can't use the onerror event
+    // to catch src url load errors. Catch with direct check instead.
+    if (subtitles) {
+      subtitles.forEach(subtitle => {
+        const subtitleSrc = endpoints.buildMediaURL(`${subtitle.url}`)
+        endpoints.checkSourceUrlResponse(subtitleSrc, "Video Subtitle")
+      })
+    }
+  }, [subtitles, endpoints])
+
   // Handle startTime changes
   useEffect(() => {
     if (videoRef.current) {
@@ -211,7 +223,6 @@ function Video({
     LOG.error(`Client Error: Video source error - ${videoUrl}`)
     endpoints.sendClientErrorToHost(
       "Video",
-      "",
       "Video source failed to load",
       "onerror triggered",
       videoUrl
@@ -247,6 +258,7 @@ function Video({
             src={endpoints.buildMediaURL(`${subtitle.url}`)}
             label={`${subtitle.label}`}
             default={idx === 0}
+            data-testid="stVideoSubtitle"
           />
         ))}
     </video>

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -71,17 +71,28 @@ function Video({
     return preventAutoplay ?? false
   }, [element.id, elementMgr])
 
+  // Create a stable dependency for checking subtitle source urls
+  const subtitleSrcArrString = useMemo(() => {
+    if (!subtitles) {
+      return JSON.stringify([])
+    }
+
+    return JSON.stringify(
+      subtitles.map(subtitle => endpoints.buildMediaURL(`${subtitle.url}`))
+    )
+  }, [subtitles, endpoints])
+
   // Check the video's subtitles for load errors
   useEffect(() => {
+    const subtitleSrcArr: string[] = JSON.parse(subtitleSrcArrString)
+    if (subtitleSrcArr.length === 0) return
+
     // Since there is no onerror event for track elements, we can't use the onerror event
     // to catch src url load errors. Catch with direct check instead.
-    if (subtitles) {
-      subtitles.forEach(subtitle => {
-        const subtitleSrc = endpoints.buildMediaURL(`${subtitle.url}`)
-        endpoints.checkSourceUrlResponse(subtitleSrc, "Video Subtitle")
-      })
-    }
-  }, [subtitles, endpoints])
+    subtitleSrcArr.forEach(subtitleSrc => {
+      endpoints.checkSourceUrlResponse(subtitleSrc, "Video Subtitle")
+    })
+  }, [subtitleSrcArrString, endpoints])
 
   // Handle startTime changes
   useEffect(() => {

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -16,6 +16,8 @@
 
 import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
 
+import { getLogger } from "loglevel"
+
 import { ISubtitleTrack, Video as VideoProto } from "@streamlit/protobuf"
 
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
@@ -23,6 +25,7 @@ import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManag
 
 import { StyledVideoIframe } from "./styled-components"
 
+const LOG = getLogger("Video")
 export interface VideoProps {
   endpoints: StreamlitEndpoints
   element: VideoProto
@@ -201,6 +204,20 @@ function Video({
     )
   }
 
+  const handleVideoError = (
+    e: React.SyntheticEvent<HTMLVideoElement>
+  ): void => {
+    const videoUrl = e.currentTarget.src
+    LOG.error(`Client Error: Video source error - ${videoUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Video",
+      "",
+      "Video source failed to load",
+      "onerror triggered",
+      videoUrl
+    )
+  }
+
   // Only in dev mode we set crossOrigin to "anonymous" to avoid CORS issues
   // when streamlit frontend and backend are running on different ports
   return (
@@ -218,6 +235,7 @@ function Video({
           ? "anonymous"
           : undefined
       }
+      onError={handleVideoError}
     >
       {subtitles &&
         subtitles.map((subtitle: ISubtitleTrack, idx: number) => (

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -247,7 +247,7 @@ function ComponentInstance(props: Props): ReactElement {
     if (isReadyTimeout && !isReadyRef.current) {
       // Send timeout error if we've timed out waiting for the READY message from the component
       LOG.error(
-        `Client Error: Custom component ${componentName} timeout error`
+        `Client Error: Custom Component ${componentName} timeout error`
       )
       registry.sendTimeoutError(
         getSrc(componentName, registry, url),

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useRef, useState } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import { useTheme } from "@emotion/react"
 import { getLogger } from "loglevel"
@@ -184,6 +191,11 @@ function ComponentInstance(props: Props): ReactElement {
     componentError
   )
 
+  const componentSourceUrl = useMemo(
+    () => getSrc(componentName, registry, url),
+    [componentName, registry, url]
+  )
+
   // Use a ref for the args so that we can use them inside the useEffect calls without the linter complaining
   // as in the useEffect dependencies array, we don't use the parsed arg objects, but their string representation
   // and a comparing function result for the jsonArgs and dataframeArgs, respectively, for deep-equal checks and to
@@ -235,8 +247,6 @@ function ComponentInstance(props: Props): ReactElement {
     })
   }, COMPONENT_READY_WARNING_TIME_MS)
 
-  const componentSourceUrl = getSrc(componentName, registry, url)
-
   useEffect(() => {
     // Iframe onerror event unreliable - check custom component
     // src on mount to catch iframe load errors
@@ -249,12 +259,9 @@ function ComponentInstance(props: Props): ReactElement {
       LOG.error(
         `Client Error: Custom Component ${componentName} timeout error`
       )
-      registry.sendTimeoutError(
-        getSrc(componentName, registry, url),
-        componentName
-      )
+      registry.sendTimeoutError(componentSourceUrl, componentName)
     }
-  }, [isReadyTimeout, componentName, registry, url])
+  }, [isReadyTimeout, componentSourceUrl, componentName, registry])
 
   // Send a render message to the custom component everytime relevant props change, such as the
   // input args or the theme / width
@@ -436,7 +443,7 @@ function ComponentInstance(props: Props): ReactElement {
         data-testid="stCustomComponentV1"
         allow={DEFAULT_IFRAME_FEATURE_POLICY}
         ref={iframeRef}
-        src={getSrc(componentName, registry, url)}
+        src={componentSourceUrl}
         width={width}
         // for undefined height we set the height to 0 to avoid inconsistent behavior
         height={frameHeight ?? 0}

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
@@ -99,10 +99,10 @@ describe("ComponentRegistry", () => {
     registry.sendTimeoutError(url, "foo")
     expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
       "Custom Component",
-      "foo",
       "Request Timeout",
       "Your app is having trouble loading the component.",
-      url
+      url,
+      "foo"
     )
   })
 
@@ -120,6 +120,10 @@ describe("ComponentRegistry", () => {
     )
     registry.checkSourceUrlResponse(url, "foo")
     expect(registryCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
-    expect(endpointsCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
+    expect(endpointsCheckSourceResponseSpy).toHaveBeenCalledWith(
+      url,
+      "Custom Component",
+      "foo"
+    )
   })
 })

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -70,9 +70,13 @@ export class ComponentRegistry {
    */
   public checkSourceUrlResponse = (
     sourceUrl: string,
-    componentName?: string
+    customComponentName: string
   ): Promise<void> => {
-    return this.endpoints.checkSourceUrlResponse(sourceUrl, componentName)
+    return this.endpoints.checkSourceUrlResponse(
+      sourceUrl,
+      "Custom Component",
+      customComponentName
+    )
   }
 
   public sendTimeoutError = (source: string, componentName: string): void => {

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -79,13 +79,16 @@ export class ComponentRegistry {
     )
   }
 
-  public sendTimeoutError = (source: string, componentName: string): void => {
+  public sendTimeoutError = (
+    source: string,
+    customComponentName: string
+  ): void => {
     this.endpoints.sendClientErrorToHost(
       "Custom Component",
-      componentName,
       "Request Timeout",
       "Your app is having trouble loading the component.",
-      source
+      source,
+      customComponentName
     )
   }
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -155,4 +155,14 @@ describe("DownloadButton widget", () => {
       expect(downloadButton).toBeDisabled()
     })
   })
+
+  it("triggers checkSourceUrlResponse to check download url", () => {
+    const props = getProps()
+    render(<DownloadButton {...props} />)
+
+    expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledWith(
+      props.element.url,
+      "Download Button"
+    )
+  })
 })

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import React, { memo, ReactElement, useEffect } from "react"
 
 import { DownloadButton as DownloadButtonProto } from "@streamlit/protobuf"
 
@@ -62,6 +62,12 @@ function DownloadButton(props: Props): ReactElement {
   } else if (element.type === "tertiary") {
     kind = BaseButtonKind.TERTIARY
   }
+
+  useEffect(() => {
+    // Since we use a hidden link to download, we can't use the onerror event
+    // to catch src url load errors. Catch with direct check instead.
+    endpoints.checkSourceUrlResponse(element.url, "Download Button")
+  }, [element.url, endpoints])
 
   const handleDownloadClick: () => void = () => {
     if (!element.ignoreRerun) {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -242,10 +242,10 @@ export type IGuestToHostMessage =
   | {
       type: "CLIENT_ERROR"
       component: string
-      customComponentName: string
       error: string | number
       message: string
       source: string
+      customComponentName?: string
     }
 
 export type VersionedMessage<Message> = {


### PR DESCRIPTION
## Describe your changes
**Part 4 of sending client errors to host: PR going into feature branch**

* Handles endpoints in `DefaultStreamlitEndpoints` by using the catch to send error message to host on failure:
    * `uploadFileUploaderFile`
    * `deleteFileAtURL`
    * `fetchCachedForwardMsg`
 
* Generally handles media load errors with `onError` property, which sends error message to the host on load failure:
    * `ImageList`
    * `Audio`
    * `Video`
    * `Logo` (both in AppView & Sidebar)
  
* Special cases that require similar methodology as `ComponentInstance` - check the source separately because `onerror` not available
    * `DownloadButton`
    * `Video` subtitles

## Testing Plan
- JS Unit Tests: ✅ 
- E2E Tests: ✅ 
- Manual Testing: ✅ 