### PR TITLE
Activate rules to prevent exception handling anti-patterns

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -74,6 +74,7 @@ select = [
   "TC",    # Linting for type-checking imports & forward references.
   "TD",    # Checks correct usage of TODO comments.
   "TID",   # Helps you write tidier imports.
+  "TRY",   # Checks for exception handling anti-patterns.
   "UP",    # pyupgrade
   "W",     # pycodestyle warnings
   "YTT",   # Checks wrong usage of sys.version / sys.version_info.
@@ -116,9 +117,10 @@ ignore = [
   "PLR0915", # Checks for functions with too many statements.
   "PLR0916", # Checks for too many boolean expressions in if statements.
   "N806",    # Checks for non-lowercased variable names in functions.
-  "N818",    # Checks for Error suffix for exceptions.
   "A002",    # Checks if function argument shadows a Python builtin.
   "S101",    # Checks for usage of assert statements.
+  "TRY003",  # Checks for exception messages that are not defined in the exception class itself.
+  "TRY300",  # Checks for return statements in try blocks.
 ]
 exclude = [
   # pympler is a vendored dependency that doesn't conform to our linting rules:
@@ -126,11 +128,11 @@ exclude = [
 ]
 
 [lint.per-file-ignores]
-"e2e_playwright/**" = ["T20", "B018", "PD", "PERF", "N999", "S"]
+"e2e_playwright/**" = ["T20", "B018", "PD", "PERF", "N999", "S", "TRY"]
 "lib/streamlit/__init__.py" = ["E402", "PLC0414", "A001"]
 "lib/setup.py" = ["INP"]
-"lib/tests/**" = ["PD", "D", "INP", "PERF", "N", "ARG", "S"]
-"scripts/**" = ["T20", "INP", "PERF", "S"]
+"lib/tests/**" = ["PD", "D", "INP", "PERF", "N", "ARG", "S", "TRY"]
+"scripts/**" = ["T20", "INP", "PERF", "S", "TRY002"]
 
 [lint.flake8-tidy-imports]
 # Disallow all relative imports.

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -78,12 +78,12 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
     def __getattribute__(self, name: str) -> Any:
         try:
             return object.__getattribute__(self, name)
-        except AttributeError as e:
+        except AttributeError:
             if hasattr(self._instance, name):
                 raise AttributeError(
                     f"`{name}` doesn't exist here, but you can call `._instance.{name}` instead"
                 )
-            raise e
+            raise
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -263,7 +263,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
                 return snowflake.connector.connect()
 
             return snowflake.connector.connect(**kwargs)
-        except SnowflakeError as e:
+        except SnowflakeError:
             if not len(st_secrets) and not kwargs:
                 raise StreamlitAPIException(
                     "Missing Snowflake connection configuration. "
@@ -272,7 +272,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
                     "See the [SnowflakeConnection configuration documentation](https://docs.streamlit.io/st.connections.snowflakeconnection-configuration) "
                     "for more details and examples."
                 )
-            raise e
+            raise
 
     def query(
         self,

--- a/lib/streamlit/elements/lib/js_number.py
+++ b/lib/streamlit/elements/lib/js_number.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import numbers
 
 
-class JSNumberBoundsException(Exception):
+class JSNumberBoundsException(Exception):  # noqa: N818
     pass
 
 
@@ -67,7 +67,7 @@ class JSNumber:
             raise JSNumberBoundsException(
                 f"{value_name} ({value}) must be >= -((1 << 53) - 1)"
             )
-        elif value > cls.MAX_SAFE_INTEGER:
+        if value > cls.MAX_SAFE_INTEGER:
             raise JSNumberBoundsException(
                 f"{value_name} ({value}) must be <= (1 << 53) - 1"
             )
@@ -95,11 +95,11 @@ class JSNumber:
 
         if not isinstance(value, (numbers.Integral, float)):
             raise JSNumberBoundsException(f"{value_name} ({value}) is not a float")
-        elif value < cls.MIN_NEGATIVE_VALUE:
+        if value < cls.MIN_NEGATIVE_VALUE:
             raise JSNumberBoundsException(
                 f"{value_name} ({value}) must be >= -1.797e+308"
             )
-        elif value > cls.MAX_VALUE:
+        if value > cls.MAX_VALUE:
             raise JSNumberBoundsException(
                 f"{value_name} ({value}) must be <= 1.797e+308"
             )

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -54,9 +54,12 @@ def index_(iterable: Iterable[_Value], x: _Value) -> int:
     for i, value in enumerate(iterable):
         if x == value:
             return i
-        elif isinstance(value, float) and isinstance(x, float):
-            if abs(x - value) < _FLOAT_EQUALITY_EPSILON:
-                return i
+        if (
+            isinstance(value, float)
+            and isinstance(x, float)
+            and abs(x - value) < _FLOAT_EQUALITY_EPSILON
+        ):
+            return i
     raise ValueError(f"{x} is not in iterable")
 
 
@@ -107,11 +110,11 @@ def _coerce_enum(from_enum_value: E1, to_enum_class: type[E2]) -> E1 | E2:
     match as well. (This is configurable in streamlist configs)
     """
     if not isinstance(from_enum_value, Enum):
-        raise ValueError(
+        raise ValueError(  # noqa: TRY004
             f"Expected an Enum in the first argument. Got {type(from_enum_value)}"
         )
     if not isinstance(to_enum_class, EnumMeta):
-        raise ValueError(
+        raise ValueError(  # noqa: TRY004
             f"Expected an EnumMeta/Type in the second argument. Got {type(to_enum_class)}"
         )
     if isinstance(from_enum_value, to_enum_class):

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -453,8 +453,7 @@ def _marshall_av_media(
         read_data = data.read()
         if read_data is None:
             return
-        else:
-            data_or_filename = read_data
+        data_or_filename = read_data
     elif type_util.is_type(data, "numpy.ndarray"):
         data_or_filename = data.tobytes()
     else:
@@ -621,7 +620,7 @@ def _parse_start_time_end_time(
     try:
         maybe_start_time = time_to_seconds(start_time, coerce_none_to_inf=False)
         if maybe_start_time is None:
-            raise ValueError
+            raise ValueError  # noqa: TRY301
         start_time = int(maybe_start_time)
     except (StreamlitAPIException, ValueError):
         error_msg = TIMEDELTA_PARSE_ERROR_MESSAGE.format(

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -940,10 +940,9 @@ class ButtonMixin:
             if is_url(page):
                 if label is None or label == "":
                     raise StreamlitMissingPageLabelError()
-                else:
-                    page_link_proto.page = page
-                    page_link_proto.external = True
-                    return self.dg._enqueue("page_link", page_link_proto)
+                page_link_proto.page = page
+                page_link_proto.external = True
+                return self.dg._enqueue("page_link", page_link_proto)
 
             ctx_main_script = ""
             all_app_pages = {}
@@ -1028,7 +1027,7 @@ class ButtonMixin:
                 raise StreamlitAPIException(
                     f"`st.button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
                 )
-            elif not is_in_form(self.dg) and is_form_submitter:
+            if not is_in_form(self.dg) and is_form_submitter:
                 raise StreamlitAPIException(
                     f"`st.form_submit_button()` must be used inside an `st.form()`.{FORM_DOCS_INFO}"
                 )
@@ -1106,7 +1105,7 @@ def marshall_file(
         data_as_bytes = data.read() or b""
         mimetype = mimetype or "application/octet-stream"
     else:
-        raise RuntimeError("Invalid binary data format: %s" % type(data))
+        raise StreamlitAPIException("Invalid binary data format: %s" % type(data))
 
     if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -49,7 +49,7 @@ class FragmentStorageKeyError(Error, KeyError):
     pass
 
 
-class FragmentHandledException(Exception):
+class FragmentHandledException(Exception):  # noqa: N818
     """An exception that is raised by the fragment
     when it has handled the exception itself.
     """
@@ -57,15 +57,15 @@ class FragmentHandledException(Exception):
     pass
 
 
-class NoStaticFiles(Error):
+class NoStaticFiles(Error):  # noqa: N818
     pass
 
 
-class NoSessionContext(Error):
+class NoSessionContext(Error):  # noqa: N818
     pass
 
 
-class MarkdownFormattedException(Error):
+class MarkdownFormattedException(Error):  # noqa: N818
     """Exceptions with Markdown in their description.
 
     Instances of this class can use markdown in their messages, which will get

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -57,7 +57,7 @@ from streamlit.runtime.caching.storage import (
     CacheStorageManager,
 )
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    InvalidCacheStorageContext,
+    InvalidCacheStorageContextError,
 )
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
@@ -270,12 +270,11 @@ class DataCaches(CacheStatsProvider):
         )
         try:
             self.get_storage_manager().check_context(cache_context)
-        except InvalidCacheStorageContext as e:
-            _LOGGER.error(
+        except InvalidCacheStorageContextError:
+            _LOGGER.exception(
                 "Cache params for function %s are incompatible with current "
                 "cache storage manager.",
                 function_name,
-                exc_info=e,
             )
             raise
 
@@ -298,11 +297,10 @@ class DataCaches(CacheStatsProvider):
     def get_storage_manager(self) -> CacheStorageManager:
         if runtime.exists():
             return runtime.get_instance().cache_storage_manager
-        else:
-            # When running in "raw mode", we can't access the CacheStorageManager,
-            # so we're falling back to InMemoryCache.
-            _LOGGER.warning("No runtime found, using MemoryCacheStorageManager")
-            return MemoryCacheStorageManager()
+        # When running in "raw mode", we can't access the CacheStorageManager,
+        # so we're falling back to InMemoryCache.
+        _LOGGER.warning("No runtime found, using MemoryCacheStorageManager")
+        return MemoryCacheStorageManager()
 
 
 # Singleton DataCaches instance

--- a/lib/streamlit/runtime/caching/storage/cache_storage_protocol.py
+++ b/lib/streamlit/runtime/caching/storage/cache_storage_protocol.py
@@ -68,7 +68,7 @@ class CacheStorageKeyNotFoundError(CacheStorageError):
     """Raised when the key is not found in the cache storage."""
 
 
-class InvalidCacheStorageContext(CacheStorageError):
+class InvalidCacheStorageContextError(CacheStorageError):
     """Raised if the cache storage manager is not able to work with
     provided CacheStorageContext.
     """

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -79,7 +79,7 @@ def _send_email(email: str) -> None:
         ).json()
         metrics_url = response_json.get("url", "")
     except Exception:
-        _LOGGER.error("Failed to fetch metrics URL")
+        _LOGGER.exception("Failed to fetch metrics URL")
         return
 
     headers = {
@@ -150,7 +150,7 @@ class Credentials:
             with open(self._conf_file) as f:
                 data = toml.load(f).get("general")
             if data is None:
-                raise Exception
+                raise RuntimeError  # noqa: TRY301
             self.activation = _verify_email(data.get("email"))
         except FileNotFoundError:
             if auto_resolve:
@@ -164,7 +164,7 @@ class Credentials:
                 self.reset()
                 self.activate(show_instructions=not auto_resolve)
                 return
-            raise Exception(
+            raise RuntimeError(
                 textwrap.dedent(
                     """
                 Unable to load credentials from %s.

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -246,11 +246,11 @@ def _fragment(
                         except (
                             RerunException,
                             StopException,
-                        ) as e:
+                        ):
                             # The wrapped_fragment function is executed
                             # inside of a exec_func_with_error_handling call, so
                             # there is a correct handler for these exceptions.
-                            raise e
+                            raise
                         except Exception as e:
                             # render error here so that the delta path is correct
                             # for full app runs, the error will be displayed by the

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -442,12 +442,12 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
                 _LOGGER.debug("Failed to collect command telemetry", exc_info=ex)
         try:
             result = non_optional_func(*args, **kwargs)
-        except RerunException as ex:
+        except RerunException:
             # Duplicated from below, because static analysis tools get confused
             # by deferring the rethrow.
             if tracking_activated and command_telemetry:
                 command_telemetry.time = to_microseconds(timer() - exec_start)
-            raise ex
+            raise
         finally:
             # Activate tracking again if command executes without any exceptions
             # we only want to do that if this command has set the

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -596,7 +596,7 @@ class Runtime:
             elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                 pass
             else:
-                raise RuntimeError(f"Bad Runtime state at start: {self._state}")
+                raise RuntimeError(f"Bad Runtime state at start: {self._state}")  # noqa: TRY301
 
             # Signal that we're started and ready to accept sessions
             async_objs.started.set_result(None)

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -297,7 +297,7 @@ class ScriptRunner:
 
         """
         if self._script_thread is not None:
-            raise Exception("ScriptRunner was already started")
+            raise RuntimeError("ScriptRunner was already started")
 
         self._script_thread = threading.Thread(
             target=self._run_script_thread,
@@ -626,11 +626,11 @@ class ScriptRunner:
                                         " Usually this doesn't happen or no action is"
                                         " required, so its mainly for debugging."
                                     )
-                            except (RerunException, StopException) as e:
+                            except (RerunException, StopException):
                                 # The wrapped_fragment function is executed
                                 # inside of a exec_func_with_error_handling call, so
                                 # there is a correct handler for these exceptions.
-                                raise e
+                                raise
                             except Exception:  # noqa: S110
                                 # Ignore exceptions raised by fragments here as we don't
                                 # want to stop the execution of other fragments. The

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -58,17 +58,17 @@ class QueryParams(MutableMapping[str, str]):
         If the key is not present, raise KeyError.
         """
         self._ensure_single_query_api_used()
+        if key in EMBED_QUERY_PARAMS_KEYS:
+            raise KeyError(missing_key_error_message(key))
+
         try:
-            if key in EMBED_QUERY_PARAMS_KEYS:
-                raise KeyError(missing_key_error_message(key))
             value = self._query_params[key]
             if isinstance(value, list):
                 if len(value) == 0:
                     return ""
-                else:
-                    # Return the last value to mimic Tornado's behavior
-                    # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_query_argument
-                    return value[-1]
+                # Return the last value to mimic Tornado's behavior
+                # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_query_argument
+                return value[-1]
             return value
         except KeyError:
             raise KeyError(missing_key_error_message(key))
@@ -97,9 +97,9 @@ class QueryParams(MutableMapping[str, str]):
 
     def __delitem__(self, key: str) -> None:
         self._ensure_single_query_api_used()
+        if key in EMBED_QUERY_PARAMS_KEYS:
+            raise KeyError(missing_key_error_message(key))
         try:
-            if key in EMBED_QUERY_PARAMS_KEYS:
-                raise KeyError(missing_key_error_message(key))
             del self._query_params[key]
             self._send_query_param_msg()
         except KeyError:

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -112,8 +112,8 @@ def _on_server_start(server: Server) -> None:
     # errors and display them here.
     try:
         secrets.load_if_toml_exists()
-    except Exception as ex:
-        _LOGGER.error("Failed to load secrets.toml file", exc_info=ex)
+    except Exception:
+        _LOGGER.exception("Failed to load secrets.toml file")
 
     def maybe_open_browser():
         if config.get_option("server.headless"):

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -212,7 +212,7 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             if isinstance(payload, str):
                 # Sanity check. (The frontend should only be sending us bytes;
                 # Protobuf.ParseFromString does not accept str input.)
-                raise RuntimeError(
+                raise TypeError(  # noqa: TRY301
                     "WebSocket received an unexpected `str` message. "
                     "(We expect `bytes` only.)"
                 )

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -57,7 +57,9 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
                 contents = file.read()
         except OSError:
             sanitized_abspath = abspath.replace("\n", "").replace("\r", "")
-            _LOGGER.exception("ComponentRequestHandler: GET %s read error", sanitized_abspath)
+            _LOGGER.exception(
+                "ComponentRequestHandler: GET %s read error", sanitized_abspath
+            )
             self.write("read error")
             self.set_status(404)
             return

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -55,10 +55,8 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         try:
             with open(abspath, "rb") as file:
                 contents = file.read()
-        except OSError as e:
-            _LOGGER.error(
-                "ComponentRequestHandler: GET %s read error", abspath, exc_info=e
-            )
+        except OSError:
+            _LOGGER.exception("ComponentRequestHandler: GET %s read error", abspath)
             self.write("read error")
             self.set_status(404)
             return
@@ -102,13 +100,12 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         # As of 2015-07-21 there is no bzip2 encoding defined at
         # http://www.iana.org/assignments/media-types/media-types.xhtml
         # So for that (and any other encoding), use octet-stream.
-        elif encoding is not None:
+        if encoding is not None:
             return "application/octet-stream"
-        elif mime_type is not None:
+        if mime_type is not None:
             return mime_type
         # if mime_type not detected, use application/octet-stream
-        else:
-            return "application/octet-stream"
+        return "application/octet-stream"
 
     @staticmethod
     def get_url(file_id: str) -> str:

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -56,7 +56,8 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             with open(abspath, "rb") as file:
                 contents = file.read()
         except OSError:
-            _LOGGER.exception("ComponentRequestHandler: GET %s read error", abspath)
+            sanitized_abspath = abspath.replace("\n", "").replace("\r", "")
+            _LOGGER.exception("ComponentRequestHandler: GET %s read error", sanitized_abspath)
             self.write("read error")
             self.set_status(404)
             return

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -87,7 +87,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         try:
             self._storage.get_file(absolute_path)
         except MediaFileStorageError:
-            _LOGGER.error("MediaFileHandler: Missing file %s", absolute_path)
+            _LOGGER.exception("MediaFileHandler: Missing file %s", absolute_path)
             raise tornado.web.HTTPError(404, "not found")
 
         return absolute_path
@@ -121,7 +121,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
             # abspath is the hash as used `get_absolute_path`
             media_file = cls._storage.get_file(abspath)
         except Exception:
-            _LOGGER.error("MediaFileHandler: Missing file %s", abspath)
+            _LOGGER.exception("MediaFileHandler: Missing file %s", abspath)
             return None
 
         _LOGGER.debug(

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -110,9 +110,9 @@ class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):
 
     def _parse_provider_token(self) -> str | None:
         provider_token = self.get_argument("provider", None)
+        if provider_token is None:
+            return None
         try:
-            if provider_token is None:
-                raise StreamlitAuthError("Missing provider token")
             payload = decode_provider_token(provider_token)
         except StreamlitAuthError:
             return None
@@ -180,7 +180,7 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             _, _, recorded_provider, code = key.split("_")
             state_provider_mapping[code] = recorded_provider
 
-        provider: str | None = state_provider_mapping.get(state_code_from_url, None)
+        provider: str | None = state_provider_mapping.get(state_code_from_url)
         return provider
 
     def _get_origin_from_secrets(self) -> str | None:

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -78,13 +78,13 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
                 if os.path.sep != "/":
                     url_path = url_path.replace(os.path.sep, "/")
                 if any(url_path.endswith(x) for x in self._reserved_paths):
-                    raise e
+                    raise
 
                 self.path = self.parse_url_path(self.default_filename or "index.html")
                 absolute_path = self.get_absolute_path(self.root, self.path)
                 return super().validate_absolute_path(root, absolute_path)
 
-            raise e
+            raise
 
     def write_error(self, status_code: int, **kwargs) -> None:
         if status_code == 404:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -112,7 +112,7 @@ AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
 AUTH_LOGOUT_ENDPOINT: Final = "/auth/logout"
 
 
-class RetriesExceeded(Exception):
+class RetriesExceededError(Exception):
     pass
 
 
@@ -175,7 +175,7 @@ def _get_ssl_options(cert_file: str | None, key_file: str | None) -> SSLContext 
         try:
             ssl_ctx.load_cert_chain(cert_file, key_file)
         except ssl.SSLError:
-            _LOGGER.error(
+            _LOGGER.exception(
                 "Failed to load SSL certificate. Make sure "
                 "cert file '%s' and key file '%s' are correct.",
                 cert_file,
@@ -218,7 +218,7 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
         except OSError as e:
             if e.errno == errno.EADDRINUSE:
                 if server_port_is_manually_set():
-                    _LOGGER.error("Port %s is already in use", port)
+                    _LOGGER.error("Port %s is already in use", port)  # noqa: TRY400
                     sys.exit(1)
                 else:
                     _LOGGER.debug(
@@ -237,7 +237,7 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
                 raise
 
     if call_count >= MAX_PORT_SEARCH_RETRIES:
-        raise RetriesExceeded(
+        raise RetriesExceededError(
             f"Cannot start Streamlit server. Port {port} is already in use, and "
             f"Streamlit was unable to find a free port after {MAX_PORT_SEARCH_RETRIES} attempts.",
         )

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -101,9 +101,10 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
 
         try:
             if not self._is_active_session(session_id):
-                raise Exception("Invalid session_id")
-        except Exception as e:
-            self.send_error(400, reason=str(e))
+                self.send_error(400, reason="Invalid session_id")
+                return
+        except Exception as ex:
+            self.send_error(400, reason=str(ex))
             return
 
         uploaded_files: list[UploadedFileRec] = []

--- a/lib/streamlit/web/server/websocket_headers.py
+++ b/lib/streamlit/web/server/websocket_headers.py
@@ -49,7 +49,7 @@ def _get_websocket_headers() -> dict[str, str] | None:
         return None
 
     if not isinstance(session_client, BrowserWebSocketHandler):
-        raise RuntimeError(
+        raise TypeError(
             f"SessionClient is not a BrowserWebSocketHandler! ({session_client})"
         )
 

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -46,7 +46,7 @@ from streamlit.runtime.caching.storage import (
     CacheStorageManager,
 )
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    InvalidCacheStorageContext,
+    InvalidCacheStorageContextError,
 )
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     DummyCacheStorage,
@@ -634,7 +634,7 @@ class CacheDataValidateParamsTest(DeltaGeneratorTestCase):
 
     def test_error_logged_and_raised_on_improperly_configured_cache_data(self):
         with (
-            self.assertRaises(InvalidCacheStorageContext) as e,
+            self.assertRaises(InvalidCacheStorageContextError) as e,
             self.assertLogs(
                 "streamlit.runtime.caching.cache_data_api", level=logging.ERROR
             ) as logs,
@@ -732,4 +732,4 @@ class AlwaysFailingTestCacheStorageManager(CacheStorageManager):
         pass
 
     def check_context(self, context: CacheStorageContext) -> None:
-        raise InvalidCacheStorageContext("This CacheStorageManager always fails")
+        raise InvalidCacheStorageContextError("This CacheStorageManager always fails")

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -394,7 +394,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         bootstrap._on_server_start(Mock())
         mock_log_error.assert_called_once_with(
             "Failed to load secrets.toml file",
-            exc_info=mock_exception,
+            exc_info=True,
         )
 
     @patch("streamlit.config.get_config_options")

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -42,7 +42,7 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime, RuntimeState
 from streamlit.web.server.server import (
     MAX_PORT_SEARCH_RETRIES,
-    RetriesExceeded,
+    RetriesExceededError,
     Server,
     start_listening,
 )
@@ -294,8 +294,8 @@ class PortRotateAHundredTest(unittest.TestCase):
     def test_rotates_a_hundred_ports(self):
         app = mock.MagicMock()
 
-        RetriesExceeded = streamlit.web.server.server.RetriesExceeded
-        with pytest.raises(RetriesExceeded) as pytest_wrapped_e:
+        RetriesExceededError = streamlit.web.server.server.RetriesExceededError
+        with pytest.raises(RetriesExceededError) as pytest_wrapped_e:
             with patch(
                 "streamlit.web.server.server.HTTPServer",
                 return_value=self.get_httpserver(),
@@ -328,7 +328,7 @@ class PortRotateOneTest(unittest.TestCase):
         app = mock.MagicMock()
 
         patched_server_port_is_manually_set.return_value = False
-        with pytest.raises(RetriesExceeded):
+        with pytest.raises(RetriesExceededError):
             with patch(
                 "streamlit.web.server.server.HTTPServer",
                 return_value=self.get_httpserver(),

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -85,11 +85,7 @@ def verify_pep440(version):
     use an object that does all that.  This verifies its a valid
     version.
     """
-
-    try:
-        return packaging.version.Version(version)
-    except packaging.version.InvalidVersion as e:
-        raise (e)
+    return packaging.version.Version(version)
 
 
 def verify_semver(version):
@@ -97,11 +93,7 @@ def verify_semver(version):
 
     https://semver.org/
     """
-
-    try:
-        return str(semver.Version.parse(version))
-    except ValueError as e:
-        raise (e)
+    return str(semver.Version.parse(version))
 
 
 def update_files(data, version):


### PR DESCRIPTION
## Describe your changes

Activates linting rules to prevent exception handling anti-patterns in Python:
- [tryceratops (TRY)](https://docs.astral.sh/ruff/rules/#tryceratops-try)
- [N818](https://docs.astral.sh/ruff/rules/error-suffix-on-exception-name/)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
