### PR TITLE
Migrate issue view counter badge to own provider

### DIFF
--- a/.github/workflows/community-voting.yml
+++ b/.github/workflows/community-voting.yml
@@ -22,7 +22,7 @@ jobs:
 
             Your vote helps us identify which enhancements matter most to our users.
 
-            ![Views](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
+            ![Views](https://api.views-badge.org/badge/st-issue-${{ github.event.issue.number }})
       - name: Upvote issue
         uses: actions/github-script@v7
         with:
@@ -49,7 +49,7 @@ jobs:
 
             Your feedback helps us prioritize which bugs to investigate and address first.
 
-            ![Views](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Fstreamlit%2Fstreamlit%2Fissues%2F${{ github.event.issue.number }}&label=Views&style=flat-square&labelStyle=none)
+            ![Views](https://api.views-badge.org/badge/st-issue-${{ github.event.issue.number }})
       - name: Upvote issue
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Describe your changes

https://github.com/streamlit/streamlit/pull/10922 migrated our view badge in community voting to https://visitorbadge.io/. However, this doesn't provide a good way to access the statistics for analysis. Therefore, I have implemented a very lightweight cloudflare worker using the cloudlfare key-value store to provide such a feature:

The badge is available via:
```
https://api.views-badge.org/badge/<key>
```

And the stats can be accessed via:
```
https://api.views-badge.org/stats/<key>
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
