### PR TITLE
Fix issue with background color handling in sidebar theming

### DIFF
--- a/e2e_playwright/theming/sidebar_custom_theme_test.py
+++ b/e2e_playwright/theming/sidebar_custom_theme_test.py
@@ -40,6 +40,7 @@ def configure_sidebar_custom_theme():
     os.environ["STREAMLIT_CLIENT_TOOLBAR_MODE"] = "minimal"
     yield
     del os.environ["STREAMLIT_THEME_BASE"]
+    del os.environ["STREAMLIT_THEME_BASE_FONT_SIZE"]
     del os.environ["STREAMLIT_THEME_BASE_RADIUS"]
     del os.environ["STREAMLIT_THEME_SHOW_BORDER_AROUND_INPUTS"]
     del os.environ["STREAMLIT_THEME_SIDEBAR_BACKGROUND_COLOR"]

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -18,7 +18,12 @@ import React from "react"
 
 import { screen } from "@testing-library/react"
 
-import { emotionLightTheme, mockEndpoints, render } from "@streamlit/lib"
+import {
+  emotionLightTheme,
+  mockEndpoints,
+  render,
+  ThemeConfig,
+} from "@streamlit/lib"
 import { CustomThemeConfig } from "@streamlit/protobuf"
 
 import { SidebarProps } from "./Sidebar"
@@ -82,7 +87,7 @@ describe("ThemedSidebar Component", () => {
 })
 
 describe("createSidebarTheme", () => {
-  const createMockTheme = (overrides: any = {}) => ({
+  const createMockTheme = (overrides: any = {}): ThemeConfig => ({
     name: "mockTheme",
     basewebTheme: {},
     primitives: {},

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -19,9 +19,10 @@ import React from "react"
 import { screen } from "@testing-library/react"
 
 import { emotionLightTheme, mockEndpoints, render } from "@streamlit/lib"
+import { CustomThemeConfig } from "@streamlit/protobuf"
 
 import { SidebarProps } from "./Sidebar"
-import ThemedSidebar from "./ThemedSidebar"
+import ThemedSidebar, { createSidebarTheme } from "./ThemedSidebar"
 
 function getProps(
   props: Partial<SidebarProps> = {}
@@ -77,5 +78,101 @@ describe("ThemedSidebar Component", () => {
     // Check the app pages passed
     expect(screen.getByText("streamlit app")).toBeInTheDocument()
     expect(screen.getByText("other app page")).toBeInTheDocument()
+  })
+})
+
+describe("createSidebarTheme", () => {
+  const createMockTheme = (overrides: any = {}) => ({
+    name: "mockTheme",
+    basewebTheme: {},
+    primitives: {},
+    themeInput: {},
+    emotion: {
+      colors: {
+        secondaryBg: "#FFFFFF",
+        bgColor: "#F0F0F0",
+      },
+    },
+    ...overrides,
+  })
+
+  it("creates a light theme when background is light", () => {
+    const theme = createMockTheme()
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.base).toBe(
+      CustomThemeConfig.BaseTheme.LIGHT
+    )
+  })
+
+  it("creates a dark theme when background is dark", () => {
+    const theme = createMockTheme({
+      emotion: {
+        colors: {
+          secondaryBg: "#000000",
+          bgColor: "#1A1A1A",
+        },
+      },
+    })
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.base).toBe(
+      CustomThemeConfig.BaseTheme.DARK
+    )
+  })
+
+  it("uses sidebar-specific background color when provided", () => {
+    const theme = createMockTheme({
+      themeInput: {
+        sidebar: {
+          backgroundColor: "#FF0000",
+        },
+      },
+    })
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.backgroundColor).toBe("#FF0000")
+  })
+
+  it("uses secondary background color as fallback when no sidebar background specified", () => {
+    const theme = createMockTheme({
+      emotion: {
+        colors: {
+          secondaryBg: "#CCCCCC",
+          bgColor: "#F0F0F0",
+        },
+      },
+    })
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.backgroundColor).toBe("#CCCCCC")
+  })
+
+  it("uses secondary background color as fallback when sidebar background is empty string", () => {
+    const theme = createMockTheme({
+      themeInput: {
+        sidebar: {
+          backgroundColor: "",
+        },
+      },
+      emotion: {
+        colors: {
+          secondaryBg: "#CCCCCC",
+          bgColor: "#F0F0F0",
+        },
+      },
+    })
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.backgroundColor).toBe("#CCCCCC")
+  })
+
+  it("applies sidebar-specific overrides", () => {
+    const theme = createMockTheme({
+      themeInput: {
+        sidebar: {
+          primaryColor: "#FF0000",
+          backgroundColor: "#00FF00",
+        },
+      },
+    })
+    const sidebarTheme = createSidebarTheme(theme)
+    expect(sidebarTheme.themeInput?.primaryColor).toBe("#FF0000")
+    expect(sidebarTheme.themeInput?.backgroundColor).toBe("#00FF00")
   })
 })

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
@@ -30,7 +30,7 @@ import { CustomThemeConfig } from "@streamlit/protobuf"
 
 import Sidebar, { SidebarProps } from "./Sidebar"
 
-const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
+export const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
   let sidebarOverride = {}
   if (notNullOrUndefined(theme.themeInput?.sidebar)) {
     sidebarOverride = theme.themeInput.sidebar
@@ -38,24 +38,31 @@ const createSidebarTheme = (theme: ThemeConfig): ThemeConfig => {
 
   // Either use the configured background color or secondary background from main theme:
   const sidebarBackground =
-    theme.themeInput?.sidebar?.backgroundColor ??
+    theme.themeInput?.sidebar?.backgroundColor ||
     theme.emotion.colors.secondaryBg
 
-  // Eeither use the configured secondary background color or background from main theme:
+  // Either use the configured secondary background color or background from main theme:
   const secondaryBackgroundColor =
-    theme.themeInput?.sidebar?.secondaryBackgroundColor ??
+    theme.themeInput?.sidebar?.secondaryBackgroundColor ||
     theme.emotion.colors.bgColor
+
+  // Override the background and secondary background colors in sidebar overwrites:
+  sidebarOverride = {
+    ...sidebarOverride,
+    backgroundColor: sidebarBackground,
+    secondaryBackgroundColor: secondaryBackgroundColor,
+  }
+
+  const baseTheme =
+    getLuminance(sidebarBackground) > 0.5
+      ? CustomThemeConfig.BaseTheme.LIGHT
+      : CustomThemeConfig.BaseTheme.DARK
 
   return createTheme(
     "Sidebar",
     {
       ...theme.themeInput, // Use the theme props from the main theme as basis
-      base:
-        getLuminance(sidebarBackground) > 0.5
-          ? CustomThemeConfig.BaseTheme.LIGHT
-          : CustomThemeConfig.BaseTheme.DARK,
-      backgroundColor: sidebarBackground,
-      secondaryBackgroundColor: secondaryBackgroundColor,
+      base: baseTheme,
       ...sidebarOverride,
     },
     undefined, // Creating a new theme from scratch


### PR DESCRIPTION
## Describe your changes

There was an issue with the current sidebar theme handling if `backgroundColor` or `secondaryBackgroundColor` was configured to be an empty string. This PR fixes this by correctly falling back to the main theme colors (from emotion) on empty string.

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
