### PR TITLE
Support emoji favicons through navigation

### DIFF
--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
@@ -58,6 +58,17 @@ describe("Dynamic icon", () => {
     expect(testId.textContent).toEqual(icon.textContent)
   })
 
+  it("renders without crashing with prefixed Emoji icon", () => {
+    const props = getProps({ iconValue: "emoji:⛰️" })
+    render(<DynamicIcon {...props} />)
+    const testId = screen.getByTestId("stIconEmoji")
+    const icon = screen.getByText("⛰️")
+
+    expect(testId).toBeInTheDocument()
+    expect(icon).toBeInTheDocument()
+    expect(testId.textContent).toEqual(icon.textContent)
+  })
+
   it("renders without crashing Styled image", () => {
     const props = getProps({ iconValue: ":material/star_filled:" })
     render(<DynamicIcon {...props} />)

--- a/frontend/lib/src/components/shared/Icon/Icon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Icon.tsx
@@ -89,14 +89,21 @@ export const EmojiIcon = ({
   children,
   color,
   testid,
-}: EmojiIconProps): ReactElement => (
-  <StyledEmojiIcon
-    data-testid={testid || "stIconEmoji"}
-    aria-hidden="true"
-    {...getDefaultProps({ size, margin, padding, color })}
-  >
-    {children}
-  </StyledEmojiIcon>
-)
+}: EmojiIconProps): ReactElement => {
+  // Handle the case where the emoji is prefixed with emoji:
+  if (typeof children === "string") {
+    children = children.replace(/^emoji:/, "")
+  }
+
+  return (
+    <StyledEmojiIcon
+      data-testid={testid || "stIconEmoji"}
+      aria-hidden="true"
+      {...getDefaultProps({ size, margin, padding, color })}
+    >
+      {children}
+    </StyledEmojiIcon>
+  )
+}
 
 export default Icon

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -31,6 +31,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ScriptRunContext,
     get_script_run_ctx,
 )
+from streamlit.string_util import is_emoji
 
 if TYPE_CHECKING:
     from streamlit.source_util import PageHash, PageInfo
@@ -349,7 +350,7 @@ def _navigation(
             p = msg.navigation.app_pages.add()
             p.page_script_hash = page._script_hash
             p.page_name = page.title
-            p.icon = page.icon
+            p.icon = f"emoji:{page.icon}" if is_emoji(page.icon) else page.icon
             p.is_default = page._default
             p.section_header = section_header
             p.url_pathname = page.url_path

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -336,6 +336,21 @@ class NavigationTest(DeltaGeneratorTestCase):
         assert c.app_pages[1].section_header == "Section 1"
         assert c.app_pages[2].section_header == "Section 2"
 
+    def test_navigation_sends_prefixed_emoji_icons(self):
+        """Test navigation with pages with emoji icons prefix them correctly"""
+
+        page = st.navigation(
+            [
+                st.Page("page1.py", icon="🚀"),
+                st.Page("page2.py", icon=":material/settings:"),
+            ]
+        )
+        assert isinstance(page, StreamlitPage)
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 2
+        assert c.app_pages[0].icon == "emoji:🚀"
+        assert c.app_pages[1].icon == ":material/settings:"
+
     def test_navigation_duplicate_paths_with_mixed_types_including_pathlib_path(
         self,
     ):


### PR DESCRIPTION
## Describe your changes

In #10912, I made a change that ensures emojis are verified from the backend and informs the frontend through the `emoji:` prefix. This inadvertently broke page icons in pages for `st.navigation`. This change fixes that by detecting the emoji in the navigation call and prefix it accordingly.

This fixes the favicon but is also used in the sidebar nav, so we needed the `EmojiIcon` to support both emojis with and without the prefix.

## Testing Plan

- JS and Python unit tests updated
- E2E test should continue to show the same icons

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
