### PR TITLE
Remove usage of old printf-style formatting

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -42,7 +42,6 @@ ignore = [
   "EM102",  # Checks for the use of f-strings in exception constructors.
   "TRY003", # Checks for exception messages that are not defined in the exception class itself.
   "N806",   # Checks for non-lowercased variable names in functions.
-  "UP031",  # Checks for printf-style string formatting, and offers to replace it with str.format calls.
   "G004",   # Checks for usage of f-strings in logging messages.
   # Ignored rule sets:
   "DTZ", # Checks for usage of unsafe naive datetime class.

--- a/e2e_playwright/config_arrow_truncation.py
+++ b/e2e_playwright/config_arrow_truncation.py
@@ -19,6 +19,6 @@ import streamlit as st
 
 np.random.seed(0)
 
-df = pd.DataFrame(np.random.randn(50000, 20), columns=("col %d" % i for i in range(20)))
+df = pd.DataFrame(np.random.randn(50000, 20), columns=(f"col_{i}" for i in range(20)))
 
 st.dataframe(df)

--- a/e2e_playwright/st_chat_message.py
+++ b/e2e_playwright/st_chat_message.py
@@ -26,7 +26,7 @@ np.random.seed(0)
 # Generate a random dataframe
 df = pd.DataFrame(
     np.random.randn(5, 5),
-    columns=("col_%d" % i for i in range(5)),
+    columns=(f"col_{i}" for i in range(5)),
 )
 
 with st.chat_message("user"):

--- a/e2e_playwright/st_data_editor_config.py
+++ b/e2e_playwright/st_data_editor_config.py
@@ -28,7 +28,7 @@ st.set_page_config(layout="wide")
 # Generate a random dataframe
 df = pd.DataFrame(
     np.random.randn(5, 5),
-    columns=("col_%d" % i for i in range(5)),
+    columns=(f"col_{i}" for i in range(5)),
 )
 
 st.header("Disabled parameter:")

--- a/e2e_playwright/st_dataframe_config.py
+++ b/e2e_playwright/st_dataframe_config.py
@@ -28,7 +28,7 @@ st.set_page_config(layout="wide")
 # Generate a random dataframe
 df = pd.DataFrame(
     np.random.randn(5, 5),
-    columns=("col_%d" % i for i in range(5)),
+    columns=(f"col_{i}" for i in range(5)),
 )
 
 
@@ -580,7 +580,7 @@ st.dataframe(
 
 df = pd.DataFrame(
     np.random.randn(5, 25),
-    columns=("col_%d" % i for i in range(25)),
+    columns=(f"col_{i}" for i in range(25)),
 )
 st.header("Pinned columns:")
 st.dataframe(

--- a/e2e_playwright/st_dataframe_selections.py
+++ b/e2e_playwright/st_dataframe_selections.py
@@ -26,7 +26,7 @@ random.seed(0)
 # Generate a random dataframe
 df = pd.DataFrame(
     np.random.randn(5, 5),
-    columns=("col_%d" % i for i in range(5)),
+    columns=(f"col_{i}" for i in range(5)),
 )
 
 # set fixed column with so our pixel-clicks in the test are stable

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -101,7 +101,7 @@ def echo(
         show_code(code_string, "python")
 
     except FileNotFoundError as err:
-        show_warning("Unable to display code. %s" % err)
+        show_warning(f"Unable to display code. {err}")
 
 
 def _get_initial_indent(lines: Iterable[str]) -> int:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1301,7 +1301,8 @@ def get_where_defined(key: str) -> str:
         config_options = get_config_options()
 
         if key not in config_options:
-            raise RuntimeError('Config key "%s" not defined.' % key)
+            msg = f'Config key "{key}" not defined.'
+            raise RuntimeError(msg)
         return config_options[key].where_defined
 
 

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -189,7 +189,7 @@ class ConfigOption:
         if self.replaced_by:
             self.deprecated = True
             if deprecation_text is None:
-                deprecation_text = "Replaced by %s." % self.replaced_by
+                deprecation_text = f"Replaced by {self.replaced_by}."
 
         if self.deprecated:
             if not expiration_date:

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -84,7 +84,7 @@ def show_config(
             continue
 
         out.append("")
-        append_section("[%s]" % section)
+        append_section(f"[{section}]")
         out.append("")
 
         for option in section_options.values():
@@ -125,8 +125,7 @@ def show_config(
                     append_comment(line)
                 append_comment("")
                 append_comment(
-                    "This option will be removed on or after %s."
-                    % option.expiration_date
+                    f"This option will be removed on or after {option.expiration_date}."
                 )
 
             import toml
@@ -138,7 +137,7 @@ def show_config(
                 # Ensure a line break before appending "Default" comment, if not already there
                 if out[-1] != "#":
                     append_comment("")
-                append_comment("Default: %s" % toml_default)
+                append_comment(f"Default: {toml_default}")
             else:
                 # Don't say "Default: (unset)" here because this branch applies
                 # to complex config settings too.
@@ -151,7 +150,7 @@ def show_config(
             if option_is_manually_set:
                 if out[-1] != "# ":
                     append_comment("")
-                append_comment("The value below was set in %s" % option.where_defined)
+                append_comment(f"The value below was set in {option.where_defined}")
 
             toml_setting = toml.dumps({key: option.value})
 

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -237,18 +237,10 @@ def _format_syntax_error_message(exception: SyntaxError) -> str:
         )
 
         return (
-            'File "%(filename)s", line %(lineno)s\n'
-            "  %(text)s\n"
-            "  %(caret_indent)s^\n"
-            "%(errname)s: %(msg)s"
-            % {
-                "filename": exception.filename,
-                "lineno": exception.lineno,
-                "text": exception.text.rstrip(),
-                "caret_indent": caret_indent,
-                "errname": type(exception).__name__,
-                "msg": exception.msg,
-            }
+            f'File "{exception.filename}", line {exception.lineno}\n'
+            f"  {exception.text.rstrip()}\n"
+            f"  {caret_indent}^\n"
+            f"{type(exception).__name__}: {exception.msg}"
         )
     # If a few edge cases, SyntaxErrors don't have all these nice fields. So we
     # have a fall back here.

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -141,7 +141,7 @@ def marshall(
         engine = "dot"
     else:
         raise StreamlitAPIException(
-            "Unhandled type for graphviz chart: %s" % type(figure_or_dot)
+            f"Unhandled type for graphviz chart: {type(figure_or_dot)}"
         )
 
     proto.spec = dot

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -286,14 +286,13 @@ class HeadingMixin:
                 proto.anchor = anchor
             elif anchor is True:  # type: ignore
                 raise StreamlitAPIException(
-                    "Anchor parameter has invalid value: %s. "
-                    "Supported values: None, any string or False" % anchor
+                    f"Anchor parameter has invalid value: {anchor}. "
+                    "Supported values: None, any string or False"
                 )
             else:
                 raise StreamlitAPIException(
-                    "Anchor parameter has invalid type: %s. "
+                    f"Anchor parameter has invalid type: {type(anchor).__name__}. "
                     "Supported values: None, any string or False"
-                    % type(anchor).__name__
                 )
 
         if help:

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -160,8 +160,7 @@ def _verify_np_shape(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
         raise StreamlitAPIException("Numpy shape has to be of length 2 or 3.")
     if len(shape) == 3 and shape[-1] not in (1, 3, 4):
         raise StreamlitAPIException(
-            "Channel can only be 1, 3, or 4 got %d. Shape is %s"
-            % (shape[-1], str(shape))
+            f"Channel can only be 1, 3, or 4 got {shape[-1]}. Shape is {shape}"
         )
 
     # If there's only one channel, convert is to x, y
@@ -437,7 +436,7 @@ def marshall_images(
 
         # We use the index of the image in the input image list to identify this image inside
         # MediaFileManager. For this, we just add the index to the image's "coordinates".
-        image_id = "%s-%i" % (coordinates, coord_suffix)
+        image_id = f"{coordinates}-{coord_suffix}"
 
         proto_img.url = image_to_url(
             single_image, width, clamp, channels, output_format, image_id

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -252,7 +252,7 @@ class MarkdownMixin:
             body = sympy.latex(body)
 
         latex_proto = MarkdownProto()
-        latex_proto.body = "$$\n%s\n$$" % clean_text(body)
+        latex_proto.body = f"$$\n{clean_text(body)}\n$$"
         latex_proto.element_type = MarkdownProto.Type.LATEX
         if help:
             latex_proto.help = help

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -478,7 +478,7 @@ def _marshall_av_media(
     elif type_util.is_type(data, "numpy.ndarray"):
         data_or_filename = cast("npt.NDArray[Any]", data).tobytes()
     else:
-        raise RuntimeError("Invalid binary data format: %s" % type(data))
+        raise RuntimeError(f"Invalid binary data format: {type(data)}")
 
     if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -66,17 +66,17 @@ def _get_value(value: FloatOrInt) -> int:
         if 0 <= value <= 100:
             return value
         raise StreamlitAPIException(
-            "Progress Value has invalid value [0, 100]: %d" % value
+            f"Progress Value has invalid value [0, 100]: {value}"
         )
 
     if isinstance(value, float):
         if _check_float_between(value, low=0.0, high=1.0):
             return int(value * 100)
         raise StreamlitAPIException(
-            "Progress Value has invalid value [0.0, 1.0]: %f" % value
+            f"Progress Value has invalid value [0.0, 1.0]: {value:f}"
         )
     raise StreamlitAPIException(
-        "Progress Value has invalid type: %s" % type(value).__name__
+        f"Progress Value has invalid type: {type(value).__name__}"
     )
 
 

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -73,7 +73,7 @@ def _get_value(value: FloatOrInt) -> int:
         if _check_float_between(value, low=0.0, high=1.0):
             return int(value * 100)
         raise StreamlitAPIException(
-            f"Progress Value has invalid value [0.0, 1.0]: {value:f}"
+            f"Progress Value has invalid value [0.0, 1.0]: {value}"
         )
     raise StreamlitAPIException(
         f"Progress Value has invalid type: {type(value).__name__}"

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1105,7 +1105,7 @@ def marshall_file(
         data_as_bytes = data.read() or b""
         mimetype = mimetype or "application/octet-stream"
     else:
-        raise StreamlitAPIException("Invalid binary data format: %s" % type(data))
+        raise StreamlitAPIException(f"Invalid binary data format: {type(data)}")
 
     if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -206,25 +206,19 @@ class ColorPickerMixin:
 
         # make sure the value is a string
         if not isinstance(value, str):
-            raise StreamlitAPIException(
-                """
-                Color Picker Value has invalid type: %s. Expects a hex string
-                like '#00FFAA' or '#000'.
-                """
-                % type(value).__name__
-            )
+            raise StreamlitAPIException(f"""
+Color Picker Value has invalid type: {type(value).__name__}. Expects a hex string
+like '#00FFAA' or '#000'.
+""")
 
         # validate the value and expects a hex string
         match = re.match(r"^#(?:[0-9a-fA-F]{3}){1,2}$", value)
 
         if not match:
-            raise StreamlitAPIException(
-                """
-                '%s' is not a valid hex code for colors. Valid ones are like
-                '#00FFAA' or '#000'.
-                """
-                % value
-            )
+            raise StreamlitAPIException(f"""
+'{value}' is not a valid hex code for colors. Valid ones are like
+'#00FFAA' or '#000'.
+""")
 
         color_picker_proto = ColorPickerProto()
         color_picker_proto.id = element_id

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -351,7 +351,7 @@ class RadioMixin:
 
         if not isinstance(index, int) and index is not None:
             raise StreamlitAPIException(
-                "Radio Value has invalid type: %s" % type(index).__name__
+                f"Radio Value has invalid type: {type(index).__name__}"
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -495,7 +495,7 @@ class SelectboxMixin:
 
         if not isinstance(index, int) and index is not None:
             raise StreamlitAPIException(
-                "Selectbox Value has invalid type: %s" % type(index).__name__
+                f"Selectbox Value has invalid type: {type(index).__name__}"
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -813,17 +813,13 @@ class SliderMixin:
         )
 
         if not int_args and not float_args and not timelike_args:
-            raise StreamlitAPIException(
+            msg = (
                 "Slider value arguments must be of matching types."
-                "\n`min_value` has %(min_type)s type."
-                "\n`max_value` has %(max_type)s type."
-                "\n`step` has %(step)s type."
-                % {
-                    "min_type": type(min_value).__name__,
-                    "max_type": type(max_value).__name__,
-                    "step": type(step).__name__,
-                }
+                f"\n`min_value` has {type(min_value).__name__} type."
+                f"\n`max_value` has {type(max_value).__name__} type."
+                f"\n`step` has {type(step).__name__} type."
             )
+            raise StreamlitAPIException(msg)
 
         # Ensure that the value matches arguments' types.
         all_ints = data_type == SliderProto.INT and int_args
@@ -831,17 +827,13 @@ class SliderMixin:
         all_timelikes = data_type in TIMELIKE_TYPES and timelike_args
 
         if not all_ints and not all_floats and not all_timelikes:
-            raise StreamlitAPIException(
+            msg = (
                 "Both value and arguments must be of the same type."
-                "\n`value` has %(value_type)s type."
-                "\n`min_value` has %(min_type)s type."
-                "\n`max_value` has %(max_type)s type."
-                % {
-                    "value_type": type(value).__name__,
-                    "min_type": type(min_value).__name__,
-                    "max_type": type(max_value).__name__,
-                }
+                f"\n`value` has {type(value).__name__} type."
+                f"\n`min_value` has {type(min_value).__name__} type."
+                f"\n`max_value` has {type(max_value).__name__} type."
             )
+            raise StreamlitAPIException(msg)
 
         # Ensure that min <= value(s) <= max, adjusting the bounds as necessary.
         min_value = min(min_value, max_value)

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -369,8 +369,7 @@ class TextWidgetsMixin:
             text_input_proto.type = TextInputProto.PASSWORD
         else:
             raise StreamlitAPIException(
-                "'%s' is not a valid text_input type. Valid types are 'default' and 'password'."
-                % type
+                f"'{type}' is not a valid text_input type. Valid types are 'default' and 'password'."
             )
 
         # Marshall the autocomplete param. If unspecified, this will be

--- a/lib/streamlit/hello/animation_demo.py
+++ b/lib/streamlit/hello/animation_demo.py
@@ -42,7 +42,7 @@ def animation_demo() -> None:
     for frame_num, a in enumerate(np.linspace(0.0, 4 * np.pi, 100)):
         # Here were setting value for these two elements.
         progress_bar.progress(frame_num)
-        frame_text.text("Frame %i/100" % (frame_num + 1))
+        frame_text.text(f"Frame {frame_num + 1}/100")
 
         # Performing some fractal wizardry.
         c = separation * np.exp(1j * a)

--- a/lib/streamlit/hello/mapping_demo.py
+++ b/lib/streamlit/hello/mapping_demo.py
@@ -26,7 +26,7 @@ def mapping_demo() -> None:
     def from_data_file(filename: str) -> pd.DataFrame:
         url = (
             "https://raw.githubusercontent.com/streamlit/"
-            "example-data/master/hello/v1/%s" % filename
+            f"example-data/master/hello/v1/{filename}"
         )
         return pd.read_json(url)
 
@@ -95,11 +95,10 @@ def mapping_demo() -> None:
             st.error("Please choose at least one layer above.")
     except URLError as e:
         st.error(
-            """
+            f"""
             **This demo requires internet access.**
-            Connection error: %s
+            Connection error: {e.reason}
         """
-            % e.reason
         )
 
 

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -46,7 +46,7 @@ def set_log_level(level: str | int) -> None:
     elif level in {"DEBUG", logging.DEBUG}:
         log_level = logging.DEBUG
     else:
-        msg = 'undefined log level "%s"' % level
+        msg = f'undefined log level "{level}"'
         logger.critical(msg)
         sys.exit(1)
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -92,26 +92,25 @@ class UserHashError(StreamlitAPIException):
         args = self._get_error_message_args(orig_exc, cached_func)
 
         return (
-            """
-%(orig_exception_desc)s
+            f"""
+{args["orig_exception_desc"]}
 
-This error is likely due to a bug in %(hash_func_name)s, which is a
-user-defined hash function that was passed into the `%(cache_primitive)s` decorator of
-%(object_desc)s.
+This error is likely due to a bug in {args["hash_func_name"]}, which is a
+user-defined hash function that was passed into the `{args["cache_primitive"]}` decorator of
+{args["object_desc"]}.
 
-%(hash_func_name)s failed when hashing an object of type
-`%(failed_obj_type_str)s`.  If you don't know where that object is coming from,
+{args["hash_func_name"]} failed when hashing an object of type
+`{args["failed_obj_type_str"]}`.  If you don't know where that object is coming from,
 try looking at the hash chain below for an object that you do recognize, then
 pass that to `hash_funcs` instead:
 
 ```
-%(hash_stack)s
+{args["hash_stack"]}
 ```
 
 If you think this is actually a Streamlit bug, please
 [file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose).
 """
-            % args
         ).strip("\n")
 
     def _get_error_message_args(

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -263,41 +263,28 @@ class Credentials:
                 if self.activation.is_valid:
                     self.save()
                     # IMPORTANT: Break the text below at 80 chars.
-                    TELEMETRY_TEXT = """
-  You can find our privacy policy at %(link)s
+                    TELEMETRY_TEXT = f"""
+  You can find our privacy policy at {cli_util.style_for_cli("https://streamlit.io/privacy-policy", underline=True)}
 
   Summary:
   - This open source library collects usage statistics.
   - We cannot see and do not store information contained inside Streamlit apps,
     such as text, charts, images, etc.
   - Telemetry data is stored in servers in the United States.
-  - If you'd like to opt out, add the following to %(config)s,
+  - If you'd like to opt out, add the following to {cli_util.style_for_cli(_CONFIG_FILE_PATH)},
     creating that file if necessary:
 
     [browser]
     gatherUsageStats = false
-""" % {
-                        "link": cli_util.style_for_cli(
-                            "https://streamlit.io/privacy-policy", underline=True
-                        ),
-                        "config": cli_util.style_for_cli(_CONFIG_FILE_PATH),
-                    }
+"""
 
                     cli_util.print_to_cli(TELEMETRY_TEXT)
                     if show_instructions:
                         # IMPORTANT: Break the text below at 80 chars.
-                        INSTRUCTIONS_TEXT = """
-  %(start)s
-  %(prompt)s %(hello)s
-""" % {
-                            "start": cli_util.style_for_cli(
-                                "Get started by typing:", fg="blue", bold=True
-                            ),
-                            "prompt": cli_util.style_for_cli("$", fg="blue"),
-                            "hello": cli_util.style_for_cli(
-                                "streamlit hello", bold=True
-                            ),
-                        }
+                        INSTRUCTIONS_TEXT = f"""
+  {cli_util.style_for_cli("Get started by typing:", fg="blue", bold=True)}
+  {cli_util.style_for_cli("$", fg="blue")} {cli_util.style_for_cli("streamlit hello", bold=True)}
+"""
 
                         cli_util.print_to_cli(INSTRUCTIONS_TEXT)
                     activated = True

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -70,15 +70,14 @@ def report_watchdog_availability() -> None:
         msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
 
         cli_util.print_to_cli(
-            "  %s" % "For better performance, install the Watchdog module:",
+            "  For better performance, install the Watchdog module:",
             fg="blue",
             bold=True,
         )
         cli_util.print_to_cli(
-            """%s
+            f"""{msg}
   $ pip install watchdog
             """
-            % msg
         )
 
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -210,7 +210,7 @@ def _print_url(is_running_hello: bool) -> None:
                 named_urls.append(("External URL", server_util.get_url(external_ip)))
 
     cli_util.print_to_cli("")
-    cli_util.print_to_cli("  %s" % title_message, fg="blue", bold=True)
+    cli_util.print_to_cli(f"  {title_message}", fg="blue", bold=True)
     cli_util.print_to_cli("")
 
     for url_name, url in named_urls:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -428,7 +428,7 @@ class Server:
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
                         {
-                            "path": "%s/" % static_path,
+                            "path": f"{static_path}/",
                             "default_filename": "index.html",
                             "reserved_paths": [
                                 # These paths are required for identifying

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -320,13 +320,10 @@ class ConfigTest(unittest.TestCase):
         )
 
         # Override it with some TOML
-        NEW_TOML = (
-            """
+        NEW_TOML = f"""
             [_test]
-            tomlTest="%s"
+            tomlTest="{DUMMY_VAL_2}"
         """
-            % DUMMY_VAL_2
-        )
         config._update_config_with_toml(NEW_TOML, DUMMY_DEFINITION)
         assert config.get_option("_test.tomlTest") == DUMMY_VAL_2
         assert config.get_where_defined("_test.tomlTest") == DUMMY_DEFINITION

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -159,7 +159,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         st.number_input("the label", value=10.5)
 
         c = self.get_delta_from_queue().new_element.number_input
-        assert "%0.2f" % c.step == "0.01"
+        assert f"{c.step:0.2f}" == "0.01"
 
     def test_default_format_int(self):
         st.number_input("the label", value=10)
@@ -185,7 +185,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.number_input
         assert c.format == "%f"
-        assert "%0.2f" % c.step == "0.01"
+        assert f"{c.step:0.2f}" == "0.01"
 
     def test_accept_valid_formats(self):
         # note: We decided to accept %u even though it is slightly problematic.
@@ -238,29 +238,25 @@ class NumberInputTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             int_value = JSNumber.MAX_SAFE_INTEGER + 1
             st.number_input("Label", value=int_value)
-        assert "`value` (%s) must be <= (1 << 53) - 1" % str(int_value) == str(
-            exc.value
-        )
+        assert f"`value` ({int_value}) must be <= (1 << 53) - 1" == str(exc.value)
 
         # Min int
         with pytest.raises(StreamlitAPIException) as exc:
             int_value = JSNumber.MIN_SAFE_INTEGER - 1
             st.number_input("Label", value=int_value)
-        assert "`value` (%s) must be >= -((1 << 53) - 1)" % str(int_value) == str(
-            exc.value
-        )
+        assert f"`value` ({int_value}) must be >= -((1 << 53) - 1)" == str(exc.value)
 
         # Max float
         with pytest.raises(StreamlitAPIException) as exc:
             float_val = 2e308
             st.number_input("Label", value=float_val)
-        assert "`value` (%s) must be <= 1.797e+308" % str(float_val) == str(exc.value)
+        assert f"`value` ({float_val}) must be <= 1.797e+308" == str(exc.value)
 
         # Min float
         with pytest.raises(StreamlitAPIException) as exc:
             float_val = -2e308
             st.number_input("Label", value=float_val)
-        assert "`value` (%s) must be >= -1.797e+308" % str(float_val) == str(exc.value)
+        assert f"`value` ({float_val}) must be >= -1.797e+308" == str(exc.value)
 
     def test_min_and_max_setting_for_integer_inputs(self):
         """Test min & max set by user respected, otherwise use defaults."""

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -219,15 +219,13 @@ class SliderTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             max_value = JSNumber.MAX_SAFE_INTEGER + 1
             st.slider("Label", max_value=max_value)
-        assert "`max_value` (%s) must be <= (1 << 53) - 1" % str(max_value) == str(
-            exc.value
-        )
+        assert f"`max_value` ({max_value}) must be <= (1 << 53) - 1" == str(exc.value)
 
         # Min int
         with pytest.raises(StreamlitAPIException) as exc:
             min_value = JSNumber.MIN_SAFE_INTEGER - 1
             st.slider("Label", min_value=min_value)
-        assert "`min_value` (%s) must be >= -((1 << 53) - 1)" % str(min_value) == str(
+        assert f"`min_value` ({min_value}) must be >= -((1 << 53) - 1)" == str(
             exc.value
         )
 
@@ -235,17 +233,13 @@ class SliderTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             max_value = 2e308
             st.slider("Label", value=0.5, max_value=max_value)
-        assert "`max_value` (%s) must be <= 1.797e+308" % str(max_value) == str(
-            exc.value
-        )
+        assert f"`max_value` ({max_value}) must be <= 1.797e+308" == str(exc.value)
 
         # Min float
         with pytest.raises(StreamlitAPIException) as exc:
             min_value = -2e308
             st.slider("Label", value=0.5, min_value=min_value)
-        assert "`min_value` (%s) must be >= -1.797e+308" % str(min_value) == str(
-            exc.value
-        )
+        assert f"`min_value` ({min_value}) must be >= -1.797e+308" == str(exc.value)
 
     def test_step_zero(self):
         with pytest.raises(StreamlitAPIException) as exc:

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -949,7 +949,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # Ensure that each runner's radio value is as expected.
         for ii, runner in enumerate(runners):
             self._assert_text_deltas(
-                runner, ["False", "ahoy!", "%s" % ii, "False", "loop_forever"]
+                runner, ["False", "ahoy!", str(ii), "False", "loop_forever"]
             )
             runner.request_stop()
 

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/widgets_script.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/widgets_script.py
@@ -22,16 +22,16 @@ import streamlit as st
 # 1-delta loop. If you change this, please change that file too.
 
 checkbox = st.checkbox("checkbox", False)
-st.text("%s" % checkbox)
+st.text(checkbox)
 
 text_area = st.text_area("text_area", "ahoy!")
-st.text("%s" % text_area)
+st.text(text_area)
 
 radio = st.radio("radio", ("0", "1", "2"), 0)
-st.text("%s" % radio)
+st.text(radio)
 
 button = st.button("button")
-st.text("%s" % button)
+st.text(button)
 
 # Loop forever so that our test can check widget states
 # without the scriptrunner shutting down.

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -337,7 +337,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         def modify_mock_file():
             self.mock_util.path_modification_time = lambda *args: mod_count[0]
             self.mock_util.calc_md5_with_blocking_retries = (
-                lambda _, **kwargs: "%d" % mod_count[0]
+                lambda _, **kwargs: f"{mod_count[0]}"
             )
 
             ev = events.FileSystemEvent(filename)

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -45,15 +45,14 @@ class FileWatcherTest(unittest.TestCase):
         msg = "\n  $ xcode-select --install"
         calls = [
             call(
-                "  %s" % "For better performance, install the Watchdog module:",
+                "  For better performance, install the Watchdog module:",
                 fg="blue",
                 bold=True,
             ),
             call(
-                """%s
+                f"""{msg}
   $ pip install watchdog
             """
-                % msg
             ),
         ]
         mock_echo.assert_has_calls(calls)
@@ -98,15 +97,14 @@ class FileWatcherTest(unittest.TestCase):
         msg = ""
         calls = [
             call(
-                "  %s" % "For better performance, install the Watchdog module:",
+                "  For better performance, install the Watchdog module:",
                 fg="blue",
                 bold=True,
             ),
             call(
-                """%s
+                f"""{msg}
   $ pip install watchdog
             """
-                % msg
             ),
         ]
         mock_echo.assert_has_calls(calls)

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -199,7 +199,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         def modify_mock_file():
             self.util_mock.path_modification_time = lambda *args: mod_count[0]
             self.util_mock.calc_md5_with_blocking_retries = (
-                lambda _, **kwargs: "%d" % mod_count[0]
+                lambda _, **kwargs: f"{mod_count[0]}"
             )
 
             mod_count[0] += 1.0

--- a/lib/tests/streamlit/web/server/app_static_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/app_static_file_handler_test.py
@@ -126,7 +126,7 @@ class AppStaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 (
                     r"/app/static/(.*)",
                     AppStaticFileHandler,
-                    {"path": "%s" % self._tmpdir.name},
+                    {"path": self._tmpdir.name},
                 )
             ]
         )

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -72,7 +72,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def _request_component(self, path, headers=None):
         if headers is None:
             headers = {}
-        return self.fetch("/component/%s" % path, method="GET", headers=headers)
+        return self.fetch(f"/component/{path}", method="GET", headers=headers)
 
     def test_success_request(self):
         """Test request success when valid parameters are provided."""

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -106,12 +106,11 @@ def update_files(data: dict[str, str], version: str) -> None:
         for line in fileinput.input(file_path, inplace=True):
             if pattern.match(line.rstrip()):
                 matched = True
-            updated_line = re.sub(regex, r"\g<pre>%s\g<post>" % version, line.rstrip())
+            updated_line = re.sub(regex, rf"\g<pre>{version}\g<post>", line.rstrip())
             print(updated_line)
         if not matched:
-            raise Exception(
-                'In file "%s", did not find regex "%s"' % (file_path, regex)
-            )
+            msg = f'In file "{file_path}", did not find regex "{regex}"'
+            raise Exception(msg)
 
 
 def main() -> None:
@@ -119,7 +118,7 @@ def main() -> None:
 
     if len(sys.argv) != 2:
         e = Exception(
-            'Specify semvver version as an argument, e.g.: "%s 1.2.3"' % sys.argv[0]
+            f'Specify semvver version as an argument, e.g.: "{sys.argv[0]} 1.2.3"'
         )
         raise (e)
 


### PR DESCRIPTION
## Describe your changes

This removes all uses of the old printf string formatting style and activates the `UP031` ruff rule to enforce the usage of f-strings everywhere. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
