### PR TITLE
[Refactor] [AdvancedLayouts] Simplify width styling on VerticalBlock

### DIFF
--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -195,5 +195,5 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     wait_until(
         app,
         lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
-        timeout=7000,
+        timeout=10000,
     )

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -193,7 +193,5 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with path
     wait_until(
-        app,
-        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
-        timeout=10000,
+        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH)
     )

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -195,4 +195,5 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     wait_until(
         app,
         lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
+        timeout=7000,
     )

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -81,11 +81,12 @@ def test_radio_has_correct_default_values(app: Page):
 
 def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
+    wait_for_app_run(app)
     for index, element in enumerate(app.get_by_test_id("stRadio").all()):
         if index not in [2, 3]:  # skip disabled and no-options widget
             element.scroll_into_view_if_needed()
             radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
-            radio_option.click(delay=50, force=True)
+            radio_option.click(delay=50)
             wait_for_app_run(app)
 
     expected = [

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -14,7 +14,10 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     expect_help_tooltip,

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -83,8 +83,9 @@ def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
     for index, element in enumerate(app.get_by_test_id("stRadio").all()):
         if index not in [2, 3]:  # skip disabled and no-options widget
+            element.scroll_into_view_if_needed()
             radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
-            radio_option.click()
+            radio_option.click(delay=50, force=True)
             wait_for_app_run(app)
 
     expected = [

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -81,12 +81,10 @@ def test_radio_has_correct_default_values(app: Page):
 
 def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
-    radio_widgets = app.get_by_test_id("stRadio").all()
-    for index, element in enumerate(radio_widgets):
+    for index, element in enumerate(app.get_by_test_id("stRadio").all()):
         if index not in [2, 3]:  # skip disabled and no-options widget
             radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
-            expect(radio_option).to_be_visible()
-            radio_option.click(force=True)
+            radio_option.click()
             wait_for_app_run(app)
 
     expected = [
@@ -106,16 +104,9 @@ def test_set_value_correctly_when_click(app: Page):
         "value 13: male",
     ]
 
-    for index, (markdown_element, expected_text) in enumerate(
-        zip(app.get_by_test_id("stMarkdown").all(), expected)
+    for markdown_element, expected_text in zip(
+        app.get_by_test_id("stMarkdown").all(), expected
     ):
-        if not markdown_element.text_content() == expected_text:
-            # Retry the click due to flakyness.
-            radio_widgets[index].locator('label[data-baseweb="radio"]').nth(1).click(
-                force=True
-            )
-            wait_for_app_run(app)
-
         expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
 
 

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -81,11 +81,12 @@ def test_radio_has_correct_default_values(app: Page):
 
 def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
-    for index, element in enumerate(app.get_by_test_id("stRadio").all()):
+    radio_widgets = app.get_by_test_id("stRadio").all()
+    for index, element in enumerate(radio_widgets):
         if index not in [2, 3]:  # skip disabled and no-options widget
-            second_radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
-            expect(second_radio_option).to_be_visible()
-            second_radio_option.click(force=True)
+            radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
+            expect(radio_option).to_be_visible()
+            radio_option.click(force=True)
             wait_for_app_run(app)
 
     expected = [
@@ -105,9 +106,16 @@ def test_set_value_correctly_when_click(app: Page):
         "value 13: male",
     ]
 
-    for markdown_element, expected_text in zip(
-        app.get_by_test_id("stMarkdown").all(), expected
+    for index, (markdown_element, expected_text) in enumerate(
+        zip(app.get_by_test_id("stMarkdown").all(), expected)
     ):
+        if not markdown_element.text_content() == expected_text:
+            # retry the click due to flakyness.
+            radio_widgets[index].locator('label[data-baseweb="radio"]').nth(
+                index
+            ).click(force=True)
+            wait_for_app_run(app)
+
         expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
 
 

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -110,10 +110,10 @@ def test_set_value_correctly_when_click(app: Page):
         zip(app.get_by_test_id("stMarkdown").all(), expected)
     ):
         if not markdown_element.text_content() == expected_text:
-            # retry the click due to flakyness.
-            radio_widgets[index].locator('label[data-baseweb="radio"]').nth(
-                index
-            ).click(force=True)
+            # Retry the click due to flakyness.
+            radio_widgets[index].locator('label[data-baseweb="radio"]').nth(1).click(
+                force=True
+            )
             wait_for_app_run(app)
 
         expect(markdown_element).to_have_text(expected_text, use_inner_text=True)

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -41,9 +41,9 @@ if (!rootDomNode) {
 const reactRoot = createRoot(rootDomNode)
 
 reactRoot.render(
-  <StrictMode>
-    <StyletronProvider value={engine}>
-      <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
-    </StyletronProvider>
-  </StrictMode>
+  //<StrictMode>
+  <StyletronProvider value={engine}>
+    <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
+  </StyletronProvider>
+  //</StrictMode>
 )

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -41,9 +41,9 @@ if (!rootDomNode) {
 const reactRoot = createRoot(rootDomNode)
 
 reactRoot.render(
-  //<StrictMode>
-  <StyletronProvider value={engine}>
-    <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
-  </StyletronProvider>
-  //</StrictMode>
+  <StrictMode>
+    <StyletronProvider value={engine}>
+      <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
+    </StyletronProvider>
+  </StrictMode>
 )

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -23,7 +23,6 @@ import { Block as BlockProto } from "@streamlit/protobuf"
 import { render } from "~lib/test_util"
 import { BlockNode } from "~lib/AppNode"
 import { ScriptRunState } from "~lib/ScriptRunState"
-import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
 import VerticalBlock from "./Block"
 
@@ -131,44 +130,4 @@ describe("Vertical Block Component", () => {
       screen.getAllByTestId("stVerticalBlockBorderWrapper")[0]
     ).toHaveStyle("border: 1px solid rgba(49, 51, 63, 0.2);")
   })
-
-  // describe("should never have a width of 0", () => {
-  //   describe("when observed width is 0", () => {
-  //     beforeEach(() => {
-  //       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
-  //         elementRef: { current: null },
-  //         forceRecalculate: vitest.fn(),
-  //         values: [0],
-  //       })
-  //     })
-
-  //     it("should have a width of -1px", () => {
-  //       const block = makeVerticalBlock([makeHorizontalBlock(4)])
-  //       render(makeVerticalBlockComponent(block))
-
-  //       expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
-  //         "width: -1px"
-  //       )
-  //     })
-  //   })
-
-  //   describe("when observed width is a positive value", () => {
-  //     beforeEach(() => {
-  //       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
-  //         elementRef: { current: null },
-  //         forceRecalculate: vitest.fn(),
-  //         values: [100],
-  //       })
-  //     })
-
-  //     it("should have the observed width", () => {
-  //       const block = makeVerticalBlock([makeHorizontalBlock(4)])
-  //       render(makeVerticalBlockComponent(block))
-
-  //       expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
-  //         "width: 100px"
-  //       )
-  //     })
-  //   })
-  // })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -116,7 +116,7 @@ describe("Vertical Block Component", () => {
 
     expect(
       screen.getAllByTestId("stVerticalBlockBorderWrapper")[0]
-    ).toHaveStyle("overflow: auto")
+    ).toHaveStyle("overflow-y: auto")
   })
 
   it("should show border when border is True", () => {

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -116,7 +116,7 @@ describe("Vertical Block Component", () => {
 
     expect(
       screen.getAllByTestId("stVerticalBlockBorderWrapper")[0]
-    ).toHaveStyle("overflow-y: auto")
+    ).toHaveStyle("overflow: auto")
   })
 
   it("should show border when border is True", () => {

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -132,43 +132,43 @@ describe("Vertical Block Component", () => {
     ).toHaveStyle("border: 1px solid rgba(49, 51, 63, 0.2);")
   })
 
-  describe("should never have a width of 0", () => {
-    describe("when observed width is 0", () => {
-      beforeEach(() => {
-        vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
-          elementRef: { current: null },
-          forceRecalculate: vitest.fn(),
-          values: [0],
-        })
-      })
+  // describe("should never have a width of 0", () => {
+  //   describe("when observed width is 0", () => {
+  //     beforeEach(() => {
+  //       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+  //         elementRef: { current: null },
+  //         forceRecalculate: vitest.fn(),
+  //         values: [0],
+  //       })
+  //     })
 
-      it("should have a width of -1px", () => {
-        const block = makeVerticalBlock([makeHorizontalBlock(4)])
-        render(makeVerticalBlockComponent(block))
+  //     it("should have a width of -1px", () => {
+  //       const block = makeVerticalBlock([makeHorizontalBlock(4)])
+  //       render(makeVerticalBlockComponent(block))
 
-        expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
-          "width: -1px"
-        )
-      })
-    })
+  //       expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
+  //         "width: -1px"
+  //       )
+  //     })
+  //   })
 
-    describe("when observed width is a positive value", () => {
-      beforeEach(() => {
-        vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
-          elementRef: { current: null },
-          forceRecalculate: vitest.fn(),
-          values: [100],
-        })
-      })
+  //   describe("when observed width is a positive value", () => {
+  //     beforeEach(() => {
+  //       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+  //         elementRef: { current: null },
+  //         forceRecalculate: vitest.fn(),
+  //         values: [100],
+  //       })
+  //     })
 
-      it("should have the observed width", () => {
-        const block = makeVerticalBlock([makeHorizontalBlock(4)])
-        render(makeVerticalBlockComponent(block))
+  //     it("should have the observed width", () => {
+  //       const block = makeVerticalBlock([makeHorizontalBlock(4)])
+  //       render(makeVerticalBlockComponent(block))
 
-        expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
-          "width: 100px"
-        )
-      })
-    })
-  })
+  //       expect(screen.getAllByTestId("stVerticalBlock")[0]).toHaveStyle(
+  //         "width: 100px"
+  //       )
+  //     })
+  //   })
+  // })
 })

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -54,11 +54,6 @@ export interface BlockPropsWithoutWidth extends BaseBlockProps {
   node: BlockNode
 }
 
