### PR TITLE
[refactor] Lazily load react-syntax-highlighter to reduce initial bundle size

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -248,6 +248,11 @@ module.exports = {
             name: "timezone-mock",
             message: "Please use the withTimezones test harness instead",
           },
+          {
+            name: "react-syntax-highlighter",
+            message:
+              "Please use the LazySyntaxHighlighter import instead of the direct import of react-syntax-highlighter for bundle size reasons.",
+          },
         ],
       },
     ],

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
@@ -16,6 +16,8 @@
 
 import React from "react"
 
+import { waitFor } from "@testing-library/react"
+
 import { render } from "~lib/test_util"
 
 import StreamlitSyntaxHighlighter, {
@@ -35,49 +37,65 @@ st.write("Hello")
 })
 
 describe("CustomCodeTag Element", () => {
-  it("should render without crashing", () => {
+  it("should render without crashing", async () => {
     const props = getStreamlitSyntaxHighlighterProps()
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
 
-    expect(baseElement.querySelectorAll("pre code")).toHaveLength(1)
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(baseElement.querySelectorAll("pre code")).toHaveLength(1)
+    })
   })
 
-  it("should render as plaintext", () => {
+  it("should render as plaintext", async () => {
     const props = getStreamlitSyntaxHighlighterProps({ language: "plaintext" })
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
 
-    expect(baseElement.querySelector("pre code")?.outerHTML).toBe(
-      '<code class="language-plaintext" style="white-space: pre;"><span>import streamlit as st\n' +
-        "</span>\n" +
-        'st.write("Hello")\n' +
-        "</code>"
-    )
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(baseElement.querySelector("pre code")?.outerHTML).toBe(
+        '<code class="language-plaintext" style="white-space: pre;"><span>import streamlit as st\n' +
+          "</span>\n" +
+          'st.write("Hello")\n' +
+          "</code>"
+      )
+    })
   })
 
-  it("should render as plaintext if no language specified", () => {
+  it("should render as plaintext if no language specified", async () => {
     const props = getStreamlitSyntaxHighlighterProps({ language: "plaintext" })
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
 
-    expect(baseElement.querySelector("pre code")?.outerHTML).toBe(
-      '<code class="language-plaintext" style="white-space: pre;"><span>import streamlit as st\n' +
-        "</span>\n" +
-        'st.write("Hello")\n' +
-        "</code>"
-    )
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(baseElement.querySelector("pre code")?.outerHTML).toBe(
+        '<code class="language-plaintext" style="white-space: pre;"><span>import streamlit as st\n' +
+          "</span>\n" +
+          'st.write("Hello")\n' +
+          "</code>"
+      )
+    })
   })
 
-  it("should render as python", () => {
+  it("should render as python", async () => {
     const props = getStreamlitSyntaxHighlighterProps({ language: "python" })
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
-    expect(
-      baseElement.querySelector("pre code .token.string")?.innerHTML
-    ).toBe('"Hello"')
+
+    await waitFor(() => {
+      expect(
+        // eslint-disable-next-line testing-library/no-node-access
+        baseElement.querySelector("pre code .token.string")?.innerHTML
+      ).toBe('"Hello"')
+    })
   })
 
-  it("applies height style when height prop is provided", () => {
+  it("applies height style when height prop is provided", async () => {
     const props = getStreamlitSyntaxHighlighterProps({ height: 200 })
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
 
-    expect(baseElement.querySelector("pre")).toHaveStyle({ height: "200px" })
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(baseElement.querySelector("pre")).toHaveStyle({ height: "200px" })
+    })
   })
 })

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback } from "react"
+import React, { memo, ReactElement, Suspense, useCallback } from "react"
 
 import {
   SyntaxHighlighter,
@@ -94,24 +94,26 @@ function StreamlitSyntaxHighlighter({
   return (
     <StyledCodeBlock className="stCode" data-testid="stCode">
       <StyledPre height={height}>
-        <SyntaxHighlighter
-          language={language}
-          PreTag="div"
-          customStyle={{ backgroundColor: "transparent" }}
-          // We set an empty style object here because we have our own CSS styling that
-          // reacts on our theme.
-          style={{}}
-          lineNumberStyle={{}}
-          showLineNumbers={showLineNumbers}
-          wrapLongLines={wrapLines}
-          // Fix bug with wrapLongLines+showLineNumbers (see link below) by
-          // using a renderer that wraps individual lines of code in their
-          // own spans.
-          // https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/376
-          renderer={needsCustomRenderer ? renderer : undefined}
-        >
-          {children}
-        </SyntaxHighlighter>
+        <Suspense fallback={<></>}>
+          <SyntaxHighlighter
+            language={language}
+            PreTag="div"
+            customStyle={{ backgroundColor: "transparent" }}
+            // We set an empty style object here because we have our own CSS styling that
+            // reacts on our theme.
+            style={{}}
+            lineNumberStyle={{}}
+            showLineNumbers={showLineNumbers}
+            wrapLongLines={wrapLines}
+            // Fix bug with wrapLongLines+showLineNumbers (see link below) by
+            // using a renderer that wraps individual lines of code in their
+            // own spans.
+            // https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/376
+            renderer={needsCustomRenderer ? renderer : undefined}
+          >
+            {children}
+          </SyntaxHighlighter>
+        </Suspense>
       </StyledPre>
       {typeof children === "string" && children.trim() !== "" && (
         <StyledCopyButtonContainer>

--- a/frontend/lib/src/components/shared/LazySyntaxHighlighter/ReactSyntaxHighlighter.ts
+++ b/frontend/lib/src/components/shared/LazySyntaxHighlighter/ReactSyntaxHighlighter.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { lazy, useEffect, useState } from "react"
+
+/**
+ * This is a lazy-loaded Prism component from react-syntax-highlighter.
+ * It's done async because the react-syntax-highlighter package is large.
+ *
+ * @returns The Prism component from react-syntax-highlighter
+ */
+export const SyntaxHighlighter = lazy(() =>
+  import("react-syntax-highlighter").then(m => {
+    return {
+      default: m.Prism,
+    }
+  })
+)
+
+export type CreateElementFunction =
+  typeof import("react-syntax-highlighter").createElement
+
+/**
+ * This is a lazy-loaded createElement function from react-syntax-highlighter.
+ * It's done async because the react-syntax-highlighter package is large.
+ *
+ * @returns The createElement function from react-syntax-highlighter, or null if it's not loaded yet.
+ */
+export const useLazyCreateElement = (): CreateElementFunction | null => {
+  const [loadedCreateElementFn, setLoadedCreateElementFn] =
+    useState<CreateElementFunction | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const doWork = async (): Promise<void> => {
+      const loadedModule = await import("react-syntax-highlighter")
+      const { createElement } = loadedModule
+
+      if (isMounted) {
+        setLoadedCreateElementFn(() => createElement)
+      }
+    }
+
+    doWork()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return loadedCreateElementFn
+}

--- a/frontend/lib/src/components/shared/LazySyntaxHighlighter/index.ts
+++ b/frontend/lib/src/components/shared/LazySyntaxHighlighter/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./ReactSyntaxHighlighter"

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -39,11 +39,11 @@ const getHeadingProps = (
 })
 
 describe("Heading", () => {
-  it("renders properly after a new line", () => {
+  it("renders properly after a new line", async () => {
     const props = getHeadingProps()
     render(<Heading {...props} />)
 
-    const heading = screen.getByRole("heading")
+    const heading = await screen.findByRole("heading")
     expect(heading).toHaveTextContent("hello world")
     expect(heading).not.toHaveTextContent("this is a new line")
     expect(screen.getByText("this is a new line")).toBeInTheDocument()
@@ -162,7 +162,7 @@ describe("Heading", () => {
     expect(screen.queryByRole("blockquote")).not.toBeInTheDocument()
   })
 
-  it("does not render tables", () => {
+  it("does not render tables", async () => {
     const props = getHeadingProps({
       body: `| Syntax | Description |
            | ----------- | ----------- |
@@ -171,7 +171,7 @@ describe("Heading", () => {
     })
     render(<Heading {...props} />)
 
-    expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
+    expect(await screen.findByTestId("stMarkdownContainer")).toHaveTextContent(
       "| Syntax | Description || ----------- | ----------- | | Header | Title | | Paragraph | Text |"
     )
     expect(screen.getByRole("heading")).toHaveTextContent(
@@ -188,12 +188,12 @@ describe("Heading", () => {
     expect(screen.queryByTestId("stHeadingDivider")).not.toBeInTheDocument()
   })
 
-  it("renders a divider with given color", () => {
+  it("renders a divider with given color", async () => {
     // correct divider color mapping handled in Block.tsx
     const props = getHeadingProps({ divider: "#0068c9" })
     render(<Heading {...props} />)
 
-    const divider = screen.getByTestId("stHeadingDivider")
+    const divider = await screen.findByTestId("stHeadingDivider")
     expect(divider).toBeInTheDocument()
     expect(divider).toHaveStyle("background-color: #0068c9")
   })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -46,27 +46,27 @@ describe("Heading", () => {
     const heading = await screen.findByRole("heading")
     expect(heading).toHaveTextContent("hello world")
     expect(heading).not.toHaveTextContent("this is a new line")
-    expect(screen.getByText("this is a new line")).toBeInTheDocument()
+    expect(await screen.findByText("this is a new line")).toBeInTheDocument()
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
 
     const headingElement = screen.getByTestId("stHeading")
     expect(headingElement).toHaveClass("stHeading")
   })
 
-  it("renders properly without a new line", () => {
+  it("renders properly without a new line", async () => {
     const props = getHeadingProps({ body: "hello" })
     render(<Heading {...props} />)
 
-    expect(screen.getByRole("heading")).toHaveTextContent("hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("hello")
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
   })
 
-  it("renders anchor link", () => {
+  it("renders anchor link", async () => {
     const props = getHeadingProps({ body: "hello" })
     render(<Heading {...props} />)
 
     // trying to trigger the :hover css state did not work, so using 'hidden: true' here. We have an e2e test to check the hovering.
-    const link = screen.getByRole("link", { hidden: true })
+    const link = await screen.findByRole("link", { hidden: true })
     expect(link).toHaveAttribute("href", "#some-anchor")
   })
 
@@ -97,18 +97,18 @@ describe("Heading", () => {
     expect(screen.queryByRole("link")).not.toBeInTheDocument()
   })
 
-  it("renders properly with help text", () => {
+  it("renders properly with help text", async () => {
     const props = getHeadingProps({ body: "hello", help: "help text" })
     render(<Heading {...props} />)
 
-    expect(screen.getByRole("heading")).toHaveTextContent("hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("hello")
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
 
-    const tooltip = screen.getByTestId("stTooltipIcon")
+    const tooltip = await screen.findByTestId("stTooltipIcon")
     expect(tooltip).toBeInTheDocument()
   })
 
-  it("renders properly with help text in sidebar", () => {
+  it("renders properly with help text in sidebar", async () => {
     const props = getHeadingProps({ body: "hello", help: "help text" })
     render(
       <IsSidebarContext.Provider value={true}>
@@ -116,14 +116,14 @@ describe("Heading", () => {
       </IsSidebarContext.Provider>
     )
 
-    expect(screen.getByRole("heading")).toHaveTextContent("hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("hello")
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
 
-    const tooltip = screen.getByTestId("stTooltipIcon")
+    const tooltip = await screen.findByTestId("stTooltipIcon")
     expect(tooltip).toBeInTheDocument()
   })
 
-  it("renders properly with help text in dialog", () => {
+  it("renders properly with help text in dialog", async () => {
     const props = getHeadingProps({ body: "hello", help: "help text" })
     render(
       <IsDialogContext.Provider value={true}>
@@ -131,34 +131,34 @@ describe("Heading", () => {
       </IsDialogContext.Provider>
     )
 
-    expect(screen.getByRole("heading")).toHaveTextContent("hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("hello")
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
 
-    const tooltip = screen.getByTestId("stTooltipIcon")
+    const tooltip = await screen.findByTestId("stTooltipIcon")
     expect(tooltip).toBeInTheDocument()
   })
 
-  it("does not render ol block", () => {
+  it("does not render ol block", async () => {
     const props = getHeadingProps({ body: "1) hello" })
     render(<Heading {...props} />)
 
-    expect(screen.getByRole("heading")).toHaveTextContent("1) hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("1) hello")
     expect(screen.queryByRole("list")).not.toBeInTheDocument()
   })
 
-  it("does not render ul block", () => {
+  it("does not render ul block", async () => {
     const props = getHeadingProps({ body: "* hello" })
     render(<Heading {...props} />)
 
-    expect(screen.getByRole("heading")).toHaveTextContent("* hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent("* hello")
     expect(screen.queryByRole("list")).not.toBeInTheDocument()
   })
 
-  it("does not render blockquote with >", () => {
+  it("does not render blockquote with >", async () => {
     const props = getHeadingProps({ body: ">hello" })
     render(<Heading {...props} />)
 
-    expect(screen.getByRole("heading")).toHaveTextContent(">hello")
+    expect(await screen.findByRole("heading")).toHaveTextContent(">hello")
     expect(screen.queryByRole("blockquote")).not.toBeInTheDocument()
   })
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -18,7 +18,7 @@ import React, { ReactElement } from "react"
 
 import ReactMarkdown from "react-markdown"
 // eslint-disable-next-line testing-library/no-manual-cleanup
-import { cleanup, screen } from "@testing-library/react"
+import { cleanup, screen, waitFor } from "@testing-library/react"
 import { transparentize } from "color2k"
 
 import { render } from "~lib/test_util"
@@ -535,8 +535,12 @@ describe("CustomCodeTag Element", () => {
     const props = getCustomCodeTagProps({ className: "language-plaintext" })
     render(<CustomCodeTag {...props} />)
 
-    const stCode = await screen.findByTestId("stCode")
-    expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(-1)
+    await waitFor(async () => {
+      const stCode = await screen.findByTestId("stCode")
+      expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(
+        -1
+      )
+    })
   })
 
   it("should render copy button when code block has content", async () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -523,28 +523,28 @@ st.write("Hello")
 })
 
 describe("CustomCodeTag Element", () => {
-  it("should render without crashing", () => {
+  it("should render without crashing", async () => {
     const props = getCustomCodeTagProps()
     render(<CustomCodeTag {...props} />)
 
-    const stCode = screen.getByTestId("stCode")
+    const stCode = await screen.findByTestId("stCode")
     expect(stCode).toBeInTheDocument()
   })
 
-  it("should render as plaintext", () => {
+  it("should render as plaintext", async () => {
     const props = getCustomCodeTagProps({ className: "language-plaintext" })
     render(<CustomCodeTag {...props} />)
 
-    const stCode = screen.getByTestId("stCode")
+    const stCode = await screen.findByTestId("stCode")
     expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(-1)
   })
 
-  it("should render copy button when code block has content", () => {
+  it("should render copy button when code block has content", async () => {
     const props = getCustomCodeTagProps({
       children: ["i am not empty"],
     })
     render(<CustomCodeTag {...props} />)
-    const copyButton = screen.getByTitle("Copy to clipboard")
+    const copyButton = await screen.findByTitle("Copy to clipboard")
 
     expect(copyButton).not.toBeNull()
   })


### PR DESCRIPTION
## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
