### PR TITLE
Increase the dependabot PR limit for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -149,7 +149,7 @@ updates:
       interval: "daily"
     # Allow a limited number of update PRs at a time
     # to keep the number of parallel dependency updates manageable.
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
 
     labels:
       - "change:chore"


### PR DESCRIPTION
## Describe your changes

Increases the limit of open dependabot PRs for Python to three (same as frontend). 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
