### PR TITLE
Ensure script lifecycle occurs for MPAv1 use case

### DIFF
--- a/e2e_playwright/multipage_apps/pages/12_page12.py
+++ b/e2e_playwright/multipage_apps/pages/12_page12.py
@@ -15,3 +15,18 @@
 import streamlit as st
 
 st.header("Page 12")
+
+layout_mode = st.segmented_control(
+    "layout mode",
+    ["layout1", "layout2"],
+    selection_mode="single",
+    default="layout1",
+    key="layout_mode",
+)
+
+if layout_mode == "layout1":
+    st.write("layout1")
+    r = st.radio("Select a value", ["A", "B", "C"], horizontal=True, key="_radio")
+    st.write(f"radio value: {r}, state value: {st.session_state['_radio']}")
+elif layout_mode == "layout2":
+    st.write("layout2")

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -865,3 +865,43 @@ def is_child_bounding_box_inside_parent(
         and (child_box["y"] + child_box["height"])
         <= (parent_box["y"] + parent_box["height"])
     )
+
+
+def get_button_group(app: Page, key: str) -> Locator:
+    """Get a button group with the given key.
+
+    Parameters
+    ----------
+    app : Page
+        The page to search for the button group.
+
+    key : str
+        The key of the button group to get.
+
+    Returns
+    -------
+    Locator
+        The button group.
+    """
+    return get_element_by_key(app, key).get_by_test_id("stButtonGroup").first
+
+
+def get_segment_button(locator: Locator, text: str) -> Locator:
+    """Get a segment button with the given button group.
+
+    Parameters
+    ----------
+    locator : Locator
+        The locator of the button groupto search for the segment button.
+
+    text : str
+        The text of the segment button to get.
+
+    Returns
+    -------
+    Locator
+        The segment button.
+    """
+    return locator.get_by_test_id(
+        re.compile("stBaseButton-segmented_control(Active)?")
+    ).filter(has_text=text)

--- a/e2e_playwright/st_segmented_control_test.py
+++ b/e2e_playwright/st_segmented_control_test.py
@@ -14,7 +14,7 @@
 
 import re
 
-from playwright.sync_api import Locator, Page, expect
+from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
@@ -24,19 +24,11 @@ from e2e_playwright.shared.app_utils import (
     click_form_button,
     expect_help_tooltip,
     expect_markdown,
+    get_button_group,
     get_element_by_key,
     get_markdown,
+    get_segment_button,
 )
-
-
-def get_button_group(app: Page, key: str) -> Locator:
-    return get_element_by_key(app, key).get_by_test_id("stButtonGroup").first
-
-
-def get_segment_button(locator: Locator, text: str) -> Locator:
-    return locator.get_by_test_id(
-        re.compile("stBaseButton-segmented_control(Active)?")
-    ).filter(has_text=text)
 
 
 def test_click_multiple_segmented_control_button_and_take_snapshot(

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -161,9 +161,7 @@ def _mpa_v1(main_script_path: str):
         expanded=False,
     )
 
-    if page._page != main_page._page:
-        # Only run the page if it is not pointing to this script:
-        page.run()
+    page.run()
 
 
 class ScriptRunner:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -164,8 +164,6 @@ def _mpa_v1(main_script_path: str):
     if page._page != main_page._page:
         # Only run the page if it is not pointing to this script:
         page.run()
-        # Finish the script execution here to only run the selected page
-        raise StopException()
 
 
 class ScriptRunner:
@@ -645,7 +643,8 @@ class ScriptRunner:
                     else:
                         if PagesManager.uses_pages_directory:
                             _mpa_v1(self._main_script_path)
-                        exec(code, module.__dict__)  # noqa: S102
+                        else:
+                            exec(code, module.__dict__)  # noqa: S102
                         self._fragment_storage.clear(
                             new_fragment_ids=ctx.new_fragment_ids
                         )


### PR DESCRIPTION
## Describe your changes

Changes in the MPA v1 handling inadvertently caused issues in clearing widget state. This is a result of the script lifecycle ending prematurely. This change forces all pages to run completely and exec in the case of MPAv0/2

## GitHub Issue Link (if applicable)

closes #11202

## Testing Plan

- E2E Tests adds this test case

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
