### PR TITLE
Preserve selectbox frontend state when clicking away and don't rerun until selecting option

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -105,3 +105,8 @@ st.selectbox(
     "selectbox 13 -> :material/check: :rainbow[Fancy] _**markdown** `label` _support_",
     options=options,
 )
+
+v14 = st.selectbox(
+    "selectbox 14 (test dismiss behavior)", options, index=0, key="selectbox_esc_test"
+)
+st.write("value 14:", v14)

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -23,7 +23,7 @@ def test_selectbox_widget_rendering(
 ):
     """Test that the selectbox widgets are correctly rendered via screenshot matching."""
     selectbox_widgets = themed_app.get_by_test_id("stSelectbox")
-    expect(selectbox_widgets).to_have_count(13)
+    expect(selectbox_widgets).to_have_count(14)
 
     assert_snapshot(selectbox_widgets.nth(0), name="st_selectbox-default")
     assert_snapshot(selectbox_widgets.nth(1), name="st_selectbox-formatted_options")
@@ -45,7 +45,7 @@ def test_selectbox_widget_rendering(
 def test_selectbox_has_correct_initial_values(app: Page):
     """Test that st.selectbox returns the correct initial values."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(13)
+    expect(markdown_elements).to_have_count(14)
 
     expected = [
         "value 1: male",
@@ -61,6 +61,7 @@ def test_selectbox_has_correct_initial_values(app: Page):
         "value 10: None",
         "value 11: male",
         "value 12: female",
+        "value 14: male",
     ]
 
     for markdown_element, expected_text in zip(markdown_elements.all(), expected):
@@ -203,3 +204,35 @@ def test_check_top_level_class(app: Page):
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
     expect(get_element_by_key(app, "selectbox8")).to_be_visible()
+
+
+def test_dismiss_change_by_clicking_away(app: Page):
+    """Test that pressing ESC during editing restores the original value."""
+    # Initial check
+    markdown_result_element = app.get_by_test_id("stMarkdown").nth(13)
+    expect(markdown_result_element).to_have_text("value 14: male", use_inner_text=True)
+
+    # Get selectbox input
+    selectbox_element = app.get_by_test_id("stSelectbox").nth(13)
+    selectbox_input = selectbox_element.locator("input")
+
+    # Click to focus the input
+    selectbox_input.click()
+
+    # Clear part of the text and type something else
+    selectbox_input.press("Backspace")
+    selectbox_input.press("Backspace")
+    selectbox_input.press("Backspace")
+    selectbox_input.type("xyz")
+    # Verify the input value is indeed updated
+    expect(selectbox_input).to_have_value("mxyz")
+
+    # Press click outside of the input field to close the dropdown and stop editing
+    app.get_by_test_id("stMarkdownContainer").get_by_text(
+        "selectbox 14 (test dismiss behavior)"
+    ).click()
+
+    # Verify original value is restored
+    # We use contain_text because the selectbox_element's text also includes the label
+    expect(selectbox_element).to_contain_text("male")
+    expect(markdown_result_element).to_have_text("value 14: male", use_inner_text=True)

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -209,6 +209,42 @@ describe("Selectbox widget", () => {
     rerender(<Selectbox {...props} />)
     expect(screen.getByText(props.options[1])).toBeInTheDocument()
   })
+
+  it("does not commit changes when clicking outside of the selectbox", async () => {
+    const user = userEvent.setup()
+    render(<Selectbox {...props} />)
+    const selectbox = screen.getByRole("combobox")
+    await user.type(selectbox, "b")
+
+    // Click outside of the selectbox
+    await user.click(document.body)
+
+    // Check that clicking outside of the selectbox does not commit the change and the default is kept
+    expect(props.onChange).toHaveBeenCalledTimes(0)
+    expect(screen.getByTestId("stSelectbox")).toHaveTextContent(
+      props.options[0]
+    )
+  })
+
+  it("does not call onChange when the user deletes characters", async () => {
+    render(<Selectbox {...props} />)
+    const selectbox = screen.getByRole("combobox")
+
+    // Simulate deleting a character
+    // we are using fireEvent here instead of userEvent because userEvent
+    // did not trigger the backspace event correctly.
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.keyDown(selectbox, {
+      key: "Backspace",
+      keyCode: 8,
+      code: "Backspace",
+    })
+
+    // ensure that onChange was not called for the remove
+    expect(props.onChange).toHaveBeenCalledTimes(0)
+    // ensure that the input-internal value was updated
+    expect(selectbox).toHaveValue("")
+  })
 })
 
 describe("Selectbox widget with optional props", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -86,6 +86,8 @@ const Selectbox: React.FC<Props> = ({
 }) => {
   const theme: EmotionTheme = useTheme()
   const [value, setValue] = useState<number | null>(propValue)
+  // This ref is used to store the value before the user starts removing characters so that we can restore
+  // the value in case the user dismisses the changes by clicking away.
   const valueBeforeRemoval = useRef<number | null>(value)
 
   // Update the value whenever the value provided by the props changes
@@ -96,21 +98,20 @@ const Selectbox: React.FC<Props> = ({
 
   const handleChange = useCallback(
     (params: OnChangeParams): void => {
-      // eslint-disable-next-line no-console
-      console.log("handleChange", params)
-
       if (params.type === "remove") {
         valueBeforeRemoval.current = params.option?.value
+        // We set the value so that BaseWeb updates the element's value while typing.
+        // We don't want to commit the change yet, so we don't call onChange.
         setValue(null)
         return
       }
 
       valueBeforeRemoval.current = null
-      // if (params.value.length === 0) {
-      //   setValue(null)
-      //   onChange(null)
-      //   return
-      // }
+      if (params.type === "clear") {
+        setValue(null)
+        onChange(null)
+        return
+      }
       const [selected] = params.value
       const newValue = parseInt(selected.value, 10)
       setValue(newValue)
@@ -119,18 +120,7 @@ const Selectbox: React.FC<Props> = ({
     [onChange]
   )
 
-  // const handleInputChange = useCallback(
-  //   (params: OnInputChangeEventType): void => {
-  //     // eslint-disable-next-line no-console
-  //     console.log("handleInputChange", params)
-  //     setNewValue(params.target.value)
-  //   },
-  //   []
-  // )
-
   const handleBlur = useCallback(() => {
-    // eslint-disable-next-line no-console
-    console.log("handleBlur", valueBeforeRemoval.current)
     if (valueBeforeRemoval.current !== null) {
       setValue(valueBeforeRemoval.current)
     }
@@ -190,7 +180,6 @@ const Selectbox: React.FC<Props> = ({
         labelKey="label"
         aria-label={label || ""}
         onChange={handleChange}
-        // onInputChange={handleInputChange}
         onBlur={handleBlur}
         options={selectOptions}
         filterOptions={filterOptions}

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, useCallback, useEffect, useState } from "react"
+import React, { memo, useCallback, useEffect, useRef, useState } from "react"
 
 import { isMobile } from "react-device-detect"
 import { ChevronDown } from "baseui/icon"
@@ -86,6 +86,7 @@ const Selectbox: React.FC<Props> = ({
 }) => {
   const theme: EmotionTheme = useTheme()
   const [value, setValue] = useState<number | null>(propValue)
+  const valueBeforeRemoval = useRef<number | null>(value)
 
   // Update the value whenever the value provided by the props changes
   // TODO: Find a better way to handle this to prevent unneeded re-renders
@@ -95,12 +96,21 @@ const Selectbox: React.FC<Props> = ({
 
   const handleChange = useCallback(
     (params: OnChangeParams): void => {
-      if (params.value.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log("handleChange", params)
+
+      if (params.type === "remove") {
+        valueBeforeRemoval.current = params.option?.value
         setValue(null)
-        onChange(null)
         return
       }
 
+      valueBeforeRemoval.current = null
+      // if (params.value.length === 0) {
+      //   setValue(null)
+      //   onChange(null)
+      //   return
+      // }
       const [selected] = params.value
       const newValue = parseInt(selected.value, 10)
       setValue(newValue)
@@ -108,6 +118,23 @@ const Selectbox: React.FC<Props> = ({
     },
     [onChange]
   )
+
+  // const handleInputChange = useCallback(
+  //   (params: OnInputChangeEventType): void => {
+  //     // eslint-disable-next-line no-console
+  //     console.log("handleInputChange", params)
+  //     setNewValue(params.target.value)
+  //   },
+  //   []
+  // )
+
+  const handleBlur = useCallback(() => {
+    // eslint-disable-next-line no-console
+    console.log("handleBlur", valueBeforeRemoval.current)
+    if (valueBeforeRemoval.current !== null) {
+      setValue(valueBeforeRemoval.current)
+    }
+  }, [])
 
   const filterOptions = useCallback(
     (options: readonly Option[], filterValue: string): readonly Option[] =>
@@ -163,6 +190,8 @@ const Selectbox: React.FC<Props> = ({
         labelKey="label"
         aria-label={label || ""}
         onChange={handleChange}
+        // onInputChange={handleInputChange}
+        onBlur={handleBlur}
         options={selectOptions}
         filterOptions={filterOptions}
         clearable={clearable || false}


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue in `st.selectbox` where when you type and e.g. remove some characters and then click outside of the selectbox, the backend value will stay the same but the frontend selectbox is empty.
Also, it does not trigger a rerun until a value is selected.


### Dismiss behavior
Before:

https://github.com/user-attachments/assets/4c635bb5-14dc-4818-b6d7-4f6d14ba94ea

After:

https://github.com/user-attachments/assets/c39159da-5b52-4d03-81ef-4bc2d7b8634b




## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
