### PR TITLE
Add a new config option to configure a CORS allowlist

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -819,6 +819,18 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "server.corsAllowedOrigins",
+    description="""
+        If CORS protection is enabled (when server.enableCORS=True), allows an
+        app developer to set a comma separated list of allowed origins that the
+        Streamlit server will accept traffic from.
+
+        This config option does nothing if CORS protection is disabled.
+    """,
+    default_val="",
+    type_=str,
+)
 
 _create_option(
     "server.enableXsrfProtection",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -823,13 +823,14 @@ _create_option(
     "server.corsAllowedOrigins",
     description="""
         If CORS protection is enabled (when server.enableCORS=True), allows an
-        app developer to set a comma separated list of allowed origins that the
-        Streamlit server will accept traffic from.
+        app developer to set a list of allowed origins that the Streamlit server
+        will accept traffic from.
 
         This config option does nothing if CORS protection is disabled.
+
+        Example: ['http://example.com', 'https://streamlit.io']
     """,
-    default_val="",
-    type_=str,
+    default_val=[],
 )
 
 _create_option(

--- a/lib/streamlit/web/server/__init__.py
+++ b/lib/streamlit/web/server/__init__.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
-from streamlit.web.server.routes import allow_cross_origin_requests
+from streamlit.web.server.routes import (
+    allow_all_cross_origin_requests,
+    is_allowed_origin,
+)
 from streamlit.web.server.server import Server, server_address_is_unix_socket
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
 
@@ -21,6 +24,7 @@ __all__ = [
     "ComponentRequestHandler",
     "Server",
     "StatsRequestHandler",
-    "allow_cross_origin_requests",
+    "allow_all_cross_origin_requests",
+    "is_allowed_origin",
     "server_address_is_unix_socket",
 ]

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -83,8 +83,12 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             self.set_header("Cache-Control", "public")
 
     def set_default_headers(self) -> None:
-        if streamlit.web.server.routes.allow_cross_origin_requests():
+        if streamlit.web.server.routes.allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
+        elif streamlit.web.server.routes.is_allowed_origin(
+            origin := self.request.headers.get("Origin")
+        ):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks."""

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import mimetypes
 import os
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, cast
 
 import tornado.web
 
@@ -88,7 +88,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         elif streamlit.web.server.routes.is_allowed_origin(
             origin := self.request.headers.get("Origin")
         ):
-            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks."""

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -25,7 +25,7 @@ from streamlit.runtime.memory_media_file_storage import (
     MemoryMediaFileStorage,
     get_extension_for_mimetype,
 )
-from streamlit.web.server import allow_cross_origin_requests
+from streamlit.web.server import allow_all_cross_origin_requests, is_allowed_origin
 
 _LOGGER = get_logger(__name__)
 
@@ -44,8 +44,10 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         cls._storage = storage
 
     def set_default_headers(self) -> None:
-        if allow_cross_origin_requests():
+        if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
+        elif is_allowed_origin(origin := self.request.headers.get("Origin")):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
     def set_extra_headers(self, path: str) -> None:
         """Add Content-Disposition header for downloadable files.
@@ -84,7 +86,11 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
     # static content from a database), override `get_content`,
     # `get_content_size`, `get_modified_time`, `get_absolute_path`, and
     # `validate_absolute_path`.
-    def validate_absolute_path(self, root: str, absolute_path: str) -> str:  # noqa: ARG002
+    def validate_absolute_path(
+        self,
+        root: str,  # noqa: ARG002
+        absolute_path: str,
+    ) -> str:
         try:
             self._storage.get_file(absolute_path)
         except MediaFileStorageError:

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import tornado.web
@@ -47,7 +47,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
         elif is_allowed_origin(origin := self.request.headers.get("Origin")):
-            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
 
     def set_extra_headers(self, path: str) -> None:
         """Add Content-Disposition header for downloadable files.

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -21,6 +21,7 @@ import tornado.web
 
 from streamlit import config, file_util
 from streamlit.web.server.server_util import (
+    allowlisted_origins,
     emit_endpoint_deprecation_notice,
     is_xsrf_enabled,
 )
@@ -29,17 +30,22 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Sequence
 
 
-def allow_cross_origin_requests() -> bool:
-    """True if cross-origin requests are allowed.
+def allow_all_cross_origin_requests() -> bool:
+    """True if cross-origin requests from any origin are allowed.
 
-    We only allow cross-origin requests when CORS protection has been disabled
-    with server.enableCORS=False or if using the Node server. When using the
-    Node server, we have a dev and prod port, which count as two origins.
-
+    We only allow ALL cross-origin requests when CORS protection has been
+    disabled with server.enableCORS=False or if using the Node server in dev
+    mode. When in dev mode, we have a dev and prod port, which count as two
+    origins.
     """
+
     return not config.get_option("server.enableCORS") or config.get_option(
         "global.developmentMode"
     )
+
+
+def is_allowed_origin(origin: str) -> bool:
+    return origin in allowlisted_origins()
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
@@ -111,8 +117,10 @@ class _SpecialRequestHandler(tornado.web.RequestHandler):
 
     def set_default_headers(self) -> None:
         self.set_header("Cache-Control", "no-cache")
-        if allow_cross_origin_requests():
+        if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
+        elif is_allowed_origin(origin := self.request.headers.get("Origin")):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks.

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import tornado.web
 
@@ -44,7 +44,9 @@ def allow_all_cross_origin_requests() -> bool:
     )
 
 
-def is_allowed_origin(origin: str) -> bool:
+def is_allowed_origin(origin: Any) -> bool:
+    if not isinstance(origin, str):
+        return False
     return origin in allowlisted_origins()
 
 
@@ -120,7 +122,7 @@ class _SpecialRequestHandler(tornado.web.RequestHandler):
         if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
         elif is_allowed_origin(origin := self.request.headers.get("Origin")):
-            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks.

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -31,6 +31,15 @@ DEVELOPMENT_PORT: Final = 3000
 AUTH_COOKIE_NAME: Final = "_streamlit_user"
 
 
+def allowlisted_origins() -> set[str]:
+    allowlist_str = config.get_option("server.corsAllowedOrigins")
+
+    if not allowlist_str:
+        return set()
+
+    return {origin.strip() for origin in allowlist_str.split(",")}
+
+
 def is_url_from_allowed_origins(url: str) -> bool:
     """Return True if URL is from allowed origins (for CORS purpose).
 
@@ -58,6 +67,11 @@ def is_url_from_allowed_origins(url: str) -> bool:
         # Then try the options that depend on HTTP requests or opening sockets.
         net_util.get_internal_ip,
         net_util.get_external_ip,
+        # NOTE: Need to look into whether this is what we want to do here:
+        # This helper function should probably be named is_url_from_allowed_domains
+        # rather than *_origins since origins should contain a scheme. We keep
+        # the more lax behavior for now but should double-check that this is ok.
+        *[url_util.get_hostname(origin) for origin in allowlisted_origins()],
     ]
 
     for allowed_domain in allowed_domains:

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -37,7 +37,7 @@ def allowlisted_origins() -> set[str]:
     if not allowlist_str:
         return set()
 
-    return {origin.strip() for origin in allowlist_str.split(",")}
+    return {origin.strip() for origin in allowlist_str.split(",") if origin.strip()}
 
 
 def is_url_from_allowed_origins(url: str) -> bool:

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -51,10 +51,6 @@ def is_url_from_allowed_origins(url: str) -> bool:
 
     hostname = url_util.get_hostname(url)
 
-    # NOTE: Need to look into whether this is what we want to do here:
-    # This helper function should probably be named is_url_from_allowed_domains
-    # rather than *_origins since origins should contain a scheme. We keep
-    # the more lax behavior for now but should double-check that this is ok.
     allowlisted_domains = [
         url_util.get_hostname(origin) for origin in allowlisted_origins()
     ]

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -32,12 +32,7 @@ AUTH_COOKIE_NAME: Final = "_streamlit_user"
 
 
 def allowlisted_origins() -> set[str]:
-    allowlist_str = config.get_option("server.corsAllowedOrigins")
-
-    if not allowlist_str:
-        return set()
-
-    return {origin.strip() for origin in allowlist_str.split(",") if origin.strip()}
+    return {origin.strip() for origin in config.get_option("server.corsAllowedOrigins")}
 
 
 def is_url_from_allowed_origins(url: str) -> bool:

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -56,7 +56,15 @@ def is_url_from_allowed_origins(url: str) -> bool:
 
     hostname = url_util.get_hostname(url)
 
-    allowed_domains: list[str | Callable[[], str | None]] = [
+    # NOTE: Need to look into whether this is what we want to do here:
+    # This helper function should probably be named is_url_from_allowed_domains
+    # rather than *_origins since origins should contain a scheme. We keep
+    # the more lax behavior for now but should double-check that this is ok.
+    allowlisted_domains = [
+        url_util.get_hostname(origin) for origin in allowlisted_origins()
+    ]
+
+    allowed_domains: list[str | None | Callable[[], str | None]] = [
         # Check localhost first.
         "localhost",
         "0.0.0.0",  # noqa: S104
@@ -67,11 +75,7 @@ def is_url_from_allowed_origins(url: str) -> bool:
         # Then try the options that depend on HTTP requests or opening sockets.
         net_util.get_internal_ip,
         net_util.get_external_ip,
-        # NOTE: Need to look into whether this is what we want to do here:
-        # This helper function should probably be named is_url_from_allowed_domains
-        # rather than *_origins since origins should contain a scheme. We keep
-        # the more lax behavior for now but should double-check that this is ok.
-        *[url_util.get_hostname(origin) for origin in allowlisted_origins()],
+        *allowlisted_domains,
     ]
 
     for allowed_domain in allowed_domains:

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 import tornado.web
 
-from streamlit.web.server import allow_cross_origin_requests
+from streamlit.web.server import allow_all_cross_origin_requests, is_allowed_origin
 from streamlit.web.server.server_util import emit_endpoint_deprecation_notice
 
 if TYPE_CHECKING:
@@ -31,8 +31,10 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         self._manager = stats_manager
 
     def set_default_headers(self) -> None:
-        if allow_cross_origin_requests():
+        if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
+        elif is_allowed_origin(origin := self.request.headers.get("Origin")):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks."""

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import tornado.web
 
@@ -34,7 +34,7 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         if allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
         elif is_allowed_origin(origin := self.request.headers.get("Origin")):
-            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
 
     def options(self) -> None:
         """/OPTIONS handler for preflight CORS checks."""

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -60,8 +60,10 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken, Content-Type")
             self.set_header("Vary", "Origin")
             self.set_header("Access-Control-Allow-Credentials", "true")
-        elif routes.allow_cross_origin_requests():
+        elif routes.allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
+        elif routes.is_allowed_origin(origin := self.request.headers.get("Origin")):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
     def options(self, **kwargs: Any) -> None:
         """/OPTIONS handler for preflight CORS checks.

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import tornado.httputil
 import tornado.web
@@ -63,7 +63,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         elif routes.allow_all_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
         elif routes.is_allowed_origin(origin := self.request.headers.get("Origin")):
-            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
 
     def options(self, **kwargs: Any) -> None:
         """/OPTIONS handler for preflight CORS checks.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -533,6 +533,7 @@ class ConfigTest(unittest.TestCase):
                 "server.baseUrlPath",
                 "server.enableCORS",
                 "server.cookieSecret",
+                "server.corsAllowedOrigins",
                 "server.scriptHealthCheckEnabled",
                 "server.enableWebsocketCompression",
                 "server.enableXsrfProtection",

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -28,7 +28,7 @@ from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.web.server import ComponentRequestHandler, Server
-from tests.testutil import create_mock_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx, patch_config_options
 
 URL = "http://not.a.real.url:3001"
 PATH = "/not/a/real/path"
@@ -69,8 +69,10 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             ]
         )
 
-    def _request_component(self, path):
-        return self.fetch("/component/%s" % path, method="GET")
+    def _request_component(self, path, headers=None):
+        if headers is None:
+            headers = {}
+        return self.fetch("/component/%s" % path, method="GET", headers=headers)
 
     def test_success_request(self):
         """Test request success when valid parameters are provided."""
@@ -89,6 +91,32 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 200
         assert response.body == b"Test Content"
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    @mock.patch(
+        "streamlit.web.server.routes.allow_all_cross_origin_requests",
+        mock.MagicMock(return_value=False),
+    )
+    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    def test_success_request_allowlisted_origin(self):
+        """Test request success when valid parameters are provided with an allowlisted origin."""
+
+        with mock.patch(MOCK_IS_DIR_PATH):
+            # We don't need the return value in this case.
+            declare_component("test", path=PATH)
+
+        with mock.patch(
+            "streamlit.web.server.component_request_handler.open",
+            mock.mock_open(read_data="Test Content"),
+        ):
+            response = self._request_component(
+                "tests.streamlit.web.server.component_request_handler_test.test",
+                headers={"Origin": "http://example.com"},
+            )
+
+        assert response.code == 200
+        assert response.body == b"Test Content"
+        assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
     def test_outside_component_root_request(self):
         """Tests to ensure a path based on the root directory (and therefore

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -97,7 +97,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.routes.allow_all_cross_origin_requests",
         mock.MagicMock(return_value=False),
     )
-    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    @patch_config_options({"server.corsAllowedOrigins": ["http://example.com"]})
     def test_success_request_allowlisted_origin(self):
         """Test request success when valid parameters are provided with an allowlisted origin."""
 

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -167,6 +167,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         """Test request failure when invalid component name is provided."""
 
         response = self._request_component("invalid_component")
+
         assert response.code == 404
         assert response.body == b"not found"
 
@@ -217,7 +218,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             )
 
         assert response.code == 200
-        assert payload == response.body
+        assert response.body == payload
 
     def test_mimetype_is_overridden_by_server(self):
         """Test get_content_type function."""

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -25,6 +25,7 @@ from parameterized import parameterized
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.web.server.media_file_handler import MediaFileHandler
+from tests.testutil import patch_config_options
 
 MOCK_ENDPOINT: Final = "/mock/media"
 
@@ -56,7 +57,30 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert rsp.code == 200
         assert rsp.body == b"mock_data"
         assert rsp.headers["Content-Type"] == "video/mp4"
-        assert str(len(b"mock_data")) == rsp.headers["Content-Length"]
+        assert rsp.headers["Content-Length"] == str(len(b"mock_data"))
+        assert rsp.headers["Access-Control-Allow-Origin"] == "*"
+
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        MagicMock(return_value="mock_session_id"),
+    )
+    @mock.patch(
+        "streamlit.web.server.media_file_handler.allow_all_cross_origin_requests",
+        mock.MagicMock(return_value=False),
+    )
+    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    def test_media_file_allowed_origin(self) -> None:
+        """Requests for media files in MediaFileManager should succeed with allowlisted origin."""
+        # Add a media file and read it back
+        url = self.media_file_manager.add(b"mock_data", "video/mp4", "mock_coords")
+
+        rsp = self.fetch(url, method="GET", headers={"Origin": "http://example.com"})
+
+        assert rsp.code == 200
+        assert rsp.body == b"mock_data"
+        assert rsp.headers["Content-Type"] == "video/mp4"
+        assert rsp.headers["Content-Length"] == str(len(b"mock_data"))
+        assert rsp.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -122,9 +122,9 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert rsp.code == 200
         assert rsp.body == b"mock_data"
