### PR TITLE
Fix `tabs` and `link_button` from getting disabled on disconnect

### DIFF
--- a/e2e_playwright/websocket_disconnect.py
+++ b/e2e_playwright/websocket_disconnect.py
@@ -16,6 +16,8 @@ from datetime import date, time
 
 import streamlit as st
 
+st.subheader("Widgets should be disabled")
+
 options = ("female", "male")
 
 w1 = st.checkbox("I am human", True)
@@ -36,3 +38,17 @@ w7 = st.selectbox("Options", options, 1)
 w8 = st.time_input("Set an alarm for", time(8, 45))
 
 w9 = st.date_input("A date to celebrate", date(2019, 7, 6))
+
+st.subheader("Non-widget elements should not be disabled")
+
+st.link_button("Link Button", "https://streamlit.io")
+
+tab1, tab2 = st.tabs(["Tab 1", "Tab 2"])
+
+with tab1:
+    st.write("Hello")
+
+with tab2:
+    st.write("World")
+
+st.expander("Expander").write("Hello")

--- a/e2e_playwright/websocket_disconnect_test.py
+++ b/e2e_playwright/websocket_disconnect_test.py
@@ -64,6 +64,10 @@ def test_disconnected_states(app: Page, assert_snapshot: ImageCompareFunction):
 
     expect(app.get_by_test_id("stMarkdown").first).to_contain_text("Value 1: 25")
 
+    expect(app.get_by_test_id("stLinkButton").locator("a")).not_to_be_disabled()
+    expect(app.get_by_test_id("stTab").first).not_to_be_disabled()
+    expect(app.get_by_test_id("stExpander").locator("details")).not_to_be_disabled()
+
     # After some time the disconnected dialog will appear.
     # It would be nicer to have this in a separate function, but we can't do that easily
     # because the runtime is shutdown for all test functions. We would need to start the

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -608,8 +608,7 @@ const RawElementNodeRenderer = (
 
     case "linkButton": {
       const linkButtonProto = node.element.linkButton as LinkButtonProto
-      widgetProps.disabled = widgetProps.disabled || linkButtonProto.disabled
-      return <LinkButton element={linkButtonProto} {...widgetProps} />
+      return <LinkButton element={linkButtonProto} {...elementProps} />
     }
 
     case "multiselect": {

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -93,6 +93,13 @@ describe("LinkButton widget", () => {
         const linkButton = screen.getByTestId(`stBaseLinkButton-${type}`)
         expect(linkButton).toBeInTheDocument()
       })
+
+      it(`renders disabled ${type} correctly`, () => {
+        render(<LinkButton {...getProps({ type, disabled: true })} />)
+
+        const linkButton = screen.getByRole("link")
+        expect(linkButton).toHaveAttribute("disabled")
+      })
     })
   })
 })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -34,7 +34,6 @@ const getProps = (
     url: "https://streamlit.io",
     ...elementProps,
   }),
-  disabled: false,
   ...widgetProps,
 })
 
