### PR TITLE
Docstrings for 1.45.0

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -67,8 +67,12 @@ class AlertMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
         width : int or "stretch"
-            The width of the alert. Can be either an integer (pixels) or "stretch".
-            Defaults to "stretch".
+            The desired width of the alert expressed in pixels. If this is
+            ``"stretch"`` (default), Streamlit sets the width of the alert to
+            match the width of the parent container. Otherwise, this must be an
+            integer. If the specified width is greater than the width of the
+            parent container, Streamlit sets the width of the alert to match
+            the width of the parent container.
 
         Example
         -------
@@ -134,8 +138,12 @@ class AlertMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
         width : int or "stretch"
-            The width of the alert. Can be either an integer (pixels) or "stretch".
-            Defaults to "stretch".
+            The desired width of the alert expressed in pixels. If this is
+            ``"stretch"`` (default), Streamlit sets the width of the alert to
+            match the width of the parent container. Otherwise, this must be an
+            integer. If the specified width is greater than the width of the
+            parent container, Streamlit sets the width of the alert to match
+            the width of the parent container.
 
         Example
         -------
@@ -200,8 +208,12 @@ class AlertMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
         width : int or "stretch"
-            The width of the alert. Can be either an integer (pixels) or "stretch".
-            Defaults to "stretch".
+            The desired width of the alert expressed in pixels. If this is
+            ``"stretch"`` (default), Streamlit sets the width of the alert to
+            match the width of the parent container. Otherwise, this must be an
+            integer. If the specified width is greater than the width of the
+            parent container, Streamlit sets the width of the alert to match
+            the width of the parent container.
 
         Example
         -------
@@ -267,8 +279,12 @@ class AlertMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
         width : int or "stretch"