-        assert mimetype == rsp.headers["Content-Type"]
-        assert str(len(b"mock_data")) == rsp.headers["Content-Length"]
-        assert content_disposition_header == rsp.headers["Content-Disposition"]
+        assert rsp.headers["Content-Type"] == mimetype
+        assert rsp.headers["Content-Length"] == str(len(b"mock_data"))
+        assert rsp.headers["Content-Disposition"] == content_disposition_header
 
     def test_invalid_file(self) -> None:
         """Requests for invalid files fail with 404."""

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -68,7 +68,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.media_file_handler.allow_all_cross_origin_requests",
         mock.MagicMock(return_value=False),
     )
-    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    @patch_config_options({"server.corsAllowedOrigins": ["http://example.com"]})
     def test_media_file_allowed_origin(self) -> None:
         """Requests for media files in MediaFileManager should succeed with allowlisted origin."""
         # Add a media file and read it back

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -18,6 +18,7 @@ import json
 import mimetypes
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import tornado.httpserver
 import tornado.testing
@@ -58,10 +59,24 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch("/_stcore/health")
         assert response.code == 200
         assert response.body == b"ok"
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
 
         self._is_healthy = False
         response = self.fetch("/_stcore/health")
         assert response.code == 503
+
+    @patch(
+        "streamlit.web.server.routes.allow_all_cross_origin_requests",
+        MagicMock(return_value=False),
+    )
+    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    def test_health_allowed_origins(self):
+        response = self.fetch(
+            "/_stcore/health", headers={"Origin": "http://example.com"}
+        )
+        assert response.code == 200
+        assert response.body == b"ok"
+        assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
     def test_health_head(self):
         response = self.fetch("/_stcore/health", method="HEAD")

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -69,7 +69,7 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.routes.allow_all_cross_origin_requests",
         MagicMock(return_value=False),
     )
