### PR TITLE
Handle visual glitch for duplicated options

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -154,10 +154,13 @@ const Selectbox: React.FC<Props> = ({
     }
   }
 
-  const selectOptions: SelectOption[] = opts.map((option: string) => ({
-    label: option,
-    value: option,
-  }))
+  const selectOptions: SelectOption[] = opts.map(
+    (option: string, index: number) => ({
+      label: option,
+      value: option,
+      id: `${option}_${index}`,
+    })
+  )
 
   // Check if we have more than 10 options in the selectbox.
   // If that's true, we show the keyboard on mobile. If not, we hide it.

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -158,6 +158,8 @@ const Selectbox: React.FC<Props> = ({
     (option: string, index: number) => ({
       label: option,
       value: option,
+      // We are using an id because if multiple options are equal,
+      // we have observed weird UI glitches
       id: `${option}_${index}`,
     })
   )

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -120,9 +120,11 @@ const VirtualDropdown = React.forwardRef<any, any>((props, ref) => {
         height={height}
         itemCount={children.length}
         itemData={children}
-        itemKey={(index: number, data: { props: OptionListProps }[]) =>
-          data[index].props.item.value
-        }
+        itemKey={(index: number, data: { props: OptionListProps }[]) => {
+          const { id, value } = data[index].props.item
+
+          return id ?? value
+        }}
         itemSize={convertRemToPx(theme.sizes.dropdownItemHeight)}
       >
         {FixedSizeListItem}

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -123,6 +123,8 @@ const VirtualDropdown = React.forwardRef<any, any>((props, ref) => {
         itemKey={(index: number, data: { props: OptionListProps }[]) => {
           const { id, value } = data[index].props.item
 
+          // For all current use cases, id should always be defined, but
+          // we also allow the value to be used as a fallback.
           return id ?? value
         }}
         itemSize={convertRemToPx(theme.sizes.dropdownItemHeight)}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -209,12 +209,15 @@ const Multiselect: FC<Props> = props => {
       placeholder = "Add options"
     }
   }
-  const selectOptions: MultiselectOption[] = options.map((option: string) => {
-    return {
-      label: option,
-      value: option,
+  const selectOptions: MultiselectOption[] = options.map(
+    (option: string, index: number) => {
+      return {
+        label: option,
+        value: option,
+        id: `${option}_${index}`,
+      }
     }
-  })
+  )
 
   // Check if we have more than 10 options in the selectbox.
   // If that's true, we show the keyboard on mobile. If not, we hide it.

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -214,6 +214,8 @@ const Multiselect: FC<Props> = props => {
       return {
         label: option,
         value: option,
+        // We are using an id because if multiple options are equal,
+        // we have observed weird UI glitches
         id: `${option}_${index}`,
       }
     }


### PR DESCRIPTION
## Describe your changes

Adds an id to the select options, which is passed to the baseweb component and supplied to the key to include the value AND the original index of the options. This makes the keys unique and therefore prevents this glitch

## GitHub Issue Link (if applicable)

closes #11215

## Testing Plan

- We _could_ add a screenshot test here, but it seems a little heavy handed for this type of fix (let me know if you disagree)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
