### PR TITLE
Remove all uses of assert in production code

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -40,7 +40,6 @@ ignore = [
   # Rules planned to be supported in the future:
   "EM101",  # Checks for the use of string literals in exception constructors.
   "EM102",  # Checks for the use of f-strings in exception constructors.
-  "S101",   # Checks for usage of assert statements.
   "TRY003", # Checks for exception messages that are not defined in the exception class itself.
   "N806",   # Checks for non-lowercased variable names in functions.
   "UP031",  # Checks for printf-style string formatting, and offers to replace it with str.format calls.

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -91,9 +91,10 @@ def _new_fragment_id_queue(
         )
 
     new_queue = list(dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue))
-    assert new_queue, (
-        "Could not find current_fragment_id in fragment_id_queue. This should never happen."
-    )
+    if not new_queue:
+        raise RuntimeError(
+            "Could not find current_fragment_id in fragment_id_queue. This should never happen."
+        )
 
     return new_queue
 

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -33,7 +33,8 @@ def _get_module_name(caller_frame: FrameType) -> str:
     # Get the caller's module name. `__name__` gives us the module's
     # fully-qualified name, which includes its package.
     module = inspect.getmodule(caller_frame)
-    assert module is not None
+    if module is None:
+        raise RuntimeError("module is None. This should never happen.")
     module_name = module.__name__
 
     # If the caller was the main module that was executed (that is, if the
