### PR TITLE
[fix] RTL eslint rule scoping

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -43,8 +43,6 @@ module.exports = {
     // This will display prettier errors as ESLint errors.
     // Make sure this is always the last configuration in the extends array.
     "plugin:prettier/recommended",
-    // Uses the recommended rules from React Testing Library:
-    "plugin:testing-library/react",
     // Uses the recommended rules from lodash
     "plugin:lodash/recommended",
     // This uses the `-legacy` nomenclature since we're on an older version of
@@ -275,6 +273,7 @@ module.exports = {
     {
       // test-only rules
       files: ["**/*.test.ts", "**/*.test.tsx"],
+      // Uses the recommended rules from React Testing Library:
       extends: ["plugin:testing-library/react"],
       rules: {
         "testing-library/prefer-user-event": "error",

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -112,8 +112,6 @@ const Toast = lazy(() => import("~lib/components/elements/Toast"))
 // when the sidebar is toggled, which significantly slows down the app.
 const BokehChart = lazy(() => import("~lib/components/elements/BokehChart"))
 
-// RTL ESLint triggers a false positive on this render function
-// eslint-disable-next-line testing-library/render-result-naming-convention
 const DebouncedBokehChart = withCalculatedWidth(
   debounceRender(BokehChart, 100)
 )


### PR DESCRIPTION
## Describe your changes

- Per the directions in [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library?tab=readme-ov-file#run-the-plugin-only-against-test-files), this PR ensures that the RTL rules are only run on test files, not source files.
- Before this change, it was possible to get false positives

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This is a lint change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
