### PR TITLE
[Fix] Nightly build permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,6 +74,9 @@ jobs:
     permissions:
       # Pass additional permission needed to upload constraints
       contents: write
+      # Additional permissions for py-coverage-report
+      actions: read
+      pull-requests: write
     uses: ./.github/workflows/python-tests.yml
     with:
       ref: ${{needs.create-nightly-tag.outputs.tag}}


### PR DESCRIPTION
## Describe your changes
Nightly build job is failing last several nights based on lack of permissions for called job `python-tests` > `py-coverage-report`
<img width="700" alt="Screenshot 2025-03-31 at 11 58 12 p m" src="https://github.com/user-attachments/assets/134e05a9-7022-4fde-a46d-926c28351bf2" />

**Failed run examples:**
* 3/31: https://github.com/streamlit/streamlit/actions/runs/14143132776
* 3/30: https://github.com/streamlit/streamlit/actions/runs/14165602252
* 3/29: https://github.com/streamlit/streamlit/actions/runs/14153490357
* 3/28: https://github.com/streamlit/streamlit/actions/runs/14143132776