### PR TITLE
Introduce stableRandomMachineId to metrics by resurrecting old machine_id_v2 code

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -237,6 +237,7 @@ const NEW_SESSION_JSON: INewSession = {
     userInfo: {
       installationId: "installationId",
       installationIdV3: "installationIdV3",
+      stableRandomId: "mockStableRandomId",
     },
     environmentInfo: {
       streamlitVersion: "streamlitVersion",
@@ -1305,6 +1306,7 @@ describe("App", () => {
         userInfo: {
           installationId: "installationId",
           installationIdV3: "installationIdV3",
+          stableRandomId: "mockStableRandomId",
         },
         environmentInfo: {
           streamlitVersion: "streamlitVersion",

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -237,7 +237,7 @@ const NEW_SESSION_JSON: INewSession = {
     userInfo: {
       installationId: "installationId",
       installationIdV3: "installationIdV3",
-      stableRandomId: "mockStableRandomId",
+      stableRandomMachineId: "mockStableRandomMachineId",
     },
     environmentInfo: {
       streamlitVersion: "streamlitVersion",
@@ -1306,7 +1306,7 @@ describe("App", () => {
         userInfo: {
           installationId: "installationId",
           installationIdV3: "installationIdV3",
-          stableRandomId: "mockStableRandomId",
+          stableRandomMachineId: "mockStableRandomMachineId",
         },
         environmentInfo: {
           streamlitVersion: "streamlitVersion",

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -66,6 +66,7 @@ const DEFAULT_EVENT_DATA = {
   streamlitVersion: "mockStreamlitVersion",
   isHello: false,
   machineIdV3: "mockInstallationIdV3",
+  stableRandomId: "mockStableRandomId",
   contextPageUrl: window.location.href,
   contextPageTitle: document.title,
   contextPagePath: window.location.pathname,
@@ -98,6 +99,7 @@ const checkDefaultEventData = (
   )
   expect(generatedProto.isHello).toEqual(expectedData.isHello)
   expect(generatedProto.machineIdV3).toEqual(expectedData.machineIdV3)
+  expect(generatedProto.stableRandomId).toEqual(expectedData.stableRandomId)
   // Context Data Fields
   expect(generatedProto.contextPageUrl).toEqual(expectedData.contextPageUrl)
   expect(generatedProto.contextPageTitle).toEqual(
@@ -408,4 +410,5 @@ test("tracks installation data", () => {
 
   const trackCall = mm.track.mock.calls[0][0]
   expect(trackCall.machineIdV3).toEqual(sessionInfo.current.installationIdV3)
+  expect(trackCall.stableRandomId).toEqual(sessionInfo.current.stableRandomId)
 })

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -66,7 +66,7 @@ const DEFAULT_EVENT_DATA = {
   streamlitVersion: "mockStreamlitVersion",
   isHello: false,
   machineIdV3: "mockInstallationIdV3",
-  stableRandomId: "mockStableRandomId",
+  stableRandomMachineId: "mockStableRandomMachineId",
   contextPageUrl: window.location.href,
   contextPageTitle: document.title,
   contextPagePath: window.location.pathname,
@@ -99,7 +99,9 @@ const checkDefaultEventData = (
   )
   expect(generatedProto.isHello).toEqual(expectedData.isHello)
   expect(generatedProto.machineIdV3).toEqual(expectedData.machineIdV3)
-  expect(generatedProto.stableRandomId).toEqual(expectedData.stableRandomId)
+  expect(generatedProto.stableRandomMachineId).toEqual(
+    expectedData.stableRandomMachineId
+  )
   // Context Data Fields
   expect(generatedProto.contextPageUrl).toEqual(expectedData.contextPageUrl)
   expect(generatedProto.contextPageTitle).toEqual(
@@ -410,5 +412,7 @@ test("tracks installation data", () => {
 
   const trackCall = mm.track.mock.calls[0][0]
   expect(trackCall.machineIdV3).toEqual(sessionInfo.current.installationIdV3)
-  expect(trackCall.stableRandomId).toEqual(sessionInfo.current.stableRandomId)
+  expect(trackCall.stableRandomMachineId).toEqual(
+    sessionInfo.current.stableRandomMachineId
+  )
 })

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -260,7 +260,7 @@ export class MetricsManager {
   private getInstallationData(): Partial<IMetricsEvent> {
     return {
       machineIdV3: this.sessionInfo.current.installationIdV3,
-      stableRandomId: this.sessionInfo.current.stableRandomId,
+      stableRandomMachineId: this.sessionInfo.current.stableRandomMachineId,
     }
   }
 

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -260,6 +260,7 @@ export class MetricsManager {
   private getInstallationData(): Partial<IMetricsEvent> {
     return {
       machineIdV3: this.sessionInfo.current.installationIdV3,
+      stableRandomId: this.sessionInfo.current.stableRandomId,
     }
   }
 

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -162,7 +162,7 @@ class StreamlitLibExample extends PureComponent<Props, State> {
       pythonVersion: "",
       installationId: "",
       installationIdV3: "",
-      stableRandomId: "",
+      stableRandomMachineId: "",
       commandLine: "",
       isHello: false,
       isConnected: true,

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -162,6 +162,7 @@ class StreamlitLibExample extends PureComponent<Props, State> {
       pythonVersion: "",
       installationId: "",
       installationIdV3: "",
+      stableRandomId: "",
       commandLine: "",
       isHello: false,
       isConnected: true,

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -51,7 +51,7 @@ function generateNewSession(changes = {}): NewSession {
       userInfo: {
         installationId: "installationId",
         installationIdV3: "installationIdV3",
-        stableRandomId: "mockStableRandomId",
+        stableRandomMachineId: "mockStableRandomMachineId",
       },
       environmentInfo: {
         streamlitVersion: "streamlitVersion",

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -51,6 +51,7 @@ function generateNewSession(changes = {}): NewSession {
       userInfo: {
         installationId: "installationId",
         installationIdV3: "installationIdV3",
+        stableRandomId: "mockStableRandomId",
       },
       environmentInfo: {
         streamlitVersion: "streamlitVersion",

--- a/frontend/lib/src/SessionInfo.test.ts
+++ b/frontend/lib/src/SessionInfo.test.ts
@@ -71,6 +71,7 @@ test("Props can be initialized from a protobuf", () => {
       userInfo: {
         installationId: "installationId",
         installationIdV3: "installationIdV3",
+        stableRandomId: "mockStableRandomId",
       },
       environmentInfo: {
         streamlitVersion: "streamlitVersion",
@@ -91,6 +92,7 @@ test("Props can be initialized from a protobuf", () => {
   expect(props.pythonVersion).toEqual("pythonVersion")
   expect(props.installationId).toEqual("installationId")
   expect(props.installationIdV3).toEqual("installationIdV3")
+  expect(props.stableRandomId).toEqual("mockStableRandomId")
   expect(props.maxCachedMessageAge).toEqual(31)
   expect(props.commandLine).toBeUndefined()
   expect(props.isHello).toBeFalsy()

--- a/frontend/lib/src/SessionInfo.test.ts
+++ b/frontend/lib/src/SessionInfo.test.ts
@@ -71,7 +71,7 @@ test("Props can be initialized from a protobuf", () => {
       userInfo: {
         installationId: "installationId",
         installationIdV3: "installationIdV3",
-        stableRandomId: "mockStableRandomId",
+        stableRandomMachineId: "mockStableRandomMachineId",
       },
       environmentInfo: {
         streamlitVersion: "streamlitVersion",
@@ -92,7 +92,7 @@ test("Props can be initialized from a protobuf", () => {
   expect(props.pythonVersion).toEqual("pythonVersion")
   expect(props.installationId).toEqual("installationId")
   expect(props.installationIdV3).toEqual("installationIdV3")
-  expect(props.stableRandomId).toEqual("mockStableRandomId")
+  expect(props.stableRandomMachineId).toEqual("mockStableRandomMachineId")
   expect(props.maxCachedMessageAge).toEqual(31)
   expect(props.commandLine).toBeUndefined()
   expect(props.isHello).toBeFalsy()

--- a/frontend/lib/src/SessionInfo.ts
+++ b/frontend/lib/src/SessionInfo.ts
@@ -34,6 +34,7 @@ export interface Props {
   readonly pythonVersion: string
   readonly installationId: string
   readonly installationIdV3: string
+  readonly stableRandomId: string
   readonly maxCachedMessageAge: number
   readonly commandLine?: string // Unused, but kept around for compatibility
   readonly isHello: boolean
@@ -107,6 +108,7 @@ export class SessionInfo {
       pythonVersion: environmentInfo.pythonVersion,
       installationId: userInfo.installationId,
       installationIdV3: userInfo.installationIdV3,
+      stableRandomId: userInfo.stableRandomId,
       maxCachedMessageAge: config.maxCachedMessageAge,
       isHello: initialize.isHello,
       // We assume we are always connected because the message came directly from the server.

--- a/frontend/lib/src/SessionInfo.ts
+++ b/frontend/lib/src/SessionInfo.ts
@@ -34,7 +34,7 @@ export interface Props {
   readonly pythonVersion: string
   readonly installationId: string
   readonly installationIdV3: string
-  readonly stableRandomId: string
+  readonly stableRandomMachineId: string
   readonly maxCachedMessageAge: number
   readonly commandLine?: string // Unused, but kept around for compatibility
   readonly isHello: boolean
@@ -108,7 +108,7 @@ export class SessionInfo {
       pythonVersion: environmentInfo.pythonVersion,
       installationId: userInfo.installationId,
       installationIdV3: userInfo.installationIdV3,
-      stableRandomId: userInfo.stableRandomId,
+      stableRandomMachineId: userInfo.stableRandomMachineId,
       maxCachedMessageAge: config.maxCachedMessageAge,
       isHello: initialize.isHello,
       // We assume we are always connected because the message came directly from the server.

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -30,7 +30,7 @@ export function mockSessionInfoProps(
     pythonVersion: "mockPythonVersion",
     installationId: "mockInstallationId",
     installationIdV3: "mockInstallationIdV3",
-    stableRandomId: "mockStableRandomId",
+    stableRandomMachineId: "mockStableRandomMachineId",
     maxCachedMessageAge: 123,
     isHello: false,
     isConnected: true,

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -30,6 +30,7 @@ export function mockSessionInfoProps(
     pythonVersion: "mockPythonVersion",
     installationId: "mockInstallationId",
     installationIdV3: "mockInstallationIdV3",
+    stableRandomId: "mockStableRandomId",
     maxCachedMessageAge: 123,
     isHello: false,
     isConnected: true,

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -985,4 +985,4 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
     inst = Installation.instance()
     msg.installation_id = inst.installation_id
     msg.installation_id_v3 = inst.installation_id_v3
-    msg.stable_random_id = inst.stable_random_id
+    msg.stable_random_machine_id = inst.stable_random_machine_id

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -608,11 +608,11 @@ class AppSession:
 
             self._clear_queue(fragment_ids_this_run)
 
-            self._enqueue_forward_msg(
-                self._create_new_session_message(
-                    page_script_hash, fragment_ids_this_run, pages
-                )
+            msg = self._create_new_session_message(
+                page_script_hash, fragment_ids_this_run, pages
             )
+
+            self._enqueue_forward_msg(msg)
 
         elif (
             event == ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
@@ -982,5 +982,7 @@ def _populate_theme_msg(msg: CustomThemeConfig, section: str = "theme") -> None:
 
 
 def _populate_user_info_msg(msg: UserInfo) -> None:
-    msg.installation_id = Installation.instance().installation_id
-    msg.installation_id_v3 = Installation.instance().installation_id_v3
+    inst = Installation.instance()
+    msg.installation_id = inst.installation_id
+    msg.installation_id_v3 = inst.installation_id_v3
+    msg.stable_random_id = inst.stable_random_id

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -182,7 +182,7 @@ def _get_machine_id_v3() -> str:
     return machine_id
 
 
-def _get_stable_random_id() -> str:
+def _get_stable_random_machine_id() -> str:
     """Get a random ID that is stable for each machine, generating if needed.
 
     This is a unique identifier for a user for tracking metrics.
@@ -190,14 +190,14 @@ def _get_stable_random_id() -> str:
     generate a UUID and store it in the ~/.streamlit hidden folder.
     """
     # If gatherUsageStats is False skip this whole code.
-    # This is just for people who don't want the extra stable_random_id file
+    # This is just for people who don't want the extra stable_random_machine_id file
     # in their file system.
     if not config.get_option("browser.gatherUsageStats"):
         # This value will never be sent to our telemetry. Just including it here
         # to help debug.
         return "no-stable-random-id"
 
-    filepath = file_util.get_streamlit_file_path("stable_random_id")
+    filepath = file_util.get_streamlit_file_path("stable_random_machine_id")
     stable_id = None
 
     if os.path.exists(filepath):
@@ -233,7 +233,7 @@ class Installation:
             uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v3())
         )
 
-        self.stable_random_id = _get_stable_random_id()
+        self.stable_random_machine_id = _get_stable_random_machine_id()
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -25,7 +25,7 @@ from collections.abc import Sized
 from functools import wraps
 from typing import Any, Callable, Final, TypeVar, cast, overload
 
-from streamlit import config, util
+from streamlit import config, file_util, util
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.PageProfile_pb2 import Argument, Command
@@ -168,7 +168,6 @@ def _get_machine_id_v3() -> str:
     - at times a hash of the same string, when running in a Docker container
     """
 
-    machine_id = str(uuid.getnode())
     if os.path.isfile(_ETC_MACHINE_ID_PATH):
         with open(_ETC_MACHINE_ID_PATH) as f:
             machine_id = f.read()
@@ -177,7 +176,32 @@ def _get_machine_id_v3() -> str:
         with open(_DBUS_MACHINE_ID_PATH) as f:
             machine_id = f.read()
 
+    else:
+        machine_id = str(uuid.getnode())
+
     return machine_id
+
+
+def _get_stable_random_id() -> str:
+    """Get a random ID that is stable for each machine, generating if needed.
+
+    This is a unique identifier for a user for tracking metrics.
+    Instead of relying on a hardware address in the container or host we'll
+    generate a UUID and store it in the ~/.streamlit hidden folder.
+    """
+    filepath = file_util.get_streamlit_file_path(".stable_random_id")
+    stable_id = None
+
+    if os.path.exists(filepath):
+        with file_util.streamlit_read(filepath) as input:
+            stable_id = input.read()
+
+    if not stable_id:
+        stable_id = str(uuid.uuid4())
+        with file_util.streamlit_write(filepath) as output:
+            output.write(stable_id)
+
+    return stable_id
 
 
 class Installation:
@@ -200,6 +224,8 @@ class Installation:
         self.installation_id_v3 = str(
             uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v3())
         )
+
+        self.stable_random_id = _get_stable_random_id()
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -195,7 +195,7 @@ def _get_stable_random_machine_id() -> str:
     if not config.get_option("browser.gatherUsageStats"):
         # This value will never be sent to our telemetry. Just including it here
         # to help debug.
-        return "no-stable-random-id"
+        return "no-stable-random-machine-id"
 
     filepath = file_util.get_streamlit_file_path("stable_random_machine_id")
     stable_id = None

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -189,7 +189,15 @@ def _get_stable_random_id() -> str:
     Instead of relying on a hardware address in the container or host we'll
     generate a UUID and store it in the ~/.streamlit hidden folder.
     """
-    filepath = file_util.get_streamlit_file_path(".stable_random_id")
+    # If gatherUsageStats is False skip this whole code.
+    # This is just for people who don't want the extra stable_random_id file
+    # in their file system.
+    if not config.get_option("browser.gatherUsageStats"):
+        # This value will never be sent to our telemetry. Just including it here
+        # to help debug.
+        return "no-stable-random-id"
+
+    filepath = file_util.get_streamlit_file_path("stable_random_id")
     stable_id = None
 
     if os.path.exists(filepath):

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -146,6 +146,7 @@ FD = FieldDescriptor
             {
                 ("installation_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
                 ("installation_id_v3", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("stable_random_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
             },
         ),
         (

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -146,7 +146,7 @@ FD = FieldDescriptor
             {
                 ("installation_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
                 ("installation_id_v3", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
-                ("stable_random_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("stable_random_machine_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
             },
         ),
         (

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -30,6 +30,7 @@ from streamlit.connections import SnowparkConnection, SQLConnection
 from streamlit.runtime import metrics_util
 from streamlit.runtime.caching import cache_data_api, cache_resource_api
 from streamlit.runtime.scriptrunner import get_script_run_ctx, magic_funcs
+from streamlit.testing.v1.util import patch_config_options
 from streamlit.web.server import websocket_headers
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -107,6 +108,7 @@ class MetricsUtilTest(unittest.TestCase):
             patch("streamlit.runtime.metrics_util.uuid.uuid4", return_value=UUID),
             patch("streamlit.file_util.open", mock_open()) as open,
             patch("streamlit.file_util.os.makedirs"),
+            patch_config_options({"browser.gatherUsageStats": True}),
         ):
             machine_id = metrics_util._get_stable_random_id()
             open().write.assert_called_once_with(UUID)
@@ -122,6 +124,7 @@ class MetricsUtilTest(unittest.TestCase):
         with (
             patch("streamlit.runtime.metrics_util.os.path.exists", return_value=True),
             patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open,
+            patch_config_options({"browser.gatherUsageStats": True}),
         ):
             machine_id = metrics_util._get_stable_random_id()
             open().read.assert_called_once()
@@ -139,6 +142,7 @@ class MetricsUtilTest(unittest.TestCase):
             patch("streamlit.runtime.metrics_util.uuid.uuid4", return_value=UUID),
             patch("streamlit.file_util.open", mock_open(read_data="")) as open,
             patch("streamlit.file_util.os.makedirs"),
+            patch_config_options({"browser.gatherUsageStats": True}),
         ):
             machine_id = metrics_util._get_stable_random_id()
             open().read.assert_called_once()

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -110,7 +110,7 @@ class MetricsUtilTest(unittest.TestCase):
             patch("streamlit.file_util.os.makedirs"),
             patch_config_options({"browser.gatherUsageStats": True}),
         ):
-            machine_id = metrics_util._get_stable_random_id()
+            machine_id = metrics_util._get_stable_random_machine_id()
             open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)
 
@@ -126,7 +126,7 @@ class MetricsUtilTest(unittest.TestCase):
             patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open,
             patch_config_options({"browser.gatherUsageStats": True}),
         ):
-            machine_id = metrics_util._get_stable_random_id()
+            machine_id = metrics_util._get_stable_random_machine_id()
             open().read.assert_called_once()
         self.assertEqual(machine_id, UUID)
 
@@ -144,7 +144,7 @@ class MetricsUtilTest(unittest.TestCase):
             patch("streamlit.file_util.os.makedirs"),
             patch_config_options({"browser.gatherUsageStats": True}),
         ):
-            machine_id = metrics_util._get_stable_random_id()
+            machine_id = metrics_util._get_stable_random_machine_id()
             open().read.assert_called_once()
             open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -95,6 +95,56 @@ class MetricsUtilTest(unittest.TestCase):
             machine_id = metrics_util._get_machine_id_v3()
         assert machine_id == MAC
 
+    @patch(
+        "streamlit.runtime.metrics_util.file_util.get_streamlit_file_path",
+        mock_get_path,
+    )
+    def test_stable_id_not_exists(self):
+        """Test creating a stable id"""
+
+        with (
+            patch("streamlit.runtime.metrics_util.os.path.exists", return_value=False),
+            patch("streamlit.runtime.metrics_util.uuid.uuid4", return_value=UUID),
+            patch("streamlit.file_util.open", mock_open()) as open,
+            patch("streamlit.file_util.os.makedirs"),
+        ):
+            machine_id = metrics_util._get_stable_random_id()
+            open().write.assert_called_once_with(UUID)
+        self.assertEqual(machine_id, UUID)
+
+    @patch(
+        "streamlit.runtime.metrics_util.file_util.get_streamlit_file_path",
+        mock_get_path,
+    )
+    def test_stable_id_exists_and_valid(self):
+        """Test getting a stable valid id"""
+
+        with (
+            patch("streamlit.runtime.metrics_util.os.path.exists", return_value=True),
+            patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open,
+        ):
+            machine_id = metrics_util._get_stable_random_id()
+            open().read.assert_called_once()
+        self.assertEqual(machine_id, UUID)
+
+    @patch(
+        "streamlit.runtime.metrics_util.file_util.get_streamlit_file_path",
+        mock_get_path,
+    )
+    def test_stable_id_exists_and_invalid(self):
+        """Test getting a stable invalid id"""
+
+        with (
+            patch("streamlit.runtime.metrics_util.os.path.exists", return_value=True),
+            patch("streamlit.runtime.metrics_util.uuid.uuid4", return_value=UUID),
+            patch("streamlit.file_util.open", mock_open(read_data="")) as open,
+            patch("streamlit.file_util.os.makedirs"),
+        ):
+            machine_id = metrics_util._get_stable_random_id()
+            open().read.assert_called_once()
+            open().write.assert_called_once_with(UUID)
+        self.assertEqual(machine_id, UUID)
+
 
 class PageTelemetryTest(DeltaGeneratorTestCase):
     def setUp(self):

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -28,7 +28,7 @@ message MetricsEvent {
   string event = 1;
   string anonymous_id = 2;
   string machine_id_v3 = 3;
-  string stable_random_id = 41;
+  string stable_random_machine_id = 41;
   string report_hash = 4;
   bool dev = 5;
   string source = 6;

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -28,6 +28,7 @@ message MetricsEvent {
   string event = 1;
   string anonymous_id = 2;
   string machine_id_v3 = 3;
+  string stable_random_id = 41;
   string report_hash = 4;
   bool dev = 5;
   string source = 6;
@@ -79,7 +80,7 @@ message MetricsEvent {
   int64 total_load_time = 39;
   BrowserInfo browser_info = 40;
 
-  // Next ID: 41
+  // Next ID: 42
 }
 
 message BrowserInfo {

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -204,7 +204,7 @@ message FontSizes {
 message UserInfo {
   string installation_id = 1;
   string installation_id_v3 = 5;
-  string stable_random_id = 6;
+  string stable_random_machine_id = 6;
 
   // DEPRECATED:
   // string email = 2;

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -204,10 +204,13 @@ message FontSizes {
 message UserInfo {
   string installation_id = 1;
   string installation_id_v3 = 5;
+  string stable_random_id = 6;
 
   // DEPRECATED:
   // string email = 2;
   reserved 2;
+
+  // Next 7
 }
 
 // Data that identifies the Streamlit app's environment.


### PR DESCRIPTION
Introduce `stableRandomMachineId` to our metrics by resurrecting old `machine_id_v2` code. The goal is to keep both stableRandomId and machineIdVx going forward, to help debug when issues arise.

The logic behind `stableRandomMachineId` is the following:
1. If `~/.streamlit/stable_random_machine_id` exists, use the contents of that file as the `stableRandomMachineId`. 
2. Otherwise, generate `stableRandomMachineId` and store into `~/.streamlit/stable_random_machine_id`. 

And, of course, telemetry is only sent if gatherUsageStats = true. 

## GitHub Issue Link (if applicable)

n/a

## Testing Plan

- ~~Explanation of why no additional tests are needed~~
- ✅  Unit Tests (JS and/or Python)
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