@@ -96,10 +97,13 @@ def declare_component(
 
     # Get our stack frame.
     current_frame: FrameType | None = inspect.currentframe()
-    assert current_frame is not None
+    if current_frame is None:
+        raise RuntimeError("current_frame is None. This should never happen.")
     # Get the stack frame of our calling function.
     caller_frame = current_frame.f_back
-    assert caller_frame is not None
+    if caller_frame is None:
+        raise RuntimeError("caller_frame is None. This should never happen.")
+
     module_name = _get_module_name(caller_frame)
 
     # Build the component name.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1618,12 +1618,12 @@ def _check_conflicts() -> None:
     LOGGER = get_logger(__name__)
 
     if get_option("global.developmentMode"):
-        if _is_unset("server.port"):
+        if not _is_unset("server.port"):
             raise RuntimeError(
                 "server.port does not work when global.developmentMode is true."
             )
 
-        if _is_unset("browser.serverPort"):
+        if not _is_unset("browser.serverPort"):
             raise RuntimeError(
                 "browser.serverPort does not work when global.developmentMode is true."
             )

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -226,9 +226,8 @@ def get_options_for_section(section: str) -> dict[str, Any]:
 
 def _create_section(section: str, description: str) -> None:
     """Create a config section and store it globally in this module."""
-    assert section not in _section_descriptions, (
-        f'Cannot define section "{section}" twice.'
-    )
+    if section in _section_descriptions:
+        raise RuntimeError(f'Cannot define section "{section}" twice.')
     _section_descriptions[section] = description
 
 
@@ -293,13 +292,12 @@ def _create_option(
         type_=type_,
         sensitive=sensitive,
     )
-    assert option.section in _section_descriptions, (
-        'Section "{}" must be one of {}.'.format(
-            option.section,
-            ", ".join(_section_descriptions.keys()),
+    if option.section not in _section_descriptions:
+        raise RuntimeError(
+            f'Section "{option.section}" must be one of {", ".join(_section_descriptions.keys())}.'
         )
-    )
-    assert key not in _config_options_template, f'Cannot define option "{key}" twice.'
+    if key in _config_options_template:
+        raise RuntimeError(f'Cannot define option "{key}" twice.')
     _config_options_template[key] = option
     return option
 
@@ -342,11 +340,13 @@ def _delete_option(key: str) -> None:
 
     Only for use in testing.
     """
+    if _config_options is None:
+        raise RuntimeError(
+            "_config_options should always be populated here. This should never happen."
+        )
+
     try:
         del _config_options_template[key]
-        assert _config_options is not None, (
-            "_config_options should always be populated here."
-        )
         del _config_options[key]
     except Exception:  # noqa: S110
         # We don't care if the option already doesn't exist.
@@ -1334,9 +1334,10 @@ def is_manually_set(option_name: str) -> bool:
 def show_config() -> None:
     """Print all config options to the terminal."""
     with _config_lock:
-        assert _config_options is not None, (
-            "_config_options should always be populated here."
-        )
+        if _config_options is None:
+            raise RuntimeError(
+                "_config_options should always be populated here. This should never happen."
+            )
         config_util.show_config(_section_descriptions, _config_options)
 
 
@@ -1359,9 +1360,9 @@ def _set_option(key: str, value: Any, where_defined: str) -> None:
         Tells the config system where this was set.
 
     """
-    assert _config_options is not None, (
-        "_config_options should always be populated here."
-    )
+    if _config_options is None:
+        raise RuntimeError("_config_options should always be populated here.")
+
     if key not in _config_options:
         # Import logger locally to prevent circular references
         from streamlit.logger import get_logger
@@ -1617,13 +1618,15 @@ def _check_conflicts() -> None:
     LOGGER = get_logger(__name__)
 
     if get_option("global.developmentMode"):
-        assert _is_unset("server.port"), (
-            "server.port does not work when global.developmentMode is true."
-        )
+        if _is_unset("server.port"):
+            raise RuntimeError(
+                "server.port does not work when global.developmentMode is true."
+            )
 
-        assert _is_unset("browser.serverPort"), (
-            "browser.serverPort does not work when global.developmentMode is true."
-        )
+        if _is_unset("browser.serverPort"):
+            raise RuntimeError(
+                "browser.serverPort does not work when global.developmentMode is true."
+            )
 
     # XSRF conflicts
     if get_option("server.enableXsrfProtection") and (

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -192,9 +192,9 @@ class ConfigOption:
                 deprecation_text = "Replaced by %s." % self.replaced_by
 
         if self.deprecated:
-            if expiration_date is None:
+            if not expiration_date:
                 raise ValueError("expiration_date is required for deprecated items.")
-            if deprecation_text is None:
+            if not deprecation_text:
                 raise ValueError("deprecation_text is required for deprecated items.")
             self.expiration_date = expiration_date
             self.deprecation_text = textwrap.dedent(deprecation_text)

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -167,7 +167,8 @@ class ConfigOption:
             r")$"
         )
         match = re.match(key_format, self.key)
-        assert match, f'Key "{self.key}" has invalid format.'
+        if match is None:
+            raise ValueError(f'Key "{self.key}" has invalid format.')
         self.section, self.name = match.group("section"), match.group("name")
 
         self.description = description
@@ -191,8 +192,10 @@ class ConfigOption:
                 deprecation_text = "Replaced by %s." % self.replaced_by
 
         if self.deprecated:
-            assert expiration_date, "expiration_date is required for deprecated items"
-            assert deprecation_text, "deprecation_text is required for deprecated items"
+            if expiration_date is None:
+                raise ValueError("expiration_date is required for deprecated items.")
+            if deprecation_text is None:
+                raise ValueError("deprecation_text is required for deprecated items.")
             self.expiration_date = expiration_date
             self.deprecation_text = textwrap.dedent(deprecation_text)
 
@@ -218,9 +221,10 @@ class ConfigOption:
             Returns self, which makes testing easier. See config_test.py.
 
         """
-        assert get_val_func.__doc__, (
-            "Complex config options require doc strings for their description."
-        )
+        if get_val_func.__doc__ is None:
+            raise RuntimeError(
+                "Complex config options require doc strings for their description."
+            )
         self.description = get_val_func.__doc__
         self._get_val_func = get_val_func
         return self

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -952,9 +952,10 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> 
     if dataframe_util.is_pandas_styler(data):
         # default_uuid is a string only if the data is a `Styler`,
         # and `None` otherwise.
-        assert isinstance(default_uuid, str), (
-            "Default UUID must be a string for Styler data."
-        )
+        if not isinstance(default_uuid, str):
+            raise StreamlitAPIException(
+                "Default UUID must be a string for Styler data."
+            )
         marshall_styler(proto, data, default_uuid)
 
     proto.data = dataframe_util.convert_anything_to_arrow_bytes(data)

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -115,8 +115,11 @@ class Dialog(DeltaGenerator):
     def _update(self, should_open: bool) -> None:
         """Send an updated proto message to indicate the open-status for the dialog."""
 
-        assert self._current_proto is not None, "Dialog not correctly initialized!"
-        assert self._delta_path is not None, "Dialog not correctly initialized!"
+        if self._current_proto is None or self._delta_path is None:
+            raise RuntimeError(
+                "Dialog not correctly initialized. This should never happen."
+            )
+
         _assert_first_dialog_to_be_opened(should_open)
         msg = ForwardMsg()
         msg.metadata.delta_path[:] = self._delta_path

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -416,13 +416,15 @@ def marshall_images(
     else:
         captions = [str(caption)]
 
-    assert isinstance(captions, list), (
-        "If image is a list then caption should be as well"
-    )
-    assert len(captions) == len(images), "Cannot pair %d captions with %d images." % (
-        len(captions),
-        len(images),
-    )
+    if not isinstance(captions, list):
+        raise StreamlitAPIException(
+            "If image is a list then caption should be a list as well."
+        )
+
+    if len(captions) != len(images):
+        raise StreamlitAPIException(
+            f"Cannot pair {len(captions)} captions with {len(images)} images."
+        )
 
     proto_imgs.width = int(width)
     # Each image in an image list needs to be kept track of at its own coordinates.

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -122,8 +122,10 @@ class StatusContainer(DeltaGenerator):
             The new state of the status container. This mainly changes the
             icon. If None, the state is not changed.
         """
-        assert self._current_proto is not None, "Status not correctly initialized!"
-        assert self._delta_path is not None, "Status not correctly initialized!"
+        if self._current_proto is None or self._delta_path is None:
+            raise RuntimeError(
+                "StatusContainer is not correctly initialized. This should never happen."
+            )
 
         msg = ForwardMsg()
         msg.metadata.delta_path[:] = self._delta_path

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -296,7 +296,7 @@ def to_deckgl_json(
     )
     df = df[used_columns]
 
-    color_arg = _convert_color_arg_or_column(df, color_arg, color_col_name)
+    converted_color_arg = _convert_color_arg_or_column(df, color_arg, color_col_name)
 
     zoom, center_lat, center_lon = _get_viewport_details(
         df, lat_col_name, lon_col_name, zoom
@@ -313,7 +313,7 @@ def to_deckgl_json(
             "getRadius": size_arg,
             "radiusMinPixels": 3,
             "radiusUnits": "meters",
-            "getFillColor": color_arg,
+            "getFillColor": converted_color_arg,
             "data": df.to_dict("records"),
         }
     ]
@@ -378,7 +378,7 @@ def _get_value_and_col_name(
     data: DataFrame,
     value_or_name: Any,
     default_value: Any,
-) -> tuple[Any, str | None]:
+) -> tuple[str, str | None]:
     """Take a value_or_name passed in by the Streamlit developer and return a PyDeck
     argument and column name for that property.
 
@@ -390,7 +390,7 @@ def _get_value_and_col_name(
     - If the user passes size="my_col_123", this returns "@@=my_col_123" and "my_col_123".
     """
 
-    pydeck_arg: str | float
+    pydeck_arg: str
 
     if isinstance(value_or_name, str) and value_or_name in data.columns:
         col_name = value_or_name
@@ -405,7 +405,7 @@ def _get_value_and_col_name(
 
 def _convert_color_arg_or_column(
     data: DataFrame,
-    color_arg: str | Color,
+    color_arg: str,
     color_col_name: str | None,
 ) -> None | str | IntColorTuple:
     """Converts color to a format accepted by PyDeck.
@@ -434,8 +434,6 @@ def _convert_color_arg_or_column(
                 f'Column "{color_col_name}" does not appear to contain valid colors.'
             )
 
-        # This is guaranteed to be a str because of _get_value_and_col_name
-        assert isinstance(color_arg, str)
         color_arg_out = color_arg
 
     elif color_arg is not None:

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -250,9 +250,10 @@ class LLMThought:
     def complete(self, final_label: str | None = None) -> None:
         """Finish the thought."""
         if final_label is None and self._state == LLMThoughtState.RUNNING_TOOL:
-            assert self._last_tool is not None, (
-                "_last_tool should never be null when _state == RUNNING_TOOL"
-            )
+            if self._last_tool is None:
+                raise RuntimeError(
+                    "_last_tool should never be null when _state == RUNNING_TOOL"
+                )
             final_label = self._labeler.get_tool_label(
                 self._last_tool, is_complete=True
             )

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -192,7 +192,8 @@ def _fragment(
             # fragment runs will generally run in a new script run, thus we'll have a
             # new ctx.
             ctx = get_script_run_ctx(suppress_warning=True)
-            assert ctx is not None
+            if ctx is None:
+                raise RuntimeError("ctx is None. This should never happen.")
 
             if ctx.fragment_ids_this_run:
                 # This script run is a run of one or more fragments. We restore the

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -374,9 +374,11 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        assert not (existing_session_id and session_id_override), (
-            "Only one of existing_session_id and session_id_override should be set!"
-        )
+        if existing_session_id and session_id_override:
+            raise RuntimeError(
+                "Only one of existing_session_id and session_id_override should be set. "
+                "This should never happen."
+            )
 
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeStoppedError(f"Can't connect_session (state={self._state})")

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -324,7 +324,7 @@ class ScriptRunner:
         """
         if not self._is_in_script_thread():
             raise RuntimeError(
-                "get_script_run_ctx must be called from the script thread."
+                "ScriptRunner._get_script_run_ctx must be called from the script thread."
             )
 
         ctx = get_script_run_ctx()
@@ -347,7 +347,7 @@ class ScriptRunner:
         """
         if not self._is_in_script_thread():
             raise RuntimeError(
-                "ScriptRunner._run_script_thread must be called from the script thread"
+                "ScriptRunner._run_script_thread must be called from the script thread."
             )
 
         _LOGGER.debug("Beginning script thread")
@@ -476,7 +476,7 @@ class ScriptRunner:
 
         if not self._is_in_script_thread():
             raise RuntimeError(
-                "ScriptRunner._run_script must be called from the script thread"
+                "ScriptRunner._run_script must be called from the script thread."
             )
 
         # An explicit loop instead of recursion to avoid stack overflows

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -322,7 +322,10 @@ class ScriptRunner:
             If there is no ScriptRunContext for the current thread.
 
         """
-        assert self._is_in_script_thread()
+        if not self._is_in_script_thread():
+            raise RuntimeError(
+                "get_script_run_ctx must be called from the script thread."
+            )
 
         ctx = get_script_run_ctx()
         if ctx is None:
@@ -342,7 +345,10 @@ class ScriptRunner:
         When the ScriptRequestQueue is empty, or when a SHUTDOWN request is
         dequeued, this function will exit and its thread will terminate.
         """
-        assert self._is_in_script_thread()
+        if not self._is_in_script_thread():
+            raise RuntimeError(
+                "ScriptRunner._run_script_thread must be called from the script thread"
+            )
 
         _LOGGER.debug("Beginning script thread")
 
@@ -372,7 +378,10 @@ class ScriptRunner:
             self._run_script(request.rerun_data)
             request = self._requests.on_scriptrunner_ready()
 
-        assert request.type == ScriptRequestType.STOP
+        if request.type != ScriptRequestType.STOP:
+            raise RuntimeError(
+                f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
+            )
 
         # Send a SHUTDOWN event before exiting, so some state can be saved
         # for use in a future script run when not triggered by the client.
@@ -434,7 +443,10 @@ class ScriptRunner:
         if request.type == ScriptRequestType.RERUN:
             raise RerunException(request.rerun_data)
 
-        assert request.type == ScriptRequestType.STOP
+        if request.type != ScriptRequestType.STOP:
+            raise RuntimeError(
+                f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
+            )
         raise StopException()
 
     @contextmanager
@@ -462,7 +474,10 @@ class ScriptRunner:
 
         """
 
-        assert self._is_in_script_thread()
+        if not self._is_in_script_thread():
+            raise RuntimeError(
+                "ScriptRunner._run_script must be called from the script thread"
+            )
 
         # An explicit loop instead of recursion to avoid stack overflows
         while True:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -284,7 +284,10 @@ class ScriptRequests:
                 self._state = ScriptRequestType.CONTINUE
                 return ScriptRequest(ScriptRequestType.RERUN, self._rerun_data)
 
-            assert self._state == ScriptRequestType.STOP
+            if self._state != ScriptRequestType.STOP:
+                raise RuntimeError(
+                    f"Unrecognized ScriptRunnerState: {self._state}. This should never happen."
+                )
             return ScriptRequest(ScriptRequestType.STOP)
 
     def on_scriptrunner_ready(self) -> ScriptRequest:

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -72,7 +72,8 @@ class SessionInfo:
         return self.client is not None
 
     def to_active(self) -> ActiveSessionInfo:
-        assert self.is_active(), "A SessionInfo with no client cannot be active!"
+        if not self.is_active():
+            raise RuntimeError("A SessionInfo with no client cannot be active!")
 
         # NOTE: The cast here (rather than copying this SessionInfo's fields into a new
         # ActiveSessionInfo) is important as the Runtime expects to be able to mutate

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -261,7 +261,10 @@ class WStates(MutableMapping[str, Any]):
         If the widget doesn't exist, raise an Exception.
         """
         metadata = self.widget_metadata.get(widget_id)
-        assert metadata is not None
+
+        if metadata is None:
+            raise RuntimeError(f"Widget {widget_id} not found.")
+
         callback = metadata.callback
         if callback is None:
             return
@@ -468,7 +471,10 @@ class SessionState:
 
         At least one of the arguments must have a value.
         """
-        assert user_key is not None or widget_id is not None
+        if user_key is None and widget_id is None:
+            raise ValueError(
+                "user_key and widget_id cannot both be None. This should never happen."
+            )
 
         if user_key is not None:
             try:

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -67,9 +67,11 @@ class WebsocketSessionManager(SessionManager):
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
-        assert not (existing_session_id and session_id_override), (
-            "Only one of existing_session_id and session_id_override should be truthy"
-        )
+        if existing_session_id and session_id_override:
+            raise RuntimeError(
+                "Only one of existing_session_id and session_id_override should be truthy. "
+                "This should never happen."
+            )
 
         if existing_session_id in self._active_session_info_by_id:
             _LOGGER.warning(
@@ -109,9 +111,11 @@ class WebsocketSessionManager(SessionManager):
             "Created new session for client %s. Session ID: %s", id(client), session.id
         )
 
-        assert session.id not in self._active_session_info_by_id, (
-            f"session.id '{session.id}' registered multiple times!"
-        )
+        if session.id in self._active_session_info_by_id:
+            raise RuntimeError(
+                f"session.id '{session.id}' registered multiple times. "
+                "This should never happen."
+            )
 
         self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
         return session.id

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -61,9 +61,12 @@ PAGE_FILENAME_REGEX = re.compile(r"([0-9]*)[_ -]*(.*)\.py")
 def page_sort_key(script_path: Path) -> tuple[float, str]:
     matches = re.findall(PAGE_FILENAME_REGEX, script_path.name)
 
-    # Failing this assert should only be possible if script_path isn't a Python
+    # Failing this should only be possible if script_path isn't a Python
     # file, which should never happen.
-    assert len(matches) > 0, f"{script_path} is not a Python file"
+    if len(matches) == 0:
+        raise ValueError(
+            f"{script_path} is not a Python file. This should never happen."
+        )
 
     [(number, label)] = matches
     label = label.lower()

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Assert statements are allowed here since the app testing logic is used within unit tests:
 # ruff: noqa: S101
 
 from __future__ import annotations

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# ruff: noqa: S101
+
 from __future__ import annotations
 
 import textwrap

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -48,7 +48,8 @@ class LocalScriptRunner(ScriptRunner):
     ) -> None:
         """Initializes the ScriptRunner for the given script_path."""
 
-        assert os.path.isfile(script_path), f"File not found at {script_path}"
+        if not os.path.isfile(script_path):
+            raise FileNotFoundError(f"File not found at {script_path}")
 
         self.forward_msg_queue = ForwardMsgQueue()
         self.script_path = script_path
@@ -77,9 +78,8 @@ class LocalScriptRunner(ScriptRunner):
         ) -> None:
             # Assert that we're not getting unexpected `sender` params
             # from ScriptRunner.on_event
