### PR TITLE
BugFix 11062: Sidebar resizing

### DIFF
--- a/e2e_playwright/st_sidebar_test.py
+++ b/e2e_playwright/st_sidebar_test.py
@@ -98,7 +98,6 @@ def test_sidebar_resize_functionality(app: Page):
 
     # Get resize handle position
     handle_box = resize_handle.bounding_box()
-    expect(handle_box).not_to_be_none()
 
     # Get the handle's starting position
     handle_x = handle_box["x"] + handle_box["width"] / 2
@@ -113,8 +112,8 @@ def test_sidebar_resize_functionality(app: Page):
 
     # Wait for the resize to take effect
     def check_width_changed():
-        after_drag_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
-        return after_drag_width > initial_width
+        current_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+        return current_width > initial_width
 
     wait_until(app, check_width_changed)
 
@@ -123,22 +122,38 @@ def test_sidebar_resize_functionality(app: Page):
 
     # Verify the width increased by approximately drag_distance
     # We use a tolerance of +/- 3px to account for rounding and rendering differences
-    width_change = after_drag_width - initial_width
-    expect(math.isclose(width_change, drag_distance, abs_tol=3)).to_be_truthy(
-        f"Expected width change of ~{drag_distance}px, got {width_change}px"
-    )
+    def check_approximate_width_change():
+        current_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+        width_change = current_width - initial_width
+        return math.isclose(width_change, drag_distance, abs_tol=3)
+
+    wait_until(app, check_approximate_width_change)
 
     # Now just click the resize handle without dragging
     resize_handle.click()
 
-    # Measure the width after clicking
-    after_click_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+    # Track width changes after clicking to detect stabilization
+    last_seen_width = after_drag_width
+    stable_count = 0
 
-    # Verify clicking didn't change the width
-    expect(after_click_width).to_equal(
-        after_drag_width,
-        f"Width changed after clicking: {after_click_width} != {after_drag_width}",
-    )
+    def check_width_stabilized():
+        nonlocal last_seen_width, stable_count
+        current_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+
+        if current_width == last_seen_width:
+            stable_count += 1
+        else:
+            # Width changed, reset counter
+            last_seen_width = current_width
+            stable_count = 0
+
+        # Consider width stable if it hasn't changed for 3 consecutive checks
+        return stable_count >= 3
+
+    wait_until(app, check_width_stabilized)
+
+    # Now get the stable width after clicking
+    click_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
 
     # Finally, test double-click to reset width
     resize_handle.dblclick()
@@ -146,7 +161,7 @@ def test_sidebar_resize_functionality(app: Page):
     # Wait for the reset to take effect
     def check_width_reset():
         reset_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
-        return reset_width != after_click_width
+        return reset_width != click_width
 
     wait_until(app, check_width_reset)
 
@@ -154,7 +169,6 @@ def test_sidebar_resize_functionality(app: Page):
     after_dblclick_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
 
     # Verify the width changed (reset to default)
