### PR TITLE
Refactor `AppContext` values

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -33,6 +33,9 @@ import {
   getHostSpecifiedTheme,
   HOST_COMM_VERSION,
   HostCommunicationManager,
+  isColoredLineDisplayed,
+  isEmbed,
+  isToolbarDisplayed,
   lightTheme,
   LocalStore,
   mockSessionInfoProps,
@@ -83,6 +86,16 @@ import { App, LOG, Props } from "./App"
 vi.mock("~lib/baseconsts", async () => {
   return {
     ...(await vi.importActual("~lib/baseconsts")),
+  }
+})
+
+vi.mock("@streamlit/lib", async () => {
+  const actualLib = await vi.importActual("@streamlit/lib")
+  return {
+    ...actualLib,
+    isEmbed: vi.fn(),
+    isToolbarDisplayed: vi.fn(),
+    isColoredLineDisplayed: vi.fn(),
   }
 })
 
@@ -603,23 +616,6 @@ describe("App", () => {
 
       expect(window.location.reload).not.toHaveBeenCalled()
     })
-  })
-
-  it("hides the top bar if hideTopBar === true", () => {
-    renderApp(getProps())
-    // hideTopBar is true by default
-
-    expect(screen.queryByTestId("stStatusWidget")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("stToolbarActions")).not.toBeInTheDocument()
-  })
-
-  it("shows the top bar if hideTopBar === false", () => {
-    renderApp(getProps())
-
-    sendForwardMessage("newSession", NEW_SESSION_JSON)
-
-    expect(screen.getByTestId("stStatusWidget")).toBeInTheDocument()
-    expect(screen.getByTestId("stToolbarActions")).toBeInTheDocument()
   })
 
   it("sends updateReport to our metrics manager", () => {
@@ -1231,6 +1227,87 @@ describe("App", () => {
       })
 
       expect(document.title).toBe("some title")
+    })
+  })
+
+  describe("Header", () => {
+    afterEach(() => {
+      vi.mocked(isEmbed).mockReset()
+      vi.mocked(isToolbarDisplayed).mockReset()
+      vi.mocked(isColoredLineDisplayed).mockReset()
+
+      vi.clearAllMocks()
+    })
+
+    it("renders with status widget, toolbar, and main menu by default", () => {
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      expect(screen.getByTestId("stHeader")).toBeVisible()
+      expect(screen.getByTestId("stToolbar")).toBeVisible()
+      expect(screen.getByTestId("stStatusWidget")).toBeVisible()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
+    })
+
+    it("hides the top bar if hideTopBar === true", () => {
+      renderApp(getProps())
+      // hideTopBar is true by default
+
+      expect(screen.queryByTestId("stStatusWidget")).toBeNull()
+      expect(screen.queryByTestId("stToolbarActions")).toBeNull()
+    })
+
+    it("shows the top bar if hideTopBar === false", () => {
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      expect(screen.getByTestId("stStatusWidget")).toBeVisible()
+      expect(screen.getByTestId("stToolbarActions")).toBeVisible()
+    })
+
+    it("does not render when app embedded & both showToolbar and showColoredLine false", () => {
+      // Mock returns of util functions
+      vi.mocked(isEmbed).mockReturnValue(true)
+      vi.mocked(isToolbarDisplayed).mockReturnValue(false)
+      vi.mocked(isColoredLineDisplayed).mockReturnValue(false)
+
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Header/main menu should not render
+      expect(screen.queryByTestId("stHeader")).toBeNull()
+      expect(screen.queryByTestId("stMainMenu")).toBeNull()
+    })
+
+    it("renders when app embedded & only showToolbar is true", () => {
+      // Mock returns of util functions
+      vi.mocked(isEmbed).mockReturnValue(true)
+      vi.mocked(isToolbarDisplayed).mockReturnValue(true)
+      vi.mocked(isColoredLineDisplayed).mockReturnValue(false)
+
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Header/main menu should render
+      expect(screen.getByTestId("stHeader")).toBeVisible()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
+    })
+
+    it("renders when app embedded & only showColoredLine is true", () => {
+      // Mock returns of util functions
+      vi.mocked(isEmbed).mockReturnValue(true)
+      vi.mocked(isToolbarDisplayed).mockReturnValue(false)
+      vi.mocked(isColoredLineDisplayed).mockReturnValue(true)
+
+      renderApp(getProps())
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Header and decoration should render, but not MainMenu since toolbar is not visible
+      expect(screen.getByTestId("stHeader")).toBeVisible()
+      expect(screen.getByTestId("stDecoration")).toBeVisible()
+      // MainMenu should not exist since showToolbar is false
+      expect(screen.queryByTestId("stMainMenu")).not.toBeInTheDocument()
     })
   })
 
