### PR TITLE
Use vite proxy for dev server backend connection

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -28,7 +28,8 @@ const DEV_BUILD = Boolean(process.env.DEV_BUILD)
 const IS_PROFILER_BUILD = Boolean(process.env.IS_PROFILER_BUILD)
 // The URL of the backend server to proxy to:
 // Can be changed to run against a remote server or different port:
-const DEV_BACKEND_URL = process.env.DEV_BACKEND_URL || `http://localhost:8501`
+const DEV_SERVER_BACKEND_URL =
+  process.env.DEV_SERVER_BACKEND_URL || `http://localhost:8501`
 
 /**
  * If this is a profiler build, we need to alias react-dom and scheduler to
@@ -92,20 +93,20 @@ export default defineConfig({
       // These endpoints need to be kept in sync with the endpoints in
       // lib/streamlit/web/server/server.py
       "/_stcore": {
-        target: DEV_BACKEND_URL,
+        target: DEV_SERVER_BACKEND_URL,
         changeOrigin: true,
         ws: true,
       },
       "/media": {
-        target: DEV_BACKEND_URL,
+        target: DEV_SERVER_BACKEND_URL,
         changeOrigin: true,
       },
       "/component": {
-        target: DEV_BACKEND_URL,
+        target: DEV_SERVER_BACKEND_URL,
         changeOrigin: true,
       },
       "/app/static": {
-        target: DEV_BACKEND_URL,
+        target: DEV_SERVER_BACKEND_URL,
         changeOrigin: true,
       },
     },

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -26,6 +26,9 @@ const HASH = process.env.OMIT_HASH_FROM_MAIN_FILES ? "" : ".[hash]"
 // This is a convenience for developers for debugging purposes
 const DEV_BUILD = Boolean(process.env.DEV_BUILD)
 const IS_PROFILER_BUILD = Boolean(process.env.IS_PROFILER_BUILD)
+// The URL of the backend server to proxy to:
+// Can be changed to run against a remote server or different port:
+const DEV_BACKEND_URL = process.env.DEV_BACKEND_URL || `http://localhost:8501`
 
 /**
  * If this is a profiler build, we need to alias react-dom and scheduler to
@@ -89,20 +92,20 @@ export default defineConfig({
       // These endpoints need to be kept in sync with the endpoints in
       // lib/streamlit/web/server/server.py
       "/_stcore": {
-        target: "http://localhost:8501",
+        target: DEV_BACKEND_URL,
         changeOrigin: true,
         ws: true,
       },
       "/media": {
-        target: "http://localhost:8501",
+        target: DEV_BACKEND_URL,
         changeOrigin: true,
       },
       "/component": {
-        target: "http://localhost:8501",
+        target: DEV_BACKEND_URL,
         changeOrigin: true,
       },
       "/app/static": {
-        target: "http://localhost:8501",
+        target: DEV_BACKEND_URL,
         changeOrigin: true,
       },
     },

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -86,8 +86,8 @@ export default defineConfig({
     port: 3000,
     host: true,
     proxy: {
-      // You can find all backend endpoints in
-      // https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/web/server/server.py
+      // These endpoints need to be kept in sync with the endpoints in
+      // lib/streamlit/web/server/server.py
       "/_stcore": {
         target: "http://localhost:8501",
         changeOrigin: true,

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
   server: {
     open: true,
     port: 3000,
+    host: true,
     proxy: {
       // You can find all backend endpoints in
       // https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/web/server/server.py

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -84,6 +84,27 @@ export default defineConfig({
   server: {
     open: true,
     port: 3000,
+    proxy: {
+      // You can find all backend endpoints in
+      // https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/web/server/server.py
+      "/_stcore": {
+        target: "http://localhost:8501",
+        changeOrigin: true,
+        ws: true,
+      },
+      "/media": {
+        target: "http://localhost:8501",
+        changeOrigin: true,
+      },
+      "/component": {
+        target: "http://localhost:8501",
+        changeOrigin: true,
+      },
+      "/app/static": {
+        target: "http://localhost:8501",
+        changeOrigin: true,
+      },
+    },
   },
   build: {
     outDir: "build",

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -41,6 +41,8 @@ interface Props {
   ) => void
 }
 
+// These endpoints need to be kept in sync with the endpoints in
+// lib/streamlit/web/server/server.py
 const MEDIA_ENDPOINT = "/media"
 const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file"
 const COMPONENT_ENDPOINT_BASE = "/component"

--- a/frontend/connection/src/constants.ts
+++ b/frontend/connection/src/constants.ts
@@ -53,12 +53,6 @@ export const WEBSOCKET_TIMEOUT_MS = 15 * 1000
 export const PING_TIMEOUT_MS = 15 * 1000
 
 /**
- * This is the port used to connect to the server web socket when in dev.
- * IMPORTANT: If changed, also change config.py
- */
-export const WEBSOCKET_PORT_DEV = "8501"
-
-/**
  * True when in development mode. We disable if we are testing to ensure
  * production conditions.
  */

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -16,8 +16,6 @@
 
 import { isHttps, makePath } from "@streamlit/utils"
 
