### PR TITLE
Add marker that icon is an emoji for set page config

### DIFF
--- a/e2e_playwright/st_set_page_config.py
+++ b/e2e_playwright/st_set_page_config.py
@@ -86,7 +86,7 @@ st.button("Page Config With Emoji Shortcode", on_click=page_config_with_emoji_sh
 def page_config_with_emoji_symbol():
     st.set_page_config(
         page_title="With Emoji Symbol",
-        page_icon="🐙",
+        page_icon="🐦‍🔥",
     )
 
 

--- a/e2e_playwright/st_set_page_config_test.py
+++ b/e2e_playwright/st_set_page_config_test.py
@@ -138,7 +138,7 @@ def test_page_icon_with_emoji_symbol(app: Page):
     favicon = app.locator("link[rel='shortcut icon']")
     expect(favicon).to_have_attribute(
         "href",
-        "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐙</text></svg>",
+        "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐦‍🔥</text></svg>",
     )
 
 

--- a/frontend/lib/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/lib/src/components/elements/Favicon/Favicon.test.tsx
@@ -78,14 +78,14 @@ describe("Favicon element", () => {
   })
 
   it("handles emoji shortcodes containing a dash correctly", () => {
-    handleFavicon("emoji::crescent-moon:", vi.fn(), endpoints)
+    handleFavicon(":crescent-moon:", vi.fn(), endpoints)
     // Check that its an svg that contains the crescent moon emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8C%99")
   })
 
   it("accepts emoji shortcodes", () => {
-    handleFavicon("emoji::pizza:", vi.fn(), endpoints)
+    handleFavicon(":pizza:", vi.fn(), endpoints)
     // Check that its an svg that contains the pizza emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8D%95")
@@ -93,7 +93,7 @@ describe("Favicon element", () => {
 
   it("updates the favicon when it changes", () => {
     handleFavicon("/media/1234567890.png", vi.fn(), endpoints)
-    handleFavicon("emoji::pizza:", vi.fn(), endpoints)
+    handleFavicon(":pizza:", vi.fn(), endpoints)
     // Check that its an svg that contains the pizza emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8D%95")
@@ -123,16 +123,16 @@ describe("Favicon element", () => {
     })
 
     it("handles emoji shortcodes", () => {
-      expect(extractEmoji("emoji::smile:")).toBe("😄")
-      expect(extractEmoji("emoji::rocket:")).toBe("🚀")
-      expect(extractEmoji("emoji::pizza:")).toBe("🍕")
-      expect(extractEmoji("emoji::star:")).toBe("⭐")
-      expect(extractEmoji("emoji::video_game:")).toBe("🎮")
+      expect(extractEmoji(":smile:")).toBe("😄")
+      expect(extractEmoji(":rocket:")).toBe("🚀")
+      expect(extractEmoji(":pizza:")).toBe("🍕")
+      expect(extractEmoji(":star:")).toBe("⭐")
+      expect(extractEmoji(":video_game:")).toBe("🎮")
     })
 
     it("handles shortcodes with dashes", () => {
-      expect(extractEmoji("emoji::crescent-moon:")).toBe("🌙")
-      expect(extractEmoji("emoji::lying-face:")).toBe("🤥")
+      expect(extractEmoji(":crescent-moon:")).toBe("🌙")
+      expect(extractEmoji(":lying-face:")).toBe("🤥")
     })
 
     it("handles skin tone modifiers", () => {
@@ -161,14 +161,14 @@ describe("Favicon element", () => {
       expect(extractEmoji("emoji:👨‍💻")).toBe("👨‍💻") // man technologist
       expect(extractEmoji("emoji:👩‍🚒")).toBe("👩‍🚒") // woman firefighter
       expect(extractEmoji("emoji:👨‍👨‍👧‍👧")).toBe("👨‍👨‍👧‍👧") // family with two men and two girls
-      expect(extractEmoji("emoji::woman_technologist:")).toBe("👩‍💻")
+      expect(extractEmoji(":woman_technologist:")).toBe("👩‍💻")
     })
 
     it("handles flags", () => {
       expect(extractEmoji("emoji:🇺🇸")).toBe("🇺🇸")
       expect(extractEmoji("emoji:🇯🇵")).toBe("🇯🇵")
       expect(extractEmoji("emoji:🇪🇸")).toBe("🇪🇸")
-      expect(extractEmoji("emoji::brazil:")).toBe("🇧🇷")
+      expect(extractEmoji(":brazil:")).toBe("🇧🇷")
     })
 
     it("handles material icons correctly", () => {

--- a/frontend/lib/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/lib/src/components/elements/Favicon/Favicon.test.tsx
@@ -16,7 +16,7 @@
 
 import { mockEndpoints } from "~lib/mocks/mocks"
 
-import { handleFavicon } from "./Favicon"
+import { extractEmoji, handleFavicon } from "./Favicon"
 
 function getFaviconHref(): string {
   const faviconElement: HTMLLinkElement | null = document.querySelector(
@@ -53,14 +53,14 @@ describe("Favicon element", () => {
   })
 
   it("accepts emojis directly", () => {
-    handleFavicon("🍕", vi.fn(), endpoints)
+    handleFavicon("emoji:🍕", vi.fn(), endpoints)
     // Check that its an svg that contains the pizza emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8D%95")
   })
 
   it("handles emoji variants correctly", () => {
-    handleFavicon("🛰", vi.fn(), endpoints)
+    handleFavicon("emoji:🛰", vi.fn(), endpoints)
     // Check that its an svg that contains the satellite emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%9B%B0")
@@ -78,14 +78,14 @@ describe("Favicon element", () => {
   })
 
   it("handles emoji shortcodes containing a dash correctly", () => {
-    handleFavicon(":crescent-moon:", vi.fn(), endpoints)
+    handleFavicon("emoji::crescent-moon:", vi.fn(), endpoints)
     // Check that its an svg that contains the crescent moon emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8C%99")
   })
 
   it("accepts emoji shortcodes", () => {
-    handleFavicon(":pizza:", vi.fn(), endpoints)
+    handleFavicon("emoji::pizza:", vi.fn(), endpoints)
     // Check that its an svg that contains the pizza emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8D%95")
@@ -93,7 +93,7 @@ describe("Favicon element", () => {
 
   it("updates the favicon when it changes", () => {
     handleFavicon("/media/1234567890.png", vi.fn(), endpoints)
-    handleFavicon(":pizza:", vi.fn(), endpoints)
+    handleFavicon("emoji::pizza:", vi.fn(), endpoints)
     // Check that its an svg that contains the pizza emoji bytecode:
     expect(getFaviconHref()).toContain("svg")
     expect(getFaviconHref()).toContain("%F0%9F%8D%95")
@@ -109,6 +109,79 @@ describe("Favicon element", () => {
     expect(sendMessageToHost).toHaveBeenCalledWith({
       favicon: "https://mock.media.url",
       type: "SET_PAGE_FAVICON",
+    })
+  })
+
+  describe("extractEmoji", () => {
+    it("handles basic emojis", () => {
+      expect(extractEmoji("emoji:😀")).toBe("😀")
+      expect(extractEmoji("emoji:🚀")).toBe("🚀")
+      expect(extractEmoji("emoji:🍕")).toBe("🍕")
+      expect(extractEmoji("emoji:⭐")).toBe("⭐")
+      expect(extractEmoji("emoji:🎮")).toBe("🎮")
+      expect(extractEmoji("emoji:🛰️")).toBe("🛰️")
+    })
+
+    it("handles emoji shortcodes", () => {
+      expect(extractEmoji("emoji::smile:")).toBe("😄")
+      expect(extractEmoji("emoji::rocket:")).toBe("🚀")
+      expect(extractEmoji("emoji::pizza:")).toBe("🍕")
+      expect(extractEmoji("emoji::star:")).toBe("⭐")
+      expect(extractEmoji("emoji::video_game:")).toBe("🎮")
+    })
+
+    it("handles shortcodes with dashes", () => {
+      expect(extractEmoji("emoji::crescent-moon:")).toBe("🌙")
+      expect(extractEmoji("emoji::lying-face:")).toBe("🤥")
+    })
+
+    it("handles skin tone modifiers", () => {
+      expect(extractEmoji("emoji:👍🏻")).toBe("👍🏻") // light skin tone
+      expect(extractEmoji("emoji:👍🏽")).toBe("👍🏽") // medium skin tone
+      expect(extractEmoji("emoji:👍🏿")).toBe("👍🏿") // dark skin tone
+    })
+
+    it("handles newer emojis", () => {
+      expect(extractEmoji("emoji:🪣")).toBe("🪣") // bucket (added in 2020)
+      expect(extractEmoji("emoji:🥹")).toBe("🥹") // face holding back tears (added in 2022)
+      expect(extractEmoji("emoji:🫠")).toBe("🫠") // melting face (added in 2022)
+      expect(extractEmoji("emoji:🫥")).toBe("🫥") // dotted line face (added in 2022)
+      expect(extractEmoji("emoji:🐦‍🔥")).toBe("🐦‍🔥") // Phoenix (added in 2023)
+      expect(extractEmoji("emoji:🍋‍🟩")).toBe("🍋‍🟩") // lime (added in 2023)
+    })
+
+    it("handles older emojis", () => {
+      expect(extractEmoji("emoji:😀")).toBe("😀") // grinning face (2015)
+      expect(extractEmoji("emoji:👨‍👩‍👦")).toBe("👨‍👩‍👦") // family (2016)
+      expect(extractEmoji("emoji:💩")).toBe("💩") // pile of poo (2010)
+      expect(extractEmoji("emoji:♥️")).toBe("♥️") // heart symbol (very early emoji)
+    })
+
+    it("handles compound emojis", () => {
+      expect(extractEmoji("emoji:👨‍💻")).toBe("👨‍💻") // man technologist
+      expect(extractEmoji("emoji:👩‍🚒")).toBe("👩‍🚒") // woman firefighter
+      expect(extractEmoji("emoji:👨‍👨‍👧‍👧")).toBe("👨‍👨‍👧‍👧") // family with two men and two girls
+      expect(extractEmoji("emoji::woman_technologist:")).toBe("👩‍💻")
+    })
+
+    it("handles flags", () => {
+      expect(extractEmoji("emoji:🇺🇸")).toBe("🇺🇸")
+      expect(extractEmoji("emoji:🇯🇵")).toBe("🇯🇵")
+      expect(extractEmoji("emoji:🇪🇸")).toBe("🇪🇸")
+      expect(extractEmoji("emoji::brazil:")).toBe("🇧🇷")
+    })
+
+    it("handles material icons correctly", () => {
+      expect(extractEmoji(":material/flag:")).toBe("")
+      expect(extractEmoji(":material/smart_display:")).toBe("")
+    })
+
+    it("handles edge cases", () => {
+      expect(extractEmoji(":invalid_emoji_code:")).toBe("")
+      expect(extractEmoji("hello")).toBe("")
+      expect(extractEmoji("12345")).toBe("")
+      expect(extractEmoji("::")).toBe("")
+      expect(extractEmoji(":")).toBe("")
     })
   })
 })

--- a/frontend/lib/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/lib/src/components/elements/Favicon/Favicon.tsx
@@ -76,15 +76,13 @@ function overwriteFavicon(imageUrl: string): void {
 // Return the emoji if it exists, or empty string otherwise
 export function extractEmoji(maybeEmoji: string): string {
   const EMOJI_PREFIX = "emoji:"
-  if (!maybeEmoji.startsWith(EMOJI_PREFIX)) {
-    return ""
+  if (maybeEmoji.startsWith(EMOJI_PREFIX)) {
+    // Remove the 'emoji:' prefix
+    return maybeEmoji.substring(EMOJI_PREFIX.length)
   }
 
-  // Remove the 'emoji:' prefix
-  const emojiName = maybeEmoji.substring(EMOJI_PREFIX.length)
-
   // At this point, it must be a shortcode, so we normalize and check if it exists
-  const shortcode = emojiName.replace("-", "_")
+  const shortcode = maybeEmoji.replace("-", "_")
   const emoji = nodeEmoji.get(shortcode)
   if (emoji !== undefined && nodeEmoji.has(emoji)) {
     // Format: pizza or :pizza:
@@ -92,5 +90,5 @@ export function extractEmoji(maybeEmoji: string): string {
     return emoji
   }
 
-  return emojiName
+  return ""
 }

--- a/frontend/lib/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/lib/src/components/elements/Favicon/Favicon.tsx
@@ -74,17 +74,23 @@ function overwriteFavicon(imageUrl: string): void {
 }
 
 // Return the emoji if it exists, or empty string otherwise
-function extractEmoji(maybeEmoji: string): string {
-  const shortcode = maybeEmoji.replace("-", "_")
+export function extractEmoji(maybeEmoji: string): string {
+  const EMOJI_PREFIX = "emoji:"
+  if (!maybeEmoji.startsWith(EMOJI_PREFIX)) {
+    return ""
+  }
+
+  // Remove the 'emoji:' prefix
+  const emojiName = maybeEmoji.substring(EMOJI_PREFIX.length)
+
+  // At this point, it must be a shortcode, so we normalize and check if it exists
+  const shortcode = emojiName.replace("-", "_")
   const emoji = nodeEmoji.get(shortcode)
   if (emoji !== undefined && nodeEmoji.has(emoji)) {
     // Format: pizza or :pizza:
     // Since has(':pizza:') == true, we must do this check first
     return emoji
   }
-  if (nodeEmoji.has(maybeEmoji)) {
-    // Format: 🍕
-    return maybeEmoji
-  }
-  return ""
+
+  return emojiName
 }

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -102,7 +102,7 @@ def _get_favicon_string(page_icon: PageIcon) -> str:
 
     # If page_icon is an emoji, return it as is.
     if isinstance(page_icon, str) and is_emoji(page_icon):
-        return page_icon
+        return f"emoji:{page_icon}"
 
     if isinstance(page_icon, str) and page_icon.startswith(":material"):
         return validate_material_icon(page_icon)

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -39,12 +39,18 @@ class PageConfigTest(DeltaGeneratorTestCase):
         c = self.get_message_from_queue().page_config_changed
         self.assertEqual(c.title, "Hello")
 
-    @parameterized.expand(["🦈", ":shark:", "https://foo.com/image.png"])
+    @parameterized.expand([":shark:", "https://foo.com/image.png"])
     def test_set_page_config_icon_strings(self, icon_string: str):
-        """page_config icons can be emojis, emoji shortcodes, and image URLs."""
+        """page_config icons can be emoji shortcodes, and image URLs."""
         st.set_page_config(page_icon=icon_string)
         c = self.get_message_from_queue().page_config_changed
         self.assertEqual(c.favicon, icon_string)
+
+    def test_set_page_config_emoji_icon_strings(self):
+        """page_config icons can be emojis."""
+        st.set_page_config(page_icon="🦈")
+        c = self.get_message_from_queue().page_config_changed
+        assert c.favicon == "emoji:🦈"
 
     def test_set_page_config_icon_random(self):
         """If page_icon == "random", we choose a random emoji."""


### PR DESCRIPTION
## Describe your changes

Updates `set_page_config` to allow for newer emojis. We utilize the backend to determine if it's an emoji. We then parse it out on the frontend.

## GitHub Issue Link (if applicable)

closes #10911

## Testing Plan

- Updated Unit Tests. Added JS test for all varieties of emojis (for future references).
- Updated E2E Tests to use a newer emoji

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