-            assert sender is None or sender == self, (
-                "Unexpected ScriptRunnerEvent sender!"
-            )
+            if sender is not None and sender != self:
+                raise RuntimeError("Unexpected ScriptRunnerEvent sender!")
 
             self.events.append(event)
             self.event_data.append(kwargs)

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -154,8 +154,6 @@ def help() -> None:  # noqa: A001
     # anything with its return value.
     _get_command_line_as_string()
 
-    assert len(sys.argv) == 2  # This is always true, but let's assert anyway.
-
     # Pretend user typed 'streamlit --help' instead of 'streamlit help'.
     sys.argv[1] = "--help"
     main(prog_name="streamlit")
@@ -171,7 +169,6 @@ def main_version() -> None:
     # anything with its return value.
     _get_command_line_as_string()
 
-    assert len(sys.argv) == 2  # This is always true, but let's assert anyway.
     sys.argv[1] = "--version"
     main()
 
@@ -363,8 +360,8 @@ def test_prog_name() -> None:
 
     parent = click.get_current_context().parent
 
-    assert parent is not None
-    assert parent.command_path == "streamlit test"
+    assert parent is not None  # noqa: S101
+    assert parent.command_path == "streamlit test"  # noqa: S101
 
 
 @main.command("init")

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -360,8 +360,13 @@ def test_prog_name() -> None:
 
     parent = click.get_current_context().parent
 