-    expect(after_dblclick_width).not_to_equal(
-        after_click_width,
-        f"Width didn't reset after double-clicking: {after_dblclick_width} == {after_click_width}",
+    assert after_dblclick_width != click_width, (
+        f"Width didn't reset after double-clicking: {after_dblclick_width} == {click_width}"
     )

--- a/e2e_playwright/st_sidebar_test.py
+++ b/e2e_playwright/st_sidebar_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
@@ -78,3 +80,71 @@ def test_sidebar_chart_and_toolbar(app: Page):
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stSidebar")
+
+
+def test_sidebar_resize_functionality(app: Page):
+    """Test that sidebar can be resized by dragging and not by clicking."""
+
+    # Get the sidebar element
+    sidebar = app.get_by_test_id("stSidebar")
+    expect(sidebar).to_be_visible()
+
+    # Get the initial width of the sidebar
+    initial_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+
+    # Find the resize handle (the element with cursor: col-resize)
+    resize_handle = app.locator("div[style*='cursor: col-resize']")
+    expect(resize_handle).to_be_visible()
+
+    # Get resize handle position
+    handle_box = resize_handle.bounding_box()
+    assert handle_box is not None
+
+    # Get the handle's starting position
+    handle_x = handle_box["x"] + handle_box["width"] / 2
+    handle_y = handle_box["y"] + handle_box["height"] / 2
+
+    # Drag the handle to the right by 20 pixels
+    drag_distance = 20
+    app.mouse.move(handle_x, handle_y)
+    app.mouse.down()
+    app.mouse.move(handle_x + drag_distance, handle_y)
+    app.mouse.up()
+
+    # Give the resize a moment to take effect
+    app.wait_for_timeout(500)
+
+    # Measure the width after dragging
+    after_drag_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+
+    # Verify the width increased by approximately drag_distance
+    # We use a tolerance of +/- 3px to account for rounding and rendering differences
+    width_change = after_drag_width - initial_width
+    assert math.isclose(width_change, drag_distance, abs_tol=3), (
+        f"Expected width change of ~{drag_distance}px, got {width_change}px"
+    )
+
+    # Now just click the resize handle without dragging
+    resize_handle.click()
+
+    # Measure the width after clicking
+    after_click_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+
+    # Verify clicking didn't change the width
+    assert after_click_width == after_drag_width, (
+        f"Width changed after clicking: {after_click_width} != {after_drag_width}"
+    )
+
+    # Finally, test double-click to reset width
+    resize_handle.dblclick()
+
+    # Give the reset a moment to take effect
+    app.wait_for_timeout(500)
+
+    # Measure the width after double-clicking
+    after_dblclick_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+
+    # Verify the width changed (reset to default)
+    assert after_dblclick_width != after_click_width, (
+        f"Width didn't reset after double-clicking: {after_dblclick_width} == {after_click_width}"
+    )

--- a/e2e_playwright/st_sidebar_test.py
+++ b/e2e_playwright/st_sidebar_test.py
@@ -16,7 +16,7 @@ import math
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_until
 from e2e_playwright.shared.app_utils import check_top_level_class
 
 
@@ -98,7 +98,7 @@ def test_sidebar_resize_functionality(app: Page):
 
     # Get resize handle position
     handle_box = resize_handle.bounding_box()
-    assert handle_box is not None
+    expect(handle_box).not_to_be_none()
 
     # Get the handle's starting position
     handle_x = handle_box["x"] + handle_box["width"] / 2
@@ -111,8 +111,12 @@ def test_sidebar_resize_functionality(app: Page):
     app.mouse.move(handle_x + drag_distance, handle_y)
     app.mouse.up()
 
-    # Give the resize a moment to take effect
-    app.wait_for_timeout(500)
+    # Wait for the resize to take effect
+    def check_width_changed():
+        after_drag_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+        return after_drag_width > initial_width
+
+    wait_until(app, check_width_changed)
 
     # Measure the width after dragging
     after_drag_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
@@ -120,7 +124,7 @@ def test_sidebar_resize_functionality(app: Page):
     # Verify the width increased by approximately drag_distance
     # We use a tolerance of +/- 3px to account for rounding and rendering differences
     width_change = after_drag_width - initial_width
-    assert math.isclose(width_change, drag_distance, abs_tol=3), (
+    expect(math.isclose(width_change, drag_distance, abs_tol=3)).to_be_truthy(
         f"Expected width change of ~{drag_distance}px, got {width_change}px"
     )
 
@@ -131,20 +135,26 @@ def test_sidebar_resize_functionality(app: Page):
     after_click_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
 
     # Verify clicking didn't change the width
-    assert after_click_width == after_drag_width, (
-        f"Width changed after clicking: {after_click_width} != {after_drag_width}"
+    expect(after_click_width).to_equal(
+        after_drag_width,
+        f"Width changed after clicking: {after_click_width} != {after_drag_width}",
     )
 
     # Finally, test double-click to reset width
     resize_handle.dblclick()
 
-    # Give the reset a moment to take effect
-    app.wait_for_timeout(500)
+    # Wait for the reset to take effect
+    def check_width_reset():
+        reset_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
+        return reset_width != after_click_width
+
+    wait_until(app, check_width_reset)
 
     # Measure the width after double-clicking
     after_dblclick_width = sidebar.evaluate("el => el.getBoundingClientRect().width")
 
     # Verify the width changed (reset to default)
-    assert after_dblclick_width != after_click_width, (
-        f"Width didn't reset after double-clicking: {after_dblclick_width} == {after_click_width}"
+    expect(after_dblclick_width).not_to_equal(
+        after_click_width,
+        f"Width didn't reset after double-clicking: {after_dblclick_width} == {after_click_width}",
     )

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -216,7 +216,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [lastInnerWidth, mediumBreakpointPx])
 
-  function resetSidebarWidth(event: any): void {
+  function resetSidebarWidth(_event: any): void {
     // Double clicking on the resize handle resets sidebar to default width
     setSidebarWidth(MIN_WIDTH)
     if (localStorageAvailable()) {

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -118,6 +118,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   )
 
   const sidebarRef = useRef<HTMLDivElement>(null)
+  const resizableRef = useRef<any>(null)
 
   const cachedSidebarWidth = localStorageAvailable()
     ? window.localStorage.getItem("sidebarWidth")
@@ -166,11 +167,14 @@ const Sidebar: React.FC<SidebarProps> = ({
   }, [])
 
   const onResizeStop = useCallback(
-    (_e: any, _direction: any, _ref: any, d: any) => {
-      const newWidth = parseInt(sidebarWidth, 10) + d.width
-      initializeSidebarWidth(newWidth)
+    (_e: any, _direction: any, ref: any, _d: any) => {
+      // Use the actual ref width, not the delta, to avoid stale delta values
+      if (ref) {
+        const newWidth = ref.clientWidth || ref.offsetWidth
+        initializeSidebarWidth(newWidth)
+      }
     },
-    [initializeSidebarWidth, sidebarWidth]
+    [initializeSidebarWidth]
   )
 
   useEffect(() => {
@@ -214,11 +218,9 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   function resetSidebarWidth(event: any): void {
     // Double clicking on the resize handle resets sidebar to default width
-    if (event.detail === 2) {
-      setSidebarWidth(MIN_WIDTH)
-      if (localStorageAvailable()) {
-        window.localStorage.setItem("sidebarWidth", MIN_WIDTH)
-      }
+    setSidebarWidth(MIN_WIDTH)
+    if (localStorageAvailable()) {
+      window.localStorage.setItem("sidebarWidth", MIN_WIDTH)
     }
   }
 
@@ -324,12 +326,13 @@ const Sidebar: React.FC<SidebarProps> = ({
           },
         }}
         handleComponent={{
-          right: <StyledResizeHandle onClick={resetSidebarWidth} />,
+          right: <StyledResizeHandle onDoubleClick={resetSidebarWidth} />,
         }}
         size={{
           width: sidebarWidth,
           height: "auto",
         }}
+        ref={resizableRef}
         as={StyledSidebar}
         onResizeStop={onResizeStop}
         // Props part of StyledSidebar, but not Resizable component

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -26,10 +26,10 @@ import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 import { useTheme } from "@emotion/react"
 import { getLogger } from "loglevel"
 import {
+  NumberSize,
   Resizable,
   ResizeCallback,
   ResizeDirection,
-  NumberSize,
 } from "re-resizable"
 
 import { StreamlitEndpoints } from "@streamlit/connection"

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -25,7 +25,12 @@ import React, {
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 import { useTheme } from "@emotion/react"
 import { getLogger } from "loglevel"
-import { Resizable } from "re-resizable"
+import {
+  Resizable,
+  ResizeCallback,
+  ResizeDirection,
+  NumberSize,
+} from "re-resizable"
 
 import { StreamlitEndpoints } from "@streamlit/connection"
 import {
@@ -118,7 +123,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   )
 
   const sidebarRef = useRef<HTMLDivElement>(null)
-  const resizableRef = useRef<any>(null)
+  const resizableRef = useRef<Resizable>(null)
 
   const cachedSidebarWidth = localStorageAvailable()
     ? window.localStorage.getItem("sidebarWidth")
@@ -166,8 +171,13 @@ const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [])
 
-  const onResizeStop = useCallback(
-    (_e: any, _direction: any, ref: any, _d: any) => {
+  const onResizeStop = useCallback<ResizeCallback>(
+    (
+      _e: MouseEvent | TouchEvent,
+      _direction: ResizeDirection,
+      ref: HTMLElement,
+      _d: NumberSize
+    ) => {
       // Use the actual ref width, not the delta, to avoid stale delta values
       if (ref) {
         const newWidth = ref.clientWidth || ref.offsetWidth
@@ -192,14 +202,14 @@ const Sidebar: React.FC<SidebarProps> = ({
       return true
     }
 
-    const handleClickOutside = (event: any): void => {
+    const handleClickOutside = (event: MouseEvent): void => {
       if (sidebarRef && window) {
         const { current } = sidebarRef
         const { innerWidth } = window
 
         if (
           current &&
-          !current.contains(event.target) &&
+          !current.contains(event.target as Node) &&
           innerWidth <= mediumBreakpointPx
         ) {
           setCollapsedSidebar(true)
@@ -216,7 +226,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [lastInnerWidth, mediumBreakpointPx])
 
-  function resetSidebarWidth(_event: any): void {
+  function resetSidebarWidth(): void {
     // Double clicking on the resize handle resets sidebar to default width
     setSidebarWidth(MIN_WIDTH)
     if (localStorageAvailable()) {


### PR DESCRIPTION
## Describe your changes
- Added a reference for the resizable element to improve width handling.
- Updated the onResizeStop callback to use the actual width of the sidebar instead of a delta value, ensuring accurate width adjustments.
- Modified the resetSidebarWidth function to reset the sidebar width on double-clicking the resize handle.

This fixes:
1. only doubleclick will reset width
2. no weird sizing when clicking or trying to resize sidebar


## GitHub Issue Link (if applicable)
fixes https://github.com/streamlit/streamlit/issues/11062

## Testing Plan

E2E tests have been added to lock in this functionality.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
