### PR TITLE
Update warnings to mention st.user instead of experimental_user

### DIFF
--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -358,7 +358,7 @@ def _get_user_info() -> UserInfo:
     ctx = _get_script_run_ctx()
     if ctx is None:
         _LOGGER.warning(
-            "No script run context available. st.experimental_user will return an empty dictionary."
+            "No script run context available. st.user will return an empty dictionary."
         )
         return {}
 
@@ -486,13 +486,13 @@ class UserInfoProxy(Mapping[str, Union[str, bool, None]]):
         try:
             return _get_user_info()[key]
         except KeyError:
-            raise KeyError(f'st.experimental_user has no key "{key}".')
+            raise KeyError(f'st.user has no key "{key}".')
 
     def __getattr__(self, key: str) -> str | bool | None:
         try:
             return _get_user_info()[key]
         except KeyError:
-            raise AttributeError(f'st.experimental_user has no attribute "{key}".')
+            raise AttributeError(f'st.user has no attribute "{key}".')
 
     def __setattr__(self, name: str, value: str | None) -> NoReturn:
         raise StreamlitAPIException("st.user cannot be modified")


### PR DESCRIPTION
## Describe your changes

Use `st.user` instead of `st.experimental_user` in the missing attribute or key errors. 
Even in case that is invoked from the `st.experimental_user`, we will show a deprecation warning once, so it makes sense to always unconditionally use `st.user` instead of `st.experimental_user`

## GitHub Issue Link (if applicable)

## Testing Plan

No change in the logic, only text changes

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
