### PR TITLE
[refactor] Add enforce-memo eslint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -245,6 +245,8 @@ module.exports = {
     "react-compiler/react-compiler": "error",
     "streamlit-custom/no-hardcoded-theme-values": "error",
     "streamlit-custom/use-strict-null-equality-checks": "error",
+    // We only turn this rule on for certain directories
+    "streamlit-custom/enforce-memo": "off",
     "no-restricted-imports": [
       "error",
       {
@@ -271,6 +273,12 @@ module.exports = {
       extends: ["plugin:testing-library/react"],
       rules: {
         "testing-library/prefer-user-event": "error",
+      },
+    },
+    {
+      files: ["**/components/elements/**/*", "**/components/widgets/**/*"],
+      rules: {
+        "streamlit-custom/enforce-memo": "error",
       },
     },
   ],

--- a/frontend/eslint-plugin-streamlit-custom/enforce-memo.js
+++ b/frontend/eslint-plugin-streamlit-custom/enforce-memo.js
@@ -1,0 +1,478 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This rule enforces the use of React.memo for React components.
+ * It detects exported components and ensures they are wrapped with memo
+ * for performance optimization.
+ */
+module.exports = {
+  meta: {
+    name: "enforce-memo",
+    type: "error",
+    docs: {
+      description: "Enforce use of React.memo for exported React components",
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    // Track state for components used in various contexts
+    const componentsUsedInHOCs = new Map() // Maps component name to HOC variable name or true if memoized
+    const hocWrappedComponents = new Set() // Set of HOC-wrapped component variable names
+    const exportedComponents = new Set() // Set of component names that are exported
+    const sourceCode = context.getSourceCode()
+    const sourceText = sourceCode.getText()
+
+    /**
+     * Checks if a component is already wrapped with React.memo in an export statement
+     */
+    const isWrappedInExport = componentName => {
+      const exportPatterns = [
+        `export\\s+default\\s+React\\.memo\\(\\s*${componentName}\\s*\\)`,
+        `export\\s+default\\s+memo\\(\\s*${componentName}\\s*\\)`,
+        `export\\s+default\\s+React\\.memo\\(\\s*\\w+\\(\\s*${componentName}\\s*\\)\\s*\\)`,
+        `export\\s+default\\s+memo\\(\\s*\\w+\\(\\s*${componentName}\\s*\\)\\s*\\)`,
+      ].map(pattern => new RegExp(pattern))
+
+      return exportPatterns.some(pattern => pattern.test(sourceText))
+    }
+
+    /**
+     * Checks if the node is part of an export declaration
+     */
+    const isExported = node => node.parent?.type === "ExportDefaultDeclaration"
+
+    /**
+     * Checks if a component is used in a HOC and the result is memoized
+     * Handles patterns like:
+     * const EnhancedComponent = someOtherHOC(MyComponent)
+     * export default memo(EnhancedComponent)
+     */
+    const isComponentUsedInMemoizedHOC = componentName => {
+      const hocPattern = new RegExp(
+        `const\\s+(\\w+)\\s*=\\s*\\w+\\(\\s*${componentName}\\s*\\)`,
+        "g"
+      )
+
+      let match
+      while ((match = hocPattern.exec(sourceText)) !== null) {
+        if (match?.[1]) {
+          const hocVarName = match[1]
+          const memoExportPattern = new RegExp(
+            `export\\s+default\\s+(React\\.memo|memo)\\(\\s*${hocVarName}\\s*\\)`
+          )
+
+          if (memoExportPattern.test(sourceText)) {
+            return true
+          }
+        }
+      }
+
+      return (
+        componentsUsedInHOCs.has(componentName) &&
+        componentsUsedInHOCs.get(componentName) === true
+      )
+    }
+
+    /**
+     * Checks if a variable is exported somewhere in the file
+     */
+    const isVariableExported = (_, componentName) => {
+      // Return early if we already know this component is exported
+      if (exportedComponents.has(componentName)) {
+        return true
+      }
+
+      // Check if used in a memoized HOC
+      if (isComponentUsedInMemoizedHOC(componentName)) {
+        return true
+      }
+
+      // Check for direct exports or HOC+memo wrapped exports
+      const patterns = [
+        new RegExp(`export\\s+default\\s+${componentName}[^\\w]`),
+        new RegExp(
+          `export\\s+default\\s+(React\\.memo|memo)\\(\\s*\\w+\\(\\s*${componentName}\\s*\\)\\s*\\)`
+        ),
+      ]
+
+      const isExported = patterns.some(pattern => pattern.test(sourceText))
+
+      if (isExported) {
+        exportedComponents.add(componentName)
+      }
+
+      return isExported
+    }
+
+    /**
+     * Checks if the file already imports memo from react using AST
+     * This properly detects all import patterns:
+     * - import { memo } from 'react'
+     * - import React, { memo } from 'react'
+     * - import * as React from 'react' (+ React.memo usage)
+     */
+    const hasMemoImport = () => {
+      const imports = sourceCode.ast.body.filter(
+        node =>
+          node.type === "ImportDeclaration" && node.source.value === "react"
+      )
+
+      // Check for named imports like: import { memo } from 'react'
+      // or import React, { memo } from 'react'
+      const hasNamedMemoImport = imports.some(importDecl =>
+        importDecl.specifiers.some(
+          specifier =>
+            specifier.type === "ImportSpecifier" &&
+            specifier.imported.name === "memo"
+        )
+      )
+
+      // Check for namespace imports like: import * as React from 'react'
+      // Since we can't statically know if React.memo is used with a namespace import,
+      // we'll check if React is imported as a namespace and if React.memo is used in the code
+      const hasNamespaceImport = imports.some(importDecl =>
+        importDecl.specifiers.some(
+          specifier => specifier.type === "ImportNamespaceSpecifier"
+        )
+      )
+
+      return hasNamedMemoImport || hasNamespaceImport
+    }
+
+    /**
+     * Adds the memo import if not already present in the file
+     * Returns a fixer or null if import already exists
+     */
+    const ensureMemoImport = fixer => {
+      if (hasMemoImport()) return null
+
+      const allImports = sourceCode.ast.body.filter(
+        node => node.type === "ImportDeclaration"
+      )
+
+      // Try to add to existing React import
+      const reactImport = allImports.find(
+        node =>
+          node.source.value === "react" &&
+          node.specifiers.every(
+            spec =>
+              spec.type !== "ImportSpecifier" || spec.imported.name !== "memo"
+          )
+      )
+
+      if (reactImport) {
+        const hasNamedImports = reactImport.specifiers.some(
+          spec => spec.type === "ImportSpecifier"
+        )
+
+        if (hasNamedImports) {
+          // Add to existing named imports
+          const lastSpecifier =
+            reactImport.specifiers[reactImport.specifiers.length - 1]
+          return fixer.insertTextAfter(lastSpecifier, ", memo")
+        } else {
+          // Add as new named import alongside default import
+          return fixer.insertTextAfter(reactImport.specifiers[0], ", { memo }")
+        }
+      } else if (allImports.length > 0) {
+        // Add after the last import
+        const lastImport = allImports[allImports.length - 1]
+        return fixer.insertTextAfter(
+          lastImport,
+          "\nimport { memo } from 'react';"
+        )
+      } else {
+        // Add at the beginning of the file
+        return fixer.insertTextBefore(
+          sourceCode.ast,
+          "import { memo } from 'react';\n\n"
+        )
+      }
+    }
+
+    /**
+     * Recursively finds all return statements in a node
+     */
+    const findReturnStatements = (node, results = []) => {
+      if (!node) return results
+
+      if (node.type === "ReturnStatement") {
+        results.push(node)
+      } else if (node.body) {
+        if (Array.isArray(node.body)) {
+          node.body.forEach(child => findReturnStatements(child, results))
+        } else {
+          findReturnStatements(node.body, results)
+        }
+      }
+
+      // Handle conditionals and switch statements
+      if (node.consequent) findReturnStatements(node.consequent, results)
+      if (node.alternate) findReturnStatements(node.alternate, results)
+      if (node.cases) node.cases.forEach(c => findReturnStatements(c, results))
+
+      return results
+    }
+
+    /**
+     * Determines if a node is likely a React component by checking if it returns JSX
+     */
+    const isLikelyReactComponent = node => {
+      if (!node?.body) return false
+
+      if (node.body.type === "BlockStatement") {
+        // Check function body for JSX in return statements
+        const returnStatements = findReturnStatements(node.body)
+        return returnStatements.some(
+          stmt =>
+            stmt.argument?.type === "JSXElement" ||
+            stmt.argument?.type === "JSXFragment"
+        )
+      }
+
+      // Check for arrow functions with implicit JSX returns
+      return (
+        node.type === "ArrowFunctionExpression" &&
+        (node.body.type === "JSXElement" || node.body.type === "JSXFragment")
+      )
+    }
+
+    /**
+     * Checks if a component is already wrapped with memo directly, in exports,
+     * or used in an HOC that is memoized
+     */
+    const isMemoWrapped = (node, componentName) =>
+      (node.parent?.type === "CallExpression" &&
+        node.parent.callee &&
+        (node.parent.callee.name === "memo" ||
+          (node.parent.callee.object?.name === "React" &&
+            node.parent.callee.property?.name === "memo"))) ||
+      isWrappedInExport(componentName) ||
+      isComponentUsedInMemoizedHOC(componentName)
+
+    /**
+     * Creates fixes for all export statements that reference a component
+     */
+    const fixExportStatements = (fixer, componentName) => {
+      const regex = new RegExp(
+        `(export\\s+default\\s+)(${componentName})([^\\w]|$)`,
+        "g"
+      )
+      let match
+      const exportMatches = []
+
+      // Find all exports of this component
+      while ((match = regex.exec(sourceText)) !== null) {
+        exportMatches.push({
+          start: match.index + match[1].length,
+          end: match.index + match[1].length + componentName.length,
+        })
+      }
+
+      // Apply fixes in reverse order to avoid position shifts
+      return exportMatches
+        .reverse()
+        .map(({ start, end }) =>
+          fixer.replaceTextRange([start, end], `memo(${componentName})`)
+        )
+    }
+
+    // Return an object with methods for each node type to analyze
+    return {
+      // Handle direct exports like: export default MyComponent
+      ExportDefaultDeclaration(node) {
+        if (node.declaration?.type === "Identifier") {
+          const exportedName = node.declaration.name
+          exportedComponents.add(exportedName)
+
+          if (hocWrappedComponents.has(exportedName)) {
+            context.report({
+              node,
+              message: "React components should be wrapped with memo",
+              fix(fixer) {
+                const fixes = []
+                const importFix = ensureMemoImport(fixer)
+                if (importFix) fixes.push(importFix)
+                fixes.push(
+                  fixer.replaceText(node.declaration, `memo(${exportedName})`)
+                )
+                return fixes.length > 0 ? fixes : null
+              },
+            })
+          }
+        }
+      },
+
+      // Handle call expressions like HOC calls and memo wrapping
+      CallExpression(node) {
+        // Capture component used in HOC call: someHOC(MyComponent)
+        if (
+          node.arguments?.[0]?.type === "Identifier" &&
+          isPascalCase(node.arguments[0].name)
+        ) {
+          const componentName = node.arguments[0].name
+
+          // If part of a variable declaration: const Enhanced = someHOC(MyComponent)
+          if (
+            node.parent?.type === "VariableDeclarator" &&
+            node.parent.id?.type === "Identifier"
+          ) {
+            const hocVarName = node.parent.id.name
+            hocWrappedComponents.add(hocVarName)
+            componentsUsedInHOCs.set(componentName, hocVarName)
+          }
+
+          // If directly exported: export default someHOC(MyComponent)
+          if (node.parent?.type === "ExportDefaultDeclaration") {
+            exportedComponents.add(componentName)
+          }
+        }
+
+        // Capture export default memo(Component)
+        if (
+          (node.callee?.name === "memo" ||
+            (node.callee?.object?.name === "React" &&
+              node.callee?.property?.name === "memo")) &&
+          node.arguments?.[0]?.type === "Identifier" &&
+          node.parent?.type === "ExportDefaultDeclaration"
+        ) {
+          exportedComponents.add(node.arguments[0].name)
+        }
+      },
+
+      // Handle memo call expressions specifically
+      "CallExpression[callee.name='memo'], CallExpression[callee.property.name='memo']"(
+        node
+      ) {
+        if (
+          node.arguments?.[0]?.type === "Identifier" &&
+          hocWrappedComponents.has(node.arguments[0].name)
+        ) {
+          // When a memo wraps an HOC variable, mark any components used in that HOC as memoized
+          for (const [
+            componentName,
+            hocName,
+          ] of componentsUsedInHOCs.entries()) {
+            if (hocName === node.arguments[0].name) {
+              componentsUsedInHOCs.set(componentName, true)
+
+              if (node.parent?.type === "ExportDefaultDeclaration") {
+                exportedComponents.add(componentName)
+              }
+            }
+          }
+        }
+      },
+
+      // Handle function declarations for components
+      FunctionDeclaration(node) {
+        // Skip if not a PascalCase React component
+        if (!isPascalCase(node.id.name) || !isLikelyReactComponent(node)) {
+          return
+        }
+
+        const componentName = node.id.name
+        if (isMemoWrapped(node, componentName)) return
+
+        // Check if exported directly or indirectly
+        const isDirectlyExported = isExported(node)
+        if (isDirectlyExported) {
+          exportedComponents.add(componentName)
+        }
+
+        const isIndirectlyExported = isVariableExported(node, componentName)
+        if (!isDirectlyExported && !isIndirectlyExported) return
+
+        // Report and fix the issue
+        context.report({
+          node,
+          message: "React components should be wrapped with memo",
+          fix(fixer) {
+            const fixes = []
+            const importFix = ensureMemoImport(fixer)
+            if (importFix) fixes.push(importFix)
+
+            if (!isDirectlyExported && isIndirectlyExported) {
+              fixes.push(...fixExportStatements(fixer, componentName))
+            }
+
+            return fixes.length > 0 ? fixes : null
+          },
+        })
+      },
+
+      // Handle variable declarations for components (arrow functions)
+      VariableDeclarator(node) {
+        // Skip if not a PascalCase component name
+        if (!node.id?.type === "Identifier" || !isPascalCase(node.id.name))
+          return
+
+        // Skip if not a function expression
+        if (
+          !node.init ||
+          (node.init.type !== "ArrowFunctionExpression" &&
+            node.init.type !== "FunctionExpression")
+        ) {
+          return
+        }
+
+        // Skip if not returning JSX
+        if (!isLikelyReactComponent(node.init)) return
+
+        const componentName = node.id.name
+        if (isMemoWrapped(node, componentName)) return
+
+        // Only trigger for exported components
+        const isVariableStatementExported = isVariableExported(
+          node,
+          componentName
+        )
+        if (!isVariableStatementExported) return
+
+        // Report and fix the issue
+        context.report({
+          node,
+          message: "React components should be wrapped with memo",
+          fix(fixer) {
+            const fixes = []
+            const importFix = ensureMemoImport(fixer)
+            if (importFix) fixes.push(importFix)
+
+            if (isVariableStatementExported) {
+              fixes.push(...fixExportStatements(fixer, componentName))
+            } else {
+              // Wrap the function definition with memo
+              const nodeText = sourceCode.getText(node.init)
+              fixes.push(fixer.replaceText(node.init, `memo(${nodeText})`))
+            }
+
+            return fixes.length > 0 ? fixes : null
+          },
+        })
+      },
+    }
+  },
+}
+
+/**
+ * Checks if a name follows PascalCase convention (used to identify components)
+ */
+const isPascalCase = name =>
+  name?.[0] === name?.[0].toUpperCase() && name?.length > 1

--- a/frontend/eslint-plugin-streamlit-custom/enforce-memo.test.js
+++ b/frontend/eslint-plugin-streamlit-custom/enforce-memo.test.js
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { RuleTester } = require("eslint")
+const enforceMemo = require("./enforce-memo")
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run("enforce-memo", enforceMemo, {
+  valid: [
+    // Already wrapped with React.memo as function declaration
+    {
+      code: `
+        function MyComponent() {
+          return <div>Hello</div>;
+        }
+        export default React.memo(MyComponent);
+      `,
+    },
+    // Already wrapped with memo as function declaration
+    {
+      code: `
+        import { memo } from 'react';
+        function MyComponent() {
+          return <div>Hello</div>;
+        }
+        export default memo(MyComponent);
+      `,
+    },
+    // Already wrapped with React.memo as arrow function
+    {
+      code: `
+        const MyComponent = (props) => {
+          return <div>Hello {props.name}</div>;
+        };
+        export default React.memo(MyComponent);
+      `,
+    },
+    // Direct memo usage
+    {
+      code: `
+        const MyComponent = React.memo((props) => {
+          return <div>Hello {props.name}</div>;
+        });
+      `,
+    },
+    // Using imported memo
+    {
+      code: `
+        import { memo } from 'react';
+        const MyComponent = memo((props) => {
+          return <div>Hello {props.name}</div>;
+        });
+      `,
+    },
+    // Non-component functions (not PascalCase) should not trigger the rule
+    {
+      code: `
+        function calculateTotal(a, b) {
+          return a + b;
+        }
+      `,
+    },
+    // Non-component arrow functions should not trigger the rule
+    {
+      code: `
+        const formatName = (user) => {
+          return user.firstName + ' ' + user.lastName;
+        };
+      `,
+    },
+    // If the component is wrapped in a HOC, and the enhanced component is
+    // memoized, then we should not trigger the rule.
+    {
+      code: `import { memo } from 'react'
+      import { someOtherHOC } from 'some-other-library'
+
+      const MyComponent = ({ name }) => {
+        return <div>Hello {name}</div>
+      }
+
+      export default memo(someOtherHOC(MyComponent))
+      `,
+    },
+    // If the component is wrapped in a HOC, and the enhanced component is
+    // memoized, then we should not trigger the rule.
+    {
+      code: `import { memo } from 'react'
+      import { someOtherHOC } from 'some-other-library'
+
+      const MyComponent = ({ name }) => {
+        return <div>Hello {name}</div>
+      }
+
+      const EnhancedComponent = someOtherHOC(MyComponent)
+      export default memo(EnhancedComponent)
+      `,
+    },
+    // Only check for memo on components that are exported
+    {
+      code: `import { memo } from 'react'
+      import { someOtherHOC } from 'some-other-library'
+
+      const MyComponentInner = ({ name }) => {
+        return <div>Hello {name}</div>
+      }
+
+      const MyComponent = ({ name }) => {
+        return <MyComponentInner name={name} />
+      }
+
+      export default memo(MyComponent)
+      `,
+    },
+    // For functions that are not components, we should not trigger the rule
+    {
+      code: `
+        export function MyFunction() {
+          return 'Hello'
+        }
+      `,
+    },
+    // For arrow functions that are not components, we should not trigger the rule
+    {
+      code: `
+        export const MyArrowFunction = () => {
+          return 'Hello'
+        }
+      `,
+    },
+    // For arrow functions that are not components but take in a props-style
+    // argument, we should not trigger the rule
+    {
+      code: `
+        export const MyArrowFunction = (props) => {
+          return 'Hello'
+        }
+      `,
+    },
+    // For functions that are not components but take in a props-style
+    // argument, we should not trigger the rule
+    {
+      code: `
+        function JsonColumn(props) {
+          return {
+            kind: 'json',
+            ...props,
+          }
+        }
+
+        export default JsonColumn
+      `,
+    },
+  ],
+  invalid: [
+    // Function declaration component with export -> should fix the export
+    {
+      code: `
+        function MyComponent() {
+          return <div>Hello</div>;
+        }
+        export default MyComponent;
+      `,
+      errors: [
+        {
+          message: "React components should be wrapped with memo",
+        },
+      ],
+      output: `
+        import { memo } from 'react';
+
+function MyComponent() {
+          return <div>Hello</div>;
+        }
+        export default memo(MyComponent);
+      `,
+    },
+    // Arrow function component with export -> should fix the export
+    {
+      code: `
+        import React from 'react';
+        const MyComponent = (props) => {
+          return <div>Hello {props.name}</div>;
+        };
+        export default MyComponent;
+      `,
+      errors: [
+        {
+          message: "React components should be wrapped with memo",
+        },
+      ],
+      output: `
+        import React, { memo } from 'react';
+        const MyComponent = (props) => {
+          return <div>Hello {props.name}</div>;
+        };
+        export default memo(MyComponent);
+      `,
+    },
+    // Test case for component with complex props and export -> should fix only the export
+    {
+      code: `
+        import 'some-styles.css';
+        import React from 'react';
+        import OtherComponent from './OtherComponent';
+
+        const ComplexComponent = ({ items, onSelect, isActive }) => {
+          return (
+            <div className={isActive ? 'active' : ''}>
+              {items.map(item => (
+                <div key={item.id} onClick={() => onSelect(item)}>
+                  {item.name}
+                </div>
+              ))}
+            </div>
+          );
+        };
+        export default ComplexComponent;
+      `,
+      errors: [
+        {
+          message: "React components should be wrapped with memo",
+        },
+      ],
+      output: `
+        import 'some-styles.css';
+        import React, { memo } from 'react';
+        import OtherComponent from './OtherComponent';
+
+        const ComplexComponent = ({ items, onSelect, isActive }) => {
+          return (
+            <div className={isActive ? 'active' : ''}>
+              {items.map(item => (
+                <div key={item.id} onClick={() => onSelect(item)}>
+                  {item.name}
+                </div>
+              ))}
+            </div>
+          );
+        };
+        export default memo(ComplexComponent);
+      `,
+    },
+    // Components that are enhanced with a HOC should be wrapped with memo
+    {
+      code: `import { memo } from 'react'
+      import { someOtherHOC } from 'some-other-library'
+
+      const MyComponent = ({ name }) => {
+        return <div>Hello {name}</div>
+      }
+
+      const EnhancedComponent = someOtherHOC(MyComponent)
+      export default EnhancedComponent
+      `,
+      errors: [
+        {
+          message: "React components should be wrapped with memo",
+        },
+      ],
+      output: `import { memo } from 'react'
+      import { someOtherHOC } from 'some-other-library'
+
+      const MyComponent = ({ name }) => {
+        return <div>Hello {name}</div>
+      }
+
+      const EnhancedComponent = someOtherHOC(MyComponent)
+      export default memo(EnhancedComponent)
+      `,
+    },
+  ],
+})
+
+console.log("All enforce-memo tests passed!")

--- a/frontend/eslint-plugin-streamlit-custom/index.js
+++ b/frontend/eslint-plugin-streamlit-custom/index.js
@@ -16,10 +16,12 @@
 
 const useStrictNullEqualityChecks = require("./use-strict-null-equality-checks")
 const noHardcodedThemeValues = require("./no-hardcoded-theme-values")
+const enforceMemo = require("./enforce-memo")
 
 module.exports = {
   rules: {
     "use-strict-null-equality-checks": useStrictNullEqualityChecks,
     "no-hardcoded-theme-values": noHardcodedThemeValues,
+    "enforce-memo": enforceMemo,
   },
 }

--- a/frontend/eslint-plugin-streamlit-custom/package.json
+++ b/frontend/eslint-plugin-streamlit-custom/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "node use-strict-null-equality-checks.test.js && node no-hardcoded-theme-values.test.js"
+    "test": "node use-strict-null-equality-checks.test.js && node no-hardcoded-theme-values.test.js && node enforce-memo.test.js"
   }
 }

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useEffect, useLayoutEffect, useRef } from "react"
+import React, { FC, memo, useEffect, useLayoutEffect, useRef } from "react"
 
 import { Global } from "@emotion/react"
 
