### PR TITLE
[chore] Add `@typescript-eslint/no-explicit-any` lint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -111,8 +111,6 @@ module.exports = {
     "@typescript-eslint/no-empty-interface": "off",
     // Empty functions are ok
     "@typescript-eslint/no-empty-function": "off",
-    // We prefer not using `any`, but don't disallow it
-    "@typescript-eslint/no-explicit-any": "off",
     // We prefer not using `any`, but don't disallow it (this rule
     // differs from the previous one in that it requires explicit types
     // for public module APIs)

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -118,6 +118,7 @@ vi.mock("@streamlit/connection", async () => {
   }
 })
 vi.mock("~lib/SessionInfo", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const actualModule = await vi.importActual<any>("~lib/SessionInfo")
 
   const MockedClass = vi.fn().mockImplementation(() => {
@@ -136,6 +137,7 @@ vi.mock("~lib/SessionInfo", async () => {
 })
 
 vi.mock("~lib/hostComm/HostCommunicationManager", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const actualModule = await vi.importActual<any>(
     "~lib/hostComm/HostCommunicationManager"
   )
@@ -155,6 +157,7 @@ vi.mock("~lib/hostComm/HostCommunicationManager", async () => {
 })
 
 vi.mock("~lib/WidgetStateManager", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const actualModule = await vi.importActual<any>("~lib/WidgetStateManager")
 
   const MockedClass = vi.fn().mockImplementation((...props) => {
@@ -172,6 +175,7 @@ vi.mock("~lib/WidgetStateManager", async () => {
 })
 
 vi.mock("@streamlit/app/src/MetricsManager", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const actualModule = await vi.importActual<any>(
     "@streamlit/app/src/MetricsManager"
   )
@@ -189,6 +193,7 @@ vi.mock("@streamlit/app/src/MetricsManager", async () => {
 })
 
 vi.mock("~lib/FileUploadClient", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const actualModule = await vi.importActual<any>("~lib/FileUploadClient")
 
   const MockedClass = vi.fn().mockImplementation((...props) => {
@@ -303,6 +308,7 @@ function renderApp(props: Props): RenderResult {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function getStoredValue<T>(Type: any): T {
   return Type.mock.results[Type.mock.results.length - 1].value
 }
@@ -316,6 +322,7 @@ function getMockConnectionManager(isConnected = false): ConnectionManager {
   return connectionManager
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function getMockConnectionManagerProp(propName: string): any {
   // @ts-expect-error
   return getStoredValue<ConnectionManager>(ConnectionManager).props[propName]
@@ -1468,6 +1475,7 @@ describe("App", () => {
   // Using this to test the functionality provided through streamlit.experimental_set_query_params.
   // Please see https://github.com/streamlit/streamlit/issues/2887 for more context on this.
   describe("App.handlePageInfoChanged", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     let pushStateSpy: any
 
     beforeEach(() => {
@@ -2785,6 +2793,7 @@ describe("App", () => {
       return hostCommunicationMgr
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     function fireWindowPostMessage(message: any): void {
       fireEvent(
         window,
@@ -3523,6 +3532,7 @@ describe("App", () => {
   })
 
   describe("page change URL handling", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     let pushStateSpy: any
 
     beforeEach(() => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -210,7 +210,9 @@ export const LOG = getLogger("App")
 // eslint-disable-next-line
 declare global {
   interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     streamlitDebug: any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     iFrameResizer: any
     __streamlit_profiles__?: Record<
       string,
@@ -781,6 +783,7 @@ export class App extends PureComponent<Props, State> {
   handleMessage = (msgProto: ForwardMsg): void => {
     // We don't have an immutableProto here, so we can't use
     // the dispatchOneOf helper
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const dispatchProto = (obj: any, name: string, funcs: any): any => {
       const whichOne = obj[name]
       if (whichOne in funcs) {

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -149,6 +149,7 @@ export class MetricsManager {
   }
 
   // Fallback - Checks if cached in localStorage, otherwise fetches the config from a default URL
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private async requestDefaultMetricsConfig(): Promise<any> {
     const isLocalStoreAvailable = localStorageAvailable()
 

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -253,6 +253,7 @@ describe("StreamlitLibExample", () => {
 
   it("handles Delta messages", async () => {
     // there's nothing within the app ui to cycle through script run messages so we need a reference
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     let streamlitLibInstance: any
     render(
       <StreamlitLibExample

--- a/frontend/app/src/components/DeployButton/DeployButton.tsx
+++ b/frontend/app/src/components/DeployButton/DeployButton.tsx
@@ -21,6 +21,7 @@ import { BaseButton, BaseButtonKind } from "@streamlit/lib"
 import { DeployButtonContainer } from "./styled-components"
 
 interface IDeployButtonProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onClick: (event: MouseEvent<HTMLButtonElement>) => any
 }
 

--- a/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
+++ b/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
@@ -25,6 +25,7 @@ export interface FontFaceDeclarationProps {
 const FontFaceDeclaration = ({
   fontFaces,
 }: FontFaceDeclarationProps): ReactElement => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const fontMarkup = fontFaces.map((font: any) => {
     const { family, weight, url, style = "normal" } = font
 

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -94,6 +94,7 @@ const getOpenInWindowCallback = (url: string) => (): void => {
 }
 
 export interface MenuItemProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   item: any
   "aria-selected": boolean
   onClick: (e: MouseEvent<HTMLLIElement>) => void
@@ -103,6 +104,7 @@ export interface MenuItemProps {
 }
 
 export interface SubMenuProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   menuItems: any[]
   closeMenu: () => void
   isDevMenu: boolean
@@ -124,6 +126,7 @@ export interface SubMenuProps {
 function buildMenuItemComponent(
   StyledMenuItemType: typeof StyledCoreItem | typeof StyledDevItem,
   metricsMgr: MetricsManager
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any {
   const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
     (
@@ -238,9 +241,12 @@ const SubMenu = (props: SubMenuProps): ReactElement => {
 
 function getDevMenuItems(
   theme: EmotionTheme,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   coreDevMenuItems: Record<string, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any[] {
   const devMenuItems = []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const preferredDevMenuOrder: any[] = [
     coreDevMenuItems.developerOptions,
     coreDevMenuItems.clearCache,
@@ -273,9 +279,13 @@ function getDevMenuItems(
 
 function getPreferredMenuOrder(
   props: Props,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   hostMenuItems: any[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   coreMenuItems: Record<string, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let preferredMenuOrder: any[]
   if (props.toolbarMode == Config.ToolbarMode.MINIMAL) {
     // If toolbar mode == minimal then show only host menu items if any.
@@ -415,6 +425,7 @@ function MainMenu(props: Readonly<Props>): ReactElement {
         }),
       label: item.label,
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   }, [] as any[])
 
   const preferredMenuOrder = getPreferredMenuOrder(
@@ -424,6 +435,7 @@ function MainMenu(props: Readonly<Props>): ReactElement {
   )
 
   // Remove empty entries, and add dividers into menu options as needed.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const menuItems: any[] = []
   let lastMenuItem = null
   for (const menuItem of preferredMenuOrder) {
@@ -440,6 +452,7 @@ function MainMenu(props: Readonly<Props>): ReactElement {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const devMenuItems: any[] = props.developmentMode
     ? getDevMenuItems(theme, coreDevMenuItems)
     : []

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -87,6 +87,7 @@ describe("ThemedSidebar Component", () => {
 })
 
 describe("createSidebarTheme", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const createMockTheme = (overrides: any = {}): ThemeConfig => ({
     name: "mockTheme",
     basewebTheme: {},

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -27,6 +27,7 @@ import { EmotionTheme, hasLightBackgroundColor } from "@streamlit/lib"
  * @returns The color of the text in the sidebar nav.
  */
 const getNavTextColor = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   theme: any,
   isActive: boolean,
   disabled: boolean = false
@@ -291,6 +292,7 @@ export interface StyledLogoProps {
   sidebarWidth?: string
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function translateLogoHeight(theme: any, size: string): string {
   if (size === "small") {
     return theme.sizes.smallLogoHeight

--- a/frontend/app/src/components/StreamlitDialog/themeUtils.ts
+++ b/frontend/app/src/components/StreamlitDialog/themeUtils.ts
@@ -31,8 +31,11 @@ import { CustomThemeConfig } from "@streamlit/protobuf"
 interface ThemeOptionBuilder {
   help: string
   title: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   component: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   options?: any[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getValue: (value: string, config: ThemeOptionBuilder) => any
 }
 
@@ -43,6 +46,7 @@ const changedColorConfig = (
   themeInput: Partial<CustomThemeConfig>,
   baseTheme: EmotionTheme
 ): Array<string> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const toLowerCaseIfString = (x: any): any => {
     if (typeof x === "string") {
       return x.toLowerCase()

--- a/frontend/app/src/util/ScreenCastRecorder.ts
+++ b/frontend/app/src/util/ScreenCastRecorder.ts
@@ -112,10 +112,12 @@ class ScreenCastRecorder {
       return false
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const logRecorderError = (e: any): void => {
       LOG.warn(`mediaRecorder.start threw an error: ${e}`)
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     this.mediaRecorder.onerror = (e: any): void => {
       logRecorderError(e)
       this.onErrorOrStopCallback()

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -214,6 +214,7 @@ describe("DefaultStreamlitEndpoints", () => {
         )
         .reply(() => [200, 1])
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockOnUploadProgress = (_: any): void => {}
       const mockCancelToken = axios.CancelToken.source().token
 
@@ -246,6 +247,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .onPut("http://example.com/upload_file/file_2")
         .reply(() => [200, 1])
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockOnUploadProgress = (_: any): void => {}
       const mockCancelToken = axios.CancelToken.source().token
 
@@ -278,6 +280,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .onPut("http://example.com/someprefix/upload_file/file_2")
         .reply(() => [200, 1])
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockOnUploadProgress = (_: any): void => {}
       const mockCancelToken = axios.CancelToken.source().token
 

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -227,6 +227,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     sessionId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<void> {
@@ -329,6 +330,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
    * Wrapper around axios.request to update the request config with
    * CSRF headers if client has CSRF protection enabled.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private csrfRequest<T = any, R = AxiosResponse<T>>(
     url: string,
     params: AxiosRequestConfig

--- a/frontend/connection/src/StaticConnection.tsx
+++ b/frontend/connection/src/StaticConnection.tsx
@@ -27,6 +27,7 @@ import { StreamlitEndpoints } from "./types"
 export const STATIC_ASSET_CONFIG = "https://data.streamlit.io/static.json"
 export const LOG = getLogger("StaticConnection")
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 type OnMessage = (ForwardMsg: any) => void
 type OnConnectionStateChange = (
   connectionState: ConnectionState,

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -43,6 +43,7 @@ const MOCK_HEALTH_RESPONSE = { status: "ok" }
 // Sets up axios get mock to fail a specific number of times before succeeding
 function setupAxiosMockWithFailures(
   retryCount: number,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   errorObj: any
 ): ReturnType<typeof vi.fn> {
   const mockImplementation = vi.fn()
@@ -101,6 +102,7 @@ describe("doInitPings", () => {
     setAllowedOrigins: vi.fn(),
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let originalAxiosGet: any
 
   beforeEach(() => {
@@ -761,6 +763,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 describe("WebsocketConnection", () => {
   let client: WebsocketConnection
   let server: WS
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let originalAxiosGet: any
 
   beforeEach(() => {
@@ -856,7 +859,9 @@ describe("WebsocketConnection", () => {
 })
 
 describe("WebsocketConnection auth token handling", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let originalAxiosGet: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let websocketSpy: any
   let server: WS
 

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -102,6 +102,7 @@ export interface Args {
 }
 
 interface MessageQueue {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [index: number]: any
 }
 

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -26,6 +26,7 @@ import { IAppPage } from "@streamlit/protobuf"
 
 import { ConnectionState } from "./ConnectionState"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export type OnMessage = (ForwardMsg: any) => void
 
 export type OnConnectionStateChange = (
@@ -137,6 +138,7 @@ export interface StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     sessionId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<void>

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -1183,11 +1183,13 @@ interface CustomMatchers<R = unknown> {
 }
 
 declare module "vitest" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining extends CustomMatchers {}
 }
 
 expect.extend({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   toBeTextNode(received, text): any {
     const elementNode = received as ElementNode
     if (isNullOrUndefined(elementNode)) {

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -103,6 +103,7 @@ export class FileUploadClient {
     widget: WidgetInfo,
     fileUploadUrl: string,
     file: File,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<void> {

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -107,6 +107,7 @@ export interface StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     sessionId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<void>

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -190,6 +190,7 @@ export class WidgetStateManager {
   // A dictionary that maps elementId -> element state keys -> element state values.
   // This is used to store frontend-only state for elements.
   // This state is not never sent to the server.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private readonly elementStates = new Map<string, Map<string, any>>()
 
   constructor(props: Props) {
@@ -494,6 +495,7 @@ export class WidgetStateManager {
 
   public setJsonValue(
     widget: WidgetInfo,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     value: any,
     source: Source,
     fragmentId: string | undefined
@@ -794,6 +796,7 @@ export class WidgetStateManager {
    * Get the element state value for the given element ID and key, if it exists.
    * This is a frontend-only state that is never sent to the server.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   public getElementState(elementId: string, key: string): any {
     return this.elementStates.get(elementId)?.get(key)
   }
@@ -809,12 +812,15 @@ export class WidgetStateManager {
    * @param {any} value - The value to set for the element's state.
    * @returns {void}
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   public setElementState(elementId: string, key: string, value: any): void {
     if (!this.elementStates.has(elementId)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       this.elementStates.set(elementId, new Map<string, any>())
     }
 
     // It's expected here that there is always an initialized map for an elementId
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     ;(this.elementStates.get(elementId) as Map<string, any>).set(key, value)
   }
 

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -155,6 +155,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
 )
 
 export interface StyledVerticalBlockProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ref?: React.RefObject<any>
   width?: React.CSSProperties["width"]
   maxWidth?: React.CSSProperties["maxWidth"]

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
@@ -28,6 +28,7 @@ import {
   getSequentialColorsArray,
 } from "~lib/theme"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function applyStreamlitTheme(config: any, theme: EmotionTheme): any {
   // This theming config contains multiple hard coded spacing values.
   // The reason is that we currently only have rem values in our spacing
@@ -152,6 +153,7 @@ export function applyStreamlitTheme(config: any, theme: EmotionTheme): any {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function applyThemeDefaults(config: any, theme: EmotionTheme): any {
   const { colors, fontSizes, genericFonts } = theme
   const themeFonts = {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/arrowUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/arrowUtils.ts
@@ -79,6 +79,7 @@ export interface WrappedNamedDataset {
 
 export function getInlineData(
   quiverData: Quiver | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): { [field: string]: any }[] | null {
   if (!quiverData || quiverData.dimensions.numDataRows === 0) {
     return null
@@ -89,12 +90,14 @@ export function getInlineData(
 
 export function getDataArrays(
   datasets: WrappedNamedDataset[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): { [dataset: string]: any[] } | null {
   const datasetMapping = getDataSets(datasets)
   if (isNullOrUndefined(datasetMapping)) {
     return null
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const datasetArrays: { [dataset: string]: any[] } = {}
 
   for (const [name, dataset] of Object.entries(datasetMapping)) {
@@ -135,6 +138,7 @@ export function getDataSets(
 export function getDataArray(
   quiverData: Quiver,
   startIndex = 0
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): { [field: string]: any }[] {
   if (quiverData.dimensions.numDataRows === 0) {
     return []
@@ -155,6 +159,7 @@ export function getDataArray(
       isDateType(firstIndexColumnType))
 
   for (let rowIndex = startIndex; rowIndex < numDataRows; rowIndex++) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const row: { [field: string]: any } = {}
 
     if (hasSupportedIndex) {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -40,8 +40,10 @@ const BOTTOM_PADDING = 20
  *
  * @param spec The Vega-Lite specification of the chart.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function prepareSpecForSelections(spec: any): void {
   if ("params" in spec && "encoding" in spec) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     spec.params.forEach((param: any) => {
       if (!("select" in param)) {
         // We are only interested in transforming select parameters.
@@ -90,6 +92,7 @@ const generateSpec = (
   isFullScreen: boolean,
   width: number,
   height?: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any => {
   const spec = JSON.parse(inputSpec)
   if (vegaLiteTheme === "streamlit") {
@@ -108,6 +111,7 @@ const generateSpec = (
     spec.height = height
 
     if ("vconcat" in spec) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       spec.vconcat.forEach((child: any) => {
         child.width = width
       })
@@ -116,6 +120,7 @@ const generateSpec = (
     spec.width = width
 
     if ("vconcat" in spec) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       spec.vconcat.forEach((child: any) => {
         child.width = width
       })

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -74,6 +74,7 @@ describe("useVegaEmbed hook", () => {
   let mockWidgetMgr: Mocked<WidgetStateManager>
   let mockVegaView: Mocked<VegaView>
   let mockEmbedReturn: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     vgSpec: any
     view: Mocked<VegaView>
     finalize: () => void
@@ -106,6 +107,7 @@ describe("useVegaEmbed hook", () => {
     ;(useVegaLiteSelections as Mock).mockReturnValue({
       maybeConfigureSelections: vi
         .fn()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         .mockImplementation((view: any) => view),
       onFormCleared: vi.fn(),
     })
@@ -126,6 +128,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     // mount hook
@@ -185,6 +188,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     // mount hook
@@ -224,6 +228,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     const { result } = renderHook(() =>
@@ -242,6 +247,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
@@ -276,6 +282,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
@@ -293,6 +300,7 @@ describe("useVegaEmbed hook", () => {
       id: "chartId",
       data: null,
       datasets: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     const { result } = renderHook(() =>
@@ -313,6 +321,7 @@ describe("useVegaEmbed hook", () => {
       dimensions: { dataRows: 5, dataCols: 2 },
       isEmpty: () => false,
       columnTypes: { index: ["int"], data: ["int"] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     await act(async () => {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -41,6 +41,7 @@ const LOG = getLogger("useVegaEmbed")
 interface UseVegaEmbedOutput {
   createView: (
     containerRef: RefObject<HTMLDivElement>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     spec: any
   ) => Promise<VegaView | null>
   updateView: (
@@ -102,6 +103,7 @@ export function useVegaEmbed(
   const createView = useCallback(
     async (
       containerRef: RefObject<HTMLDivElement>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       spec: any
     ): Promise<VegaView | null> => {
       if (containerRef.current === null) {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
@@ -49,6 +49,7 @@ describe("useVegaLiteSelections", () => {
 
     const debouncedMock = debounce as Mock
     // By default, the mocked debounce simply calls its callback immediately.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     debouncedMock.mockImplementation((_delay: number, fn: any) => fn)
   })
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
@@ -36,6 +36,7 @@ const DEBOUNCE_TIME_MS = 150
  * in the Python code.
  */
 export interface VegaLiteState {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   selection: Record<string, any>
 }
 
@@ -77,6 +78,7 @@ export const useVegaLiteSelections = (
             const viewState = vegaView.getState({
               // There are also `signals` data, but I believe its
               // not relevant for restoring the selection state.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
               data: (name?: string, _operator?: any) => {
                 // Vega lite stores the selection state in a <param name>_store parameter
                 // under `data` that can be retrieved via the getState method.

--- a/frontend/lib/src/components/elements/BokehChart/BokehChart.test.tsx
+++ b/frontend/lib/src/components/elements/BokehChart/BokehChart.test.tsx
@@ -291,7 +291,8 @@ expect.extend({
   toMatchBokehDimensions(data, width, height) {
     const plot =
       data && data.doc && data.doc.roots && data.doc.roots.references
-        ? data.doc.roots.references.find((e: any) => e.type === "Plot")
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+          data.doc.roots.references.find((e: any) => e.type === "Plot")
         : undefined
 
     if (!plot) {

--- a/frontend/lib/src/components/elements/BokehChart/BokehChart.tsx
+++ b/frontend/lib/src/components/elements/BokehChart/BokehChart.tsx
@@ -52,6 +52,7 @@ export function BokehChart({
   }, [element])
 
   const getChartDimensions = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (plot: any): Dimensions => {
       // Default values
       let chartWidth: number = plot.attributes.plot_width
@@ -76,6 +77,7 @@ export function BokehChart({
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const updateChart = (data: any): void => {
     const chart = document.getElementById(chartId)
 
@@ -88,7 +90,8 @@ export function BokehChart({
      */
     const plot =
       data && data.doc && data.doc.roots && data.doc.roots.references
-        ? data.doc.roots.references.find((e: any) => e.type === "Plot")
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+          data.doc.roots.references.find((e: any) => e.type === "Plot")
         : undefined
 
     if (plot) {

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
@@ -44,7 +44,9 @@ function StreamlitSyntaxHighlighter({
   children,
 }: Readonly<StreamlitSyntaxHighlighterProps>): ReactElement {
   const renderer = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     ({ rows, stylesheet, useInlineStyles }: any): any =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       rows.map((row: any, index: any): any => {
         const children = row.children
 

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -346,6 +346,7 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
     // If the ViewState on the server has changed, apply the diff to the current state
     if (!isEqual(deck.initialViewState, initialViewState)) {
       const diff = Object.keys(deck.initialViewState).reduce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         (diff, key): any => {
           // @ts-expect-error
           if (deck.initialViewState[key] === initialViewState?.[key]) {

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/withMapboxToken/withMapboxToken.test.tsx
@@ -114,6 +114,7 @@ describe("withMapboxToken", () => {
     })
 
     it("should throw an error if fetched token is not present", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       let wrappedComponentInstance: any
       axios.get = vi
         .fn()

--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -61,6 +61,7 @@ function Json({ element }: Readonly<JsonProps>): ReactElement {
   // theme's background is light or dark.
   const jsonTheme = hasLightBackgroundColor(theme) ? "rjv-default" : "monokai"
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const handleCopy = (copy: any): void => {
     // we use ClipboardJS to do the copying, because it allows
     // us to specify a container element. This is necessary because

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -41,6 +41,7 @@ export interface BaseLinkButtonProps {
   href: string
   target: string
   rel: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onClick: (event: MouseEvent<HTMLAnchorElement>) => any
 }
 

--- a/frontend/lib/src/components/elements/Metric/styled-components.ts
+++ b/frontend/lib/src/components/elements/Metric/styled-components.ts
@@ -81,6 +81,7 @@ export interface StyledMetricDeltaTextProps {
 }
 
 const getMetricColor = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   theme: any,
   color: MetricProto.MetricColor
 ): string => {

--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
@@ -40,6 +40,7 @@ const LOG = getLogger("PlotlyChart:CustomTheme")
  * @param theme - Theme from useTheme()
  */
 export function applyStreamlitThemeTemplateLayout(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   layout: any,
   theme: EmotionTheme
 ): void {
@@ -404,6 +405,7 @@ export function replaceTemporaryColors(
  * spec.data, spec.layout.template.data, and spec.layout.template.layout
  * @param spec - spec
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function applyStreamlitTheme(spec: any, theme: EmotionTheme): void {
   try {
     applyStreamlitThemeTemplateLayout(spec.layout.template.layout, theme)
@@ -425,8 +427,10 @@ export function applyStreamlitTheme(spec: any, theme: EmotionTheme): void {
  * @returns modified spec.layout
  */
 export function layoutWithThemeDefaults(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   layout: any,
   theme: EmotionTheme
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any {
   const { colors, genericFonts } = theme
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -361,6 +361,7 @@ export function PlotlyChart({
           setPlotlyFigure((prevFigure: PlotlyFigureType) => {
             return {
               ...prevFigure,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
               data: prevFigure.data.map((trace: any) => {
                 return {
                   ...trace,

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -152,6 +152,7 @@ describe("PlotlyChart utils", () => {
     })
 
     it("should handle an event with no points or selections", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const event = { points: undefined, selections: undefined } as any
       const widgetMgr = getWidgetMgr()
 
@@ -170,6 +171,7 @@ describe("PlotlyChart utils", () => {
             pointIndices: [1],
           },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -197,6 +199,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -216,6 +219,7 @@ describe("PlotlyChart utils", () => {
         selections: [
           { type: "path", xref: "x", yref: "y", path: "M4.0,8.0L4.0,7.8Z" },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -235,6 +239,7 @@ describe("PlotlyChart utils", () => {
         selections: [
           { type: "path", xref: "x", yref: "y", path: "M4.0,8.0L4.0,7.8Z" },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -263,6 +268,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -282,6 +288,7 @@ describe("PlotlyChart utils", () => {
       const event = {
         points: [],
         selections: [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       const widgetMgr = getWidgetMgr()
 
@@ -320,6 +327,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
 
       const widgetMgr = getWidgetMgr()
@@ -362,6 +370,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
 
       handleSelection(

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.ts
@@ -45,6 +45,7 @@ export interface PlotlySelection extends SelectionRange {
 // Python naming conventions.
 export interface PlotlyWidgetState {
   selection: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     points: Array<any>
     point_indices: number[]
     box: PlotlySelection[]
@@ -116,6 +117,7 @@ export function parseLassoPath(pathData: string): SelectionRange {
  * @param {Object} selection - The box selection object to be parsed.
  * @returns {SelectionRange} An object containing two arrays: `x` for all x coordinates and `y` for all y coordinates.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function parseBoxSelection(selection: any): SelectionRange {
   const hasRequiredFields =
     "x0" in selection &&
@@ -190,6 +192,7 @@ export function handleSelection(
   const selectedPointIndices = new Set<number>()
   const selectedBoxes: PlotlySelection[] = []
   const selectedLassos: PlotlySelection[] = []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const selectedPoints: Array<any> = []
 
   // event.selections doesn't show up in the PlotSelectionEvent
@@ -197,6 +200,7 @@ export function handleSelection(
   const { selections, points } = event
 
   if (points) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     points.forEach(function (point: any) {
       selectedPoints.push({
         ...point,
@@ -223,6 +227,7 @@ export function handleSelection(
   }
 
   if (selections) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     selections.forEach((selection: any) => {
       // box selection
       if (selection.type === "rect") {
@@ -250,6 +255,7 @@ export function handleSelection(
   }
 
   selectionState.selection.point_indices = Array.from(selectedPointIndices)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   selectionState.selection.points = selectedPoints.map((point: any) =>
     keysToSnakeCase(point)
   )

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -39,6 +39,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
   widgetsDisabled: boolean
   node: BlockNode
   isStale: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   renderTabContent: (childProps: any) => ReactElement
 }
 

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -53,6 +53,7 @@ export enum BaseButtonSize {
 export interface BaseButtonProps {
   kind: BaseButtonKind
   size?: BaseButtonSize
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onClick?: (event: MouseEvent<HTMLButtonElement>) => any
   disabled?: boolean
   // If true, the button should take up container's full width

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -71,6 +71,7 @@ export interface BaseColorPickerProps {
   showValue?: boolean
   label: string
   labelVisibility?: LabelVisibilityOptions
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onChange: (value: string) => any
   help?: string
 }

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -37,6 +37,7 @@ export interface Props {
   value: string | null
   onChange: (value: string | null) => void
   disabled: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   options: any[]
   label?: string | null
   labelVisibility?: LabelVisibilityOptions

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -57,6 +57,7 @@ function FixedSizeListItem(props: FixedSizeListItemProps): ReactElement {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const VirtualDropdown = React.forwardRef<any, any>((props, ref) => {
   const theme = useTheme()
   // TODO: Update to match React best practices

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -36,6 +36,7 @@ export enum Size {
 
 export interface ProgressBarProps {
   value: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   overrides?: Overrides<any>
   size?: Size
 }
@@ -63,6 +64,7 @@ function ProgressBar({
       },
     },
     Bar: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       style: ({ $theme }: { $theme: any }) => ({
         marginTop: theme.spacing.none,
         marginBottom: theme.spacing.none,

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -39,8 +39,11 @@ export interface Props {
   disabled: boolean
   horizontal: boolean
   value: number | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onChange: (selectedIndex: number) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   options: any[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   captions: any[]
   label?: string
   labelVisibility?: LabelVisibilityOptions

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -226,6 +226,7 @@ export const HeadingWithActionElements: FunctionComponent<
   }, [addScriptFinishedHandler, removeScriptFinishedHandler, onScriptFinished])
 
   const ref = React.useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (node: any) => {
       if (node === null) {
         return
@@ -415,6 +416,7 @@ export function RenderedMarkdown({
     })
   )
   function remarkColoringAndSmall() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     return (tree: any) => {
       visit(tree, "textDirective", (node, _index, _parent) => {
         const nodeName = String(node.name)
@@ -489,7 +491,9 @@ export function RenderedMarkdown({
   }
 
   function remarkMaterialIcons() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     return (tree: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       function replace(fullMatch: string, iconName: string): any {
         return {
           type: "text",
@@ -531,7 +535,9 @@ export function RenderedMarkdown({
   }
 
   function remarkStreamlitLogo() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     return (tree: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       function replaceStreamlit(): any {
         return {
           type: "text",
@@ -564,6 +570,7 @@ export function RenderedMarkdown({
   }
 
   function remarkTypographicalSymbols() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     return (tree: any) => {
       visit(tree, (node, index, parent) => {
         if (
@@ -708,6 +715,7 @@ const StreamlitMarkdown: React.FC<Props> = ({
 }
 
 interface LinkProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   node: any
   children: ReactNode[]
   href?: string

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -30,6 +30,7 @@ function convertRemToEm(s: string): string {
   return s.replace(/rem$/, "em")
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function sharedMarkdownStyle(theme: Theme): any {
   return {
     a: {
@@ -63,6 +64,7 @@ function getMarkdownHeadingDefinitions(
   theme: Theme,
   useSmallerHeadings: boolean,
   isCaption: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any {
   return {
     "h1, h2, h3, h4, h5, h6": {
@@ -301,12 +303,14 @@ export const StyledHeadingWithActionElements = styled.div(({ theme }) => ({
   textWrap: "pretty",
 
   // show link-icon when hovering somewhere over the heading
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledLinkIcon as any]: {
     visibility: "hidden",
   },
 
   // we have to set the hover here so that the link icon becomes visible when hovering anywhere over the heading
   "&:hover": {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     [StyledLinkIcon as any]: {
       visibility: "visible",
     },

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
@@ -90,6 +90,7 @@ export interface ToolbarProps {
   onCollapse?: () => void
   isFullScreen?: boolean
   locked?: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   target?: StyledComponent<any, any, any>
   disableFullscreenMode?: boolean
 }

--- a/frontend/lib/src/components/shared/Toolbar/styled-components.ts
+++ b/frontend/lib/src/components/shared/Toolbar/styled-components.ts
@@ -22,6 +22,7 @@ const TOP_DISTANCE = "-2.4rem"
 
 export interface StyledToolbarWrapperProps {
   locked?: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   target?: StyledComponent<any, any, any>
 }
 

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -34,6 +34,7 @@ const getProps = (
 })
 
 // Wrap in BaseProvider to avoid warnings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const renderTooltip = (props: Partial<TooltipProps> = {}): any => {
   return render(
     <BaseProvider theme={LightTheme}>

--- a/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
@@ -28,6 +28,7 @@ describe("WindowDimensionsProvider", () => {
   it("should provide the width and height of the window and take into account the theme padding", () => {
     vi.spyOn(window, "getComputedStyle").mockReturnValue({
       fontSize: "16px",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any)
 
     const MyComponent: FC = () => {

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -41,7 +41,7 @@ const expectHighlightStyle = (
   element: HTMLElement,
   should_exist = true
 ): void => {
-  // eslint-disable-next-line vitest/valid-expect
+  // eslint-disable-next-line vitest/valid-expect, @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let expectCheck: any = expect(element)
   if (!should_exist) {
     expectCheck = expect.not

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -183,6 +183,7 @@ function getButtonKindAndSize(
 function getButtonGroupOverridesStyle(
   style: ButtonGroupProto.Style,
   spacing: EmotionTheme["spacing"]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): Record<string, any> {
   const baseStyle = { flexWrap: "wrap", maxWidth: "fit-content" }
 
@@ -241,6 +242,7 @@ function createOptionChild(
   // we have to use forwardRef here because BasewebButtonGroup passes the ref down to its children
   // and we see a console.error otherwise
   return forwardRef(function BaseButtonGroup(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     props: any,
     _: Ref<BasewebButtonGroup>
   ): ReactElement {

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
@@ -26,6 +26,7 @@ import {
 } from "./styled-components"
 
 export interface CameraInputButtonProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onClick?: (event: MouseEvent<HTMLButtonElement>) => any
   disabled?: boolean
   progress?: number | null

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -22,6 +22,7 @@ import { transparentize } from "color2k"
 import { EmotionTheme } from "~lib/theme"
 
 export interface CameraInputButtonProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   onClick?: (event: MouseEvent<HTMLButtonElement>) => any
   disabled?: boolean
   children: ReactNode

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -32,7 +32,9 @@ import {
 } from "./styled-components"
 
 export interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getRootProps: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getInputProps: any
   acceptFile: AcceptFileValue
   disabled: boolean

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
@@ -24,7 +24,9 @@ import {
 } from "./styled-components"
 
 export interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getRootProps: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getInputProps: any
   acceptFile: AcceptFileValue
   inputHeight: string

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -651,6 +651,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const widgetMgr = (WidgetStateManager as any).mock.instances[0]
       expect(widgetMgr.setJsonValue).toHaveBeenCalledWith(
         element,
@@ -714,6 +715,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const widgetMgr = (WidgetStateManager as any).mock.instances[0]
       expect(widgetMgr.setBytesValue).toHaveBeenCalledWith(
         element,
@@ -763,6 +765,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const widgetMgr = (WidgetStateManager as any).mock.instances[0]
       expect(widgetMgr.setJsonValue).not.toHaveBeenCalled()
 
@@ -861,6 +864,7 @@ describe("ComponentInstance", () => {
             source: iframe.contentWindow,
           })
         )
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         const widgetMgr = (WidgetStateManager as any).mock.instances[0]
         expect(widgetMgr.setJsonValue).not.toHaveBeenCalled()
 
@@ -872,7 +876,9 @@ describe("ComponentInstance", () => {
   })
 
   function renderMsg(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     args: { [name: string]: any },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     dataframes: any[],
     disabled = false,
     theme = {
@@ -881,6 +887,7 @@ describe("ComponentInstance", () => {
       font: mockTheme.emotion.genericFonts.bodyFont,
       base: bgColorToBaseString(mockTheme.emotion.colors.bgColor),
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ): any {
     return forwardMsg(StreamlitMessageType.RENDER, {
       args,
@@ -890,12 +897,14 @@ describe("ComponentInstance", () => {
     })
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   function forwardMsg(type: StreamlitMessageType, data: any): any {
     return { type, ...data }
   }
 
   /** Create a ComponentInstance.props.element prop with the given args. */
   function createElementProp(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     jsonArgs: { [name: string]: any } = {},
     specialArgs: SpecialArg[] = []
   ): ComponentInstanceProto {

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
@@ -32,7 +32,9 @@ describe("ComponentRegistry", () => {
     const { onMessageEvent } = registry
 
     // Create some mocks
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const msgSource1: any = {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const msgSource2: any = {}
     const msgListener1 = vi.fn()
     const msgListener2 = vi.fn()

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -22,6 +22,7 @@ import { ComponentMessageType } from "./enums"
 
 export type ComponentMessageListener = (
   type: ComponentMessageType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   data: any
 ) => void
 

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -139,6 +139,7 @@ describe("test componentUtils", () => {
     it("should send message to iframe", () => {
       const handleAction = vi.fn()
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockIframe: any = {
         contentWindow: {
           postMessage: handleAction,
@@ -176,6 +177,7 @@ describe("test componentUtils", () => {
     it("should not send message when iframe is undefined", () => {
       const handleAction = vi.fn()
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockIframe: any = undefined
       sendRenderMessage({}, [], false, mockTheme.emotion, mockIframe)
       expect(handleAction).toBeCalledTimes(0)
@@ -184,6 +186,7 @@ describe("test componentUtils", () => {
     it("should not send message when iframe's content window is undefined", () => {
       const handleAction = vi.fn()
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const mockIframe: any = {
         contentWindow: undefined,
       }

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -42,6 +42,7 @@ type ReadyMessage = {
 }
 type ComponentValueMessage = {
   /* the value sent from the custom component can be anything */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   value: any
   dataType: ValueType
 }
@@ -64,10 +65,12 @@ export interface IframeMessageHandlerProps {
 }
 
 export interface Args {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [name: string]: any
 }
 export interface DataframeArg {
   key: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   value: any
 }
 
@@ -283,6 +286,7 @@ export function sendRenderMessage(
  * @returns undefined
  */
 function handleSetComponentValue(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   value: any, // we do not know what data the custom component is sending us, so we use 'any' here
   dataType: ValueType,
   source: Source,
@@ -309,9 +313,12 @@ function handleSetComponentValue(
 
 /** Return the property with the given name, if it exists. */
 function tryGetValue(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   obj: any,
   name: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   defaultValue: any = undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): any {
   return obj.hasOwnProperty(name) ? obj[name] : defaultValue
 }

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -54,6 +54,7 @@ const getProps = (
   disabled: false,
   widgetMgr: {
     getStringValue: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   } as any,
 })
 

--- a/frontend/lib/src/components/widgets/DataFrame/EditingState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/EditingState.ts
@@ -71,7 +71,9 @@ class EditingState {
       // We use snake case here since this is the widget state
       // that is sent and used in the backend. Therefore, it should
       // conform with the Python naming conventions.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       edited_rows: {} as Record<number, Record<string, any>>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       added_rows: [] as Record<string, any>[],
       deleted_rows: [] as number[],
     }
@@ -81,6 +83,7 @@ class EditingState {
     // row position -> column name -> edited value
     this.editedCells.forEach(
       (row: Map<number, GridCell>, rowIndex: number, _map) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         const editedRow: Record<string, any> = {}
         row.forEach((cell: GridCell, colIndex: number, _map) => {
           const column = columnsByIndex.get(colIndex)
@@ -96,6 +99,7 @@ class EditingState {
     // we use for the JSON-compatible widget state:
     // List of column name -> edited value
     this.addedRows.forEach((row: Map<number, GridCell>) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       const addedRow: Record<string, any> = {}
       // This flags is used to check if the row is incomplete
       // (i.e. missing required values) and should therefore not be included in
@@ -186,6 +190,7 @@ class EditingState {
     // Loop through all added rows and transform into the format that
     // we use for the editing state:
     // List of column index -> edited value
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     editingState.added_rows.forEach((row: Record<string, any>) => {
       const addedRow: Map<number, GridCell> = new Map()
       // Initialize all columns with null (empty) values first

--- a/frontend/lib/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -706,6 +706,7 @@ describe("getCellFromArrow", () => {
       styledCell,
       undefined
     )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect((cell as any).data.displayDate).toEqual("FOOO")
   })
 
@@ -766,6 +767,7 @@ describe("getCellFromArrow", () => {
     const cell = getCellFromArrow(MOCK_TIME_COLUMN, arrowCell, styledCell)
     // Should use the formatted value from the cell and not the displayContent
     // from pandas styler
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect((cell as any).data.displayDate).toEqual("2021")
   })
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
@@ -238,6 +238,7 @@ describe("ChartColumn", () => {
     [false, [0]],
   ])(
     "supports numerical array-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: any[] | null) => {
       const mockColumn = getBarChartColumn()
       const cell = mockColumn.getCell(input)
@@ -253,6 +254,7 @@ describe("ChartColumn", () => {
     [["foo", "bar"]],
     [[0.1, 0.4, "foo"]],
     [[0.1, 0.4, null]],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ])("%p results in error cell", (input: any) => {
     const mockColumn = getLineChartColumn()
     const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -84,6 +84,7 @@ function BaseChartColumn(
     kind,
     sortMode: "default",
     isEditable: false, // Chart column is always read-only
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       if (
         isNullOrUndefined(parameters.y_min) ||

--- a/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
@@ -81,6 +81,7 @@ describe("CheckboxColumn", () => {
     ["", null],
   ])(
     "supports boolean compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: boolean | null) => {
       const mockColumn = CheckboxColumn(MOCK_CHECKBOX_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
@@ -91,6 +92,7 @@ describe("CheckboxColumn", () => {
 
   it.each([["foo"], [12345], [0.1], [["foo", "bar"]]])(
     "%p results in error cell: %p",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any) => {
       const mockColumn = CheckboxColumn(MOCK_CHECKBOX_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
@@ -48,6 +48,7 @@ function CheckboxColumn(props: BaseColumnProps): BaseColumn {
     ...props,
     kind: "checkbox",
     sortMode: "default",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       let cellData = null
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
@@ -168,6 +168,7 @@ describe("DateTimeColumn", () => {
     ["1671951600", "2022-12-25T07:00:00.000"],
   ])(
     "supports datetime-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = DateTimeColumn(MOCK_DATETIME_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
@@ -175,6 +176,7 @@ describe("DateTimeColumn", () => {
     }
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
     const mockColumn = DateTimeColumn(MOCK_DATETIME_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)
@@ -277,6 +279,7 @@ describe("DateTimeColumn", () => {
         pandasType: {
           ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType.pandasType,
           metadata: { timezone: "+05:00" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         } as any,
       },
     }
@@ -351,6 +354,7 @@ describe("DateColumn", () => {
     ["1671951600", "2022-12-25"],
   ])(
     "supports date-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = DateColumn(MOCK_DATE_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
@@ -358,6 +362,7 @@ describe("DateColumn", () => {
     }
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
     const mockColumn = DateColumn(MOCK_DATE_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)
@@ -501,6 +506,7 @@ describe("TimeColumn", () => {
     ["1671951600", "07:00:00.000"],
   ])(
     "supports time-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = TimeColumn(MOCK_TIME_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
@@ -508,6 +514,7 @@ describe("TimeColumn", () => {
     }
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
     const mockColumn = TimeColumn(MOCK_TIME_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -142,6 +142,7 @@ function BaseDateTimeColumn(
     },
   } as DatePickerType
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const validateInput = (data?: any): boolean | Date => {
     const cellData: Date | null | undefined = toSafeDate(data)
     if (cellData === null) {
@@ -183,6 +184,7 @@ function BaseDateTimeColumn(
     kind,
     sortMode: "default",
     validateInput,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any, validate?: boolean): GridCell {
       if (validate === true) {
         const validationResult = validateInput(data)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.test.ts
@@ -90,6 +90,7 @@ describe("ImageColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = ImageColumn(MOCK_IMAGE_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.ts
@@ -42,6 +42,7 @@ function ImageColumn(props: BaseColumnProps): BaseColumn {
     kind: "image",
     sortMode: "default",
     isEditable: false, // Image columns are always read-only
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       // The native image cell implementation in glide-data-grid expects an array
       // of image URLs. For our usecase, we only support single images. We

--- a/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.test.ts
@@ -92,6 +92,7 @@ describe("JsonColumn", () => {
     [undefined, null, ""],
   ])(
     "handles different JSON-compatible values (%p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, expected: any, displayValue: string) => {
       const mockColumn = JsonColumn(MOCK_JSON_COLUMN_PROPS)
       const cell = mockColumn.getCell(input) as JsonCell

--- a/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.ts
@@ -51,6 +51,7 @@ function JsonColumn(props: BaseColumnProps): BaseColumn {
     kind: "json",
     sortMode: "default",
     isEditable: false, // Json columns are read-only.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       try {
         const displayValue = notNullOrUndefined(data)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -71,6 +71,7 @@ describe("LinkColumn", () => {
     // should also be supported by the UrlColumn.
   ])(
     "supports string-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: any | null) => {
       const mockColumn = LinkColumn(MOCK_LINK_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -113,10 +113,12 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
     kind: "link",
     sortMode: "default",
     validateInput,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any, validate?: boolean): GridCell {
       if (isNullOrUndefined(data)) {
         return {
           ...cellTemplate,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
           data: null as any,
           isMissingValue: true,
           onClickUri: () => {},

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.test.ts
@@ -100,6 +100,7 @@ describe("ListColumn", () => {
     ],
   ])(
     "supports array-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: any[] | null) => {
       const mockColumn = ListColumn(MOCK_LIST_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
@@ -118,9 +119,11 @@ describe("ListColumn", () => {
     [[true, false], "true,false"],
   ])(
     "correctly prepares data for copy (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, copyData: string | undefined) => {
       const mockColumn = ListColumn(MOCK_LIST_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       expect((cell as any).copyData).toEqual(copyData)
     }
   )

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.ts
@@ -43,6 +43,7 @@ function ListColumn(props: BaseColumnProps): BaseColumn {
     kind: "list",
     sortMode: "default",
     isEditable: false, // List column is always readonly
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       const cellData = isNullOrUndefined(data) ? [] : toSafeArray(data)
 
@@ -53,6 +54,7 @@ function ListColumn(props: BaseColumnProps): BaseColumn {
         copyData: isNullOrUndefined(data)
           ? ""
           : toSafeString(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
               cellData.map((x: any) =>
                 // Replace commas with spaces since commas are used to
                 // separate the list items.

--- a/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -156,7 +156,9 @@ describe("NumberColumn", () => {
 
     const mockCell = mockColumn.getCell("104")
     expect(mockCell.kind).toEqual(GridCellKind.Number)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect((mockCell as any).fixedDecimals).toEqual(0)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect((mockCell as any).allowNegative).toEqual(false)
   })
 
@@ -249,6 +251,7 @@ describe("NumberColumn", () => {
     ["--123"],
     ["2,,2"],
     ["12345678987654321"],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ])("%p results in error cell", (input: any) => {
     const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE)
     const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -100,6 +100,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
     thousandSeparator: "",
   } as NumberCell
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const validateInput = (data?: any): boolean | number => {
     let cellData: number | null = toSafeNumber(data)
 
@@ -149,6 +150,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
     kind: "number",
     sortMode: "smart",
     validateInput,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any, validate?: boolean): GridCell {
       if (validate === true) {
         const validationResult = validateInput(data)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
@@ -92,6 +92,7 @@ describe("ObjectColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = ObjectColumn(MOCK_OBJECT_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.ts
@@ -47,6 +47,7 @@ function ObjectColumn(props: BaseColumnProps): BaseColumn {
     kind: "object",
     sortMode: "default",
     isEditable: false, // Object columns are read-only.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       try {
         const cellData = notNullOrUndefined(data) ? toSafeString(data) : null

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -116,6 +116,7 @@ describe("ProgressColumn", () => {
     [0.1234, 0.1234],
   ])(
     "supports number-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: number | null) => {
       const mockColumn = getProgressColumn()
       const cell = mockColumn.getCell(input)
@@ -131,6 +132,7 @@ describe("ProgressColumn", () => {
     ["123.124.123"],
     ["--123"],
     ["2,,2"],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ])("%p results in error cell", (input: any) => {
     const mockColumn = getProgressColumn()
     const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -107,6 +107,7 @@ function ProgressColumn(props: BaseColumnProps): BaseColumn {
     kind: "progress",
     sortMode: "smart",
     isEditable: false, // Progress column is always readonly
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any): GridCell {
       if (isNullOrUndefined(data)) {
         // TODO(lukasmasuch): Use a missing cell?

--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -173,6 +173,7 @@ describe("SelectboxColumn", () => {
 
   it.each([[null], [undefined], [""]])(
     "%p is interpreted as missing value",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any) => {
       const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
         options: ["foo", "bar"],

--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
@@ -92,6 +92,7 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
     ...props,
     kind: "selectbox",
     sortMode: "default",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any, validate?: boolean): GridCell {
       // Empty string refers to a missing value
       let cellData = null

--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
@@ -81,6 +81,7 @@ describe("TextColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (input: any, value: string | null) => {
       const mockColumn = TextColumn(MOCK_TEXT_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
@@ -65,6 +65,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     style: props.isPinned ? "faded" : "normal",
   } as TextCell
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const validateInput = (data?: any): boolean | string => {
     if (isNullOrUndefined(data)) {
       if (props.isRequired) {
@@ -99,6 +100,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     kind: "text",
     sortMode: "default",
     validateInput,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     getCell(data?: any, validate?: boolean): GridCell {
       if (typeof validateRegex === "string") {
         // The regex is invalid, we return an error to indicate this

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.test.tsx
@@ -29,6 +29,7 @@ describe("JsonCell renderer", () => {
       data: { kind: "json-cell", value: { test: "value" } },
       allowOverlay: true,
       copyData: "",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
     expect(renderer.isMatch(jsonCell)).toBe(true)
@@ -41,8 +42,10 @@ describe("JsonCell renderer", () => {
 
     const cell = {
       data: { kind: "json-cell", value: { test: "value" } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     } as any
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const width = renderer.measure!(ctx, cell, mockTheme as any)
     expect(width).toBeGreaterThan(0)
   })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
@@ -84,6 +84,7 @@ export const JsonTextCellEditor: ReturnType<
  */
 const renderer: CustomRenderer<JsonCell> = {
   kind: GridCellKind.Custom,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   isMatch: (c): c is JsonCell => (c.data as any).kind === "json-cell",
   draw: (args, cell) => {
     const { value, displayValue } = cell.data

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -39,6 +39,7 @@ const StyledJsonWrapper = styled.div(({ theme }) => ({
 
 interface JsonViewerProps {
   jsonValue: string | object | undefined | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   theme: any
 }
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -755,12 +755,14 @@ describe("toJsonString", () => {
     // Circular reference (should use toSafeString fallback)
     [
       (() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         const circular: any = { a: 1 }
         circular.self = circular
         return circular
       })(),
       "[object Object]",
     ],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   ])("converts %o to JSON string %s", (input: any, expected: string) => {
     expect(toJsonString(input)).toBe(expected)
   })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -70,6 +70,7 @@ export interface BaseColumnProps {
   // A help text that is displayed on hovering the column header.
   readonly help?: string
   // Configuration options related to the column type:
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   readonly columnTypeOptions?: Record<string, any>
   // The content alignment of the column:
   readonly contentAlignment?: "left" | "center" | "right"
@@ -96,10 +97,13 @@ export interface BaseColumn extends BaseColumnProps {
   // Validate the input data for compatibility with the column type:
   // Either returns a boolean indicating if the data is valid or not, or
   // returns the corrected value.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   validateInput?(data?: any): boolean | any
   // Get a cell with the provided data for the column type:
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getCell(data?: any, validate?: boolean): GridCell
   // Get the raw value of the given cell:
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getCellValue(cell: GridCell): any | null
 }
 
@@ -257,8 +261,11 @@ export function toGlideColumn(column: BaseColumn): GridColumn {
  * @returns The merged column parameters.
  */
 export function mergeColumnParameters(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   defaultParams: Record<string, any> | undefined | null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   userParams: Record<string, any> | undefined | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): Record<string, any> {
   if (isNullOrUndefined(defaultParams)) {
     return userParams || {}
@@ -279,6 +286,7 @@ export function mergeColumnParameters(
  *
  * @returns The converted array or an empty array if the value cannot be interpreted as an array.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toSafeArray(data: any): any[] {
   if (isNullOrUndefined(data)) {
     return []
@@ -319,6 +327,7 @@ export function toSafeArray(data: any): any[] {
       return [toSafeString(parsedData)]
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     return parsedData.map((value: any) =>
       ["string", "number", "boolean", "null"].includes(typeof value)
         ? value
@@ -339,6 +348,7 @@ export function toSafeArray(data: any): any[] {
  *
  * @returns `true` if the data might be a JSON string.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function isMaybeJson(data: any): boolean {
   return data && data.startsWith("{") && data.endsWith("}")
 }
@@ -351,6 +361,7 @@ export function isMaybeJson(data: any): boolean {
  *
  * @return The converted string or a string showing the type of the object as fallback.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toSafeString(data: any): string {
   try {
     try {
@@ -376,6 +387,7 @@ export function toSafeString(data: any): string {
  * @return The converted boolean, null if the value is empty or undefined if the
  *         value cannot be interpreted as a boolean.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toSafeBoolean(value: any): boolean | null | undefined {
   if (isNullOrUndefined(value)) {
     return null
@@ -406,6 +418,7 @@ export function toSafeBoolean(value: any): boolean | null | undefined {
  * @returns The converted number or null if the value is empty or undefined or NaN if the
  *          value cannot be interpreted as a number.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toSafeNumber(value: any): number | null {
   // TODO(lukasmasuch): Should this return null as replacement for NaN?
 
@@ -450,6 +463,7 @@ export function toSafeNumber(value: any): number | null {
  *
  * @returns The converted JSON string or a string showing the type of the object as fallback.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toJsonString(value: any): string {
   if (isNullOrUndefined(value)) {
     return ""
@@ -563,6 +577,7 @@ export function formatNumber(
     }).format(value)
   } else if (["compact", "scientific", "engineering"].includes(format)) {
     return new Intl.NumberFormat(undefined, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       notation: format as any,
     }).format(value)
   } else if (format === "accounting") {
@@ -627,6 +642,7 @@ export function formatMoment(
  *
  * @returns The converted date or null if the value cannot be interpreted as a date.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toSafeDate(value: any): Date | null | undefined {
   if (isNullOrUndefined(value)) {
     return null

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
@@ -33,6 +33,7 @@ type ColumnFormattingReturn = {
  */
 function useColumnFormatting(
   setColumnConfigMapping: React.Dispatch<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     React.SetStateAction<Map<string, any>>
   >
 ): ColumnFormattingReturn {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -140,6 +140,7 @@ describe("applyColumnConfig", () => {
     const column1 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
     expect(column1.isEditable).toBe(true)
     expect(column1.width).toBe(COLUMN_WIDTH_MAPPING.small)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect((column1.columnTypeOptions as any).type).toBe("text")
     expect(column1).toEqual({
       ...MOCK_COLUMNS[1],

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -103,6 +103,7 @@ const mergeColumnConfig = (
   source: ColumnConfigProps
 ): ColumnConfigProps => {
   // Don't merge arrays, just overwrite the old value with the new value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const customMergeArrays = (objValue: object, srcValue: object): any => {
     // If the new value is an array, just return it as is (overwriting the old)
     if (isArray(srcValue)) {
@@ -208,6 +209,7 @@ export function applyColumnConfig(
  *
  * @returns the user-defined column configuration.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function getColumnConfig(configJson: string): Map<string, any> {
   if (!configJson) {
     return new Map()
@@ -229,6 +231,7 @@ type ColumnLoaderReturn = {
   allColumns: BaseColumn[]
   // Callback to set the column config state:
   setColumnConfigMapping: React.Dispatch<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     React.SetStateAction<Map<string, any>>
   >
 }
@@ -290,6 +293,7 @@ function useColumnLoader(
   // We need that to allow changing the column config state
   // (e.g. via changes by the user in the UI)
   const [columnConfigMapping, setColumnConfigMapping] =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     React.useState<Map<string, any>>(parsedColumnConfig)
 
   // Resync state whenever the parsed column config from the proto changes:

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.ts
@@ -51,6 +51,7 @@ function useColumnPinning(
   minColumnWidth: number,
   clearSelection: (keepRows?: boolean, keepColumns?: boolean) => void,
   setColumnConfigMapping: React.Dispatch<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     React.SetStateAction<Map<string, any>>
   >
 ): ColumnPinningReturn {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
@@ -38,6 +38,7 @@ type ColumnVisibilityReturn = {
 function useColumnVisibility(
   clearSelection: (keepRows?: boolean, keepColumns?: boolean) => void,
   setColumnConfigMapping: React.Dispatch<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     React.SetStateAction<Map<string, any>>
   >
 ): ColumnVisibilityReturn {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
@@ -32,6 +32,7 @@ const mockClose = vi.fn()
 
 // The native-file-system-adapter is not available in tests, so we need to mock it.
 vi.mock("native-file-system-adapter", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   showSaveFilePicker: vi.fn().mockImplementation((_object: any) => {
     return {
       createWritable: vi.fn().mockImplementation(() => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -42,6 +42,7 @@ const CSV_SPECIAL_CHARS_REGEX = new RegExp(
 )
 const LOG = getLogger("useDataExporter")
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function toCsvRow(rowValues: any[]): string {
   return (
     rowValues.map(cell => escapeValue(cell)).join(CSV_DELIMITER) +
@@ -54,6 +55,7 @@ export function toCsvRow(rowValues: any[]): string {
  *
  * Makes sure that the value is a string, and special characters are escaped correctly.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function escapeValue(value: any): string {
   if (isNullOrUndefined(value)) {
     return ""
@@ -107,6 +109,7 @@ async function writeCsv(
   await writable.write(textEncoder.encode(toCsvRow(headers)))
 
   for (let row = 0; row < numRows; row++) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const rowData: any[] = []
     columns.forEach((column: BaseColumn, col: number, _map) => {
       rowData.push(column.getCellValue(getCellContent([col, row])))

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
@@ -47,6 +47,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1], // [col, row]
         kind: "cell",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any)
     })
 
@@ -70,6 +71,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1],
         kind: "cell",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any)
     })
 
@@ -78,6 +80,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: undefined,
         kind: "out-of-bounds",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any)
     })
 
@@ -94,6 +97,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1],
         kind: "cell",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any)
     })
 
@@ -102,6 +106,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 2],
         kind: "cell",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any)
     })
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTooltips.ts
@@ -63,6 +63,7 @@ function useTooltips(
   const [tooltip, setTooltip] = React.useState<
     { content: string; left: number; top: number } | undefined
   >()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const timeoutRef = React.useRef<any>(null)
 
   const onItemHovered = React.useCallback(

--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -40,7 +40,9 @@ export const StyledResizableContainer =
         // don't support custom scrollbars (e.g. Firefox). Also, applying this
         // in Chrome causes the scrollbar to change to the default scrollbar style.
         ...(!hasCustomizedScrollbars && { scrollbarWidth: "thin" }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         ["overflowX" as any]: "auto !important",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
         ["overflowY" as any]: "auto !important",
       },
       "& .gdg-seveqep": {

--- a/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
@@ -43,7 +43,9 @@ type IntlWeekInfo = {
 const getWeekInfo = (intlLocale: Intl.Locale): IntlWeekInfo | null => {
   return (
     // Casting is necessary here since the types are not yet up-to-date
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (intlLocale as any)?.getWeekInfo?.() ??
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (intlLocale as any)?.weekInfo ??
     null
   )

--- a/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
@@ -131,39 +131,49 @@ export const StyledFileError = styled.small(({ theme }) => ({
 export const StyledFileErrorIcon = styled.span({})
 
 const compactFileUploader = (theme: EmotionTheme): CSSObject => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledFileDropzoneSection as any]: {
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledFileDropzoneInstructions as any]: {
     marginBottom: theme.spacing.lg,
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledFileDropzoneInstructionsFileUploaderIcon as any]: {
     display: "none",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledUploadedFiles as any]: {
     paddingRight: theme.spacing.lg,
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledUploadedFile as any]: {
     maxWidth: "inherit",
     flex: 1,
     alignItems: "flex-start",
     marginBottom: theme.spacing.sm,
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledUploadedFileName as any]: {
     width: theme.sizes.full,
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledUploadedFileData as any]: {
     flexDirection: "column",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledFileError as any]: {
     height: "auto",
     whiteSpace: "initial",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledFileErrorIcon as any]: {
     display: "none",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   [StyledUploadedFilesListItem as any]: {
     margin: theme.spacing.none,
     padding: theme.spacing.none,

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
@@ -23,16 +23,20 @@ import { usePrevious } from "~lib/util/Hooks"
 import Pagination from "./Pagination"
 
 export interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   items: any[]
   pageSize: number
   resetOnAdd: boolean
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const calculateNumPages = (items: any[], pageSize: number): number =>
   Math.ceil(items.length / pageSize)
 
 const withPagination = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   WrappedComponent: ComponentType<React.PropsWithChildren<any>>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): ComponentType<React.PropsWithChildren<any>> => {
   const WithPagination = ({
     pageSize,
@@ -45,6 +49,7 @@ const withPagination = (
       calculateNumPages(items, pageSize)
     )
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const prevItems: any[] = usePrevious(items)
 
     useEffect(() => {

--- a/frontend/lib/src/dataframes/Quiver.ts
+++ b/frontend/lib/src/dataframes/Quiver.ts
@@ -286,6 +286,7 @@ export class Quiver {
    *
    * Index columns only exist if the DataFrame was created based on a Pandas DataFrame.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private getIndexValue(rowIndex: number, columnIndex: number): any {
     const index = this._pandasIndexData[columnIndex]
     const value =
@@ -294,6 +295,7 @@ export class Quiver {
   }
 
   /** Get the raw value of a data cell. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private getDataValue(rowIndex: number, columnIndex: number): any {
     return this._data.getChildAt(columnIndex)?.get(rowIndex)
   }

--- a/frontend/lib/src/dataframes/arrowFormatUtils.test.ts
+++ b/frontend/lib/src/dataframes/arrowFormatUtils.test.ts
@@ -347,6 +347,7 @@ describe("formatPeriodFromFreq", () => {
     [1, "W", "1"],
     [1, "W-INVALID", "1"],
   ])("formats %s with frequency %s to %s", (value, freq, expected) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     expect(formatPeriodFromFreq(value, freq as any)).toEqual(expected)
   })
 })

--- a/frontend/lib/src/dataframes/arrowFormatUtils.ts
+++ b/frontend/lib/src/dataframes/arrowFormatUtils.ts
@@ -439,6 +439,7 @@ function formatPeriod(duration: number | bigint, field?: Field): string {
  * @param field The field metadata from arrow containing metadata about the column.
  * @returns The formatted JSON string.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function formatObject(object: any, field?: Field): string {
   if (field?.type instanceof Struct) {
     // This type is used by python dictionary values

--- a/frontend/lib/src/dataframes/arrowTypeUtils.ts
+++ b/frontend/lib/src/dataframes/arrowTypeUtils.ts
@@ -55,6 +55,7 @@ export interface PandasColumnType {
   numpy_type: string
 
   /** Type metadata. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   meta?: Record<string, any> | null
 }
 
@@ -85,6 +86,7 @@ export interface PandasColumnMetadata {
    * Column-specific metadata. Only used by certain column types
    * (e.g. CategoricalIndex has `num_categories`.)
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   metadata: Record<string, any> | null
 
   /** The name of the column. */
@@ -166,6 +168,7 @@ export interface ArrowType {
  * @param vector The Arrow vector to convert.
  * @returns The list of strings.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function convertVectorToList(vector: Vector<any>): string[] {
   const values = []
 

--- a/frontend/lib/src/hooks/useScrollSpy.test.ts
+++ b/frontend/lib/src/hooks/useScrollSpy.test.ts
@@ -70,6 +70,7 @@ describe("debounce function", () => {
 
 describe("useScrollSpy hook", () => {
   let target: HTMLElement
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let eventHandler: ({ timeStampLow }: any) => void
 
   beforeEach(() => {

--- a/frontend/lib/src/hooks/useScrollSpy.ts
+++ b/frontend/lib/src/hooks/useScrollSpy.ts
@@ -47,8 +47,10 @@ import { useCallback, useLayoutEffect, useMemo, useRef } from "react"
  * @returns A debounced version of the `fn` function.
  */
 export function debounce(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   fn: (...args: any[]) => void,
   ms: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): (...args: any[]) => void {
   if (!ms) {
     return fn
@@ -96,6 +98,7 @@ const DEFAULT_DEBOUNCE_MS = 100
  */
 export default function useScrollSpy(
   target: HTMLElement | null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   eventHandler: ({ timeStampLow }: any) => void
 ): void {
   const onEventRef = useRef(eventHandler)
@@ -111,6 +114,7 @@ export default function useScrollSpy(
   )
 
   const handleEvent = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     (event: any) => {
       event.timeStampLow = Date.now()
 

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -24,9 +24,11 @@ import HostCommunicationManager, {
 
 // Mocking "message" event listeners on the window;
 // returns function to establish a listener
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function mockEventListeners(): (type: string, event: any) => void {
   const listeners: { [name: string]: ((event: Event) => void)[] } = {}
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   window.addEventListener = vi.fn((event: string, cb: any) => {
     listeners[event] = listeners[event] || []
     listeners[event].push(cb)
@@ -546,6 +548,7 @@ describe("HostCommunicationManager messaging", () => {
 
 describe("Test different origins", () => {
   let hostCommunicationMgr: HostCommunicationManager
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let dispatchEvent: any
 
   beforeEach(() => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -174,6 +174,7 @@ export default class HostCommunicationManager {
    * Register a function to handle a message from the Host
    */
   public receiveHostMessage = (event: MessageEvent): void => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     const message: VersionedMessage<IHostToGuestMessage> | any = event.data
 
     // Messages coming from the parent frame of a deployed Streamlit app

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -105,6 +105,7 @@ export const customRenderLibContext = (
   })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function arrayFromVector(vector: any): any {
   if (Array.isArray(vector)) {
     return vector.map(arrayFromVector)

--- a/frontend/lib/src/theme/createBaseUiTheme.ts
+++ b/frontend/lib/src/theme/createBaseUiTheme.ts
@@ -84,6 +84,7 @@ const createBaseUiThemePrimitives = (
  */
 const createBaseUiThemeOverrides = (
   theme: EmotionTheme
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): Record<string, any> => {
   const { inSidebar, colors, genericFonts, fontSizes, lineHeights, radii } =
     theme
@@ -246,6 +247,7 @@ const createBaseUiThemeOverrides = (
 export const createBaseUiTheme = (
   theme: EmotionTheme,
   primitives = lightBaseThemePrimitives
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): BaseTheme & Record<string, any> =>
   createBaseTheme(
     createBaseUiThemePrimitives(primitives, theme),

--- a/frontend/lib/src/theme/getColors.ts
+++ b/frontend/lib/src/theme/getColors.ts
@@ -97,6 +97,7 @@ export const createEmotionColors = (genericColors: {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function getDividerColors(theme: EmotionTheme): any {
   const lightTheme = hasLightBackgroundColor(theme)
   const blue = lightTheme ? theme.colors.blue60 : theme.colors.blue90
@@ -118,6 +119,7 @@ export function getDividerColors(theme: EmotionTheme): any {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function getMarkdownTextColors(theme: EmotionTheme): any {
   const lightTheme = hasLightBackgroundColor(theme)
   const primary = theme.colors.primary
@@ -143,6 +145,7 @@ export function getMarkdownTextColors(theme: EmotionTheme): any {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function getMarkdownBgColors(theme: EmotionTheme): any {
   const lightTheme = hasLightBackgroundColor(theme)
 

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -59,13 +59,16 @@ const matchMediaFillers = {
 
 const LOG = getLogger("theme:utils")
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const windowLocationSearch = (search: string): any => ({
   location: {
     search,
   },
 })
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const windowMatchMedia = (theme: "light" | "dark"): any => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   matchMedia: (query: any) => ({
     matches: query === `(prefers-color-scheme: ${theme})`,
     media: query,

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -205,6 +205,7 @@ export const createEmotionTheme = (
   // by default for all custom themes.
   newGenericColors.secondary = newGenericColors.primary
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const conditionalOverrides: any = {}
 
   conditionalOverrides.colors = createEmotionColors(newGenericColors)
@@ -295,6 +296,7 @@ export const createEmotionTheme = (
     conditionalOverrides.showSidebarBorder = showSidebarBorder
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const fontOverrides: any = {}
   if (headingFont) {
     fontOverrides.headingFont = parseFont(headingFont)

--- a/frontend/lib/src/util/Hooks.test.ts
+++ b/frontend/lib/src/util/Hooks.test.ts
@@ -16,6 +16,7 @@
 
 import { useIsOverflowing } from "./Hooks"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 const stateSetters: Array<any> = []
 
 vi.mock("react", async () => ({

--- a/frontend/lib/src/util/Hooks.ts
+++ b/frontend/lib/src/util/Hooks.ts
@@ -22,6 +22,7 @@ import {
   useState,
 } from "react"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export const usePrevious = (value: any): any => {
   const ref = useRef()
 

--- a/frontend/lib/src/util/UriUtil.test.ts
+++ b/frontend/lib/src/util/UriUtil.test.ts
@@ -107,11 +107,13 @@ describe("isValidOrigin", () => {
     // issue is fixed.
     const OrigURL = globalThis.URL
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       globalThis.URL = function (url: string, ...rest: any[]) {
         if (url.includes("*")) {
           throw new Error("Invalid URL")
         }
         return new OrigURL(url, ...rest)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
       } as any
       expect(
         isValidOrigin(

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -39,9 +39,12 @@ const GENERATED_ELEMENT_ID_PREFIX = "$$ID"
  * will only be called after the full interval has elapsed since the last
  * call.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export function debounce(delay: number, fn: any): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let timerId: any
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   return (...args: any[]) => {
     if (timerId) {
       clearTimeout(timerId)
@@ -371,6 +374,7 @@ export function isValidElementId(
  * If the element has a valid ID, returns it. Otherwise, returns undefined.
  */
 export function getElementId(element: Element): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   const elementId = get(element as any, [requireNonNull(element.type), "id"])
   if (elementId && isValidElementId(elementId)) {
     // We only care about valid element IDs (with the correct prefix)
@@ -578,7 +582,9 @@ export function extractPageNameFromPathName(
  * // }
  */
 export function keysToSnakeCase(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   obj: Record<string, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 ): Record<string, any> {
   return Object.keys(obj).reduce((acc, key) => {
     const newKey = decamelize(key, {
@@ -598,6 +604,7 @@ export function keysToSnakeCase(
 
     acc[newKey] = value
     return acc
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   }, {} as Record<string, any>)
 }
 

--- a/frontend/utils/src/polyfills/index.ts
+++ b/frontend/utils/src/polyfills/index.ts
@@ -30,6 +30,7 @@ declare global {
   interface PromiseWithResolvers<T> {
     promise: Promise<T>
     resolve: (value: T | PromiseLike<T>) => void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     reject: (reason?: any) => void
   }
 


### PR DESCRIPTION
## Describe your changes

- Why add this? From [the docs](https://typescript-eslint.io/rules/no-explicit-any/):

> The any type in TypeScript is a dangerous "escape hatch" from the type system. Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code. This rule reports on explicit uses of the any keyword as a type annotation.
> 
> Preferable alternatives to any include:
>  - If the type is known, describing it in an interface or type
>  - If the type is not known, using the safer unknown type

To not change any existing code, this inline disables any existing usages

## GitHub Issue Link (if applicable)

## Testing Plan

- This is a lint change, will be covered by CI checks

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
