### PR TITLE
[fix] Flakiness in WebsocketConnection tests

### DIFF
--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -119,7 +119,7 @@ describe("doInitPings", () => {
   // Helper function to create retry callbacks that advance timers
   const createTimerAdvancingRetryCallback = (
     originalCallback?: typeof MOCK_PING_DATA.retryCallback
-  ) => {
+  ): ReturnType<typeof vi.fn> => {
     return vi.fn((_times, _errorNode, timeout) => {
       if (originalCallback) {
         originalCallback(_times, _errorNode, timeout)

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -116,13 +116,28 @@ describe("doInitPings", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let originalAxiosGet: any
 
+  // Helper function to create retry callbacks that advance timers
+  const createTimerAdvancingRetryCallback = (
+    originalCallback?: typeof MOCK_PING_DATA.retryCallback
+  ) => {
+    return vi.fn((_times, _errorNode, timeout) => {
+      if (originalCallback) {
+        originalCallback(_times, _errorNode, timeout)
+      }
+      vi.advanceTimersByTime(timeout)
+    })
+  }
+
   beforeEach(() => {
+    vi.useFakeTimers()
     originalAxiosGet = axios.get
     MOCK_PING_DATA.retryCallback = vi.fn()
     MOCK_PING_DATA.setAllowedOrigins = vi.fn()
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     axios.get = originalAxiosGet
     window.__STREAMLIT_HOST_CONFIG_BASE_URL = undefined
   })
@@ -203,14 +218,21 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    const uriIndex = await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback()
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    const uriIndex = await pingPromise
+
     expect(uriIndex).toEqual(1)
     expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_ORIGINS_CONFIG
@@ -229,14 +251,22 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
@@ -257,14 +287,22 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
@@ -289,14 +327,22 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
@@ -319,14 +365,22 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
@@ -369,14 +423,22 @@ describe("doInitPings", () => {
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA_LOCALHOST.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA_LOCALHOST.uri,
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA_LOCALHOST.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA_LOCALHOST.retryCallback).toHaveBeenCalledWith(
       1,
@@ -405,14 +467,22 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
@@ -438,18 +508,27 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
+
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      `Connection failed with status ${TEST_ERROR.response.status}, and response "${TEST_ERROR.response.data}".`,
+      `Connection failed with status ${TEST_ERROR.response.status}, ` +
+        `and response "${TEST_ERROR.response.data}".`,
       expect.anything()
     )
   })
@@ -478,14 +557,22 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
-    await doInitPings(
+    const retryCallback = createTimerAdvancingRetryCallback(
+      MOCK_PING_DATA.retryCallback
+    )
+
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      MOCK_PING_DATA.retryCallback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledTimes(5)
   })
@@ -515,15 +602,17 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
     const timeouts: number[] = []
-    const callback = (
+    const retryCallback = (
       _times: number,
       _errorNode: React.ReactNode,
       timeout: number
     ): void => {
       timeouts.push(timeout)
+      // Advance timers to allow the next retry to execute
+      vi.advanceTimersByTime(timeout)
     }
 
-    await doInitPings(
+    const pingPromise = doInitPings(
       [
         {
           hostname: "not.a.real.host",
@@ -533,10 +622,14 @@ If you are trying to access a Streamlit app running on another server, this coul
       ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      callback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(timeouts.length).toEqual(5)
     expect(timeouts[0]).toEqual(10)
@@ -575,22 +668,28 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
     const timeouts: number[] = []
-    const callback = (
+    const retryCallback = (
       _times: number,
       _errorNode: React.ReactNode,
       timeout: number
     ): void => {
       timeouts.push(timeout)
+      // Advance timers to allow the next retry to execute
+      vi.advanceTimersByTime(timeout)
     }
 
-    await doInitPings(
+    const pingPromise = doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      callback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise
 
     expect(timeouts.length).toEqual(5)
     expect(timeouts[0]).toEqual(10)
@@ -624,15 +723,17 @@ If you are trying to access a Streamlit app running on another server, this coul
       .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
 
     const timeouts: number[] = []
-    const callback = (
+    const retryCallback = (
       _times: number,
       _errorNode: React.ReactNode,
       timeout: number
     ): void => {
       timeouts.push(timeout)
+      // Advance timers to allow the next retry to execute
+      vi.advanceTimersByTime(timeout)
     }
 
-    await doInitPings(
+    const pingPromise1 = doInitPings(
       [
         {
           hostname: "not.a.real.host",
@@ -642,21 +743,27 @@ If you are trying to access a Streamlit app running on another server, this coul
       ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      callback,
+      retryCallback,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
 
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise1
+
     const timeouts2: number[] = []
-    const callback2 = (
+    const retryCallback2 = (
       _times: number,
       _errorNode: React.ReactNode,
       timeout: number
     ): void => {
       timeouts2.push(timeout)
+      // Advance timers to allow the next retry to execute
+      vi.advanceTimersByTime(timeout)
     }
 
-    await doInitPings(
+    const pingPromise2 = doInitPings(
       [
         {
           hostname: "not.a.real.host",
@@ -666,10 +773,14 @@ If you are trying to access a Streamlit app running on another server, this coul
       ],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
-      callback2,
+      retryCallback2,
       MOCK_PING_DATA.sendClientError,
       MOCK_PING_DATA.setAllowedOrigins
     )
+
+    // Run any remaining timers to complete the ping process
+    await vi.runAllTimersAsync()
+    await pingPromise2
 
     expect(timeouts[0]).toEqual(10)
     expect(timeouts[1]).toBeGreaterThan(timeouts[0])
@@ -691,14 +802,20 @@ If you are trying to access a Streamlit app running on another server, this coul
         },
       })
 
-      await doInitPings(
+      const retryCallback = createTimerAdvancingRetryCallback()
+
+      const pingPromise = doInitPings(
         MOCK_PING_DATA.uri,
         MOCK_PING_DATA.timeoutMs,
         MOCK_PING_DATA.maxTimeoutMs,
-        MOCK_PING_DATA.retryCallback,
+        retryCallback,
         sendClientErrorSpy,
         MOCK_PING_DATA.setAllowedOrigins
       )
+
+      // Run any remaining timers to complete the ping process
+      await vi.runAllTimersAsync()
+      await pingPromise
 
       // Verify that sendClientError was called with the expected arguments
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
@@ -722,14 +839,20 @@ If you are trying to access a Streamlit app running on another server, this coul
         },
       })
 
-      await doInitPings(
+      const retryCallback = createTimerAdvancingRetryCallback()
+
+      const pingPromise = doInitPings(
         MOCK_PING_DATA.uri,
         MOCK_PING_DATA.timeoutMs,
         MOCK_PING_DATA.maxTimeoutMs,
-        MOCK_PING_DATA.retryCallback,
+        retryCallback,
         sendClientErrorSpy,
         MOCK_PING_DATA.setAllowedOrigins
       )
+
+      // Run any remaining timers to complete the ping process
+      await vi.runAllTimersAsync()
+      await pingPromise
 
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         403,
@@ -752,14 +875,20 @@ If you are trying to access a Streamlit app running on another server, this coul
         },
       })
 
-      await doInitPings(
+      const retryCallback = createTimerAdvancingRetryCallback()
+
+      const pingPromise = doInitPings(
         MOCK_PING_DATA.uri,
         MOCK_PING_DATA.timeoutMs,
         MOCK_PING_DATA.maxTimeoutMs,
-        MOCK_PING_DATA.retryCallback,
+        retryCallback,
         sendClientErrorSpy,
         MOCK_PING_DATA.setAllowedOrigins
       )
+
+      // Run any remaining timers to complete the ping process
+      await vi.runAllTimersAsync()
+      await pingPromise
 
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         500,
@@ -778,14 +907,20 @@ If you are trying to access a Streamlit app running on another server, this coul
         },
       })
 
-      await doInitPings(
+      const retryCallback = createTimerAdvancingRetryCallback()
+
+      const pingPromise = doInitPings(
         MOCK_PING_DATA.uri,
         MOCK_PING_DATA.timeoutMs,
         MOCK_PING_DATA.maxTimeoutMs,
-        MOCK_PING_DATA.retryCallback,
+        retryCallback,
         sendClientErrorSpy,
         MOCK_PING_DATA.setAllowedOrigins
       )
+
+      // Run any remaining timers to complete the ping process
+      await vi.runAllTimersAsync()
+      await pingPromise
 
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         "No response received from server",


### PR DESCRIPTION
## Describe your changes

- Fixes a test issue where cleanup was not properly happening in some cases in CI [[example workflow run here](https://github.com/streamlit/streamlit/actions/runs/15208536408/job/42777130803?pr=11438#step:14:8751)].
- Leverages fake timers to handle this instead. Another positive side-effect is that this test suite now runs in ~200ms rather than ~3.5s locally

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
