### PR TITLE
Preserve context_info fields on rerun triggered by `st.rerun`

### DIFF
--- a/e2e_playwright/st_context.py
+++ b/e2e_playwright/st_context.py
@@ -22,3 +22,8 @@ st.write(f"Timezone offset: {st.context.timezone_offset}")
 st.write(f"Locale primary language: {st.context.locale}")
 
 st.write(f"Full url: {st.context.url}")
+
+rerun_script = st.button("Trigger rerun")
+
+if rerun_script:
+    st.rerun()

--- a/e2e_playwright/st_context_test.py
+++ b/e2e_playwright/st_context_test.py
@@ -15,7 +15,10 @@
 import pytest
 from playwright.sync_api import Page
 
-from e2e_playwright.shared.app_utils import expect_prefixed_markdown
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    expect_prefixed_markdown,
+)
 
 
 @pytest.mark.browser_context_args(timezone_id="Europe/Berlin")
@@ -40,3 +43,16 @@ def test_url(app: Page, app_port):
     """Test that the URL is correctly set."""
     expected_url = f"http://localhost:{app_port}/"
     expect_prefixed_markdown(app, "Full url:", expected_url)
+
+
+@pytest.mark.browser_context_args(timezone_id="Europe/Paris")
+def test_rerun_preserves_context(app: Page):
+    """Test that the timezone is preserved after rerun."""
+    # Check the initial timezone
+    expect_prefixed_markdown(app, "Timezone name:", "Europe/Paris")
+
+    # Click the rerun button
+    click_button(app, "Trigger rerun")
+
+    # Check that the timezone is still correct after rerun
+    expect_prefixed_markdown(app, "Timezone name:", "Europe/Paris")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -149,6 +149,7 @@ def rerun(  # type: ignore[misc]
                 fragment_id_queue=_new_fragment_id_queue(ctx, scope),
                 is_fragment_scoped_rerun=scope == "fragment",
                 cached_message_hashes=cached_message_hashes,
+                context_info=ctx.context_info,
             )
         )
         # Force a yield point so the runner can do the rerun

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -74,6 +74,7 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_false(patched_get_script_run_ctx
             fragment_id_queue=[],
             is_fragment_scoped_rerun=False,
             cached_message_hashes=ctx.cached_message_hashes,
+            context_info=ctx.context_info,
         )
     )
 
@@ -96,6 +97,7 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_true(patched_get_script_run_ctx)
             fragment_id_queue=["some_fragment_ids"],
             is_fragment_scoped_rerun=True,
             cached_message_hashes=ctx.cached_message_hashes,
+            context_info=ctx.context_info,
         )
     )
 


### PR DESCRIPTION
## Describe your changes

Send `contex_info` fields to RerunData when script rerun triggered by `st.rerun` call.

## GitHub Issue Link (if applicable)
Fix #11111 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests DONE ✅ 
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
