### PR TITLE
[feat] Add `level` property for st.toast

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -404,6 +404,7 @@ const RawElementNodeRenderer = (
           key={node.scriptRunId}
           body={toastProto.body}
           icon={toastProto.icon}
+          level={toastProto.level}
           {...elementProps}
         />
       )

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -41,9 +41,30 @@ import {
 export interface ToastProps {
   body: string
   icon?: string
+  level?: string | null
 }
 
-function generateToastOverrides(theme: EmotionTheme): ToastOverrides {
+function getToastBgColor(theme: EmotionTheme, level?: string | null): string {
+  switch (level) {
+    case "info":
+      return theme.colors.infoBg
+    case "success":
+      return theme.colors.successBg
+    case "warning":
+      return theme.colors.warningBg
+    case "error":
+      return theme.colors.dangerBg
+    default:
+      return hasLightBackgroundColor(theme)
+        ? theme.colors.gray10
+        : theme.colors.gray90
+  }
+}
+
+function generateToastOverrides(
+  theme: EmotionTheme,
+  level?: string | null
+): ToastOverrides {
   const lightBackground = hasLightBackgroundColor(theme)
   return {
     Body: {
@@ -66,9 +87,7 @@ function generateToastOverrides(theme: EmotionTheme): ToastOverrides {
         paddingBottom: theme.spacing.lg,
         paddingLeft: theme.spacing.twoXL,
         paddingRight: theme.spacing.twoXL,
-        backgroundColor: lightBackground
-          ? theme.colors.gray10
-          : theme.colors.gray90,
+        backgroundColor: getToastBgColor(theme, level),
         color: theme.colors.bodyText,
         // Take standard BaseWeb shadow and adjust for dark backgrounds
         boxShadow: lightBackground
@@ -111,7 +130,7 @@ export function shortenMessage(fullMessage: string): string {
   return fullMessage
 }
 
-function Toast({ body, icon }: Readonly<ToastProps>): ReactElement {
+function Toast({ body, icon, level }: Readonly<ToastProps>): ReactElement {
   const theme: EmotionTheme = useTheme()
   const displayMessage = shortenMessage(body)
   const shortened = body !== displayMessage
@@ -123,7 +142,10 @@ function Toast({ body, icon }: Readonly<ToastProps>): ReactElement {
     setExpanded(!expanded)
   }, [expanded])
 
-  const styleOverrides = useMemo(() => generateToastOverrides(theme), [theme])
+  const styleOverrides = useMemo(
+    () => generateToastOverrides(theme, level),
+    [theme, level]
+  )
 
   const toastContent = useMemo(
     () => (

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Toast_pb2 import Toast as ToastProto
@@ -34,6 +34,15 @@ def validate_text(toast_text: SupportsStr) -> SupportsStr:
     return toast_text
 
 
+def validate_level(level: str) -> str:
+    if level not in ["info", "success", "warning", "error"]:
+        raise StreamlitAPIException(
+            f"Invalid toast level: {level}. Must be one of: "
+            "'info', 'success', 'warning', or 'error'."
+        )
+    return level
+
+
 class ToastMixin:
     @gather_metrics("toast")
     def toast(
@@ -41,6 +50,7 @@ class ToastMixin:
         body: SupportsStr,
         *,  # keyword-only args:
         icon: str | None = None,
+        level: Literal["info", "success", "warning", "error"] | None = None,
     ) -> DeltaGenerator:
         """Display a short message, known as a notification "toast".
         The toast appears in the app's top-right corner and disappears after four seconds.
@@ -79,6 +89,10 @@ class ToastMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
+        level : None, "info", "success", "warning", "error"
+            The level of the toast. This determines the color of the toast.
+            The default is None.
+
 
         Example
         -------
@@ -89,6 +103,8 @@ class ToastMixin:
         toast_proto = ToastProto()
         toast_proto.body = clean_text(validate_text(body))
         toast_proto.icon = validate_icon_or_emoji(icon)
+        if level:
+            toast_proto.level = validate_level(level)
         return self.dg._enqueue("toast", toast_proto)
 
     @property

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1370,6 +1370,7 @@ class TimeInput(Widget):
 class Toast(Element):
     proto: ToastProto = field(repr=False)
     icon: str
+    level: str | None
 
     def __init__(self, proto: ToastProto, root: ElementTree) -> None:
         self.proto = proto

--- a/lib/tests/streamlit/toast_test.py
+++ b/lib/tests/streamlit/toast_test.py
@@ -47,6 +47,14 @@ class ToastTest(DeltaGeneratorTestCase):
         self.assertEqual(c.body, "toast text")
         self.assertEqual(c.icon, "🦄")
 
+    def test_valid_level(self):
+        """Test that it can be called passing a valid level."""
+        st.toast("toast text", level="success")
+
+        c = self.get_delta_from_queue().new_element.toast
+        self.assertEqual(c.body, "toast text")
+        self.assertEqual(c.level, "success")
+
     def test_invalid_icon(self):
         """Test that an error is raised if an invalid icon is provided."""
         with self.assertRaises(StreamlitAPIException) as e:
@@ -54,4 +62,13 @@ class ToastTest(DeltaGeneratorTestCase):
         self.assertEqual(
             str(e.exception),
             'The value "invalid" is not a valid emoji. Shortcodes are not allowed, please use a single character instead.',
+        )
+
+    def test_invalid_level(self):
+        """Test that an error is raised if an invalid level is provided."""
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.toast("toast text", level="invalid")
+        self.assertEqual(
+            str(e.exception),
+            "Invalid toast level: invalid. Must be one of: 'info', 'success', 'warning', or 'error'.",
         )

--- a/proto/streamlit/proto/Toast.proto
+++ b/proto/streamlit/proto/Toast.proto
@@ -25,4 +25,7 @@ message Toast {
 
     // Emoji
     string icon = 2;
+
+    // Level
+    optional string level = 3;
 }


### PR DESCRIPTION
## Describe your changes
Add `level` property for st.toast, which changes background color of st.toast under different levels

![Screenshot 2025-05-21 at 18 59 09](https://github.com/user-attachments/assets/c69e7aba-2746-49bd-b75d-36f1526d965f)


## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/10304

## Testing Plan
Explanation of why no additional tests are needed
Unit Tests (JS and/or Python)
E2E Tests
Any manual testing needed?

----

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