-    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    @patch_config_options({"server.corsAllowedOrigins": ["http://example.com"]})
     def test_health_allowed_origins(self):
         response = self.fetch(
             "/_stcore/health", headers={"Origin": "http://example.com"}

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -27,9 +27,51 @@ from tests import testutil
 
 
 class ServerUtilTest(unittest.TestCase):
+    def test_allowlisted_origins_empty_string(self):
+        with testutil.patch_config_options({"server.corsAllowedOrigins": ""}):
+            assert server_util.allowlisted_origins() == set()
+
+    def test_allowlisted_origins_singleton(self):
+        with testutil.patch_config_options(
+            {"server.corsAllowedOrigins": "http://example.com"}
+        ):
+            assert server_util.allowlisted_origins() == {"http://example.com"}
+
+    def test_allowlisted_origins_multiple_entries(self):
+        with testutil.patch_config_options(
+            {"server.corsAllowedOrigins": "http://example.com,https://streamlit.io"}
+        ):
+            assert server_util.allowlisted_origins() == {
+                "http://example.com",
+                "https://streamlit.io",
+            }
+
+    def test_allowlisted_origins_string_with_whitespace(self):
+        with testutil.patch_config_options(
+            {
+                "server.corsAllowedOrigins": " http://example.com,     https://streamlit.io\t"
+            }
+        ):
+            assert server_util.allowlisted_origins() == {
+                "http://example.com",
+                "https://streamlit.io",
+            }
+
     def test_is_url_from_allowed_origins_allowed_domains(self):
-        assert server_util.is_url_from_allowed_origins("localhost")
-        assert server_util.is_url_from_allowed_origins("127.0.0.1")
+        with testutil.patch_config_options(
+            {"server.corsAllowedOrigins": "http://example.com,https://streamlit.io"}
+        ):
+            for origin in [
+                "localhost",
+                "127.0.0.1",
+                "http://example.com",
+                "https://streamlit.io",
+            ]:
+                assert server_util.is_url_from_allowed_origins(origin)
+
+            assert not server_util.is_url_from_allowed_origins(
+                "http://some-other-origin.com"
+            )
 
     def test_is_url_from_allowed_origins_CORS_off(self):
         with patch(

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -28,18 +28,23 @@ from tests import testutil
 
 class ServerUtilTest(unittest.TestCase):
     def test_allowlisted_origins_empty_string(self):
-        with testutil.patch_config_options({"server.corsAllowedOrigins": ""}):
+        with testutil.patch_config_options({"server.corsAllowedOrigins": []}):
             assert server_util.allowlisted_origins() == set()
 
     def test_allowlisted_origins_singleton(self):
         with testutil.patch_config_options(
-            {"server.corsAllowedOrigins": "http://example.com"}
+            {"server.corsAllowedOrigins": ["http://example.com"]}
         ):
             assert server_util.allowlisted_origins() == {"http://example.com"}
 
     def test_allowlisted_origins_multiple_entries(self):
         with testutil.patch_config_options(
-            {"server.corsAllowedOrigins": "http://example.com,https://streamlit.io"}
+            {
+                "server.corsAllowedOrigins": [
+                    "http://example.com",
+                    "https://streamlit.io",
+                ]
+            }
         ):
             assert server_util.allowlisted_origins() == {
                 "http://example.com",
@@ -49,7 +54,10 @@ class ServerUtilTest(unittest.TestCase):
     def test_allowlisted_origins_string_with_whitespace(self):
         with testutil.patch_config_options(
             {
-                "server.corsAllowedOrigins": " http://example.com,     https://streamlit.io\t"
+                "server.corsAllowedOrigins": [
+                    " http://example.com       ",
+                    "       https://streamlit.io ",
+                ]
             }
         ):
             assert server_util.allowlisted_origins() == {
@@ -59,7 +67,12 @@ class ServerUtilTest(unittest.TestCase):
 
     def test_is_url_from_allowed_origins_allowed_domains(self):
         with testutil.patch_config_options(
-            {"server.corsAllowedOrigins": "http://example.com,https://streamlit.io"}
+            {
+                "server.corsAllowedOrigins": [
+                    "http://example.com",
+                    "https://streamlit.io",
+                ]
+            }
         ):
             for origin in [
                 "localhost",
@@ -87,11 +100,7 @@ class ServerUtilTest(unittest.TestCase):
             ),
             patch(
                 "streamlit.web.server.server_util.config.get_option",
-                side_effect=[
-                    True,
-                    "browser.server.address",
-                    "",
-                ],
+                side_effect=[True, [], "browser.server.address"],
             ),
         ):
             assert server_util.is_url_from_allowed_origins("browser.server.address")

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -87,7 +87,11 @@ class ServerUtilTest(unittest.TestCase):
             ),
             patch(
                 "streamlit.web.server.server_util.config.get_option",
-                side_effect=[True, "browser.server.address"],
+                side_effect=[
+                    True,
+                    "browser.server.address",
+                    "",
+                ],
             ),
         ):
             assert server_util.is_url_from_allowed_origins("browser.server.address")

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -17,16 +17,17 @@
 from __future__ import annotations
 
 from typing import NamedTuple
+from unittest.mock import MagicMock, patch
 
 import requests
 import tornado.testing
 import tornado.web
 import tornado.websocket
-
 from streamlit.logger import get_logger
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.web.server.server import UPLOAD_FILE_ENDPOINT
 from streamlit.web.server.upload_file_request_handler import UploadFileRequestHandler
+from tests.testutil import patch_config_options
 
 LOGGER = get_logger(__name__)
 
@@ -59,7 +60,10 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             ]
         )
 
