### PR TITLE
Reduce flakiness of st_radio_test by adding an expect before clicking.

### DIFF
--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -80,7 +80,9 @@ def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
     for index, element in enumerate(app.get_by_test_id("stRadio").all()):
         if index not in [2, 3]:  # skip disabled and no-options widget
-            element.locator('label[data-baseweb="radio"]').nth(1).click(force=True)
+            second_radio_option = element.locator('label[data-baseweb="radio"]').nth(1)
+            expect(second_radio_option).to_be_visible()
+            second_radio_option.click(force=True)
             wait_for_app_run(app)
 
     expected = [


### PR DESCRIPTION
## Describe your changes

I have noticed that this test is flaky lately. I looked at the Radio.tsx component and couldn't find any evidence that there is unmounting/mounting or similar that would be causing the flakiness so this PR adds an expect to harden the test.

## GitHub Issue Link (if applicable)

## Testing Plan

Test Only. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
