### PR TITLE
Fix data editor when adding and deleting rows

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -305,14 +305,22 @@ def _apply_row_additions(
 
     import pandas as pd
 
-    # This is only used if the dataframe has a range index:
-    # There seems to be a bug in older pandas versions with RangeIndex in
-    # combination with loc. As a workaround, we manually track the values here:
-    range_index_stop = None
-    range_index_step = None
+    index_type: Literal["range", "integer", "other"] = "other"
+
+    # This is only used if the dataframe has a range or integer index that can be
+    # auto incremented:
+    index_stop: int | None = None
+    index_step: int | None = None
     if isinstance(df.index, pd.RangeIndex):
-        range_index_stop = df.index.stop
-        range_index_step = df.index.step
+        index_type = "range"
+        index_stop = cast("int", df.index.stop)
+        index_step = cast("int", df.index.step)
+    elif isinstance(df.index, pd.Index) and pd.api.types.is_integer_dtype(
+        df.index.dtype
+    ):
+        index_type = "integer"
+        index_stop = 0 if df.index.empty else df.index.max() + 1
+        index_step = 1
 
     for added_row in added_rows:
         index_value = None
@@ -326,18 +334,33 @@ def _apply_row_additions(
             else:
                 col_pos = df.columns.get_loc(col_name)
                 new_row[col_pos] = _parse_value(value, dataframe_schema[col_name])
-        # Append the new row to the dataframe
-        if range_index_stop is not None:
-            df.loc[range_index_stop, :] = new_row
-            # Increment to the next range index value
-            range_index_stop += range_index_step
-        elif index_value is not None:
-            # TODO(lukasmasuch): we are only adding rows that have a non-None index
-            # value to prevent issues in the frontend component. Also, it just overwrites
-            # the row in case the index value already exists in the dataframe.
-            # In the future, it would be better to require users to provide unique
-            # non-None values for the index with some kind of visual indications.
+
+        if index_value is not None and index_type != "range":
+            # Case 1: Non-range index with an explicitly provided index value
+            # Add row using the user-provided index value.
+            # This handles any type of index that cannot be auto incremented.
+
+            # Note: this just overwrites the row in case the index value
+            # already exists. In the future, it would be better to
+            # require users to provide unique non-None values for the index with
+            # some kind of visual indications.
             df.loc[index_value, :] = new_row
+            continue
+
+        if index_stop is not None and index_step is not None:
+            # Case 2: Range or integer index that can be auto incremented.
+            # Add row using the next value in the sequence
+            df.loc[index_stop, :] = new_row
+            # Increment to the next range index value
+            index_stop += index_step
+            continue
+
+        # Row cannot be added -> skip it and log a warning.
+        _LOGGER.warning(
+            "Cannot automatically add row for the index "
+            f"of type {type(df.index).__name__} without an explicit index value. "
+            "Row addition skipped."
+        )
 
 
 def _apply_row_deletions(df: pd.DataFrame, deleted_rows: list[int]) -> None:

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -280,6 +280,26 @@ def _apply_cell_edits(
                 )
 
 
+def _parse_added_row(
+    df: pd.DataFrame,
+    added_row: dict[str, Any],
+    dataframe_schema: DataframeSchema,
+) -> tuple[Any, list[Any]]:
+    """Parse the added row into an optional index value and a list of row values."""
+    index_value = None
+    new_row: list[Any] = [None for _ in range(len(dataframe_schema))]
+    for col_name, value in added_row.items():
+        if col_name == INDEX_IDENTIFIER:
+            # TODO(lukasmasuch): To support multi-index in the future:
+            # use a tuple of values here instead of a single value
+            index_value = _parse_value(value, dataframe_schema[INDEX_IDENTIFIER])
+        else:
+            col_pos = cast("int", df.columns.get_loc(col_name))
+            new_row[col_pos] = _parse_value(value, dataframe_schema[col_name])
+
+    return index_value, new_row
+
+
 def _apply_row_additions(
     df: pd.DataFrame,
     added_rows: list[dict[str, Any]],
@@ -306,34 +326,26 @@ def _apply_row_additions(
     import pandas as pd
 
     index_type: Literal["range", "integer", "other"] = "other"
-
     # This is only used if the dataframe has a range or integer index that can be
     # auto incremented:
     index_stop: int | None = None
     index_step: int | None = None
+
     if isinstance(df.index, pd.RangeIndex):
+        # Extract metadata from the range index:
         index_type = "range"
         index_stop = cast("int", df.index.stop)
         index_step = cast("int", df.index.step)
     elif isinstance(df.index, pd.Index) and pd.api.types.is_integer_dtype(
         df.index.dtype
     ):
+        # Get highest integer value and increment it by 1 to get unique index value.
         index_type = "integer"
         index_stop = 0 if df.index.empty else df.index.max() + 1
         index_step = 1
 
     for added_row in added_rows:
-        index_value = None
-        new_row: list[Any] = [None for _ in range(df.shape[1])]
-        for col_name in added_row.keys():
-            value = added_row[col_name]
-            if col_name == INDEX_IDENTIFIER:
-                # TODO(lukasmasuch): To support multi-index in the future:
-                # use a tuple of values here instead of a single value
-                index_value = _parse_value(value, dataframe_schema[INDEX_IDENTIFIER])
-            else:
-                col_pos = df.columns.get_loc(col_name)
-                new_row[col_pos] = _parse_value(value, dataframe_schema[col_name])
+        index_value, new_row = _parse_added_row(df, added_row, dataframe_schema)
 
         if index_value is not None and index_type != "range":
             # Case 1: Non-range index with an explicitly provided index value

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -287,7 +287,7 @@ def _parse_added_row(
 ) -> tuple[Any, list[Any]]:
     """Parse the added row into an optional index value and a list of row values."""
     index_value = None
-    new_row: list[Any] = [None for _ in range(len(dataframe_schema))]
+    new_row: list[Any] = [None for _ in range(df.shape[1])]
     for col_name, value in added_row.items():
         if col_name == INDEX_IDENTIFIER:
             # TODO(lukasmasuch): To support multi-index in the future:

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -304,6 +304,150 @@ class DataEditorUtilTest(unittest.TestCase):
             },
         )
 
+    def test_apply_row_additions_range_index(self):
+        """Test adding rows to a DataFrame with a RangeIndex."""
+        df = pd.DataFrame({"col1": [1, 2]}, index=pd.RangeIndex(0, 2, 1))
+        added_rows: list[dict[str, Any]] = [
+            {"col1": 10},
+            {"col1": 11},
+        ]
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        expected_df = pd.DataFrame(
+            {"col1": [1, 2, 10, 11]}, index=pd.RangeIndex(0, 4, 1)
+        )
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+    def test_apply_row_additions_int_index_non_contiguous(self):
+        """Test adding rows to a DataFrame with a non-contiguous integer index."""
+        df = pd.DataFrame({"col1": [1, 3]}, index=pd.Index([0, 2], dtype="int64"))
+        added_rows: list[dict[str, Any]] = [
+            {"col1": 10},
+            {"col1": 11},
+        ]
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        expected_df = pd.DataFrame(
+            {"col1": [1, 3, 10, 11]}, index=pd.Index([0, 2, 3, 4], dtype="int64")
+        )
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+    def test_apply_row_additions_empty_df(self):
+        """Test adding rows to an empty DataFrame."""
+        df = pd.DataFrame({"col1": pd.Series(dtype="int")})
+        self.assertTrue(df.empty)
+        added_rows: list[dict[str, Any]] = [
+            {"col1": 10},
+            {"col1": 11},
+        ]
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        expected_df = pd.DataFrame({"col1": [10, 11]}, index=pd.RangeIndex(0, 2, 1))
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+    @patch("streamlit.elements.widgets.data_editor._LOGGER")
+    def test_apply_row_additions_other_index_no_value_logs_warning(self, mock_logger):
+        """Test adding to non-auto-increment index without value logs warning."""
+        df = pd.DataFrame(
+            {"col1": [1, 2]},
+            index=pd.to_datetime(["2023-01-01", "2023-01-02"]),
+        )
+        added_rows: list[dict[str, Any]] = [
+            {"col1": 10},  # No _index provided
+        ]
+        original_len = len(df)
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        # Verify row was NOT added
+        self.assertEqual(len(df), original_len)
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once()
+        self.assertIn(
+            "Cannot automatically add row", mock_logger.warning.call_args[0][0]
+        )
+
+    def test_apply_row_additions_other_index_with_value(self):
+        """Test adding to non-auto-increment index with provided value."""
+        index = pd.to_datetime(["2023-01-01", "2023-01-02"])
+        df = pd.DataFrame({"col1": [1, 2]}, index=index)
+        added_rows: list[dict[str, Any]] = [
+            {"_index": "2023-01-03", "col1": 10},
+        ]
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        expected_index = pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"])
+        expected_df = pd.DataFrame({"col1": [1, 2, 10]}, index=expected_index)
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+    def test_apply_row_additions_range_index_with_value(self):
+        r"""Test adding row to RangeIndex with explicit _index provided
+        (should still auto-increment)."""
+        # This tests the `index_type != \"range\"` condition in the first branch.
+        df = pd.DataFrame({"col1": [1, 2]}, index=pd.RangeIndex(0, 2, 1))
+        added_rows: list[dict[str, Any]] = [
+            {"_index": 99, "col1": 10},  # Provide an index value
+        ]
+
+        _apply_row_additions(
+            df, added_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        # Even though _index=99 was provided, it should auto-increment the RangeIndex.
+        expected_df = pd.DataFrame({"col1": [1, 2, 10]}, index=pd.RangeIndex(0, 3, 1))
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+    def test_apply_dataframe_edits_delete_and_add_range_index(self):
+        """Test applying edits involving deletion and addition on a RangeIndex."""
+        # Initial DF with RangeIndex
+        df = pd.DataFrame({"col1": [1, 2, 3, 4]}, index=pd.RangeIndex(0, 4, 1))
+
+        # Delete row at index 1 (value 2)
+        deleted_rows: list[int] = [1]
+        # Add a new row
+        added_rows: list[dict[str, Any]] = [
+            {"col1": 10},
+        ]
+        # No cell edits for this test
+        edited_rows: dict[int, Any] = {}
+
+        # Expected state after edits:
+        # - Row 1 (value 2) deleted.
+        # - Index becomes integer index [0, 2, 3].
+        # - New row added with index max+1 = 4.
+        # - Final index: integer index [0, 2, 3, 4]
+        # - Final values: [1, 3, 4, 10]
+        expected_df = pd.DataFrame(
+            {"col1": [1, 3, 4, 10]}, index=pd.Index([0, 2, 3, 4], dtype="int64")
+        )
+
+        _apply_dataframe_edits(
+            df,
+            {
+                "deleted_rows": deleted_rows,
+                "added_rows": added_rows,
+                "edited_rows": edited_rows,
+            },
+            determine_dataframe_schema(df, _get_arrow_schema(df)),
+        )
+
+        # Check dtypes=False because deletion/addition might change column dtypes
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
 
 class DataEditorTest(DeltaGeneratorTestCase):
     def test_default_params(self):

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -340,7 +340,9 @@ class DataEditorUtilTest(unittest.TestCase):
 
     def test_apply_row_additions_empty_df(self):
         """Test adding rows to an empty DataFrame."""
-        df = pd.DataFrame({"col1": pd.Series(dtype="int")})
+        df = pd.DataFrame(
+            {"col1": pd.Series(dtype="int")}, index=pd.RangeIndex(0, 0, 1)
+        )
         self.assertTrue(df.empty)
         added_rows: list[dict[str, Any]] = [
             {"col1": 10},


### PR DESCRIPTION
## Describe your changes

Fix a bug (regression?) with data editor that prevents adding added rows to the result dataframe if existing rows got deleted. The root cause is that deleting rows might cause the index to be changed from range index to integer index, breaking our automatic increment logic when adding new rows. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11180

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
