### PR TITLE
Migrate issue views badge to different provider

### DIFF
--- a/.github/workflows/community-voting.yml
+++ b/.github/workflows/community-voting.yml
@@ -22,7 +22,7 @@ jobs:
 
             Your vote helps us identify which enhancements matter most to our users.
 
-            ![Visits](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
+            ![Views](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
       - name: Upvote issue
         uses: actions/github-script@v7
         with:
@@ -49,7 +49,7 @@ jobs:
 
             Your feedback helps us prioritize which bugs to investigate and address first.
 
-            ![Visits](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
+            ![Views](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
       - name: Upvote issue
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/community-voting.yml
+++ b/.github/workflows/community-voting.yml
@@ -22,7 +22,7 @@ jobs:
 
             Your vote helps us identify which enhancements matter most to our users.
 
-            ![Visits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&title=visits&edge_flat=false)
+            ![Visits](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
       - name: Upvote issue
         uses: actions/github-script@v7
         with:
@@ -49,7 +49,7 @@ jobs:
 
             Your feedback helps us prioritize which bugs to investigate and address first.
 
-            ![Visits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&title=visits&edge_flat=false)
+            ![Visits](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
       - name: Upvote issue
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Describe your changes

We have a visit tracker automatically added to Github issues. Unfortunately, the older provider isn't working anymore. This PR is replacing it with badges from https://visitorbadge.io/.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
