### PR TITLE
Activate ruff linting rule to prevent commented-out code

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -39,6 +39,7 @@ select = [
   "C4",     # Helps you write better list/set/dict comprehensions.
   "D",      # Check docstrings.
   "E",      # pycodestyle errors
+  "ERA",    # Checks for commented out code.
   "F",      # pyflakes
   "FA",     # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
   "FIX",    # Only allow todo comments in the codebase.

--- a/e2e_playwright/hello_app_test.py
+++ b/e2e_playwright/hello_app_test.py
@@ -96,7 +96,7 @@ def test_mapping_demo_page(app: Page) -> None:
 
     # The snapshot test here is flaky, the map doesn't seem to always result
     # in the same image.
-    # assert_snapshot(app, name="hello_app-mapping_demo_page")
+    # assert_snapshot(app, name="hello_app-mapping_demo_page")  # noqa: ERA001
 
 
 def _load_dataframe_demo_page(app: Page):

--- a/e2e_playwright/shared/data_mocks.py
+++ b/e2e_playwright/shared/data_mocks.py
@@ -434,13 +434,13 @@ UNSUPPORTED_TYPES_DF = pd.DataFrame(
         "dicts": pd.Series([{"a": 1}, {"b": 2}, {"c": 2}, None]),
         "objects": pd.Series([TestObject(), TestObject(), TestObject(), None]),
         # TODO(lukasmasuch): Not supported, but currently leads to error
-        # "mixed_types_list": pd.Series(
-        #     [random.choice([1, 1.0, None, "foo"]) for _ in range(10)]
-        #     for _ in range(n_rows)
-        # ),
+        # > "mixed_types_list": pd.Series(
+        # >     [random.choice([1, 1.0, None, "foo"]) for _ in range(10)]
+        # >     for _ in range(n_rows)
+        # > ),
         # TODO(lukasmasuch): Sparse array is supported, but currently leads to error
-        # "sparse-array": pd.Series(
-        #     pd.arrays.SparseArray([random.choice([0, 1, 2]) for _ in range(n_rows)])
-        # ),
+        # > "sparse-array": pd.Series(
+        # >     pd.arrays.SparseArray([random.choice([0, 1, 2]) for _ in range(n_rows)])
+        # > ),
     }
 )

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -335,8 +335,9 @@ def test_in_form_selection_and_session_state(app: Page):
         empty_selection,
     )
 
