### PR TITLE
Ensure filename extension check is normalized

### DIFF
--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -58,14 +58,14 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     types set by the app developer. In theory, this should never happen, since we
     enforce file type check by extension on the frontend, but we check it on backend
     before returning file to the user to protect ourselves.
-
-    NOTE: allowed_types should be a list of lowercase strings.
     """
     normalized_filename = filename.lower()
     base_name, extension = os.path.splitext(normalized_filename)
+    normalized_allowed_types = [allowed_type.lower() for allowed_type in allowed_types]
 
     if not any(
-        normalized_filename.endswith(allowed_type) for allowed_type in allowed_types
+        normalized_filename.endswith(allowed_type)
+        for allowed_type in normalized_allowed_types
     ):
         raise StreamlitAPIException(
             f"Invalid file extension: `{extension}`. Allowed: {allowed_types}"

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -59,9 +59,12 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     enforce file type check by extension on the frontend, but we check it on backend
     before returning file to the user to protect ourselves.
     """
-    base_name, extension = os.path.splitext(filename.lower())
+    normalized_filename = filename.lower()
+    base_name, extension = os.path.splitext(normalized_filename)
 
-    if not any(filename.endswith(allowed_type) for allowed_type in allowed_types):
+    if not any(
+        normalized_filename.endswith(allowed_type) for allowed_type in allowed_types
+    ):
         raise StreamlitAPIException(
             f"Invalid file extension: `{extension}`. Allowed: {allowed_types}"
         )

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -58,6 +58,8 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     types set by the app developer. In theory, this should never happen, since we
     enforce file type check by extension on the frontend, but we check it on backend
     before returning file to the user to protect ourselves.
+
+    NOTE: allowed_types should be a list of lowercase strings.
     """
     normalized_filename = filename.lower()
     base_name, extension = os.path.splitext(normalized_filename)

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -68,6 +68,7 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
                 [".tar.gz", ".pdf"],
                 True,
             ),
+            ("extension_is_uppercase", "document.CSV", [".csv"], True),
             # Invalid cases
             ("invalid_single_extension", "document.docx", [".pdf", ".png"], False),
             (

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -59,6 +59,7 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
             # Valid cases
             ("valid_single_extension_pdf", "document.pdf", [".pdf", ".png"], True),
             ("valid_single_extension_png", "image.png", [".pdf", ".png"], True),
+            ("case_insensitive", "image.png", [".PDF", ".PNG"], True),
             ("valid_multi_part_tar_gz", "archive.tar.gz", [".tar.gz", ".zip"], True),
             ("valid_multi_part_zip", "data.zip", [".tar.gz", ".zip"], True),
             ("valid_tar_gz_allowed_gz", "archive.tar.gz", [".gz"], True),


### PR DESCRIPTION
## Describe your changes

We have a bug where the filename has an uppercase extension that did not pass the file extension enforcement and caused issues. This ensures we are checking the lowercase filename.

## GitHub Issue Link (if applicable)
closes #11259

## Testing Plan

- Python unit tests updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
