### PR TITLE
`font` -> `family` in theme.fontFaces docs

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1126,7 +1126,7 @@ _create_theme_options(
         - "sans-serif"
         - "serif"
         - "monospace"
-        - the `font` value for a custom font table under [[theme.fontFaces]]
+        - the `family` value for a custom font table under [[theme.fontFaces]]
         - a comma-separated list of these (as a single string) to specify
           fallbacks
 
@@ -1146,7 +1146,7 @@ _create_theme_options(
         - "sans-serif"
         - "serif"
         - "monospace"
-        - the `font` value for a custom font table under [[theme.fontFaces]]
+        - the `family` value for a custom font table under [[theme.fontFaces]]
         - a comma-separated list of these (as a single string) to specify
           fallbacks
     """,
@@ -1161,7 +1161,7 @@ _create_theme_options(
         - "sans-serif"
         - "serif"
         - "monospace"
-        - the `font` value for a custom font table under [[theme.fontFaces]]
+        - the `family` value for a custom font table under [[theme.fontFaces]]
         - a comma-separated list of these (as a single string) to specify
           fallbacks
 
@@ -1187,7 +1187,7 @@ _create_theme_options(
         follows:
 
             [[theme.fontFaces]]
-            font = "font_name"
+            family = "font_name"
             url = "app/static/font_file.woff"
             weight = 400
             style = "normal"

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1176,7 +1176,7 @@ _create_theme_options(
         An array of fonts to use in your app.
 
         Each font in the array is a table (dictionary) with the following three
-        attributes: font, url, weight, and style.
+        attributes: family, url, weight, and style.
 
         To host a font with your app, enable static file serving with
         `server.enableStaticServing=true`.


### PR DESCRIPTION
## Describe your changes

When I tried to follow the docs as-is, I got this error 

```
google.protobuf.json_format.ParseError: Message type "FontFace" has no field named "font" at "FontFace".
 Available Fields(except extensions): "['url', 'family', 'weight', 'style']"
 ```

Here was the config I was trying to use 

```toml
[theme]
font = "SF Mono"

[[theme.fontFaces]]
font = "SF Mono"
url = "app/static/SFMono-Heavy.otf"
weight = 400
style = "normal"
```
 
 So I tried `family` instead of `font`, and it worked

```toml
[theme]
font = "SF Mono"

[[theme.fontFaces]]
family = "SF Mono" # Changed font -> family
url = "app/static/SFMono-Heavy.otf"
weight = 400
style = "normal"
```

This was with streamlit 1.45.1

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
