### PR TITLE
Skip flaky audio e2e error tests for webkit

### DIFF
--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -168,6 +168,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     wait_until(
         app,
         lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_URL),
+        timeout=10000,
     )
 
 
@@ -193,5 +194,7 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with path
     wait_until(
-        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH)
+        app,
+        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
+        timeout=10000,
     )

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -145,7 +145,7 @@ def test_audio_uses_unified_height(
 
 
 # TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
-@pytest.mark.skip_browser("firefox", "webkit")
+@pytest.mark.only_browser("chromium")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -170,8 +170,8 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
-# TODO(mgbarnes): Figure out why this test is flaky on Firefox.
-@pytest.mark.skip_browser("firefox")
+# TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
+@pytest.mark.only_browser("chromium")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -144,8 +144,8 @@ def test_audio_uses_unified_height(
     assert_snapshot(audio_element, name="st_audio-unified_height")
 
 
-# TODO(mgbarnes): Figure out why this test is flaky on Firefox.
-@pytest.mark.skip_browser("firefox")
+# TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
+@pytest.mark.skip_browser("firefox", "webkit")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -166,9 +166,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with url
     wait_until(
-        app,
-        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_URL),
-        timeout=10000,
+        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_URL)
     )
 
 
@@ -194,7 +192,5 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with path
     wait_until(
-        app,
-        lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH),
-        timeout=10000,
+        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH)
     )


### PR DESCRIPTION
## Describe your changes

Skips two flaky audio e2e tests for webkit. This will probably need some more investigation in a follow up.  

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
