### PR TITLE
[WIP] [Prototype] Use entrypoint dir for config

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -26,6 +26,7 @@ from enum import Enum
 from typing import Any, Callable, Final, Literal
 
 from blinker import Signal
+from typing_extensions import Self
 
 from streamlit import config_util, development, env_util, file_util, util
 from streamlit.config_option import ConfigOption
@@ -66,6 +67,25 @@ _DEFINED_BY_FLAG: Final = "command-line argument or environment variable"
 _DEFINED_BY_ENV_VAR: Final = "environment variable"
 
 _LOGGER: Final = logging.getLogger(__name__)
+
+
+class Entrypoint:
+    _instance = None
+    _dir = None
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @property
+    def dir(self) -> str | None:
+        return self._dir
+
+    def set_dir(self, dir: str):
+        if not isinstance(dir, str):
+            raise TypeError("dir must be a string")
+        self._dir = dir
 
 
 class ShowErrorDetailsConfigOptions(str, Enum):
@@ -1270,7 +1290,8 @@ _create_option(
         # NOTE: The order here is important! Project-level secrets should overwrite
         # global secrets.
         file_util.get_streamlit_file_path("secrets.toml"),
-        file_util.get_project_streamlit_file_path("secrets.toml"),
+        file_util.get_working_dir_streamlit_file_path("secrets.toml"),
+        ## TODO: Add path to entrypoint directory
     ],
 )
 
@@ -1522,7 +1543,7 @@ _on_config_parsed = Signal(doc="Emitted when the config file is parsed.")
 
 CONFIG_FILENAMES = [
     file_util.get_streamlit_file_path("config.toml"),
-    file_util.get_project_streamlit_file_path("config.toml"),
+    file_util.get_working_dir_streamlit_file_path("config.toml"),
 ]
 
 
@@ -1574,6 +1595,16 @@ def get_config_options(
 
         # Values set in files later in the CONFIG_FILENAMES list overwrite those
         # set earlier.
+        if len(CONFIG_FILENAMES) < 3 and Entrypoint().dir is not None:
+            # If there are less than 3 config files, we need to add the
+            # entrypoint directory config file to the list. We are updating a
+            # value in the parent scope because we don't have access to the
+            # entrypoint_dir variable when the config file is imported.
+            CONFIG_FILENAMES.append(
+                file_util.get_project_streamlit_file_path(
+                    Entrypoint().dir, "config.toml"
+                )
+            )
         for filename in CONFIG_FILENAMES:
             if not os.path.exists(filename):
                 continue

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -148,12 +148,20 @@ def get_streamlit_file_path(*filepath: str) -> str:
     return str(home / CONFIG_FOLDER_NAME / Path(*filepath))
 
 
-def get_project_streamlit_file_path(*filepath: str) -> str:
+def get_working_dir_streamlit_file_path(*filepath: str) -> str:
     """Return the full path to a filepath in ${CWD}/.streamlit.
 
     This doesn't guarantee that the file (or its directory) exists.
     """
     return str(Path.cwd() / CONFIG_FOLDER_NAME / Path(*filepath))
+
+
+def get_project_streamlit_file_path(entrypoint_dir: str, *filepath: str) -> str:
+    """Return the full path to a filepath in ${entrypoint dir}/.streamlit.
+
+    This doesn't guarantee that the file (or its directory) exists.
+    """
+    return str(Path(entrypoint_dir).resolve() / CONFIG_FOLDER_NAME / Path(*filepath))
 
 
 def file_is_in_folder_glob(filepath: str, folderpath_glob: str) -> bool:

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -205,7 +205,9 @@ def main_run(target: str, args: list[str] | None = None, **kwargs: Any) -> None:
 
     """
     from streamlit import url_util
+    from streamlit.config import Entrypoint
 
+    Entrypoint().set_dir(os.path.dirname(target))
     bootstrap.load_config_options(flag_options=kwargs)
 
     _, extension = os.path.splitext(target)

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -99,7 +99,7 @@ class FileUtilTest(unittest.TestCase):
             )
             assert str(e.value) == error_msg
 
-    def test_get_project_streamlit_file_path(self):
+    def test_get_working_dir_streamlit_file_path(self):
         expected = os.path.join(
             os.getcwd(), file_util.CONFIG_FOLDER_NAME, "some/random/file"
         )


### PR DESCRIPTION
Check the entrypoint dir for configuration before the working directory, then global user directory.

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
