### PR TITLE
Activate rules to prevent return statement anti-patterns 

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -68,6 +68,7 @@ select = [
   "PLW",   # Pylint warning rules
   "PYI",   # Linting rules for type annotations.
   "Q",     # Linting rules for quotes.
+  "RET",   # Linting rules for return statements.
   "RUF",   # Ruff specific rules.
   "S",     # Linting rules to enforce secure code.
   "SIM",   # Checks for code that can be simplified.
@@ -124,6 +125,7 @@ ignore = [
   "SIM115",  # Enforces context manager for opening files.
   "SIM117",  # Enforces single with statement with multiple contexts.
   "SIM905",  # Enforces list instead of st.split.
+  "RET504",  # Checks for assignments that immediately precede a return of the assigned variable (too opinionated).
 ]
 exclude = [
   # pympler is a vendored dependency that doesn't conform to our linting rules:

--- a/e2e_playwright/shared/animation_utils.py
+++ b/e2e_playwright/shared/animation_utils.py
@@ -54,13 +54,12 @@ def check_if_offscreen(app: Page, img: Locator) -> bool:
         return False
 
     # Check if the bounding box is entirely outside the viewport
-    is_outside = (
+    return (
         bbox["x"] + bbox["width"] <= 0  # Left of viewport
         or bbox["x"] >= viewport["width"]  # Right of viewport
         or bbox["y"] + bbox["height"] <= 0  # Above viewport
         or bbox["y"] >= viewport["height"]  # Below viewport
     )
-    return is_outside
 
 
 def check_if_onscreen(app: Page, img: Locator) -> bool:
@@ -89,7 +88,7 @@ def check_if_onscreen(app: Page, img: Locator) -> bool:
 
 def wait_for_animation_to_be_hidden(
     app: Page, animation_images: Locator, timeout: int = 5000
-):
+) -> None:
     """
     Waits for all animation elements to move outside the viewport.
 
@@ -110,7 +109,7 @@ def wait_for_animation_to_be_hidden(
         )
 
 
-def assert_animation_is_hidden(app: Page, animation_images: Locator):
+def assert_animation_is_hidden(app: Page, animation_images: Locator) -> None:
     """
     Asserts that all animation elements are outside the viewport.
 

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -369,7 +369,7 @@ def expect_exception(
     expect(exception_el).to_be_visible()
 
 
-def expect_no_exception(locator: Locator | Page):
+def expect_no_exception(locator: Locator | Page) -> None:
     exception_el = locator.get_by_test_id("stException")
     expect(exception_el).not_to_be_attached()
 
@@ -662,7 +662,7 @@ def check_top_level_class(app: Page, test_id: str) -> None:
 
 def register_connection_status_observer(page_or_frame: Page | Frame | None) -> None:
     if page_or_frame is None:
-        return None
+        return
 
     page_or_frame.evaluate("""async () => {
         window.streamlitPlaywrightDebugConnectionStatuses = [];
@@ -724,7 +724,7 @@ def expect_connection_status(
     """
 
     if page_or_frame is None:
-        return None
+        return
 
     status = page_or_frame.evaluate(
         """async ([expectedStatus]) => {

--- a/e2e_playwright/shared/dataframe_utils.py
+++ b/e2e_playwright/shared/dataframe_utils.py
@@ -345,7 +345,7 @@ def get_open_cell_overlay(page: Page | Locator) -> Locator:
 
 def expect_canvas_to_be_stable(
     locator: Locator, timeout_ms: int = 2000, stability_ms: int = 300
-):
+) -> None:
     """
     Wait for canvas to become stable (no visual changes).
 
@@ -400,7 +400,7 @@ def expect_canvas_to_be_stable(
     # Continue anyway - the test may still succeed
 
 
-def expect_canvas_to_be_visible(locator: Locator):
+def expect_canvas_to_be_visible(locator: Locator) -> None:
     """Expect canvas to be visible.
 
     Should be used before trying to click on it or similar.
@@ -466,3 +466,4 @@ def retry_interaction(
 
     if last_exception:
         raise last_exception
+    return None

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -64,38 +64,38 @@ def _new_fragment_id_queue(
     if scope == "app":
         return []
 
-    else:  # scope == "fragment"
-        curr_queue = ctx.fragment_ids_this_run
+    # > scope == "fragment"
+    curr_queue = ctx.fragment_ids_this_run
 
-        # If st.rerun(scope="fragment") is called during a full script run, we raise an
-        # exception. This occurs, of course, if st.rerun(scope="fragment") is called
-        # outside of a fragment, but it somewhat surprisingly occurs if it gets called
-        # from within a fragment during a run of the full script. While this behavior may
-        # be surprising, it seems somewhat reasonable given that the correct behavior of
-        # calling st.rerun(scope="fragment") in this situation is unclear to me:
-        #   * Rerunning just the fragment immediately may cause weirdness down the line
-        #     as any part of the script that occurs after the fragment will not be
-        #     executed.
-        #   * Waiting until the full script run completes before rerunning the fragment
-        #     seems odd (even if we normally do this before running a fragment not
-        #     triggered by st.rerun()) because it defers the execution of st.rerun().
-        #   * Rerunning the full app feels incorrect as we're seemingly ignoring the
-        #     `scope` argument.
-        # With these issues and given that it seems pretty unnatural to have a
-        # fragment-scoped rerun happen during a full script run to begin with, it seems
-        # reasonable to just disallow this completely for now.
-        if not curr_queue:
-            raise StreamlitAPIException(
-                'scope="fragment" can only be specified from `@st.fragment`-decorated '
-                "functions during fragment reruns."
-            )
-
-        new_queue = list(dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue))
-        assert new_queue, (
-            "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+    # If st.rerun(scope="fragment") is called during a full script run, we raise an
+    # exception. This occurs, of course, if st.rerun(scope="fragment") is called
+    # outside of a fragment, but it somewhat surprisingly occurs if it gets called
+    # from within a fragment during a run of the full script. While this behavior may
+    # be surprising, it seems somewhat reasonable given that the correct behavior of
+    # calling st.rerun(scope="fragment") in this situation is unclear to me:
+    #   * Rerunning just the fragment immediately may cause weirdness down the line
+    #     as any part of the script that occurs after the fragment will not be
+    #     executed.
+    #   * Waiting until the full script run completes before rerunning the fragment
+    #     seems odd (even if we normally do this before running a fragment not
+    #     triggered by st.rerun()) because it defers the execution of st.rerun().
+    #   * Rerunning the full app feels incorrect as we're seemingly ignoring the
+    #     `scope` argument.
+    # With these issues and given that it seems pretty unnatural to have a
+    # fragment-scoped rerun happen during a full script run to begin with, it seems
+    # reasonable to just disallow this completely for now.
+    if not curr_queue:
+        raise StreamlitAPIException(
+            'scope="fragment" can only be specified from `@st.fragment`-decorated '
+            "functions during fragment reruns."
         )
 
-        return new_queue
+    new_queue = list(dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue))
+    assert new_queue, (
+        "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+    )
+
+    return new_queue
 
 
 @gather_metrics("rerun")

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -262,10 +262,9 @@ class HeadingMixin:
         ]
         if divider in valid_colors:
             return cast("str", divider)
-        else:
-            raise StreamlitAPIException(
-                f"Divider parameter has invalid value: `{divider}`. Please choose from: {', '.join(valid_colors)}."
-            )
+        raise StreamlitAPIException(
+            f"Divider parameter has invalid value: `{divider}`. Please choose from: {', '.join(valid_colors)}."
+        )
 
     @staticmethod
     def _create_heading_proto(

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -113,10 +113,9 @@ class HtmlMixin:
             # If true, there are only style tags - send html to the event container
             html_proto.body = html_content
             return self._event_dg._enqueue("html", html_proto)
-        else:
-            # Otherwise, send the html to the main container as normal
-            html_proto.body = html_content
-            return self.dg._enqueue("html", html_proto)
+        # Otherwise, send the html to the main container as normal
+        html_proto.body = html_content
+        return self.dg._enqueue("html", html_proto)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -559,7 +559,7 @@ def _melt_data(
 
     # Arrow has problems with object types after melting two different dtypes
     # > pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
-    fixed_df = dataframe_util.fix_arrow_incompatible_column_types(
+    return dataframe_util.fix_arrow_incompatible_column_types(
         melted_df,
         selected_columns=[
             *columns_to_leave_alone,
@@ -567,8 +567,6 @@ def _melt_data(
             new_y_column_name,
         ],
     )
-
-    return fixed_df
 
 
 def _maybe_reset_index_in_place(

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -335,9 +335,8 @@ def image_to_url(
         url = runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
         caching.save_media_data(image_data, mimetype, image_id)
         return url
-    else:
-        # When running in "raw mode", we can't access the MediaFileManager.
-        return ""
+    # When running in "raw mode", we can't access the MediaFileManager.
+    return ""
 
 
 def _4d_to_list_3d(array: npt.NDArray[Any]) -> list[npt.NDArray[Any]]:

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -92,8 +92,7 @@ def get_default_indices(
     indexable_options: Sequence[T], default: Sequence[Any] | Any | None = None
 ) -> list[int]:
     default_indices = check_and_convert_to_indices(indexable_options, default)
-    default_indices = default_indices if default_indices is not None else []
-    return default_indices
+    return default_indices if default_indices is not None else []
 
 
 E1 = TypeVar("E1", bound=Enum)

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -213,9 +213,7 @@ def _pandas_style_to_css(
     selector = ", ".join(selectors)
 
     declaration_block = "; ".join(declarations)
-    rule_set = selector + " { " + declaration_block + " }"
-
-    return rule_set
+    return selector + " { " + declaration_block + " }"
 
 
 def _marshall_display_values(

--- a/lib/streamlit/elements/lib/subtitle_utils.py
+++ b/lib/streamlit/elements/lib/subtitle_utils.py
@@ -104,9 +104,7 @@ def _srt_to_vtt(srt_data: str | bytes) -> bytes:
     # Add WebVTT file header
     vtt_content = "WEBVTT\n\n" + vtt_data
     # Convert the vtt content to bytes
-    vtt_content = vtt_content.strip().encode("utf-8")
-
-    return vtt_content
+    return vtt_content.strip().encode("utf-8")
 
 
 def _handle_string_or_path_data(data_or_path: str | Path) -> bytes:
@@ -123,14 +121,14 @@ def _handle_string_or_path_data(data_or_path: str | Path) -> bytes:
         with open(data_or_path, "rb") as file:
             content = file.read()
         return _srt_to_vtt(content) if file_extension == ".srt" else content
-    elif isinstance(data_or_path, Path):
-        raise ValueError(f"File {data_or_path} does not exist.")
+    if isinstance(data_or_path, Path):
+        raise ValueError(f"File {data_or_path} does not exist.")  # noqa: TRY004
 
     content_string = data_or_path.strip()
 
     if content_string.startswith("WEBVTT") or content_string == "":
         return content_string.encode("utf-8")
-    elif _is_srt(content_string):
+    if _is_srt(content_string):
         return _srt_to_vtt(content_string)
     raise ValueError("The provided string neither matches valid VTT nor SRT format.")
 
@@ -173,6 +171,5 @@ def process_subtitle_data(
         )
         caching.save_media_data(subtitle_data, "text/vtt", coordinates)
         return file_url
-    else:
-        # When running in "raw mode", we can't access the MediaFileManager.
-        return ""
+    # When running in "raw mode", we can't access the MediaFileManager.
+    return ""

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -357,8 +357,7 @@ def _get_lat_or_lon_col_name(
                 f"Map data must contain a {human_readable_name} column named: "
                 f"{formatted_allowed_col_name}. Existing columns: {formmated_col_names}"
             )
-        else:
-            col_name = candidate_col_name
+        col_name = candidate_col_name
 
     # Check that the column is well-formed.
     # IMPLEMENTATION NOTE: We can't use isnull().values.any() because .values can return

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -537,8 +537,7 @@ class PlotlyMixin:
 
             self.dg._enqueue("plotly_chart", plotly_chart_proto)
             return cast("PlotlyState", widget_state.value)
-        else:
-            return self.dg._enqueue("plotly_chart", plotly_chart_proto)
+        return self.dg._enqueue("plotly_chart", plotly_chart_proto)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -31,8 +31,7 @@ def validate_text(toast_text: SupportsStr) -> SupportsStr:
         raise StreamlitAPIException(
             "Toast body cannot be blank - please provide a message."
         )
-    else:
-        return toast_text
+    return toast_text
 
 
 class ToastMixin:

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -127,7 +127,7 @@ def _process_avatar_input(
 
     if avatar is None:
         return AvatarType.ICON, ""
-    elif isinstance(avatar, str) and avatar in {item.value for item in PresetNames}:
+    if isinstance(avatar, str) and avatar in {item.value for item in PresetNames}:
         # On the frontend, we only support "assistant" and "user" for the avatar.
         return (
             AvatarType.ICON,
@@ -137,25 +137,24 @@ def _process_avatar_input(
                 else "user"
             ),
         )
-    elif isinstance(avatar, str) and is_emoji(avatar):
+    if isinstance(avatar, str) and is_emoji(avatar):
         return AvatarType.EMOJI, avatar
 
-    elif isinstance(avatar, str) and avatar.startswith(":material"):
+    if isinstance(avatar, str) and avatar.startswith(":material"):
         return AvatarType.ICON, validate_material_icon(avatar)
-    else:
-        try:
-            return AvatarType.IMAGE, image_to_url(
-                avatar,
-                width=WidthBehavior.ORIGINAL,
-                clamp=False,
-                channels="RGB",
-                output_format="auto",
-                image_id=delta_path,
-            )
-        except Exception as ex:
-            raise StreamlitAPIException(
-                "Failed to load the provided avatar value as an image."
-            ) from ex
+    try:
+        return AvatarType.IMAGE, image_to_url(
+            avatar,
+            width=WidthBehavior.ORIGINAL,
+            clamp=False,
+            channels="RGB",
+            output_format="auto",
+            image_id=delta_path,
+        )
+    except Exception as ex:
+        raise StreamlitAPIException(
+            "Failed to load the provided avatar value as an image."
+        ) from ex
 
 
 def _pop_upload_files(
@@ -208,16 +207,15 @@ class ChatInputSerde:
             return None
         if not self.accept_files:
             return ui_value.data
-        else:
-            uploaded_files = _pop_upload_files(ui_value.file_uploader_state)
-            for file in uploaded_files:
-                if self.allowed_types and not isinstance(file, DeletedFile):
-                    enforce_filename_restriction(file.name, self.allowed_types)
+        uploaded_files = _pop_upload_files(ui_value.file_uploader_state)
+        for file in uploaded_files:
+            if self.allowed_types and not isinstance(file, DeletedFile):
+                enforce_filename_restriction(file.name, self.allowed_types)
 
-            return ChatInputValue(
-                text=ui_value.data,
-                files=uploaded_files,
-            )
+        return ChatInputValue(
+            text=ui_value.data,
+            files=uploaded_files,
+        )
 
     def serialize(self, v: str | None) -> ChatInputValueProto:
         return ChatInputValueProto(data=v)

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -127,7 +127,7 @@ class FileUploaderSerde:
 
         if not files:
             return state_proto
-        elif not isinstance(files, list):
+        if not isinstance(files, list):
             files = [files]
 
         for f in files:
@@ -497,7 +497,7 @@ class FileUploaderMixin:
 
         if isinstance(widget_state.value, DeletedFile):
             return None
-        elif isinstance(widget_state.value, list):
+        if isinstance(widget_state.value, list):
             return [f for f in widget_state.value if not isinstance(f, DeletedFile)]
 
         return widget_state.value

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -341,12 +341,11 @@ class RadioMixin:
         def handle_captions(caption: str | None) -> str:
             if caption is None:
                 return ""
-            elif isinstance(caption, str):
+            if isinstance(caption, str):
                 return caption
-            else:
-                raise StreamlitAPIException(
-                    f"Radio captions must be strings. Passed type: {type(caption).__name__}"
-                )
+            raise StreamlitAPIException(
+                f"Radio captions must be strings. Passed type: {type(caption).__name__}"
+            )
 
         session_state = get_session_state().filtered_state
         if key is not None and key in session_state and session_state[key] is None:

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -102,8 +102,7 @@ class SelectSliderSerde(Generic[T]):
             if start > end:
                 slider_value = [end, start]
             return slider_value
-        else:
-            return [index_(self.options, v)]
+        return [index_(self.options, v)]
 
 
 class SelectSliderMixin:
@@ -367,15 +366,14 @@ class SelectSliderMixin:
                 if start > end:
                     slider_value = [end, start]
                 return slider_value
-            else:
-                # Simplify future logic by always making value a list
-                try:
-                    return [index_(opt, v)]
-                except ValueError:
-                    if value is not None:
-                        raise
+            # Simplify future logic by always making value a list
+            try:
+                return [index_(opt, v)]
+            except ValueError:
+                if value is not None:
+                    raise
 
-                    return [0]
+                return [0]
 
         # Convert element to index of the elements
         slider_value = as_index_list(value)

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -289,12 +289,11 @@ class StreamlitPage:
             if callable(self._page):
                 self._page()
                 return
-            else:
-                code = ctx.pages_manager.get_page_script_byte_code(str(self._page))
-                module = types.ModuleType("__main__")
-                # We want __file__ to be the string path to the script
-                module.__dict__["__file__"] = str(self._page)
-                exec(code, module.__dict__)  # noqa: S102
+            code = ctx.pages_manager.get_page_script_byte_code(str(self._page))
+            module = types.ModuleType("__main__")
+            # We want __file__ to be the string path to the script
+            module.__dict__["__file__"] = str(self._page)
+            exec(code, module.__dict__)  # noqa: S102
 
     @property
     def _script_hash(self) -> str:

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -30,7 +30,7 @@ def get_cached_func_name_md(func: Any) -> str:
     """Get markdown representation of the function name."""
     if hasattr(func, "__name__"):
         return f"`{func.__name__}()`"
-    elif hasattr(type(func), "__name__"):
+    if hasattr(type(func), "__name__"):
         return f"`{type(func).__name__}`"
     return f"`{type(func)}`"
 

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -218,8 +218,7 @@ class CachedMessageReplayContext(threading.local):
         """
         if len(self._seen_dg_stack) > 0 and acting_on_id in self._seen_dg_stack[-1]:
             return acting_on_id
-        else:
-            return invoked_id
+        return invoked_id
 
     def save_image_data(
         self, image_data: bytes | str, mimetype: str, image_id: str

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -131,9 +131,8 @@ class InMemoryCacheStorageWrapper(CacheStorage):
                 _LOGGER.debug("Memory cache HIT: %s", key)
                 return entry
 
-            else:
-                _LOGGER.debug("Memory cache MISS: %s", key)
-                raise CacheStorageKeyNotFoundError("Key not found in mem cache")
+            _LOGGER.debug("Memory cache MISS: %s", key)
+            raise CacheStorageKeyNotFoundError("Key not found in mem cache")
 
     def _write_to_mem_cache(self, key: str, entry_bytes: bytes) -> None:
         with self._mem_cache_lock:

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -328,11 +328,7 @@ class ContextProxy:
         url_without_page_prefix = maybe_trim_page_path(
             url_from_frontend, ctx.pages_manager
         )
-        url_with_page_prefix = maybe_add_page_path(
-            url_without_page_prefix, ctx.pages_manager
-        )
-
-        return url_with_page_prefix
+        return maybe_add_page_path(url_without_page_prefix, ctx.pages_manager)
 
     @property
     @gather_metrics("context.ip_address")

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -38,8 +38,7 @@ def _get_session_id() -> str:
         # "streamlit run myscript.py". In which case the session ID doesn't
         # matter and can just be a constant, as there's only ever "session".
         return "dontcare"
-    else:
-        return ctx.session_id
+    return ctx.session_id
 
 
 class MediaFileMetadata:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -252,8 +252,7 @@ class WStates(MutableMapping[str, Any]):
             for widget_id in self.states
             if self.get_serialized(widget_id)
         ]
-        states = cast("list[WidgetStateProto]", states)
-        return states
+        return cast("list[WidgetStateProto]", states)
 
     def call_callback(self, widget_id: str) -> None:
         """Call the given widget's callback and return the callback's

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1342,8 +1342,7 @@ class TimeInput(Widget):
         """The current value of the widget. (time)"""  # noqa: D400
         if not isinstance(self._value, InitialValue):
             v = self._value
-            v = v.time() if isinstance(v, datetime) else v
-            return v
+            return v.time() if isinstance(v, datetime) else v
         state = self.root.session_state
         assert state
         return state[self.id]  # type: ignore
@@ -1689,8 +1688,7 @@ def format_dict(d: dict[Any, Any]) -> str:
         lines.append(line)
     r = ",\n".join(lines)
     r = textwrap.indent(r, " " * 4)
-    r = f"{{\n{r}\n}}"
-    return r
+    return f"{{\n{r}\n}}"
 
 
 @dataclass(repr=False)

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -127,8 +127,7 @@ class LocalScriptRunner(ScriptRunner):
             self.start()
         require_widgets_deltas(self, timeout)
 
-        tree = parse_tree_from_messages(self.forward_msgs())
-        return tree
+        return parse_tree_from_messages(self.forward_msgs())
 
     def script_stopped(self) -> bool:
         return any(e == ScriptRunnerEvent.SHUTDOWN for e in self.events)

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -91,7 +91,7 @@ def is_url(
 
         if result.scheme in ["http", "https"]:
             return bool(result.netloc)
-        elif result.scheme in ["mailto", "data"]:
+        if result.scheme in ["mailto", "data"]:
             return bool(result.path)
 
     except ValueError:

--- a/lib/tests/streamlit/elements/doc_string_test.py
+++ b/lib/tests/streamlit/elements/doc_string_test.py
@@ -45,8 +45,7 @@ class ConditionalHello:
     def __getattribute__(self, name):
         if name == "say_hello" and not self.available:
             raise self.ExceptionType(f"{name} is not accessible when x is even")
-        else:
-            return object.__getattribute__(self, name)
+        return object.__getattribute__(self, name)
 
     def say_hello(self):
         pass

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -206,6 +206,7 @@ class StMapTest(DeltaGeneratorTestCase):
             for prefix, expected_color_values in expected_values.items():
                 if col_name.startswith(prefix):
                     return expected_color_values
+            return None
 
         for color_column in color_columns:
             expected_color_values = get_expected_color_values(color_column)

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -54,7 +54,7 @@ def merge_dicts(x, y):
     return z
 
 
-def create_advanced_altair_chart() -> alt.Chart:
+def create_advanced_altair_chart() -> alt.Chart | alt.VConcatChart:
     """Create an advanced Altair chart based on concatenation and with parameters."""
     iris = alt.UrlData(
         "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/iris.json"
@@ -80,8 +80,7 @@ def create_advanced_altair_chart() -> alt.Chart:
             row |= base.encode(x=x_encoding, y=y_encoding)
         chart &= row
     chart = chart.add_params(point)
-    chart = chart.add_params(interval)
-    return chart
+    return chart.add_params(interval)
 
 
 class AltairChartTest(DeltaGeneratorTestCase):
@@ -1145,6 +1144,7 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
             for prefix, expected_color_values in expected_values.items():
                 if col_name.startswith(prefix):
                     return expected_color_values
+            return None
 
         for color_column in color_columns:
             expected_color_values = get_expected_color_values(color_column)

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -626,7 +626,9 @@ class AppSessionTest(unittest.TestCase):
         mock_enqueue.assert_called_once_with(expected_msg)
 
 
-def _mock_get_options_for_section(overrides=None) -> Callable[..., Any]:
+def _mock_get_options_for_section(
+    overrides: dict[str, Any] | None = None,
+) -> Callable[..., Any]:
     if not overrides:
         overrides = {}
 
@@ -690,7 +692,7 @@ def _mock_get_options_for_section(overrides=None) -> Callable[..., Any]:
     def get_options_for_section(section):
         if section == "theme":
             return theme_opts
-        elif section == "theme.sidebar":
+        if section == "theme.sidebar":
             return sidebar_theme_opts
         return config.get_options_for_section(section)
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -56,8 +56,10 @@ def get_text_or_block(delta):
         element = delta.new_element
         if element.WhichOneof("type") == "text":
             return element.text.body
-    elif delta.WhichOneof("type") == "add_block":
+        return None
+    if delta.WhichOneof("type") == "add_block":
         return "new_block"
+    return None
 
 
 def as_cached_result(value: Any) -> CachedResult:
@@ -84,12 +86,11 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
     def get_text_delta_contents(self) -> list[str]:
         deltas = self.get_all_deltas_from_queue()
-        text = [
+        return [
             element.text.body
             for element in (delta.new_element for delta in deltas)
             if element.WhichOneof("type") == "text"
         ]
-        return text
 
     @parameterized.expand(
         [("cache_data", cache_data), ("cache_resource", cache_resource)]

--- a/lib/tests/streamlit/test_data/cached_widget_replay.py
+++ b/lib/tests/streamlit/test_data/cached_widget_replay.py
@@ -22,8 +22,7 @@ st.button("click to rerun")
 @st.cache_data(experimental_allow_widgets=True, show_spinner=False)
 def foo(i):
     options = ["foo", "bar", "baz", "qux"]
-    r = st.radio("radio", options, index=i)
-    return r
+    return st.radio("radio", options, index=i)
 
 
 r = foo(1)

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -176,10 +176,9 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 from io import BytesIO
 
                 return BytesIO(payload)
-            else:
-                from io import TextIOWrapper
+            from io import TextIOWrapper
 
-                return TextIOWrapper(str(payload, encoding=encoding))
+            return TextIOWrapper(str(payload, encoding=encoding))
 
         with mock.patch(MOCK_IS_DIR_PATH):
             declare_component("test", path=PATH)

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -56,8 +56,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
             "/not/a/script.py",
             is_hello=False,
         )
-        app = self.server._create_app()
-        return app
+        return self.server._create_app()
 
     def get_ws_url(self, path):
         """Return a ws:// URL with the given path for our test server."""

--- a/scripts/update_e2e_snapshots.py
+++ b/scripts/update_e2e_snapshots.py
@@ -25,7 +25,7 @@ import sys
 import tempfile
 import time
 import zipfile
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -111,12 +111,11 @@ def wait_for_workflow_completion(
             if conclusion == "failure":
                 # Only failed runs are expected to have updated snapshots.
                 return workflow_run
-            else:
-                print(
-                    f"The latest workflow run completed with status: {conclusion}. "
-                    "The snapshot update is only working on failed runs."
-                )
-                sys.exit(1)
+            print(
+                f"The latest workflow run completed with status: {conclusion}. "
+                "The snapshot update is only working on failed runs."
+            )
+            sys.exit(1)
         print(
             f"Workflow is still {status}. Waiting 60 seconds before checking again..."
         )
@@ -138,8 +137,7 @@ def get_artifacts(
             f"Error getting artifacts: {response.status_code} {response.text}"
         )
     data = response.json()
-    artifacts = data.get("artifacts", [])
-    return artifacts  # type: ignore
+    return cast("list[dict[str, Any]]", data.get("artifacts", []))
 
 
 def download_artifact(artifact_url: str, token: str, download_path: str) -> None:


### PR DESCRIPTION
## Describe your changes

Activates the [flake8-return (RET)](https://docs.astral.sh/ruff/rules/#flake8-return-ret) linting rule set in ruff which checks for some return statement anti-patterns. The majority of these rules provide safe auto-fixes. Most of the changes in this PR are auto-fixes. I deactivated `RET504` since it was a bit annoying during development and felt a bit too opinionated.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
