### PR TITLE
Unpin nwsapi

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "testCoverage": "vitest run --coverage"
   },
   "resolutions": {
-    "nwsapi": "2.2.9",
     "d3-color": "^3.1.0",
     "dompurify": "^3.2.4",
     "vite": "^6.2.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14813,10 +14813,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:2.2.9":
-  version: 2.2.9
-  resolution: "nwsapi@npm:2.2.9"
-  checksum: 10c0/e6ebbaedf44d1c1e13f7193e5129c8da1b2e8064862b70458ab9bd9e9640b8ad035a0e48d509e787527ecdddea74d5a02798420cd971264a4e03c2b173fadac8
+"nwsapi@npm:^2.2.12":
+  version: 2.2.20
+  resolution: "nwsapi@npm:2.2.20"
+  checksum: 10c0/07f4dafa3186aef7c007863e90acd4342a34ba9d44b22f14f644fdb311f6086887e21c2fc15efaa826c2bc39ab2bc841364a1a630e7c87e0cb723ba59d729297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

There was an issue in nwsapi that was breaking our tests, so we pinned it. It has [since been fixed](https://github.com/dperini/nwsapi/pull/125), so we can now unpin it.

## Testing Plan

- Tests (Especially JS tests) should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