-    def _upload_files(self, files_body, session_id, file_id):
+    def _upload_files(self, files_body, session_id, file_id, headers=None):
+        if headers is None:
+            headers = {}
+
         # We use requests.Request to construct our multipart/form-data request
         # here, because they are absurdly fiddly to compose, and Tornado
         # doesn't include a utility for building them. We then use self.fetch()
@@ -68,6 +72,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             method="PUT",
             url=self.get_url(f"{UPLOAD_FILE_ENDPOINT}/{session_id}/{file_id}"),
             files=files_body,
+            headers=headers,
         ).prepare()
 
         return self.fetch(
@@ -91,6 +96,64 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             (rec.file_id, rec.name, rec.data)
             for rec in self.file_mgr.get_files("test_session_id", [file.name])
         ]
+        assert (
+            response.headers["Access-Control-Allow-Origin"] == "http://localhost:3000"
+        )
+
+    @patch(
+        "streamlit.web.server.upload_file_request_handler.is_xsrf_enabled",
+        MagicMock(return_value=False),
+    )
+    def test_upload_one_file_xsrf_and_cors_protection_off(self):
+        """Uploading a file should populate our file_mgr with xsrf and cors protection
+        off."""
+        file = MockFile("filename", b"123")
+        params = {file.name: file.data}
+        response = self._upload_files(
+            params, session_id="test_session_id", file_id=file.name
+        )
+
+        self.assertEqual(204, response.code, response.reason)
+
+        self.assertEqual(
+            [(file.name, file.name, file.data)],
+            [
+                (rec.file_id, rec.name, rec.data)
+                for rec in self.file_mgr.get_files("test_session_id", [file.name])
+            ],
+        )
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    @patch(
+        "streamlit.web.server.upload_file_request_handler.is_xsrf_enabled",
+        MagicMock(return_value=False),
+    )
+    @patch(
+        "streamlit.web.server.upload_file_request_handler.routes.allow_all_cross_origin_requests",
+        MagicMock(return_value=False),
+    )
+    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    def test_upload_one_file_allowed_origins(self):
+        """Uploading a file should populate our file_mgr."""
+        file = MockFile("filename", b"123")
+        params = {file.name: file.data}
+        response = self._upload_files(
+            params,
+            session_id="test_session_id",
+            file_id=file.name,
+            headers={"Origin": "http://example.com"},
+        )
+
+        self.assertEqual(204, response.code, response.reason)
+
+        self.assertEqual(
+            [(file.name, file.name, file.data)],
+            [
+                (rec.file_id, rec.name, rec.data)
+                for rec in self.file_mgr.get_files("test_session_id", [file.name])
+            ],
+        )
+        assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
     def test_upload_multiple_files_error(self):
         """Uploading multiple files will error"""

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -23,6 +23,7 @@ import requests
 import tornado.testing
 import tornado.web
 import tornado.websocket