@@ -93,13 +92,6 @@ describe("LinkButton widget", () => {
 
         const linkButton = screen.getByTestId(`stBaseLinkButton-${type}`)
         expect(linkButton).toBeInTheDocument()
-      })
-
-      it(`renders disabled ${type} correctly`, () => {
-        render(<LinkButton {...getProps({ type }, { disabled: true })} />)
-
-        const linkButton = screen.getByRole("link")
-        expect(linkButton).toHaveAttribute("disabled")
       })
     })
   })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, MouseEvent, ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { LinkButton as LinkButtonProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import React, { memo, MouseEvent, ReactElement } from "react"
 
 import { LinkButton as LinkButtonProto } from "@streamlit/protobuf"
 
@@ -42,6 +42,13 @@ function LinkButton(props: Readonly<Props>): ReactElement {
     kind = BaseButtonKind.TERTIARY
   }
 
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>): void => {
+    // Prevent the link from being followed if the button is disabled.
+    if (element.disabled) {
+      e.preventDefault()
+    }
+  }
+
   return (
     <Box className="stLinkButton" data-testid="stLinkButton">
       <BaseButtonTooltip
@@ -53,11 +60,13 @@ function LinkButton(props: Readonly<Props>): ReactElement {
         <BaseLinkButton
           kind={kind}
           size={BaseButtonSize.SMALL}
+          disabled={element.disabled}
+          onClick={handleClick}
           containerWidth={element.useContainerWidth}
           href={element.url}
-          onClick={() => {}}
           target="_blank"
           rel="noreferrer"
+          aria-disabled={element.disabled}
         >
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseLinkButton>

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -55,6 +55,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           size={BaseButtonSize.SMALL}
           containerWidth={element.useContainerWidth}
           href={element.url}
+          onClick={() => {}}
           target="_blank"
           rel="noreferrer"
         >

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -29,25 +29,17 @@ import { Box } from "~lib/components/shared/Base/styled-components"
 import BaseLinkButton from "./BaseLinkButton"
 
 export interface Props {
-  disabled: boolean
   element: LinkButtonProto
 }
 
 function LinkButton(props: Readonly<Props>): ReactElement {
-  const { disabled, element } = props
+  const { element } = props
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
     kind = BaseButtonKind.PRIMARY
   } else if (element.type === "tertiary") {
     kind = BaseButtonKind.TERTIARY
-  }
-
-  const handleClick = (e: MouseEvent<HTMLAnchorElement>): void => {
-    // Prevent the link from being followed if the button is disabled.
-    if (props.disabled) {
-      e.preventDefault()
-    }
   }
 
   return (
@@ -61,13 +53,10 @@ function LinkButton(props: Readonly<Props>): ReactElement {
         <BaseLinkButton
           kind={kind}
           size={BaseButtonSize.SMALL}
-          disabled={disabled}
-          onClick={handleClick}
           containerWidth={element.useContainerWidth}
           href={element.url}
           target="_blank"
           rel="noreferrer"
-          aria-disabled={disabled}
         >
           <DynamicButtonLabel icon={element.icon} label={element.label} />
         </BaseLinkButton>

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -76,7 +76,7 @@ describe("st.tabs", () => {
     })
   })
 
-  it("can be disabled", () => {
+  it("doesn't disable tabs when widgets are disabled", () => {
     render(<Tabs {...getProps({ widgetsDisabled: true })} />)
     const tabs = screen.getAllByRole("tab")
 
@@ -85,7 +85,7 @@ describe("st.tabs", () => {
       if (index == 0) {
         return
       }
-      expect(tabs[index]).toBeDisabled()
+      expect(tabs[index]).not.toBeDisabled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -111,13 +111,10 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
            https://github.com/streamlit/streamlit/issues/5069
          */
         renderAll={true}
-        disabled={widgetsDisabled}
         overrides={{
           TabHighlight: {
             style: () => ({
-              backgroundColor: widgetsDisabled
-                ? theme.colors.fadedText40
-                : theme.colors.primary,
+              backgroundColor: theme.colors.primary,
               height: TAB_BORDER_HEIGHT,
             }),
           },
@@ -188,7 +185,8 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
               // TODO: Update to match React best practices
               // eslint-disable-next-line @eslint-react/no-array-index-key
               key={index}
-              disabled={widgetsDisabled}
+              // Disable tab if the tab is stale but not the entire tab container:
+              disabled={!isStale && isStaleTab}
               overrides={{
                 TabPanel: {
                   style: () => ({
@@ -208,27 +206,19 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
                     paddingBottom: theme.spacing.none,
                     fontSize: theme.fontSizes.sm,
                     background: "transparent",
-                    color: widgetsDisabled
-                      ? theme.colors.fadedText40
-                      : theme.colors.bodyText,
+                    color: theme.colors.bodyText,
                     ":focus": {
                       outline: "none",
-                      color: widgetsDisabled
-                        ? theme.colors.fadedText40
-                        : theme.colors.primary,
+                      color: theme.colors.primary,
                       background: "none",
                     },
                     ":hover": {
-                      color: widgetsDisabled
-                        ? theme.colors.fadedText40
-                        : theme.colors.primary,
+                      color: theme.colors.primary,
                       background: "none",
                     },
                     ...(isSelected
                       ? {
-                          color: widgetsDisabled
-                            ? theme.colors.fadedText40
-                            : theme.colors.primary,
+                          color: theme.colors.primary,
                         }
                       : {}),
                     // Add minimal required padding to hide the overscroll gradient


### PR DESCRIPTION
## Describe your changes

The `widgetsDisabled` flag (used when the connection is lost) should only disable elements that are actually triggering reruns in the Python backend. Everything else should stay usable. Link buttons and tabs are currently getting disabled even though they cannot trigger reruns in the backend. This PR fixes it by keeping `st.link_button` and `st.tabs` functional.


https://github.com/user-attachments/assets/daa5418b-ef18-4052-aa88-4c1fb2030867

## Testing Plan

- Updated unit tests.
- Added to e2e test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