-            The width of the alert. Can be either an integer (pixels) or "stretch".
-            Defaults to "stretch".
+            The desired width of the alert expressed in pixels. If this is
+            ``"stretch"`` (default), Streamlit sets the width of the alert to
+            match the width of the parent container. Otherwise, this must be an
+            integer. If the specified width is greater than the width of the
+            parent container, Streamlit sets the width of the alert to match
+            the width of the parent container.
 
         Example
         -------

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -48,9 +48,9 @@ class ExceptionMixin:
     ) -> DeltaGenerator:
         """Display an exception.
 
-        In the lower-right corner of the exception, Streamlit displays links to
-        Google and ChatGPT that are prefilled with the contents of the
-        exception message.
+        When accessing the app through ``localhost``, in the lower-right corner
+        of the exception, Streamlit displays links to Google and ChatGPT that
+        are prefilled with the contents of the exception message.
 
         Parameters
         ----------

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -57,8 +57,12 @@ class ExceptionMixin:
         exception : Exception
             The exception to display.
         width : int or "stretch"
-            The width of the exception display. Can be either an integer (pixels) or "stretch".
-            Defaults to "stretch".
+            The desired width of the exception expressed in pixels. If this is
+            ``"stretch"`` (default), Streamlit sets the width of the exception
+            to match the width of the parent container. Otherwise, this must be
+            an integer. If the specified width is greater than the width of the
+            parent container, Streamlit sets the width of the exception to
+            match the width of the parent container.
 
         Example
         -------

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -61,6 +61,15 @@ class HtmlMixin:
               convert the object to a string. ``body._repr_html_()`` takes
               precedence over ``str(body)`` when available.
 
+            If the resulting HTML content is empty, Streamlit will raise an
+            error.
+
+            If ``body`` is a path to a CSS file, Streamlit will wrap the CSS
+            content in ``<style>`` tags automatically. When the resulting HTML
+            content only contains style tags, Streamlit will send the content
+            to the event container instead of the main container to avoid
+            taking up space in the app.
+
         Example
         -------
         >>> import streamlit as st

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -72,7 +72,7 @@ class IframeMixin:
             - ``None`` (default): Uses the browser's default behavior.
             - ``-1``: Removes the iframe from sequential navigation, but still
               allows it to be focused programmatically.
-            - ``0``: Includes the iframe in seuqential navigation in the order
+            - ``0``: Includes the iframe in sequential navigation in the order
               it appears in the document but after all elements with a positive
               ``tab_index``.
             - Positive integer: Includes the iframe in sequential navigation.

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -62,11 +62,26 @@ class IframeMixin:
             does not show a scrollbar. If this is ``True``, Streamlit shows a
             scrollbar when the content is larger than the iframe.
 
-        tab_index : int, optional
-            Specifies the tab order of the iframe. Possible values are:
-            - ``None`` (default): Browser default behavior.
-            - ``-1``: Removes the iframe from the natural tab order, but it can still be focused programmatically.
-            - ``0`` or positive integer: Includes the iframe in the natural tab order.
+        tab_index : int or None
+            Specifies how and if the iframe is sequentially focusable.
+            Users typically use the ``Tab`` key for sequential focus
+            navigation.
+
+            This can be one of the following values:
+
+            - ``None`` (default): Uses the browser's default behavior.
+            - ``-1``: Removes the iframe from sequential navigation, but still
+              allows it to be focused programmatically.
+            - ``0``: Includes the iframe in seuqential navigation in the order
+              it appears in the document but after all elements with a positive
+              ``tab_index``.
+            - Positive integer: Includes the iframe in sequential navigation.
+              Elements are navigated in ascending order of their positive
+              ``tab_index``.
+
+            For more information, see the `tabindex
+            <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
+            documentation on MDN.
 
         Example
         -------
@@ -127,11 +142,26 @@ class IframeMixin:
             does not show a scrollbar. If this is ``True``, Streamlit shows a
             scrollbar when the content is larger than the iframe.
 
-        tab_index : int, optional
-            Specifies the tab order of the iframe. Possible values are:
-            - ``None`` (default): Browser default behavior.
-            - ``-1``: Removes the iframe from the natural tab order, but it can still be focused programmatically.
-            - ``0`` or positive integer: Includes the iframe in the natural tab order.
+        tab_index : int or None
+            Specifies how and if the iframe is sequentially focusable.
+            Users typically use the ``Tab`` key for sequential focus
+            navigation.
+
+            This can be one of the following values:
+
+            - ``None`` (default): Uses the browser's default behavior.
+            - ``-1``: Removes the iframe from sequential navigation, but still
+              allows it to be focused programmatically.
+            - ``0``: Includes the iframe in seuqential navigation in the order
+              it appears in the document but after all elements with a positive
+              ``tab_index``.
+            - Positive integer: Includes the iframe in sequential navigation.
+              Elements are navigated in ascending order of their positive
+              ``tab_index``.
+
+            For more information, see the `tabindex
+            <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
+            documentation on MDN.
 
         Example
         -------

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -152,7 +152,7 @@ class IframeMixin:
             - ``None`` (default): Uses the browser's default behavior.
             - ``-1``: Removes the iframe from sequential navigation, but still
               allows it to be focused programmatically.
-            - ``0``: Includes the iframe in seuqential navigation in the order
+            - ``0``: Includes the iframe in sequential navigation in the order
               it appears in the document but after all elements with a positive
               ``tab_index``.
             - Positive integer: Includes the iframe in sequential navigation.

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -303,10 +303,15 @@ class MultiSelectMixin:
         max_selections: int
             The max selections that can be selected at a time.
 
-        placeholder: str | None
+        placeholder: str or  None
             A string to display when no options are selected.
-            Defaults to "Choose an option." or, if
-            ``accept_new_options`` is set to ``True``, to "Choose or add an option".
+            If this is ``None`` (default), the widget displays one of the two
+            following placeholder strings:
+
+            - "Choose an option" is displayed if you set
+              ``accept_new_options=False``.
+            - "Choose or add an option" is displayed if you set
+              ``accept_new_options=True``.
 
         disabled: bool
             An optional boolean that disables the multiselect widget if set
@@ -319,30 +324,65 @@ class MultiSelectMixin:
             If this is ``"collapsed"``, Streamlit displays no label or spacer.
 
         accept_new_options: bool
-            If ``True``, the user can enter new options that don't exist in the
-            original options. The ``max_options`` argument is still enforced.
-            The default is ``False``.
+            Whether the user can add selections that aren't included in ``options``.
+            If this is ``False`` (default), the user can only select from the
+            items in ``options``. If this is ``True``, the user can enter new
+            items that don't exist in ``options``.
+
+            When a user enters and selects a new item, it is included in the
+            widget's returned list as a string. The new item is not added to
+            the widget's drop-down menu. Streamlit will use a case-insenstive
+            match from ``options`` before adding a new item, and a new item
+            can't be added if a case-insensitive match is already selected. The
+            ``max_selections`` argument is still enforced.
 
         Returns
         -------
         list
             A list with the selected options
 
-        Example
-        -------
+        Examples
+        --------
+        **Example 1: Use a basic multiselect widget**
+
+        You can declare one or more initial selections with the ``default``
+        parameter.
+
         >>> import streamlit as st
         >>>
         >>> options = st.multiselect(
-        ...     "What are your favorite colors",
+        ...     "What are your favorite colors?",
         ...     ["Green", "Yellow", "Red", "Blue"],
-        ...     ["Yellow", "Red"],
+        ...     default=["Yellow", "Red"],
         ... )
         >>>
         >>> st.write("You selected:", options)
 
         .. output::
            https://doc-multiselect.streamlit.app/
-           height: 420px
+           height: 350px
+
+        **Example 2: Let users to add new options**
+
+        To allow users to enter and select new options that aren't included in
+        the ``options`` list, use the ``accept_new_options`` parameter. To
+        prevent users from adding an unbounded number of new options, use the
+        ``max_selections`` parameter.
+
+        >>> import streamlit as st
+        >>>
+        >>> options = st.multiselect(
+        ...     "What are your favorite cat names?",
+        ...     ["Jellybeans", "Fish Biscuit", "Madam President"],
+        ...     max_selections=5,
+        ...     accept_new_options=True,
+        ... )
+        >>>
+        >>> st.write("You selected:", options)
+
+        .. output::
+           https://doc-multiselect-accept-new-options.streamlit.app/
+           height: 350px
 
         """
         ctx = get_script_run_ctx()

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -331,7 +331,7 @@ class MultiSelectMixin:
 
             When a user enters and selects a new item, it is included in the
             widget's returned list as a string. The new item is not added to
