### PR TITLE
fix Uncontrolled data used in path expression on ()component_request_handler lead to path traversal

### DIFF
--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -42,10 +42,10 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             self.set_status(404)
             return
 
-        # follow symlinks to get an accurate normalized path
+        # Normalize component_root to resolve symlinks and ensure an absolute path
         component_root = os.path.realpath(component_root)
         filename = "/".join(parts[1:])
-        abspath = os.path.normpath(os.path.join(component_root, filename))
+        abspath = os.path.realpath(os.path.join(component_root, filename))
 
         # Do NOT expose anything outside of the component root.
         if os.path.commonpath([component_root, abspath]) != component_root:


### PR DESCRIPTION
https://github.com/streamlit/streamlit/blob/41c538c1be0472eec09fb583be56279feaf484d4/lib/streamlit/web/server/component_request_handler.py#L56-L56

fix the issue need to ensure that the constructed `abspath` is strictly contained within the `component_root` directory. This can be achieved by:
1. Normalizing both `component_root` and `abspath` using `os.path.realpath` to resolve symlinks and ensure absolute paths.
2. Verifying that `abspath` starts with `component_root` using `os.path.commonpath`.

The updated code will:
- Normalize `component_root` using `os.path.realpath` before constructing `abspath`.
- Use `os.path.commonpath` to validate that `abspath` is within `component_root`.

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

## POC
a file name is read from an HTTP request and then used to access a file. However, a malicious user could enter a file name that is an absolute path, such as `"/etc/passwd"`. 

it appears that the user is restricted to opening a file within the `"user"` home directory. However, a malicious user could enter a file name containing special characters, the string `"../../../etc/passwd"` will result in the code reading the file located at `"/server/static/images/../../../etc/passwd"`, which is the system's password file. This file would then be sent back to the user, giving them access to all the system's passwords. Note that a user could also use an absolute path here, since the result of `os.path.join("/server/static/images/", "/etc/passwd")` is `"/etc/passwd"`.

In the third the path used to access the file system is normalized before being checked against a known prefix. This ensures that regardless of the user input, the resulting path is safe.
```py
import os.path
from flask import Flask, request, abort

app = Flask(__name__)

@app.route("/user_picture1")
def user_picture1():
    filename = request.args.get('p')
    # BAD: This could read any file on the file system
    data = open(filename, 'rb').read()
    return data

@app.route("/user_picture2")
def user_picture2():
    base_path = '/server/static/images'
    filename = request.args.get('p')
    # BAD: This could still read any file on the file system
    data = open(os.path.join(base_path, filename), 'rb').read()
    return data

@app.route("/user_picture3")
def user_picture3():
    base_path = '/server/static/images'
    filename = request.args.get('p')
    #GOOD -- Verify with normalised version of path
    fullpath = os.path.normpath(os.path.join(base_path, filename))
    if not fullpath.startswith(base_path):
        raise Exception("not allowed")
    data = open(fullpath, 'rb').read()
    return data
```
## References
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[CWE-23](https://cwe.mitre.org/data/definitions/23.html)
[CWE-36](https://cwe.mitre.org/data/definitions/36.html)
[CWE-73](https://cwe.mitre.org/data/definitions/73.html)
[CWE-99](https://cwe.mitre.org/data/definitions/99.html)