-    assert parent is not None  # noqa: S101
-    assert parent.command_path == "streamlit test"  # noqa: S101
+    if parent is None:
+        raise AssertionError("parent is None")
+
+    if parent.command_path != "streamlit test":
+        raise AssertionError(
+            f"Parent command path is {parent.command_path} not streamlit test."
+        )
 
 
 @main.command("init")

--- a/lib/streamlit/web/server/oidc_mixin.py
+++ b/lib/streamlit/web/server/oidc_mixin.py
@@ -81,7 +81,6 @@ class TornadoOAuth2App(OAuth2Mixin, OpenIDMixin, BaseApp):  # type: ignore[misc]
             "state": request_handler.get_argument("state"),
         }
 
-        assert self.framework.cache is not None
         session = None
 
         claims_options = kwargs.pop("claims_options", None)
@@ -103,7 +102,6 @@ class TornadoOAuth2App(OAuth2Mixin, OpenIDMixin, BaseApp):  # type: ignore[misc]
         """
         state = kwargs.pop("state", None)
         if state:
-            assert self.framework.cache is not None
             session = None
             self.framework.set_state_data(session, state, kwargs)
         else:

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -38,7 +38,10 @@ class NewFragmentIdQueueTest(unittest.TestCase):
         ctx.fragment_ids_this_run = ["some_fragment_id"]
         ctx.current_fragment_id = "some_other_fragment_id"
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(
+            RuntimeError,
+            match="Could not find current_fragment_id in fragment_id_queue. This should never happen.",
+        ):
             _new_fragment_id_queue(ctx, scope="fragment")
 
     def test_drops_items_in_queue_until_curr_id(self):

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -229,6 +229,41 @@ class DeclareComponentTest(unittest.TestCase):
         components.declare_component("test", url=URL)
         self.assertIsInstance(ComponentRegistry.instance(), LocalComponentRegistry)
 
+    @patch("streamlit.components.v1.component_registry.inspect.currentframe")
+    def test_declare_component_raises_runtime_error_if_current_frame_is_none(
+        self, mock_currentframe
+    ):
+        """Test that declare_component raises RuntimeError if inspect.currentframe returns None."""
+        mock_currentframe.return_value = None
+        with pytest.raises(
+            RuntimeError, match="current_frame is None. This should never happen."
+        ) as e:
+            components.declare_component("test_component", url="http://example.com")
+
+    @patch("streamlit.components.v1.component_registry.inspect.currentframe")
+    def test_declare_component_raises_runtime_error_if_caller_frame_is_none(
+        self, mock_currentframe
+    ):
+        """Test that declare_component raises RuntimeError if inspect.currentframe().f_back is None."""
+        mock_frame = MagicMock()
+        mock_frame.f_back = None
+        mock_currentframe.return_value = mock_frame
+        with pytest.raises(
+            RuntimeError, match="caller_frame is None. This should never happen."
+        ):
+            components.declare_component("test_component", url="http://example.com")
+
+    @patch("streamlit.components.v1.component_registry.inspect.getmodule")
+    def test_declare_component_raises_runtime_error_if_module_is_none(
+        self, mock_getmodule
+    ):
+        """Test that declare_component raises RuntimeError if inspect.getmodule returns None."""
+        mock_getmodule.return_value = None
+        with pytest.raises(
+            RuntimeError, match="module is None. This should never happen."
+        ):
+            components.declare_component("test_component", url="http://example.com")
+
 
 class ComponentRegistryTest(unittest.TestCase):
     """Test component registration."""

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -237,7 +237,7 @@ class DeclareComponentTest(unittest.TestCase):
         mock_currentframe.return_value = None
         with pytest.raises(
             RuntimeError, match="current_frame is None. This should never happen."
-        ) as e:
+        ):
             components.declare_component("test_component", url="http://example.com")
 
     @patch("streamlit.components.v1.component_registry.inspect.currentframe")

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -34,9 +34,11 @@ class ConfigOptionTest(unittest.TestCase):
         ]
     )
     def test_invalid_key(self, key):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(
+            ValueError,
+            match=f'Key "{key}" has invalid format.',
+        ):
             ConfigOption(key)
-        self.assertEqual('Key "%s" has invalid format.' % key, str(e.value))
 
     @parameterized.expand(
         [
@@ -76,16 +78,14 @@ class ConfigOptionTest(unittest.TestCase):
         key = "mysection.myName"
         c = ConfigOption(key)
 
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(
+            RuntimeError,
+            match="Complex config options require doc strings for their description.",
+        ):
 
             @c
             def someRandomFunction():
                 pass
-
-        self.assertEqual(
-            "Complex config options require doc strings for their description.",
-            str(e.value),
-        )
 
     def test_value(self):
         my_value = "myValue"

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -144,7 +144,10 @@ class ConfigTest(unittest.TestCase):
 
         This is because the doc string forms the option's description.
         """
