### PR TITLE
Clarify file creation instruction in Quickstart section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The app features a bunch of examples of what you can do with Streamlit. Jump to 
 
 ### A little example
 
-Create a new file `streamlit_app.py` with the following code:
+Create a new file named `streamlit_app.py` in your project directory with the following code:
 ```python
 import streamlit as st
 x = st.slider("Select a value")


### PR DESCRIPTION
## Describe your changes

Updated the "Quickstart" section in README.md to clarify where to create the file for beginners.
Changed "Create a new file streamlit_app.py with the following code:" to "Create a new file named `streamlit_app.py` in your project directory with the following code:".
No issue was created as this is a small documentation fix, per the Contributing Wiki (https://github.com/streamlit/streamlit/wiki/Contributing).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Explanation of why no additional tests are needed**: This is a documentation change in README.md, which does not affect the codebase or functionality of Streamlit. As per the Contributing Wiki, tests are not required for documentation updates.
- **Unit Tests (JS and/or Python)**: Not applicable.
- **E2E Tests**: Not applicable.
- **Any manual testing needed?** I previewed the updated README.md using VS Code’s Markdown Preview to confirm the change renders correctly and improves clarity for beginners.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.