-            the widget's drop-down menu. Streamlit will use a case-insenstive
+            the widget's drop-down menu. Streamlit will use a case-insensitive
             match from ``options`` before adding a new item, and a new item
             can't be added if a case-insensitive match is already selected. The
             ``max_selections`` argument is still enforced.

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -292,9 +292,10 @@ class NumberInputMixin:
             If this is ``"collapsed"``, Streamlit displays no label or spacer.
 
         icon : str, None
-            An optional emoji or icon to display next to the alert. If ``icon``
-            is ``None`` (default), no icon is displayed. If ``icon`` is a
-            string, the following options are valid:
+            An optional emoji or icon to display within the input field to the
+            left of the value. If ``icon`` is ``None`` (default), no icon is
+            displayed. If ``icon`` is a string, the following options are
+            valid:
 
             - A single-character emoji. For example, you can set ``icon="🚨"``
               or ``icon="🔥"``. Emoji short codes are not supported.

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -341,7 +341,7 @@ class SelectboxMixin:
 
             When a user enters a new item, it is returned by the widget as a
             string. The new item is not added to the widget's drop-down menu.
-            Streamlit will use a case-insenstive match from ``options`` before
+            Streamlit will use a case-insensitive match from ``options`` before
             adding a new item.
 
         Returns

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -313,10 +313,15 @@ class SelectboxMixin:
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
 
-        placeholder : str
+        placeholder : str or None
             A string to display when no options are selected.
-            Defaults to "Choose an option." or, if
-            ``accept_new_options`` is set to ``True``, to "Choose or add an option".
+            If this is ``None`` (default), the widget displays one of the two
+            following placeholder strings:
+
+            - "Choose an option" is displayed if you set
+              ``accept_new_options=False``.
+            - "Choose or add an option" is displayed if you set
+              ``accept_new_options=True``.
 
         disabled : bool
             An optional boolean that disables the selectbox if set to ``True``.
@@ -329,17 +334,27 @@ class SelectboxMixin:
             If this is ``"collapsed"``, Streamlit displays no label or spacer.
 
         accept_new_options : bool
-            If ``True``, the user can enter a new option in the UI that is not part of
-            passed the options. The newly entered option gets selected.
-            The default is ``False``.
+            Whether the user can add a selection that isn't included in ``options``.
+            If this is ``False`` (default), the user can only select from the
+            items in ``options``. If this is ``True``, the user can enter a new
+            item that doesn't exist in ``options``.
+
+            When a user enters a new item, it is returned by the widget as a
+            string. The new item is not added to the widget's drop-down menu.
+            Streamlit will use a case-insenstive match from ``options`` before
+            adding a new item.
 
         Returns
         -------
         any
             The selected option or ``None`` if no option is selected.
 
