### PR TITLE
Deexperimentalization of st.user

### DIFF
--- a/e2e_playwright/auth.py
+++ b/e2e_playwright/auth.py
@@ -22,6 +22,6 @@ if x:
     st.login("testprovider")
 
 
-if st.experimental_user.get("is_logged_in"):
-    st.markdown(f"YOU ARE LOGGED IN: {st.experimental_user.email}")
-    st.markdown(st.experimental_user["name"])
+if st.user.get("is_logged_in"):
+    st.markdown(f"YOU ARE LOGGED IN: {st.user.email}")
+    st.markdown(st.user["name"])

--- a/e2e_playwright/st_write_objects.py
+++ b/e2e_playwright/st_write_objects.py
@@ -42,7 +42,7 @@ st.write(["foo", "bar"])
 st.write({"foo": "bar"})
 
 st.write(st.session_state)
-st.write(st.experimental_user)
+st.write(st.user)
 st.write(st.query_params)
 
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -60,7 +60,6 @@ _os.environ["MPLBACKEND"] = "Agg"
 from streamlit import logger as _logger
 from streamlit import config as _config
 from streamlit.deprecation_util import deprecate_func_name as _deprecate_func_name
-from streamlit.deprecation_util import deprecate_obj_name as _deprecate_obj_name
 from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STRING
 
 # Give the package a version.
@@ -118,6 +117,7 @@ from streamlit.runtime.state import (
 )
 from streamlit.user_info import (
     UserInfoProxy as _UserInfoProxy,
+    DeprecatedUserInfoProxy as _DeprecatedUserInfoProxy,
     login as _login,
     logout as _logout,
 )
@@ -285,12 +285,7 @@ user = _UserInfoProxy()
 experimental_audio_input = _main.experimental_audio_input
 experimental_dialog = _experimental_dialog_decorator
 experimental_fragment = _experimental_fragment
-experimental_user = _deprecate_obj_name(
-    _UserInfoProxy(),
-    "experimental_user",
-    "user",
-    "2025-11-06",
-)
+experimental_user = _DeprecatedUserInfoProxy()
 
 _EXPERIMENTAL_QUERY_PARAMS_DEPRECATE_MSG = "Refer to our [docs page](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.query_params) for more information."
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -60,6 +60,7 @@ _os.environ["MPLBACKEND"] = "Agg"
 from streamlit import logger as _logger
 from streamlit import config as _config
 from streamlit.deprecation_util import deprecate_func_name as _deprecate_func_name
+from streamlit.deprecation_util import deprecate_obj_name as _deprecate_obj_name
 from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STRING
 
 # Give the package a version.
@@ -277,11 +278,19 @@ fragment = _fragment
 login = _login
 logout = _logout
 
+# User
+user = _UserInfoProxy()
+
 # Experimental APIs
 experimental_audio_input = _main.experimental_audio_input
 experimental_dialog = _experimental_dialog_decorator
 experimental_fragment = _experimental_fragment
-experimental_user = _UserInfoProxy()
+experimental_user = _deprecate_obj_name(
+    _UserInfoProxy(),
+    "experimental_user",
+    "user",
+    "2025-11-06",
+)
 
 _EXPERIMENTAL_QUERY_PARAMS_DEPRECATE_MSG = "Refer to our [docs page](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.query_params) for more information."
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -336,7 +336,6 @@ def _is_from_streamlit(obj: object) -> bool:
 
 def is_custom_dict(obj: object) -> TypeGuard[CustomDict]:
     """True if input looks like one of the Streamlit custom dictionaries."""
