### PR TITLE
Add `is_embedded` to st.context

### DIFF
--- a/e2e_playwright/hostframe_app.py
+++ b/e2e_playwright/hostframe_app.py
@@ -48,5 +48,7 @@ st.color_picker("Pick a color")
 with st.expander("Show URL"):
     st.write(f"Full url: {st.context.url}")
 
+st.write("Is app embedded: ", st.context.is_embedded)
+
 # Allows for testing of script re-run / stop behavior
 time.sleep(3)

--- a/e2e_playwright/hostframe_app_test.py
+++ b/e2e_playwright/hostframe_app_test.py
@@ -66,6 +66,21 @@ def _load_html_and_get_locators(
     return frame_locator, toolbar_buttons
 
 
+def _open_embed(iframed_app: IframedPage, embed: bool = False) -> FrameLocator:
+    """Open the iframe with embed=True and return the frame locator."""
+    src_query_params = {}
+    if embed:
+        src_query_params["embed"] = "true"
+
+    frame_locator: FrameLocator = iframed_app.open_app(
+        IframedPageAttrs(
+            src_query_params=src_query_params,
+        )
+    )
+    wait_for_app_run(frame_locator)
+    return frame_locator
+
+
 def _check_widgets_and_sidebar_nav_links_disabled(frame_locator: FrameLocator):
     # Verify that the app's widgets & sidebar nav links are disabled
     # Note: checking via .to_be_disabled() only works on native control elements (HTML button, input, select, textarea, option, optgroup)
@@ -192,6 +207,20 @@ def test_handles_set_file_upload_client_config_message(iframed_app: IframedPage)
 
     assert headers["header1"] == "header1value"
     assert headers["header2"] == "header2value"
+
+
+def test_set_is_embedded_context_field_embed_true(iframed_app: IframedPage):
+    frame_locator = _open_embed(iframed_app, embed=True)
+
+    # Check that the context option is set correctly to True
+    expect_prefixed_markdown(frame_locator, "Is app embedded:", "True")
+
+
+def test_set_is_embedded_context_field_embed_false(iframed_app: IframedPage):
+    frame_locator, toolbar_buttons = _load_html_and_get_locators(iframed_app)
+
+    # Check that the context option is set correctly to False
+    expect_prefixed_markdown(frame_locator, "Is app embedded:", "False")
 
 
 def test_handles_host_rerun_script_message(iframed_app: IframedPage):

--- a/e2e_playwright/hostframe_app_test.py
+++ b/e2e_playwright/hostframe_app_test.py
@@ -66,15 +66,11 @@ def _load_html_and_get_locators(
     return frame_locator, toolbar_buttons
 
 
-def _open_embed(iframed_app: IframedPage, embed: bool = False) -> FrameLocator:
+def _open_embed(iframed_app: IframedPage) -> FrameLocator:
     """Open the iframe with embed=True and return the frame locator."""
-    src_query_params = {}
-    if embed:
-        src_query_params["embed"] = "true"
-
     frame_locator: FrameLocator = iframed_app.open_app(
         IframedPageAttrs(
-            src_query_params=src_query_params,
+            src_query_params={"embed": "true"},
         )
     )
     wait_for_app_run(frame_locator)
@@ -210,7 +206,7 @@ def test_handles_set_file_upload_client_config_message(iframed_app: IframedPage)
 
 
 def test_set_is_embedded_context_field_embed_true(iframed_app: IframedPage):
-    frame_locator = _open_embed(iframed_app, embed=True)
+    frame_locator = _open_embed(iframed_app)
 
     # Check that the context option is set correctly to True
     expect_prefixed_markdown(frame_locator, "Is app embedded:", "True")

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2350,6 +2350,7 @@ describe("App", () => {
           widgetStates: {},
           contextInfo: {
             locale: "en-US",
+            isEmbedded: false,
             timezone: "UTC",
             timezoneOffset: 0,
             url: "http://localhost:3000/",
@@ -2920,6 +2921,7 @@ describe("App", () => {
           widgetStates: {},
           contextInfo: {
             locale: "en-US",
+            isEmbedded: false,
             timezone: "UTC",
             timezoneOffset: 0,
             url: "http://localhost:3000/",
@@ -3133,6 +3135,7 @@ describe("App", () => {
           widgetStates: {},
           contextInfo: {
             locale: "en-US",
+            isEmbedded: false,
             timezone: "UTC",
             timezoneOffset: 0,
             url: "http://localhost:3000/",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1589,6 +1589,7 @@ export class App extends PureComponent<Props, State> {
       timezoneOffset: getTimezoneOffset(),
       locale: getLocaleLanguage(),
       url: getUrl(),
+      isEmbedded: isEmbed(),
     }
 
     if (pageScriptHash) {

--- a/frontend/hostframe.html
+++ b/frontend/hostframe.html
@@ -295,4 +295,4 @@ Usage:
   <button onclick="setInputsDisabled()">Disable Inputs</button>
 </div>
 
-<iframe id="guest" src="http://localhost:3000/?embed=true" />
+<iframe id="guest" src="http://localhost:3000" />

--- a/frontend/hostframe.html
+++ b/frontend/hostframe.html
@@ -295,4 +295,4 @@ Usage:
   <button onclick="setInputsDisabled()">Disable Inputs</button>
 </div>
 
-<iframe id="guest" src="http://localhost:3000" />
+<iframe id="guest" src="http://localhost:3000/?embed=true" />

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -321,3 +321,12 @@ class ContextProxy:
                 return None
             return remote_ip
         return None
+
+    @property
+    @gather_metrics("context.is_embedded")
+    def is_embedded(self) -> bool | None:
+        """Whether the app is embedded."""
+        ctx = get_script_run_ctx()
+        if ctx is None or ctx.context_info is None:
+            return None
+        return ctx.context_info.is_embedded

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -27,6 +27,7 @@ message ContextInfo {
   optional int32 timezone_offset = 2;
   optional string locale = 3;
   optional string url = 4;
+  optional bool is_embedded = 5;
 }
 
 message ClientState {


### PR DESCRIPTION
## Describe your changes

Add `is_embedded` to st.context. 

According to [the spec](https://www.notion.so/snowflake-corp/Spec-50dd7dd7df2c4282abc93e836702de88?pvs=4#1657170bb41680198d64d9109611278b), this field should show the existence of `?embed=True` query param. 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests DONE!
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