-import { IS_DEV_ENV, WEBSOCKET_PORT_DEV } from "./constants"
-
 const FINAL_SLASH_RE = /\/+$/
 const INITIAL_SLASH_RE = /^\/+/
 
@@ -26,13 +24,8 @@ const INITIAL_SLASH_RE = /^\/+/
  */
 export function getWindowBaseUriParts(): URL {
   const currentUrl = new URL(window.location.href)
-  // If dev, always connect to 8501, since window.location.port is the Node
-  // server's port 3000.
-  // If changed, also change config.py
 
-  if (IS_DEV_ENV) {
-    currentUrl.port = WEBSOCKET_PORT_DEV
-  } else if (!currentUrl.port) {
+  if (!currentUrl.port) {
     currentUrl.port = isHttps() ? "443" : "80"
   }
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -91,6 +91,9 @@ MAX_PORT_SEARCH_RETRIES: Final = 100
 # to an unix socket.
 UNIX_SOCKET_PREFIX: Final = "unix://"
 
+# Please make sure to also update frontend/app/vite.config.ts
+# dev server proxy when changing or updating these endpoints as well
+# as the endpoints in frontend/connection/src/DefaultStreamlitEndpoints
 MEDIA_ENDPOINT: Final = "/media"
 COMPONENT_ENDPOINT: Final = "/component"
 STATIC_SERVING_ENDPOINT: Final = "/app/static"

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -92,8 +92,8 @@ MAX_PORT_SEARCH_RETRIES: Final = 100
 UNIX_SOCKET_PREFIX: Final = "unix://"
 
 MEDIA_ENDPOINT: Final = "/media"
-COMPONENT_ENDPOINT: Final = "component"
-STATIC_SERVING_ENDPOINT: Final = "app/static"
+COMPONENT_ENDPOINT: Final = "/component"
+STATIC_SERVING_ENDPOINT: Final = "/app/static"
 UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -92,8 +92,8 @@ MAX_PORT_SEARCH_RETRIES: Final = 100
 UNIX_SOCKET_PREFIX: Final = "unix://"
 
 MEDIA_ENDPOINT: Final = "/media"
-COMPONENT_ENDPOINT: Final = "/component"
-STATIC_SERVING_ENDPOINT: Final = "/app/static"
+COMPONENT_ENDPOINT: Final = "component"
+STATIC_SERVING_ENDPOINT: Final = "app/static"
 UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"
@@ -104,7 +104,6 @@ HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
     r"(?:script-health-check|_stcore/script-health-check)"
 )
-
 
 OAUTH2_CALLBACK_ENDPOINT: Final = "/oauth2callback"
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -92,6 +92,8 @@ MAX_PORT_SEARCH_RETRIES: Final = 100
 UNIX_SOCKET_PREFIX: Final = "unix://"
 
 MEDIA_ENDPOINT: Final = "/media"
+COMPONENT_ENDPOINT: Final = "/component"
+STATIC_SERVING_ENDPOINT: Final = "/app/static"
 UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"
@@ -102,6 +104,7 @@ HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
     r"(?:script-health-check|_stcore/script-health-check)"
 )
+
 
 OAUTH2_CALLBACK_ENDPOINT: Final = "/oauth2callback"
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
@@ -351,7 +354,7 @@ class Server:
                 {"path": ""},
             ),
             (
-                make_url_path_regex(base, "component/(.*)"),
+                make_url_path_regex(base, f"{COMPONENT_ENDPOINT}/(.*)"),
                 ComponentRequestHandler,
                 {"registry": self._runtime.component_registry},
             ),
@@ -374,7 +377,7 @@ class Server:
             routes.extend(
                 [
                     (
-                        make_url_path_regex(base, "app/static/(.*)"),
+                        make_url_path_regex(base, f"{STATIC_SERVING_ENDPOINT}/(.*)"),
                         AppStaticFileHandler,
                         {"path": file_util.get_app_static_dir(self.main_script_path)},
                     ),


### PR DESCRIPTION
## Describe your changes

Uses the vite proxy configuration to proxy requests to the Streamlit backend instead of connecting to a a different port in the frontend. This is a necessary change to eventually add a devcontainer setup to this repo:  #7242 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
