### PR TITLE
Fix/sqlite test repeatable

### DIFF
--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -463,6 +463,7 @@ class DataframeUtilTest(unittest.TestCase):
 
         con = sqlite3.connect("file::memory:")
         cur = con.cursor()
+        cur.execute("DROP TABLE IF EXISTS movie")
         cur.execute("CREATE TABLE movie(title, year, score)")
         cur.execute("""
             INSERT INTO movie VALUES

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -461,9 +461,8 @@ class DataframeUtilTest(unittest.TestCase):
         """Verify that sqlite3 cursor can be used as a data source."""
         import sqlite3
 
-        con = sqlite3.connect("file::memory:")
+        con = sqlite3.connect("file::memory:", uri=True)
         cur = con.cursor()
-        cur.execute("DROP TABLE IF EXISTS movie")
         cur.execute("CREATE TABLE movie(title, year, score)")
         cur.execute("""
             INSERT INTO movie VALUES


### PR DESCRIPTION
## Describe your changes

I noticed that this test is now creating a file on disk and if the test is run twice in a row it fails since the table/data already exists. After some research, it seems we need to pass in `uri=True` to ensure the db is created in-memory. 

## GitHub Issue Link (if applicable)

## Testing Plan

No functional changes, test-only. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
