### PR TITLE
Exclude dot files and __init__.py from pages

### DIFF
--- a/e2e_playwright/multipage_apps/pages/.dotfile.py
+++ b/e2e_playwright/multipage_apps/pages/.dotfile.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/e2e_playwright/multipage_apps/pages/__init__.py
+++ b/e2e_playwright/multipage_apps/pages/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -134,7 +134,14 @@ def _mpa_v1(main_script_path: str):
     # Read out the my_pages folder and create a page for every script:
     pages = PAGES_FOLDER.glob("*.py")
     pages = sorted(
-        [page for page in pages if page.name.endswith(".py")], key=page_sort_key
+        [
+            page
+            for page in pages
+            if page.name.endswith(".py")
+            and not page.name.startswith(".")
+            and not page.name == "__init__.py"
+        ],
+        key=page_sort_key,
     )
 
     # Use this script as the main page and


### PR DESCRIPTION
## Describe your changes

The work in https://github.com/streamlit/streamlit/pull/10276 missed out on a detail in determine which pages were eligible for MPAv1. This change excludes dotfiles and `__init__.py` similar to how it was done before (See [previous setup](https://github.com/streamlit/streamlit/blob/1.43.0/lib/streamlit/source_util.py#L152))

## GitHub Issue Link (if applicable)

Closes #11006

## Testing Plan

- Updated E2E tests to include a dot file and `__init__.py` these should ensure they work by not adding to current screenshots or number of links detected.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