-        with self.assertRaises(AssertionError):
+        with pytest.raises(
+            RuntimeError,
+            match="Complex config options require doc strings for their description.",
+        ):
 
             @ConfigOption("_test.noDocString")
             def no_doc_string():
@@ -152,23 +155,32 @@ class ConfigTest(unittest.TestCase):
 
     def test_invalid_config_name(self):
         """Test setting an invalid config section."""
-        with self.assertRaises(AssertionError):
+        with pytest.raises(
+            ValueError,
+            match='Key "_test.myParam." has invalid format.',
+        ):
             ConfigOption("_test.myParam.")
 
     def test_invalid_config_section(self):
         """Test setting an invalid config section."""
-        with self.assertRaises(AssertionError):
+        with pytest.raises(RuntimeError):
             config._create_option("mySection.myParam")
 
     def test_cannot_overwrite_config_section(self):
         """Test overwriting a config section using _create_section."""
-        with self.assertRaises(AssertionError):
+        with pytest.raises(
+            RuntimeError,
+            match='Cannot define section "_test2" twice.',
+        ):
             config._create_section("_test2", "A test section.")
             config._create_section("_test2", "A test section.")
 
     def test_cannot_overwrite_config_key(self):
         """Test overwriting a config option using _create_option."""
-        with self.assertRaises(AssertionError):
+        with pytest.raises(
+            RuntimeError,
+            match='Cannot define option "_test.overwriteKey" twice.',
+        ):
             config._create_option("_test.overwriteKey")
             config._create_option("_test.overwriteKey")
 
