### PR TITLE
[refactor] Update no-unused-vars eslint rule to be stricter

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -121,7 +121,7 @@ module.exports = {
       "error",
       {
         vars: "all",
-        args: "after-used",
+        args: "all",
         ignoreRestSiblings: false,
         argsIgnorePattern: "^_",
       },

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -547,7 +547,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   override componentDidUpdate(
-    prevProps: Readonly<Props>,
+    _prevProps: Readonly<Props>,
     prevState: Readonly<State>
   ): void {
     // @ts-expect-error

--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -115,7 +115,7 @@ describe("SidebarNav", () => {
     it("are added to each link", () => {
       const buildAppPageURL = vi
         .fn()
-        .mockImplementation((pageLinkBaseURL: string, page: IAppPage) => {
+        .mockImplementation((_pageLinkBaseURL: string, page: IAppPage) => {
           return `http://mock/app/page/${page.urlPathname}`
         })
       const props = getProps({ endpoints: mockEndpoints({ buildAppPageURL }) })

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -226,7 +226,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   public async uploadFileUploaderFile(
     fileUploadUrl: string,
     file: File,
-    sessionId: string,
+    _sessionId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken

--- a/frontend/connection/src/testUtils.ts
+++ b/frontend/connection/src/testUtils.ts
@@ -32,7 +32,7 @@ export function mockEndpoints(
     buildAppPageURL: vi
       .fn()
       .mockImplementation(
-        (pageLinkBaseURL: string, page: IAppPage, pageIndex: number) => {
+        (_pageLinkBaseURL: string, page: IAppPage, pageIndex: number) => {
           return `http://mock/app/page/${page.pageName}.${pageIndex}`
         }
       ),

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -99,7 +99,7 @@ export class WidgetStateDict {
 
   /** Remove the state of widgets that are not contained in `activeIds`. */
   public removeInactive(activeIds: Set<string>): void {
-    this.widgetStates.forEach((value, key) => {
+    this.widgetStates.forEach((_value, key) => {
       if (!activeIds.has(key)) {
         this.widgetStates.delete(key)
       }

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/utils/colors.test.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/utils/colors.test.ts
@@ -162,7 +162,7 @@ describe("#getContextualFillColor", () => {
     ],
   ]
 
-  it.each(testCases)("%s", (description, args, expected) => {
+  it.each(testCases)("%s", (_description, args, expected) => {
     expect(getContextualFillColor(args)).toEqual(expected)
   })
 })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -596,7 +596,7 @@ function createRemarkStreamlitLogo() {
 function createRemarkTypographicalSymbols() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   return () => (tree: any) => {
-    visit(tree, (node, index, parent) => {
+    visit(tree, (node, _index, parent) => {
       if (
         parent &&
         (parent.type === "link" || parent.type === "linkReference")

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -104,7 +104,7 @@ const mergeColumnConfig = (
 ): ColumnConfigProps => {
   // Don't merge arrays, just overwrite the old value with the new value
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const customMergeArrays = (objValue: object, srcValue: object): any => {
+  const customMergeArrays = (_objValue: object, srcValue: object): any => {
     // If the new value is an array, just return it as is (overwriting the old)
     if (isArray(srcValue)) {
       return srcValue

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -179,7 +179,7 @@ export function useBasicWidgetState<
   Dispatch<SetStateAction<ValueWithSource<T> | null>>
 ] {
   const getDefaultState = useCallback<(wm: WidgetStateManager, el: P) => T>(
-    (wm, el) => {
+    (_wm, el) => {
       return getDefaultStateFromProto(el)
     },
     [getDefaultStateFromProto]

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -63,7 +63,7 @@ export function mockEndpoints(
     buildAppPageURL: vi
       .fn()
       .mockImplementation(
-        (pageLinkBaseURL: string, page: IAppPage, pageIndex: number) => {
+        (_pageLinkBaseURL: string, page: IAppPage, pageIndex: number) => {
           return `http://mock/app/page/${page.pageName}.${pageIndex}`
         }
       ),


### PR DESCRIPTION
## Describe your changes

- Makes the `no-used-vars` rule stricter so that we don't let cases like https://github.com/streamlit/streamlit/pull/11378/files#r2093532212 slip through moving forward

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This is a lint change, which is checked at CI time

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