-interface BlockPropsWithWidth extends BaseBlockProps {
-  node: BlockNode
-  width: React.CSSProperties["width"]
-}
-
 // Render BlockNodes (i.e. container nodes).
 const BlockNodeRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
   const { node } = props

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -47,7 +47,6 @@ import {
   StyledVerticalBlock,
   StyledVerticalBlockBorderWrapper,
   StyledVerticalBlockBorderWrapperProps,
-  StyledVerticalBlockWrapper,
 } from "./styled-components"
 
 export interface BlockPropsWithoutWidth extends BaseBlockProps {
@@ -306,17 +305,15 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
       data-testid="stVerticalBlockBorderWrapper"
       data-test-scroll-behavior="normal"
     >
-      <StyledVerticalBlockWrapper>
-        <StyledVerticalBlock
-          className={classNames(
-            "stVerticalBlock",
-            convertKeyToClassName(userKey)
-          )}
-          data-testid="stVerticalBlock"
-        >
-          <ChildRenderer {...props} />
-        </StyledVerticalBlock>
-      </StyledVerticalBlockWrapper>
+      <StyledVerticalBlock
+        className={classNames(
+          "stVerticalBlock",
+          convertKeyToClassName(userKey)
+        )}
+        data-testid="stVerticalBlock"
+      >
+        <ChildRenderer {...props} />
+      </StyledVerticalBlock>
     </VerticalBlockBorderWrapper>
   )
 }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -297,15 +297,15 @@ function ScrollToBottomVerticalBlockWrapper(
 // Currently, only VerticalBlocks will ever contain leaf elements. But this is only enforced on the
 // Python side.
 const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
-  const {
-    values: [observedWidth],
-    elementRef: wrapperElement,
-    forceRecalculate,
-  } = useResizeObserver(useMemo(() => ["width"], []))
+  // const {
+  //   values: [observedWidth],
+  //   elementRef: wrapperElement,
+  //   forceRecalculate,
+  // } = useResizeObserver(useMemo(() => ["width"], []))
 
-  // The width should never be set to 0 since it can cause
-  // flickering effects.
-  const calculatedWidth = observedWidth <= 0 ? -1 : observedWidth
+  // // The width should never be set to 0 since it can cause
+  // // flickering effects.
+  // const calculatedWidth = observedWidth <= 0 ? -1 : observedWidth
 
   const border = props.node.deltaBlock.vertical?.border ?? false
   const height = props.node.deltaBlock.vertical?.height || undefined
@@ -320,9 +320,9 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
 
   // We need to update the observer whenever the scrolling is activated or deactivated
   // Otherwise, it still tries to measure the width of the old wrapper element.
-  useEffect(() => {
-    forceRecalculate()
-  }, [forceRecalculate, activateScrollToBottom])
+  // useEffect(() => {
+  //   forceRecalculate()
+  // }, [forceRecalculate, activateScrollToBottom])
 
   // Decide which wrapper to use based on whether we need to activate scrolling to bottom
   // This is done for performance reasons, to prevent the usage of useScrollToBottom
@@ -334,7 +334,7 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // Extract the user-specified key from the block ID (if provided):
   const userKey = getKeyFromId(props.node.deltaBlock.id)
   const styles = useLayoutStyles({
-    width: calculatedWidth,
+    width: "",
     element: undefined,
   })
 
@@ -356,7 +356,7 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
       data-testid="stVerticalBlockBorderWrapper"
       data-test-scroll-behavior="normal"
     >
-      <StyledVerticalBlockWrapper ref={wrapperElement}>
+      <StyledVerticalBlockWrapper>
         <StyledVerticalBlock
           className={classNames(
             "stVerticalBlock",

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -297,10 +297,6 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // Extract the user-specified key from the block ID (if provided):
   const userKey = getKeyFromId(props.node.deltaBlock.id)
 
-  // Widths of children autosizes to container width (and therefore window width).
-  // StyledVerticalBlocks are the only things that calculate their own widths. They should never use
-  // the width value coming from the parent via props.
-
   // To apply a border, we need to wrap the StyledVerticalBlockWrapper again, otherwise the width
   // calculation would not take the padding into consideration.
   return (

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -334,7 +334,7 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // Extract the user-specified key from the block ID (if provided):
   const userKey = getKeyFromId(props.node.deltaBlock.id)
   const styles = useLayoutStyles({
-    width: "",
+    width: "100%",
     element: undefined,
   })
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  ReactElement,
-  ReactNode,
-  useContext,
-  useEffect,
-  useMemo,
-} from "react"
+import React, { ReactElement, ReactNode, useContext } from "react"
 
 import classNames from "classnames"
 import { useTheme } from "@emotion/react"
@@ -37,8 +31,6 @@ import ChatMessage from "~lib/components/elements/ChatMessage"
 import Dialog from "~lib/components/elements/Dialog"
 import Expander from "~lib/components/elements/Expander"
 import { useScrollToBottom } from "~lib/hooks/useScrollToBottom"
-import { useResizeObserver } from "~lib/hooks/useResizeObserver"
-import { useLayoutStyles } from "~lib/components/core/Layout/useLayoutStyles"
 
 import {
   assignDividerColor,
@@ -68,7 +60,7 @@ interface BlockPropsWithWidth extends BaseBlockProps {
 }
 
 // Render BlockNodes (i.e. container nodes).
-const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
+const BlockNodeRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
   const { node } = props
   const { fragmentIdsThisRun } = useContext(LibContext)
 
@@ -183,14 +175,6 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   }
 
   if (node.deltaBlock.tabContainer) {
-    // Due to an issue with unnecessary unmounts/remounts, we see undesired
-    // horizontal scrolling in Webkit/Safari. We are planning a fix for the
-    // underlying issue, but, for now, only rendering the component when we have
-    // a width != 0 fixes the scrolling issue.
-    if (!childProps.width) {
-      return <div />
-    }
-
     const renderTabContent = (
       mappedChildProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
     ): ReactElement => {
@@ -205,7 +189,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   return child
 }
 
-const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
+const ChildRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
   const { libConfig } = useContext(LibContext)
 
   // Handle cycling of colors for dividers:
@@ -297,16 +281,6 @@ function ScrollToBottomVerticalBlockWrapper(
 // Currently, only VerticalBlocks will ever contain leaf elements. But this is only enforced on the
 // Python side.
 const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
-  // const {
-  //   values: [observedWidth],
-  //   elementRef: wrapperElement,
-  //   forceRecalculate,
-  // } = useResizeObserver(useMemo(() => ["width"], []))
-
-  // // The width should never be set to 0 since it can cause
-  // // flickering effects.
-  // const calculatedWidth = observedWidth <= 0 ? -1 : observedWidth
-
   const border = props.node.deltaBlock.vertical?.border ?? false
   const height = props.node.deltaBlock.vertical?.height || undefined
 
@@ -318,12 +292,6 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
       )
     })
 
-  // We need to update the observer whenever the scrolling is activated or deactivated
-  // Otherwise, it still tries to measure the width of the old wrapper element.
-  // useEffect(() => {
-  //   forceRecalculate()
-  // }, [forceRecalculate, activateScrollToBottom])
-
   // Decide which wrapper to use based on whether we need to activate scrolling to bottom
   // This is done for performance reasons, to prevent the usage of useScrollToBottom
   // if it is not needed.
@@ -333,15 +301,6 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
 
   // Extract the user-specified key from the block ID (if provided):
   const userKey = getKeyFromId(props.node.deltaBlock.id)
-  const styles = useLayoutStyles({
-    width: "100%",
-    element: undefined,
-  })
-
-  const propsWithCalculatedWidth = {
-    ...props,
-    width: styles.width,
-  }
 
   // Widths of children autosizes to container width (and therefore window width).
   // StyledVerticalBlocks are the only things that calculate their own widths. They should never use
@@ -363,16 +322,15 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
             convertKeyToClassName(userKey)
           )}
           data-testid="stVerticalBlock"
