### PR TITLE
Fix #8767: Ensure hover color overrides colored text.

### DIFF
--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -106,6 +106,12 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       width: containerWidth ? "100%" : "auto",
       cursor: "pointer",
       userSelect: "none",
+      "&:hover": {
+        color: theme.colors.primary,
+        "*": {
+          color: `${theme.colors.primary} !important`,
+        },
+      },
       "&:focus": {
         outline: "none",
       },


### PR DESCRIPTION
Before this fix, when hovering over buttons containing colored text, the text color inside (e.g., <span> elements) was not changing as expected. This fix ensures that all text inside the button correctly adopts the hover color.

I solved this by forcing inner elements (e.g., <span>) to inherit the button’s hover color by adding color: inherit in the hover state.