@@ -178,7 +190,10 @@ class ConfigTest(unittest.TestCase):
         Note the exception is the "_test" section which is used
         for unit testing.
         """
-        with self.assertRaises(AssertionError):
+        with pytest.raises(
+            ValueError,
+            match='Key "_test.snake_case" has invalid format.',
+        ):
             config._create_option("_test.snake_case")
 
     def test_get_set_and_complex_config_options(self):
@@ -548,12 +563,11 @@ class ConfigTest(unittest.TestCase):
     def test_check_conflicts_server_port(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("server.port", 1234, "test")
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(
+            RuntimeError,
+            match="server.port does not work when global.developmentMode is true.",
+        ):
             config._check_conflicts()
-        self.assertEqual(
-            str(e.value),
-            "server.port does not work when global.developmentMode is true.",
-        )
 
     @patch("streamlit.logger.get_logger")
     def test_check_conflicts_server_csrf(self, get_logger):
@@ -566,12 +580,11 @@ class ConfigTest(unittest.TestCase):
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("browser.serverPort", 1234, "test")
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(
+            RuntimeError,
+            match="browser.serverPort does not work when global.developmentMode is true.",
+        ):
             config._check_conflicts()
-        self.assertEqual(
-            str(e.value),
-            "browser.serverPort does not work when global.developmentMode is true.",
-        )
 
     def test_maybe_convert_to_number(self):
         self.assertEqual(1234, config._maybe_convert_to_number("1234"))

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -1034,6 +1034,86 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             handle_backmsg_exception.assert_not_called()
             patched_logger.warning.assert_not_called()
 
+    async def test_event_handler_raises_error_if_page_hash_none_on_script_started(
+        self,
+    ):
+        """Test that _handle_scriptrunner_event_on_event_loop raises RuntimeError
+        if page_script_hash is None when event is SCRIPT_STARTED.
+        """
+        session = _create_test_session(asyncio.get_running_loop())
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+
+        with pytest.raises(
+            RuntimeError,
+            match="page_script_hash must be set for the SCRIPT_STARTED event. This should never happen.",
+        ):
+            session._handle_scriptrunner_event_on_event_loop(
+                sender=mock_scriptrunner,
+                event=ScriptRunnerEvent.SCRIPT_STARTED,
+                page_script_hash=None,  # This is the condition we're testing
+            )
+
+    async def test_event_handler_raises_error_if_exception_none_on_compile_error(
+        self,
+    ):
+        """Test that _handle_scriptrunner_event_on_event_loop raises RuntimeError
+        if exception is None when event is SCRIPT_STOPPED_WITH_COMPILE_ERROR.
+        """
+        session = _create_test_session(asyncio.get_running_loop())
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+
+        with pytest.raises(
+            RuntimeError,
+            match="exception must be set for the SCRIPT_STOPPED_WITH_COMPILE_ERROR event. This should never happen.",
+        ):
+            session._handle_scriptrunner_event_on_event_loop(
+                sender=mock_scriptrunner,
+                event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR,
+                exception=None,  # This is the condition we're testing
+            )
+
+    async def test_event_handler_raises_error_if_client_state_none_on_shutdown(
+        self,
+    ):
+        """Test that _handle_scriptrunner_event_on_event_loop raises RuntimeError
+        if client_state is None when event is SHUTDOWN.
+        """
+        session = _create_test_session(asyncio.get_running_loop())
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+
+        with pytest.raises(
+            RuntimeError,
+            match="client_state must be set for the SHUTDOWN event. This should never happen.",
+        ):
+            session._handle_scriptrunner_event_on_event_loop(
+                sender=mock_scriptrunner,
+                event=ScriptRunnerEvent.SHUTDOWN,
+                client_state=None,  # This is the condition we're testing
+            )
+
+    async def test_event_handler_raises_error_if_forward_msg_none_on_enqueue(
+        self,
+    ):
+        """Test that _handle_scriptrunner_event_on_event_loop raises RuntimeError
+        if forward_msg is None when event is ENQUEUE_FORWARD_MSG.
+        """
+        session = _create_test_session(asyncio.get_running_loop())
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+
+        with pytest.raises(
+            RuntimeError,
+            match="null forward_msg in ENQUEUE_FORWARD_MSG event. This should never happen.",
+        ):
+            session._handle_scriptrunner_event_on_event_loop(
+                sender=mock_scriptrunner,
+                event=ScriptRunnerEvent.ENQUEUE_FORWARD_MSG,
+                forward_msg=None,  # This is the condition we're testing
+            )
+
 
 class PopulateCustomThemeMsgTest(unittest.TestCase):
     @patch("streamlit.runtime.app_session.config")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -902,7 +902,11 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
                 "streamlit.runtime.app_session.asyncio.get_running_loop",
                 return_value=MagicMock(),
             ),
-            pytest.raises(AssertionError),
+            pytest.raises(
+                RuntimeError,
+                match="This function must only be called on the eventloop thread "
+                "the AppSession was created on. This should never happen.",
+            ),
         ):
             session._handle_scriptrunner_event_on_event_loop(
                 sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -143,7 +143,10 @@ class RuntimeTest(RuntimeTestCase):
         """Test that setting both existing_session_id and session_id_override is an error."""
         await self.runtime.start()
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(
+            RuntimeError,
+            match="Only one of existing_session_id and session_id_override should be set. This should never happen.",
+        ):
             self.runtime.connect_session(
                 client=MockSessionClient(),
                 user_info=MagicMock(),

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -78,8 +78,11 @@ class WebsocketSessionManagerTests(unittest.TestCase):
 
         assert session_info.session.id == session_id
 
-    def test_connect_session_assert(self):
-        with pytest.raises(AssertionError):
+    def test_connect_session_check(self):
+        with pytest.raises(
+            RuntimeError,
+            match="Only one of existing_session_id and session_id_override should be truthy. This should never happen.",
+        ):
             self.connect_session(
                 existing_session_id="existing_session_id",
                 session_id_override="session_id_override",
@@ -115,7 +118,7 @@ class WebsocketSessionManagerTests(unittest.TestCase):
     def test_connect_session_explodes_if_ID_collission(self):
         session_id = self.connect_session()
         with (
-            pytest.raises(AssertionError),
+            pytest.raises(RuntimeError),
             patch("streamlit.runtime.app_session.uuid.uuid4", return_value=session_id),
         ):
             self.connect_session()

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -44,10 +44,11 @@ class PageHelperFunctionTests(unittest.TestCase):
         assert source_util.page_sort_key(Path(path_str)) == expected
 
     def test_page_sort_key_error(self):
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(
+            ValueError,
+            match="/foo/bar/baz.rs is not a Python file. This should never happen.",
+        ):
             source_util.page_sort_key(Path("/foo/bar/baz.rs"))
-
-        assert str(e.value) == f"{Path('/foo/bar/baz.rs')} is not a Python file"
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Describe your changes

Assertions are removed when Python is run with optimization requested, which is a common practice in production environments. As such, it is suggested not to use asserts in production code. This also activates the [S101](https://docs.astral.sh/ruff/rules/assert/) rule to prevent usage of `assert` in our library code. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
