### PR TITLE
Allow backend URLs to be configurable via window variables

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1069,7 +1069,13 @@ export class App extends PureComponent<Props, State> {
     isViewingMainPage: boolean
   ): void => {
     const baseUriParts = this.getBaseUriParts()
-    if (baseUriParts) {
+
+    // TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_URL
+    // is set, so the Streamlit backend URL is set to be different from where
+    // we loaded index.html. Until this is done, the browser's back/forward
+    // buttons may not work correctly with multipage apps when
+    // window.__STREAMLIT_BACKEND_URL is set.
+    if (baseUriParts && !window.__STREAMLIT_BACKEND_URL) {
       const { pathname } = baseUriParts
 
       const prevPageNameInPath = extractPageNameFromPathName(
@@ -1218,6 +1224,12 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Handler called when the history state changes, e.g. `popstate` event.
+   *
+   * TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_URL
+   * is set, so the Streamlit backend URL is set to be different from where
+   * we loaded index.html. Until this is done, the browser's back/forward
+   * buttons may not work correctly with multipage apps when
+   * window.__STREAMLIT_BACKEND_URL is set.
    */
   onHistoryChange = (): void => {
     const { currentPageScriptHash } = this.state
@@ -1647,6 +1659,14 @@ export class App extends PureComponent<Props, State> {
       // click the "Rerun" button in the main menu. In this case, we
       // rerun the current page.
       pageScriptHash = currentPageScriptHash
+    } else if (window.__STREAMLIT_BACKEND_URL) {
+      // We currently don't support navigating directly to a subpage of a
+      // multipage app when setting the backend URL of an app to be a different
+      // location from where we load index.html. In this case, we set both
+      // pageName and pageScriptHash to the empty string, which will result in
+      // the app's main page being run.
+      pageName = ""
+      pageScriptHash = ""
     } else {
       // We must be in the case where the user is navigating directly to a
       // non-main page of this app. Since we haven't received the list of the

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1070,12 +1070,12 @@ export class App extends PureComponent<Props, State> {
   ): void => {
     const baseUriParts = this.getBaseUriParts()
 
-    // TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_URL
+    // TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_BASE_URL
     // is set, so the Streamlit backend URL is set to be different from where
     // we loaded index.html. Until this is done, the browser's back/forward
     // buttons may not work correctly with multipage apps when
-    // window.__STREAMLIT_BACKEND_URL is set.
-    if (baseUriParts && !window.__STREAMLIT_BACKEND_URL) {
+    // window.__STREAMLIT_BACKEND_BASE_URL is set.
+    if (baseUriParts && !window.__STREAMLIT_BACKEND_BASE_URL) {
       const { pathname } = baseUriParts
 
       const prevPageNameInPath = extractPageNameFromPathName(
@@ -1225,11 +1225,11 @@ export class App extends PureComponent<Props, State> {
   /**
    * Handler called when the history state changes, e.g. `popstate` event.
    *
-   * TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_URL
+   * TODO(vdonato): Support the situation where window.__STREAMLIT_BACKEND_BASE_URL
    * is set, so the Streamlit backend URL is set to be different from where
    * we loaded index.html. Until this is done, the browser's back/forward
    * buttons may not work correctly with multipage apps when
-   * window.__STREAMLIT_BACKEND_URL is set.
+   * window.__STREAMLIT_BACKEND_BASE_URL is set.
    */
   onHistoryChange = (): void => {
     const { currentPageScriptHash } = this.state
@@ -1659,12 +1659,14 @@ export class App extends PureComponent<Props, State> {
       // click the "Rerun" button in the main menu. In this case, we
       // rerun the current page.
       pageScriptHash = currentPageScriptHash
-    } else if (window.__STREAMLIT_BACKEND_URL) {
+    } else if (window.__STREAMLIT_BACKEND_BASE_URL) {
       // We currently don't support navigating directly to a subpage of a
       // multipage app when setting the backend URL of an app to be a different
       // location from where we load index.html. In this case, we set both
       // pageName and pageScriptHash to the empty string, which will result in
       // the app's main page being run.
+      // TODO(vdonato): Support this case or decide we can do without it when
+      // setting a different backend URL.
       pageName = ""
       pageScriptHash = ""
     } else {

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -22,6 +22,7 @@ import { buildHttpUri } from "@streamlit/utils"
 import { DefaultStreamlitEndpoints } from "./DefaultStreamlitEndpoints"
 
 const MOCK_SERVER_URI = {
+  protocol: "http:",
   hostname: "streamlit.mock",
   port: "80",
   pathname: "/mock/base/path",

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -26,6 +26,7 @@ import { getLogger } from "loglevel"
 // Note we expect the polyfill to load from this import
 import { buildHttpUri } from "@streamlit/utils"
 
+import { getBaseUriParts } from "./utils"
 import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   HOST_CONFIG_PATH,
@@ -128,7 +129,15 @@ If you are trying to access a Streamlit app running on another server, this coul
   connect = () => {
     const uriParts = uriPartsList[uriNumber]
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
-    const hostConfigUri = buildHttpUri(uriParts, HOST_CONFIG_PATH)
+
+    const hostConfigServerUriParts = window.__STREAMLIT_HOST_CONFIG_BACKEND_URL
+      ? getBaseUriParts(window.__STREAMLIT_HOST_CONFIG_BACKEND_URL)
+      : uriParts
+
+    const hostConfigUri = buildHttpUri(
+      hostConfigServerUriParts,
+      HOST_CONFIG_PATH
+    )
 
     LOG.info(`Attempting to connect to ${healthzUri}.`)
 

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -130,8 +130,8 @@ If you are trying to access a Streamlit app running on another server, this coul
     const uriParts = uriPartsList[uriNumber]
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
 
-    const hostConfigServerUriParts = window.__STREAMLIT_HOST_CONFIG_BACKEND_URL
-      ? getBaseUriParts(window.__STREAMLIT_HOST_CONFIG_BACKEND_URL)
+    const hostConfigServerUriParts = window.__STREAMLIT_HOST_CONFIG_BASE_URL
+      ? getBaseUriParts(window.__STREAMLIT_HOST_CONFIG_BASE_URL)
       : uriParts
 
     const hostConfigUri = buildHttpUri(

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -73,6 +73,7 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     endpoints: mockEndpoints(),
     baseUriPartsList: [
       {
+        protocol: "http:",
         hostname: "localhost",
         port: "1234",
         pathname: "/",
@@ -92,8 +93,18 @@ function createMockArgs(overrides?: Partial<Args>): Args {
 describe("doInitPings", () => {
   const MOCK_PING_DATA = {
     uri: [
-      { hostname: "not.a.real.host", port: "3000", pathname: "/" },
-      { hostname: "not.a.real.host", port: "3001", pathname: "/" },
+      {
+        protocol: "http:",
+        hostname: "not.a.real.host",
+        port: "3000",
+        pathname: "/",
+      },
+      {
+        protocol: "http:",
+        hostname: "not.a.real.host",
+        port: "3001",
+        pathname: "/",
+      },
     ] as URL[],
     timeoutMs: 10,
     maxTimeoutMs: 100,
@@ -113,6 +124,7 @@ describe("doInitPings", () => {
 
   afterEach(() => {
     axios.get = originalAxiosGet
+    window.__STREAMLIT_HOST_CONFIG_BACKEND_URL = undefined
   })
 
   it("calls the /_stcore/health endpoint when pinging server", async () => {
@@ -133,6 +145,32 @@ describe("doInitPings", () => {
     expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_ORIGINS_CONFIG
     )
+  })
+
+  it("makes the host config call using window.__STREAMLIT_HOST_CONFIG_BACKEND_URL if set", async () => {
+    window.__STREAMLIT_HOST_CONFIG_BACKEND_URL = "https://example.com:1234"
+    axios.get = vi
+      .fn()
+      .mockResolvedValueOnce(MOCK_HEALTH_RESPONSE)
+      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+
+    const uriIndex = await doInitPings(
+      MOCK_PING_DATA.uri,
+      MOCK_PING_DATA.timeoutMs,
+      MOCK_PING_DATA.maxTimeoutMs,
+      MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
+      MOCK_PING_DATA.setAllowedOrigins
+    )
+    expect(uriIndex).toEqual(0)
+    expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_CONFIG
+    )
+    // @ts-expect-error
+    expect(axios.get.mock.calls[1]).toEqual([
+      "https://example.com:1234/_stcore/host-config",
+      { timeout: 15000 },
+    ])
   })
 
   it("returns the uri index and sets hostConfig for the first successful ping (0)", async () => {
@@ -301,8 +339,18 @@ describe("doInitPings", () => {
     const MOCK_PING_DATA_LOCALHOST = {
       ...MOCK_PING_DATA,
       uri: [
-        { hostname: "localhost", port: "3000", pathname: "/" },
-        { hostname: "localhost", port: "3001", pathname: "/" },
+        {
+          protocol: "http:",
+          hostname: "localhost",
+          port: "3000",
+          pathname: "/",
+        },
+        {
+          protocol: "http:",
+          hostname: "localhost",
+          port: "3001",
+          pathname: "/",
+        },
       ] as URL[],
     }
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -124,7 +124,7 @@ describe("doInitPings", () => {
 
   afterEach(() => {
     axios.get = originalAxiosGet
-    window.__STREAMLIT_HOST_CONFIG_BACKEND_URL = undefined
+    window.__STREAMLIT_HOST_CONFIG_BASE_URL = undefined
   })
 
   it("calls the /_stcore/health endpoint when pinging server", async () => {
@@ -147,8 +147,8 @@ describe("doInitPings", () => {
     )
   })
 
-  it("makes the host config call using window.__STREAMLIT_HOST_CONFIG_BACKEND_URL if set", async () => {
-    window.__STREAMLIT_HOST_CONFIG_BACKEND_URL = "https://example.com:1234"
+  it("makes the host config call using window.__STREAMLIT_HOST_CONFIG_BASE_URL if set", async () => {
+    window.__STREAMLIT_HOST_CONFIG_BASE_URL = "https://example.com:1234"
     axios.get = vi
       .fn()
       .mockResolvedValueOnce(MOCK_HEALTH_RESPONSE)

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -26,6 +26,14 @@ import { IAppPage } from "@streamlit/protobuf"
 
 import { ConnectionState } from "./ConnectionState"
 
+// eslint-disable-next-line
+declare global {
+  interface Window {
+    __STREAMLIT_BACKEND_URL?: string
+    __STREAMLIT_HOST_CONFIG_BACKEND_URL?: string
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export type OnMessage = (ForwardMsg: any) => void
 

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -28,9 +28,15 @@ import { ConnectionState } from "./ConnectionState"
 
 // eslint-disable-next-line
 declare global {
+  // These window variables are used so that some deployments of Streamlit can
+  // edit the index.html served to the client so that a Streamlit server at an
+  // origin different from where the frontend static assets are served can be
+  // set. Note that we also need to have a separate `declare global` block here
+  // rather than adding to the one in App.tsx as these also need to be
+  // accessible within this package when no app exists.
   interface Window {
-    __STREAMLIT_BACKEND_URL?: string
-    __STREAMLIT_HOST_CONFIG_BACKEND_URL?: string
+    __STREAMLIT_BACKEND_BASE_URL?: string
+    __STREAMLIT_HOST_CONFIG_BASE_URL?: string
   }
 }
 

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -16,11 +16,7 @@
 
 import { buildHttpUri } from "@streamlit/utils"
 
-import {
-  buildWsUri,
-  getPossibleBaseUris,
-  getWindowBaseUriParts,
-} from "./utils"
+import { buildWsUri, getBaseUriParts, getPossibleBaseUris } from "./utils"
 
 const location: Partial<Location> = {}
 
@@ -30,17 +26,19 @@ Object.defineProperty(window, "location", { value: location })
 test("gets all window URI parts", () => {
   location.href = "https://the_host:9988/foo"
 
-  const { hostname, port, pathname } = getWindowBaseUriParts()
-  expect(hostname).toBe("the_host")
-  expect(port).toBe("9988")
-  expect(pathname).toBe("/foo")
+  expect(getBaseUriParts()).toMatchObject({
+    protocol: "https:",
+    hostname: "the_host",
+    port: "9988",
+    pathname: "/foo",
+  })
 })
 
 test("gets window URI parts without basePath", () => {
   location.href = "https://the_host:9988"
 
-  const parts = getWindowBaseUriParts()
-  expect(parts).toMatchObject({
+  expect(getBaseUriParts()).toMatchObject({
+    protocol: "https:",
     hostname: "the_host",
     port: "9988",
     pathname: "/",
@@ -50,25 +48,43 @@ test("gets window URI parts without basePath", () => {
 test("gets window URI parts with long basePath", () => {
   location.href = "https://the_host:9988/foo/bar"
 
-  const { hostname, port, pathname } = getWindowBaseUriParts()
-  expect(hostname).toBe("the_host")
-  expect(port).toBe("9988")
-  expect(pathname).toBe("/foo/bar")
+  expect(getBaseUriParts()).toMatchObject({
+    protocol: "https:",
+    hostname: "the_host",
+    port: "9988",
+    pathname: "/foo/bar",
+  })
 })
 
 test("gets window URI parts with weird basePath", () => {
   location.href = "https://the_host:9988///foo/bar//"
 
-  const { hostname, port, pathname } = getWindowBaseUriParts()
-  expect(hostname).toBe("the_host")
-  expect(port).toBe("9988")
-  expect(pathname).toBe("/foo/bar")
+  expect(getBaseUriParts()).toMatchObject({
+    protocol: "https:",
+    hostname: "the_host",
+    port: "9988",
+    pathname: "/foo/bar",
+  })
+})
+
+test("Uses provided URL instead of window.location.href to get URI parts if provided", () => {
+  location.href = "https://the_host:9988/foo/bar"
+
+  expect(
+    getBaseUriParts("https://the_other_host:9999/foo/bar/baz")
+  ).toMatchObject({
+    protocol: "https:",
+    hostname: "the_other_host",
+    port: "9999",
+    pathname: "/foo/bar/baz",
+  })
 })
 
 test("builds HTTP URI correctly", () => {
   location.href = "http://something"
   const uri = buildHttpUri(
     {
+      protocol: "http:",
       hostname: "the_host",
       port: "9988",
       pathname: "foo/bar",
@@ -82,6 +98,7 @@ test("builds HTTPS URI correctly", () => {
   location.href = "https://something"
   const uri = buildHttpUri(
     {
+      protocol: "https:",
       hostname: "the_host",
       port: "9988",
       pathname: "foo/bar",
@@ -95,6 +112,7 @@ test("builds HTTP URI with no base path", () => {
   location.href = "http://something"
   const uri = buildHttpUri(
     {
+      protocol: "http:",
       hostname: "the_host",
       port: "9988",
       pathname: "",
@@ -108,6 +126,7 @@ test("builds WS URI correctly", () => {
   location.href = "http://something"
   const uri = buildWsUri(
     {
+      protocol: "http:",
       hostname: "the_host",
       port: "9988",
       pathname: "foo/bar",
@@ -118,9 +137,9 @@ test("builds WS URI correctly", () => {
 })
 
 test("builds WSS URI correctly", () => {
-  location.href = "https://something"
   const uri = buildWsUri(
     {
+      protocol: "https:",
       hostname: "the_host",
       port: "9988",
       pathname: "foo/bar",
@@ -134,6 +153,7 @@ test("builds WS URI with no base path", () => {
   location.href = "http://something"
   const uri = buildWsUri(
     {
+      protocol: "http:",
       hostname: "the_host",
       port: "9988",
       pathname: "",
@@ -152,6 +172,7 @@ describe("getPossibleBaseUris", () => {
 
   afterEach(() => {
     window.location.pathname = originalPathName
+    window.__STREAMLIT_BACKEND_URL = undefined
   })
 
   const testCases = [
@@ -184,6 +205,24 @@ describe("getPossibleBaseUris", () => {
       expect(getPossibleBaseUris().map(b => b.pathname)).toEqual(
         expectedBasePaths
       )
+    })
+  })
+
+  it("Calculates possibleBaseUris with window.__STREAMLIT_BACKEND_URL if set", () => {
+    window.__STREAMLIT_BACKEND_URL = "https://used_host:443/foo/bar"
+    window.location.href = "https://unused_host:443/foo/bar"
+
+    const possibleBaseUris = getPossibleBaseUris()
+    expect(possibleBaseUris[0]).toMatchObject({
+      protocol: "https:",
+      hostname: "used_host",
+      pathname: "/foo/bar",
+    })
+
+    expect(possibleBaseUris[1]).toMatchObject({
+      protocol: "https:",
+      hostname: "used_host",
+      pathname: "/foo",
     })
   })
 })

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -172,7 +172,7 @@ describe("getPossibleBaseUris", () => {
 
   afterEach(() => {
     window.location.pathname = originalPathName
-    window.__STREAMLIT_BACKEND_URL = undefined
+    window.__STREAMLIT_BACKEND_BASE_URL = undefined
   })
 
   const testCases = [
@@ -208,8 +208,8 @@ describe("getPossibleBaseUris", () => {
     })
   })
 
-  it("Calculates possibleBaseUris with window.__STREAMLIT_BACKEND_URL if set", () => {
-    window.__STREAMLIT_BACKEND_URL = "https://used_host:443/foo/bar"
+  it("Calculates possibleBaseUris with window.__STREAMLIT_BACKEND_BASE_URL if set", () => {
+    window.__STREAMLIT_BACKEND_BASE_URL = "https://used_host:443/foo/bar"
     window.location.href = "https://unused_host:443/foo/bar"
 
     const possibleBaseUris = getPossibleBaseUris()

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { isHttps, makePath } from "@streamlit/utils"
+import { makePath } from "@streamlit/utils"
 
 const FINAL_SLASH_RE = /\/+$/
 const INITIAL_SLASH_RE = /^\/+/
 
 /**
- * Return the BaseUriParts for the global window
+ * Return the BaseUriParts for either the given url or the global window
  */
-export function getWindowBaseUriParts(): URL {
-  const currentUrl = new URL(window.location.href)
+export function getBaseUriParts(url?: string): URL {
+  const currentUrl = new URL(url ?? window.location.href)
 
   if (!currentUrl.port) {
-    currentUrl.port = isHttps() ? "443" : "80"
+    currentUrl.port = currentUrl.protocol === "https:" ? "443" : "80"
   }
 
   currentUrl.pathname = currentUrl.pathname
@@ -49,7 +49,7 @@ export function getWindowBaseUriParts(): URL {
 // the best path forward may be tricky as I wasn't able to come up with an
 // easy solution covering every deployment scenario.
 export function getPossibleBaseUris(): Array<URL> {
-  const baseUriParts = getWindowBaseUriParts()
+  const baseUriParts = getBaseUriParts(window.__STREAMLIT_BACKEND_URL)
   const { pathname } = baseUriParts
 
   if (pathname === "/") {
@@ -77,10 +77,10 @@ export function getPossibleBaseUris(): Array<URL> {
  * Create a ws:// or wss:// URI for the given path.
  */
 export function buildWsUri(
-  { hostname, port, pathname }: URL,
+  { hostname, port, pathname, protocol }: URL,
   path: string
 ): string {
-  const protocol = isHttps() ? "wss" : "ws"
+  const wsProtocol = protocol === "https:" ? "wss" : "ws"
   const fullPath = makePath(pathname, path)
-  return `${protocol}://${hostname}:${port}/${fullPath}`
+  return `${wsProtocol}://${hostname}:${port}/${fullPath}`
 }

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -49,7 +49,7 @@ export function getBaseUriParts(url?: string): URL {
 // the best path forward may be tricky as I wasn't able to come up with an
 // easy solution covering every deployment scenario.
 export function getPossibleBaseUris(): Array<URL> {
-  const baseUriParts = getBaseUriParts(window.__STREAMLIT_BACKEND_URL)
+  const baseUriParts = getBaseUriParts(window.__STREAMLIT_BACKEND_BASE_URL)
   const { pathname } = baseUriParts
 
   if (pathname === "/") {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -563,7 +563,7 @@ export function extractPageNameFromPathName(
   // regex special-characters. This is why we're stuck with the
   // weird-looking triple `replace()`.
   return decodeURIComponent(
-    document.location.pathname
+    pathname
       .replace(basePath, "")
       .replace(new RegExp("^/?"), "")
       .replace(new RegExp("/$"), "")

--- a/frontend/utils/src/uri/index.test.ts
+++ b/frontend/utils/src/uri/index.test.ts
@@ -16,7 +16,7 @@
 
 import { MockInstance } from "vitest"
 
-import { buildHttpUri, isHttps, isLocalhost, makePath } from "."
+import { buildHttpUri, isLocalhost, makePath } from "."
 
 describe("uri", () => {
   let originalLocation: Location
@@ -33,12 +33,9 @@ describe("uri", () => {
 
   describe("buildHttpUri", () => {
     it("builds HTTP URI correctly", () => {
-      windowSpy.mockReturnValue({
-        ...originalLocation,
-        href: "http://something",
-      })
       const uri = buildHttpUri(
         {
+          protocol: "http:",
           hostname: "the_host",
           port: "9988",
           pathname: "foo/bar",
@@ -49,12 +46,9 @@ describe("uri", () => {
     })
 
     it("builds HTTPS URI correctly", () => {
-      windowSpy.mockReturnValue({
-        ...originalLocation,
-        href: "https://something",
-      })
       const uri = buildHttpUri(
         {
+          protocol: "https:",
           hostname: "the_host",
           port: "9988",
           pathname: "foo/bar",
@@ -65,12 +59,9 @@ describe("uri", () => {
     })
 
     it("builds HTTP URI with no base path", () => {
-      windowSpy.mockReturnValue({
-        ...originalLocation,
-        href: "http://something",
-      })
       const uri = buildHttpUri(
         {
+          protocol: "http:",
           hostname: "the_host",
           port: "9988",
           pathname: "",
@@ -90,24 +81,6 @@ describe("uri", () => {
     it("makes path with no base path", () => {
       const path = makePath("", "baz")
       expect(path).toBe("baz")
-    })
-  })
-
-  describe("isHttps", () => {
-    it("returns true for HTTPS", () => {
-      windowSpy.mockReturnValue({
-        ...originalLocation,
-        href: "https://something",
-      })
-      expect(isHttps()).toBe(true)
-    })
-
-    it("returns false for HTTP", () => {
-      windowSpy.mockReturnValue({
-        ...originalLocation,
-        href: "http://something",
-      })
-      expect(isHttps()).toBe(false)
     })
   })
 

--- a/frontend/utils/src/uri/index.ts
+++ b/frontend/utils/src/uri/index.ts
@@ -21,12 +21,11 @@ const INITIAL_SLASH_RE = /^\/+/
  * Create an HTTP URI for the given path.
  */
 export function buildHttpUri(
-  { hostname, port, pathname }: URL,
+  { hostname, port, pathname, protocol }: URL,
   path: string
 ): string {
-  const protocol = isHttps() ? "https" : "http"
   const fullPath = makePath(pathname, path)
-  return `${protocol}://${hostname}:${port}/${fullPath}`
+  return `${protocol}//${hostname}:${port}/${fullPath}`
 }
 
 export function makePath(basePath: string, subPath: string): string {
@@ -38,13 +37,6 @@ export function makePath(basePath: string, subPath: string): string {
   }
 
   return `${basePath}/${subPath}`
-}
-
-/**
- * True if we're connected to the host via HTTPS.
- */
-export function isHttps(): boolean {
-  return window.location.href.startsWith("https://")
 }
 
 export const isLocalhost = (): boolean => {


### PR DESCRIPTION
## Describe your changes

In some new (Snowflake-internal) deployments of Streamlit, we want to be able to configure an
app to load its `index.html` from one origin but make requests to a Streamlit server at another.
This PR enables this by reading the `window.__STREAMLIT_BACKEND_BASE_URL` and
`window.__STREAMLIT_HOST_CONFIG_BASE_URL` variables and sending requests meant
for the Streamlit server to those URLs if the variables are set. Otherwise, we continue to assume
that the server can be reached at `window.location.href` as usual.

The `index.html` served by this deployment will then be modified to set these variables in
`<script>` tags to configure these URLs.

This may also eventually be useful more generally by the Open Source community in some scenarios
where an app developer, for example, wants to serve the static assets of their app from a CDN while
hosting their Streamlit server at a different origin, but we'll need to make improvements to our
documentation + provide some additional tooling before we can consider this broadly supported.

Note that:

* We also made a small refactor to get rid of the `isHttps` helper function since it's redundant on top
   of the `protocol` field that's already set when parsing a URL.
* When `window.__STREAMLIT_BACKEND_BASE_URL` is set, we currently expect there to be some weirdness
   that happens with multipage apps and the browser's forward/back buttons, but given this behavior isn't
   exposed unless you're changing Streamlit internals, and since fixing this will require some thought, we punt
   on it for now.

## Testing Plan

- Unit Tests (JS and/or Python)
   - Added JS unit tests 
- Any manual testing needed?
   - We're not quite at the point where we can test this e2e just yet and won't be for a few weeks, but merging this code should still be fine since behavior will be totally unchanged in the regular PyPI distribution of Streamlit. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.