### PR TITLE
Nicer handling of connection errors

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1792,7 +1792,7 @@ export class App extends PureComponent<Props, State> {
    * Updates the app body when there's a connection error.
    */
   handleConnectionError = (errMarkdown: string): void => {
-    // This is just a regular error dialog, bug with type CONNECTION_ERROR
+    // This is just a regular error dialog, but with type CONNECTION_ERROR
     // instead of WARNING, so we can rescind the dialog later when reconnected.
     this.showError(
       "Connection error",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -113,6 +113,7 @@ import ToolbarActions from "@streamlit/app/src/components/ToolbarActions"
 import DeployButton from "@streamlit/app/src/components/DeployButton"
 import Header from "@streamlit/app/src/components/Header"
 import {
+  ConnectionErrorProps,
   DialogProps,
   ScriptCompileErrorProps,
   StreamlitDialog,
@@ -602,7 +603,7 @@ export class App extends PureComponent<Props, State> {
    * to be handled by the host.
    */
   maybeShowErrorDialog(
-    newDialog: WarningProps | ScriptCompileErrorProps,
+    newDialog: WarningProps | ConnectionErrorProps | ScriptCompileErrorProps,
     errorMsg: string
   ): void {
     // Show dialog only if blockErrorDialogs host config is false
@@ -624,21 +625,16 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
-  showError(title: string, errorMarkdown: string): void {
+  showError(
+    title: string,
+    errorMarkdown: string,
+    dialogType:
+      | DialogType.WARNING
+      | DialogType.CONNECTION_ERROR = DialogType.WARNING
+  ): void {
     LOG.error(errorMarkdown)
-    const newDialog: DialogProps = {
-      type: DialogType.WARNING,
-      title,
-      msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
-      onClose: () => {},
-    }
-    this.maybeShowErrorDialog(newDialog, errorMarkdown)
-  }
-
-  showConnectionError(title: string, errorMarkdown: string): void {
-    LOG.error(errorMarkdown)
-    const newDialog: DialogProps = {
-      type: DialogType.CONNECTION_ERROR,
+    const newDialog: WarningProps | ConnectionErrorProps = {
+      type: dialogType,
       title,
       msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
       onClose: () => {},
@@ -1796,7 +1792,13 @@ export class App extends PureComponent<Props, State> {
    * Updates the app body when there's a connection error.
    */
   handleConnectionError = (errMarkdown: string): void => {
-    this.showConnectionError("Connection error", errMarkdown)
+    // This is just a regular error dialog, bug with type CONNECTION_ERROR
+    // instead of WARNING, so we can rescind the dialog later when reconnected.
+    this.showError(
+      "Connection error",
+      errMarkdown,
+      DialogType.CONNECTION_ERROR
+    )
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -635,6 +635,17 @@ export class App extends PureComponent<Props, State> {
     this.maybeShowErrorDialog(newDialog, errorMarkdown)
   }
 
+  showConnectionError(title: string, errorMarkdown: string): void {
+    LOG.error(errorMarkdown)
+    const newDialog: DialogProps = {
+      type: DialogType.CONNECTION_ERROR,
+      title,
+      msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
+      onClose: () => {},
+    }
+    this.maybeShowErrorDialog(newDialog, errorMarkdown)
+  }
+
   showDeployError = (
     title: string,
     errorNode: ReactNode,
@@ -723,6 +734,9 @@ export class App extends PureComponent<Props, State> {
       ) {
         LOG.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+        this.setState({ dialog: null })
+      } else if (this.state.dialog?.type === DialogType.CONNECTION_ERROR) {
+        // Rescind the "Connection error" dialog if currently shown.
         this.setState({ dialog: null })
       }
 
@@ -1782,7 +1796,7 @@ export class App extends PureComponent<Props, State> {
    * Updates the app body when there's a connection error.
    */
   handleConnectionError = (errMarkdown: string): void => {
-    this.showError("Connection error", errMarkdown)
+    this.showConnectionError("Connection error", errMarkdown)
   }
 
   /**

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -83,9 +83,9 @@ export function StreamlitDialog(dialogProps: DialogProps): ReactNode {
     case DialogType.DEPLOY_ERROR:
       return <DeployErrorDialog {...dialogProps} />
     case undefined:
-      return <NoDialog {...dialogProps} />
+      return noDialog(dialogProps)
     default:
-      return <TypeNotRecognizedDialog {...dialogProps} />
+      return typeNotRecognizedDialog(dialogProps)
   }
 }
 
@@ -315,7 +315,7 @@ function DeployErrorDialog({
 /**
  * Returns an empty dictionary, indicating that no object is to be displayed.
  */
-function NoDialog({ onClose }: { onClose: PlainEventHandler }): ReactElement {
+function noDialog({ onClose }: { onClose: PlainEventHandler }): ReactElement {
   return <Modal isOpen={false} onClose={onClose} />
 }
 
@@ -327,7 +327,7 @@ interface NotRecognizedProps {
 /**
  * If the dialog type is not recognized, display this dialog.
  */
-function TypeNotRecognizedDialog(props: NotRecognizedProps): ReactElement {
+function typeNotRecognizedDialog(props: NotRecognizedProps): ReactElement {
   return (
     <Modal isOpen onClose={props.onClose}>
       <ModalBody>{`Dialog type "${props.type}" not recognized.`}</ModalBody>

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -61,29 +61,31 @@ export type DialogProps =
   | WarningProps
   | DeployErrorProps
   | DeployDialogProps
+  | ConnectionErrorProps
 
 export function StreamlitDialog(dialogProps: DialogProps): ReactNode {
   switch (dialogProps.type) {
     case DialogType.ABOUT:
-      return aboutDialog(dialogProps)
+      return <AboutDialog {...dialogProps} />
     case DialogType.CLEAR_CACHE:
-      return clearCacheDialog(dialogProps)
+      return <ClearCacheDialog {...dialogProps} />
     case DialogType.SETTINGS:
-      return settingsDialog(dialogProps)
+      return <SettingsDialog {...dialogProps} />
     case DialogType.SCRIPT_COMPILE_ERROR:
-      return scriptCompileErrorDialog(dialogProps)
+      return <ScriptCompileErrorDialog {...dialogProps} />
     case DialogType.THEME_CREATOR:
       return <ThemeCreatorDialog {...dialogProps} />
     case DialogType.WARNING:
-      return warningDialog(dialogProps)
+    case DialogType.CONNECTION_ERROR:
+      return <WarningDialog {...dialogProps} />
     case DialogType.DEPLOY_DIALOG:
       return <DeployDialog {...dialogProps} />
     case DialogType.DEPLOY_ERROR:
-      return deployErrorDialog(dialogProps)
+      return <DeployErrorDialog {...dialogProps} />
     case undefined:
-      return noDialog(dialogProps)
+      return <NoDialog {...dialogProps} />
     default:
-      return typeNotRecognizedDialog(dialogProps)
+      return <TypeNotRecognizedDialog {...dialogProps} />
   }
 }
 
@@ -99,7 +101,7 @@ interface AboutProps {
 }
 
 /** About Dialog */
-function aboutDialog(props: AboutProps): ReactElement {
+function AboutDialog(props: AboutProps): ReactElement {
   if (props.aboutSectionMd) {
     const markdownStyle: CSSProperties = {
       overflowY: "auto",
@@ -175,7 +177,7 @@ interface ClearCacheProps {
  * confirmCallback - callback to send the clear_cache request to the Proxy
  * onClose         - callback to close the dialog
  */
-function clearCacheDialog(props: ClearCacheProps): ReactElement {
+function ClearCacheDialog(props: ClearCacheProps): ReactElement {
   // Markdown New line is 2 spaces + \n
   const newLineMarkdown = "  \n"
   const clearCacheInfo = [
@@ -214,7 +216,7 @@ export interface ScriptCompileErrorProps {
   onClose: PlainEventHandler
 }
 
-function scriptCompileErrorDialog(
+function ScriptCompileErrorDialog(
   props: ScriptCompileErrorProps
 ): ReactElement {
   return (
@@ -234,24 +236,26 @@ function scriptCompileErrorDialog(
   )
 }
 
-/**
- * Shows the settings dialog.
- */
-function settingsDialog(props: SettingsProps): ReactElement {
-  return <SettingsDialog {...props} />
-}
-
-export interface WarningProps {
-  type: DialogType.WARNING
+interface CommonWarningProps {
   title: string
   msg: ReactNode
   onClose: PlainEventHandler
 }
 
+export interface WarningProps extends CommonWarningProps {
+  type: DialogType.WARNING
+}
+
+export interface ConnectionErrorProps extends CommonWarningProps {
+  type: DialogType.CONNECTION_ERROR
+}
+
 /**
  * Prints out a warning
  */
-function warningDialog(props: WarningProps): ReactElement {
+function WarningDialog(
+  props: WarningProps | ConnectionErrorProps
+): ReactElement {
   return (
     <Modal isOpen onClose={props.onClose}>
       <ModalHeader>{props.title}</ModalHeader>
@@ -272,7 +276,7 @@ interface DeployErrorProps {
 /**
  * Modal used to show deployment errors
  */
-function deployErrorDialog({
+function DeployErrorDialog({
   title,
   msg,
   onClose,
@@ -311,7 +315,7 @@ function deployErrorDialog({
 /**
  * Returns an empty dictionary, indicating that no object is to be displayed.
  */
-function noDialog({ onClose }: { onClose: PlainEventHandler }): ReactElement {
+function NoDialog({ onClose }: { onClose: PlainEventHandler }): ReactElement {
   return <Modal isOpen={false} onClose={onClose} />
 }
 
@@ -323,7 +327,7 @@ interface NotRecognizedProps {
 /**
  * If the dialog type is not recognized, display this dialog.
  */
-function typeNotRecognizedDialog(props: NotRecognizedProps): ReactElement {
+function TypeNotRecognizedDialog(props: NotRecognizedProps): ReactElement {
   return (
     <Modal isOpen onClose={props.onClose}>
       <ModalBody>{`Dialog type "${props.type}" not recognized.`}</ModalBody>

--- a/frontend/app/src/components/StreamlitDialog/constants.ts
+++ b/frontend/app/src/components/StreamlitDialog/constants.ts
@@ -17,6 +17,7 @@
 export enum DialogType {
   ABOUT = "about",
   CLEAR_CACHE = "clearCache",
+  CONNECTION_ERROR = "connectionError",
   SETTINGS = "settings",
   SCRIPT_COMPILE_ERROR = "scriptCompileError",
   THEME_CREATOR = "themeCreator",

--- a/frontend/app/src/components/StreamlitDialog/index.ts
+++ b/frontend/app/src/components/StreamlitDialog/index.ts
@@ -15,6 +15,7 @@
  */
 export { StreamlitDialog } from "./StreamlitDialog"
 export type {
+  ConnectionErrorProps,
   DialogProps,
   PlainEventHandler,
   ScriptCompileErrorProps,

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -23,15 +23,8 @@ import { establishStaticConnection } from "./StaticConnection"
 import { IHostConfigResponse, StreamlitEndpoints } from "./types"
 import { getPossibleBaseUris } from "./utils"
 import { WebsocketConnection } from "./WebsocketConnection"
+import { MAX_RETRIES_BEFORE_CLIENT_ERROR } from "./constants"
 
-/**
- * When the websocket connection retries this many times, we show a dialog
- * letting the user know we're having problems connecting. This happens
- * after about 15 seconds as, before the 6th retry, we've set timeouts for
- * a total of approximately 0.5 + 1 + 2 + 4 + 8 = 15.5 seconds (+/- some
- * due to jitter).
- */
-const RETRY_COUNT_FOR_WARNING = 6
 const LOG = getLogger("ConnectionManager")
 
 interface Props {
@@ -232,7 +225,7 @@ export class ConnectionManager {
     // used in tests.
     _retryTimeout: number
   ): void => {
-    if (totalRetries === RETRY_COUNT_FOR_WARNING) {
+    if (totalRetries >= MAX_RETRIES_BEFORE_CLIENT_ERROR) {
       this.props.onConnectionError(latestError)
     }
   }

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -29,9 +29,9 @@ import { buildHttpUri } from "@streamlit/utils"
 import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   HOST_CONFIG_PATH,
+  MAX_RETRIES_BEFORE_CLIENT_ERROR,
   PING_TIMEOUT_MS,
   SERVER_PING_PATH,
-  MAX_RETRIES_BEFORE_CLIENT_ERROR,
 } from "./constants"
 import { IHostConfigResponse, OnRetry } from "./types"
 

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -31,11 +31,11 @@ import {
   HOST_CONFIG_PATH,
   PING_TIMEOUT_MS,
   SERVER_PING_PATH,
+  MAX_RETRIES_BEFORE_CLIENT_ERROR,
 } from "./constants"
 import { IHostConfigResponse, OnRetry } from "./types"
 
 const LOG = getLogger("DoInitPings")
-export const THRESHOLD_FOR_CONNECTION_ERROR_DIALOG = 6
 
 export function doInitPings(
   uriPartsList: URL[],
@@ -95,7 +95,26 @@ streamlit run yourscript.py
       `
       retry(markdownMessage)
     } else {
-      retry("Connection failed with status 0.")
+      // Show nice, informatative error messages. We use navigator.onLine here to track
+      // whether the machine is connected to a network:
+      //
+      // - When false, this means the machine is definitely not connected to the
+      // internet.
+      //
+      // - When true, the machine is connected to a network, which may or may
+      // not be connected to the internet.
+      //
+      // (This if condition also makes it easier for use to debug when someone
+      // sends us a screenshot of this dialog)
+      //
+      if (navigator.onLine) {
+        retry(
+          "Streamlit server is not responding. " +
+            "Are you connected to the internet?"
+        )
+      } else {
+        retry("No internet connection.")
+      }
     }
   }
 
@@ -151,11 +170,10 @@ If you are trying to access a Streamlit app running on another server, this coul
       .catch(error => {
         // If its our 6th try (retry count at which we show connection error dialog), send a client error
         // to inform the host of connection error
-        const shouldSendClientError =
-          totalTries === THRESHOLD_FOR_CONNECTION_ERROR_DIALOG
+        const tooManyRetries = totalTries >= MAX_RETRIES_BEFORE_CLIENT_ERROR
 
         if (error.code === "ECONNABORTED") {
-          if (shouldSendClientError) {
+          if (tooManyRetries) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
             const source = determineUrlSource(error.config?.url)
             LOG.error("Client error: DoInitPings timed out")
@@ -177,7 +195,7 @@ If you are trying to access a Streamlit app running on another server, this coul
           const source = determineUrlSource(error.response.config?.url)
 
           if (status === /* NO RESPONSE */ 0) {
-            if (shouldSendClientError) {
+            if (tooManyRetries) {
               LOG.error(
                 `Client Error: response received with status ${status} when attempting to reach ${source}`
               )
@@ -191,7 +209,7 @@ If you are trying to access a Streamlit app running on another server, this coul
           }
 
           if (status === 403) {
-            if (shouldSendClientError) {
+            if (tooManyRetries) {
               LOG.error(
                 `Client Error: response received with status ${status} when attempting to reach ${source}`
               )
@@ -200,7 +218,7 @@ If you are trying to access a Streamlit app running on another server, this coul
             return retryWhenIsForbidden()
           }
 
-          if (shouldSendClientError) {
+          if (tooManyRetries) {
             LOG.error(
               `Client Error: response received with status ${status} when attempting to reach ${source}`
             )
@@ -211,12 +229,13 @@ If you are trying to access a Streamlit app running on another server, this coul
               `and response "${data}".`
           )
         }
+
         if (error.request) {
           // The request was made but no response was received
           // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
           // http.ClientRequest in node.js
 
-          if (shouldSendClientError) {
+          if (tooManyRetries) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
             const source = determineUrlSource(error.request.path)
             LOG.error(
@@ -230,8 +249,9 @@ If you are trying to access a Streamlit app running on another server, this coul
           }
           return retryWhenTheresNoResponse()
         }
+
         // Something happened in setting up the request that triggered an Error
-        if (shouldSendClientError) {
+        if (tooManyRetries) {
           // Handle retrieving the source URL from the error (health or host-config endpoint)
           const source = determineUrlSource(error.config?.url)
           LOG.error(

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -95,26 +95,10 @@ streamlit run yourscript.py
       `
       retry(markdownMessage)
     } else {
-      // Show nice, informatative error messages. We use navigator.onLine here to track
-      // whether the machine is connected to a network:
-      //
-      // - When false, this means the machine is definitely not connected to the
-      // internet.
-      //
-      // - When true, the machine is connected to a network, which may or may
-      // not be connected to the internet.
-      //
-      // (This if condition also makes it easier for use to debug when someone
-      // sends us a screenshot of this dialog)
-      //
-      if (navigator.onLine) {
-        retry(
-          "Streamlit server is not responding. " +
-            "Are you connected to the internet?"
-        )
-      } else {
-        retry("No internet connection.")
-      }
+      retry(
+        "Streamlit server is not responding. " +
+          "Are you connected to the internet?"
+      )
     }
   }
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -23,10 +23,8 @@ import { BackMsg } from "@streamlit/protobuf"
 import { ConnectionState } from "./ConnectionState"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
 import { CORS_ERROR_MESSAGE_DOCUMENTATION_LINK } from "./constants"
-import {
-  doInitPings,
-  THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
-} from "./DoInitPings"
+import { MAX_RETRIES_BEFORE_CLIENT_ERROR } from "./constants"
+import { doInitPings } from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
 
 const MOCK_ALLOWED_ORIGINS_CONFIG = {
@@ -235,7 +233,7 @@ describe("doInitPings", () => {
     )
   })
 
-  it("calls retry with 'Connection failed with status 0.' when there is no response", async () => {
+  it("calls retry with 'Streamlit server is not responding. Are you connected to the internet?' when there is no response", async () => {
     const TEST_ERROR = {
       response: {
         status: 0,
@@ -262,12 +260,12 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      "Connection failed with status 0.",
+      "Streamlit server is not responding. Are you connected to the internet?",
       expect.anything()
     )
   })
 
-  it("calls retry with 'Connection failed with status 0.' when the request was made but no response was received", async () => {
+  it("calls retry with 'Streamlit server is not responding. Are you connected to the internet?' when the request was made but no response was received", async () => {
     const TEST_ERROR = {
       request: {},
     }
@@ -292,7 +290,7 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      "Connection failed with status 0.",
+      "Streamlit server is not responding. Are you connected to the internet?",
       expect.anything()
     )
   })
@@ -633,18 +631,15 @@ If you are trying to access a Streamlit app running on another server, this coul
       const sendClientErrorSpy = vi.fn()
 
       // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(
-        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
-        {
-          response: {
-            status: 0,
-            statusText: "No response",
-            config: {
-              url: "https://example.com/health",
-            },
+      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
+        response: {
+          status: 0,
+          statusText: "No response",
+          config: {
+            url: "https://example.com/health",
           },
-        }
-      )
+        },
+      })
 
       await doInitPings(
         MOCK_PING_DATA.uri,
@@ -667,18 +662,15 @@ If you are trying to access a Streamlit app running on another server, this coul
       const sendClientErrorSpy = vi.fn()
 
       // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(
-        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
-        {
-          response: {
-            status: 403,
-            statusText: "Forbidden",
-            config: {
-              url: "https://example.com/health",
-            },
+      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
+        response: {
+          status: 403,
+          statusText: "Forbidden",
+          config: {
+            url: "https://example.com/health",
           },
-        }
-      )
+        },
+      })
 
       await doInitPings(
         MOCK_PING_DATA.uri,
@@ -700,18 +692,15 @@ If you are trying to access a Streamlit app running on another server, this coul
       const sendClientErrorSpy = vi.fn()
 
       // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(
-        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
-        {
-          response: {
-            status: 500,
-            statusText: "Internal Server Error",
-            config: {
-              url: "https://example.com/health",
-            },
+      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
+        response: {
+          status: 500,
+          statusText: "Internal Server Error",
+          config: {
+            url: "https://example.com/health",
           },
-        }
-      )
+        },
+      })
 
       await doInitPings(
         MOCK_PING_DATA.uri,
@@ -733,14 +722,11 @@ If you are trying to access a Streamlit app running on another server, this coul
       const sendClientErrorSpy = vi.fn()
 
       // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(
-        THRESHOLD_FOR_CONNECTION_ERROR_DIALOG,
-        {
-          request: {
-            path: "https://example.com/health",
-          },
-        }
-      )
+      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
+        request: {
+          path: "https://example.com/health",
+        },
+      })
 
       await doInitPings(
         MOCK_PING_DATA.uri,

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -22,8 +22,10 @@ import { BackMsg } from "@streamlit/protobuf"
 
 import { ConnectionState } from "./ConnectionState"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
-import { CORS_ERROR_MESSAGE_DOCUMENTATION_LINK } from "./constants"
-import { MAX_RETRIES_BEFORE_CLIENT_ERROR } from "./constants"
+import {
+  CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
+  MAX_RETRIES_BEFORE_CLIENT_ERROR,
+} from "./constants"
 import { doInitPings } from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
 

--- a/frontend/connection/src/constants.ts
+++ b/frontend/connection/src/constants.ts
@@ -39,8 +39,13 @@ export const HOST_CONFIG_PATH = "_stcore/host-config"
 /**
  * Min and max wait time between pings in millis.
  */
-export const PING_MINIMUM_RETRY_PERIOD_MS = 500
-export const PING_MAXIMUM_RETRY_PERIOD_MS = 1000 * 60
+export const PING_MINIMUM_RETRY_PERIOD_MS = 100
+export const PING_MAXIMUM_RETRY_PERIOD_MS = 2000
+
+/**
+ * Max number of times we retry pinging the server before we show an error.
+ */
+export const MAX_RETRIES_BEFORE_CLIENT_ERROR = 6
 
 /**
  * Timeout when attempting to connect to a websocket, in millis.


### PR DESCRIPTION
## Describe your changes

Today, when the Streamlit frontend is unable to connect to the server we eventually show an error dialog (after plenty of retries). But there are two issues:

1. The messaging in the error dialog is a bit cryptic.

    → This PR makes the message nicer to the user

1. While the error dialog is visible, we continue retrying to connect to the server. But if we're suddenly successful at establishing a connection to the sever, the "disconnected" dialog stays open.

    → This PR closes that dialog when reconnected.

PS: This PR also reduces the min and max time we use in our connection retry logic.

## GitHub Issue Link (if applicable)

n/a

## Testing Plan

- ~~Explanation of why no additional tests are needed~~
- ✅ Unit Tests (JS and/or Python)
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
