### PR TITLE
[Feat] Send client errors to host

### DIFF
--- a/e2e_playwright/custom_components/component_errors.py
+++ b/e2e_playwright/custom_components/component_errors.py
@@ -1,0 +1,22 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit_ace import st_ace
+
+import streamlit as st
+
+## Spawn a new Ace editor
+st.subheader("Ace Editor Component", divider="blue")
+content = st_ace()
+st.write(content)

--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -1,0 +1,102 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, Route, expect
+
+from e2e_playwright.conftest import wait_for_app_run, wait_until
+
+# The timeout value from ComponentInstance.tsx
+COMPONENT_READY_WARNING_TIME_MS = 60000  # 60 seconds
+
+
+def handle_component_source_failure(route: Route):
+    """Handle custom component source request by returning a 404 status."""
+    route.fulfill(status=404, headers={"Content-Type": "text/plain"}, body="Not Found")
+
+
+def handle_component_timeout_failure(route: Route):
+    """Handle custom component request by aborting the request (trigger catch in fetch)."""
+    route.abort("failed")
+
+
+def test_component_source_failure(page: Page, app_port: int):
+    """Test that a component source failure is handled correctly."""
+    # Ensure custom component source requests return a 404 status
+    page.route(
+        f"http://localhost:{app_port}/component/**", handle_component_source_failure
+    )
+
+    # Capture console messages
+    messages = []
+    page.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    page.goto(f"http://localhost:{app_port}")
+    wait_for_app_run(page)
+
+    # Expect the iframe to be attached
+    expect(page.get_by_test_id("stCustomComponentV1")).to_be_attached()
+
+    # Wait until the expected error is logged, which indicates CLIENT_ERROR was sent
+    wait_until(
+        page,
+        lambda: any(
+            "Client Error: Custom component streamlit_ace.streamlit_ace source error"
+            in message
+            for message in messages
+        ),
+    )
+
+
+def test_component_timeout_failure(page: Page, app_port: int):
+    """Test that a component timeout failure is handled correctly."""
+    # Ensure custom component requests times out
+    page.route(
+        f"http://localhost:{app_port}/component/**", handle_component_timeout_failure
+    )
+
+    # Capture console messages
+    messages = []
+    page.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    page.goto(f"http://localhost:{app_port}")
+
+    # Expect the iframe to be attached
+    expect(page.get_by_test_id("stCustomComponentV1")).to_be_attached()
+
+    # Fetch error should be logged
+    wait_until(
+        page,
+        lambda: any(
+            "Client Error: Custom component streamlit_ace.streamlit_ace fetch error"
+            in message
+            for message in messages
+        ),
+    )
+
+    # Wait for the component to timeout
+    page.wait_for_timeout(COMPONENT_READY_WARNING_TIME_MS)
+
+    wait_until(
+        page,
+        lambda: any(
+            "Client Error: Custom component streamlit_ace.streamlit_ace timeout error"
+            in message
+            for message in messages
+        ),
+    )
+
+    # Wait for the warning to appear and verify
+    expect(page.get_by_test_id("stAlert")).to_be_visible()

--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -52,7 +52,7 @@ def test_component_source_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace source error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace source error"
             in message
             for message in messages
         ),
@@ -80,7 +80,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace fetch error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace fetch error"
             in message
             for message in messages
         ),
@@ -92,7 +92,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     wait_until(
         page,
         lambda: any(
-            "Client Error: Custom component streamlit_ace.streamlit_ace timeout error"
+            "Client Error: Custom Component streamlit_ace.streamlit_ace timeout error"
             in message
             for message in messages
         ),

--- a/e2e_playwright/host_config.py
+++ b/e2e_playwright/host_config.py
@@ -17,6 +17,23 @@ import pandas as pd
 
 import streamlit as st
 
+
+def page2():
+    st.header("Page 2")
+
+
+def page3():
+    st.header("Page 3")
+
+
+# Make MPA to use for dialog blocking test
+st.navigation(
+    [
+        st.Page(page2, title="02_App_Page_2", default=True),
+        st.Page(page3, title="03_App_Page_3"),
+    ]
+)
+
 # always generate the same data
 np.random.seed(0)
 

--- a/e2e_playwright/host_config_test.py
+++ b/e2e_playwright/host_config_test.py
@@ -14,13 +14,18 @@
 
 from playwright.sync_api import Page, Route, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_loaded
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_until,
+)
 
 
-def handle_route_hostconfig_disable_fullscreen(route: Route) -> None:
+def handle_route_hostconfig_disable_fullscreen_and_error_dialogs(route: Route) -> None:
     response = route.fetch()
     body = response.json()
     body["disableFullscreenMode"] = True
+    body["blockErrorDialogs"] = True
     route.fulfill(
         # Pass all fields from the response.
         response=response,
@@ -33,7 +38,10 @@ def test_disable_fullscreen(
     page: Page, app_port: int, assert_snapshot: ImageCompareFunction
 ):
     """Test that fullscreen mode is disabled for elements when set via host-config."""
-    page.route("**/_stcore/host-config", handle_route_hostconfig_disable_fullscreen)
+    page.route(
+        "**/_stcore/host-config",
+        handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
+    )
     page.goto(f"http://localhost:{app_port}")
     wait_for_app_loaded(page)
 
@@ -52,3 +60,36 @@ def test_disable_fullscreen(
     assert_snapshot(
         dataframe_toolbar, name="host_config-dataframe_disabled_fullscreen_mode"
     )
+
+
+def test_block_error_dialogs(page: Page, app_port: int):
+    """Test that error dialogs are blocked and sent to host when set via host-config."""
+    # Need to be more specific about the route to allow for successful redirect
+    page.route(
+        f"http://localhost:{app_port}/_stcore/host-config",
+        handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
+    )
+
+    # Initial load of page
+    page.goto(f"http://localhost:{app_port}")
+    wait_for_app_loaded(page)
+
+    # Capture console messages
+    messages = []
+    page.on("console", lambda msg: messages.append(msg))
+
+    # Navigate to a non-existent page to trigger page not found error
+    page.goto(f"http://localhost:{app_port}/nonexistent_page")
+
+    # Wait until the expected error is logged - console should include 2 404 errors (health & host-config) then the page not found error
+    wait_until(
+        page,
+        lambda: any(
+            "The page that you have requested does not seem to exist. Running the app's main page."
+            in message.text
+            for message in messages
+        ),
+    )
+
+    # Verify no error dialog is shown
+    expect(page.get_by_role("dialog")).not_to_be_attached()

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import FilePayload, Page, expect
+from playwright.sync_api import FilePayload, Page, Route, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, rerun_app, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    rerun_app,
+    wait_for_app_run,
+    wait_until,
+)
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 
 
@@ -488,3 +493,101 @@ def test_file_uploader_works_with_fragments(app: Page):
 
     expect(app.get_by_text("File uploader in Fragment: True")).to_be_visible()
     expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+
+def test_file_uploader_upload_error(app: Page, app_port: int):
+    """Test that the file uploader upload error is correctly logged."""
+    # Ensure file upload source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
+    uploader_index = 0
+
+    # Upload a file
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+        ]
+    )
+    wait_for_app_run(app)
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: any(
+            "Client Error: File uploader error on file upload" in message
+            for message in messages
+        ),
+    )
+
+
+def test_file_uploader_delete_error(app: Page, app_port: int):
+    """Test that the file uploader delete error is correctly logged."""
+
+    # Allow GET requests to pass through, but block DELETE requests
+    def allow_file_upload_block_delete(route: Route):
+        if route.request.method == "DELETE":
+            route.fulfill(
+                status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+            )
+        else:
+            route.fallback()
+
+    # Ensure file upload source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        allow_file_upload_block_delete,
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    file_name1 = "file1.txt"
+    file_content1 = b"file1content"
+    uploader_index = 0
+
+    # Upload a file
+    with app.expect_file_chooser() as fc_info:
+        app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index).click()
+
+    file_chooser = fc_info.value
+    file_chooser.set_files(
+        files=[
+            FilePayload(name=file_name1, mimeType="text/plain", buffer=file_content1)
+        ]
+    )
+    wait_for_app_run(app)
+
+    # Delete the file
+    app.get_by_test_id("stFileUploaderDeleteBtn").first.click()
+    wait_for_app_run(app)
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: any(
+            "Client Error: File uploader error on file delete" in message
+            for message in messages
+        ),
+    )

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -16,12 +16,28 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_until
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     get_element_by_key,
     get_image,
 )
