### PR TITLE
fix incorrect comment in `_make_function_key` used by cache_* APIs

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -473,8 +473,9 @@ def _make_function_key(cache_type: CacheType, func: FunctionType) -> str:
 
     # Include the function's __module__ and __qualname__ strings in the hash.
     # This means that two identical functions in different modules
-    # will not share a hash; it also means that two identical *nested*
-    # functions in the same module will not share a hash.
+    # will not share a hash.
+    # It also means that two identical *nested* functions in the same module
+    # *will* share a hash (see https://github.com/streamlit/streamlit/issues/11157).
     update_hash(
         (func.__module__, func.__qualname__),
         hasher=func_hasher,


### PR DESCRIPTION
## Describe your changes`

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/11157 (which cannot be fixed by this PR, or be fixed easily)

## Testing Plan

no: only comment is changed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
