### PR TITLE
Fix `showErrorDetails` showing wrong value in `streamlit config show`

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -568,7 +568,7 @@ _create_option(
         - False        : This is deprecated. Streamlit displays "stacktrace"
                          error details.
     """,
-    default_val=ShowErrorDetailsConfigOptions.FULL,
+    default_val=str(ShowErrorDetailsConfigOptions.FULL.value),
     type_=str,
     scriptable=True,
 )

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -568,7 +568,7 @@ _create_option(
         - False        : This is deprecated. Streamlit displays "stacktrace"
                          error details.
     """,
-    default_val=str(ShowErrorDetailsConfigOptions.FULL.value),
+    default_val=ShowErrorDetailsConfigOptions.FULL.value,
     type_=str,
     scriptable=True,
 )

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -281,3 +281,18 @@ class ConfigUtilTest(unittest.TestCase):
         lines = output.split("\n")
 
         self.assertNotIn("# This is a hidden option.", lines)
+
+    @patch("click.secho")
+    def test_correctly_handles_show_error_details(self, patched_echo):
+        """Test that show_config correctly handles showErrorDetails = "full"
+        based on a regression.
+        """
+        config_util.show_config(
+            CONFIG_SECTION_DESCRIPTIONS,
+            create_config_options({}),
+        )
+
+        [(args, _)] = patched_echo.call_args_list
+        output = re.compile(r"\x1b[^m]*m").sub("", args[0])
+
+        self.assertIn('showErrorDetails = "full"', output)


### PR DESCRIPTION
## Describe your changes

Fixes an issue where the value of `showErrorDetails` is shown as list and not string in `streamlit config show`:

```
# Default: [ "f", "u", "l", "l",]
# showErrorDetails = [ "f", "u", "l", "l",]
```

This seems to be caused by the value being passed in as Enum and not as string.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10913

## Testing Plan

- Add a unit test to ensure this is correct.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