+
+IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT = 37
+
+
+def check_image_source_error_count(messages: list[str], expected_count: int):
+    """Check that the expected number of image source error messages are logged."""
+    assert (
+        len(
+            [
+                message
+                for message in messages
+                if "Client Error: Image source error" in message
+            ]
+        )
+        == expected_count
+    )
 
 
 def test_image_display(app: Page):
@@ -215,3 +231,29 @@ def test_markdown_caption_support(app: Page, assert_snapshot: ImageCompareFuncti
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stImage")
+
+
+def test_image_source_error(app: Page, app_port: int):
+    """Test `st.image` source error."""
+    # Ensure image source request return a 404 status
+    app.route(
+        f"http://localhost:{app_port}/media/**",
+        lambda route: route.fulfill(
+            status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
+        ),
+    )
+
+    # Capture console messages
+    messages = []
+    app.on("console", lambda msg: messages.append(msg.text))
+
+    # Navigate to the app
+    app.goto(f"http://localhost:{app_port}")
+
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
+    wait_until(
+        app,
+        lambda: check_image_source_error_count(
+            messages, IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT
+        ),
+    )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -376,6 +376,22 @@ export class App extends PureComponent<Props, State> {
     this.endpoints = new DefaultStreamlitEndpoints({
       getServerUri: this.getBaseUriParts,
       csrfEnabled: true,
+      sendClientError: (
+        component: string,
+        customComponentName: string,
+        error: string | number,
+        message: string,
+        source: string
+      ) => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "CLIENT_ERROR",
+          component,
+          error,
+          message,
+          customComponentName,
+          source,
+        })
+      },
     })
 
     this.uploadClient = new FileUploadClient({

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -378,18 +378,18 @@ export class App extends PureComponent<Props, State> {
       csrfEnabled: true,
       sendClientError: (
         component: string,
-        customComponentName: string,
         error: string | number,
         message: string,
-        source: string
+        source: string,
+        customComponentName?: string
       ) => {
         this.hostCommunicationMgr.sendMessageToHost({
           type: "CLIENT_ERROR",
           component,
           error,
           message,
-          customComponentName,
           source,
+          customComponentName,
         })
       },
     })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -109,7 +109,9 @@ import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"
 import {
   DialogProps,
+  ScriptCompileErrorProps,
   StreamlitDialog,
+  WarningProps,
 } from "@streamlit/app/src/components/StreamlitDialog"
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {
@@ -424,12 +426,14 @@ export class App extends PureComponent<Props, State> {
           mapboxToken,
           enforceDownloadInNewTab,
           metricsUrl,
+          blockErrorDialogs,
         } = response
 
         const appConfig: AppConfig = {
           allowedOrigins,
           useExternalAuthToken,
           enableCustomParentMessages,
+          blockErrorDialogs,
         }
         const libConfig: LibConfig = {
           mapboxToken,
@@ -550,6 +554,33 @@ export class App extends PureComponent<Props, State> {
     window.removeEventListener("popstate", this.onHistoryChange, false)
   }
 
+  /**
+   * Checks whether to show error dialog or send error info
+   * to be handled by the host.
+   */
+  maybeShowErrorDialog(
+    newDialog: WarningProps | ScriptCompileErrorProps,
+    errorMsg: string
+  ): void {
+    // Show dialog only if blockErrorDialogs host config is false
+    const { blockErrorDialogs } = this.state.appConfig
+    if (!blockErrorDialogs) {
+      this.openDialog(newDialog)
+    }
+
+    const isScriptCompileError =
+      newDialog.type === DialogType.SCRIPT_COMPILE_ERROR
+    // script compile error has no title
+    const error = isScriptCompileError ? newDialog.type : newDialog.title
+
+    // Send error info to host via postMessage
+    this.hostCommunicationMgr.sendMessageToHost({
+      type: "CLIENT_ERROR_DIALOG",
+      error,
+      message: errorMsg,
+    })
+  }
+
   showError(title: string, errorMarkdown: string): void {
     LOG.error(errorMarkdown)
     const newDialog: DialogProps = {
@@ -558,7 +589,7 @@ export class App extends PureComponent<Props, State> {
       msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
       onClose: () => {},
     }
-    this.openDialog(newDialog)
+    this.maybeShowErrorDialog(newDialog, errorMarkdown)
   }
 
   showDeployError = (
@@ -566,14 +597,15 @@ export class App extends PureComponent<Props, State> {
     errorNode: ReactNode,
     onContinue?: () => void
   ): void => {
-    this.openDialog({
+    const newDialog: DialogProps = {
       type: DialogType.DEPLOY_ERROR,
       title,
       msg: errorNode,
       onContinue,
       onClose: () => {},
       onTryAgain: this.sendLoadGitInfoBackMsg,
-    })
+    }
+    this.openDialog(newDialog)
   }
 
   /**
@@ -956,7 +988,10 @@ export class App extends PureComponent<Props, State> {
         exception: sessionEvent.scriptCompilationException,
         onClose: () => {},
       }
-      this.openDialog(newDialog)
+      this.maybeShowErrorDialog(
+        newDialog,
+        sessionEvent.scriptCompilationException?.message ?? "No message"
+      )
     }
   }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -433,6 +433,19 @@ export class App extends PureComponent<Props, State> {
       connectionStateChanged: this.handleConnectionStateChanged,
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
+      sendClientError: (
+        error: string | number,
+        message: string,
+        source: string
+      ) => {
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "CLIENT_ERROR",
+          component: "Websocket Connection",
+          error,
+          message,
+          source,
+        })
+      },
       onHostConfigResp: (response: IHostConfigResponse) => {
         const {
           allowedOrigins,

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -54,8 +54,25 @@ class Endpoints implements StreamlitEndpoints {
     throw new Error("Unimplemented")
   }
 
-  public buildComponentURL(): string {
+  public sendClientErrorToHost(
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ): void {
     throw new Error("Unimplemented")
+  }
+
+  public checkSourceUrlResponse(
+    sourceUrl: string,
+    componentName?: string
+  ): Promise<void> {
+    return Promise.reject(new Error("Unimplemented"))
+  }
+
+  public buildComponentURL(componentName: string, path: string): string {
+    return path
   }
 
   public buildMediaURL(url: string): string {

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -56,10 +56,10 @@ class Endpoints implements StreamlitEndpoints {
 
   public sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void {
     throw new Error("Unimplemented")
   }

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen, within } from "@testing-library/react"
+import { fireEvent, screen, within } from "@testing-library/react"
 
 import {
   AppRoot,
@@ -75,7 +75,12 @@ function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   }
 }
 
-const mockEndpointProp = mockEndpoints()
+const buildMediaURL = vi.fn((url: string) => url)
+const sendClientErrorToHost = vi.fn()
+const mockEndpointProp = mockEndpoints({
+  buildMediaURL,
+  sendClientErrorToHost,
+})
 
 function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
   const formsData = createFormsData()
@@ -492,6 +497,22 @@ describe("AppView element", () => {
     it("renders logo - large size when specified", () => {
       render(<AppView {...getProps({ appLogo: imageWithSize })} />)
       expect(screen.getByTestId("stLogo")).toHaveStyle({ height: "2rem" })
+    })
+
+    it("sends an CLIENT_ERROR message when the logo source fails to load", () => {
+      const props = getProps({ appLogo: imageOnly })
+      render(<AppView {...props} />)
+      const logoElement = screen.getByTestId("stLogo")
+      expect(logoElement).toBeInTheDocument()
+
+      fireEvent.error(logoElement)
+
+      expect(sendClientErrorToHost).toHaveBeenCalledWith(
+        "Logo",
+        "Logo source failed to load",
+        "onerror triggered",
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png"
+      )
     })
   })
 

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -16,6 +16,8 @@
 
 import React, { ReactElement } from "react"
 
+import { getLogger } from "loglevel"
+
 import { StreamlitEndpoints } from "@streamlit/connection"
 import {
   AppRoot,
@@ -54,6 +56,7 @@ import {
 } from "./styled-components"
 import ScrollToBottomContainer from "./ScrollToBottomContainer"
 
+const LOG = getLogger("AppView")
 export interface AppViewProps {
   elements: AppRoot
 
@@ -178,6 +181,18 @@ function AppView(props: AppViewProps): ReactElement {
     removeScriptFinishedHandler,
   ])
 
+  const handleLogoError = (logoUrl: string): void => {
+    // StyledLogo does not retain the e.currentEvent.src like other onerror cases
+    // store and read from ref instead
+    LOG.error(`Client Error: Logo source error - ${logoUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Logo",
+      "Logo source failed to load",
+      "onerror triggered",
+      logoUrl
+    )
+  }
+
   const renderLogo = (appLogo: Logo): ReactElement => {
     const displayImage = appLogo.iconImage ? appLogo.iconImage : appLogo.image
     const source = endpoints.buildMediaURL(displayImage)
@@ -189,6 +204,8 @@ function AppView(props: AppViewProps): ReactElement {
         alt="Logo"
         className="stLogo"
         data-testid="stLogo"
+        // Save to logo's src to send on load error
+        onError={_ => handleLogoError(source)}
       />
     )
 

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -34,7 +34,12 @@ vi.mock("~lib/util/Hooks", async () => ({
   useIsOverflowing: vi.fn(),
 }))
 
-const mockEndpointProp = mockEndpoints()
+const buildMediaURL = vi.fn((url: string) => url)
+const sendClientErrorToHost = vi.fn()
+const mockEndpointProp = mockEndpoints({
+  buildMediaURL,
+  sendClientErrorToHost,
+})
 
 function renderSidebar(props: Partial<SidebarProps> = {}): RenderResult {
   return render(
@@ -360,6 +365,23 @@ describe("Sidebar Component", () => {
       // L & R padding (twoXL) + R margin (sm) + collapse button (2.25rem)
       expect(sidebarLogo).toHaveStyle(
         `max-width: calc(${sidebarWidth} - 2 * 1.5rem - 0.5rem - 2.25rem)`
+      )
+    })
+
+    it("sends an CLIENT_ERROR message when the logo source fails to load", () => {
+      renderSidebar({ appLogo: fullAppLogo })
+      const sidebarLogo = within(
+        screen.getByTestId("stSidebarHeader")
+      ).getByTestId("stLogo")
+      expect(sidebarLogo).toBeInTheDocument()
+
+      fireEvent.error(sidebarLogo)
+
+      expect(sendClientErrorToHost).toHaveBeenCalledWith(
+        "Sidebar Logo",
+        "Logo source failed to load",
+        "onerror triggered",
+        "https://global.discourse-cdn.com/business7/uploads/streamlit/original/2X/8/8cb5b6c0e1fe4e4ebfd30b769204c0d30c332fec.png"
       )
     })
   })

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -208,7 +208,7 @@ function clearCacheDialog(props: ClearCacheProps): ReactElement {
   )
 }
 
-interface ScriptCompileErrorProps {
+export interface ScriptCompileErrorProps {
   type: DialogType.SCRIPT_COMPILE_ERROR
   exception: IException | null | undefined
   onClose: PlainEventHandler
@@ -241,7 +241,7 @@ function settingsDialog(props: SettingsProps): ReactElement {
   return <SettingsDialog {...props} />
 }
 
-interface WarningProps {
+export interface WarningProps {
   type: DialogType.WARNING
   title: string
   msg: ReactNode

--- a/frontend/app/src/components/StreamlitDialog/index.ts
+++ b/frontend/app/src/components/StreamlitDialog/index.ts
@@ -14,4 +14,9 @@
  * limitations under the License.
  */
 export { StreamlitDialog } from "./StreamlitDialog"
-export type { DialogProps, PlainEventHandler } from "./StreamlitDialog"
+export type {
+  DialogProps,
+  PlainEventHandler,
+  ScriptCompileErrorProps,
+  WarningProps,
+} from "./StreamlitDialog"

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -70,6 +70,16 @@ interface Props {
   resetHostAuthToken: () => void
 
   /**
+   * Sends message to host when websocket connection errors encountered to
+   * inform where/why the error occurred.
+   */
+  sendClientError: (
+    error: string | number,
+    message: string,
+    source: string
+  ) => void
+
+  /**
    * Function to set the host config for this app (if in a relevant deployment
    * scenario).
    */
@@ -168,7 +178,12 @@ export class ConnectionManager {
         this.websocketConnection = await this.connectToRunningServer()
       } catch (e) {
         const err = e instanceof Error ? e : new Error(`${e}`)
-        LOG.error(err.message)
+        LOG.error(`Client Error: Websocket connection - ${err.message}`)
+        this.props.sendClientError(
+          "Failed to establish websocket connection",
+          err.message,
+          "Connection Manager"
+        )
         this.setConnectionState(
           ConnectionState.DISCONNECTED_FOREVER,
           err.message
@@ -220,6 +235,7 @@ export class ConnectionManager {
       onRetry: this.showRetryError,
       claimHostAuthToken: this.props.claimHostAuthToken,
       resetHostAuthToken: this.props.resetHostAuthToken,
+      sendClientError: this.props.sendClientError,
       onHostConfigResp: this.props.onHostConfigResp,
     })
   }

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -59,6 +59,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,
+        sendClientError: vi.fn(),
       })
       expect(() => endpoint.buildComponentURL("foo", "index.html")).toThrow()
     })
@@ -68,6 +69,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,
+        sendClientError: vi.fn(),
       })
 
       // "Connect" to the server. `buildComponentURL` will succeed.
