### PR TITLE
Optimize `st.write` usage with single string arg

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -407,6 +407,14 @@ class WriteMixin:
                 kwargs,
             )
 
+        if len(args) == 1 and isinstance(args[0], str):
+            # Optimization: If there is only one arg, and it's a string,
+            # we can just call markdown directly and skip the buffer logic.
+            # This also prevents unnecessary usage of `st.empty()`.
+            # This covers > 80% of all `st.write` uses.
+            self.dg.markdown(args[0], unsafe_allow_html=unsafe_allow_html)
+            return
+
         string_buffer: list[str] = []
 
         # This bans some valid cases like: e = st.empty(); e.write("a", "b").


### PR DESCRIPTION
## Describe your changes

If `st.write` is called with a single string arg, we directly pass this to `st.markdown` instead of applying our buffer logic + `st.empty` trick. This covers >80% of all uses of `st.write`.

A bit more context here: https://github.com/streamlit/streamlit/pull/9562#discussion_r2023085071

## Testing Plan

- Added unit test. Existing tests should also cover this. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