+
 from streamlit.logger import get_logger
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.web.server.server import UPLOAD_FILE_ENDPOINT
@@ -128,7 +129,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.upload_file_request_handler.routes.allow_all_cross_origin_requests",
         MagicMock(return_value=False),
     )
-    @patch_config_options({"server.corsAllowedOrigins": "http://example.com"})
+    @patch_config_options({"server.corsAllowedOrigins": ["http://example.com"]})
     def test_upload_one_file_allowed_origins(self):
         """Uploading a file should populate our file_mgr."""
         file = MockFile("filename", b"123")

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -113,15 +113,11 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             params, session_id="test_session_id", file_id=file.name
         )
 
-        self.assertEqual(204, response.code, response.reason)
-
-        self.assertEqual(
-            [(file.name, file.name, file.data)],
-            [
-                (rec.file_id, rec.name, rec.data)
-                for rec in self.file_mgr.get_files("test_session_id", [file.name])
-            ],
-        )
+        assert response.code == 204, response.reason
+        assert [(file.name, file.name, file.data)] == [
+            (rec.file_id, rec.name, rec.data)
+            for rec in self.file_mgr.get_files("test_session_id", [file.name])
+        ]
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
     @patch(
@@ -144,15 +140,11 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             headers={"Origin": "http://example.com"},
         )
 
