### PR TITLE
[WIP] Fix flaky `st.audio` source error tests

### DIFF
--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -144,8 +144,7 @@ def test_audio_uses_unified_height(
     assert_snapshot(audio_element, name="st_audio-unified_height")
 
 
-# TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
-@pytest.mark.only_browser("chromium")
+@pytest.mark.skip_browser("webkit")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -170,8 +169,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
-# TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
-@pytest.mark.only_browser("chromium")
+@pytest.mark.skip_browser("webkit")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -29,6 +29,10 @@ AUDIO_ELEMENTS_WITH_URL = 3
 
 def check_audio_source_error_count(messages: list[str], expected_count: int):
     """Check that the expected number of audio source error messages are logged."""
+    print("========HELPER===========", flush=True)
+    print(f"Messages: {messages}", flush=True)
+    print(f"Expected count: {expected_count}", flush=True)
+    print("=========HELPER==========", flush=True)
     assert (
         len(
             [
@@ -186,10 +190,10 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     # Navigate to the app
     app.goto(f"http://localhost:{app_port}")
 
+    print("===================", flush=True)
+    print(f"Messages: {messages}", flush=True)
+    print("===================", flush=True)
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     wait_until(
-        app,
-        lambda: any(
-            "Client Error: Audio source error" in message for message in messages
-        ),
+        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH)
     )

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -144,7 +144,7 @@ def test_audio_uses_unified_height(
     assert_snapshot(audio_element, name="st_audio-unified_height")
 
 
-@pytest.mark.skip_browser("webkit")
+@pytest.mark.only_browser("chromium")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -169,7 +169,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
-@pytest.mark.skip_browser("webkit")
+@pytest.mark.only_browser("chromium")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -41,8 +41,6 @@ def check_audio_source_error_count(messages: list[str], expected_count: int):
                 if "Client Error: Audio source error" in message
             ]
         )
-        # when test run on webkit, it will sometimes log extra instances of the error
-        # for the same source - so we use >= expected_count to avoid flakiness
         >= expected_count
     )
 
@@ -148,7 +146,7 @@ def test_audio_uses_unified_height(
     assert_snapshot(audio_element, name="st_audio-unified_height")
 
 
-@pytest.mark.only_browser("chromium")
+@pytest.mark.skip_browser("webkit")
 def test_audio_source_error_with_url(app: Page, app_port: int):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
@@ -173,6 +171,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
+@pytest.mark.skip_browser("webkit")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -169,7 +169,6 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     )
 
 
-@pytest.mark.only_browser("chromium")
 def test_audio_source_error_with_path(app: Page, app_port: int):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status
@@ -187,8 +186,10 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     # Navigate to the app
     app.goto(f"http://localhost:{app_port}")
 
-    # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
-    # Should be 3 instances of the error, one for each audio element with path
+    # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     wait_until(
-        app, lambda: check_audio_source_error_count(messages, AUDIO_ELEMENTS_WITH_PATH)
+        app,
+        lambda: any(
+            "Client Error: Audio source error" in message for message in messages
+        ),
     )

--- a/e2e_playwright/st_camera_input_test.py
+++ b/e2e_playwright/st_camera_input_test.py
@@ -50,7 +50,7 @@ def test_clear_photo(app: Page):
     expect(app.get_by_test_id("stImage")).to_have_count(0)
 
 
-@pytest.mark.skip_browser("webkit")
+@pytest.mark.skip_browser("firefox")
 def test_shows_disabled_widget_correctly(
     themed_app: Page,
     assert_snapshot: ImageCompareFunction,
@@ -73,7 +73,7 @@ def test_shows_disabled_widget_correctly(
 
 
 # Webkit CI camera permission issue
-@pytest.mark.skip_browser("webkit")
+@pytest.mark.skip_browser("firefox")
 def test_take_photo_button_styling(app: Page):
     """Test that the Take Photo button is rendered properly when active/disabled."""
     camera_input_widgets = app.get_by_test_id("stCameraInput")


### PR DESCRIPTION
## Describe your changes
Manual testing of console errors (block fetches of audio sources, disabled browser cache) on firefox/edge shows it is working, but tests flaky. Also the current specification of `only_browser("chromium")` is not working since `st.audio` source error tests are flaking on webkit.