-    # submit the form. The selection uses a debounce of 200ms; if we click too early, the state is not updated correctly and we submit the old, unselected values
-    # app.wait_for_timeout(210)
+    # submit the form. The selection uses a debounce of 200ms; if we click too early,
+    # the state is not updated correctly and we submit the old, unselected values
+    app.wait_for_timeout(210)
     click_form_button(app, "Submit")
 
     expected_selection = re.compile(

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -69,7 +69,7 @@ def test_audio_end_time_loop(app: Page):
     audio_element = app.get_by_test_id("stAudio").nth(2)
     audio_element.evaluate("el => el.play()")
     # The corresponding element definition looks like this:
-    # st.audio(url2, start_time=15, end_time=19, loop=True)
+    # > st.audio(url2, start_time=15, end_time=19, loop=True)
     # We wait for 6 seconds, which mean the current time should be
     # approximately 17 (4 seconds until end_time and 2 seconds starting from start time)
     app.wait_for_timeout(6000)

--- a/e2e_playwright/st_data_editor_index_types.py
+++ b/e2e_playwright/st_data_editor_index_types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: ERA001
 import random
 
 import numpy as np

--- a/e2e_playwright/st_dataframe_config.py
+++ b/e2e_playwright/st_dataframe_config.py
@@ -707,8 +707,8 @@ st.dataframe(
         "localized time": st.column_config.TimeColumn(format="localized"),
         "iso8601": st.column_config.DatetimeColumn(format="iso8601"),
         # We cannot reliably test distance via e2e tests because it wouldn't
-        # stay stable.
-        # "distance": st.column_config.DatetimeColumn(format="distance"),
+        # stay stable:
+        # "distance": st.column_config.DatetimeColumn(format="distance"),  # noqa: ERA001
     },
     hide_index=True,
     use_container_width=False,

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -147,12 +147,6 @@ def test_svg_images(app: Page, assert_snapshot: ImageCompareFunction):
     expect(meta_tag_svg).to_have_css("max-width", "100%")
     assert_snapshot(meta_tag_svg, name="st_image-svg_with_meta_tags")
 
-    # TODO(lukasmasuch): This svg does not correctly work in Safari and Firefox
-    # Test "Red Circle"
-    # red_circle = get_image(app, "Red Circle.").locator("img")
-    # expect(red_circle).to_have_css("max-width", "100%")
-    # assert_snapshot(red_circle, name="st_image-svg_red_circle")
-
     # Test "Red Circle with internal dimensions"
     red_circle_internal_dim = get_image(
         app, "Red Circle with internal dimensions."

--- a/e2e_playwright/st_pyplot_test.py
+++ b/e2e_playwright/st_pyplot_test.py
@@ -42,7 +42,7 @@ def test_displays_a_pyplot_figures(
 
     # Snapshot testing the global object is flaky. But we anyways want to remove this,
     # functionality so we can just comment it out for now.
-    # assert_snapshot(pyplot_elements.nth(6), name="st_pyplot-global_figure")
+    # assert_snapshot(pyplot_elements.nth(6), name="st_pyplot-global_figure")  # noqa: ERA001
 
 
 def test_shows_deprecation_warning(app: Page):

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1561,8 +1561,8 @@ def _check_conflicts() -> None:
 
     # When using the Node server, we must always connect to 8501 (this is
     # hard-coded in JS). Otherwise, the browser would decide what port to
-    # connect to based on window.location.port, which in dev is going to
-    # be (3000)
+    # connect to based on window.location.port, which in dev is going
+    # to be (3000)
 
     # Import logger locally to prevent circular references
     from streamlit.logger import get_logger

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -149,18 +149,14 @@ def _marshall(doc_string_proto: DocStringProto, obj: Any) -> None:
 
 def _get_name(obj):
     # Try to get the fully-qualified name of the object.
-    # For example:
-    #   st.help(bar.Baz(123))
-    #
-    #   The name is bar.Baz
+    # For example: st.help(bar.Baz(123))
+    #    The name is bar.Baz
     name = getattr(obj, "__qualname__", None)
     if name:
         return name
 
     # Try to get the name of the object.
-    # For example:
-    #   st.help(bar.Baz(123))
-    #
+    # For example: st.help(bar.Baz(123))
     #   The name is Baz
     return getattr(obj, "__name__", None)
 
@@ -174,10 +170,6 @@ def _get_signature(obj):
         return None
 
     sig = ""
-
-    # TODO: Can we replace below with this?
-    # with contextlib.suppress(ValueError):
-    #     sig = str(inspect.signature(obj))
 
     try:
         sig = str(inspect.signature(obj))
@@ -248,20 +240,20 @@ def _get_variable_name_from_code_str(code):
 
     # Example:
     #
-    # tree = Module(
-    #   body=[
-    #     Expr(
-    #       value=Call(
-    #         args=[
-    #           Name(id='the variable name')
-    #         ],
-    #         keywords=[
-    #           ???
-    #         ],
-    #       )
-    #     )
-    #   ]
-    # )
+    # > tree = Module(
+    # >   body=[
+    # >     Expr(
+    # >       value=Call(
+    # >         args=[
+    # >           Name(id='the variable name')
+    # >         ],
+    # >         keywords=[
+    # >           ???
+    # >         ],
+    # >       )
+    # >     )
+    # >   ]
+    # > )
 
     # Check if this is an magic call (i.e. it's not st.help or st.write).
     # If that's the case, just clean it up and return it.

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -366,8 +366,8 @@ def _infer_vegalite_type(
         return "quantitative"
 
     elif typ == "categorical" and data.cat.ordered:
-        # STREAMLIT MOD: The original code returns a tuple here:
-        # return ("ordinal", data.cat.categories.tolist())
+        # The original code returns a tuple here:
+        # return ("ordinal", data.cat.categories.tolist())  # noqa: ERA001
         # But returning the tuple here isn't compatible with our
         # built-in chart implementation. And it also doesn't seem to be necessary.
         # Altair already extracts the correct sort order somewhere else.
@@ -387,11 +387,11 @@ def _infer_vegalite_type(
         return "temporal"
     else:
         # STREAMLIT MOD: I commented this out since Streamlit doesn't use warnings.warn.
-        # warnings.warn(
-        #     "I don't know how to infer vegalite type from '{}'.  "
-        #     "Defaulting to nominal.".format(typ),
-        #     stacklevel=1,
-        # )
+        # > warnings.warn(
+        # >     "I don't know how to infer vegalite type from '{}'.  "
+        # >     "Defaulting to nominal.".format(typ),
+        # >     stacklevel=1,
+        # > )
         return "nominal"
 
 
@@ -551,7 +551,7 @@ def _melt_data(
         )
 
     # Arrow has problems with object types after melting two different dtypes
-    # pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
+    # > pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
     fixed_df = dataframe_util.fix_arrow_incompatible_column_types(
         melted_df,
         selected_columns=[

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -188,7 +188,7 @@ def _determine_data_kind_via_arrow(field: pa.Field) -> ColumnDataKind:
 
     # Interval does not seem to work correctly:
     # if pa.types.is_interval(field_type):
-    #     return ColumnDataKind.INTERVAL
+    #     return ColumnDataKind.INTERVAL  # noqa: ERA001
 
     if pa.types.is_binary(field_type):
         return ColumnDataKind.BYTES

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -196,13 +196,13 @@ def _pandas_style_to_css(
 
     # In pandas >= 1.1.0
     # translated_style["cellstyle"] has the following shape:
-    # [
-    #   {
-    #       "props": [("color", " black"), ("background-color", "orange"), ("", "")],
-    #       "selectors": ["row0_col0"]
-    #   }
-    #   ...
-    # ]
+    # > [
+    # >   {
+    # >       "props": [("color", " black"), ("background-color", "orange"), ("", "")],
+    # >       "selectors": ["row0_col0"]
+    # >   }
+    # >   ...
+    # > ]
     if style_type == "table_styles":
         cell_selectors = [style["selector"]]
     else:

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -230,7 +230,7 @@ class MapMixin:
         #
         # For reference, this was the docstring for map_style:
         #
-        #   map_style : str or None
+        #   map_style : str, None
         #       One of Mapbox's map style URLs. A full list can be found here:
         #       https://docs.mapbox.com/api/maps/styles/#mapbox-styles
         #

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -256,8 +256,8 @@ def _prepare_vega_lite_spec(
     **kwargs,
 ) -> VegaLiteSpec:
     if kwargs:
-        # Support passing in kwargs. Example:
-        #   marshall(proto, {foo: 'bar'}, baz='boz')
+        # Support passing in kwargs.
+        # > marshall(proto, {foo: 'bar'}, baz='boz')
         # Merge spec with unflattened kwargs, where kwargs take precedence.
         # This only works for string keys, but kwarg keys are strings anyways.
         spec = dict(spec, **dicttools.unflatten(kwargs, _CHANNELS))
@@ -313,10 +313,10 @@ def _marshall_chart_data(
         del spec["datasets"]
 
     # Pull data out of spec dict when it's in a top-level 'data' key:
-    #   {data: df}
-    #   {data: {values: df, ...}}
-    #   {data: {url: 'url'}}
-    #   {data: {name: 'foo'}}
+    # > {data: df}
+    # > {data: {values: df, ...}}
+    # > {data: {url: 'url'}}
+    # > {data: {name: 'foo'}}
     if "data" in spec:
         data_spec = spec["data"]
 

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -128,8 +128,8 @@ class SelectSliderMixin:
     # The overload-overlap error given by mypy here stems from
     # the fact that
     #
-    #   opt:List[object] = [1, 2, "3"]
-    #   select_slider("foo", options=opt, value=[1, 2])
+    # > opt:List[object] = [1, 2, "3"]
+    # > select_slider("foo", options=opt, value=[1, 2])
     #
     # matches both overloads; "opt" matches
     # OptionsSequence[T] in each case, binding T to object.

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -32,8 +32,8 @@ MIN_GIT_VERSION = (2, 7, 0)
 
 class GitRepo:
     def __init__(self, path):
-        # If we have a valid repo, git_version will be a tuple of 3+ ints:
-        # (major, minor, patch, possible_additional_patch_number)
+        # If we have a valid repo, git_version will be a tuple
+        # of 3+ ints: (major, minor, patch, possible_additional_patch_number)
         self.git_version: tuple[int, ...] | None = None
 
         try:

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -82,13 +82,13 @@ class ForwardMsgQueue:
         # since the queue can be flushed to the browser at any time.
         # For example:
         # queue 1:
-        # empty [0, 0]  <- skipped
-        # markdown [0, 0]
-        # empty [1, 0]  <- send to frontend
+        # > empty [0, 0]  <- skipped
+        # > markdown [0, 0]
+        # > empty [1, 0]  <- send to frontend
         #
         # queue 2:
-        # markdown [1, 0]
-        # ...
+        # > markdown [1, 0]
+        # > ...
 
         delta_key = tuple(msg.metadata.delta_path)
         if delta_key in self._delta_index_map:
@@ -204,9 +204,9 @@ def _maybe_compose_delta_msgs(
         # We never replace add_block deltas, because blocks can have
         # other dependent deltas later in the queue. For example:
         #
-        #   placeholder = st.empty()
-        #   placeholder.columns(1)
-        #   placeholder.empty()
+        # >  placeholder = st.empty()
+        # >  placeholder.columns(1)
+        # >  placeholder.empty()
         #
         # The call to "placeholder.columns(1)" creates two blocks, a parent
         # container with delta_path (0, 0), and a column child with

--- a/lib/streamlit/runtime/scriptrunner/magic.py
+++ b/lib/streamlit/runtime/scriptrunner/magic.py
@@ -21,8 +21,7 @@ from typing import Any, Final
 from streamlit import config
 
 # When a Streamlit app is magicified, we insert a `magic_funcs` import near the top of
-# its module's AST:
-# import streamlit.runtime.scriptrunner.magic_funcs as __streamlitmagic__
+# its module's AST: import streamlit.runtime.scriptrunner.magic_funcs as __streamlitmagic__
 MAGIC_MODULE_NAME: Final = "__streamlitmagic__"
 
 
@@ -217,8 +216,8 @@ def _get_st_write_from_expr(
         return None
 
     # If tuple, call st.write(*the_tuple). This allows us to add a comma at the end of a
-    # statement to turn it into an expression that should be st-written. Ex:
-    # "np.random.randn(1000, 2),"
+    # statement to turn it into an expression that should be
+    # st-written. Ex: "np.random.randn(1000, 2),"
     args = node.value.elts if type(node.value) is ast.Tuple else [node.value]
     return _build_st_write_call(args)
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -265,7 +265,7 @@ class ScriptRunner:
         # _maybe_handle_execution_control_request.
         self._execing = False
 
-        # This is initialized in start()
+        # This is initialized in the start() method
         self._script_thread: threading.Thread | None = None
 
     def __repr__(self) -> str:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -232,10 +232,10 @@ def is_graphviz_chart(
 ) -> TypeGuard[graphviz.Graph | graphviz.Digraph]:
     """True if input looks like a GraphViz chart."""
     return (
-        # GraphViz < 0.18
+        # In GraphViz < 0.18
         is_type(obj, "graphviz.dot.Graph")
         or is_type(obj, "graphviz.dot.Digraph")
-        # GraphViz >= 0.18
+        # In GraphViz >= 0.18
         or is_type(obj, "graphviz.graphs.Graph")
         or is_type(obj, "graphviz.graphs.Digraph")
         or is_type(obj, "graphviz.sources.Source")

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -335,8 +335,8 @@ def run(
         await server.stopped
 
     # Run the server. This function will not return until the server is shut down.
-    # FIX RuntimeError: asyncio.run() cannot be called from a running event loop on Python 3.10.16
-    # asyncio.run(run_server())
+    # FIX RuntimeError: asyncio.run() cannot be called from a running event loop
+    # asyncio.run(run_server())  # noqa: ERA001
 
     # Define a main function to handle the event loop logic
     async def main():

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -276,7 +276,7 @@ def _main_run(
     bootstrap.run(file, is_hello, args, flag_options)
 
 
-# SUBCOMMAND: cache
+# SUBCOMMAND cache
 
 
 @main.group("cache")
@@ -299,7 +299,7 @@ def cache_clear():
     caching.cache_resource.clear()
 
 
-# SUBCOMMAND: config
+# SUBCOMMAND config
 
 
 @main.group("config")
@@ -318,7 +318,7 @@ def config_show(**kwargs):
     _config.show_config()
 
 
-# SUBCOMMAND: activate
+# SUBCOMMAND activate
 
 
 @main.group("activate", invoke_without_command=True)
@@ -335,7 +335,7 @@ def activate_reset():
     Credentials.get_current().reset()
 
 
-# SUBCOMMAND: test
+# SUBCOMMAND test
 
 
 @main.group("test", hidden=True)

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -659,7 +659,6 @@ class AlternativeComponentRegistryTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         registry = AlternativeComponentRegistryTest.AlternativeComponentRegistry()
-        # ComponentRegistry.initialize(registry)
         self.assertEqual(ComponentRegistry.instance(), registry)
         self.assertIsInstance(
             registry, AlternativeComponentRegistryTest.AlternativeComponentRegistry

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -192,8 +192,8 @@ class ColumnsTest(DeltaGeneratorTestCase):
 
         columns_blocks = all_deltas[1:4]
 
-        # 4 elements will be created: 1 horizontal block, 3 columns, each receives
-        # border=True
+        # 4 elements will be created: 1 horizontal block, 3 columns,
+        # each receives: border=True
         self.assertEqual(len(all_deltas), 4)
         self.assertTrue(columns_blocks[0].add_block.column.show_border)
         self.assertTrue(columns_blocks[1].add_block.column.show_border)

--- a/lib/tests/streamlit/logger_test.py
+++ b/lib/tests/streamlit/logger_test.py
@@ -32,21 +32,6 @@ DUMMY_CONFIG_OPTIONS = OrderedDict()
 class LoggerTest(unittest.TestCase):
     """Logger Unittest class."""
 
-    # Need to fix this test:
-    # https://trello.com/c/ZwNR7fWI
-    # def test_set_log_level_by_name(self):
-    #     """Test streamlit.logger.set_log_level."""
-    #     data = {
-    #         'critical': logging.CRITICAL,
-    #         'error': logging.ERROR,
-    #         'warning': logging.WARNING,
-    #         'info': logging.INFO,
-    #         'debug': logging.DEBUG,
-    #     }
-    #     for k, v in data.items():
-    #         streamlit.logger.set_log_level(k)
-    #         self.assertEqual(v, logging.getLogger().getEffectiveLevel())
-
     def test_set_log_level_by_constant(self):
         """Test streamlit.logger.set_log_level."""
         data = [
@@ -66,21 +51,6 @@ class LoggerTest(unittest.TestCase):
             logger.set_log_level(90)
         self.assertEqual(e.type, SystemExit)
         self.assertEqual(e.value.code, 1)
-
-    # Need to fix this test:
-    # https://trello.com/c/ZwNR7fWI
-    # def test_set_log_level_resets(self):
-    #     """Test streamlit.logger.set_log_level."""
-    #     streamlit.logger.set_log_level('debug')
-    #     test1 = streamlit.logger.get_logger('test1')
-    #     self.assertEqual(logging.DEBUG, test1.getEffectiveLevel())
-    #
-    #     streamlit.logger.set_log_level('warning')
-    #     self.assertEqual(logging.WARNING, test1.getEffectiveLevel())
-    #
-    #     streamlit.logger.set_log_level('critical')
-    #     test2 = streamlit.logger.get_logger('test2')
-    #     self.assertEqual(logging.CRITICAL, test2.getEffectiveLevel())
 
     @parameterized.expand(
         [
@@ -116,11 +86,3 @@ class LoggerTest(unittest.TestCase):
         loggers = [x for x in logger._loggers.keys() if "tornado." in x]
         truth = ["tornado.access", "tornado.application", "tornado.general"]
         self.assertEqual(sorted(truth), sorted(loggers))
-
-    # Need to fix this test:
-    # https://trello.com/c/ZwNR7fWI
-    # def test_get_logger(self):
-    #     """Test streamlit.logger.get_logger."""
-    #     # Test that get_logger with no args, figures out its caller
-    #     logger = streamlit.logger.get_logger()
-    #     self.assertTrue('.logger_test' in streamlit.logger.LOGGERS.keys())

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -316,7 +316,7 @@ class AppSessionTest(unittest.TestCase):
 
         # leaving the following code line in to show that the fragment id
         # is not set in the fragment storage!
-        # session._fragment_storage.set(fragment_id, lambda: None)
+        # session._fragment_storage.set(fragment_id, lambda: None)  # noqa: ERA001
 
         mock_active_scriptrunner = MagicMock(spec=ScriptRunner)
         session._scriptrunner = mock_active_scriptrunner

--- a/lib/tests/streamlit/runtime/caching/cache_errors_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_errors_test.py
@@ -65,8 +65,6 @@ def unhashable_type_func(_lock, ...):
         self.assertEqual(
             testutil.normalize_md(expected_message), testutil.normalize_md(ep.message)
         )
-        # Stack trace doesn't show in test :(
-        # self.assertNotEqual(len(ep.stack_trace), 0)
         self.assertEqual(ep.message_is_markdown, True)
         self.assertEqual(ep.is_warning, False)
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -184,19 +184,19 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         # Changing the value of any other argument will increase the call
         # count. We test each argument type:
 
-        # arg1 (POSITIONAL_OR_KEYWORD)
+        # > arg1 (POSITIONAL_OR_KEYWORD)
         foo(None, 2, 3, kwarg1=4, _kwarg2=5, kwarg3=6, _kwarg4=7)
         self.assertEqual([2], call_count)
 
-        # *arg (VAR_POSITIONAL)
+        # > *arg (VAR_POSITIONAL)
         foo(1, 2, None, kwarg1=4, _kwarg2=5, kwarg3=6, _kwarg4=7)
         self.assertEqual([3], call_count)
 
-        # kwarg1 (KEYWORD_ONLY)
+        # > kwarg1 (KEYWORD_ONLY)
         foo(1, 2, 3, kwarg1=None, _kwarg2=5, kwarg3=6, _kwarg4=7)
         self.assertEqual([4], call_count)
 
-        # **kwarg (VAR_KEYWORD)
+        # > **kwarg (VAR_KEYWORD)
         foo(1, 2, 3, kwarg1=4, _kwarg2=5, kwarg3=None, _kwarg4=7)
         self.assertEqual([5], call_count)
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -248,7 +248,6 @@ class HashTest(unittest.TestCase):
         # Note: We're able to break the recursive cycle caused by the identity
         # hash func but it causes all cycles to hash to the same thing.
         # https://github.com/streamlit/streamlit/issues/1659
-        # self.assertNotEqual(foo(2), foo(1))
 
     def test_tuple(self):
         self.assertEqual(get_hash((1, 2)), get_hash((1, 2)))

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -207,8 +207,8 @@ def test_importtime_median_under_threshold():
         cmd = [sys.executable, "-X", "importtime", "-c", "import streamlit"]
         p = subprocess.run(cmd, stderr=subprocess.PIPE, check=True)
 
-        # The last line of stderr has the total import time, e.g.:
-        # "import time: self [us] | cumulative [us] | streamlit"
+        # The last line of stderr has the total import time:
+        # import time: self [us] | cumulative [us] | streamlit
         line = p.stderr.splitlines()[-1]
         field = line.split(b"|")[-2].strip()  # e.g. b"123456"
         total_us = int(field)  # convert to integer microseconds

--- a/lib/tests/streamlit/typing/number_input_types.py
+++ b/lib/tests/streamlit/typing/number_input_types.py
@@ -39,9 +39,9 @@ if TYPE_CHECKING:
     # The next tests would indicate we will return a float instead of raising an error, because mypy considers
     # int to be a subclass of float. This is unavoidable, and not a real issue because we don't expect people
     # who care about type checking their code to use more than one positional numerical argument anyways.
-    # number_input("foo", 5, 5.0)
-    # number_input("foo", 5.0, 5.0, 5)
-    # number_input("foo", 5.0, 5.0, 5.0, 1)
+    # number_input("foo", 5, 5.0)  # noqa: ERA001
+    # number_input("foo", 5.0, 5.0, 5)  # noqa: ERA001
+    # number_input("foo", 5.0, 5.0, 5.0, 1)  # noqa: ERA001
 
     # Check keyword argument types
     assert_type(number_input("foo", min_value=1), int)
@@ -66,9 +66,9 @@ if TYPE_CHECKING:
     assert_type(number_input("foo", min_value=1.0, value="min"), float)
     # The next tests would indicate we will return a float instead of raising an error,
     # because mypy considers int to be a subclass of float. This is unavoidable.
-    # number_input("foo", min_value=1, max_value=5.0)
-    # number_input("foo", step=1, min_value=5.0)
-    # number_input("foo", value="min", step=1, max_value=5.0)
+    # number_input("foo", min_value=1, max_value=5.0)  # noqa: ERA001
+    # number_input("foo", step=1, min_value=5.0)  # noqa: ERA001
+    # number_input("foo", value="min", step=1, max_value=5.0)  # noqa: ERA001
 
     # Check value=none
     assert_type(number_input("foo", step=5, value=None), Union[int, None])
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
     assert_type(number_input("foo", max_value=5, value=None), Union[int, None])
     assert_type(number_input("foo", value=None), Union[float, None])
     # Same deal about mixing and matching ints and floats applies here too.
-    # number_input("foo", max_value=5, value=None, step=5.0)
+    # number_input("foo", max_value=5, value=None, step=5.0)  # noqa: ERA001
 
     # Check "min" value
     assert_type(number_input("foo", value="min"), float)

--- a/lib/tests/streamlit/typing/slider_types.py
+++ b/lib/tests/streamlit/typing/slider_types.py
@@ -59,8 +59,9 @@ if TYPE_CHECKING:
     )
     assert_type(slider("foo", max_value=10.0, value=5.0, step=1.0), float)
     assert_type(slider("foo", max_value=10.0, step=1.0), float)
-    # kwsingularfloat7 = slider("foo", step=1.0)
+    # kwsingularfloat7 = slider("foo", step=1.0)  # noqa: ERA001
     # ^ This actually raises an exception and is an invalid signature
+
     assert_type(slider("foo", min_value=5.0, max_value=10.0), float)
     assert_type(slider("foo", min_value=5.0, max_value=10.0, step=1.0), float)
 
@@ -117,8 +118,10 @@ if TYPE_CHECKING:
         slider("foo", max_value=_2024_5_20, value=_2024_5_8, step=_1DAYSPAN), date
     )
     assert_type(slider("foo", max_value=_2024_5_20, step=_1DAYSPAN), date)
-    # kwsingulardate7 = slider("foo", step=_1DAYSPAN)
+
+    # kwsingulardate7 = slider("foo", step=_1DAYSPAN)  # noqa: ERA001
     # ^ This actually raises an exception and is an invalid signature
+
     assert_type(slider("foo", min_value=_2024_5_1, max_value=_2024_5_20), date)
     assert_type(
         slider("foo", min_value=_2024_5_1, max_value=_2024_5_20, step=_1DAYSPAN), date
@@ -169,8 +172,10 @@ if TYPE_CHECKING:
     )
     assert_type(slider("foo", max_value=_2000, value=_1400, step=_5MINUTESPAN), time)
     assert_type(slider("foo", max_value=_2000, step=_5MINUTESPAN), time)
-    # kwsingulartime7 = slider("foo", step=_5MINUTESPAN)
+
+    # kwsingulartime7 = slider("foo", step=_5MINUTESPAN)  # noqa: ERA001
     # ^ This actually raises an exception and is an invalid signature
+
     assert_type(slider("foo", min_value=_0800, max_value=_2000), time)
     assert_type(
         slider("foo", min_value=_0800, max_value=_2000, step=_5MINUTESPAN), time


### PR DESCRIPTION
## Describe your changes

Activates the [eradicate (ERA)](https://docs.astral.sh/ruff/rules/#eradicate-era) linting rule in ruff to prevent commented-out code. The rule has a couple strange quirks (see https://github.com/astral-sh/ruff/issues/6100), but overall on our full codebase there are only a few false positives. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
