### PR TITLE
Use github token for downloading develop coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -439,7 +439,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const COVERAGE_CHANGE_THRESHOLD = 0.02; // 0.02%
+            const COVERAGE_CHANGE_THRESHOLD = 0.03; // 0.03%
 
             try {
               // Read current coverage from the existing file

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -430,6 +430,9 @@ jobs:
           run-id: ${{ steps.get-latest-run.outputs.run_id }}
           name: combined_coverage_json
           path: /tmp/develop_coverage
+          # Needs a token to download the artifact from another
+          # workflow run:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check coverage changes and comment
         if: github.event_name == 'pull_request'

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -645,6 +645,50 @@ class HashTest(unittest.TestCase):
 
         self.assertNotEqual(get_hash(enum_a), get_hash(enum_b))
 
+    def test_reduce_not_hashable(self):
+        class A:
+            def __init__(self):
+                self.x = [1, 2, 3]
+
+        with self.assertRaises(UnhashableTypeError):
+            get_hash(A().__reduce__())
+
+    def test_reduce_fallback(self):
+        """Test that objects with __reduce__ method can be hashed using the fallback mechanism."""
+
+        class CustomClass:
+            def __init__(self, value):
+                self.value = value
+
+            def __reduce__(self):
+                return (CustomClass, (self.value,))
+
+        obj1 = CustomClass(42)
+        obj2 = CustomClass(42)
+        obj3 = CustomClass(43)
+
+        # Same objects should hash to the same value
+        self.assertEqual(get_hash(obj1), get_hash(obj2))
+
+        # Different objects should hash to different values
+        self.assertNotEqual(get_hash(obj1), get_hash(obj3))
+
+        # Test with a more complex object
+        class ComplexClass:
+            def __init__(self, name, items):
+                self.name = name
+                self.items = items
+
+            def __reduce__(self):
+                return (ComplexClass, (self.name, self.items))
+
+        complex_obj1 = ComplexClass("test", [1, 2, 3])
+        complex_obj2 = ComplexClass("test", [1, 2, 3])
+        complex_obj3 = ComplexClass("test", [1, 2, 4])
+
+        self.assertEqual(get_hash(complex_obj1), get_hash(complex_obj2))
+        self.assertNotEqual(get_hash(complex_obj1), get_hash(complex_obj3))
+
 
 class NotHashableTest(unittest.TestCase):
     """Tests for various unhashable types."""


### PR DESCRIPTION
## Describe your changes

Specifying a run ID in the [download-artifact](https://github.com/actions/download-artifact) doesn't seem to be enough, it also requires a github token to access artifacts from other worklfows. Otherwise, it is just downloading the artifacts from its own workflow run.

Also added an additional test for hashing since this is the one file that is different in testing coverage in develop & PRs.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