-        Example
-        -------
+        Examples
+        --------
+        **Example 1: Use a basic selectbox widget**
+
+        If no index is provided, the first option is selected by default.
+
         >>> import streamlit as st
         >>>
         >>> option = st.selectbox(
@@ -353,7 +368,9 @@ class SelectboxMixin:
            https://doc-selectbox.streamlit.app/
            height: 320px
 
-        To initialize an empty selectbox, use ``None`` as the index value:
+        **Example 2: Use a selectbox widget with no initial selection**
+
+        To initialize an empty selectbox, use ``None`` as the index value.
 
         >>> import streamlit as st
         >>>
@@ -368,6 +385,28 @@ class SelectboxMixin:
 
         .. output::
            https://doc-selectbox-empty.streamlit.app/
+           height: 320px
+
+        **Example 3: Let users add a new option**
+
+        To allow users to add a new option that isn't included in the
+        ``options`` list, use the ``accept_new_options=True`` parameter. You
+        can also customize the placeholder text.
+
+        >>> import streamlit as st
+        >>>
+        >>> option = st.selectbox(
+        ...     "Default email",
+        ...     ["foo@example.com", "bar@example.com", "baz@example.com"],
+        ...     index=None,
+        ...     placeholder="Select a saved email or enter a new one",
+        ...     accept_new_options=True,
+        ... )
+        >>>
+        >>> st.write("You selected:", option)
+
+        .. output::
+           https://doc-selectbox-accept-new-options.streamlit.app/
            height: 320px
 
         """

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -216,9 +216,10 @@ class TextWidgetsMixin:
             label, which can help keep the widget alligned with other widgets.
 
         icon : str, None
-            An optional emoji or icon to display next to the alert. If ``icon``
-            is ``None`` (default), no icon is displayed. If ``icon`` is a
-            string, the following options are valid:
+            An optional emoji or icon to display within the input field to the
+            left of the value. If ``icon`` is ``None`` (default), no icon is
+            displayed. If ``icon`` is a string, the following options are
+            valid:
 
             - A single-character emoji. For example, you can set ``icon="🚨"``
               or ``icon="🔥"``. Emoji short codes are not supported.

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -648,8 +648,9 @@ class TimeWidgetsMixin:
     ) -> DateWidgetReturn:
         r"""Display a date input widget.
 
-        The first day of the week is determined from the user's locale in their
-        browser.
+        The date input widget can be configured to accept a single date or a
+        date range. The first day of the week is determined from the user's
+        locale in their browser.
 
         Parameters
         ----------

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -113,8 +113,8 @@ def login(provider: str | None = None) -> None:
         - For security reasons, authentication is not supported for embedded
           apps.
 
-    .. |st.experimental_user| replace:: ``st.experimental_user``
-    .. _st.experimental_user: https://docs.streamlit.io/develop/api-reference/utilities/st.experimental_user
+    .. |st.user| replace:: ``st.user``
+    .. _st.user: https://docs.streamlit.io/develop/api-reference/user/st.user
 
     Parameters
     ----------
@@ -155,13 +155,13 @@ def login(provider: str | None = None) -> None:
 
     >>> import streamlit as st
     >>>
-    >>> if not st.experimental_user.is_logged_in:
+    >>> if not st.user.is_logged_in:
     >>>     if st.button("Log in"):
     >>>         st.login()
     >>> else:
     >>>     if st.button("Log out"):
     >>>         st.logout()
-    >>>     st.write(f"Hello, {st.experimental_user.name}!")
+    >>>     st.write(f"Hello, {st.user.name}!")
 
     **Example 2: Use a named identity provider**
 
@@ -193,10 +193,10 @@ def login(provider: str | None = None) -> None:
 
     >>> import streamlit as st
     >>>
-    >>> if not st.experimental_user.is_logged_in:
+    >>> if not st.user.is_logged_in:
     >>>     st.login("microsoft")
     >>> else:
-    >>>     st.write(f"Hello, {st.experimental_user.name}!")
+    >>>     st.write(f"Hello, {st.user.name}!")
 
     **Example 3: Use multiple, named providers**
 
@@ -226,7 +226,7 @@ def login(provider: str | None = None) -> None:
 
     >>> import streamlit as st
     >>>
-    >>> if not st.experimental_user.is_logged_in:
+    >>> if not st.user.is_logged_in:
     >>>     st.header("Log in:")
     >>>     if st.button("Microsoft"):
     >>>         st.login("microsoft")
@@ -235,7 +235,7 @@ def login(provider: str | None = None) -> None:
     >>> else:
     >>>     if st.button("Log out"):
     >>>         st.logout()
-    >>>     st.write(f"Hello, {st.experimental_user.name}!")
+    >>>     st.write(f"Hello, {st.user.name}!")
 
     **Example 4: Change the default connection settings**
 
@@ -267,10 +267,10 @@ def login(provider: str | None = None) -> None:
     >>> import streamlit as st
     >>> if st.button("Log in"):
     >>>     st.login("auth0")
-    >>> if st.experimental_user.is_logged_in:
+    >>> if st.user.is_logged_in:
     >>>     if st.button("Log out"):
     >>>         st.logout()
-    >>>     st.write(f"Hello, {st.experimental_user.name}!)
+    >>>     st.write(f"Hello, {st.user.name}!)
 
     """
     if provider is None:
@@ -293,15 +293,15 @@ def login(provider: str | None = None) -> None:
 def logout() -> None:
     """Logout the current user.
 
-    This command removes the user's information from ``st.experimental_user``,
+    This command removes the user's information from ``st.user``,
     deletes their identity cookie, and redirects them back to your app's home
     page. This creates a new session.
 
     If the user has multiple sessions open in the same browser,
-    ``st.experimental_user`` will not be cleared in any other session.
-    ``st.experimental_user`` only reads from the identity cookie at the start
+    ``st.user`` will not be cleared in any other session.
+    ``st.user`` only reads from the identity cookie at the start
     of a session. After a session is running, you must call ``st.login()`` or
-    ``st.logout()`` within that session to update ``st.experimental_user``.
+    ``st.logout()`` within that session to update ``st.user``.
 
     .. Note::
         This does not log the user out of their underlying account from the
@@ -322,13 +322,13 @@ def logout() -> None:
 
     >>> import streamlit as st
     >>>
-    >>> if not st.experimental_user.is_logged_in:
+    >>> if not st.user.is_logged_in:
     >>>     if st.button("Log in"):
     >>>         st.login()
     >>> else:
     >>>     if st.button("Log out"):
     >>>         st.logout()
-    >>>     st.write(f"Hello, {st.experimental_user.name}!")
+    >>>     st.write(f"Hello, {st.user.name}!")
     """
     context = _get_script_run_ctx()
     if context is not None:
@@ -376,20 +376,20 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
     A read-only, dict-like object for accessing information about the current\
     user.
 
-    ``st.experimental_user`` is dependent on the host platform running your
-    Streamlit app. If the host platform has not configured the function, it
-    will behave as in a locally running app.
+    ``st.user`` is dependent on the host platform running your
+    Streamlit app. If your host platform has not configured the object,
+    ``st.user`` will behave as it does in a locally running app.
 
     When authentication is configured in ``secrets.toml``, Streamlit will parse
     the OpenID Connect (OIDC) identity token and copy the attributes to
-    ``st.experimental_user``. Check your provider's documentation for their
+    ``st.user``. Check your provider's documentation for their
     available attributes (known as claims).
 
-    When authentication is not configured, ``st.experimental_user`` has no
+    When authentication is not configured, ``st.user`` has no
     attributes.
 
     You can access values via key or attribute notation. For example, use
-    ``st.experimental_user["email"]`` or ``st.experimental_user.email`` to
+    ``st.user["email"]`` or ``st.user.email`` to
     access the ``email`` attribute.
 
     .. Important::
@@ -411,7 +411,7 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
 
     If you configure a basic Google OIDC connection as shown in Example 1 of
     ``st.login()``, the following data is available in
-    ``st.experimental_user``. Streamlit adds the ``is_logged_in`` attribute.
+    ``st.user``. Streamlit adds the ``is_logged_in`` attribute.
     Additional attributes may be available depending on the configuration of
     the user's Google account. For more information about Google's identity
     tokens, see `Obtain user information from the ID token
@@ -422,8 +422,8 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
 
     >>> import streamlit as st
     >>>
-    >>> if st.experimental_user.is_logged_in:
-    >>>     st.write(st.experimental_user)
+    >>> if st.user.is_logged_in:
+    >>>     st.write(st.user)
 
     Displayed data when a user is logged in:
 
@@ -449,7 +449,7 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
 
     If you configure a basic Microsoft OIDC connection as shown in Example 2 of
     ``st.login()``, the following data is available in
-    ``st.experimental_user``. For more information about Microsoft's identity
+    ``st.user``. For more information about Microsoft's identity
     tokens, see `ID token claims reference
     <https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference>`_
     in Microsoft's docs.
@@ -458,8 +458,8 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
 
     >>> import streamlit as st
     >>>
-    >>> if st.experimental_user.is_logged_in:
-    >>>     st.write(st.experimental_user)
+    >>> if st.user.is_logged_in:
+    >>>     st.write(st.user)
 
     Displayed data when a user is logged in:
 


### PR DESCRIPTION
## Describe your changes
Docstring updates for version 1.45.0
* `st.text_input` and `st.number_input` icons
* User-defined options for `st.multiselect` and `st.selectbox`
* Hide Google and ChatGPT links in `st.exception` outside of `localhost`
* Automatic style tags for CSS in `st.html`
* De-experimentalization of `st.user`
* Widths for alerts and exceptions
* Tab index for custom components

## Testing Plan
None. Docstrings only.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
