### PR TITLE
Add logging if cookie content is too large

### DIFF
--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -74,6 +74,13 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
 
     def set_auth_cookie(self, user_info: dict[str, Any]) -> None:
         serialized_cookie_value = json.dumps(user_info)
+
+        # log error if cookie value is larger than 4096 bytes
+        if len(serialized_cookie_value.encode()) > 4096:
+            _LOGGER.error(
+                "Authentication cookie size exceeds maximum browser limit of 4096 bytes. Authentication may fail."
+            )
+
         try:
             # We don't specify Tornado secure flag here because it leads to missing cookie on Safari.
             # The OIDC flow should work only on secure context anyway (localhost or HTTPS),


### PR DESCRIPTION
## Describe your changes
Add log error if the Auth cookie content is too large

## GitHub Issue Link (if applicable)
Related to #11168
## Testing Plan

- Explanation of why no additional tests are needed:  **Just logging added.**
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
