### PR TITLE
Activate pep8 naming linting rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -51,6 +51,7 @@ select = [
   "INP",    # Checks implicit namespace packages.
   "ISC",    # Encourage correct string literal concatenation.
   "LOG",    # Checks for issues using the standard library logging module.
+  "N",      # Linting rules for pep8 naming conventions.
   "NPY",    # Linting rules for numpy
   "PD",     # Opinionated linting for pandas.
   "PERF",   # Rules to prevent performance anti-patterns.
@@ -102,6 +103,8 @@ ignore = [
   "D202",    # Checks for no-blank line after docstring.
   "FIX002",  # Checks todo comments (which we want to allow).
   "PGH003",  # Checks for blanket type ignore.
+  "N806",    # Checks for non-lowercased variable names in functions.
+  "N818",    # Checks for Error suffix for exceptions.
 ]
 exclude = [
   # pympler is a vendored dependency that doesn't conform to our linting rules:
@@ -109,10 +112,10 @@ exclude = [
 ]
 
 [lint.per-file-ignores]
-"e2e_playwright/**" = ["T20", "B018", "PD", "PERF"]
+"e2e_playwright/**" = ["T20", "B018", "PD", "PERF", "N999"]
 "lib/streamlit/__init__.py" = ["E402", "PLC0414"]
 "lib/setup.py" = ["INP"]
-"lib/tests/**" = ["PD", "D", "INP", "PERF"]
+"lib/tests/**" = ["PD", "D", "INP", "PERF", "N"]
 "scripts/**" = ["T20", "INP", "PERF"]
 ".github/**" = ["T20", "INP", "PERF"]
 

--- a/e2e_playwright/multipage_apps/mpa_configure_sidebar.py
+++ b/e2e_playwright/multipage_apps/mpa_configure_sidebar.py
@@ -30,12 +30,12 @@ st.subheader("Page Navigation:")
 st.logo(logo, link="https://www.example.com", icon_image=small_logo)
 
 
-colA, colB = st.container(key="page_link_container").columns(2)
+col_a, col_b = st.container(key="page_link_container").columns(2)
 
-with colA:
+with col_a:
     st.page_link("mpa_configure_sidebar.py", label="Home", icon="🏠")
     st.page_link(Path("pages/02_page2.py"), label="Page 2", icon=":material/article:")
     st.page_link("pages/03_page3.py", label="Page 3", icon="📈", disabled=True)
 
-with colB:
+with col_b:
     st.page_link("pages/04_page_with_duplicate_name.py", label="Page 4", icon="🧪")

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -94,7 +94,7 @@ def test_typing_new_hex_color_on_color_picker_works_with_callback(
     assert_snapshot(color_pickers.nth(0), name="st_color_picker-typed_new_hex_color")
 
 
-def test_typing_new_RGB_color_on_color_picker_works(
+def test_typing_new_rgb_color_on_color_picker_works(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     color_pickers = app.get_by_test_id("stColorPicker")
@@ -117,7 +117,7 @@ def test_typing_new_RGB_color_on_color_picker_works(
     assert_snapshot(color_pickers.nth(0), name="st_color_picker-typed_new_rgb_color")
 
 
-def test_typing_new_HSL_color_on_color_picker_works(
+def test_typing_new_hsl_color_on_color_picker_works(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     color_pickers = app.get_by_test_id("stColorPicker")

--- a/e2e_playwright/st_download_button_test.py
+++ b/e2e_playwright/st_download_button_test.py
@@ -132,7 +132,7 @@ def test_reset_on_other_widget_change(app: Page):
     )
 
 
-def test_downloads_RAR_file_on_click(app: Page):
+def test_downloads_rar_file_on_click(app: Page):
     # Start waiting for the download
     with app.expect_download() as download_info:
         # Perform the action that initiates download

--- a/e2e_playwright/st_pyplot.py
+++ b/e2e_playwright/st_pyplot.py
@@ -43,14 +43,14 @@ st.pyplot(fig, use_container_width=False)
 st.write("Advanced Seaborn figure:")
 # Generate data
 data_points = 100
-xData: "np.typing.NDArray[np.float64]" = (np.random.randn(data_points, 1) * 30) + 30
-yData: "np.typing.NDArray[np.float64]" = np.random.randn(data_points, 1) * 30
+x_data: "np.typing.NDArray[np.float64]" = (np.random.randn(data_points, 1) * 30) + 30
+y_data: "np.typing.NDArray[np.float64]" = np.random.randn(data_points, 1) * 30
 data: "np.typing.NDArray[np.float64]" = np.random.randn(data_points, 2)
 
 # Generate plot
 fig, ax = plt.subplots(figsize=(4.5, 4.5))
 sns.set_context(rc={"font.size": 10})
-p = sns.regplot(x=xData, y=yData, data=data, ci=None, ax=ax, color="grey")
+p = sns.regplot(x=x_data, y=y_data, data=data, ci=None, ax=ax, color="grey")
 
 p.set_title("An Extremely and Really Really Long Long Long Title", fontweight="bold")
 p.set_xlabel("Very long long x label")

--- a/e2e_playwright/st_session_state_test.py
+++ b/e2e_playwright/st_session_state_test.py
@@ -38,7 +38,7 @@ def test_has_correct_starting_values(app: Page):
     expect(app.get_by_test_id("stJson")).to_be_visible()
 
 
-def test_can_do_CRUD_for_session_state_items(app: Page):
+def test_can_do_crud_for_session_state_items(app: Page):
     expect(app.get_by_text("item_counter: 0")).to_have_count(1)
     expect(app.get_by_text("attr_counter: 0")).to_have_count(1)
 
@@ -59,7 +59,7 @@ def test_can_do_CRUD_for_session_state_items(app: Page):
     expect(app.get_by_text("len(st.session_state): 4")).to_have_count(1)
 
 
-def test_can_do_CRUD_for_session_state_attributes(app: Page):
+def test_can_do_crud_for_session_state_attributes(app: Page):
     expect(app.get_by_text("item_counter: 0")).to_have_count(1)
     expect(app.get_by_text("attr_counter: 0")).to_have_count(1)
 

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -27,9 +27,7 @@ import streamlit
 from streamlit.proto.DocString_pb2 import DocString as DocStringProto
 from streamlit.proto.DocString_pb2 import Member as MemberProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner.script_runner import (
-    __file__ as SCRIPTRUNNER_FILENAME,
-)
+from streamlit.runtime.scriptrunner import script_runner
 from streamlit.runtime.secrets import Secrets
 from streamlit.string_util import is_mem_address_str
 
@@ -353,7 +351,7 @@ def _get_scriptrunner_frame():
         if frame.code_context is None:
             return None
 
-        if frame.filename == SCRIPTRUNNER_FILENAME:
+        if frame.filename == script_runner.__file__:
             scriptrunner_frame = prev_frame
             break
 

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -27,7 +27,9 @@ import streamlit
 from streamlit.proto.DocString_pb2 import DocString as DocStringProto
 from streamlit.proto.DocString_pb2 import Member as MemberProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner import script_runner
+from streamlit.runtime.scriptrunner.script_runner import (
+    __file__ as SCRIPTRUNNER_FILENAME,  # noqa: N812
+)
 from streamlit.runtime.secrets import Secrets
 from streamlit.string_util import is_mem_address_str
 
@@ -351,7 +353,7 @@ def _get_scriptrunner_frame():
         if frame.code_context is None:
             return None
 
-        if frame.filename == script_runner.__file__:
+        if frame.filename == SCRIPTRUNNER_FILENAME:
             scriptrunner_frame = prev_frame
             break
 

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Allow function names with uppercase letters:
+# ruff: noqa: N802
+
 from __future__ import annotations
 
 import datetime

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -122,7 +122,7 @@ def _validate_image_format_string(
     return "JPEG"
 
 
-def _PIL_to_bytes(
+def _pil_to_bytes(
     image: PILImage,
     format: ImageFormat = "JPEG",
     quality: int = 100,
@@ -139,7 +139,7 @@ def _PIL_to_bytes(
     return tmp.getvalue()
 
 
-def _BytesIO_to_bytes(data: io.BytesIO) -> bytes:
+def _bytesio_to_bytes(data: io.BytesIO) -> bytes:
     data.seek(0)
     return data.getvalue()
 
@@ -151,7 +151,7 @@ def _np_array_to_bytes(array: npt.NDArray[Any], output_format: str = "JPEG") -> 
     img = Image.fromarray(array.astype(np.uint8))
     format = _validate_image_format_string(img, output_format)
 
-    return _PIL_to_bytes(img, format)
+    return _pil_to_bytes(img, format)
 
 
 def _verify_np_shape(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
@@ -199,11 +199,11 @@ def _ensure_image_size_and_format(
         # versions. The types don't seem to reflect this, though, hence the type: ignore
         # below.
         pil_image = pil_image.resize((width, new_height), resample=Image.BILINEAR)  # type: ignore[attr-defined]
-        return _PIL_to_bytes(pil_image, format=image_format, quality=90)
+        return _pil_to_bytes(pil_image, format=image_format, quality=90)
 
     if pil_image.format != image_format:
         # We need to reformat the image.
-        return _PIL_to_bytes(pil_image, format=image_format, quality=90)
+        return _pil_to_bytes(pil_image, format=image_format, quality=90)
 
     # No resizing or reformatting necessary - return the original bytes.
     return image_data
@@ -302,13 +302,13 @@ def image_to_url(
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
         format = _validate_image_format_string(image, output_format)
-        image_data = _PIL_to_bytes(image, format)
+        image_data = _pil_to_bytes(image, format)
 
     # BytesIO
     # Note: This doesn't support SVG. We could convert to png (cairosvg.svg2png)
     # or just decode BytesIO to string and handle that way.
     elif isinstance(image, io.BytesIO):
-        image_data = _BytesIO_to_bytes(image)
+        image_data = _bytesio_to_bytes(image)
 
     # Numpy Arrays (ie opencv)
     elif isinstance(image, np.ndarray):

--- a/lib/streamlit/hello/dataframe_demo.py
+++ b/lib/streamlit/hello/dataframe_demo.py
@@ -23,13 +23,13 @@ from streamlit.hello.utils import show_code
 
 def data_frame_demo():
     @st.cache_data
-    def get_UN_data():
+    def get_un_data():
         AWS_BUCKET_URL = "https://streamlit-demo-data.s3-us-west-2.amazonaws.com"
         df = pd.read_csv(AWS_BUCKET_URL + "/agri.csv.gz")
         return df.set_index("Region")
 
     try:
-        df = get_UN_data()
+        df = get_un_data()
         countries = st.multiselect(
             "Choose countries", list(df.index), ["China", "United States of America"]
         )

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -27,7 +27,7 @@ from streamlit.util import calc_md5
 
 
 @gather_metrics("Page")
-def Page(
+def Page(  # noqa: N802
     page: str | Path | Callable[[], None],
     *,
     title: str | None = None,

--- a/lib/streamlit/runtime/scriptrunner/exec_code.py
+++ b/lib/streamlit/runtime/scriptrunner/exec_code.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner_utils.script_run_context import ScriptRunContext
 
 
-class modified_sys_path:
+class modified_sys_path:  # noqa: N801
     """A context for prepending a directory to sys.path for a second.
 
     Code inspired by IPython:

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -33,7 +33,7 @@ from streamlit.elements.lib.image_utils import (
     WidthBehavior,
     _image_may_have_alpha_channel,
     _np_array_to_bytes,
-    _PIL_to_bytes,
+    _pil_to_bytes,
     image_to_url,
     marshall_images,
 )
@@ -408,7 +408,7 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         self.assertEqual(el.imgs.imgs[0].caption, "some caption")
 
         # locate resultant file in the file manager and check its metadata.
-        file_id = _calculate_file_id(_PIL_to_bytes(img, format="PNG"), "image/png")
+        file_id = _calculate_file_id(_pil_to_bytes(img, format="PNG"), "image/png")
         media_file = self.media_file_storage.get_file(file_id)
         self.assertIsNotNone(media_file)
         self.assertEqual(media_file.mimetype, "image/png")
@@ -437,7 +437,7 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         # locate resultant file in the file manager and check its metadata.
         for idx in range(len(imgs)):
             file_id = _calculate_file_id(
-                _PIL_to_bytes(imgs[idx], format="PNG"), "image/png"
+                _pil_to_bytes(imgs[idx], format="PNG"), "image/png"
             )
             self.assertEqual(el.imgs.imgs[idx].caption, "some caption")
             media_file = self.media_file_storage.get_file(file_id)


### PR DESCRIPTION
## Describe your changes

Activates the [pep8-naming (N)](https://docs.astral.sh/ruff/rules/#pep8-naming-n) linting rule set in ruff. This checks our code against the pep8 naming conventions.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