@@ -123,4 +123,4 @@ const ArrowVegaLiteChart: FC<Props> = ({
 
 const ArrowVegaLiteChartWithFullScreen =
   withFullScreenWrapper(ArrowVegaLiteChart)
-export default ArrowVegaLiteChartWithFullScreen
+export default memo(ArrowVegaLiteChartWithFullScreen)

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useCallback } from "react"
+import React, { memo, ReactElement, useCallback } from "react"
 
 import {
   createElement,
@@ -36,7 +36,7 @@ export interface StreamlitSyntaxHighlighterProps {
   height?: number
 }
 
-export default function StreamlitSyntaxHighlighter({
+function StreamlitSyntaxHighlighter({
   language,
   showLineNumbers,
   wrapLines,
@@ -104,3 +104,5 @@ export default function StreamlitSyntaxHighlighter({
     </StyledCodeBlock>
   )
 }
+
+export default memo(StreamlitSyntaxHighlighter)

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/MapboxTokenError.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/MapboxTokenError.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import ErrorElement from "~lib/components/shared/ErrorElement"
 import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
@@ -97,4 +97,4 @@ const MapboxTokenError = ({ error, deltaType }: Props): ReactElement => {
   )
 }
 
-export default MapboxTokenError
+export default memo(MapboxTokenError)

--- a/frontend/lib/src/components/elements/LinkButton/BaseLinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/BaseLinkButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import {
   BaseButtonKind,
@@ -67,4 +67,4 @@ function BaseLinkButton({
 }
 export type BaseButtonProps = BaseLinkButtonPropsT
 export { BaseButtonKind, BaseButtonSize }
-export default BaseLinkButton
+export default memo(BaseLinkButton)

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInputErrorState.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInputErrorState.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import {
   StyledErrorContainerDiv,
@@ -31,4 +31,4 @@ const AudioInputErrorState = (): ReactElement => {
   )
 }
 
-export default AudioInputErrorState
+export default memo(AudioInputErrorState)

--- a/frontend/lib/src/components/widgets/AudioInput/NoMicPermissions.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/NoMicPermissions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { ENABLE_PERIPHERALS_DOCS_URL } from "~lib/urls"
 
@@ -37,4 +37,4 @@ const NoMicPermissions = (): ReactElement => {
   )
 }
 
-export default NoMicPermissions
+export default memo(NoMicPermissions)

--- a/frontend/lib/src/components/widgets/AudioInput/Placeholder.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/Placeholder.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import {
   StyledPlaceholderContainerDiv,
@@ -29,4 +29,4 @@ const Placeholder = (): ReactElement => {
   )
 }
 
-export default Placeholder
+export default memo(Placeholder)

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { MouseEvent, ReactElement, ReactNode } from "react"
+import React, { memo, MouseEvent, ReactElement, ReactNode } from "react"
 
 import ProgressBar, {
   Size as ProgressBarSize,
@@ -78,4 +78,4 @@ function CameraInputButton({
   )
 }
 
-export default CameraInputButton
+export default memo(CameraInputButton)

--- a/frontend/lib/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { SwitchCamera } from "@emotion-icons/material-rounded"
 
@@ -52,4 +52,4 @@ const SwitchFacingModeButton = ({
   )
 }
 
-export default SwitchFacingModeButton
+export default memo(SwitchFacingModeButton)

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, {
+  memo,
   ReactElement,
   useCallback,
   useEffect,
@@ -181,4 +182,4 @@ const WebcamComponent = ({
   )
 }
 
-export default WebcamComponent
+export default memo(WebcamComponent)

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import { AttachFile } from "@emotion-icons/material-outlined"
 
@@ -75,4 +75,4 @@ const ChatFileUploadButton = ({
   </StyledFileUploadButtonContainer>
 )
 
-export default ChatFileUploadButton
+export default memo(ChatFileUploadButton)

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import { AcceptFileValue } from "~lib/util/utils"
 
@@ -48,4 +48,4 @@ const ChatFileUploadDropzone = ({
   </>
 )
 
-export default ChatFileUploadDropzone
+export default memo(ChatFileUploadDropzone)

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFile.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFile.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import React, { FC, memo } from "react"
 
 import {
   Clear,
@@ -116,4 +116,4 @@ const ChatUploadedFile = ({
   </StyledChatUploadedFile>
 )
 
-export default ChatUploadedFile
+export default memo(ChatUploadedFile)

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFiles.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFiles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { UploadFileInfo } from "~lib/components/widgets/FileUploader/UploadFileInfo"
 
@@ -42,4 +42,4 @@ const ChatUploadedFiles = ({ items, onDelete }: Props): ReactElement => (
   </StyledChatUploadedFiles>
 )
 
-export default ChatUploadedFiles
+export default memo(ChatUploadedFiles)

--- a/frontend/lib/src/components/widgets/DataFrame/Tooltip.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/Tooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import { useTheme } from "@emotion/react"
 import { ACCESSIBILITY_TYPE, PLACEMENT, Popover } from "baseui/popover"
@@ -137,4 +137,4 @@ function Tooltip({
   )
 }
 
-export default Tooltip
+export default memo(Tooltip)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -104,4 +104,4 @@ export const JsonViewer: React.FC<JsonViewerProps> = ({
   )
 }
 
-export default JsonViewer
+export default React.memo(JsonViewer)

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import Dropzone, { FileRejection } from "react-dropzone"
 
@@ -82,4 +82,4 @@ const FileDropzone = ({
   </Dropzone>
 )
 
-export default FileDropzone
+export default memo(FileDropzone)

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import { CloudUpload } from "@emotion-icons/material-outlined"
 
@@ -60,4 +60,4 @@ const FileDropzoneInstructions = ({
   </StyledFileDropzoneInstructions>
 )
 
-export default FileDropzoneInstructions
+export default memo(FileDropzoneInstructions)

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import {
   Clear,
@@ -106,4 +106,4 @@ const UploadedFile = ({ fileInfo, onDelete }: Props): React.ReactElement => {
   )
 }
 
-export default UploadedFile
+export default memo(UploadedFile)

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFiles.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFiles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { memo, ReactElement } from "react"
 
 import withPagination, { PaginationProps } from "./withPagination"
 import UploadedFile from "./UploadedFile"
@@ -49,4 +49,4 @@ const UploadedFiles = (props: Props & PaginationProps): ReactElement => (
     <PaginatedFiles {...props} />
   </StyledUploadedFiles>
 )
-export default UploadedFiles
+export default memo(UploadedFiles)

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { memo } from "react"
 
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 
@@ -53,4 +53,4 @@ const Pagination = ({
   )
 }
 
-export default Pagination
+export default memo(Pagination)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9506,15 +9506,15 @@ __metadata:
 
 "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom::locator=%40streamlit%2Fapp%40workspace%3Aapp":
   version: 1.0.0
-  resolution: "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom#../eslint-plugin-streamlit-custom::hash=c66950&locator=%40streamlit%2Fapp%40workspace%3Aapp"
-  checksum: 10c0/6b9c770d5aef73537fd3d246bacd021b8828751646a35f6c752c4628e0cfd18ee4488e3f58282ea2039fd97fbd609c0e278581ffb1accbfe3a8361792c239f33
+  resolution: "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom#../eslint-plugin-streamlit-custom::hash=8326b0&locator=%40streamlit%2Fapp%40workspace%3Aapp"
+  checksum: 10c0/95c60220f91f17b9ccfe5ad3dd0e7c8f27ee51393151b90990103108af32e2213c59ded8d786fc2252b1ed499b75e7f0b73061c5a25c1517611eb2eb9a22ef6d
   languageName: node
   linkType: hard
 
 "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom::locator=%40streamlit%2Flib%40workspace%3Alib":
   version: 1.0.0
-  resolution: "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom#../eslint-plugin-streamlit-custom::hash=c66950&locator=%40streamlit%2Flib%40workspace%3Alib"
-  checksum: 10c0/6b9c770d5aef73537fd3d246bacd021b8828751646a35f6c752c4628e0cfd18ee4488e3f58282ea2039fd97fbd609c0e278581ffb1accbfe3a8361792c239f33
+  resolution: "eslint-plugin-streamlit-custom@file:../eslint-plugin-streamlit-custom#../eslint-plugin-streamlit-custom::hash=8326b0&locator=%40streamlit%2Flib%40workspace%3Alib"
+  checksum: 10c0/95c60220f91f17b9ccfe5ad3dd0e7c8f27ee51393151b90990103108af32e2213c59ded8d786fc2252b1ed499b75e7f0b73061c5a25c1517611eb2eb9a22ef6d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

- Per a work item in our tech debt DB, which is aligned with the overall performance workstream, this adds an `enforce-memo` eslint rule
- This eslint rule enforces that exported React components utilizes `memo`
  - The eslint rule also has an automatic fixer built in, making the integration into IDEs much nicer and enabling `--fix` on the command line
  - Note: One of the intentional trade-offs is that we only check for exported React components to have `memo` as a first pass. If we think it's worthwhile to have _every_ React component in a given file utilize `memo`, we can adjust the rule
- We only apply it to certain directories
  - Note: This is another intentional trade-off for the first pass of this PR. If we want to expand the directories, it is trivial to do so by adjusting the `.eslintrc` file and running the eslint autofix

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Adds unit tests for the rule definition

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
