### PR TITLE
Fix crash when editing df index with data editor

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -270,8 +270,11 @@ def _apply_cell_edits(
                 # The edited cell is part of the index
                 # TODO(lukasmasuch): To support multi-index in the future:
                 # use a tuple of values here instead of a single value
-                df.index.to_numpy()[row_pos] = _parse_value(
-                    value, dataframe_schema[INDEX_IDENTIFIER]
+                old_idx_value = df.index[row_pos]
+                new_idx_value = _parse_value(value, dataframe_schema[INDEX_IDENTIFIER])
+                df.rename(
+                    index={old_idx_value: new_idx_value},
+                    inplace=True,  # noqa: PD002
                 )
             else:
                 col_pos = df.columns.get_loc(col_name)
@@ -697,7 +700,7 @@ class DataEditorMixin:
             - A string to set the display label of the column.
 
             - One of the column types defined under ``st.column_config``, e.g.
-              ``st.column_config.NumberColumn("Dollar values”, format=”$ %d")`` to show
+              ``st.column_config.NumberColumn("Dollar values", format="$ %d")`` to show
               a column as dollar amounts. See more info on the available column types
               and config options `here <https://docs.streamlit.io/develop/api-reference/data/st.column_config>`_.
 


### PR DESCRIPTION
## Describe your changes

Fixes a segmentation fault crash that happens in some environments when editing dataframe index values with data editor. This seems be a bug with pandas or numpy and only happens when combined with a value from session state and only in some environments. An alternative way of updating index values via `df.rename` seems to work fine. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11434

## Testing Plan

- Added a unit test covering the editing behaviour described in the bug. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