@@ -89,6 +91,7 @@ describe("DefaultStreamlitEndpoints", () => {
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,
       csrfEnabled: false,
+      sendClientError: vi.fn(),
     })
 
     afterEach(() => {
@@ -121,6 +124,7 @@ describe("DefaultStreamlitEndpoints", () => {
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,
       csrfEnabled: false,
+      sendClientError: vi.fn(),
     })
 
     it("builds URL correctly for files being uploaded to the tornado server", () => {
@@ -152,6 +156,7 @@ describe("DefaultStreamlitEndpoints", () => {
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,
       csrfEnabled: false,
+      sendClientError: vi.fn(),
     })
 
     const appPages = [
@@ -202,6 +207,7 @@ describe("DefaultStreamlitEndpoints", () => {
       endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
+        sendClientError: vi.fn(),
       })
     })
 
@@ -343,6 +349,7 @@ describe("DefaultStreamlitEndpoints", () => {
       endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
+        sendClientError: vi.fn(),
       })
     })
 
@@ -410,6 +417,7 @@ describe("DefaultStreamlitEndpoints", () => {
       endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
+        sendClientError: vi.fn(),
       })
     })
 
@@ -467,6 +475,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: true,
+        sendClientError: vi.fn(),
       })
 
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
@@ -484,6 +493,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
+        sendClientError: vi.fn(),
       })
 
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
@@ -493,6 +503,69 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(spyRequest).toHaveBeenCalledWith({
         url,
       })
