### PR TITLE
Update workflows to support packageManager in package.json

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -14,8 +14,6 @@ runs:
     - name: Enable and Prepare Latest Yarn
       run: |
         corepack enable
-        cd frontend
-        corepack install
       shell: bash
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -14,7 +14,8 @@ runs:
     - name: Enable and Prepare Latest Yarn
       run: |
         corepack enable
-        corepack prepare yarn@4.5.3 --activate
+        cd frontend
+        corepack install
       shell: bash
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -12,8 +12,7 @@ runs:
   using: composite
   steps:
     - name: Enable and Prepare Latest Yarn
-      run: |
-        corepack enable
+      run: corepack enable
       shell: bash
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          cd frontend
+          corepack install
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          cd frontend
-          corepack install
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: "recursive"
           fetch-depth: 2
 
-      - name: Enable and Prepare Latest Yarn
+      - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -19,8 +19,7 @@ jobs:
           fetch-depth: 2
 
       - name: Enable and Prepare Latest Yarn
-        run: |
-          corepack enable
+        run: corepack enable
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/enforce-pre-commit.yml
+++ b/.github/workflows/enforce-pre-commit.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          cd frontend
+          corepack install
         shell: bash
       - name: Install prettier
         run: cd frontend && yarn install

--- a/.github/workflows/enforce-pre-commit.yml
+++ b/.github/workflows/enforce-pre-commit.yml
@@ -54,8 +54,6 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          cd frontend
-          corepack install
         shell: bash
       - name: Install prettier
         run: cd frontend && yarn install

--- a/.github/workflows/enforce-pre-commit.yml
+++ b/.github/workflows/enforce-pre-commit.yml
@@ -51,7 +51,7 @@ jobs:
           pip install pre-commit
           pre-commit install-hooks
         shell: bash
-      - name: Enable and Prepare Latest Yarn
+      - name: Enable Corepack
         run: corepack enable
         shell: bash
       - name: Install prettier

--- a/.github/workflows/enforce-pre-commit.yml
+++ b/.github/workflows/enforce-pre-commit.yml
@@ -52,8 +52,7 @@ jobs:
           pre-commit install-hooks
         shell: bash
       - name: Enable and Prepare Latest Yarn
-        run: |
-          corepack enable
+        run: corepack enable
         shell: bash
       - name: Install prettier
         run: cd frontend && yarn install

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          cd frontend
+          corepack install
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
           submodules: "recursive"
           fetch-depth: 2
-      - name: Enable and Prepare Latest Yarn
+      - name: Enable Corepack
         run: corepack enable
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -102,8 +102,6 @@ jobs:
       - name: Enable and Prepare Latest Yarn
         run: |
           corepack enable
-          cd frontend
-          corepack install
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -100,8 +100,7 @@ jobs:
           submodules: "recursive"
           fetch-depth: 2
       - name: Enable and Prepare Latest Yarn
-        run: |
-          corepack enable
+        run: corepack enable
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Describe your changes

When I originally did the conversion to yarn, I thought the version of yarn needed to be specified in CI. I now realize that all that is necessary is to enable corepack and then the yarn version specified in packageManager should be downloaded.

## Testing Plan

- Tests should just pass with the correct yarn version

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