-
     return (
         isinstance(obj, Mapping)
         and _is_from_streamlit(obj)

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -29,6 +29,10 @@ from streamlit.auth_util import (
     is_authlib_installed,
     validate_auth_credentials,
 )
+from streamlit.deprecation_util import (
+    make_deprecated_name_warning,
+    show_deprecation_warning,
+)
 from streamlit.errors import StreamlitAPIException, StreamlitAuthError
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
@@ -516,3 +520,38 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
             A dictionary of the current user's information.
         """
         return _get_user_info()
+
+
+has_shown_experimental_user_warning = False
+
+
+def maybe_show_deprecated_user_warning() -> None:
+    """Show a deprecation warning for the experimental_user alias."""
+    global has_shown_experimental_user_warning  # noqa: PLW0603
+
+    if not has_shown_experimental_user_warning:
+        has_shown_experimental_user_warning = True
+        show_deprecation_warning(
+            make_deprecated_name_warning(
+                "experimental_user",
+                "user",
+                "2025-11-06",
+            )
+        )
+
+
+class DeprecatedUserInfoProxy(UserInfoProxy):
+    """
+    A deprecated alias for UserInfoProxy.
+
+    This class is deprecated and will be removed in a future version of
+    Streamlit.
+    """
+
+    def __getattribute__(self, name: str):
+        maybe_show_deprecated_user_warning()
+        return super().__getattribute__(name)
+
+    def __getitem__(self, key: str):
+        maybe_show_deprecated_user_warning()
+        return super().__getitem__(key)

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -55,14 +55,14 @@ def login(provider: str | None = None) -> None:
     the user authenticates their identity, they are redirected back to the
     home page of your app. Streamlit stores a cookie with the user's identity
     information in the user's browser . You can access the identity information
-    through |st.experimental_user|_. Call ``st.logout()`` to remove the cookie
+    through |st.user|_. Call ``st.logout()`` to remove the cookie
     and start a new session.
 
     You can use any OIDC provider, including Google, Microsoft, Okta, and more.
     You must configure the provider through secrets management. Although OIDC
     is an extension of OAuth 2.0, you can't use generic OAuth providers.
     Streamlit parses the user's identity token and surfaces its attributes in
-    ``st.experimental_user``. If the provider returns an access token, that
+    ``st.user``. If the provider returns an access token, that
     token is ignored. Therefore, this command will not allow your app to act on
     behalf of a user in a secure system.
 
@@ -491,10 +491,10 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
             raise AttributeError(f'st.experimental_user has no attribute "{key}".')
 
     def __setattr__(self, name: str, value: str | None) -> NoReturn:
-        raise StreamlitAPIException("st.experimental_user cannot be modified")
+        raise StreamlitAPIException("st.user cannot be modified")
 
     def __setitem__(self, name: str, value: str | None) -> NoReturn:
-        raise StreamlitAPIException("st.experimental_user cannot be modified")
+        raise StreamlitAPIException("st.user cannot be modified")
 
     def __iter__(self) -> Iterator[str]:
         return iter(_get_user_info())
@@ -507,7 +507,7 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
         Get user info as a dictionary.
 
         This method primarily exists for internal use and is not needed for
-        most cases. ``st.experimental_user`` returns an object that inherits from
+        most cases. ``st.user`` returns an object that inherits from
         ``dict`` by default.
 
         Returns

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -73,6 +73,7 @@ NON_ELEMENT_COMMANDS: set[str] = {
     "sidebar",
     "stop",
     "switch_page",
+    "user",
 }
 
 # Element commands that are exposed on the DeltaGenerator

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 import json
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from parameterized import parameterized
 
@@ -143,6 +143,18 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
             raise e
         finally:
             add_script_run_ctx(threading.current_thread(), orig_report_ctx)
+
+    @patch("streamlit.deprecation_util.show_deprecation_warning")
+    def test_deprecate_st_experimental_user(self, mock_show_warning: Mock):
+        """Test that we show deprecation warning."""
+        st.write(st.experimental_user)
+        expected_warning = (
+            "Please replace `st.experimental_user` with `st.user`.\n\n"
+            "`st.experimental_user` will be removed after 2025-11-06."
+        )
+
+        # We only show the warning a single time for a given object.
+        mock_show_warning.assert_called_once_with(expected_warning)
 
 
 @patch(

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 import json
 import threading
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -144,10 +144,12 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         finally:
             add_script_run_ctx(threading.current_thread(), orig_report_ctx)
 
-    @patch("streamlit.deprecation_util.show_deprecation_warning")
-    def test_deprecate_st_experimental_user(self, mock_show_warning: Mock):
-        """Test that we show deprecation warning."""
+    @patch("streamlit.user_info.show_deprecation_warning")
+    @patch("streamlit.user_info.has_shown_experimental_user_warning", False)
+    def test_deprecate_st_experimental_user(self, mock_show_warning: MagicMock):
+        """Test that we show deprecation warning only once."""
         st.write(st.experimental_user)
+
         expected_warning = (
             "Please replace `st.experimental_user` with `st.user`.\n\n"
             "`st.experimental_user` will be removed after 2025-11-06."
@@ -155,6 +157,10 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
 
         # We only show the warning a single time for a given object.
         mock_show_warning.assert_called_once_with(expected_warning)
+        mock_show_warning.reset_mock()
+
+        st.write(st.experimental_user)
+        mock_show_warning.assert_not_called()
 
 
 @patch(

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -60,59 +60,59 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
 
     def test_user_email_attr(self):
         """Test that `st.user.email` returns user info from ScriptRunContext"""
-        self.assertEqual(st.experimental_user.email, "test@example.com")
+        self.assertEqual(st.user.email, "test@example.com")
 
     def test_user_email_key(self):
-        self.assertEqual(st.experimental_user["email"], "test@example.com")
+        self.assertEqual(st.user["email"], "test@example.com")
 
     def test_user_non_existing_attr(self):
         """Test that an error is raised when called non existed attr."""
         with self.assertRaises(AttributeError):
-            st.write(st.experimental_user.attribute)
+            st.write(st.user.attribute)
 
     def test_user_non_existing_key(self):
         """Test that an error is raised when called non existed key."""
         with self.assertRaises(KeyError):
-            st.write(st.experimental_user["key"])
+            st.write(st.user["key"])
 
     def test_user_cannot_be_modified_existing_key(self):
         """
         Test that an error is raised when try to assign new value to existing key.
         """
         with self.assertRaises(StreamlitAPIException) as e:
-            st.experimental_user["email"] = "NEW_VALUE"
+            st.user["email"] = "NEW_VALUE"
 
-        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
+        self.assertEqual(str(e.exception), "st.user cannot be modified")
 
     def test_user_cannot_be_modified_new_key(self):
         """
         Test that an error is raised when try to assign new value to new key.
         """
         with self.assertRaises(StreamlitAPIException) as e:
-            st.experimental_user["foo"] = "bar"
+            st.user["foo"] = "bar"
 
-        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
+        self.assertEqual(str(e.exception), "st.user cannot be modified")
 
     def test_user_cannot_be_modified_existing_attr(self):
         """
         Test that an error is raised when try to assign new value to existing attr.
         """
         with self.assertRaises(StreamlitAPIException) as e:
-            st.experimental_user.email = "bar"
+            st.user.email = "bar"
 
-        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
+        self.assertEqual(str(e.exception), "st.user cannot be modified")
 
     def test_user_cannot_be_modified_new_attr(self):
         """
         Test that an error is raised when try to assign new value to new attr.
         """
         with self.assertRaises(StreamlitAPIException) as e:
-            st.experimental_user.foo = "bar"
+            st.user.foo = "bar"
 
-        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
+        self.assertEqual(str(e.exception), "st.user cannot be modified")
 
     def test_user_len(self):
-        self.assertEqual(len(st.experimental_user), 1)
+        self.assertEqual(len(st.user), 1)
 
     def test_st_user_reads_from_context_(self):
         """Test that st.user reads information from current ScriptRunContext
@@ -138,7 +138,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
                 ),
             )
 
-            self.assertEqual(st.experimental_user.email, "something@else.com")
+            self.assertEqual(st.user.email, "something@else.com")
         except Exception as e:
             raise e
         finally:


### PR DESCRIPTION
## Describe your changes

Deexperimentalize `st.experimental_user` -> `st.user`. 
The `experimental_user` will continue to be present in streamlit codebase until at least `2025-11-06`.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE!
- E2E Tests (Covered by existing tests)
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
