### PR TITLE
Remove unused global variable

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -29,7 +29,7 @@ from streamlit.web.server.server_util import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_LOGGER: Final = get_logger(__name__)
+
 
 
 def allow_cross_origin_requests() -> bool:

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,12 +15,11 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import tornado.web
 
 from streamlit import config, file_util
-from streamlit.logger import get_logger
 from streamlit.web.server.server_util import (
     emit_endpoint_deprecation_notice,
     is_xsrf_enabled,
@@ -28,8 +27,6 @@ from streamlit.web.server.server_util import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
 
 
 def allow_cross_origin_requests() -> bool:


### PR DESCRIPTION
Potential fix for [https://github.com/streamlit/streamlit/security/code-scanning/10017](https://github.com/streamlit/streamlit/security/code-scanning/10017)

To fix the problem, we should remove the unused `_LOGGER` variable. This will clean up the code and eliminate any confusion about its purpose. Since `_LOGGER` is not used anywhere in the provided code snippet, we can safely remove its definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