-        self.assertEqual(204, response.code, response.reason)
-
-        self.assertEqual(
-            [(file.name, file.name, file.data)],
-            [
-                (rec.file_id, rec.name, rec.data)
-                for rec in self.file_mgr.get_files("test_session_id", [file.name])
-            ],
-        )
+        assert response.code == 204, response.reason
+        assert [(file.name, file.name, file.data)] == [
+            (rec.file_id, rec.name, rec.data)
+            for rec in self.file_mgr.get_files("test_session_id", [file.name])
+        ]
         assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
     def test_upload_multiple_files_error(self):


### PR DESCRIPTION
## Describe your changes

In some new (Snowflake-internal) deployments of Streamlit, we want to be able to enable CORS for a
Streamlit server, but we don't want to accept requests from any origin, which is what currently happens
if you turn CORS protection off.

To address this, we add a new generally usable config option `server.corsAllowedOrigins` that, if set,
allows a Streamlit app developer to specify a list of origins to accept requests from. We then use this
new config option in each of the Tornado server's endpoints to read an incoming request's `"Origin"`
header and set a `"Access-Control-Allow-Origin"` header in the response if the request's origin is
in our configured allowlist.

We also did some drive-by refactors to change lots of `self.assert*` usage to use `pytest`-style
raw assert statements, and we tried to keep this isolated from the rest of our changes for
reviewability's sake by making most of these mechanical changes in a separate commit, so the PR
will be a bit more reviewable if read commit-wise.

## Testing Plan

- Unit Tests (JS and/or Python)
   - Added Python unit tests 
- Any manual testing needed?
   - Built the package and manually verified that headers are set as expected when this config option is set and we send a request from an allowlisted origin (using curl)
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
