### PR TITLE
[Fix]: Button hover color overwrites colored text

### DIFF
--- a/e2e_playwright/st_button.py
+++ b/e2e_playwright/st_button.py
@@ -94,3 +94,7 @@ conn_types = [
 ]
 for i in range(len(conn_types)):
     cols[i % 3].button(conn_types[i], use_container_width=True)
+
+st.button("Foo :blue[bar] baz", type="primary")
+st.button("Foo :blue[bar] baz")
+st.button("Foo :blue[bar] baz", type="tertiary")

--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -22,13 +22,15 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
 )
 
+TOTAL_BUTTONS = 25
+
 
 def test_button_widget_rendering(
     themed_app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test that the button widgets are correctly rendered via screenshot matching."""
     button_elements = themed_app.get_by_test_id("stButton")
-    expect(button_elements).to_have_count(22)
+    expect(button_elements).to_have_count(TOTAL_BUTTONS)
 
     assert_snapshot(button_elements.nth(0), name="st_button-default")
     assert_snapshot(button_elements.nth(1), name="st_button-disabled")
@@ -137,3 +139,42 @@ def test_shows_cursor_pointer(app: Page):
     """Test that the button shows cursor pointer when hovered."""
     button_element = app.get_by_test_id("stButton").first
     expect(button_element.locator("button")).to_have_css("cursor", "pointer")
+
+
+def test_colored_text_hover(app: Page):
+    """Test that the colored text is correctly rendered and changes color on hover."""
+    # Check hover behavior for colored text in primary button
+    primary_button_element = app.get_by_test_id("stButton").nth(22)
+    expect(primary_button_element.locator("span")).to_have_class("colored-text")
+    expect(primary_button_element.locator("span")).to_have_css(
+        "color", "rgb(0, 104, 201)"
+    )
+    primary_button_element.locator("button").hover()
+    # For primary buttons, the colored text should be white on hover to match the rest of the text
+    expect(primary_button_element.locator("span")).to_have_css(
+        "color", "rgb(255, 255, 255)"
+    )
+
+    # Check hover behavior for colored text in secondary button
+    secondary_button_element = app.get_by_test_id("stButton").nth(23)
+    expect(secondary_button_element.locator("span")).to_have_class("colored-text")
+    expect(secondary_button_element.locator("span")).to_have_css(
+        "color", "rgb(0, 104, 201)"
+    )
+    secondary_button_element.locator("button").hover()
+    # For secondary buttons, the colored text should be red on hover to match the rest of the text
+    expect(secondary_button_element.locator("span")).to_have_css(
+        "color", "rgb(255, 75, 75)"
+    )
+
+    # Check hover behavior for colored text in tertiary button
+    tertiary_button_element = app.get_by_test_id("stButton").nth(24)
+    expect(tertiary_button_element.locator("span")).to_have_class("colored-text")
+    expect(tertiary_button_element.locator("span")).to_have_css(
+        "color", "rgb(0, 104, 201)"
+    )
+    tertiary_button_element.locator("button").hover()
+    # For tertiary buttons, the colored text should be red on hover to match the rest of the text
+    expect(tertiary_button_element.locator("span")).to_have_css(
+        "color", "rgb(255, 75, 75)"
+    )

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -107,9 +107,11 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       cursor: "pointer",
       userSelect: "none",
       "&:hover": {
-        color: theme.colors.primary,
-        "*": {
-          color: `${theme.colors.primary} !important`,
+        // override text color on hover for colored text - note since text color applied
+        // as inline style (highest specificity) we need to use !important
+        // use inherit to handle all button types
+        "span.colored-text": {
+          color: "inherit !important",
         },
       },
       "&:focus": {

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -106,6 +106,12 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       width: containerWidth ? "100%" : "auto",
       cursor: "pointer",
       userSelect: "none",
+      "&:hover": {
+        color: theme.colors.primary,
+        "*": {
+          color: `${theme.colors.primary} !important`,
+        },
+      },
       "&:focus": {
         outline: "none",
       },

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -411,6 +411,7 @@ describe("StreamlitMarkdown", () => {
       const tagName = markdown.nodeName.toLowerCase()
       expect(tagName).toBe("span")
       expect(markdown).toHaveStyle(`color: ${style}`)
+      expect(markdown).toHaveClass("colored-text")
 
       // Removes rendered StreamlitMarkdown component before next case run
       cleanup()

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -464,6 +464,9 @@ export function RenderedMarkdown({
           data.hName = "span"
           data.hProperties = data.hProperties || {}
           data.hProperties.style = style
+          // Add class name specific to colored text used for button hover selector
+          // to override text color
+          data.hProperties.className = "colored-text"
           // Add class for background color for custom styling
           if (
             style &&


### PR DESCRIPTION
## Describe your changes
Resolve hover color overwrite of colored text
* Add class name to colored text
* Target spans of that specific class name for hover color override

Extension of solution by @guilhermep21 in https://github.com/streamlit/streamlit/pull/10885
## GitHub Issue Link (if applicable)
Closes #8767 

## Testing Plan
- Unit Tests (JS and/or Python): ✅ Added
- E2E Tests: ✅ 
- Manual Testing: ✅ 