### PR TITLE
Remove rainbow from badge color literal

### DIFF
--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -291,7 +291,6 @@ class MarkdownMixin:
             "violet",
             "gray",
             "grey",
-            "rainbow",
             "primary",
         ] = "blue",
     ) -> DeltaGenerator:


### PR DESCRIPTION
## Describe your changes

The `Literal` type for the `color` parameter of `st.badge` mentioned you can use `"rainbow"`, even though that's not supported. So removed it here. 

## GitHub Issue Link (if applicable)

## Testing Plan

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
