### PR TITLE
[Fix] `st.camera_input` disabled button styling

### DIFF
--- a/e2e_playwright/st_camera_input_test.py
+++ b/e2e_playwright/st_camera_input_test.py
@@ -72,6 +72,8 @@ def test_shows_disabled_widget_correctly(
     assert_snapshot(disabled_camera_input, name="st_camera_input-disabled")
 
 
+# Webkit CI camera permission issue
+@pytest.mark.skip_browser("webkit")
 def test_take_photo_button_styling(app: Page):
     """Test that the Take Photo button is rendered properly when active/disabled."""
     camera_input_widgets = app.get_by_test_id("stCameraInput")

--- a/e2e_playwright/st_camera_input_test.py
+++ b/e2e_playwright/st_camera_input_test.py
@@ -72,6 +72,40 @@ def test_shows_disabled_widget_correctly(
     assert_snapshot(disabled_camera_input, name="st_camera_input-disabled")
 
 
+def test_take_photo_button_styling(app: Page):
+    """Test that the Take Photo button is rendered properly when active/disabled."""
+    camera_input_widgets = app.get_by_test_id("stCameraInput")
+    expect(camera_input_widgets).to_have_count(2)
+
+    # Active button styling
+    active_camera_input = camera_input_widgets.nth(0)
+    take_photo_button = active_camera_input.get_by_test_id("stCameraInputButton")
+
+    # Check that the button is enabled and has the correct cursor
+    expect(take_photo_button).to_be_enabled()
+    expect(take_photo_button).to_have_css("cursor", "pointer")
+
+    # Check that the button is styled correctly when hovered over
+    take_photo_button.hover()
+    expect(take_photo_button).to_have_css("color", "rgb(255, 75, 75)")
+    expect(take_photo_button).to_have_css("border-color", "rgb(255, 75, 75)")
+    expect(take_photo_button).to_have_css("background-color", "rgb(255, 255, 255)")
+
+    # Disabled button styling
+    disabled_camera_input = camera_input_widgets.nth(1)
+    take_photo_button = disabled_camera_input.get_by_test_id("stCameraInputButton")
+
+    # Check that the button is disabled and has the correct cursor
+    expect(take_photo_button).to_be_disabled()
+    expect(take_photo_button).to_have_css("cursor", "not-allowed")
+
+    # Check that the button is styled correctly when hovered over
+    take_photo_button.hover()
+    expect(take_photo_button).to_have_css("color", "rgba(49, 51, 63, 0.4)")
+    expect(take_photo_button).to_have_css("border-color", "rgba(49, 51, 63, 0.2)")
+    expect(take_photo_button).to_have_css("background-color", "rgb(255, 255, 255)")
+
+
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stCameraInput")

--- a/e2e_playwright/test_assets/hostframe.html
+++ b/e2e_playwright/test_assets/hostframe.html
@@ -40,7 +40,7 @@ Usage:
 
 <script>
   window.addEventListener("message", (event) => {
-    console.log("Received message event:", event.data.type);
+    console.log("Received message event:", event);
   });
 
   function sendMessage(data) {

--- a/e2e_playwright/test_assets/hostframe.html
+++ b/e2e_playwright/test_assets/hostframe.html
@@ -40,7 +40,7 @@ Usage:
 
 <script>
   window.addEventListener("message", (event) => {
-    console.log("Received message event:", event);
+    console.log("Received message event:", event.data.type);
   });
 
   function sendMessage(data) {

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.test.tsx
@@ -48,4 +48,14 @@ describe("Testing Camera Input Button", () => {
     const progress = screen.getByRole("progressbar")
     expect(progress).toHaveAttribute("aria-valuenow", "50")
   })
+
+  it("renders disabled button properly", () => {
+    const props = getProps({ disabled: true })
+
+    render(<CameraInputButton {...props} />)
+
+    const button = screen.getByTestId("stCameraInputButton")
+    expect(button).toBeDisabled()
+    expect(button).toHaveStyle("cursor: not-allowed")
+  })
 })

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -155,6 +155,9 @@ export const StyledCameraInputBaseButton =
     },
     "&:disabled, &:disabled:hover, &:disabled:active": {
       color: theme.colors.fadedText40,
+      borderColor: theme.colors.borderColor,
+      backgroundColor: theme.colors.lightenedBg05,
+      cursor: "not-allowed",
     },
     fontWeight: theme.fontWeights.normal,
     padding: `${theme.spacing.xs} ${theme.spacing.md}`,


### PR DESCRIPTION
## Describe your changes
- Fix hover styling for disabled `Take Photo` button - should not change border color for disabled button like below, only if active
<img width="450" alt="Screenshot 2025-04-16 at 1 37 24 p m" src="https://github.com/user-attachments/assets/15a28708-8503-44ef-9eb5-108bfc7a62d3" />

- Fix click styling for disabled `Take Photo` button - should not change background color for disabled button, and should use not-allowed cursor like other buttons
<img width="450" alt="Screenshot 2025-04-16 at 1 36 28 p m" src="https://github.com/user-attachments/assets/e3b01bc4-025d-4c3c-95c7-8b4b565fe759" />

## Testing Plan
- JS Unit Tests: ✅ Added
- E2E Tests: ✅  Added
- Manual Testing: ✅ 
