### PR TITLE
Refactor/move width config to element

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -113,7 +113,7 @@ describe("FlexBoxContainer Block Component", () => {
     const block: BlockNode = makeVerticalBlock(
       [makeHorizontalBlockWithColumns(4)],
       {
-        flexContainer: { heightConfig: { pixelHeight: 100 } },
+        heightConfig: { pixelHeight: 100 },
       }
     )
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -256,9 +256,6 @@ const BlockNodeRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
 
   const styles = useLayoutStyles({
     element: node.deltaBlock,
-    subElement:
-      (node.deltaBlock.type && node.deltaBlock[node.deltaBlock.type]) ||
-      undefined,
   })
 
   if (node.isEmpty && !node.deltaBlock.allowEmpty) {

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -256,6 +256,9 @@ const BlockNodeRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
 
   const styles = useLayoutStyles({
     element: node.deltaBlock,
+    subElement:
+      (node.deltaBlock.type && node.deltaBlock[node.deltaBlock.type]) ||
+      undefined,
   })
 
   if (node.isEmpty && !node.deltaBlock.allowEmpty) {

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -31,8 +31,6 @@ export const StyledElementContainerLayoutWrapper: FC<
 > = ({ node, ...rest }) => {
   const styles = useLayoutStyles({
     element: node.element,
-    subElement:
-      (node.element?.type && node.element[node.element.type]) || undefined,
   })
 
   return <StyledElementContainer {...rest} {...styles} />

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -31,6 +31,8 @@ export const StyledElementContainerLayoutWrapper: FC<
 > = ({ node, ...rest }) => {
   const styles = useLayoutStyles({
     element: node.element,
+    subElement:
+      (node.element?.type && node.element[node.element.type]) || undefined,
   })
 
   return <StyledElementContainer {...rest} {...styles} />

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -316,7 +316,7 @@ describe("getHeightBackwardsCompatible", () => {
     {
       description:
         "returns pixelHeight when flexContainer.heightConfig.pixelHeight exists",
-      blockProto: { flexContainer: { heightConfig: { pixelHeight: 100 } } },
+      blockProto: { heightConfig: { pixelHeight: 100 } },
       expected: 100,
     },
     {
@@ -333,7 +333,7 @@ describe("getHeightBackwardsCompatible", () => {
       description:
         "prioritizes flexContainer.heightConfig.pixelHeight when both exist",
       blockProto: {
-        flexContainer: { heightConfig: { pixelHeight: 300 } },
+        heightConfig: { pixelHeight: 300 },
         vertical: { height: 400 },
       },
       expected: 300,
@@ -389,7 +389,7 @@ describe("getActivateScrollToBottomBackwardsCompatible", () => {
 
   it("returns true when flexContainer has heightConfig and has chatMessage child", () => {
     const mockNode = createBlockNode(
-      { flexContainer: { heightConfig: { pixelHeight: 100 } } },
+      { heightConfig: { pixelHeight: 100 } },
       true // Has chatMessage child
     )
 
@@ -407,7 +407,7 @@ describe("getActivateScrollToBottomBackwardsCompatible", () => {
 
   it("returns false when has height but no chatMessage child", () => {
     const mockNode = createBlockNode(
-      { flexContainer: { heightConfig: { pixelHeight: 100 } } },
+      { heightConfig: { pixelHeight: 100 } },
       false // No chatMessage child
     )
 

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -236,8 +236,8 @@ export function getHeightBackwardsCompatible(
   // TODO: when height and width are added for containers, this will be calculated with
   // useLayoutStyles. Currently we are only using pixel height based on the pre-advanced layouts
   // feature.
-  if (blockProto.flexContainer?.heightConfig?.pixelHeight) {
-    return blockProto.flexContainer?.heightConfig?.pixelHeight
+  if (blockProto.heightConfig?.pixelHeight) {
+    return blockProto.heightConfig?.pixelHeight
   } else if (blockProto.vertical?.height) {
     return blockProto.vertical?.height
   }

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -209,8 +209,7 @@ export function getActivateScrollToBottomBackwardsCompatible(
   blockNode: BlockNode
 ): boolean {
   const hasHeight =
-    blockNode.deltaBlock.flexContainer?.heightConfig ||
-    blockNode.deltaBlock.vertical?.height
+    blockNode.deltaBlock.heightConfig || blockNode.deltaBlock.vertical?.height
   if (
     hasHeight &&
     blockNode.children.some(node => {

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -23,13 +23,16 @@ import { useLayoutStyles, UseLayoutStylesShape } from "./useLayoutStyles"
 
 class MockElement implements Element {
   widthConfig?: streamlit.WidthConfig | null
-
   heightConfig?: streamlit.HeightConfig | null
-
-  type?: "imgs" | "textArea"
+  type?: "imgs" | "textArea" | "button" | "alert";
+  [key: string]: any
 
   constructor(props: Partial<MockElement> = {}) {
     Object.assign(this, props)
+    // If type is provided, set the subElement as a property with the same name
+    if (props.type && props[props.type]) {
+      this[props.type] = props[props.type]
+    }
   }
 
   toJSON(): MockElement {
@@ -56,11 +59,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({})],
         [100, getDefaultStyles({ width: 100 })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement()
-        const subElement = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const element = new MockElement({
+          type: "button",
+          button: { width, useContainerWidth },
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -75,18 +78,16 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({ width: "100%" })],
         [100, getDefaultStyles({ width: "100%" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement()
-        const subElement = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const element = new MockElement({
+          type: "button",
+          button: { width, useContainerWidth },
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
 
     describe("that is an image list", () => {
-      const useContainerWidth = false
-
       it.each([
         [undefined, getDefaultStyles({ width: "100%" })],
         [0, getDefaultStyles({ width: "100%" })],
@@ -94,11 +95,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({ width: "100%" })],
         [100, getDefaultStyles({ width: "100%" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement({ type: "imgs" })
-        const subElement = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const element = new MockElement({
+          type: "imgs",
+          imgs: { width },
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -138,11 +139,12 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with a widthConfig value of %o and useContainerWidth %s, returns %o",
         (widthConfig, useContainerWidth, expected) => {
-          const element = new MockElement({ widthConfig })
-          const subElement = { useContainerWidth }
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement })
-          )
+          const element = new MockElement({
+            type: "button",
+            button: { useContainerWidth },
+            widthConfig,
+          })
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -162,12 +164,11 @@ describe("#useLayoutStyles", () => {
         "and with a pixelWidth value of %s and useContainerWidth %s, returns %o",
         (pixelWidth, useContainerWidth, expected) => {
           const element = new MockElement({
+            type: "button",
+            button: { useContainerWidth },
             widthConfig: new streamlit.WidthConfig({ pixelWidth }),
           })
-          const subElement = { useContainerWidth }
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement })
-          )
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -185,12 +186,11 @@ describe("#useLayoutStyles", () => {
         ],
       ])("and with element %o, returns %o", (props, expected) => {
         const element = new MockElement({
+          type: "button",
+          button: { useContainerWidth: props.useContainerWidth },
           widthConfig: props.widthConfig,
         })
-        const subElement = { useContainerWidth: props.useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -257,17 +257,11 @@ describe("#useLayoutStyles", () => {
         "and with element props %o and useContainerWidth %s, returns %o",
         (props, useContainerWidth, expected) => {
           const element = new MockElement({
+            type: "button",
+            button: { width: props.width, useContainerWidth },
             widthConfig: props.widthConfig,
           })
-
-          const subElement = {
-            width: props.width,
-            useContainerWidth,
-          }
-
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement })
-          )
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -289,17 +283,11 @@ describe("#useLayoutStyles", () => {
         "and with a width value of %s, useContainerWidth %s, and widthConfig %s, returns %o",
         (width, useContainerWidth, widthConfig, expected) => {
           const element = new MockElement({
+            type: "button",
+            button: { width, useContainerWidth },
             widthConfig,
           })
-
-          const subElement = {
-            width,
-            useContainerWidth,
-          }
-
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement })
-          )
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -322,7 +310,11 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with a heightConfig value of %o, returns %o",
         (heightConfig, expected) => {
-          const element = new MockElement({ heightConfig })
+          const element = new MockElement({
+            type: "button",
+            button: {},
+            heightConfig,
+          })
           const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
@@ -338,6 +330,8 @@ describe("#useLayoutStyles", () => {
         "and with a pixelHeight value of %s, returns %o",
         (pixelHeight, expected) => {
           const element = new MockElement({
+            type: "button",
+            button: {},
             heightConfig: new streamlit.HeightConfig({ pixelHeight }),
           })
           const { result } = renderHook(() => useLayoutStyles({ element }))
@@ -362,16 +356,11 @@ describe("#useLayoutStyles", () => {
         "and with a height value of %s and heightConfig %s, returns %o",
         (height, heightConfig, expected) => {
           const element = new MockElement({
+            type: "button",
+            button: { height },
             heightConfig,
           })
-
-          const subElement = {
-            height,
-          }
-
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement })
-          )
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -385,11 +374,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({})],
         [100, getDefaultStyles({ height: 100, overflow: "auto" })],
       ])("and with a height value of %s, returns %o", (height, expected) => {
-        const element = new MockElement()
-        const subElement = { height }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const element = new MockElement({
+          type: "button",
+          button: { height },
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -413,9 +402,9 @@ describe("#useLayoutStyles", () => {
       ])("and with heightConfig %s, returns %o", (heightConfig, expected) => {
         const element = new MockElement({
           type: "textArea",
+          textArea: {},
           heightConfig,
         })
-
         const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
@@ -467,16 +456,11 @@ describe("#useLayoutStyles", () => {
         ],
       ])("and with element props %o, returns %o", (props, expected) => {
         const element = new MockElement({
+          type: "button",
+          button: { height: props.height },
           heightConfig: props.heightConfig,
         })
-
-        const subElement = {
-          height: props.height,
-        }
-
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
+        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -505,7 +489,11 @@ describe("#useLayoutStyles", () => {
           getDefaultStyles({ width: "fit-content", height: "auto" }),
         ],
       ])("and with element props %o, returns %o", (props, expected) => {
-        const element = new MockElement(props)
+        const element = new MockElement({
+          type: "button",
+          button: {},
+          ...props,
+        })
         const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
@@ -528,10 +516,11 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with subElement props %o, returns %o",
         (subElementProps, expected) => {
-          const element = new MockElement()
-          const { result } = renderHook(() =>
-            useLayoutStyles({ element, subElement: subElementProps })
-          )
+          const element = new MockElement({
+            type: "button",
+            button: subElementProps,
+          })
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )
@@ -566,19 +555,13 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with subElement widthConfig %o, returns %o",
         (props, expected) => {
-          const element = new MockElement()
-
-          // Use type assertion to bypass TypeScript checks
-          const subElement = {
-            widthConfig: props.subElementWidthConfig,
-          } as IAlert
-
-          const { result } = renderHook(() =>
-            useLayoutStyles({
-              element,
-              subElement,
-            })
-          )
+          const element = new MockElement({
+            type: "alert",
+            alert: {
+              widthConfig: props.subElementWidthConfig,
+            },
+          })
+          const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
       )

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -23,16 +23,13 @@ import { useLayoutStyles, UseLayoutStylesShape } from "./useLayoutStyles"
 
 class MockElement implements Element {
   widthConfig?: streamlit.WidthConfig | null
+
   heightConfig?: streamlit.HeightConfig | null
-  type?: "imgs" | "textArea" | "button" | "alert";
-  [key: string]: any
+
+  type?: "imgs" | "textArea"
 
   constructor(props: Partial<MockElement> = {}) {
     Object.assign(this, props)
-    // If type is provided, set the subElement as a property with the same name
-    if (props.type && props[props.type]) {
-      this[props.type] = props[props.type]
-    }
   }
 
   toJSON(): MockElement {
@@ -59,11 +56,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({})],
         [100, getDefaultStyles({ width: 100 })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement({
-          type: "button",
-          button: { width, useContainerWidth },
-        })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+        const element = new MockElement()
+        const subElement = { width, useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
@@ -78,16 +75,18 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({ width: "100%" })],
         [100, getDefaultStyles({ width: "100%" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement({
-          type: "button",
-          button: { width, useContainerWidth },
-        })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+        const element = new MockElement()
+        const subElement = { width, useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
 
     describe("that is an image list", () => {
+      const useContainerWidth = false
+
       it.each([
         [undefined, getDefaultStyles({ width: "100%" })],
         [0, getDefaultStyles({ width: "100%" })],
@@ -95,11 +94,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({ width: "100%" })],
         [100, getDefaultStyles({ width: "100%" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement({
-          type: "imgs",
-          imgs: { width },
-        })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+        const element = new MockElement({ type: "imgs" })
+        const subElement = { width, useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
@@ -139,12 +138,11 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with a widthConfig value of %o and useContainerWidth %s, returns %o",
         (widthConfig, useContainerWidth, expected) => {
-          const element = new MockElement({
-            type: "button",
-            button: { useContainerWidth },
-            widthConfig,
-          })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+          const element = new MockElement({ widthConfig })
+          const subElement = { useContainerWidth }
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -164,11 +162,12 @@ describe("#useLayoutStyles", () => {
         "and with a pixelWidth value of %s and useContainerWidth %s, returns %o",
         (pixelWidth, useContainerWidth, expected) => {
           const element = new MockElement({
-            type: "button",
-            button: { useContainerWidth },
             widthConfig: new streamlit.WidthConfig({ pixelWidth }),
           })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+          const subElement = { useContainerWidth }
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -186,11 +185,12 @@ describe("#useLayoutStyles", () => {
         ],
       ])("and with element %o, returns %o", (props, expected) => {
         const element = new MockElement({
-          type: "button",
-          button: { useContainerWidth: props.useContainerWidth },
           widthConfig: props.widthConfig,
         })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+        const subElement = { useContainerWidth: props.useContainerWidth }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
@@ -257,11 +257,17 @@ describe("#useLayoutStyles", () => {
         "and with element props %o and useContainerWidth %s, returns %o",
         (props, useContainerWidth, expected) => {
           const element = new MockElement({
-            type: "button",
-            button: { width: props.width, useContainerWidth },
             widthConfig: props.widthConfig,
           })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+
+          const subElement = {
+            width: props.width,
+            useContainerWidth,
+          }
+
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -283,11 +289,17 @@ describe("#useLayoutStyles", () => {
         "and with a width value of %s, useContainerWidth %s, and widthConfig %s, returns %o",
         (width, useContainerWidth, widthConfig, expected) => {
           const element = new MockElement({
-            type: "button",
-            button: { width, useContainerWidth },
             widthConfig,
           })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+
+          const subElement = {
+            width,
+            useContainerWidth,
+          }
+
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -310,11 +322,7 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with a heightConfig value of %o, returns %o",
         (heightConfig, expected) => {
-          const element = new MockElement({
-            type: "button",
-            button: {},
-            heightConfig,
-          })
+          const element = new MockElement({ heightConfig })
           const { result } = renderHook(() => useLayoutStyles({ element }))
           expect(result.current).toEqual(expected)
         }
@@ -330,8 +338,6 @@ describe("#useLayoutStyles", () => {
         "and with a pixelHeight value of %s, returns %o",
         (pixelHeight, expected) => {
           const element = new MockElement({
-            type: "button",
-            button: {},
             heightConfig: new streamlit.HeightConfig({ pixelHeight }),
           })
           const { result } = renderHook(() => useLayoutStyles({ element }))
@@ -356,11 +362,16 @@ describe("#useLayoutStyles", () => {
         "and with a height value of %s and heightConfig %s, returns %o",
         (height, heightConfig, expected) => {
           const element = new MockElement({
-            type: "button",
-            button: { height },
             heightConfig,
           })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+
+          const subElement = {
+            height,
+          }
+
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -374,11 +385,11 @@ describe("#useLayoutStyles", () => {
         [NaN, getDefaultStyles({})],
         [100, getDefaultStyles({ height: 100, overflow: "auto" })],
       ])("and with a height value of %s, returns %o", (height, expected) => {
-        const element = new MockElement({
-          type: "button",
-          button: { height },
-        })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+        const element = new MockElement()
+        const subElement = { height }
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
@@ -402,9 +413,9 @@ describe("#useLayoutStyles", () => {
       ])("and with heightConfig %s, returns %o", (heightConfig, expected) => {
         const element = new MockElement({
           type: "textArea",
-          textArea: {},
           heightConfig,
         })
+
         const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
@@ -456,11 +467,16 @@ describe("#useLayoutStyles", () => {
         ],
       ])("and with element props %o, returns %o", (props, expected) => {
         const element = new MockElement({
-          type: "button",
-          button: { height: props.height },
           heightConfig: props.heightConfig,
         })
-        const { result } = renderHook(() => useLayoutStyles({ element }))
+
+        const subElement = {
+          height: props.height,
+        }
+
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, subElement })
+        )
         expect(result.current).toEqual(expected)
       })
     })
@@ -489,11 +505,7 @@ describe("#useLayoutStyles", () => {
           getDefaultStyles({ width: "fit-content", height: "auto" }),
         ],
       ])("and with element props %o, returns %o", (props, expected) => {
-        const element = new MockElement({
-          type: "button",
-          button: {},
-          ...props,
-        })
+        const element = new MockElement(props)
         const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
@@ -516,11 +528,10 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with subElement props %o, returns %o",
         (subElementProps, expected) => {
-          const element = new MockElement({
-            type: "button",
-            button: subElementProps,
-          })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+          const element = new MockElement()
+          const { result } = renderHook(() =>
+            useLayoutStyles({ element, subElement: subElementProps })
+          )
           expect(result.current).toEqual(expected)
         }
       )
@@ -555,13 +566,19 @@ describe("#useLayoutStyles", () => {
       ])(
         "and with subElement widthConfig %o, returns %o",
         (props, expected) => {
-          const element = new MockElement({
-            type: "alert",
-            alert: {
-              widthConfig: props.subElementWidthConfig,
-            },
-          })
-          const { result } = renderHook(() => useLayoutStyles({ element }))
+          const element = new MockElement()
+
+          // Use type assertion to bypass TypeScript checks
+          const subElement = {
+            widthConfig: props.subElementWidthConfig,
+          } as IAlert
+
+          const { result } = renderHook(() =>
+            useLayoutStyles({
+              element,
+              subElement,
+            })
+          )
           expect(result.current).toEqual(expected)
         }
       )

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -27,11 +27,10 @@ type SubElement = {
   widthConfig?: streamlit.IWidthConfig | null | undefined
 }
 
-export type UseLayoutStylesArgs<T> = {
-  element: Element | BlockProto
-  // subElement supports older config where the width/height is set on the lower
-  // level element.
-  subElement?: T & SubElement
+export type UseLayoutStylesArgs = {
+  element: (Element | BlockProto) & {
+    [key: string]: any
+  }
 }
 
 const isNonZeroPositiveNumber = (value: unknown): value is number =>
@@ -100,7 +99,7 @@ const getWidth = (
 
 const getHeight = (
   element: Element | BlockProto,
-  // subElement supports older config where the height is set on the lower
+  // subElement supports older config where the width is set on the lower
   // level element.
   subElement?: SubElement
 ): LayoutDimensionConfig => {
@@ -144,10 +143,9 @@ export type UseLayoutStylesShape = {
 /**
  * Returns the contextually-aware style values for an element container
  */
-export const useLayoutStyles = <T>({
+export const useLayoutStyles = ({
   element,
-  subElement,
-}: UseLayoutStylesArgs<T>): UseLayoutStylesShape => {
+}: UseLayoutStylesArgs): UseLayoutStylesShape => {
   // Note: Consider rounding the width to the nearest pixel so we don't have
   // subpixel widths, which leads to blurriness on screen
   const layoutStyles = useMemo((): UseLayoutStylesShape => {
@@ -158,6 +156,12 @@ export const useLayoutStyles = <T>({
         overflow: "visible",
       }
     }
+
+    // subElement supports older config where the height is set on the lower
+    // level element. This will be the proto corresponding to the element type, e.g. "textArea".
+    const subElement: SubElement | undefined = element.type
+      ? element[element.type]
+      : undefined
 
     // The st.image element is potentially a list of images, so we always want
     // the enclosing container to be full width. The size of individual
@@ -211,7 +215,7 @@ export const useLayoutStyles = <T>({
       height,
       overflow,
     }
-  }, [element, subElement])
+  }, [element])
 
   return layoutStyles
 }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -16,7 +16,12 @@
 
 import { useMemo } from "react"
 
-import { Block as BlockProto, Element, streamlit } from "@streamlit/protobuf"
+import {
+  Block as BlockProto,
+  Element,
+  streamlit,
+  IEmpty,
+} from "@streamlit/protobuf"
 
 type SubElement = {
   useContainerWidth?: boolean | null
@@ -29,7 +34,7 @@ type SubElement = {
 
 export type UseLayoutStylesArgs = {
   element: (Element | BlockProto) & {
-    [key: string]: any
+    [key: string]: SubElement | null | undefined | IEmpty
   }
 }
 
@@ -160,7 +165,7 @@ export const useLayoutStyles = ({
     // subElement supports older config where the height is set on the lower
     // level element. This will be the proto corresponding to the element type, e.g. "textArea".
     const subElement: SubElement | undefined = element.type
-      ? element[element.type]
+      ? (element[element.type] as SubElement | undefined)
       : undefined
 
     // The st.image element is potentially a list of images, so we always want

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -33,9 +33,10 @@ type SubElement = {
 }
 
 export type UseLayoutStylesArgs = {
-  element: (Element | BlockProto) & {
-    [key: string]: SubElement | null | undefined | IEmpty
-  }
+  element: Element | BlockProto
+  // subElement supports older config where the height is set on the lower
+  // level element. This will be the proto corresponding to the element type, e.g. "textArea".
+  subElement?: SubElement
 }
 
 const isNonZeroPositiveNumber = (value: unknown): value is number =>
@@ -150,6 +151,7 @@ export type UseLayoutStylesShape = {
  */
 export const useLayoutStyles = ({
   element,
+  subElement,
 }: UseLayoutStylesArgs): UseLayoutStylesShape => {
   // Note: Consider rounding the width to the nearest pixel so we don't have
   // subpixel widths, which leads to blurriness on screen
@@ -161,12 +163,6 @@ export const useLayoutStyles = ({
         overflow: "visible",
       }
     }
-
-    // subElement supports older config where the height is set on the lower
-    // level element. This will be the proto corresponding to the element type, e.g. "textArea".
-    const subElement: SubElement | undefined = element.type
-      ? (element[element.type] as SubElement | undefined)
-      : undefined
 
     // The st.image element is potentially a list of images, so we always want
     // the enclosing container to be full width. The size of individual
@@ -220,7 +216,7 @@ export const useLayoutStyles = ({
       height,
       overflow,
     }
-  }, [element])
+  }, [element, subElement])
 
   return layoutStyles
 }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -16,12 +16,7 @@
 
 import { useMemo } from "react"
 
-import {
-  Block as BlockProto,
-  Element,
-  streamlit,
-  IEmpty,
-} from "@streamlit/protobuf"
+import { Block as BlockProto, Element, streamlit } from "@streamlit/protobuf"
 
 type SubElement = {
   useContainerWidth?: boolean | null

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -19,7 +19,11 @@ import types
 from collections import ChainMap, UserDict
 from typing import TYPE_CHECKING, Any, cast
 
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.type_util import (
@@ -139,12 +143,9 @@ class JsonMixin:
             )
 
         validate_width(width)
-        if isinstance(width, int):
-            json_proto.width_config.pixel_width = width
-        else:
-            json_proto.width_config.use_stretch = True
+        layout_config = LayoutConfig(width=width)
 
-        return self.dg._enqueue("json", json_proto)
+        return self.dg._enqueue("json", json_proto, layout_config=layout_config)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -160,7 +160,9 @@ class LayoutsMixin:
 
             height_config = HeightConfig()
             height_config.pixel_height = height
-            block_proto.flex_container.height_config.CopyFrom(height_config)
+            # Use block-level height_config instead of flex_container
+            block_proto.height_config.CopyFrom(height_config)
+
             if border is None:
                 # If border is None, we activated the
                 # border as default setting for scrolling

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -19,10 +19,9 @@ from typing import TYPE_CHECKING, Union, cast
 
 from typing_extensions import TypeAlias
 
-from streamlit.elements.lib.layout_utils import validate_width
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_width
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Progress_pb2 import Progress as ProgressProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
@@ -158,18 +157,10 @@ class ProgressMixin:
         if text is not None:
             progress_proto.text = text
 
-        width_config = WidthConfig()
-
         validate_width(width)
+        layout_config = LayoutConfig(width=width)
 
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-
-        progress_proto.width_config.CopyFrom(width_config)
-
-        return self.dg._enqueue("progress", progress_proto)
+        return self.dg._enqueue("progress", progress_proto, layout_config=layout_config)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -22,7 +22,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import validate_width
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_width
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -38,7 +38,6 @@ from streamlit.elements.widgets.file_uploader import _get_upload_files
 from streamlit.proto.AudioInput_pb2 import AudioInput as AudioInputProto
 from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStateProto
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -253,14 +252,8 @@ class AudioInputMixin:
         if label and help is not None:
             audio_input_proto.help = dedent(help)
 
-        # Set width configuration
         validate_width(width)
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        audio_input_proto.width_config.CopyFrom(width_config)
+        layout_config = LayoutConfig(width=width)
 
         serde = AudioInputSerde()
 
@@ -275,7 +268,7 @@ class AudioInputMixin:
             value_type="file_uploader_state_value",
         )
 
-        self.dg._enqueue("audio_input", audio_input_proto)
+        self.dg._enqueue("audio_input", audio_input_proto, layout_config=layout_config)
 
         if isinstance(audio_input_state.value, DeletedFile):
             return None

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -22,7 +22,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import validate_width
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_width
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -38,7 +38,6 @@ from streamlit.elements.widgets.file_uploader import _get_upload_files
 from streamlit.proto.CameraInput_pb2 import CameraInput as CameraInputProto
 from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStateProto
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -248,12 +247,7 @@ class CameraInputMixin:
             camera_input_proto.help = dedent(help)
 
         validate_width(width)
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        camera_input_proto.width_config.CopyFrom(width_config)
+        layout_config = LayoutConfig(width=width)
 
         serde = CameraInputSerde()
 
@@ -268,7 +262,9 @@ class CameraInputMixin:
             value_type="file_uploader_state_value",
         )
 
-        self.dg._enqueue("camera_input", camera_input_proto)
+        self.dg._enqueue(
+            "camera_input", camera_input_proto, layout_config=layout_config
+        )
 
         if isinstance(camera_input_state.value, DeletedFile):
             return None

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -34,6 +34,7 @@ from streamlit.elements.lib.file_uploader_utils import (
 from streamlit.elements.lib.form_utils import is_in_form
 from streamlit.elements.lib.image_utils import AtomicImage, WidthBehavior, image_to_url
 from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
     Width,
     WidthWithoutContent,
     validate_width,
@@ -350,11 +351,11 @@ class ChatMixin:
             width_config.use_content = True
         else:
             width_config.use_stretch = True
-        message_container_proto.width_config.CopyFrom(width_config)
 
         block_proto = BlockProto()
         block_proto.allow_empty = True
         block_proto.chat_message.CopyFrom(message_container_proto)
+        block_proto.width_config.CopyFrom(width_config)
 
         return self.dg._block(block_proto=block_proto)
 
@@ -582,8 +583,6 @@ class ChatMixin:
             writes_allowed=False,
         )
 
-        validate_width(width)
-
         if accept_file not in {True, False, "multiple"}:
             raise StreamlitAPIException(
                 "The `accept_file` parameter must be a boolean or 'multiple'."
@@ -644,13 +643,6 @@ class ChatMixin:
         chat_input_proto.file_type[:] = file_type if file_type is not None else []
         chat_input_proto.max_upload_size_mb = config.get_option("server.maxUploadSize")
 
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        chat_input_proto.width_config.CopyFrom(width_config)
-
         serde = ChatInputSerde(
             accept_files=bool(accept_file),
             allowed_types=file_type,
@@ -666,6 +658,9 @@ class ChatMixin:
             value_type="chat_input_value",
         )
 
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
         chat_input_proto.disabled = disabled
         if widget_state.value_changed and widget_state.value is not None:
             chat_input_proto.value = widget_state.value
@@ -677,10 +672,12 @@ class ChatMixin:
             # We need to enqueue the chat input into the bottom container
             # instead of the currently active dg.
             get_dg_singleton_instance().bottom_dg._enqueue(
-                "chat_input", chat_input_proto
+                "chat_input", chat_input_proto, layout_config=layout_config
             )
         else:
-            self.dg._enqueue("chat_input", chat_input_proto)
+            self.dg._enqueue(
+                "chat_input", chat_input_proto, layout_config=layout_config
+            )
 
         return widget_state.value if not widget_state.value_changed else None
 

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -26,7 +26,11 @@ from streamlit.elements.lib.file_uploader_utils import (
     normalize_upload_file_type,
 )
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -41,7 +45,6 @@ from streamlit.elements.lib.utils import (
 from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStateProto
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -486,14 +489,11 @@ class FileUploaderMixin:
         )
 
         validate_width(width)
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        file_uploader_proto.width_config.CopyFrom(width_config)
+        layout_config = LayoutConfig(width=width)
 
-        self.dg._enqueue("file_uploader", file_uploader_proto)
+        self.dg._enqueue(
+            "file_uploader", file_uploader_proto, layout_config=layout_config
+        )
 
         if isinstance(widget_state.value, DeletedFile):
             return None

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -23,7 +23,11 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.js_number import JSNumber, JSNumberBoundsException
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -43,7 +47,6 @@ from streamlit.errors import (
     StreamlitValueBelowMinError,
 )
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -437,7 +440,6 @@ class NumberInputMixin:
             default_value=value if value != "min" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         element_id = compute_and_register_element_id(
             "number_input",
@@ -605,14 +607,6 @@ class NumberInputMixin:
         if icon is not None:
             number_input_proto.icon = validate_icon_or_emoji(icon)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        number_input_proto.width_config.CopyFrom(width_config)
-
         serde = NumberInputSerde(value, data_type)
         widget_state = register_widget(
             number_input_proto.id,
@@ -647,7 +641,12 @@ class NumberInputMixin:
                 number_input_proto.value = widget_state.value
             number_input_proto.set_value = True
 
-        self.dg._enqueue("number_input", number_input_proto)
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue(
+            "number_input", number_input_proto, layout_config=layout_config
+        )
         return widget_state.value
 
     @property

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -29,7 +29,7 @@ from typing_extensions import TypeGuard
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import validate_width
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_width
 from streamlit.elements.lib.options_selector_utils import (
     index_,
     maybe_coerce_enum,
@@ -49,7 +49,6 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -396,14 +395,8 @@ class SelectSliderMixin:
         if help is not None:
             slider_proto.help = dedent(help)
 
-        # Set width config
         validate_width(width)
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        slider_proto.width_config.CopyFrom(width_config)
+        layout_config = LayoutConfig(width=width)
 
         serde = SelectSliderSerde(opt, slider_value, _is_range_value(value))
 
@@ -431,7 +424,7 @@ class SelectSliderMixin:
         if ctx:
             save_for_app_testing(ctx, element_id, format_func)
 
-        self.dg._enqueue("slider", slider_proto)
+        self.dg._enqueue("slider", slider_proto, layout_config=layout_config)
         return widget_state.value
 
     @property

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -20,7 +20,11 @@ from typing_extensions import Never
 
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.elements.lib.options_selector_utils import (
     create_mappings,
     index_,
@@ -40,7 +44,6 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -488,7 +491,6 @@ class SelectboxMixin:
             default_value=None if index == 0 else index,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         opt = convert_anything_to_list(options)
         check_python_comparable(opt)
@@ -549,14 +551,6 @@ class SelectboxMixin:
         if help is not None:
             selectbox_proto.help = dedent(help)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        selectbox_proto.width_config.CopyFrom(width_config)
-
         serde = SelectboxSerde(
             opt,
             formatted_options=formatted_options,
@@ -581,9 +575,12 @@ class SelectboxMixin:
                 selectbox_proto.raw_value = serialized_value
             selectbox_proto.set_value = True
 
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
         if ctx:
             save_for_app_testing(ctx, element_id, format_func)
-        self.dg._enqueue("selectbox", selectbox_proto)
+        self.dg._enqueue("selectbox", selectbox_proto, layout_config=layout_config)
         return widget_state.value
 
     @property

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -34,7 +34,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.js_number import JSNumber, JSNumberBoundsException
-from streamlit.elements.lib.layout_utils import validate_width
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_width
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -52,7 +52,6 @@ from streamlit.errors import (
     StreamlitValueBelowMinError,
 )
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -972,14 +971,9 @@ class SliderMixin:
             slider_proto.set_value = True
 
         validate_width(width)
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        slider_proto.width_config.CopyFrom(width_config)
+        layout_config = LayoutConfig(width=width)
 
-        self.dg._enqueue("slider", slider_proto)
+        self.dg._enqueue("slider", slider_proto, layout_config=layout_config)
         return cast("SliderReturn", widget_state.value)
 
     @property

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -19,7 +19,11 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -34,7 +38,6 @@ from streamlit.elements.lib.utils import (
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -308,7 +311,6 @@ class TextWidgetsMixin:
             default_value=None if value == "" else value,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         # Make sure value is always string or None:
         value = str(value) if value is not None else None
@@ -355,14 +357,6 @@ class TextWidgetsMixin:
         if icon is not None:
             text_input_proto.icon = validate_icon_or_emoji(icon)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        text_input_proto.width_config.CopyFrom(width_config)
-
         if type == "default":
             text_input_proto.type = TextInputProto.DEFAULT
         elif type == "password":
@@ -397,7 +391,10 @@ class TextWidgetsMixin:
                 text_input_proto.value = widget_state.value
             text_input_proto.set_value = True
 
-        self.dg._enqueue("text_input", text_input_proto)
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue("text_input", text_input_proto, layout_config=layout_config)
         return widget_state.value
 
     @overload
@@ -614,7 +611,6 @@ class TextWidgetsMixin:
             default_value=None if value == "" else value,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         value = str(value) if value is not None else None
 
@@ -658,14 +654,6 @@ class TextWidgetsMixin:
         if placeholder is not None:
             text_area_proto.placeholder = str(placeholder)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        text_area_proto.width_config.CopyFrom(width_config)
-
         serde = TextAreaSerde(value)
         widget_state = register_widget(
             text_area_proto.id,
@@ -683,7 +671,10 @@ class TextWidgetsMixin:
                 text_area_proto.value = widget_state.value
             text_area_proto.set_value = True
 
-        self.dg._enqueue("text_area", text_area_proto)
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue("text_area", text_area_proto, layout_config=layout_config)
         return widget_state.value
 
     @property

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -31,7 +31,11 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.form_utils import current_form_id
-from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_width,
+)
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
@@ -46,7 +50,6 @@ from streamlit.elements.lib.utils import (
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -514,7 +517,6 @@ class TimeWidgetsMixin:
             default_value=value if value != "now" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         parsed_time: time | None
         parsed_time = None if value is None else _convert_timelike_to_time(value)
@@ -560,14 +562,6 @@ class TimeWidgetsMixin:
         if help is not None:
             time_input_proto.help = dedent(help)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        time_input_proto.width_config.CopyFrom(width_config)
-
         serde = TimeInputSerde(parsed_time)
         widget_state = register_widget(
             time_input_proto.id,
@@ -585,7 +579,10 @@ class TimeWidgetsMixin:
                 time_input_proto.value = serialized_value
             time_input_proto.set_value = True
 
-        self.dg._enqueue("time_input", time_input_proto)
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue("time_input", time_input_proto, layout_config=layout_config)
         return widget_state.value
 
     @overload
@@ -873,7 +870,6 @@ class TimeWidgetsMixin:
             default_value=value if value != "today" else None,
         )
         maybe_raise_label_warnings(label, label_visibility)
-        validate_width(width)
 
         def parse_date_deterministic_for_id(v: NullableScalarDateValue) -> str | None:
             if v == "today":
@@ -973,14 +969,6 @@ class TimeWidgetsMixin:
         if help is not None:
             date_input_proto.help = dedent(help)
 
-        # Set up width configuration
-        width_config = WidthConfig()
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-        date_input_proto.width_config.CopyFrom(width_config)
-
         serde = DateInputSerde(parsed_values)
 
         widget_state = register_widget(
@@ -998,7 +986,10 @@ class TimeWidgetsMixin:
             date_input_proto.value[:] = serde.serialize(widget_state.value)
             date_input_proto.set_value = True
 
-        self.dg._enqueue("date_input", date_input_proto)
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue("date_input", date_input_proto, layout_config=layout_config)
         return widget_state.value
 
     @property

--- a/lib/tests/streamlit/elements/audio_input_test.py
+++ b/lib/tests/streamlit/elements/audio_input_test.py
@@ -67,7 +67,7 @@ class AudioInputTest(DeltaGeneratorTestCase):
         """Test width config with 'stretch' value."""
         st.audio_input("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.audio_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -78,7 +78,7 @@ class AudioInputTest(DeltaGeneratorTestCase):
         """Test width config with pixel value."""
         st.audio_input("the label", width=100)
 
-        c = self.get_delta_from_queue().new_element.audio_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -89,7 +89,7 @@ class AudioInputTest(DeltaGeneratorTestCase):
         """Test width config with default value."""
         st.audio_input("the label")
 
-        c = self.get_delta_from_queue().new_element.audio_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/camera_input_test.py
+++ b/lib/tests/streamlit/elements/camera_input_test.py
@@ -101,7 +101,7 @@ class CameraInputWidthTest(DeltaGeneratorTestCase):
     def test_camera_input_with_width_pixels(self):
         """Test that camera_input can be displayed with a specific width in pixels."""
         st.camera_input("Label", width=500)
-        c = self.get_delta_from_queue().new_element.camera_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -111,7 +111,7 @@ class CameraInputWidthTest(DeltaGeneratorTestCase):
     def test_camera_input_with_width_stretch(self):
         """Test that camera_input can be displayed with a width of 'stretch'."""
         st.camera_input("Label", width="stretch")
-        c = self.get_delta_from_queue().new_element.camera_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -121,7 +121,7 @@ class CameraInputWidthTest(DeltaGeneratorTestCase):
     def test_camera_input_with_default_width(self):
         """Test that the default width is used when not specified."""
         st.camera_input("Label")
-        c = self.get_delta_from_queue().new_element.camera_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -316,10 +316,10 @@ class ChatTest(DeltaGeneratorTestCase):
 
         message_block = self.get_delta_from_queue()
         assert (
-            message_block.add_block.chat_message.width_config.WhichOneof("width_spec")
+            message_block.add_block.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert message_block.add_block.chat_message.width_config.use_stretch
+        assert message_block.add_block.width_config.use_stretch
 
     def test_chat_message_width_config_pixel(self):
         """Test that pixel width works properly for chat_message."""
@@ -328,10 +328,10 @@ class ChatTest(DeltaGeneratorTestCase):
 
         message_block = self.get_delta_from_queue()
         assert (
-            message_block.add_block.chat_message.width_config.WhichOneof("width_spec")
+            message_block.add_block.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
         )
-        assert message_block.add_block.chat_message.width_config.pixel_width == 300
+        assert message_block.add_block.width_config.pixel_width == 300
 
     def test_chat_message_width_config_content(self):
         """Test that 'content' width works properly for chat_message."""
@@ -340,10 +340,10 @@ class ChatTest(DeltaGeneratorTestCase):
 
         message_block = self.get_delta_from_queue()
         assert (
-            message_block.add_block.chat_message.width_config.WhichOneof("width_spec")
+            message_block.add_block.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_CONTENT.value
         )
-        assert message_block.add_block.chat_message.width_config.use_content
+        assert message_block.add_block.width_config.use_content
 
     def test_chat_message_width_config_stretch(self):
         """Test that 'stretch' width works properly for chat_message."""
@@ -352,10 +352,10 @@ class ChatTest(DeltaGeneratorTestCase):
 
         message_block = self.get_delta_from_queue()
         assert (
-            message_block.add_block.chat_message.width_config.WhichOneof("width_spec")
+            message_block.add_block.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert message_block.add_block.chat_message.width_config.use_stretch
+        assert message_block.add_block.width_config.use_stretch
 
     @parameterized.expand(
         [
@@ -375,7 +375,7 @@ class ChatTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch' for chat_input."""
         st.chat_input("Placeholder")
 
-        c = self.get_delta_from_queue().new_element.chat_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -386,7 +386,7 @@ class ChatTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly for chat_input."""
         st.chat_input("Placeholder", width=300)
 
-        c = self.get_delta_from_queue().new_element.chat_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -397,7 +397,7 @@ class ChatTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly for chat_input."""
         st.chat_input("Placeholder", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.chat_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -337,7 +337,7 @@ class DateInputTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.date_input("the label")
 
-        c = self.get_delta_from_queue().new_element.date_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -348,7 +348,7 @@ class DateInputTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.date_input("the label", width=200)
 
-        c = self.get_delta_from_queue().new_element.date_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -359,7 +359,7 @@ class DateInputTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.date_input("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.date_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/doc_string_test.py
+++ b/lib/tests/streamlit/elements/doc_string_test.py
@@ -96,27 +96,24 @@ class StHelpAPITest(DeltaGeneratorTestCase):
 
     def test_help_width(self):
         """Test that help() correctly handles width parameter."""
-        # Test with stretch width
         st.help(st, width="stretch")
-        c = self.get_delta_from_queue().new_element.doc_string
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
         assert c.width_config.use_stretch
 
-        # Test with pixel width
         st.help(st, width=500)
-        c = self.get_delta_from_queue().new_element.doc_string
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
         )
         assert c.width_config.pixel_width == 500
 
-        # Test default width (should be stretch)
         st.help(st)
-        c = self.get_delta_from_queue().new_element.doc_string
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -254,7 +254,7 @@ class FileUploaderWidthTest(DeltaGeneratorTestCase):
     def test_file_uploader_with_width_pixels(self):
         """Test that file_uploader can be displayed with a specific width in pixels."""
         st.file_uploader("Label", width=500)
-        c = self.get_delta_from_queue().new_element.file_uploader
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -264,7 +264,7 @@ class FileUploaderWidthTest(DeltaGeneratorTestCase):
     def test_file_uploader_with_width_stretch(self):
         """Test that file_uploader can be displayed with a width of 'stretch'."""
         st.file_uploader("Label", width="stretch")
-        c = self.get_delta_from_queue().new_element.file_uploader
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -274,7 +274,7 @@ class FileUploaderWidthTest(DeltaGeneratorTestCase):
     def test_file_uploader_with_default_width(self):
         """Test that the default width is used when not specified."""
         st.file_uploader("Label")
-        c = self.get_delta_from_queue().new_element.file_uploader
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -86,10 +86,10 @@ class StJsonAPITest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         assert (
-            el.json.width_config.WhichOneof("width_spec")
+            el.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
         )
-        assert el.json.width_config.pixel_width == 500
+        assert el.width_config.pixel_width == 500
 
     def test_st_json_with_width_stretch(self):
         """Test st.json with stretch width."""
@@ -97,10 +97,10 @@ class StJsonAPITest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         assert (
-            el.json.width_config.WhichOneof("width_spec")
+            el.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert el.json.width_config.use_stretch is True
+        assert el.width_config.use_stretch is True
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -34,10 +34,10 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         assert el.json.expanded is True
         assert el.json.HasField("max_expand_depth") is False
         assert (
-            el.json.width_config.WhichOneof("width_spec")
+            el.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert el.json.width_config.use_stretch is True
+        assert el.width_config.use_stretch is True
 
         # Test that an object containing non-json-friendly keys can still
         # be displayed.  Resultant json body will be missing those keys.
@@ -49,10 +49,10 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.json.body == '{"array": "array([1, 2, 3, 4, 5])"}'
         assert (
-            el.json.width_config.WhichOneof("width_spec")
+            el.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert el.json.width_config.use_stretch is True
+        assert el.width_config.use_stretch is True
 
     def test_expanded_param(self):
         """Test expanded parameter for `st.json`"""
@@ -67,10 +67,10 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         assert el.json.expanded is True
         assert el.json.max_expand_depth == 2
         assert (
-            el.json.width_config.WhichOneof("width_spec")
+            el.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert el.json.width_config.use_stretch is True
+        assert el.width_config.use_stretch is True
 
         with pytest.raises(TypeError):
             st.json(

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -374,9 +374,7 @@ class ContainerTest(DeltaGeneratorTestCase):
         st.container(height=100)
 
         container_block = self.get_delta_from_queue()
-        assert (
-            container_block.add_block.height_config.pixel_height == 100
-        )
+        assert container_block.add_block.height_config.pixel_height == 100
         # Should allow empty and have a border as default:
         assert container_block.add_block.flex_container.border
         assert container_block.add_block.allow_empty

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -375,7 +375,7 @@ class ContainerTest(DeltaGeneratorTestCase):
 
         container_block = self.get_delta_from_queue()
         assert (
-            container_block.add_block.flex_container.height_config.pixel_height == 100
+            container_block.add_block.height_config.pixel_height == 100
         )
         # Should allow empty and have a border as default:
         assert container_block.add_block.flex_container.border

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -366,7 +366,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.number_input("the label")
 
-        c = self.get_delta_from_queue().new_element.number_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -377,7 +377,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.number_input("the label", width=100)
 
-        c = self.get_delta_from_queue().new_element.number_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -388,7 +388,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.number_input("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.number_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/progress_test.py
+++ b/lib/tests/streamlit/elements/progress_test.py
@@ -77,7 +77,7 @@ class DeltaGeneratorProgressTest(DeltaGeneratorTestCase):
     def test_progress_width(self):
         """Test Progress with width parameter."""
         st.progress(50, width="stretch")
-        c = self.get_delta_from_queue().new_element.progress
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -85,7 +85,7 @@ class DeltaGeneratorProgressTest(DeltaGeneratorTestCase):
         assert c.width_config.use_stretch
 
         st.progress(50, width=500)
-        c = self.get_delta_from_queue().new_element.progress
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -93,7 +93,7 @@ class DeltaGeneratorProgressTest(DeltaGeneratorTestCase):
         assert c.width_config.pixel_width == 500
 
         st.progress(50)
-        c = self.get_delta_from_queue().new_element.progress
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -349,32 +349,32 @@ class SelectSliderWidthTest(DeltaGeneratorTestCase):
     def test_select_slider_with_width_pixels(self):
         """Test that select_slider can be displayed with a specific width in pixels."""
         st.select_slider("Label", options=["a", "b", "c"], width=500)
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
         )
-        assert c.width_config.pixel_width == 500
+        assert element.width_config.pixel_width == 500
 
     def test_select_slider_with_width_stretch(self):
         """Test that select_slider can be displayed with a width of 'stretch'."""
         st.select_slider("Label", options=["a", "b", "c"], width="stretch")
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert c.width_config.use_stretch is True
+        assert element.width_config.use_stretch is True
 
     def test_select_slider_with_default_width(self):
         """Test that the default width is used when not specified."""
         st.select_slider("Label", options=["a", "b", "c"])
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert c.width_config.use_stretch is True
+        assert element.width_config.use_stretch is True
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -219,7 +219,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.selectbox("the label", ("m", "f"))
 
-        c = self.get_delta_from_queue().new_element.selectbox
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -230,7 +230,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.selectbox("the label", ("m", "f"), width=200)
 
-        c = self.get_delta_from_queue().new_element.selectbox
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -241,7 +241,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.selectbox("the label", ("m", "f"), width="stretch")
 
-        c = self.get_delta_from_queue().new_element.selectbox
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -364,32 +364,32 @@ class SliderWidthTest(DeltaGeneratorTestCase):
     def test_slider_with_width_pixels(self):
         """Test that slider can be displayed with a specific width in pixels."""
         st.slider("Label", min_value=0, max_value=10, width=500)
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
         )
-        assert c.width_config.pixel_width == 500
+        assert element.width_config.pixel_width == 500
 
     def test_slider_with_width_stretch(self):
         """Test that slider can be displayed with a width of 'stretch'."""
         st.slider("Label", min_value=0, max_value=10, width="stretch")
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert c.width_config.use_stretch is True
+        assert element.width_config.use_stretch is True
 
     def test_slider_with_default_width(self):
         """Test that the default width is used when not specified."""
         st.slider("Label", min_value=0, max_value=10)
-        c = self.get_delta_from_queue().new_element.slider
+        element = self.get_delta_from_queue().new_element
         assert (
-            c.width_config.WhichOneof("width_spec")
+            element.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
         )
-        assert c.width_config.use_stretch is True
+        assert element.width_config.use_stretch is True
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -165,7 +165,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.text_area("the label")
 
-        c = self.get_delta_from_queue().new_element.text_area
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -176,7 +176,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.text_area("the label", width=100)
 
-        c = self.get_delta_from_queue().new_element.text_area
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -187,7 +187,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.text_area("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.text_area
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -200,7 +200,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.text_input("the label")
 
-        c = self.get_delta_from_queue().new_element.text_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -211,7 +211,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.text_input("the label", width=100)
 
-        c = self.get_delta_from_queue().new_element.text_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -222,7 +222,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.text_input("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.text_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -163,7 +163,7 @@ class TimeInputTest(DeltaGeneratorTestCase):
         """Test that default width is 'stretch'."""
         st.time_input("the label")
 
-        c = self.get_delta_from_queue().new_element.time_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value
@@ -174,7 +174,7 @@ class TimeInputTest(DeltaGeneratorTestCase):
         """Test that pixel width works properly."""
         st.time_input("the label", width=200)
 
-        c = self.get_delta_from_queue().new_element.time_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.PIXEL_WIDTH.value
@@ -185,7 +185,7 @@ class TimeInputTest(DeltaGeneratorTestCase):
         """Test that 'stretch' width works properly."""
         st.time_input("the label", width="stretch")
 
-        c = self.get_delta_from_queue().new_element.time_input
+        c = self.get_delta_from_queue().new_element
         assert (
             c.width_config.WhichOneof("width_spec")
             == WidthConfigFields.USE_STRETCH.value

--- a/proto/streamlit/proto/AudioInput.proto
+++ b/proto/streamlit/proto/AudioInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "AudioInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message AudioInput {
   string id = 1;
@@ -29,5 +28,4 @@ message AudioInput {
   string form_id = 4;
   bool disabled = 5;
   LabelVisibilityMessage label_visibility = 6;
-  streamlit.WidthConfig width_config = 7;
 }

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -55,19 +55,17 @@ message Block {
 
   message FlexContainer {
     bool border = 1;
-    // TODO (lwilby): move this to use block level field.
-    streamlit.HeightConfig height_config = 2;
 
-    streamlit.GapConfig gap_config = 4;
-    float scale = 5;
+    streamlit.GapConfig gap_config = 2;
+    float scale = 3;
 
     enum Direction {
       DIRECTION_UNDEFINED = 0;
       VERTICAL = 1;
       HORIZONTAL = 2;
     }
-    Direction direction = 6;
-    bool wrap = 7;
+    Direction direction = 4;
+    bool wrap = 5;
   }
 
   message Column {
@@ -138,8 +136,6 @@ message Block {
     string name = 1;
     string avatar = 2;
     AvatarType avatar_type = 3;
-    // TODO (lwilby): move this to use block level field.
-    optional streamlit.WidthConfig width_config = 4;
   }
 
   // Next ID: 14

--- a/proto/streamlit/proto/CameraInput.proto
+++ b/proto/streamlit/proto/CameraInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "CameraInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message CameraInput {
   string id = 1;
@@ -29,5 +28,4 @@ message CameraInput {
   string form_id = 4;
   bool disabled = 5;
   LabelVisibilityMessage label_visibility = 6;
-  optional streamlit.WidthConfig width_config = 7;
 }

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -19,8 +19,6 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "ChatInputProto";
 
-import "streamlit/proto/WidthConfig.proto";
-
 message ChatInput {
   string id = 1;
   string placeholder = 2;
@@ -48,7 +46,4 @@ message ChatInput {
 
   // Max file size allowed by server config
   int32 max_upload_size_mb = 11;
-
-  // Optional width configuration for the ChatInput
-  optional streamlit.WidthConfig width_config = 12;
 }

--- a/proto/streamlit/proto/Code.proto
+++ b/proto/streamlit/proto/Code.proto
@@ -19,8 +19,6 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "CodeProto";
 
-import "streamlit/proto/WidthConfig.proto";
-
 // st.code
 message Code {
   // Content to display.

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "DateInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message DateInput {
   string id = 1;
@@ -36,5 +35,4 @@ message DateInput {
   bool disabled = 11;
   LabelVisibilityMessage label_visibility = 12;
   string format = 13;
-  optional streamlit.WidthConfig width_config = 14;
 }

--- a/proto/streamlit/proto/DocString.proto
+++ b/proto/streamlit/proto/DocString.proto
@@ -19,8 +19,6 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "DocStringProto";
 
-import "streamlit/proto/WidthConfig.proto";
-
 // Formatted text
 message DocString {
 
@@ -50,9 +48,6 @@ message DocString {
 
   // List of this object's methods and member variables.
   repeated Member members = 8;
-
-  // Indicates the width setting: "stetch" or a pixel value.
-  streamlit.WidthConfig width_config = 9;
 }
 
 

--- a/proto/streamlit/proto/FileUploader.proto
+++ b/proto/streamlit/proto/FileUploader.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "FileUploaderProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 // file_uploader widget
 message FileUploader {
@@ -46,8 +45,6 @@ message FileUploader {
   bool disabled = 9;
 
   LabelVisibilityMessage label_visibility = 10;
-
-  optional streamlit.WidthConfig width_config = 11;
 
   reserved 5;
 }

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -19,8 +19,6 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "JsonProto";
 
-import "streamlit/proto/WidthConfig.proto";
-
 message Json {
   // Content to display.
   string body = 1;
@@ -29,6 +27,4 @@ message Json {
   bool expanded = 2;
   // The maximum depth to expand the JSON object.
   optional int32 max_expand_depth = 3;
-  // Width configuration
-  streamlit.WidthConfig width_config = 4;
 }

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "NumberInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message NumberInput {
   enum DataType {
@@ -50,7 +49,6 @@ message NumberInput {
   LabelVisibilityMessage label_visibility = 22;
   string placeholder = 23;
   string icon = 24;
-  optional streamlit.WidthConfig width_config = 25;
 
   reserved 4, 5, 6, 7, 9, 10;
 }

--- a/proto/streamlit/proto/Progress.proto
+++ b/proto/streamlit/proto/Progress.proto
@@ -19,10 +19,7 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "ProgressProto";
 
-import "streamlit/proto/WidthConfig.proto";
-
 message Progress {
   uint32 value = 1;
   string text = 2;
-  streamlit.WidthConfig width_config = 3;
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "SelectboxProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message Selectbox {
   string id = 1;
@@ -40,8 +39,6 @@ message Selectbox {
   LabelVisibilityMessage label_visibility = 10;
   string placeholder = 11;
   optional bool accept_new_options = 12;
-
-  optional streamlit.WidthConfig width_config = 14;
 
   // Next: 15
 }

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "SliderProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message Slider {
   enum DataType {
@@ -57,7 +56,4 @@ message Slider {
   string help = 14;
   bool disabled = 15;
   LabelVisibilityMessage label_visibility = 16;
-
-  Type type = 17;
-  optional streamlit.WidthConfig width_config = 18;
 }

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -56,4 +56,5 @@ message Slider {
   string help = 14;
   bool disabled = 15;
   LabelVisibilityMessage label_visibility = 16;
+  Type type = 17;
 }

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "TextAreaProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message TextArea {
   string id = 1;
@@ -35,5 +34,4 @@ message TextArea {
   string placeholder = 10;
   bool disabled = 11;
   LabelVisibilityMessage label_visibility = 12;
-  optional streamlit.WidthConfig width_config = 13;
 }

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "TextInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message TextInput {
   enum Type {
@@ -45,5 +44,4 @@ message TextInput {
   bool disabled = 12;
   LabelVisibilityMessage label_visibility = 13;
   string icon = 14;
-  optional streamlit.WidthConfig width_config = 15;
 }

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -20,7 +20,6 @@ option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "TimeInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
-import "streamlit/proto/WidthConfig.proto";
 
 message TimeInput {
   string id = 1;
@@ -33,5 +32,4 @@ message TimeInput {
   bool disabled = 8;
   LabelVisibilityMessage label_visibility = 9;
   int64 step = 10;
-  optional streamlit.WidthConfig width_config = 11;
 }


### PR DESCRIPTION
## Describe your changes

In https://github.com/streamlit/streamlit/pull/11355 we added `widthConfig`, onto `Element.proto`. This PR follows up and changes all elements that have yet to be released to use this field instead of having the field on their own proto. 

## GitHub Issue Link (if applicable)

## Testing Plan

Covered by existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
