### PR TITLE
Exclude tornado 6.5.0 version

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -66,7 +66,9 @@ SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython>=3.0.7, <4, !=3.1.19",
     "pydeck>=0.8.0b4, <1",
     # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
-    "tornado>=6.0.3, <7",
+    # Tornado 6.5.0 is skipped due to a bug with Unicode characters in the filename.
+    # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
+    "tornado>=6.0.3, <7, !=6.5.0",
 ]
 
 if not os.getenv("SNOWPARK_CONDA_BUILD"):


### PR DESCRIPTION
## Describe your changes

Exclude Tornado 6.5.0 version due to the bug with uploaded unicode filenames. 
See: https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391

Closes: https://github.com/streamlit/streamlit/issues/11396 , https://github.com/streamlit/streamlit/issues/11436

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
