### PR TITLE
[refactor] Improve rendering perf of StreamlitMarkdown

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
@@ -53,6 +53,16 @@ function makeMarkdownHeading(tag: string, markdown: string): string {
   }
 }
 
+const OVERRIDE_COMPONENTS = {
+  p: Fragment,
+  h1: Fragment,
+  h2: Fragment,
+  h3: Fragment,
+  h4: Fragment,
+  h5: Fragment,
+  h6: Fragment,
+}
+
 function Heading(props: HeadingProtoProps): ReactElement {
   const { element } = props
   const { tag, anchor, body, help, hideAnchor, divider } = element
@@ -79,15 +89,7 @@ function Heading(props: HeadingProtoProps): ReactElement {
             allowHTML={false}
             source={makeMarkdownHeading(tag, heading)}
             // this is purely an inline string
-            overrideComponents={{
-              p: Fragment,
-              h1: Fragment,
-              h2: Fragment,
-              h3: Fragment,
-              h4: Fragment,
-              h5: Fragment,
-              h6: Fragment,
-            }}
+            overrideComponents={OVERRIDE_COMPONENTS}
           />
         </HeadingWithActionElements>
         {/* Only the first line of the body is used as a heading, the remaining text is added as regular mardkown below. */}

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
@@ -16,6 +16,8 @@
 
 import React, { Fragment, ReactElement, useContext } from "react"
 
+import type { Components } from "react-markdown/lib/ast-to-react"
+
 import { Heading as HeadingProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
@@ -53,7 +55,7 @@ function makeMarkdownHeading(tag: string, markdown: string): string {
   }
 }
 
-const OVERRIDE_COMPONENTS = {
+const OVERRIDE_COMPONENTS: Components = {
   p: Fragment,
   h1: Fragment,
   h2: Fragment,

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -636,7 +636,7 @@ function createRemarkTypographicalSymbols() {
 }
 
 // Standard remark plugins that don't depend on theme or props
-const baseRemarkPlugins = [
+const BASE_REMARK_PLUGINS = [
   remarkMathPlugin,
   remarkEmoji,
   remarkGfm,
@@ -719,7 +719,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
 
   const remarkPlugins = useMemo(
     () => [
-      ...baseRemarkPlugins,
+      ...BASE_REMARK_PLUGINS,
       createRemarkColoringAndSmall(theme, colorMapping),
       createRemarkMaterialIcons(theme),
     ],

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -27,6 +27,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react"
 
@@ -363,26 +364,23 @@ export const CustomPreTag: FunctionComponent<
   )
 }
 
-export function RenderedMarkdown({
-  allowHTML,
-  source,
-  overrideComponents,
-  isLabel,
-  disableLinks,
-}: Readonly<RenderedMarkdownProps>): ReactElement {
-  const renderers: Components = {
-    pre: CustomPreTag,
-    code: CustomCodeTag,
-    a: LinkWithTargetBlank,
-    h1: CustomHeading,
-    h2: CustomHeading,
-    h3: CustomHeading,
-    h4: CustomHeading,
-    h5: CustomHeading,
-    h6: CustomHeading,
-    ...(overrideComponents || {}),
-  }
-  const theme: EmotionTheme = useTheme()
+// These are common renderers that don't depend on props or context
+const baseRenderers: Components = {
+  pre: CustomPreTag,
+  code: CustomCodeTag,
+  h1: CustomHeading,
+  h2: CustomHeading,
+  h3: CustomHeading,
+  h4: CustomHeading,
+  h5: CustomHeading,
+  h6: CustomHeading,
+}
+
+/**
+ * Create a color mapping based on the theme.
+ * Extracted from RenderedMarkdown to reduce re-calculations.
+ */
+function createColorMapping(theme: EmotionTheme): Map<string, string> {
   const { red, orange, yellow, green, blue, violet, purple, gray, primary } =
     getMarkdownTextColors(theme)
   const {
@@ -395,8 +393,9 @@ export function RenderedMarkdown({
     purplebg,
     graybg,
     primarybg,
-  } = getMarkdownBgColors(theme)
-  const colorMapping = new Map(
+  }: Record<string, string> = getMarkdownBgColors(theme)
+
+  return new Map(
     Object.entries({
       red: `color: ${red}`,
       blue: `color: ${blue}`,
@@ -422,257 +421,343 @@ export function RenderedMarkdown({
         ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg});`,
     })
   )
-  function remarkColoringAndSmall() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    return (tree: any) => {
-      visit(tree, "textDirective", (node, _index, _parent) => {
-        const nodeName = String(node.name)
+}
 
-        // Handle small text directive (:small[])
-        if (nodeName === "small") {
-          const data = node.data || (node.data = {})
-          data.hName = "span"
-          data.hProperties = data.hProperties || {}
-          data.hProperties.style = `font-size: ${theme.fontSizes.sm};`
+/**
+ * Factory function to create the color and small text directive plugin
+ */
+function createRemarkColoringAndSmall(
+  theme: EmotionTheme,
+  colorMapping: Map<string, string>
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  return () => (tree: any) => {
+    visit(tree, "textDirective", (node, _index, _parent) => {
+      const nodeName = String(node.name)
+
+      // Handle small text directive (:small[])
+      if (nodeName === "small") {
+        const data = node.data || (node.data = {})
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
+        data.hProperties.style = `font-size: ${theme.fontSizes.sm};`
+        return
+      }
+
+      // Handle badge directives (:color-badge[])
+      const badgeMatch = nodeName.match(/^(.+)-badge$/)
+      if (badgeMatch && colorMapping.has(badgeMatch[1])) {
+        const color = badgeMatch[1]
+
+        // rainbow-badge is not supported because the rainbow text effect uses
+        // background-clip: text with a transparent color, which conflicts with
+        // having a background color for the badge.
+        // We *could* support it by using a nested span structure, but that breaks
+        // the material icon handling below.
+        // We can support that in the future if we want to, but I think a
+        // rainbow-colored badge shouldn't be a common use case anyway.
+        if (color === "rainbow") {
           return
         }
 
-        // Handle badge directives (:color-badge[])
-        const badgeMatch = nodeName.match(/^(.+)-badge$/)
-        if (badgeMatch && colorMapping.has(badgeMatch[1])) {
-          const color = badgeMatch[1]
+        const textColor = colorMapping.get(color)
+        const bgColor = colorMapping.get(`${color}-background`)
 
-          // rainbow-badge is not supported because the rainbow text effect uses
-          // background-clip: text with a transparent color, which conflicts with
-          // having a background color for the badge.
-          // We *could* support it by using a nested span structure, but that breaks
-          // the material icon handling below.
-          // We can support that in the future if we want to, but I think a
-          // rainbow-colored badge shouldn't be a common use case anyway.
-          if (color === "rainbow") {
-            return
-          }
-
-          const textColor = colorMapping.get(color)
-          const bgColor = colorMapping.get(`${color}-background`)
-
-          if (textColor && bgColor) {
-            const data = node.data || (node.data = {})
-            data.hName = "span"
-            data.hProperties = data.hProperties || {}
-            data.hProperties.className = "is-badge"
-            data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`
-            return
-          }
-        }
-
-        // Handle color directives (:color[] or :color-background[])
-        if (colorMapping.has(nodeName)) {
+        if (textColor && bgColor) {
           const data = node.data || (node.data = {})
-          const style = colorMapping.get(nodeName)
           data.hName = "span"
           data.hProperties = data.hProperties || {}
-          data.hProperties.style = style
-          // Add class name specific to colored text used for button hover selector
-          // to override text color
-          data.hProperties.className = "colored-text"
-          // Add class for background color for custom styling
-          if (
-            style &&
-            (/background-color:/.test(style) || /background:/.test(style))
-          ) {
-            data.hProperties.className = "has-background-color"
-          }
+          data.hProperties.className = "is-badge"
+          data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`
           return
         }
-
-        // Handle unsupported directives
-        // We convert unsupported text directives to plain text to avoid them being
-        // ignored / not rendered. See https://github.com/streamlit/streamlit/issues/8726,
-        // https://github.com/streamlit/streamlit/issues/5968
-        node.type = "text"
-        node.value = `:${nodeName}`
-        node.data = {}
-      })
-    }
-  }
-
-  function remarkMaterialIcons() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    return (tree: any) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      function replace(fullMatch: string, iconName: string): any {
-        return {
-          type: "text",
-          value: fullMatch,
-          data: {
-            hName: "span",
-            hProperties: {
-              role: "img",
-              ariaLabel: iconName + " icon",
-              // Prevent the icon text from being translated
-              // this would break the icon display in the UI.
-              // https://github.com/streamlit/streamlit/issues/10168
-              translate: "no",
-              style: {
-                display: "inline-block",
-                fontFamily: theme.genericFonts.iconFont,
-                fontWeight: theme.fontWeights.normal,
-                // Disable selection for copying it as text.
-                // Allowing this leads to copying the underlying icon name,
-                // which can be confusing / unexpected.
-                userSelect: "none",
-                verticalAlign: "bottom",
-                whiteSpace: "nowrap",
-                wordWrap: "normal",
-              },
-            },
-            hChildren: [{ type: "text", value: iconName }],
-          },
-        }
       }
-      // We replace all `:material/` occurrences with `:material_` to avoid
-      // conflicts with the directive plugin.
-      // Since all `:material/` already got replaced with `:material_`
-      // within the markdown text (see below), we need to use `:material_`
-      // within the regex.
-      findAndReplace(tree, [[/:material_(\w+):/g, replace]])
-      return tree
-    }
-  }
 
-  function remarkStreamlitLogo() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    return (tree: any) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      function replaceStreamlit(): any {
-        return {
-          type: "text",
-          value: "",
-          data: {
-            hName: "img",
-            hProperties: {
-              src: streamlitLogo,
-              alt: "Streamlit logo",
-              style: {
-                display: "inline-block",
-                // Disable selection for copying it as text.
-                // Allowing this leads to copying the alt text,
-                // which can be confusing / unexpected.
-                userSelect: "none",
-                height: "0.75em",
-                verticalAlign: "baseline",
-                // The base of the Streamlit logo is curved, so move it down a bit to
-                // make it look aligned with the text.
-                // eslint-disable-next-line streamlit-custom/no-hardcoded-theme-values
-                marginBottom: "-0.05ex",
-              },
-            },
-          },
-        }
-      }
-      findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit]])
-      return tree
-    }
-  }
-
-  function remarkTypographicalSymbols() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    return (tree: any) => {
-      visit(tree, (node, index, parent) => {
+      // Handle color directives (:color[] or :color-background[])
+      if (colorMapping.has(nodeName)) {
+        const data = node.data || (node.data = {})
+        const style = colorMapping.get(nodeName)
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
+        data.hProperties.style = style
+        // Add class name specific to colored text used for button hover selector
+        // to override text color
+        data.hProperties.className = "colored-text"
+        // Add class for background color for custom styling
         if (
-          parent &&
-          (parent.type === "link" || parent.type === "linkReference")
+          style &&
+          (/background-color:/.test(style) || /background:/.test(style))
         ) {
-          // Don't replace symbols in links.
-          // Note that remark extensions are not applied in code blocks and latex
-          // formulas, so we don't need to worry about them here.
-          return
+          data.hProperties.className = "has-background-color"
         }
+        return
+      }
 
-        if (node.type === "text" && node.value) {
-          // Only replace symbols wrapped in spaces, so it's a bit safer in case the
-          // symbols are used as part of a word or longer string of symbols.
-          const replacements = [
-            [/(^|\s)<->(\s|$)/g, "$1↔$2"],
-            [/(^|\s)->(\s|$)/g, "$1→$2"],
-            [/(^|\s)<-(\s|$)/g, "$1←$2"],
-            [/(^|\s)--(\s|$)/g, "$1—$2"],
-            [/(^|\s)>=(\s|$)/g, "$1≥$2"],
-            [/(^|\s)<=(\s|$)/g, "$1≤$2"],
-            [/(^|\s)~=(\s|$)/g, "$1≈$2"],
-          ]
+      // Handle unsupported directives
+      // We convert unsupported text directives to plain text to avoid them being
+      // ignored / not rendered. See https://github.com/streamlit/streamlit/issues/8726,
+      // https://github.com/streamlit/streamlit/issues/5968
+      node.type = "text"
+      node.value = `:${nodeName}`
+      node.data = {}
+    })
+    return tree
+  }
+}
 
-          let newValue = node.value
-          for (const [pattern, replacement] of replacements) {
-            newValue = newValue.replace(pattern, replacement as string)
-          }
-
-          if (newValue !== node.value) {
-            node.value = newValue
-          }
-        }
-      })
-
-      return tree
+/**
+ * Factory function to create the material icons directive plugin
+ */
+function createRemarkMaterialIcons(theme: EmotionTheme) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  return () => (tree: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+    function replace(fullMatch: string, iconName: string): any {
+      return {
+        type: "text",
+        value: fullMatch,
+        data: {
+          hName: "span",
+          hProperties: {
+            role: "img",
+            ariaLabel: iconName + " icon",
+            // Prevent the icon text from being translated
+            // this would break the icon display in the UI.
+            // https://github.com/streamlit/streamlit/issues/10168
+            translate: "no",
+            style: {
+              display: "inline-block",
+              fontFamily: theme.genericFonts.iconFont,
+              fontWeight: theme.fontWeights.normal,
+              // Disable selection for copying it as text.
+              // Allowing this leads to copying the underlying icon name,
+              // which can be confusing / unexpected.
+              userSelect: "none",
+              verticalAlign: "bottom",
+              whiteSpace: "nowrap",
+              wordWrap: "normal",
+            },
+          },
+          hChildren: [{ type: "text", value: iconName }],
+        },
+      }
     }
+    // We replace all `:material/` occurrences with `:material_` to avoid
+    // conflicts with the directive plugin.
+    // Since all `:material/` already got replaced with `:material_`
+    // within the markdown text (see below), we need to use `:material_`
+    // within the regex.
+    findAndReplace(tree, [[/:material_(\w+):/g, replace]])
+    return tree
+  }
+}
+
+/**
+ * Factory function to create the streamlit logo plugin
+ */
+function createRemarkStreamlitLogo() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  return () => (tree: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+    function replaceStreamlit(): any {
+      return {
+        type: "text",
+        value: "",
+        data: {
+          hName: "img",
+          hProperties: {
+            src: streamlitLogo,
+            alt: "Streamlit logo",
+            style: {
+              display: "inline-block",
+              // Disable selection for copying it as text.
+              // Allowing this leads to copying the alt text,
+              // which can be confusing / unexpected.
+              userSelect: "none",
+              height: "0.75em",
+              verticalAlign: "baseline",
+              // The base of the Streamlit logo is curved, so move it down a bit to
+              // make it look aligned with the text.
+              // eslint-disable-next-line streamlit-custom/no-hardcoded-theme-values
+              marginBottom: "-0.05ex",
+            },
+          },
+        },
+      }
+    }
+    findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit]])
+    return tree
+  }
+}
+
+/**
+ * Factory function to create typographical symbols plugin
+ */
+function createRemarkTypographicalSymbols() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  return () => (tree: any) => {
+    visit(tree, (node, index, parent) => {
+      if (
+        parent &&
+        (parent.type === "link" || parent.type === "linkReference")
+      ) {
+        // Don't replace symbols in links.
+        // Note that remark extensions are not applied in code blocks and latex
+        // formulas, so we don't need to worry about them here.
+        return
+      }
+
+      if (node.type === "text" && node.value) {
+        // Only replace symbols wrapped in spaces, so it's a bit safer in case the
+        // symbols are used as part of a word or longer string of symbols.
+        const replacements = [
+          [/(^|\s)<->(\s|$)/g, "$1↔$2"],
+          [/(^|\s)->(\s|$)/g, "$1→$2"],
+          [/(^|\s)<-(\s|$)/g, "$1←$2"],
+          [/(^|\s)--(\s|$)/g, "$1—$2"],
+          [/(^|\s)>=(\s|$)/g, "$1≥$2"],
+          [/(^|\s)<=(\s|$)/g, "$1≤$2"],
+          [/(^|\s)~=(\s|$)/g, "$1≈$2"],
+        ]
+
+        let newValue = node.value
+        for (const [pattern, replacement] of replacements) {
+          newValue = newValue.replace(pattern, replacement as string)
+        }
+
+        if (newValue !== node.value) {
+          node.value = newValue
+        }
+      }
+    })
+
+    return tree
+  }
+}
+
+// Standard remark plugins that don't depend on theme or props
+const baseRemarkPlugins = [
+  remarkMathPlugin,
+  remarkEmoji,
+  remarkGfm,
+  remarkDirective,
+  createRemarkStreamlitLogo(),
+  createRemarkTypographicalSymbols(),
+]
+
+// Sets disallowed markdown for widget labels
+const LABEL_DISALLOWED_ELEMENTS = [
+  // Restricts table elements, headings, unordered/ordered lists, task lists, horizontal rules, & blockquotes
+  // Note that images are allowed but have a max height equal to the text height
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "ul",
+  "ol",
+  "li",
+  "input",
+  "hr",
+  "blockquote",
+]
+
+// Add link disallowing to the base disallowed elements
+const LINKS_DISALLOWED_ELEMENTS = [...LABEL_DISALLOWED_ELEMENTS, "a"]
+
+interface LinkProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  node: any
+  children: ReactNode[]
+  href?: string
+  title?: string
+  target?: string
+  rel?: string
+}
+
+// Using target="_blank" without rel="noopener noreferrer" is a security risk:
+// see https://mathiasbynens.github.io/rel-noopener
+export function LinkWithTargetBlank(props: LinkProps): ReactElement {
+  // if it's a #hash link, don't open in new tab
+  const { href } = props
+  if (href && href.startsWith("#")) {
+    const { children, ...rest } = props
+    return <a {...omit(rest, "node")}>{children}</a>
   }
 
-  const plugins = [
-    remarkMathPlugin,
-    remarkEmoji,
-    remarkGfm,
-    remarkDirective,
-    remarkColoringAndSmall,
-    remarkMaterialIcons,
-    remarkStreamlitLogo,
-    remarkTypographicalSymbols,
-  ]
+  const { title, children, target, rel, ...rest } = props
+  return (
+    <a
+      href={href}
+      title={title}
+      target={target || "_blank"}
+      rel={rel || "noopener noreferrer"}
+      {...omit(rest, "node")}
+    >
+      {children}
+    </a>
+  )
+}
 
-  const rehypePlugins: PluggableList = [
-    rehypeKatex,
-    ...(allowHTML ? [rehypeRaw] : []),
-  ]
+export const RenderedMarkdown = memo(function RenderedMarkdown({
+  allowHTML,
+  source,
+  overrideComponents,
+  isLabel,
+  disableLinks,
+}: Readonly<RenderedMarkdownProps>): ReactElement {
+  const theme: EmotionTheme = useTheme()
 
-  // :material/ is detected as an directive by remark directive logic.
-  // However, the directive logic ignores emoji shortcodes. As a workaround,
-  // we can make it look like an emoji shortcode by replacing the `/` with `_`.
-  const processedSource = source.replaceAll(":material/", ":material_")
+  const colorMapping = useMemo(() => createColorMapping(theme), [theme])
 
-  // Sets disallowed markdown for widget labels
-  const disallowed = [
-    // Restricts table elements, headings, unordered/ordered lists, task lists, horizontal rules, & blockquotes
-    // Note that images are allowed but have a max height equal to the text height
-    "table",
-    "thead",
-    "tbody",
-    "tr",
-    "th",
-    "td",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "ul",
-    "ol",
-    "li",
-    "input",
-    "hr",
-    "blockquote",
-    // additionally restrict links
-    ...(disableLinks ? ["a"] : []),
-  ]
+  const remarkPlugins = useMemo(
+    () => [
+      ...baseRemarkPlugins,
+      createRemarkColoringAndSmall(theme, colorMapping),
+      createRemarkMaterialIcons(theme),
+    ],
+    [theme, colorMapping]
+  )
+
+  const rehypePlugins: PluggableList = useMemo(
+    () => (allowHTML ? [rehypeKatex, rehypeRaw] : [rehypeKatex]),
+    [allowHTML]
+  )
+
+  const renderers = useMemo(
+    () => ({
+      ...baseRenderers,
+      a: LinkWithTargetBlank,
+      ...(overrideComponents || {}),
+    }),
+    [overrideComponents]
+  )
+
+  const processedSource = useMemo(
+    () => source.replaceAll(":material/", ":material_"),
+    [source]
+  )
+
+  const disallowed = useMemo(() => {
+    if (!isLabel) return []
+    return disableLinks ? LINKS_DISALLOWED_ELEMENTS : LABEL_DISALLOWED_ELEMENTS
+  }, [isLabel, disableLinks])
 
   return (
     <ErrorBoundary>
       <ReactMarkdown
-        remarkPlugins={plugins}
+        remarkPlugins={remarkPlugins}
         rehypePlugins={rehypePlugins}
         components={renderers}
         transformLinkUri={transformLinkUri}
-        disallowedElements={isLabel ? disallowed : []}
+        disallowedElements={disallowed}
         // unwrap and render children from invalid markdown
         unwrapDisallowed={true}
       >
@@ -680,7 +765,7 @@ export function RenderedMarkdown({
       </ReactMarkdown>
     </ErrorBoundary>
   )
-}
+})
 
 /**
  * Wraps the <ReactMarkdown> component to include our standard
@@ -718,40 +803,6 @@ const StreamlitMarkdown: FC<Props> = ({
         disableLinks={disableLinks}
       />
     </StyledStreamlitMarkdown>
-  )
-}
-
-interface LinkProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  node: any
-  children: ReactNode[]
-  href?: string
-  title?: string
-  target?: string
-  rel?: string
-}
-
-// Using target="_blank" without rel="noopener noreferrer" is a security risk:
-// see https://mathiasbynens.github.io/rel-noopener
-export function LinkWithTargetBlank(props: LinkProps): ReactElement {
-  // if it's a #hash link, don't open in new tab
-  const { href } = props
-  if (href && href.startsWith("#")) {
-    const { children, ...rest } = props
-    return <a {...omit(rest, "node")}>{children}</a>
-  }
-
-  const { title, children, target, rel, ...rest } = props
-  return (
-    <a
-      href={href}
-      title={title}
-      target={target || "_blank"}
-      rel={rel || "noopener noreferrer"}
-      {...omit(rest, "node")}
-    >
-      {children}
-    </a>
   )
 }
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -365,7 +365,7 @@ export const CustomPreTag: FunctionComponent<
 }
 
 // These are common renderers that don't depend on props or context
-const baseRenderers: Components = {
+const BASE_RENDERERS: Components = {
   pre: CustomPreTag,
   code: CustomCodeTag,
   h1: CustomHeading,
@@ -733,7 +733,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
 
   const renderers = useMemo(
     () => ({
-      ...baseRenderers,
+      ...BASE_RENDERERS,
       a: LinkWithTargetBlank,
       ...(overrideComponents || {}),
     }),


### PR DESCRIPTION
## Describe your changes

- `StreamlitMarkdown` was needlessly re-rendering due to inefficiencies such as rehype plugins being recreated on every re-render.
- This PR stabilizes functions and constants in the component so that re-renders are greatly reduced
- Note for reviewers: it is probably easier to review if you utilize [hide whitespace](https://github.com/streamlit/streamlit/pull/11362/files?w=1)

## GitHub Issue Link (if applicable)

## Testing Plan

- There should be no logic changes, so all existing unit + snapshot tests should cover this

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