+    })
+  })
+
+  describe("checkSourceUrlResponse", () => {
+    it("calls the passed source - sends error to host if error on response", async () => {
+      // Mock fetch for checkSourceUrlResponse - response is not ok
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        } as Response)
+      )
+      const endpoints = new DefaultStreamlitEndpoints({
+        getServerUri: () => MOCK_SERVER_URI,
+        csrfEnabled: false,
+        sendClientError: vi.fn(),
+      })
+
+      const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+
+      expect(fetch).toHaveBeenCalledWith(url)
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "Custom Component",
+        "mockComponent",
+        404,
+        "Not Found",
+        url
+      )
+    })
+
+    it("calls the passed source - sends error to host if fetch fails", async () => {
+      const endpoints = new DefaultStreamlitEndpoints({
+        getServerUri: () => MOCK_SERVER_URI,
+        csrfEnabled: false,
+        sendClientError: vi.fn(),
+      })
+
+      // Mock fetch for checkSourceUrlResponse - fetch fails
+      global.fetch = vi.fn(() => Promise.reject(new Error("mockError")))
+
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+      const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
+      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+
+      expect(fetch).toHaveBeenCalledWith(url)
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "Custom Component",
+        "mockComponent",
+        "Error fetching source",
+        "mockError",
+        url
+      )
     })
   })
 })

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -329,6 +329,11 @@ describe("DefaultStreamlitEndpoints", () => {
         .onPut("http://streamlit.mock:80/mock/base/path/_stcore/upload_file")
         .reply(() => [400])
 
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
       await expect(
         endpoints.uploadFileUploaderFile(
           "/_stcore/upload_file",
@@ -336,6 +341,13 @@ describe("DefaultStreamlitEndpoints", () => {
           "mockSessionId"
         )
       ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "File Uploader",
+        "Error uploading file",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/upload_file"
+      )
     })
   })
 
@@ -406,6 +418,33 @@ describe("DefaultStreamlitEndpoints", () => {
         data: { sessionId: "mockSessionId" },
       })
     })
+
+    it("errors on bad status", async () => {
+      axiosMock
+        .onDelete(
+          "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
+        )
+        .reply(() => [400])
+
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
+      await expect(
+        endpoints.deleteFileAtURL(
+          "/_stcore/upload_file/file_1",
+          "mockSessionId"
+        )
+      ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "File Uploader",
+        "Error deleting file",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
+      )
+    })
   })
 
   describe("fetchCachedForwardMsg()", () => {
@@ -450,9 +489,21 @@ describe("DefaultStreamlitEndpoints", () => {
         )
         .reply(() => [400])
 
+      const sendClientErrorToHostSpy = vi.spyOn(
+        endpoints,
+        "sendClientErrorToHost"
+      )
+
       await expect(
         endpoints.fetchCachedForwardMsg("mockHash")
       ).rejects.toThrow("Request failed with status code 400")
+
+      expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+        "Forward Message Cache",
+        "Error fetching cached forward message",
+        "Request failed with status code 400",
+        "http://streamlit.mock:80/mock/base/path/_stcore/message?hash=mockHash"
+      )
     })
   })
 
