### PR TITLE
BugFix 11064: st.dataframe({}) shouldn't show errors

### DIFF
--- a/e2e_playwright/st_dataframe_input_data_test.py
+++ b/e2e_playwright/st_dataframe_input_data_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import expect_markdown
 from e2e_playwright.shared.data_mocks import SHARED_TEST_CASES
 from e2e_playwright.shared.dataframe_utils import (
@@ -70,9 +70,9 @@ def test_empty_dataframe_hover_no_error(app: Page):
 
         # Hover over the first row
         dataframe_element.hover(position={"x": first_cell_x, "y": first_row_y})
+        # Wait a moment for any potential tooltip to appear
+        app.wait_for_timeout(1000)
 
-        # Wait and verify no error tooltips appear
-        wait_until(
-            app,
-            lambda: not app.get_by_text("This error should never happen").is_visible(),
-        )
+        # verify no error tooltips appear
+        error_tooltip = app.get_by_text("This error should never happen", exact=False)
+        expect(error_tooltip).to_have_count(0, timeout=1000)

--- a/e2e_playwright/st_dataframe_input_data_test.py
+++ b/e2e_playwright/st_dataframe_input_data_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import expect_markdown
 from e2e_playwright.shared.data_mocks import SHARED_TEST_CASES
 from e2e_playwright.shared.dataframe_utils import (
@@ -74,5 +74,7 @@ def test_empty_dataframe_hover_no_error(app: Page):
         app.wait_for_timeout(1000)
 
         # verify no error tooltips appear
-        error_tooltip = app.get_by_text("This error should never happen", exact=False)
-        expect(error_tooltip).to_have_count(0, timeout=1000)
+        wait_until(
+            app,
+            lambda: not app.get_by_text("This error should never happen").is_visible(),
+        )

--- a/e2e_playwright/st_dataframe_input_data_test.py
+++ b/e2e_playwright/st_dataframe_input_data_test.py
@@ -14,9 +14,13 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import expect_markdown
 from e2e_playwright.shared.data_mocks import SHARED_TEST_CASES
+from e2e_playwright.shared.dataframe_utils import (
+    calc_middle_cell_position,
+    expect_canvas_to_be_stable,
+)
 
 
 def test_dataframe_input_format_rendering(
@@ -42,3 +46,33 @@ def test_dataframe_input_format_rendering(
         expect(dataframe_element).to_be_visible()
         app.wait_for_selector("[data-testid='stDataFrame']", state="attached")
         assert_snapshot(dataframe_element, name=f"st_dataframe-input_data_{index}")
+
+
+def test_empty_dataframe_hover_no_error(app: Page):
+    """Test that hovering over an empty dataframe doesn't show 'This error should never happen' text."""
+    # Test each empty dataframe variant (indices 0-8 in SHARED_TEST_CASES)
+    for index in range(9):
+        # Set the test case to an empty dataframe variant
+        number_input = app.get_by_test_id("stNumberInput").locator("input")
+        number_input.fill(str(index))
+        number_input.press("Enter")
+        wait_for_app_run(app, wait_delay=200)
+
+        # Ensure the dataframe is visible and stable
+        dataframe_element = app.get_by_test_id("stDataFrame")
+        expect(dataframe_element).to_be_visible()
+        expect_canvas_to_be_stable(dataframe_element)
+
+        # Calculate position for first row using the utility function
+        # First row is at row_pos=1 (row 0 is the header)
+        # First column is at col_pos=0
+        first_cell_x, first_row_y = calc_middle_cell_position(1, 0)
+
+        # Hover over the first row
+        dataframe_element.hover(position={"x": first_cell_x, "y": first_row_y})
+
+        # Wait and verify no error tooltips appear
+        wait_until(
+            app,
+            lambda: not app.get_by_text("This error should never happen").is_visible(),
+        )

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -539,20 +539,26 @@ function DataFrame({
       clearSelection
     )
 
-  const {
-    tooltip,
-    clearTooltip,
-    onItemHovered: handleTooltips,
-  } = useTooltips(
-    columns,
-    getCellContent,
+  const ignoredRowIndices = React.useMemo(() => {
     // If empty table, ignore row index 0 which is just a visual gimmick
     // If dynamic editing is enabled, we need to ignore the last row (trailing row)
     // because it would result in some undesired errors in the tooltips.
     // The index are 0-based -> therefore, numRows will point to the trailing row
     // (which is not part of the actual data).
-    isEmptyTable ? [0] : isDynamicAndEditable ? [numRows] : []
-  )
+    if (isEmptyTable) {
+      return [0]
+    }
+    if (isDynamicAndEditable) {
+      return [numRows]
+    }
+    return []
+  }, [isEmptyTable, isDynamicAndEditable, numRows])
+
+  const {
+    tooltip,
+    clearTooltip,
+    onItemHovered: handleTooltips,
+  } = useTooltips(columns, getCellContent, ignoredRowIndices)
 
   const { drawCell, customRenderers } = useCustomRenderer(columns)
   const { provideEditor } = useCustomEditors()

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -546,11 +546,12 @@ function DataFrame({
   } = useTooltips(
     columns,
     getCellContent,
+    // If empty table, ignore row index 0 which is just a visual gimmick
     // If dynamic editing is enabled, we need to ignore the last row (trailing row)
     // because it would result in some undesired errors in the tooltips.
     // The index are 0-based -> therefore, numRows will point to the trailing row
     // (which is not part of the actual data).
-    isDynamicAndEditable ? [numRows] : []
+    isEmptyTable ? [0] : isDynamicAndEditable ? [numRows] : []
   )
 
   const { drawCell, customRenderers } = useCustomRenderer(columns)

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
@@ -23,6 +23,7 @@ import {
   BaseColumn,
   getErrorCell,
 } from "~lib/components/widgets/DataFrame/columns"
+import { getEmptyCell } from "~lib/components/widgets/DataFrame/columns/utils"
 import EditingState from "~lib/components/widgets/DataFrame/EditingState"
 import { getStyledCell } from "~lib/dataframes/pandasStylerUtils"
 import { Quiver } from "~lib/dataframes/Quiver"
@@ -48,6 +49,12 @@ function useDataLoader(
 ): DataLoaderReturn {
   const getCellContent = React.useCallback(
     ([col, row]: readonly [number, number]): GridCell => {
+      // Special case for empty dataframes
+      if (numRows === 0) {
+        // Return an empty cell for empty dataframes
+        return getEmptyCell()
+      }
+
       if (col > columns.length - 1) {
         return getErrorCell(
           "Column index out of bounds",

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
@@ -49,12 +49,6 @@ function useDataLoader(
 ): DataLoaderReturn {
   const getCellContent = React.useCallback(
     ([col, row]: readonly [number, number]): GridCell => {
-      // Special case for empty dataframes
-      if (numRows === 0) {
-        // Return an empty cell for empty dataframes
-        return getEmptyCell()
-      }
-
       if (col > columns.length - 1) {
         return getErrorCell(
           "Column index out of bounds",

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
@@ -23,7 +23,6 @@ import {
   BaseColumn,
   getErrorCell,
 } from "~lib/components/widgets/DataFrame/columns"
-import { getEmptyCell } from "~lib/components/widgets/DataFrame/columns/utils"
 import EditingState from "~lib/components/widgets/DataFrame/EditingState"
 import { getStyledCell } from "~lib/dataframes/pandasStylerUtils"
 import { Quiver } from "~lib/dataframes/Quiver"


### PR DESCRIPTION
## Describe your changes
When an empty dataframe is constructed, the user sees an error message that says it should never happen. This PR makes an exception for the case where `numRows` is 0.

## GitHub Issue Link (if applicable)
closes #11064 

## Testing Plan

added e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this
project are made under the Apache 2.0 license.