-          {...styles}
         >
-          <ChildRenderer {...propsWithCalculatedWidth} />
+          <ChildRenderer {...props} />
         </StyledVerticalBlock>
       </StyledVerticalBlockWrapper>
     </VerticalBlockBorderWrapper>
   )
 }
 
-const HorizontalBlock = (props: BlockPropsWithWidth): ReactElement => {
+const HorizontalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // Create a horizontal block as the parent for columns.
   // The children are always columns, but this is not checked. We just trust the Python side to
   // do the right thing, then we ask ChildRenderer to handle it.
@@ -390,7 +348,7 @@ const HorizontalBlock = (props: BlockPropsWithWidth): ReactElement => {
 }
 
 // A container block with one of two types of layouts: vertical and horizontal.
-function LayoutBlock(props: BlockPropsWithWidth): ReactElement {
+function LayoutBlock(props: BlockPropsWithoutWidth): ReactElement {
   if (props.node.deltaBlock.horizontal) {
     return <HorizontalBlock {...props} />
   }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -86,7 +86,6 @@ function getProps(
     }),
     componentRegistry: new ComponentRegistry(endpoints),
     formsData: createFormsData(),
-    width: 1000,
     ...props,
   }
 }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -755,7 +755,7 @@ const ElementNodeRenderer = (
         // Applying stale opacity in fullscreen mode
         // causes the fullscreen overlay to be transparent.
         isStale={isStale && !isFullScreen}
-        width={propsWidth}
+        //width={propsWidth}
         elementType={elementType}
         node={node}
       >

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -191,7 +191,6 @@ const StreamlitSyntaxHighlighter = React.lazy(
 
 export interface ElementNodeRendererProps extends BaseBlockProps {
   node: ElementNode
-  width: React.CSSProperties["width"]
 }
 
 interface RawElementNodeRendererProps extends ElementNodeRendererProps {
@@ -721,7 +720,7 @@ const ElementNodeRenderer = (
   props: ElementNodeRendererProps
 ): ReactElement => {
   const { isFullScreen, fragmentIdsThisRun } = React.useContext(LibContext)
-  const { node, width: propsWidth } = props
+  const { node } = props
 
   const elementType = node.element.type || ""
 
@@ -755,7 +754,6 @@ const ElementNodeRenderer = (
         // Applying stale opacity in fullscreen mode
         // causes the fullscreen overlay to be transparent.
         isStale={isStale && !isFullScreen}
-        //width={propsWidth}
         elementType={elementType}
         node={node}
       >

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -24,11 +24,11 @@ import { StyledElementContainer } from "./styled-components"
 export const StyledElementContainerLayoutWrapper: FC<
   Omit<Parameters<typeof StyledElementContainer>[0], "width"> & {
     node: ElementNode
-    width: React.CSSProperties["width"]
+    //width: React.CSSProperties["width"]
   }
-> = ({ width, node, ...rest }) => {
+> = ({ node, ...rest }) => {
   const styles = useLayoutStyles({
-    width,
+    width: "100%",
     element:
       (node.element?.type && node.element[node.element.type]) || undefined,
   })

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -24,11 +24,9 @@ import { StyledElementContainer } from "./styled-components"
 export const StyledElementContainerLayoutWrapper: FC<
   Omit<Parameters<typeof StyledElementContainer>[0], "width"> & {
     node: ElementNode
-    //width: React.CSSProperties["width"]
   }
 > = ({ node, ...rest }) => {
   const styles = useLayoutStyles({
-    width: "100%",
     element:
       (node.element?.type && node.element[node.element.type]) || undefined,
   })

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -173,14 +173,6 @@ export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
   })
 )
 
-export const StyledVerticalBlockWrapper = styled.div<StyledVerticalBlockProps>(
-  {
-    display: "flex",
-    flexDirection: "column",
-    flex: 1,
-  }
-)
-
 export interface StyledVerticalBlockBorderWrapperProps {
   border: boolean
   height?: number

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -181,6 +181,7 @@ export interface StyledVerticalBlockBorderWrapperProps {
 export const StyledVerticalBlockBorderWrapper =
   styled.div<StyledVerticalBlockBorderWrapperProps>(
     ({ theme, border, height }) => ({
+      display: "block",
       ...(border && {
         border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
         borderRadius: theme.radii.default,
@@ -188,7 +189,7 @@ export const StyledVerticalBlockBorderWrapper =
       }),
       ...(height && {
         height: `${height}px`,
-        overflow: "auto",
+        overflowY: "auto",
       }),
     })
   )

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -189,7 +189,7 @@ export const StyledVerticalBlockBorderWrapper =
       }),
       ...(height && {
         height: `${height}px`,
-        overflowY: "auto",
+        overflow: "auto",
       }),
     })
   )

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -63,6 +63,7 @@ const GLOBAL_ELEMENTS = ["balloons", "snow"]
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
   ({ theme, isStale, width, elementType }) => ({
     width,
+    maxWidth: "100%",
     // Allows to have absolutely-positioned nodes inside app elements, like
     // floating buttons.
     position: "relative",

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -161,9 +161,9 @@ export interface StyledVerticalBlockProps {
 }
 
 export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
-  ({ width, maxWidth, theme }) => ({
-    width,
-    maxWidth,
+  ({ theme }) => ({
+    width: "100%",
+    maxWidth: "100%",
     position: "relative", // Required for the automatic width computation.
     display: "flex",
     flex: 1,

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -25,17 +25,14 @@ describe("#useLayoutStyles", () => {
       const useContainerWidth = false
 
       it.each([
-        //[200, { width: 200 }],
-        //[1000, { width: 700 }],
         [undefined, { width: "auto" }],
         [0, { width: "auto" }],
         [-100, { width: "auto" }],
         [NaN, { width: "auto" }],
+        [100, { width: 100 }],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ width: 700, element })
-        )
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -44,17 +41,30 @@ describe("#useLayoutStyles", () => {
       const useContainerWidth = true
 
       it.each([
-        //[200, { width: 700 }],
-        //[1000, { width: 700 }],
         [undefined, { width: "100%" }],
         [0, { width: "100%" }],
         [-100, { width: "100%" }],
         [NaN, { width: "100%" }],
+        [100, { width: "100%" }],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ width: 700, element })
-        )
+        const { result } = renderHook(() => useLayoutStyles({ element }))
+        expect(result.current).toEqual(expected)
+      })
+    })
+
+    describe("that is an image list", () => {
+      const useContainerWidth = false
+
+      it.each([
+        [undefined, { width: "100%" }],
+        [0, { width: "100%" }],
+        [-100, { width: "100%" }],
+        [NaN, { width: "100%" }],
+        [100, { width: "100%" }],
+      ])("and with a width value of %s, returns %o", (width, expected) => {
+        const element = { width, useContainerWidth, imgs: [] }
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -20,21 +20,6 @@ import { renderHook } from "@testing-library/react"
 import { useLayoutStyles } from "./useLayoutStyles"
 
 describe("#useLayoutStyles", () => {
-  // describe("when rendering in the top-level container", () => {
-  //   describe("without an element", () => {
-  //     const element = undefined
-
-  //     it("should return default styles", () => {
-  //       const { result } = renderHook(() =>
-  //         useLayoutStyles({ width: 100, element })
-  //       )
-  //       expect(result.current).toEqual({
-  //         width: 100,
-  //       })
-  //     })
-  //   })
-  // })
-
   describe("with an element", () => {
     describe("that has useContainerWidth set to a falsy value", () => {
       const useContainerWidth = false

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -20,28 +20,28 @@ import { renderHook } from "@testing-library/react"
 import { useLayoutStyles } from "./useLayoutStyles"
 
 describe("#useLayoutStyles", () => {
-  describe("when rendering in the top-level container", () => {
-    describe("without an element", () => {
-      const element = undefined
+  // describe("when rendering in the top-level container", () => {
+  //   describe("without an element", () => {
+  //     const element = undefined
 
-      it("should return default styles", () => {
-        const { result } = renderHook(() =>
-          useLayoutStyles({ width: 100, element })
-        )
-        expect(result.current).toEqual({
-          width: 100,
-        })
-      })
-    })
-  })
+  //     it("should return default styles", () => {
+  //       const { result } = renderHook(() =>
+  //         useLayoutStyles({ width: 100, element })
+  //       )
+  //       expect(result.current).toEqual({
+  //         width: 100,
+  //       })
+  //     })
+  //   })
+  // })
 
   describe("with an element", () => {
     describe("that has useContainerWidth set to a falsy value", () => {
       const useContainerWidth = false
 
       it.each([
-        [200, { width: 200 }],
-        [1000, { width: 700 }],
+        //[200, { width: 200 }],
+        //[1000, { width: 700 }],
         [undefined, { width: "auto" }],
         [0, { width: "auto" }],
         [-100, { width: "auto" }],
@@ -59,12 +59,12 @@ describe("#useLayoutStyles", () => {
       const useContainerWidth = true
 
       it.each([
-        [200, { width: 700 }],
-        [1000, { width: 700 }],
-        [undefined, { width: 700 }],
-        [0, { width: 700 }],
-        [-100, { width: 700 }],
-        [NaN, { width: 700 }],
+        //[200, { width: 700 }],
+        //[1000, { width: 700 }],
+        [undefined, { width: "100%" }],
+        [0, { width: "100%" }],
+        [-100, { width: "100%" }],
+        [NaN, { width: "100%" }],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = { width, useContainerWidth }
         const { result } = renderHook(() =>

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -51,9 +51,13 @@ export const useLayoutStyles = <T>({
       return {
         width: "100%",
       }
+    } else if (commandWidth) {
+      return {
+        width: commandWidth,
+      }
     }
     return {
-      width: "fit-content",
+      width: "auto",
     }
 
     // // If we don't have an element, we are rendering a root-level node, likely a

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -22,8 +22,8 @@ export type UseLayoutStylesArgs<T> = {
     | undefined
 }
 
-// const isNonZeroPositiveNumber = (value: unknown): value is number =>
-//   typeof value === "number" && value > 0 && !isNaN(value)
+const isNonZeroPositiveNumber = (value: unknown): value is number =>
+  typeof value === "number" && value > 0 && !isNaN(value)
 
 export type UseLayoutStylesShape = {
   width: React.CSSProperties["width"]
@@ -54,7 +54,7 @@ export const useLayoutStyles = <T>({
       return {
         width: "100%",
       }
-    } else if (commandWidth) {
+    } else if (isNonZeroPositiveNumber(commandWidth)) {
       return {
         width: commandWidth,
       }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -23,8 +23,8 @@ export type UseLayoutStylesArgs<T> = {
     | undefined
 }
 
-const isNonZeroPositiveNumber = (value: unknown): value is number =>
-  typeof value === "number" && value > 0 && !isNaN(value)
+// const isNonZeroPositiveNumber = (value: unknown): value is number =>
+//   typeof value === "number" && value > 0 && !isNaN(value)
 
 export type UseLayoutStylesShape = {
   width: React.CSSProperties["width"]
@@ -51,10 +51,9 @@ export const useLayoutStyles = <T>({
       return {
         width: "100%",
       }
-    } else {
-      return {
-        width: "auto",
-      }
+    }
+    return {
+      width: "auto",
     }
 
     // // If we don't have an element, we are rendering a root-level node, likely a

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -53,7 +53,7 @@ export const useLayoutStyles = <T>({
       }
     }
     return {
-      width: "auto",
+      width: "fit-content",
     }
 
     // // If we don't have an element, we are rendering a root-level node, likely a

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -47,7 +47,12 @@ export const useLayoutStyles = <T>({
   // subpixel widths, which leads to blurriness on screen
 
   const layoutStyles = useMemo((): UseLayoutStylesShape => {
-    if (useContainerWidth) {
+    // The st.image element is potentially a list of images, so we always want
+    // the enclosing container to be full width. The size of individual
+    // images is managed in the ImageList component.
+    const isImgList = element && "imgs" in element
+
+    if (useContainerWidth || isImgList) {
       return {
         width: "100%",
       }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -17,7 +17,6 @@
 import { useMemo } from "react"
 
 export type UseLayoutStylesArgs<T> = {
-  width: React.CSSProperties["width"] | undefined
   element:
     | (T & { width?: number; useContainerWidth?: boolean | null })
     | undefined
@@ -34,7 +33,6 @@ export type UseLayoutStylesShape = {
  * Returns the contextually-aware style values for an element container
  */
 export const useLayoutStyles = <T>({
-  width: containerWidth,
   element,
 }: UseLayoutStylesArgs<T>): UseLayoutStylesShape => {
   /**
@@ -64,68 +62,7 @@ export const useLayoutStyles = <T>({
     return {
       width: "auto",
     }
-
-    // // If we don't have an element, we are rendering a root-level node, likely a
-    // // `StyledAppViewBlockContainer`
-    // if (!element) {
-    //   return {
-    //     width: containerWidth,
-    //   }
-    // }
-
-    // if ("imgs" in element) {
-    //   /**
-    //    * ImageList overrides its `width` param and handles its own width in the
-    //    * component. There should not be any element-specific carve-outs in this
-    //    * file, but given the long-standing behavior of ImageList, we have to
-    //    * make an exception here.
-    //    *
-    //    * @see WidthBehavior on the Backend
-    //    * @see the Image.proto file
-    //    */
-    //   return {
-    //     width: containerWidth,
-    //   }
-    // }
-
-    // let width =
-    //   useContainerWidth && isNonZeroPositiveNumber(containerWidth)
-    //     ? containerWidth
-    //     : commandWidth
-
-    // if (width === 0) {
-    //   // An element with no width should be treated as if it has no width set
-    //   // This is likely from the proto, where the default value is 0
-    //   width = undefined
-    // }
-
-    // if (width && width < 0) {
-    //   // If we have an invalid width, we should treat it as if it has no width set
-    //   width = undefined
-    // }
-
-    // if (width !== undefined && isNaN(width)) {
-    //   // If we have an invalid width, we should treat it as if it has no width set
-    //   width = undefined
-    // }
-
-    // if (
-    //   width !== undefined &&
-    //   containerWidth !== undefined &&
-    //   typeof containerWidth === "number" &&
-    //   width > containerWidth
-    // ) {
-    //   // If the width is greater than the container width, we should use the
-    //   // container width to prevent overflows
-    //   width = containerWidth
-    // }
-
-    // const widthWithFallback = width ?? "auto"
-
-    // return {
-    //   width: widthWithFallback,
-    // }
-  }, [useContainerWidth, commandWidth, containerWidth, element])
+  }, [useContainerWidth, commandWidth, element])
 
   return layoutStyles
 }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -47,66 +47,76 @@ export const useLayoutStyles = <T>({
   // subpixel widths, which leads to blurriness on screen
 
   const layoutStyles = useMemo((): UseLayoutStylesShape => {
-    // If we don't have an element, we are rendering a root-level node, likely a
-    // `StyledAppViewBlockContainer`
-    if (!element) {
+    if (useContainerWidth) {
       return {
-        width: containerWidth,
+        width: "100%",
+      }
+    } else {
+      return {
+        width: "auto",
       }
     }
 
-    if ("imgs" in element) {
-      /**
-       * ImageList overrides its `width` param and handles its own width in the
-       * component. There should not be any element-specific carve-outs in this
-       * file, but given the long-standing behavior of ImageList, we have to
-       * make an exception here.
-       *
-       * @see WidthBehavior on the Backend
-       * @see the Image.proto file
-       */
-      return {
-        width: containerWidth,
-      }
-    }
+    // // If we don't have an element, we are rendering a root-level node, likely a
+    // // `StyledAppViewBlockContainer`
+    // if (!element) {
+    //   return {
+    //     width: containerWidth,
+    //   }
+    // }
 
-    let width =
-      useContainerWidth && isNonZeroPositiveNumber(containerWidth)
-        ? containerWidth
-        : commandWidth
+    // if ("imgs" in element) {
+    //   /**
+    //    * ImageList overrides its `width` param and handles its own width in the
+    //    * component. There should not be any element-specific carve-outs in this
+    //    * file, but given the long-standing behavior of ImageList, we have to
+    //    * make an exception here.
+    //    *
+    //    * @see WidthBehavior on the Backend
+    //    * @see the Image.proto file
+    //    */
+    //   return {
+    //     width: containerWidth,
+    //   }
+    // }
 
-    if (width === 0) {
-      // An element with no width should be treated as if it has no width set
-      // This is likely from the proto, where the default value is 0
-      width = undefined
-    }
+    // let width =
+    //   useContainerWidth && isNonZeroPositiveNumber(containerWidth)
+    //     ? containerWidth
+    //     : commandWidth
 
-    if (width && width < 0) {
-      // If we have an invalid width, we should treat it as if it has no width set
-      width = undefined
-    }
+    // if (width === 0) {
+    //   // An element with no width should be treated as if it has no width set
+    //   // This is likely from the proto, where the default value is 0
+    //   width = undefined
+    // }
 
-    if (width !== undefined && isNaN(width)) {
-      // If we have an invalid width, we should treat it as if it has no width set
-      width = undefined
-    }
+    // if (width && width < 0) {
+    //   // If we have an invalid width, we should treat it as if it has no width set
+    //   width = undefined
+    // }
 
-    if (
-      width !== undefined &&
-      containerWidth !== undefined &&
-      typeof containerWidth === "number" &&
-      width > containerWidth
-    ) {
-      // If the width is greater than the container width, we should use the
-      // container width to prevent overflows
-      width = containerWidth
-    }
+    // if (width !== undefined && isNaN(width)) {
+    //   // If we have an invalid width, we should treat it as if it has no width set
+    //   width = undefined
+    // }
 
-    const widthWithFallback = width ?? "auto"
+    // if (
+    //   width !== undefined &&
+    //   containerWidth !== undefined &&
+    //   typeof containerWidth === "number" &&
+    //   width > containerWidth
+    // ) {
+    //   // If the width is greater than the container width, we should use the
+    //   // container width to prevent overflows
+    //   width = containerWidth
+    // }
 
-    return {
-      width: widthWithFallback,
-    }
+    // const widthWithFallback = width ?? "auto"
+
+    // return {
+    //   width: widthWithFallback,
+    // }
   }, [useContainerWidth, commandWidth, containerWidth, element])
 
   return layoutStyles

--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
@@ -40,7 +40,6 @@ describe("withCalculatedWidth", () => {
     vi.mocked(useResizeObserver).mockReturnValue({
       values: [mockWidth],
       elementRef: mockElementRef,
-      forceRecalculate: vi.fn(),
     })
 
     const EnhancedComponent = withCalculatedWidth(TestComponent)
@@ -55,7 +54,6 @@ describe("withCalculatedWidth", () => {
     vi.mocked(useResizeObserver).mockReturnValue({
       values: [0],
       elementRef: mockElementRef,
-      forceRecalculate: vi.fn(),
     })
 
     const EnhancedComponent = withCalculatedWidth(TestComponent)
@@ -68,7 +66,6 @@ describe("withCalculatedWidth", () => {
     vi.mocked(useResizeObserver).mockReturnValue({
       values: [300],
       elementRef: mockElementRef,
-      forceRecalculate: vi.fn(),
     })
 
     // Create a component that accepts additional props
@@ -93,7 +90,6 @@ describe("withCalculatedWidth", () => {
     vi.mocked(useResizeObserver).mockReturnValue({
       values: [300],
       elementRef: mockElementRef,
-      forceRecalculate: vi.fn(),
     })
 
     const EnhancedComponent = withCalculatedWidth(TestComponent)

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -70,7 +70,6 @@ describe("ArrowVegaLiteChart", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -61,7 +61,6 @@ describe("GraphVizChart Element", () => {
 
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -50,7 +50,6 @@ describe("ImageList Element", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -59,7 +59,6 @@ describe("Video Element", () => {
 
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
@@ -58,7 +58,6 @@ describe("withFullScreenWrapper HOC", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -80,7 +80,6 @@ describe("CameraInput widget", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -87,7 +87,6 @@ describe("ChatInput widget", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -83,7 +83,6 @@ describe("ComponentInstance", () => {
 
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })
@@ -397,7 +396,6 @@ describe("ComponentInstance", () => {
       let width = 100
       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
         elementRef: { current: null },
-        forceRecalculate: vitest.fn(),
         values: [width],
       })
 
@@ -437,7 +435,6 @@ describe("ComponentInstance", () => {
       // Update the spy to return the new width
       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
         elementRef: { current: null },
-        forceRecalculate: vitest.fn(),
         values: [width],
       })
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -65,7 +65,6 @@ describe("DataFrame widget", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -99,7 +99,6 @@ describe("FileUploader widget tests", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -70,7 +70,6 @@ describe("NumberInput widget", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })
@@ -621,7 +620,6 @@ describe("NumberInput widget", () => {
     it("hides stepUp and stepDown buttons when width is smaller than 120px", () => {
       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
         elementRef: { current: null },
-        forceRecalculate: vitest.fn(),
         values: [100],
       })
 
@@ -647,7 +645,6 @@ describe("NumberInput widget", () => {
     it("hides Please enter to apply text when width is smaller than 120px", async () => {
       vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
         elementRef: { current: null },
-        forceRecalculate: vitest.fn(),
         values: [100],
       })
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -76,7 +76,6 @@ describe("Slider widget", () => {
 
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [250],
     })
   })

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -229,7 +229,6 @@ describe("TextArea widget", () => {
     const props = getProps({}, {})
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [100],
     })
 
@@ -244,7 +243,6 @@ describe("TextArea widget", () => {
   it("shows Please enter to apply text when width is bigger than 180px", async () => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [190],
     })
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -53,7 +53,6 @@ describe("TextInput widget", () => {
   beforeEach(() => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [190],
     })
   })
@@ -457,7 +456,6 @@ describe("TextInput widget", () => {
   it("hides Please enter to apply text when width is smaller than 180px", async () => {
     vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
       elementRef: { current: null },
-      forceRecalculate: vitest.fn(),
       values: [100],
     })
     const user = userEvent.setup()

--- a/frontend/lib/src/hooks/useCalculatedWidth.test.ts
+++ b/frontend/lib/src/hooks/useCalculatedWidth.test.ts
@@ -39,7 +39,6 @@ describe("useCalculatedWidth", () => {
         () => ({
           values: [width],
           elementRef: { current: null },
-          forceRecalculate: vi.fn(),
         })
       )
 

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -88,11 +88,6 @@ describe("useResizeObserver", () => {
       result.current.elementRef.current = mockElement
     })
 
-    // Force recalculation
-    await act(async () => {
-      result.current.forceRecalculate()
-    })
-
     // Run any pending timers
     vi.runAllTimers()
 

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook } from "@testing-library/react"
+import { renderHook } from "@testing-library/react"
 
 import { DOMRectKeys, useResizeObserver } from "./useResizeObserver"
 

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -71,26 +71,4 @@ describe("useResizeObserver", () => {
 
     expect(mockObserve).toHaveBeenCalledWith(mockElement)
   })
-
-  it("should handle force recalculation", async () => {
-    const properties: DOMRectKeys[] = ["width", "height"]
-    const { result } = renderHook(() => useResizeObserver(properties))
-
-    // Simulate element reference
-    const mockElement = document.createElement("div")
-    vi.spyOn(mockElement, "getBoundingClientRect").mockReturnValue({
-      width: 100,
-      height: 200,
-    } as DOMRect)
-
-    // Set the ref and trigger initial calculation
-    act(() => {
-      result.current.elementRef.current = mockElement
-    })
-
-    // Run any pending timers
-    vi.runAllTimers()
-
-    expect(result.current.values).toEqual([100, 200])
-  })
 })

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -40,20 +40,16 @@ export type DOMRectKeys =
  * @returns {{
  *   values: number[],
  *   elementRef: MutableRefObject<T | null>,
- *   forceRecalculate: () => void
- *   }} An object containing the observed values, a ref to the observed element,
- *   and a function to force recalculation.
+ *   }} An object containing the observed values, a ref to the observed element.
  */
 export const useResizeObserver = <T extends HTMLDivElement>(
   properties: DOMRectKeys[]
 ): {
   values: number[]
   elementRef: MutableRefObject<T | null>
-  forceRecalculate: () => void
 } => {
   const elementRef = useRef<T | null>(null)
   const [values, setValues] = useState<number[]>([])
-
   /**
    * Gets the current values of the specified DOMRect properties.
    *
@@ -70,17 +66,6 @@ export const useResizeObserver = <T extends HTMLDivElement>(
       return rect[property]
     })
   }, [properties])
-
-  /**
-   * Forces a recalculation of the observed values.
-   *
-   * This is included for backwards compatibility after the addition of
-   * useResizeObserver but we anticipate all new cases should be implemented
-   * without this.
-   */
-  const forceRecalculate = useCallback(() => {
-    setValues(getValues())
-  }, [getValues])
 
   useEffect(() => {
     if (!elementRef.current) {
@@ -106,5 +91,5 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     }
   }, [properties, getValues])
 
-  return { values, elementRef, forceRecalculate }
+  return { values, elementRef }
 }

--- a/frontend/lib/src/hooks/useScrollToBottom.ts
+++ b/frontend/lib/src/hooks/useScrollToBottom.ts
@@ -72,7 +72,7 @@ export function useScrollToBottom<T extends HTMLElement>(): RefObject<T> {
   useEffect(() => {
     // Set isSticky to true to ensure first load scrolls to bottom
     setIsSticky(true)
-  }, [])
+  }, [setIsSticky])
 
   // Internal context
   const ignoreScrollEventBeforeRef = useRef(0)

--- a/frontend/lib/src/hooks/useScrollToBottom.ts
+++ b/frontend/lib/src/hooks/useScrollToBottom.ts
@@ -69,6 +69,11 @@ export function useScrollToBottom<T extends HTMLElement>(): RefObject<T> {
   const [isSticky, setIsSticky, isStickyRef] = useStateRef(false)
   const [isAnimating, setIsAnimating, isAnimatingRef] = useStateRef(true)
 
+  useEffect(() => {
+    // Set isSticky to true to ensure first load scrolls to bottom
+    setIsSticky(true)
+  }, [])
+
   // Internal context
   const ignoreScrollEventBeforeRef = useRef(0)
   const offsetHeightRef = useRef(0)


### PR DESCRIPTION
## Describe your changes

The purpose of this PR is to simplify some of the styling methods we have in place to make it easier to roll out the extended styling options that we are adding as part of Advanced Layouts. 

**Removing `resizeObserver` from `VerticalBlock`.** 

Based on my investigation, I believe we needed this code primarily because we used to prop-drill the container width to individual elements. A previous PR removed this prop-drilling. Most elements now use `width=100%` to expand to their container width. Some elements need an explicit pixel width, but they now get this via `useCalculatedWidth`. 

Containers (`ElementContainer` and `VerticalBlock`) will now also be set to `width=100%` when they should stretch to fill the container (`use_container_width=True`). If the user provides an explicit width, they will be set to that. `maxWidth=100%` is added to prevent container overflow. Image lists are a special case and the element container for that must always be `width=100%`. 

**Consolidating `VerticalBlockBorderWrapper` and `StyledVerticalBlockWrapper`.**

Now that we are not observing the width here, we can consolidate these two wrappers. A wrapper is still required for the scrolling behaviour which requires `display: block`. 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