@@ -2326,6 +2403,8 @@ describe("App", () => {
     })
 
     it("triggers rerunScript with is_auto_rerun set to true", () => {
+      // Since we mock the isEmbed function, we need to set its return value
+      vi.mocked(isEmbed).mockReturnValue(false)
       renderApp(getProps())
 
       const connectionManager = getMockConnectionManager()
@@ -2873,8 +2952,9 @@ describe("App", () => {
     })
 
     it("changes scriptRunState and triggers stopScript when STOP_SCRIPT message has been received", () => {
+      // Since we mock the isEmbed function, we need to set its return value
+      vi.mocked(isEmbed).mockReturnValue(false)
       const hostCommunicationMgr = prepareHostCommunicationManager()
-
       const connectionManager = getMockConnectionManager(true)
 
       // Mark the script as running
@@ -3114,6 +3194,8 @@ describe("App", () => {
     })
 
     it("responds to page change request messages", () => {
+      // Since we mock the isEmbed function, we need to set its return value
+      vi.mocked(isEmbed).mockReturnValue(false)
       prepareHostCommunicationManager()
 
       const connectionManager = getMockConnectionManager(true)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1998,12 +1998,12 @@ export class App extends PureComponent<Props, State> {
     const showColoredLine =
       (!hideColoredLine && !isEmbed()) || isColoredLineDisplayed()
     const showHeader = isEmbed() ? showToolbar || showColoredLine : true
+    const showPadding = !isEmbed() || isPaddingDisplayed()
+    const disableScrolling = isScrollingHidden()
 
     return (
       <StreamlitContextProvider
         initialSidebarState={initialSidebarState}
-        showPadding={!isEmbed() || isPaddingDisplayed()}
-        disableScrolling={isScrollingHidden()}
         pageLinkBaseUrl={pageLinkBaseUrl}
         sidebarChevronDownshift={sidebarChevronDownshift}
         widgetsDisabled={
@@ -2106,6 +2106,8 @@ export class App extends PureComponent<Props, State> {
               wideMode={userSettings.wideMode}
               embedded={isEmbed()}
               addPaddingForHeader={showToolbar || showColoredLine}
+              showPadding={showPadding}
+              disableScrolling={disableScrolling}
               hideSidebarNav={hideSidebarNav || hostHideSidebarNav}
               expandSidebarNav={expandSidebarNav}
             />

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1997,7 +1997,6 @@ export class App extends PureComponent<Props, State> {
     return (
       <StreamlitContextProvider
         initialSidebarState={initialSidebarState}
-        wideMode={userSettings.wideMode}
         embedded={isEmbed()}
         showPadding={!isEmbed() || isPaddingDisplayed()}
         disableScrolling={isScrollingHidden()}
@@ -2096,6 +2095,7 @@ export class App extends PureComponent<Props, State> {
               navSections={navSections}
               onPageChange={this.onPageChange}
               currentPageScriptHash={currentPageScriptHash}
+              wideMode={userSettings.wideMode}
               hideSidebarNav={hideSidebarNav || hostHideSidebarNav}
               expandSidebarNav={expandSidebarNav}
             />

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1994,15 +1994,16 @@ export class App extends PureComponent<Props, State> {
         })
       : null
 
+    const showToolbar = !isEmbed() || isToolbarDisplayed()
+    const showColoredLine =
+      (!hideColoredLine && !isEmbed()) || isColoredLineDisplayed()
+    const showHeader = isEmbed() ? showToolbar || showColoredLine : true
+
     return (
       <StreamlitContextProvider
         initialSidebarState={initialSidebarState}
         showPadding={!isEmbed() || isPaddingDisplayed()}
         disableScrolling={isScrollingHidden()}
-        showToolbar={!isEmbed() || isToolbarDisplayed()}
-        showColoredLine={
-          (!hideColoredLine && !isEmbed()) || isColoredLineDisplayed()
-        }
         pageLinkBaseUrl={pageLinkBaseUrl}
         sidebarChevronDownshift={sidebarChevronDownshift}
         widgetsDisabled={
@@ -2037,47 +2038,55 @@ export class App extends PureComponent<Props, State> {
             }
             data-test-connection-state={connectionState}
           >
-            {/* The tabindex below is required for testing. */}
-            <Header embedded={isEmbed()}>
-              {!hideTopBar && (
-                <>
-                  <StatusWidget
-                    connectionState={connectionState}
-                    sessionEventDispatcher={this.sessionEventDispatcher}
-                    scriptRunState={scriptRunState}
-                    rerunScript={this.rerunScript}
-                    stopScript={this.stopScript}
-                    allowRunOnSave={allowRunOnSave}
+            {showHeader && (
+              <Header
+                showToolbar={showToolbar}
+                showColoredLine={showColoredLine}
+              >
+                {!hideTopBar && (
+                  <>
+                    <StatusWidget
+                      connectionState={connectionState}
+                      sessionEventDispatcher={this.sessionEventDispatcher}
+                      scriptRunState={scriptRunState}
+                      rerunScript={this.rerunScript}
+                      stopScript={this.stopScript}
+                      allowRunOnSave={allowRunOnSave}
+                    />
+                    <ToolbarActions
+                      hostToolbarItems={hostToolbarItems}
+                      sendMessageToHost={
+                        this.hostCommunicationMgr.sendMessageToHost
+                      }
+                      metricsMgr={this.metricsMgr}
+                    />
+                  </>
+                )}
+                {this.showDeployButton() && (
+                  <DeployButton
+                    onClick={this.deployButtonClicked.bind(this)}
                   />
-                  <ToolbarActions
-                    hostToolbarItems={hostToolbarItems}
-                    sendMessageToHost={
-                      this.hostCommunicationMgr.sendMessageToHost
-                    }
-                    metricsMgr={this.metricsMgr}
-                  />
-                </>
-              )}
-              {this.showDeployButton() && (
-                <DeployButton onClick={this.deployButtonClicked.bind(this)} />
-              )}
-              <MainMenu
-                isServerConnected={this.isServerConnected()}
-                quickRerunCallback={this.rerunScript}
-                clearCacheCallback={this.openClearCacheDialog}
-                settingsCallback={this.settingsCallback}
-                aboutCallback={this.aboutCallback}
-                printCallback={this.printCallback}
-                screencastCallback={this.screencastCallback}
-                screenCastState={this.props.screenCast.currentState}
-                hostMenuItems={hostMenuItems}
-                developmentMode={developmentMode}
-                sendMessageToHost={this.hostCommunicationMgr.sendMessageToHost}
-                menuItems={menuItems}
-                metricsMgr={this.metricsMgr}
-                toolbarMode={this.state.toolbarMode}
-              />
-            </Header>
+                )}
+                <MainMenu
+                  isServerConnected={this.isServerConnected()}
+                  quickRerunCallback={this.rerunScript}
+                  clearCacheCallback={this.openClearCacheDialog}
+                  settingsCallback={this.settingsCallback}
+                  aboutCallback={this.aboutCallback}
+                  printCallback={this.printCallback}
+                  screencastCallback={this.screencastCallback}
+                  screenCastState={this.props.screenCast.currentState}
+                  hostMenuItems={hostMenuItems}
+                  developmentMode={developmentMode}
+                  sendMessageToHost={
+                    this.hostCommunicationMgr.sendMessageToHost
+                  }
+                  menuItems={menuItems}
+                  metricsMgr={this.metricsMgr}
+                  toolbarMode={this.state.toolbarMode}
+                />
+              </Header>
+            )}
 
             <AppView
               endpoints={this.endpoints}
@@ -2096,6 +2105,7 @@ export class App extends PureComponent<Props, State> {
               currentPageScriptHash={currentPageScriptHash}
               wideMode={userSettings.wideMode}
               embedded={isEmbed()}
+              addPaddingForHeader={showToolbar || showColoredLine}
               hideSidebarNav={hideSidebarNav || hostHideSidebarNav}
               expandSidebarNav={expandSidebarNav}
             />

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1968,7 +1968,6 @@ export class App extends PureComponent<Props, State> {
       hostMenuItems,
       hostToolbarItems,
       libConfig,
-      appConfig,
       inputsDisabled,
       appPages,
       navSections,
@@ -2010,7 +2009,6 @@ export class App extends PureComponent<Props, State> {
           inputsDisabled || connectionState !== ConnectionState.CONNECTED
         }
         gitInfo={this.state.gitInfo}
-        appConfig={appConfig}
         isFullScreen={isFullScreen}
         setFullScreen={this.handleFullScreen}
         addScriptFinishedHandler={this.addScriptFinishedHandler}

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1997,7 +1997,6 @@ export class App extends PureComponent<Props, State> {
     return (
       <StreamlitContextProvider
         initialSidebarState={initialSidebarState}
-        embedded={isEmbed()}
         showPadding={!isEmbed() || isPaddingDisplayed()}
         disableScrolling={isScrollingHidden()}
         showToolbar={!isEmbed() || isToolbarDisplayed()}
@@ -2039,7 +2038,7 @@ export class App extends PureComponent<Props, State> {
             data-test-connection-state={connectionState}
           >
             {/* The tabindex below is required for testing. */}
-            <Header>
+            <Header embedded={isEmbed()}>
               {!hideTopBar && (
                 <>
                   <StatusWidget
@@ -2096,6 +2095,7 @@ export class App extends PureComponent<Props, State> {
               onPageChange={this.onPageChange}
               currentPageScriptHash={currentPageScriptHash}
               wideMode={userSettings.wideMode}
+              embedded={isEmbed()}
               hideSidebarNav={hideSidebarNav || hostHideSidebarNav}
               expandSidebarNav={expandSidebarNav}
             />

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -27,18 +27,6 @@ export interface AppContextProps {
   initialSidebarState: PageConfig.SidebarState
 
   /**
-   * True if padding is enabled.
-   * @see isPaddingDisplayed
-   */
-  showPadding: boolean
-
-  /**
-   * True if scrolling is disabled.
-   * @see isScrollingHidden
-   */
-  disableScrolling: boolean
-
-  /**
    * Part of URL construction for an app page in a multi-page app;
    * this is set from the host communication manager via host message.
    * @see SidebarNav
@@ -74,8 +62,6 @@ export interface AppContextProps {
 
 export const AppContext = React.createContext<AppContextProps | null>({
   initialSidebarState: PageConfig.SidebarState.AUTO,
-  showPadding: false,
-  disableScrolling: false,
   pageLinkBaseUrl: "",
   sidebarChevronDownshift: 0,
   widgetsDisabled: false,

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -21,13 +21,6 @@ import { IGitInfo, PageConfig } from "@streamlit/protobuf"
 
 export interface AppContextProps {
   /**
-   * If true, render the app with a wider column size.
-   * Set from the UserSettings object.
-   * @see UserSettings
-   */
-  wideMode: boolean
-
-  /**
    * The sidebar's default display state.
    * Set from the PageConfig protobuf.
    */
@@ -98,7 +91,6 @@ export interface AppContextProps {
 }
 
 export const AppContext = React.createContext<AppContextProps | null>({
-  wideMode: false,
   initialSidebarState: PageConfig.SidebarState.AUTO,
   embedded: false,
   showPadding: false,

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -27,12 +27,6 @@ export interface AppContextProps {
   initialSidebarState: PageConfig.SidebarState
 
   /**
-   * True if the app is embedded.
-   * @see isEmbed
-   */
-  embedded: boolean
-
-  /**
    * True if padding is enabled.
    * @see isPaddingDisplayed
    */
@@ -92,7 +86,6 @@ export interface AppContextProps {
 
 export const AppContext = React.createContext<AppContextProps | null>({
   initialSidebarState: PageConfig.SidebarState.AUTO,
-  embedded: false,
   showPadding: false,
   disableScrolling: false,
   showToolbar: false,

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -39,18 +39,6 @@ export interface AppContextProps {
   disableScrolling: boolean
 
   /**
-   * True if the toolbar should be displayed.
-   * @see isToolbarDisplayed
-   */
-  showToolbar: boolean
-
-  /**
-   * True if the thin colored line at the top of the app should be displayed.
-   * @see isColoredLineDisplayed
-   */
-  showColoredLine: boolean
-
-  /**
    * Part of URL construction for an app page in a multi-page app;
    * this is set from the host communication manager via host message.
    * @see SidebarNav
@@ -88,8 +76,6 @@ export const AppContext = React.createContext<AppContextProps | null>({
   initialSidebarState: PageConfig.SidebarState.AUTO,
   showPadding: false,
   disableScrolling: false,
-  showToolbar: false,
-  showColoredLine: false,
   pageLinkBaseUrl: "",
   sidebarChevronDownshift: 0,
   widgetsDisabled: false,

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -16,19 +16,21 @@
 
 import React from "react"
 
-import { AppConfig } from "@streamlit/connection"
 import { IGitInfo, PageConfig } from "@streamlit/protobuf"
 
 export interface AppContextProps {
   /**
    * The sidebar's default display state.
    * Set from the PageConfig protobuf.
+   * Pulled from appContext in AppView as prop to ThemedSidebar.
+   * @see Sidebar
    */
   initialSidebarState: PageConfig.SidebarState
 
   /**
    * Part of URL construction for an app page in a multi-page app;
    * this is set from the host communication manager via host message.
+   * Pulled from appContext in SidebarNav
    * @see SidebarNav
    */
   pageLinkBaseUrl: string
@@ -38,26 +40,28 @@ export interface AppContextProps {
    * "chevron" icon is shifted. (If sidebarChevronDownshift is 0, then
    * the current theme's spacing is used.);
    * this is set from the host communication manager via host message.
-   * @see StyledSidebarCollapsedControl
+   * Pulled from appContext in AppView & ThemedSidebar
+   * @see AppView (StyledSidebarOpenContainer)
+   * @see Sidebar (StyledSidebarOpenContainer)
    */
   sidebarChevronDownshift: number
 
   /**
    * Whether to disable widgets and sidebar page navigation links, based on connection
    * state and whether the host has disabled inputs.
+   * Pulled from appContext in AppView as prop to VerticalBlock > ElementNodeRenderer
+   * Pulled from appContext in SidebarNavLink
+   * @see ElementNodeRenderer
    * @see SidebarNavLink
    */
   widgetsDisabled: boolean
 
   /**
    * The latest state of the git information related to the app.
+   * Pulled from appContext in DeployDialog
+   * @see DeployDialog
    */
   gitInfo: IGitInfo | null
-
-  /** The app-specific configuration from the apps host which is requested via the
-   * _stcore/host-config endpoint.
-   */
-  appConfig: AppConfig
 }
 
 export const AppContext = React.createContext<AppContextProps | null>({
@@ -66,6 +70,5 @@ export const AppContext = React.createContext<AppContextProps | null>({
   sidebarChevronDownshift: 0,
   widgetsDisabled: false,
   gitInfo: null,
-  appConfig: {},
 })
 AppContext.displayName = "AppContext"

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -59,8 +59,6 @@ const FAKE_SCRIPT_HASH = "fake_script_hash"
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
     initialSidebarState: PageConfig.SidebarState.AUTO,
-    showPadding: false,
-    disableScrolling: false,
     pageLinkBaseUrl: "",
     sidebarChevronDownshift: 0,
     widgetsDisabled: false,
@@ -108,6 +106,8 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     wideMode: false,
     embedded: false,
     addPaddingForHeader: false,
+    showPadding: false,
+    disableScrolling: false,
     hideSidebarNav: false,
     expandSidebarNav: false,
     ...props,
@@ -312,6 +312,18 @@ describe("AppView element", () => {
     expect(style.maxWidth).toEqual("initial")
   })
 
+  it("disables scrolling when disableScrolling is true", () => {
+    render(<AppView {...getProps({ disableScrolling: true })} />)
+    const style = window.getComputedStyle(screen.getByTestId("stMain"))
+    expect(style.overflow).toEqual("hidden")
+  })
+
+  it("allows scrolling when disableScrolling is false", () => {
+    render(<AppView {...getProps({ disableScrolling: false })} />)
+    const style = window.getComputedStyle(screen.getByTestId("stMain"))
+    expect(style.overflow).toEqual("auto")
+  })
+
   describe("handles padding an embedded app", () => {
     it("embedded triggers default padding", () => {
       render(<AppView {...getProps({ embedded: true })} />)
@@ -323,12 +335,7 @@ describe("AppView element", () => {
     })
 
     it("showPadding triggers expected padding", () => {
-      vi.spyOn(
-        StreamlitContextProviderModule,
-        "useAppContext"
-      ).mockReturnValue(getContextOutput({ showPadding: true }))
-
-      render(<AppView {...getProps({ embedded: true })} />)
+      render(<AppView {...getProps({ embedded: true, showPadding: true })} />)
       const style = window.getComputedStyle(
         screen.getByTestId("stMainBlockContainer")
       )

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -58,7 +58,6 @@ const FAKE_SCRIPT_HASH = "fake_script_hash"
 
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
-    wideMode: false,
     initialSidebarState: PageConfig.SidebarState.AUTO,
     embedded: false,
     showPadding: false,
@@ -109,6 +108,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     navSections: [],
     onPageChange: vi.fn(),
     currentPageScriptHash: "main_page_script_hash",
+    wideMode: false,
     hideSidebarNav: false,
     expandSidebarNav: false,
     ...props,
@@ -271,7 +271,7 @@ describe("AppView element", () => {
 
   it("does not render the wide class", () => {
     vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
-      getContextOutput({ wideMode: false, embedded: false })
+      getContextOutput({ embedded: false })
     )
 
     const main = new BlockNode(
@@ -311,10 +311,10 @@ describe("AppView element", () => {
 
   it("does render the wide class when specified", () => {
     vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
-      getContextOutput({ wideMode: true, embedded: false })
+      getContextOutput({ embedded: false })
     )
 
-    render(<AppView {...getProps()} />)
+    render(<AppView {...getProps({ wideMode: true })} />)
     const style = window.getComputedStyle(
       screen.getByTestId("stMainBlockContainer")
     )

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -59,7 +59,6 @@ const FAKE_SCRIPT_HASH = "fake_script_hash"
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
     initialSidebarState: PageConfig.SidebarState.AUTO,
-    embedded: false,
     showPadding: false,
     disableScrolling: false,
     showToolbar: false,
@@ -109,6 +108,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     onPageChange: vi.fn(),
     currentPageScriptHash: "main_page_script_hash",
     wideMode: false,
+    embedded: false,
     hideSidebarNav: false,
     expandSidebarNav: false,
     ...props,
@@ -270,10 +270,6 @@ describe("AppView element", () => {
   })
 
   it("does not render the wide class", () => {
-    vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
-      getContextOutput({ embedded: false })
-    )
-
     const main = new BlockNode(
       FAKE_SCRIPT_HASH,
       [],
@@ -310,10 +306,6 @@ describe("AppView element", () => {
   })
 
   it("does render the wide class when specified", () => {
-    vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
-      getContextOutput({ embedded: false })
-    )
-
     render(<AppView {...getProps({ wideMode: true })} />)
     const style = window.getComputedStyle(
       screen.getByTestId("stMainBlockContainer")
@@ -323,12 +315,7 @@ describe("AppView element", () => {
 
   describe("handles padding an embedded app", () => {
     it("embedded triggers default padding", () => {
-      vi.spyOn(
-        StreamlitContextProviderModule,
-        "useAppContext"
-      ).mockReturnValue(getContextOutput({ embedded: true }))
-
-      render(<AppView {...getProps()} />)
+      render(<AppView {...getProps({ embedded: true })} />)
       const style = window.getComputedStyle(
         screen.getByTestId("stMainBlockContainer")
       )
@@ -342,7 +329,7 @@ describe("AppView element", () => {
         "useAppContext"
       ).mockReturnValue(getContextOutput({ showPadding: true }))
 
-      render(<AppView {...getProps()} />)
+      render(<AppView {...getProps({ embedded: true })} />)
       const style = window.getComputedStyle(
         screen.getByTestId("stMainBlockContainer")
       )
@@ -356,7 +343,7 @@ describe("AppView element", () => {
         "useAppContext"
       ).mockReturnValue(getContextOutput({ showToolbar: true }))
 
-      render(<AppView {...getProps()} />)
+      render(<AppView {...getProps({ embedded: true })} />)
       const style = window.getComputedStyle(
         screen.getByTestId("stMainBlockContainer")
       )
@@ -365,11 +352,6 @@ describe("AppView element", () => {
     })
 
     it("hasSidebar triggers expected top padding", () => {
-      vi.spyOn(
-        StreamlitContextProviderModule,
-        "useAppContext"
-      ).mockReturnValue(getContextOutput({ embedded: true }))
-
       const sidebarElement = new ElementNode(
         makeElementWithInfoText("sidebar!"),
         ForwardMsgMetadata.create({}),
@@ -394,6 +376,7 @@ describe("AppView element", () => {
           FAKE_SCRIPT_HASH,
           new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
         ),
+        embedded: true,
       })
 
       render(<AppView {...props} />)

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -63,7 +63,6 @@ function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
     sidebarChevronDownshift: 0,
     widgetsDisabled: false,
     gitInfo: null,
-    appConfig: {},
     ...context,
   }
 }

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -61,8 +61,6 @@ function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
     initialSidebarState: PageConfig.SidebarState.AUTO,
     showPadding: false,
     disableScrolling: false,
-    showToolbar: false,
-    showColoredLine: false,
     pageLinkBaseUrl: "",
     sidebarChevronDownshift: 0,
     widgetsDisabled: false,
@@ -109,6 +107,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     currentPageScriptHash: "main_page_script_hash",
     wideMode: false,
     embedded: false,
+    addPaddingForHeader: false,
     hideSidebarNav: false,
     expandSidebarNav: false,
     ...props,
@@ -337,13 +336,12 @@ describe("AppView element", () => {
       expect(style.paddingBottom).toEqual("10rem")
     })
 
-    it("showToolbar triggers expected top padding", () => {
-      vi.spyOn(
-        StreamlitContextProviderModule,
-        "useAppContext"
-      ).mockReturnValue(getContextOutput({ showToolbar: true }))
-
-      render(<AppView {...getProps({ embedded: true })} />)
+    it("addPaddingForHeader triggers expected top padding", () => {
+      render(
+        <AppView
+          {...getProps({ embedded: true, addPaddingForHeader: true })}
+        />
+      )
       const style = window.getComputedStyle(
         screen.getByTestId("stMainBlockContainer")
       )

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -93,6 +93,8 @@ export interface AppViewProps {
 
   currentPageScriptHash: string
 
+  wideMode: boolean
+
   hideSidebarNav: boolean
 
   expandSidebarNav: boolean
@@ -115,6 +117,7 @@ function AppView(props: AppViewProps): ReactElement {
     navSections,
     onPageChange,
     currentPageScriptHash,
+    wideMode,
     expandSidebarNav,
     hideSidebarNav,
     sendMessageToHost,
@@ -133,7 +136,6 @@ function AppView(props: AppViewProps): ReactElement {
   }, [sendMessageToHost])
 
   const {
-    wideMode,
     initialSidebarState,
     embedded,
     showPadding,

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -99,6 +99,10 @@ export interface AppViewProps {
 
   addPaddingForHeader: boolean
 
+  showPadding: boolean
+
+  disableScrolling: boolean
+
   hideSidebarNav: boolean
 
   expandSidebarNav: boolean
@@ -124,6 +128,8 @@ function AppView(props: AppViewProps): ReactElement {
     wideMode,
     embedded,
     addPaddingForHeader,
+    showPadding,
+    disableScrolling,
     expandSidebarNav,
     hideSidebarNav,
     sendMessageToHost,
@@ -141,13 +147,8 @@ function AppView(props: AppViewProps): ReactElement {
     return () => window.removeEventListener("hashchange", listener, false)
   }, [sendMessageToHost])
 
-  const {
-    initialSidebarState,
-    showPadding,
-    disableScrolling,
-    sidebarChevronDownshift,
-    widgetsDisabled,
-  } = useAppContext()
+  const { initialSidebarState, sidebarChevronDownshift, widgetsDisabled } =
+    useAppContext()
 
   const { addScriptFinishedHandler, removeScriptFinishedHandler } =
     useContext(LibContext)

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -95,6 +95,8 @@ export interface AppViewProps {
 
   wideMode: boolean
 
+  embedded: boolean
+
   hideSidebarNav: boolean
 
   expandSidebarNav: boolean
@@ -118,6 +120,7 @@ function AppView(props: AppViewProps): ReactElement {
     onPageChange,
     currentPageScriptHash,
     wideMode,
+    embedded,
     expandSidebarNav,
     hideSidebarNav,
     sendMessageToHost,
@@ -137,7 +140,6 @@ function AppView(props: AppViewProps): ReactElement {
 
   const {
     initialSidebarState,
-    embedded,
     showPadding,
     disableScrolling,
     showToolbar,

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -97,6 +97,8 @@ export interface AppViewProps {
 
   embedded: boolean
 
+  addPaddingForHeader: boolean
+
   hideSidebarNav: boolean
 
   expandSidebarNav: boolean
@@ -121,6 +123,7 @@ function AppView(props: AppViewProps): ReactElement {
     currentPageScriptHash,
     wideMode,
     embedded,
+    addPaddingForHeader,
     expandSidebarNav,
     hideSidebarNav,
     sendMessageToHost,
@@ -142,8 +145,6 @@ function AppView(props: AppViewProps): ReactElement {
     initialSidebarState,
     showPadding,
     disableScrolling,
-    showToolbar,
-    showColoredLine,
     sidebarChevronDownshift,
     widgetsDisabled,
   } = useAppContext()
@@ -298,7 +299,7 @@ function AppView(props: AppViewProps): ReactElement {
             data-testid="stMainBlockContainer"
             isWideMode={wideMode}
             showPadding={showPadding}
-            addPaddingForHeader={showToolbar || showColoredLine}
+            addPaddingForHeader={addPaddingForHeader}
             hasBottom={hasBottomElements}
             isEmbedded={embedded}
             hasSidebar={showSidebar}

--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { screen } from "@testing-library/react"
+
+import { render } from "@streamlit/lib"
+import { PageConfig } from "@streamlit/protobuf"
+import { AppContextProps } from "@streamlit/app/src/components/AppContext"
+import * as StreamlitContextProviderModule from "@streamlit/app/src/components/StreamlitContextProvider"
+
+import Header, { HeaderProps } from "./Header"
+
+function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
+  return {
+    initialSidebarState: PageConfig.SidebarState.AUTO,
+    showPadding: false,
+    disableScrolling: false,
+    showToolbar: false,
+    showColoredLine: false,
+    pageLinkBaseUrl: "",
+    sidebarChevronDownshift: 0,
+    widgetsDisabled: false,
+    gitInfo: null,
+    appConfig: {},
+    ...context,
+  }
+}
+
+const getProps = (propOverrides: Partial<HeaderProps> = {}): HeaderProps => ({
+  embedded: false,
+  children: <div>Test</div>,
+  ...propOverrides,
+})
+
+describe("Header", () => {
+  beforeEach(() => {
+    // Mock the useAppContext hook to return default values
+    vi.spyOn(
+      StreamlitContextProviderModule,
+      "useAppContext"
+    ).mockImplementation(() => getContextOutput({}))
+  })
+
+  it("renders a Header", () => {
+    render(<Header {...getProps()} />)
+
+    expect(screen.getByTestId("stHeader")).toBeInTheDocument()
+  })
+
+  it("renders correctly when not embedded, showToolbar & showColoredLine true", () => {
+    vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
+      getContextOutput({ showToolbar: true, showColoredLine: true })
+    )
+
+    render(<Header {...getProps()} />)
+
+    expect(screen.getByTestId("stHeader")).toHaveStyle("display: block")
+    expect(screen.getByTestId("stDecoration")).toBeVisible()
+    expect(screen.getByTestId("stToolbar")).toBeVisible()
+  })
+
+  it("renders correctly when embedded, showToolbar & showColoredLine false", () => {
+    render(<Header {...getProps({ embedded: true })} />)
+
+    expect(screen.getByTestId("stHeader")).toHaveStyle("display: none")
+  })
+})

--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -19,54 +19,24 @@ import React from "react"
 import { screen } from "@testing-library/react"
 
 import { render } from "@streamlit/lib"
-import { PageConfig } from "@streamlit/protobuf"
-import { AppContextProps } from "@streamlit/app/src/components/AppContext"
-import * as StreamlitContextProviderModule from "@streamlit/app/src/components/StreamlitContextProvider"
 
 import Header, { HeaderProps } from "./Header"
 
-function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
-  return {
-    initialSidebarState: PageConfig.SidebarState.AUTO,
-    showPadding: false,
-    disableScrolling: false,
-    showToolbar: false,
-    showColoredLine: false,
-    pageLinkBaseUrl: "",
-    sidebarChevronDownshift: 0,
-    widgetsDisabled: false,
-    gitInfo: null,
-    appConfig: {},
-    ...context,
-  }
-}
-
 const getProps = (propOverrides: Partial<HeaderProps> = {}): HeaderProps => ({
-  embedded: false,
+  showToolbar: true,
+  showColoredLine: true,
   children: <div>Test</div>,
   ...propOverrides,
 })
 
 describe("Header", () => {
-  beforeEach(() => {
-    // Mock the useAppContext hook to return default values
-    vi.spyOn(
-      StreamlitContextProviderModule,
-      "useAppContext"
-    ).mockImplementation(() => getContextOutput({}))
-  })
-
-  it("renders a Header", () => {
+  it("renders a Header without crashing", () => {
     render(<Header {...getProps()} />)
 
     expect(screen.getByTestId("stHeader")).toBeInTheDocument()
   })
 
-  it("renders correctly when not embedded, showToolbar & showColoredLine true", () => {
-    vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
-      getContextOutput({ showToolbar: true, showColoredLine: true })
-    )
-
+  it("renders correctly when showToolbar & showColoredLine both true", () => {
     render(<Header {...getProps()} />)
 
     expect(screen.getByTestId("stHeader")).toHaveStyle("display: block")
@@ -74,9 +44,33 @@ describe("Header", () => {
     expect(screen.getByTestId("stToolbar")).toBeVisible()
   })
 
-  it("renders correctly when embedded, showToolbar & showColoredLine false", () => {
-    render(<Header {...getProps({ embedded: true })} />)
+  it("renders correctly when showToolbar & showColoredLine both false", () => {
+    render(
+      <Header {...getProps({ showToolbar: false, showColoredLine: false })} />
+    )
 
-    expect(screen.getByTestId("stHeader")).toHaveStyle("display: none")
+    expect(screen.getByTestId("stHeader")).toHaveStyle("display: block")
+    expect(screen.queryByTestId("stDecoration")).toBeNull()
+    expect(screen.queryByTestId("stToolbar")).toBeNull()
+  })
+
+  it("renders correctly when showToolbar false & showColoredLine true", () => {
+    render(
+      <Header {...getProps({ showToolbar: false, showColoredLine: true })} />
+    )
+
+    expect(screen.getByTestId("stHeader")).toHaveStyle("display: block")
+    expect(screen.getByTestId("stDecoration")).toBeVisible()
+    expect(screen.queryByTestId("stToolbar")).toBeNull()
+  })
+
+  it("renders correctly when showToolbar true & showColoredLine false", () => {
+    render(
+      <Header {...getProps({ showToolbar: true, showColoredLine: false })} />
+    )
+
+    expect(screen.getByTestId("stHeader")).toHaveStyle("display: block")
+    expect(screen.queryByTestId("stDecoration")).toBeNull()
+    expect(screen.getByTestId("stToolbar")).toBeVisible()
   })
 })

--- a/frontend/app/src/components/Header/Header.tsx
+++ b/frontend/app/src/components/Header/Header.tsx
@@ -25,12 +25,12 @@ import {
 } from "./styled-components"
 
 export interface HeaderProps {
+  embedded: boolean
   children: ReactNode
-  isStale?: boolean
 }
 
-function Header({ isStale, children }: Readonly<HeaderProps>): ReactElement {
-  const { wideMode, embedded, showToolbar, showColoredLine } = useAppContext()
+function Header({ embedded, children }: Readonly<HeaderProps>): ReactElement {
+  const { showToolbar, showColoredLine } = useAppContext()
 
   let showHeader = true
   if (embedded) {
@@ -39,10 +39,8 @@ function Header({ isStale, children }: Readonly<HeaderProps>): ReactElement {
   return (
     <StyledHeader
       showHeader={showHeader}
-      isWideMode={wideMode}
       // The tabindex below is required for testing.
       tabIndex={-1}
-      isStale={isStale}
       className="stAppHeader"
       data-testid="stHeader"
     >

--- a/frontend/app/src/components/Header/Header.tsx
+++ b/frontend/app/src/components/Header/Header.tsx
@@ -16,8 +16,6 @@
 
 import React, { ReactElement, ReactNode } from "react"
 
-import { useAppContext } from "@streamlit/app/src/components/StreamlitContextProvider"
-
 import {
   StyledHeader,
   StyledHeaderDecoration,
@@ -25,20 +23,18 @@ import {
 } from "./styled-components"
 
 export interface HeaderProps {
-  embedded: boolean
+  showToolbar: boolean
+  showColoredLine: boolean
   children: ReactNode
 }
 
-function Header({ embedded, children }: Readonly<HeaderProps>): ReactElement {
-  const { showToolbar, showColoredLine } = useAppContext()
-
-  let showHeader = true
-  if (embedded) {
-    showHeader = showToolbar || showColoredLine
-  }
+function Header({
+  showToolbar,
+  showColoredLine,
+  children,
+}: Readonly<HeaderProps>): ReactElement {
   return (
     <StyledHeader
-      showHeader={showHeader}
       // The tabindex below is required for testing.
       tabIndex={-1}
       className="stAppHeader"

--- a/frontend/app/src/components/Header/styled-components.ts
+++ b/frontend/app/src/components/Header/styled-components.ts
@@ -17,26 +17,23 @@
 import styled from "@emotion/styled"
 
 export interface StyledHeaderProps {
-  showHeader: boolean
   isStale?: boolean
 }
 
-export const StyledHeader = styled.header<StyledHeaderProps>(
-  ({ showHeader, theme }) => ({
-    position: "fixed",
-    top: theme.spacing.none,
-    left: theme.spacing.none,
-    right: theme.spacing.none,
-    height: theme.sizes.headerHeight,
-    background: theme.colors.bgColor,
-    outline: "none",
-    zIndex: theme.zIndices.header,
-    display: showHeader ? "block" : "none",
-    "@media print": {
-      display: "none",
-    },
-  })
-)
+export const StyledHeader = styled.header<StyledHeaderProps>(({ theme }) => ({
+  display: "block",
+  position: "fixed",
+  top: theme.spacing.none,
+  left: theme.spacing.none,
+  right: theme.spacing.none,
+  height: theme.sizes.headerHeight,
+  background: theme.colors.bgColor,
+  outline: "none",
+  zIndex: theme.zIndices.header,
+  "@media print": {
+    display: "none",
+  },
+}))
 
 export const StyledHeaderDecoration = styled.div(({ theme }) => ({
   position: "absolute",

--- a/frontend/app/src/components/Header/styled-components.ts
+++ b/frontend/app/src/components/Header/styled-components.ts
@@ -18,7 +18,6 @@ import styled from "@emotion/styled"
 
 export interface StyledHeaderProps {
   showHeader: boolean
-  isWideMode: boolean
   isStale?: boolean
 }
 

--- a/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
@@ -38,10 +38,6 @@ const getProps = (
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
     initialSidebarState: 0,
-    showPadding: false,
-    disableScrolling: false,
-    showToolbar: false,
-    showColoredLine: false,
     pageLinkBaseUrl: "",
     sidebarChevronDownshift: 0,
     widgetsDisabled: false,

--- a/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
@@ -37,9 +37,7 @@ const getProps = (
 
 function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
   return {
-    wideMode: false,
     initialSidebarState: 0,
-    embedded: false,
     showPadding: false,
     disableScrolling: false,
     showToolbar: false,

--- a/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNavLink.test.tsx
@@ -42,7 +42,6 @@ function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
     sidebarChevronDownshift: 0,
     widgetsDisabled: false,
     gitInfo: null,
-    appConfig: {},
     ...context,
   }
 }

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -33,8 +33,6 @@ import {
 // Type for AppContext props
 type AppContextValues = {
   initialSidebarState: PageConfig.SidebarState
-  showPadding: boolean
-  disableScrolling: boolean
   pageLinkBaseUrl: string
   sidebarChevronDownshift: number
   widgetsDisabled: boolean
@@ -70,8 +68,6 @@ export type StreamlitContextProviderProps = PropsWithChildren<
 const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   // AppContext
   initialSidebarState,
-  showPadding,
-  disableScrolling,
   pageLinkBaseUrl,
   sidebarChevronDownshift,
   widgetsDisabled,
@@ -97,8 +93,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   const appContextProps = useMemo<AppContextProps>(
     () => ({
       initialSidebarState,
-      showPadding,
-      disableScrolling,
       pageLinkBaseUrl,
       sidebarChevronDownshift,
       widgetsDisabled,
@@ -107,8 +101,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
     }),
     [
       initialSidebarState,
-      showPadding,
-      disableScrolling,
       pageLinkBaseUrl,
       sidebarChevronDownshift,
       widgetsDisabled,

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -32,7 +32,6 @@ import {
 
 // Type for AppContext props
 type AppContextValues = {
-  wideMode: boolean
   initialSidebarState: PageConfig.SidebarState
   embedded: boolean
   showPadding: boolean
@@ -73,7 +72,6 @@ export type StreamlitContextProviderProps = PropsWithChildren<
  */
 const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   // AppContext
-  wideMode,
   initialSidebarState,
   embedded,
   showPadding,
@@ -104,7 +102,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   // Memoized object for AppContext values
   const appContextProps = useMemo<AppContextProps>(
     () => ({
-      wideMode,
       initialSidebarState,
       embedded,
       showPadding,
@@ -118,7 +115,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       appConfig,
     }),
     [
-      wideMode,
       initialSidebarState,
       embedded,
       showPadding,

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -35,8 +35,6 @@ type AppContextValues = {
   initialSidebarState: PageConfig.SidebarState
   showPadding: boolean
   disableScrolling: boolean
-  showToolbar: boolean
-  showColoredLine: boolean
   pageLinkBaseUrl: string
   sidebarChevronDownshift: number
   widgetsDisabled: boolean
@@ -74,8 +72,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   initialSidebarState,
   showPadding,
   disableScrolling,
-  showToolbar,
-  showColoredLine,
   pageLinkBaseUrl,
   sidebarChevronDownshift,
   widgetsDisabled,
@@ -103,8 +99,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       initialSidebarState,
       showPadding,
       disableScrolling,
-      showToolbar,
-      showColoredLine,
       pageLinkBaseUrl,
       sidebarChevronDownshift,
       widgetsDisabled,
@@ -115,8 +109,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       initialSidebarState,
       showPadding,
       disableScrolling,
-      showToolbar,
-      showColoredLine,
       pageLinkBaseUrl,
       sidebarChevronDownshift,
       widgetsDisabled,

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -33,7 +33,6 @@ import {
 // Type for AppContext props
 type AppContextValues = {
   initialSidebarState: PageConfig.SidebarState
-  embedded: boolean
   showPadding: boolean
   disableScrolling: boolean
   showToolbar: boolean
@@ -73,7 +72,6 @@ export type StreamlitContextProviderProps = PropsWithChildren<
 const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   // AppContext
   initialSidebarState,
-  embedded,
   showPadding,
   disableScrolling,
   showToolbar,
@@ -103,7 +101,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   const appContextProps = useMemo<AppContextProps>(
     () => ({
       initialSidebarState,
-      embedded,
       showPadding,
       disableScrolling,
       showToolbar,
@@ -116,7 +113,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
     }),
     [
       initialSidebarState,
-      embedded,
       showPadding,
       disableScrolling,
       showToolbar,

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -16,7 +16,6 @@
 
 import React, { memo, PropsWithChildren, useMemo } from "react"
 
-import { AppConfig } from "@streamlit/connection"
 import {
   LibConfig,
   LibContext,
@@ -37,7 +36,6 @@ type AppContextValues = {
   sidebarChevronDownshift: number
   widgetsDisabled: boolean
   gitInfo: IGitInfo | null
-  appConfig: AppConfig
 }
 
 // Type for LibContext props
@@ -72,7 +70,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   sidebarChevronDownshift,
   widgetsDisabled,
   gitInfo,
-  appConfig,
   // LibContext
   isFullScreen,
   setFullScreen,
@@ -97,7 +94,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       sidebarChevronDownshift,
       widgetsDisabled,
       gitInfo,
-      appConfig,
     }),
     [
       initialSidebarState,
@@ -105,7 +101,6 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       sidebarChevronDownshift,
       widgetsDisabled,
       gitInfo,
-      appConfig,
     ]
   )
 


### PR DESCRIPTION
## Describe your changes
**Part 2 of improving our context usage & cleaning up AppView props:**

Remove unnecessary values in `AppContext` - in this case those that are unused, or those that are only used one level down in the component tree.
* `wideMode`:  used in `AppView` for styled components & setting data-layout (pulled from context but not actually used in `Header`)
* `embedded`: used in `AppView` for styled components (refactored to not need passing to `Header`)
* `showToolbar`: used in `AppView` & `Header` for styled components 
* `showColoredLine`: used in `AppView` & `Header` for styled components
* `showPadding`: used in `AppView` for styled components
* `disableScrolling`: used in `AppView` for styled components
* `appConfig`: unused

Add better notes from where values are pulled from context and where they are ultimately used

## Testing Plan
- Refactor: Existing test suites should pass if working properly
- Added new JS test file for `Header`
- Added new JS tests for `App` handling of whether to render `Header`
