### PR TITLE
Add stack trace info to missing label warning

### DIFF
--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -185,7 +185,8 @@ def maybe_raise_label_warnings(label: str | None, label_visibility: str | None):
             "`label` got an empty value. This is discouraged for accessibility "
             "reasons and may be disallowed in the future by raising an exception. "
             "Please provide a non-empty label and hide it with label_visibility "
-            "if needed."
+            "if needed.",
+            stack_info=True,
         )
     if label_visibility not in ("visible", "hidden", "collapsed"):
         raise errors.StreamlitAPIException(

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -143,6 +143,11 @@ hello
             "`label` got an empty value. This is discouraged for accessibility reasons",
             logs.records[0].msg,
         )
+        # Check that the stack trace is included in the warning message:
+        self.assertIn(
+            "Stack (most recent call last)",
+            logs.records[0].msg,
+        )
 
     def test_toggle_widget(self):
         """Test that the usage of `st.toggle` uses the correct checkbox proto config."""

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -144,10 +144,7 @@ hello
             logs.records[0].msg,
         )
         # Check that the stack trace is included in the warning message:
-        self.assertIn(
-            "Stack (most recent call last)",
-            logs.records[0].msg,
-        )
+        assert logs.records[0].stack_info is not None
 
     def test_toggle_widget(self):
         """Test that the usage of `st.toggle` uses the correct checkbox proto config."""

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -212,10 +212,7 @@ class MetricTest(DeltaGeneratorTestCase):
             logs.records[0].msg,
         )
         # Check that the stack trace is included in the warning message:
-        self.assertIn(
-            "Stack (most recent call last)",
-            logs.records[0].msg,
-        )
+        assert logs.records[0].stack_info is not None
 
     def test_invalid_value(self):
         with self.assertRaises(TypeError) as exc:

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -211,6 +211,11 @@ class MetricTest(DeltaGeneratorTestCase):
             "`label` got an empty value. This is discouraged for accessibility reasons",
             logs.records[0].msg,
         )
+        # Check that the stack trace is included in the warning message:
+        self.assertIn(
+            "Stack (most recent call last)",
+            logs.records[0].msg,
+        )
 
     def test_invalid_value(self):
         with self.assertRaises(TypeError) as exc:


### PR DESCRIPTION
## Describe your changes

Adds the stack trace info to the logged warning if an element label is set to empty to resolve a popular user request (https://github.com/streamlit/streamlit/issues/8908).

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/8908

## Testing Plan

- Extended unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