@@ -507,7 +558,7 @@ describe("DefaultStreamlitEndpoints", () => {
   })
 
   describe("checkSourceUrlResponse", () => {
-    it("calls the passed source - sends error to host if error on response", async () => {
+    it("sends error to host if error on response", async () => {
       // Mock fetch for checkSourceUrlResponse - response is not ok
       global.fetch = vi.fn(() =>
         Promise.resolve({
@@ -527,20 +578,24 @@ describe("DefaultStreamlitEndpoints", () => {
         endpoints,
         "sendClientErrorToHost"
       )
-      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+      await endpoints.checkSourceUrlResponse(
+        url,
+        "Custom Component",
+        "mockComponent"
+      )
 
       expect(fetch).toHaveBeenCalledWith(url)
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "Custom Component",
-        "mockComponent",
         404,
         "Not Found",
-        url
+        url,
+        "mockComponent"
       )
     })
 
-    it("calls the passed source - sends error to host if fetch fails", async () => {
+    it("sends error to host if fetch fails", async () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
@@ -555,16 +610,20 @@ describe("DefaultStreamlitEndpoints", () => {
         "sendClientErrorToHost"
       )
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
-      await endpoints.checkSourceUrlResponse(url, "mockComponent")
+      await endpoints.checkSourceUrlResponse(
+        url,
+        "Custom Component",
+        "mockComponent"
+      )
 
       expect(fetch).toHaveBeenCalledWith(url)
 
       expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
         "Custom Component",
-        "mockComponent",
         "Error fetching source",
         "mockError",
-        url
+        url,
+        "mockComponent"
       )
     })
   })

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -15,6 +15,7 @@
  */
 
 import axios, { AxiosRequestConfig, AxiosResponse, CancelToken } from "axios"
+import { getLogger } from "loglevel"
 
 import { IAppPage } from "@streamlit/protobuf"
 import {
@@ -26,9 +27,18 @@ import {
 
 import { FileUploadClientConfig, StreamlitEndpoints } from "./types"
 
+const LOG = getLogger("DefaultStreamlitEndpoints")
+
 interface Props {
   getServerUri: () => URL | undefined
   csrfEnabled: boolean
+  sendClientError: (
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ) => void
 }
 
 const MEDIA_ENDPOINT = "/media"
@@ -39,6 +49,14 @@ const FORWARD_MSG_CACHE_ENDPOINT = "/_stcore/message"
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
 export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   private readonly getServerUri: () => URL | undefined
+
+  private readonly sendClientError: (
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ) => void
 
   private readonly csrfEnabled: boolean
 
@@ -51,11 +69,68 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   public constructor(props: Props) {
     this.getServerUri = props.getServerUri
     this.csrfEnabled = props.csrfEnabled
+    this.sendClientError = props.sendClientError
     this.staticConfigUrl = null
   }
 
   public setStaticConfigUrl(url: string | null): void {
     this.staticConfigUrl = url
+  }
+
+  public sendClientErrorToHost(
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ): void {
+    this.sendClientError(
+      component,
+      customComponentName,
+      error,
+      message,
+      source
+    )
+  }
+
+  /**
+   * Check the source of a component for successful response (for those without onerror event)
+   * If the response is not ok, or fetch otherwise fails, send an error to the host.
+   */
+  public async checkSourceUrlResponse(
+    sourceUrl: string,
+    componentName: string
+  ): Promise<void> {
+    try {
+      const response = await fetch(sourceUrl)
+      if (!response.ok) {
+        // Send response info if unsuccessful
+        LOG.error(
+          `Client Error: Custom component ${componentName} source error - ${response.status}`
+        )
+        this.sendClientErrorToHost(
+          "Custom Component",
+          componentName,
+          response.status,
+          response.statusText,
+          sourceUrl
+        )
+      }
+      // Don't send error info on success
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      // Send fetch error info on failure
+      LOG.error(
+        `Client Error: Custom component ${componentName} fetch error - ${message}`
+      )
+      this.sendClientErrorToHost(
+        "Custom Component",
+        componentName,
+        "Error fetching source",
+        message,
+        sourceUrl
+      )
+    }
   }
 
   public buildComponentURL(componentName: string, path: string): string {

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -34,10 +34,10 @@ interface Props {
   csrfEnabled: boolean
   sendClientError: (
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ) => void
 }
 
@@ -52,10 +52,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   private readonly sendClientError: (
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ) => void
 
   private readonly csrfEnabled: boolean
@@ -79,17 +79,17 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   public sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void {
     this.sendClientError(
       component,
-      customComponentName,
       error,
       message,
-      source
+      source,
+      customComponentName
     )
   }
 
@@ -99,36 +99,39 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
    */
   public async checkSourceUrlResponse(
     sourceUrl: string,
-    componentName: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void> {
+    const componentForError = customComponentName
+      ? `${componentName} ${customComponentName}`
+      : componentName
+
     try {
       const response = await fetch(sourceUrl)
       if (!response.ok) {
         // Send response info if unsuccessful
         LOG.error(
-          `Client Error: Custom component ${componentName} source error - ${response.status}`
+          `Client Error: ${componentForError} source error - ${response.status}`
         )
         this.sendClientErrorToHost(
-          "Custom Component",
           componentName,
           response.status,
           response.statusText,
-          sourceUrl
+          sourceUrl,
+          customComponentName
         )
       }
       // Don't send error info on success
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Unknown Error"
       // Send fetch error info on failure
-      LOG.error(
-        `Client Error: Custom component ${componentName} fetch error - ${message}`
-      )
+      LOG.error(`Client Error: ${componentForError} fetch error - ${message}`)
       this.sendClientErrorToHost(
-        "Custom Component",
         componentName,
         "Error fetching source",
         message,
-        sourceUrl
+        sourceUrl,
+        customComponentName
       )
     }
   }
@@ -231,14 +234,31 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
     const headers: Record<string, string> = this.getAdditionalHeaders()
 
-    return this.csrfRequest<number>(this.buildFileUploadURL(fileUploadUrl), {
-      cancelToken,
-      method: "PUT",
-      data: form,
-      responseType: "text",
-      headers,
-      onUploadProgress,
-    }).then(() => undefined) // If the request succeeds, we don't care about the response body
+    const uploadUrl = this.buildFileUploadURL(fileUploadUrl)
+
+    try {
+      await this.csrfRequest<number>(uploadUrl, {
+        cancelToken,
+        method: "PUT",
+        data: form,
+        responseType: "text",
+        headers,
+        onUploadProgress,
+      })
+      // If the request succeeds, we don't care about the response body
+    } catch (error: unknown) {
+      // Send error info on failure
+      LOG.error(`Client Error: File uploader error on file upload - ${error}`)
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "File Uploader",
+        "Error uploading file",
+        message,
+        uploadUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      throw error
+    }
   }
 
   private getAdditionalHeaders(): Record<string, string> {
@@ -261,25 +281,55 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     sessionId: string
   ): Promise<void> {
     const headers: Record<string, string> = this.getAdditionalHeaders()
-    return this.csrfRequest<number>(this.buildFileUploadURL(fileUrl), {
-      method: "DELETE",
-      data: { sessionId },
-      headers,
-    }).then(() => undefined) // If the request succeeds, we don't care about the response body
+    const deleteUrl = this.buildFileUploadURL(fileUrl)
+
+    try {
+      await this.csrfRequest<number>(deleteUrl, {
+        method: "DELETE",
+        data: { sessionId },
+        headers,
+      })
+      // If the request succeeds, we don't care about the response body
+    } catch (error: unknown) {
+      // Send error info on failure
+      LOG.error(`Client Error: File uploader error on file delete - ${error}`)
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "File Uploader",
+        "Error deleting file",
+        message,
+        deleteUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      throw error
+    }
   }
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
     const serverURI = this.requireServerUri()
-    const rsp = await axios.request({
-      url: buildHttpUri(
-        serverURI,
-        `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
-      ),
-      method: "GET",
-      responseType: "arraybuffer",
-    })
+    const fetchUrl = buildHttpUri(
+      serverURI,
+      `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
+    )
 
-    return new Uint8Array(rsp.data)
+    try {
+      const rsp = await axios.get(fetchUrl, { responseType: "arraybuffer" })
+      return new Uint8Array(rsp.data)
+    } catch (error) {
+      // Send error info on failure
+      LOG.error(
+        `Client Error: Cached forward message error on fetch - ${error}`
+      )
+      const message = error instanceof Error ? error.message : "Unknown Error"
+      this.sendClientErrorToHost(
+        "Forward Message Cache",
+        "Error fetching cached forward message",
+        message,
+        fetchUrl
+      )
+      // Reject the promise with the error after sending the error to the host
+      return Promise.reject(error)
+    }
   }
 
   /**

--- a/frontend/connection/src/ForwardMessageCache.test.ts
+++ b/frontend/connection/src/ForwardMessageCache.test.ts
@@ -31,6 +31,8 @@ function createCache(): MockCache {
 
   const cache = new ForwardMsgCache({
     setStaticConfigUrl: vi.fn(),
+    sendClientErrorToHost: vi.fn(),
+    checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildFileUploadURL: vi.fn(),

--- a/frontend/connection/src/StaticConnection.test.tsx
+++ b/frontend/connection/src/StaticConnection.test.tsx
@@ -217,6 +217,7 @@ describe("StaticConnection", () => {
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,
       csrfEnabled: false,
+      sendClientError: vi.fn(),
     })
 
     beforeEach(() => {

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -23,7 +23,10 @@ import { BackMsg } from "@streamlit/protobuf"
 import { ConnectionState } from "./ConnectionState"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
 import { CORS_ERROR_MESSAGE_DOCUMENTATION_LINK } from "./constants"
-import { doInitPings } from "./DoInitPings"
+import {
+  doInitPings,
+  THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+} from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
 
 const MOCK_ALLOWED_ORIGINS_CONFIG = {
@@ -36,6 +39,31 @@ const MOCK_HOST_CONFIG_RESPONSE = {
 }
 
 const MOCK_HEALTH_RESPONSE = { status: "ok" }
+
+// Sets up axios get mock to fail a specific number of times before succeeding
+function setupAxiosMockWithFailures(
+  retryCount: number,
+  errorObj: any
+): ReturnType<typeof vi.fn> {
+  const mockImplementation = vi.fn()
+  axios.get = mockImplementation
+
+  // Each "totalTries" increment involves cycling through all URIs
+  // Each URI requires 2 axios calls (health + config)
+  // So total failed calls needed = retryCount * numUris * 2
+  const totalFailedCalls = retryCount * 2 * 2
+
+  // Setup all the rejected calls
+  for (let i = 0; i < totalFailedCalls; i++) {
+    mockImplementation.mockRejectedValueOnce(errorObj)
+  }
+
+  // Add final successful calls to break the loop
+  mockImplementation.mockResolvedValueOnce("") // healthzUri success
+  mockImplementation.mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE) // hostConfigUri success
+
+  return mockImplementation
+}
 
 /** Create mock WebsocketConnection arguments */
 function createMockArgs(overrides?: Partial<Args>): Args {
@@ -54,6 +82,7 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     onRetry: vi.fn(),
     claimHostAuthToken: () => Promise.resolve(undefined),
     resetHostAuthToken: vi.fn(),
+    sendClientError: vi.fn(),
     onHostConfigResp: vi.fn(),
     ...overrides,
   }
@@ -68,6 +97,7 @@ describe("doInitPings", () => {
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: vi.fn(),
+    sendClientError: vi.fn(),
     setAllowedOrigins: vi.fn(),
   }
 
@@ -94,6 +124,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(0)
@@ -113,6 +144,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(0)
@@ -136,6 +168,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
     expect(uriIndex).toEqual(1)
@@ -161,6 +194,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -188,6 +222,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -219,6 +254,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -248,6 +284,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -287,6 +324,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -322,6 +360,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -354,6 +393,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -393,6 +433,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -443,6 +484,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -496,6 +538,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -550,6 +593,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
@@ -573,12 +617,144 @@ If you are trying to access a Streamlit app running on another server, this coul
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
+      MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
     expect(timeouts[0]).toEqual(10)
     expect(timeouts[1]).toBeGreaterThan(timeouts[0])
     expect(timeouts2[0]).toEqual(10)
+  })
+
+  describe("calls sendClientError when we've reached connection error threshold", () => {
+    it("with status = 0 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 0,
+            statusText: "No response",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      // Verify that sendClientError was called with the expected arguments
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        "Response received with status 0",
+        "No response",
+        "/health"
+      )
+    })
+
+    it("with status = 403 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 403,
+            statusText: "Forbidden",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        403,
+        "Forbidden",
+        "/health"
+      )
+    })
+
+    it("with status = 500 response", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          response: {
+            status: 500,
+            statusText: "Internal Server Error",
+            config: {
+              url: "https://example.com/health",
+            },
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        500,
+        "Internal Server Error",
+        "/health"
+      )
+    })
+
+    it("with request error", async () => {
+      const sendClientErrorSpy = vi.fn()
+
+      // We need to mock axios.get to simulate connection error threshold
+      axios.get = setupAxiosMockWithFailures(
+        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
+        {
+          request: {
+            path: "https://example.com/health",
+          },
+        }
+      )
+
+      await doInitPings(
+        MOCK_PING_DATA.uri,
+        MOCK_PING_DATA.timeoutMs,
+        MOCK_PING_DATA.maxTimeoutMs,
+        MOCK_PING_DATA.retryCallback,
+        sendClientErrorSpy,
+        MOCK_PING_DATA.setAllowedOrigins
+      )
+
+      expect(sendClientErrorSpy).toHaveBeenCalledWith(
+        "No response received from server",
+        undefined,
+        "/health"
+      )
+    })
   })
 })
 

--- a/frontend/connection/src/testUtils.ts
+++ b/frontend/connection/src/testUtils.ts
@@ -24,6 +24,8 @@ export function mockEndpoints(
 ): StreamlitEndpoints {
   return {
     setStaticConfigUrl: vi.fn(),
+    sendClientErrorToHost: vi.fn(),
+    checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildFileUploadURL: vi.fn(),

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -187,6 +187,11 @@ export type AppConfig = {
    * Enables custom string messages to be sent to the host
    */
   enableCustomParentMessages?: boolean
+  /**
+   * Whether host wants to block error dialogs. If true, blocks error dialogs
+   * from being shown to the user, sends error info to host via postMessage
+   */
+  blockErrorDialogs?: boolean
 }
 
 export type MetricsConfig = {

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -63,6 +63,33 @@ export interface StreamlitEndpoints {
   setStaticConfigUrl(url: string): void
 
   /**
+   * Send postMessage to host with client errors
+   * @param component component causing the error
+   * @param customComponentName if custom component, component's name
+   * @param error error status code or message
+   * @param message additional error info
+   * @param source component src (url)
+   */
+  sendClientErrorToHost(
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ): void
+
+  /**
+   * Checks if the component src has successful response.
+   * If not, sends CLIENT_ERROR message with error info.
+   * @param sourceUrl The source to check.
+   * @param componentName The component for which the source is being checked.
+   */
+  checkSourceUrlResponse(
+    sourceUrl: string,
+    componentName?: string
+  ): Promise<void>
+
+  /**
    * Return a URL to fetch data for the given custom component.
    * @param componentName The registered name of the component.
    * @param path The path of the component resource to fetch, e.g. "index.html".

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -65,17 +65,17 @@ export interface StreamlitEndpoints {
   /**
    * Send postMessage to host with client errors
    * @param component component causing the error
-   * @param customComponentName if custom component, component's name
    * @param error error status code or message
    * @param message additional error info
    * @param source component src (url)
+   * @param customComponentName If custom component, the component's name causing the error.
    */
   sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void
 
   /**
@@ -83,10 +83,12 @@ export interface StreamlitEndpoints {
    * If not, sends CLIENT_ERROR message with error info.
    * @param sourceUrl The source to check.
    * @param componentName The component for which the source is being checked.
+   * @param customComponentName If custom component, the component's name for which the source is being checked.
    */
   checkSourceUrlResponse(
     sourceUrl: string,
-    componentName?: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void>
 
   /**

--- a/frontend/lib/src/FileUploadClient.test.ts
+++ b/frontend/lib/src/FileUploadClient.test.ts
@@ -37,6 +37,8 @@ describe("FileUploadClient Upload", () => {
       sessionInfo: mockSessionInfo(),
       endpoints: {
         setStaticConfigUrl: vi.fn(),
+        sendClientErrorToHost: vi.fn(),
+        checkSourceUrlResponse: vi.fn(),
         buildComponentURL: vi.fn(),
         buildMediaURL: vi.fn(),
         buildFileUploadURL: vi.fn(),

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -33,6 +33,33 @@ export interface StreamlitEndpoints {
   setStaticConfigUrl(url: string): void
 
   /**
+   * Send postMessage to host with client errors
+   * @param component component causing the error
+   * @param customComponentName if custom component, component's name
+   * @param error error status code or message
+   * @param message additional error info
+   * @param source component src (url)
+   */
+  sendClientErrorToHost(
+    component: string,
+    customComponentName: string,
+    error: string | number,
+    message: string,
+    source: string
+  ): void
+
+  /**
+   * Checks if the component src has successful response.
+   * If not, sends CLIENT_ERROR message with error info.
+   * @param sourceUrl The source to check.
+   * @param componentName The component for which the source is being checked.
+   */
+  checkSourceUrlResponse(
+    sourceUrl: string,
+    componentName?: string
+  ): Promise<void>
+
+  /**
    * Return a URL to fetch data for the given custom component.
    * @param componentName The registered name of the component.
    * @param path The path of the component resource to fetch, e.g. "index.html".

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -35,17 +35,17 @@ export interface StreamlitEndpoints {
   /**
    * Send postMessage to host with client errors
    * @param component component causing the error
-   * @param customComponentName if custom component, component's name
    * @param error error status code or message
    * @param message additional error info
    * @param source component src (url)
+   * @param customComponentName If custom component, the component's name causing the error.
    */
   sendClientErrorToHost(
     component: string,
-    customComponentName: string,
     error: string | number,
     message: string,
-    source: string
+    source: string,
+    customComponentName?: string
   ): void
 
   /**
@@ -53,10 +53,12 @@ export interface StreamlitEndpoints {
    * If not, sends CLIENT_ERROR message with error info.
    * @param sourceUrl The source to check.
    * @param componentName The component for which the source is being checked.
+   * @param customComponentName If custom component, the component's name for which the source is being checked.
    */
   checkSourceUrlResponse(
     sourceUrl: string,
-    componentName?: string
+    componentName: string,
+    customComponentName?: string
   ): Promise<void>
 
   /**

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -16,6 +16,8 @@
 
 import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
 
+import { getLogger } from "loglevel"
+
 import { Audio as AudioProto } from "@streamlit/protobuf"
 
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
@@ -23,6 +25,7 @@ import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManag
 
 import { StyledAudio, StyledAudioContainer } from "./styled-components"
 
+const LOG = getLogger("Audio")
 export interface AudioProps {
   endpoints: StreamlitEndpoints
   element: AudioProto
@@ -147,6 +150,19 @@ function Audio({
 
   const uri = endpoints.buildMediaURL(element.url)
 
+  const handleAudioError = (
+    e: React.SyntheticEvent<HTMLAudioElement>
+  ): void => {
+    const audioUrl = e.currentTarget.src
+    LOG.error(`Client Error: Audio source error - ${audioUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Audio",
+      "Audio source failed to load",
+      "onerror triggered",
+      audioUrl
+    )
+  }
+
   return (
     <StyledAudioContainer>
       <StyledAudio
@@ -156,6 +172,7 @@ function Audio({
         controls
         autoPlay={autoplay && !preventAutoplay}
         src={uri}
+        onError={handleAudioError}
       />
     </StyledAudioContainer>
   )

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -16,6 +16,8 @@
 
 import React, { CSSProperties, memo, ReactElement } from "react"
 
+import { getLogger } from "loglevel"
+
 import {
   ImageList as ImageListProto,
   Image as ImageProto,
@@ -35,6 +37,8 @@ import {
   StyledImageContainer,
   StyledImageList,
 } from "./styled-components"
+
+const LOG = getLogger("ImageList")
 
 export interface ImageListProps {
   endpoints: StreamlitEndpoints
@@ -113,6 +117,19 @@ function ImageList({
     imgStyle.maxWidth = "100%"
   }
 
+  const handleImageError = (
+    e: React.SyntheticEvent<HTMLImageElement>
+  ): void => {
+    const imageUrl = e.currentTarget.src
+    LOG.error(`Client Error: Image source error - ${imageUrl}`)
+    endpoints.sendClientErrorToHost(
+      "Image",
+      "Image source failed to load",
+      "onerror triggered",
+      imageUrl
+    )
+  }
+
   return (
     <StyledToolbarElementContainer
       width={elementWidth}
@@ -138,6 +155,7 @@ function ImageList({
                 style={imgStyle}
                 src={endpoints.buildMediaURL(image.url)}
                 alt={idx.toString()}
+                onError={handleImageError}
               />
               {image.caption && (
                 <StyledCaption data-testid="stImageCaption" style={imgStyle}>

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 
 import { Video as VideoProto } from "@streamlit/protobuf"
 
@@ -28,7 +28,8 @@ import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import Video, { VideoProps } from "./Video"
 
 describe("Video Element", () => {
-  const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  let buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  const sendClientErrorToHost = vi.fn()
 
   const mockSetElementState = vi.fn()
   const mockGetElementState = vi.fn()
@@ -46,7 +47,10 @@ describe("Video Element", () => {
       startTime: 0,
       ...elementProps,
     }),
-    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    endpoints: mockEndpoints({
+      buildMediaURL: buildMediaURL,
+      sendClientErrorToHost: sendClientErrorToHost,
+    }),
     elementMgr: elementMgrMock as unknown as ElementStateManager,
   })
 
@@ -82,6 +86,22 @@ describe("Video Element", () => {
     expect(await screen.findByTestId("stVideo")).toHaveAttribute(
       "src",
       "https://mock.media.url"
+    )
+  })
+
+  it("sends an CLIENT_ERROR message when the video source fails to load", () => {
+    const props = getProps()
+    render(<Video {...props} />)
+    const videoElement = screen.getByTestId("stVideo")
+    expect(videoElement).toBeInTheDocument()
+
+    fireEvent.error(videoElement)
+
+    expect(sendClientErrorToHost).toHaveBeenCalledWith(
+      "Video",
+      "Video source failed to load",
+      "onerror triggered",
+      "https://mock.media.url/"
     )
   })
 
@@ -175,6 +195,63 @@ describe("Video Element", () => {
 
       rerender(<Video {...getProps({ startTime: 10 })} />)
       expect(videoElement.currentTime).toBe(10)
+    })
+  })
+
+  describe("subtitles", () => {
+    it("renders subtitles properly", () => {
+      const props = getProps({
+        subtitles: [
+          { url: "https://mock.subtitle.url" },
+          { url: "https://mock.subtitle.url2" },
+        ],
+      })
+      props.endpoints.buildMediaURL = vi.fn(url => url)
+      render(<Video {...props} />)
+
+      // check that track elements are rendered
+      const trackElements = screen.getAllByTestId("stVideoSubtitle")
+      expect(trackElements).toHaveLength(2)
+
+      // check that the track element has the correct src
+      expect(trackElements[0]).toHaveAttribute(
+        "src",
+        "https://mock.subtitle.url"
+      )
+      expect(trackElements[1]).toHaveAttribute(
+        "src",
+        "https://mock.subtitle.url2"
+      )
+    })
+
+    it("checks the subtitles src url(s) on mount", () => {
+      buildMediaURL = vi.fn(url => url)
+      const props = getProps({
+        subtitles: [
+          { url: "https://mock.subtitle.url" },
+          { url: "https://mock.subtitle.url2" },
+        ],
+      })
+      props.endpoints.buildMediaURL = buildMediaURL
+      render(<Video {...props} />)
+
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledTimes(2)
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenNthCalledWith(
+        1,
+        "https://mock.subtitle.url",
+        "Video Subtitle"
+      )
+      expect(props.endpoints.checkSourceUrlResponse).toHaveBeenNthCalledWith(
+        2,
+        "https://mock.subtitle.url2",
+        "Video Subtitle"
+      )
+    })
+
+    it("does not call checkSourceUrlResponse if there are no subtitles", () => {
+      const props = getProps()
+      render(<Video {...props} />)
+      expect(props.endpoints.checkSourceUrlResponse).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -540,6 +540,64 @@ describe("ComponentInstance", () => {
     })
   })
 
+  describe("Error handling", () => {
+    it("triggers component registry's checkSourceUrlResponse when component is mounted", () => {
+      const componentRegistry = getComponentRegistry()
+      const checkSourceUrlResponseSpy = vi.spyOn(
+        componentRegistry,
+        "checkSourceUrlResponse"
+      )
+      render(
+        <ComponentInstance
+          element={createElementProp()}
+          registry={componentRegistry}
+          disabled={false}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: vi.fn(),
+              formsDataChanged: vi.fn(),
+            })
+          }
+        />
+      )
+
+      expect(checkSourceUrlResponseSpy).toHaveBeenCalledWith(
+        "http://a.mock.url?streamlitUrl=http%3A%2F%2Flocalhost%3A3000%2F",
+        MOCK_COMPONENT_NAME
+      )
+    })
+
+    it("triggers component registry's sendTimeoutError when component has timed out waiting for READY message", () => {
+      const componentRegistry = getComponentRegistry()
+      // spy on Component Registry's sendTimeoutError method
+      const sendTimeoutErrorSpy = vi.spyOn(
+        componentRegistry,
+        "sendTimeoutError"
+      )
+
+      render(
+        <ComponentInstance
+          element={createElementProp()}
+          registry={componentRegistry}
+          disabled={false}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: vi.fn(),
+              formsDataChanged: vi.fn(),
+            })
+          }
+        />
+      )
+      // Advance past our warning timeout, and force a re-render.
+      act(() => vi.advanceTimersByTime(COMPONENT_READY_WARNING_TIME_MS))
+
+      expect(sendTimeoutErrorSpy).toHaveBeenCalledWith(
+        "http://a.mock.url?streamlitUrl=http%3A%2F%2Flocalhost%3A3000%2F",
+        MOCK_COMPONENT_NAME
+      )
+    })
+  })
+
   describe("SET_COMPONENT_VALUE handler", () => {
     it("handles JSON values", () => {
       const jsonValue = {

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -235,6 +235,27 @@ function ComponentInstance(props: Props): ReactElement {
     })
   }, COMPONENT_READY_WARNING_TIME_MS)
 
+  const componentSourceUrl = getSrc(componentName, registry, url)
+
+  useEffect(() => {
+    // Iframe onerror event unreliable - check custom component
+    // src on mount to catch iframe load errors
+    registry.checkSourceUrlResponse(componentSourceUrl, componentName)
+  }, [componentSourceUrl, componentName, registry])
+
+  useEffect(() => {
+    if (isReadyTimeout && !isReadyRef.current) {
+      // Send timeout error if we've timed out waiting for the READY message from the component
+      LOG.error(
+        `Client Error: Custom component ${componentName} timeout error`
+      )
+      registry.sendTimeoutError(
+        getSrc(componentName, registry, url),
+        componentName
+      )
+    }
+  }, [isReadyTimeout, componentName, registry, url])
+
   // Send a render message to the custom component everytime relevant props change, such as the
   // input args or the theme / width
   useEffect(() => {

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useRef, useState } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import { useTheme } from "@emotion/react"
 import { getLogger } from "loglevel"
@@ -184,6 +191,11 @@ function ComponentInstance(props: Props): ReactElement {
     componentError
   )
 
+  const componentSourceUrl = useMemo(
+    () => getSrc(componentName, registry, url),
+    [componentName, registry, url]
+  )
+
   // Use a ref for the args so that we can use them inside the useEffect calls without the linter complaining
   // as in the useEffect dependencies array, we don't use the parsed arg objects, but their string representation
   // and a comparing function result for the jsonArgs and dataframeArgs, respectively, for deep-equal checks and to
@@ -235,8 +247,6 @@ function ComponentInstance(props: Props): ReactElement {
     })
   }, COMPONENT_READY_WARNING_TIME_MS)
 
-  const componentSourceUrl = getSrc(componentName, registry, url)
-
   useEffect(() => {
     // Iframe onerror event unreliable - check custom component
     // src on mount to catch iframe load errors
@@ -247,14 +257,11 @@ function ComponentInstance(props: Props): ReactElement {
     if (isReadyTimeout && !isReadyRef.current) {
       // Send timeout error if we've timed out waiting for the READY message from the component
       LOG.error(
-        `Client Error: Custom component ${componentName} timeout error`
+        `Client Error: Custom Component ${componentName} timeout error`
       )
-      registry.sendTimeoutError(
-        getSrc(componentName, registry, url),
-        componentName
-      )
+      registry.sendTimeoutError(componentSourceUrl, componentName)
     }
-  }, [isReadyTimeout, componentName, registry, url])
+  }, [isReadyTimeout, componentSourceUrl, componentName, registry])
 
   // Send a render message to the custom component everytime relevant props change, such as the
   // input args or the theme / width
@@ -436,7 +443,7 @@ function ComponentInstance(props: Props): ReactElement {
         data-testid="stCustomComponentV1"
         allow={DEFAULT_IFRAME_FEATURE_POLICY}
         ref={iframeRef}
-        src={getSrc(componentName, registry, url)}
+        src={componentSourceUrl}
         width={width}
         // for undefined height we set the height to 0 to avoid inconsistent behavior
         height={frameHeight ?? 0}

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
@@ -87,4 +87,39 @@ describe("ComponentRegistry", () => {
     expect(msgListener1).not.toHaveBeenCalled()
     expect(msgListener2).toHaveBeenCalledWith(messageData.type, messageData)
   })
+
+  test("Sends CLIENT_ERROR when sendTimeoutError is called", () => {
+    const registry = new ComponentRegistry(mockEndpoints())
+    const sendClientErrorToHostSpy = vi.spyOn(
+      // @ts-expect-error - registry.endpoints is private
+      registry.endpoints,
+      "sendClientErrorToHost"
+    )
+    const url = registry.getComponentURL("foo", "index.html")
+    registry.sendTimeoutError(url, "foo")
+    expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
+      "Custom Component",
+      "foo",
+      "Request Timeout",
+      "Your app is having trouble loading the component.",
+      url
+    )
+  })
+
+  test("Triggers call to endpoint's checkSourceUrlResponse when registry's checkSourceUrlResponse is called", () => {
+    const registry = new ComponentRegistry(mockEndpoints())
+    const url = registry.getComponentURL("foo", "index.html")
+    const registryCheckSourceResponseSpy = vi.spyOn(
+      registry,
+      "checkSourceUrlResponse"
+    )
+    const endpointsCheckSourceResponseSpy = vi.spyOn(
+      // @ts-expect-error - registry.endpoints is private
+      registry.endpoints,
+      "checkSourceUrlResponse"
+    )
+    registry.checkSourceUrlResponse(url, "foo")
+    expect(registryCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
+    expect(endpointsCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
+  })
 })

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
@@ -99,10 +99,10 @@ describe("ComponentRegistry", () => {
     registry.sendTimeoutError(url, "foo")
     expect(sendClientErrorToHostSpy).toHaveBeenCalledWith(
       "Custom Component",
-      "foo",
       "Request Timeout",
       "Your app is having trouble loading the component.",
-      url
+      url,
+      "foo"
     )
   })
 
@@ -120,6 +120,10 @@ describe("ComponentRegistry", () => {
     )
     registry.checkSourceUrlResponse(url, "foo")
     expect(registryCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
-    expect(endpointsCheckSourceResponseSpy).toHaveBeenCalledWith(url, "foo")
+    expect(endpointsCheckSourceResponseSpy).toHaveBeenCalledWith(
+      url,
+      "Custom Component",
+      "foo"
+    )
   })
 })

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -64,6 +64,27 @@ export class ComponentRegistry {
     }
   }
 
+  /**
+   * Check the source of a custom component for successful response
+   * If the response is not ok, or fetch otherwise fails, send an error to the host.
+   */
+  public checkSourceUrlResponse = (
+    sourceUrl: string,
+    componentName?: string
+  ): Promise<void> => {
+    return this.endpoints.checkSourceUrlResponse(sourceUrl, componentName)
+  }
+
+  public sendTimeoutError = (source: string, componentName: string): void => {
+    this.endpoints.sendClientErrorToHost(
+      "Custom Component",
+      componentName,
+      "Request Timeout",
+      "Your app is having trouble loading the component.",
+      source
+    )
+  }
+
   /** Return a URL for fetching a resource for the given component. */
   public getComponentURL = (componentName: string, path: string): string => {
     return this.endpoints.buildComponentURL(componentName, path)

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -70,18 +70,25 @@ export class ComponentRegistry {
    */
   public checkSourceUrlResponse = (
     sourceUrl: string,
-    componentName?: string
+    customComponentName: string
   ): Promise<void> => {
-    return this.endpoints.checkSourceUrlResponse(sourceUrl, componentName)
+    return this.endpoints.checkSourceUrlResponse(
+      sourceUrl,
+      "Custom Component",
+      customComponentName
+    )
   }
 
-  public sendTimeoutError = (source: string, componentName: string): void => {
+  public sendTimeoutError = (
+    source: string,
+    customComponentName: string
+  ): void => {
     this.endpoints.sendClientErrorToHost(
       "Custom Component",
-      componentName,
       "Request Timeout",
       "Your app is having trouble loading the component.",
-      source
+      source,
+      customComponentName
     )
   }
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -155,4 +155,14 @@ describe("DownloadButton widget", () => {
       expect(downloadButton).toBeDisabled()
     })
   })
+
+  it("triggers checkSourceUrlResponse to check download url", () => {
+    const props = getProps()
+    render(<DownloadButton {...props} />)
+
+    expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledWith(
+      props.element.url,
+      "Download Button"
+    )
+  })
 })

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import React, { memo, ReactElement, useEffect } from "react"
 
 import { DownloadButton as DownloadButtonProto } from "@streamlit/protobuf"
 
@@ -62,6 +62,12 @@ function DownloadButton(props: Props): ReactElement {
   } else if (element.type === "tertiary") {
     kind = BaseButtonKind.TERTIARY
   }
+
+  useEffect(() => {
+    // Since we use a hidden link to download, we can't use the onerror event
+    // to catch src url load errors. Catch with direct check instead.
+    endpoints.checkSourceUrlResponse(element.url, "Download Button")
+  }, [element.url, endpoints])
 
   const handleDownloadClick: () => void = () => {
     if (!element.ignoreRerun) {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -239,6 +239,14 @@ export type IGuestToHostMessage =
       error: string
       message?: string
     }
+  | {
+      type: "CLIENT_ERROR"
+      component: string
+      customComponentName: string
+      error: string | number
+      message: string
+      source: string
+    }
 
 export type VersionedMessage<Message> = {
   stCommVersion: number

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -50,6 +50,11 @@ export type AppConfig = {
    * Enables custom string messages to be sent to the host
    */
   enableCustomParentMessages?: boolean
+  /**
+   * Whether host wants to block error dialogs. If true, blocks error dialogs
+   * from being shown to the user, sends error info to host via postMessage
+   */
+  blockErrorDialogs?: boolean
 }
 
 export type DeployedAppMetadata = {
@@ -228,6 +233,11 @@ export type IGuestToHostMessage =
       type: "METRICS_EVENT"
       eventName: string
       data: MetricsEvent
+    }
+  | {
+      type: "CLIENT_ERROR_DIALOG"
+      error: string
+      message?: string
     }
 
 export type VersionedMessage<Message> = {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -242,10 +242,10 @@ export type IGuestToHostMessage =
   | {
       type: "CLIENT_ERROR"
       component: string
-      customComponentName: string
       error: string | number
       message: string
       source: string
+      customComponentName?: string
     }
 
 export type VersionedMessage<Message> = {

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -51,6 +51,8 @@ export function mockEndpoints(
 ): StreamlitEndpoints {
   return {
     setStaticConfigUrl: vi.fn(),
+    sendClientErrorToHost: vi.fn(),
+    checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildFileUploadURL: vi.fn(),

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -236,6 +236,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
+                "blockErrorDialogs": False,
             }
         )
         self.set_status(200)

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -305,6 +305,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
+                "blockErrorDialogs": False,
             },
             response_body,
         )


### PR DESCRIPTION
## Describe your changes
Final feature PR implements extension of `host_config` endpoint with `blockErrorDialogs`, as well as `CLIENT_ERROR` & `CLIENT_ERROR_DIALOG` messages to the host on following failures:
* Websocket connection issues
    * See https://github.com/streamlit/streamlit/pull/10831
* Custom component load
    * See https://github.com/streamlit/streamlit/pull/10781
* Media load (audio, video, image, etc)
    * See https://github.com/streamlit/streamlit/pull/10837
* Error dialogs (Page Not Found, Bad message format, etc.)
    * See https://github.com/streamlit/streamlit/pull/10760

This PR just consolidates the logic from above PRs.