### PR TITLE
`EventContainer` & toast cleanup

### DIFF
--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -326,7 +326,7 @@ function AppView(props: AppViewProps): ReactElement {
       </Component>
       {hasEventElements && (
         <Profiler id="Event">
-          <EventContainer scriptRunId={elements.event.scriptRunId}>
+          <EventContainer>
             <StyledEventBlockContainer
               className="stEvent"
               data-testid="stEvent"

--- a/frontend/app/src/components/EventContainer/EventContainer.test.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.test.tsx
@@ -24,7 +24,7 @@ import EventContainer from "./EventContainer"
 
 describe("EventContainer Component", () => {
   test("renders Toast Container", () => {
-    render(<EventContainer scriptRunId="123" />)
+    render(<EventContainer />)
 
     const toastContainer = screen.getByTestId("stToastContainer")
     expect(toastContainer).toBeInTheDocument()

--- a/frontend/app/src/components/EventContainer/EventContainer.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.tsx
@@ -14,28 +14,21 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useEffect } from "react"
+import React, { ReactElement, ReactNode } from "react"
 
-import { PLACEMENT, toaster, ToasterContainer } from "baseui/toast"
+import { PLACEMENT, ToasterContainer } from "baseui/toast"
 import { useTheme } from "@emotion/react"
 
 import { EmotionTheme } from "@streamlit/lib"
 
 export interface EventContainerProps {
-  scriptRunId: string
   children?: ReactNode
 }
 
 function EventContainer({
-  scriptRunId,
   children,
 }: Readonly<EventContainerProps>): ReactElement {
   const theme: EmotionTheme = useTheme()
-
-  useEffect(() => {
-    // Ensure all toasts cleared on script re-run
-    toaster.getRef()?.clearAll()
-  }, [scriptRunId])
 
   return (
     <>

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -172,7 +172,7 @@ function Toast({ body, icon }: Readonly<ToastProps>): ReactElement {
     return () => {
       // Disable transition so toast doesn't flicker on removal
       toaster.update(newKey, {
-        overrides: { Body: { style: { transitionDuration: 0 } } },
+        overrides: { Body: { style: { display: "none" } } },
       })
       // Remove toast on unmount
       toaster.clear(newKey)


### PR DESCRIPTION
## Describe your changes
* Removing extra cleanup in `EventContainer` for toasts
* ^ Allows for removal of `scriptRunId` passing to `EventContainer`
* Also simplify toast update on unmount (just set `display` to `"none"` vs. adjusting the `transitionDuration`)

## Testing Plan
- Refactor - existing tests should continue to pass
- Manual Testing: ✅ 