### PR TITLE
Remove anchor along with query params from the url 

### DIFF
--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -574,4 +574,66 @@ describe("getUrl", () => {
 
     expect(getUrl()).toBe("http://localhost:3000/main")
   })
+
+  it("should return document.location.href without query params or anchors when not in an iframe", () => {
+    mockIsInChildFrame.mockReturnValue(false)
+    documentSpy.mockImplementation(() => ({
+      location: {
+        href: "http://localhost:3000/main?param=value#section",
+      },
+    }))
+
+    expect(getUrl()).toBe("http://localhost:3000/main")
+  })
+
+  it("should return document.location.href without query params or anchors when in an iframe but window.top access throws error", () => {
+    mockIsInChildFrame.mockReturnValue(true)
+
+    // Simulate error when accessing top getter
+    topSpy.mockImplementation(() => {
+      throw new Error("CSP error simulation")
+    })
+
+    // Mock document location for the fallback
+    documentSpy.mockImplementation(() => ({
+      location: {
+        href: "http://iframe.com/page?iframeparam=1#top",
+      },
+    }))
+
+    expect(getUrl()).toBe("http://iframe.com/page")
+  })
+
+  it("should handle URLs with only an anchor correctly", () => {
+    mockIsInChildFrame.mockReturnValue(false)
+    documentSpy.mockImplementation(() => ({
+      location: {
+        href: "http://localhost:3000/main#section",
+      },
+    }))
+
+    expect(getUrl()).toBe("http://localhost:3000/main")
+  })
+
+  it("should handle URLs ending with / and an anchor correctly", () => {
+    mockIsInChildFrame.mockReturnValue(false)
+    documentSpy.mockImplementation(() => ({
+      location: {
+        href: "http://localhost:3000/main/#section?query=1",
+      },
+    }))
+
+    expect(getUrl()).toBe("http://localhost:3000/main/")
+  })
+
+  it("should handle complex query parameters and an anchor correctly", () => {
+    mockIsInChildFrame.mockReturnValue(false)
+    documentSpy.mockImplementation(() => ({
+      location: {
+        href: "http://localhost:3000/main?foo=bar&baz=qux&embed=true#section",
+      },
+    }))
+
+    expect(getUrl()).toBe("http://localhost:3000/main")
+  })
 })

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -233,9 +233,10 @@ export function getUrl(): string {
     url = document.location.href
   }
 
-  // Remove query parameters from the URL
+  // Remove query parameters and anchor from the URL
   const urlObj = new URL(url)
   urlObj.search = ""
+  urlObj.hash = ""
   return urlObj.toString()
 }
 


### PR DESCRIPTION
## Describe your changes
Remove anchor along with query params from the URL before sending it to the backend for `st.context.url`
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE!
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
