### PR TITLE
Prevent formatted strings in logging statements

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -42,7 +42,6 @@ ignore = [
   "EM102",  # Checks for the use of f-strings in exception constructors.
   "TRY003", # Checks for exception messages that are not defined in the exception class itself.
   "N806",   # Checks for non-lowercased variable names in functions.
-  "G004",   # Checks for usage of f-strings in logging messages.
   # Ignored rule sets:
   "DTZ", # Checks for usage of unsafe naive datetime class.
   "PTH", # Enforces usage of pathlib.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -167,7 +167,7 @@ def set_user_option(key: str, value: Any) -> None:
 
     raise StreamlitAPIException(
         f"{key} cannot be set on the fly. Set as command line option, e.g. "
-        "streamlit run script.py --{key}, or in config.toml instead."
+        f"streamlit run script.py --{key}, or in config.toml instead."
     )
 
 
@@ -1384,8 +1384,9 @@ def _set_option(key: str, value: Any, where_defined: str) -> None:
         LOGGER = get_logger(__name__)
 
         LOGGER.warning(
-            f'"{key}" is not a valid config option. If you previously had this config '
-            "option set, it may have been removed."
+            '"%s" is not a valid config option. If you previously had this config '
+            "option set, it may have been removed.",
+            key,
         )
 
     else:

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -370,8 +370,8 @@ def _apply_row_additions(
         # Row cannot be added -> skip it and log a warning.
         _LOGGER.warning(
             "Cannot automatically add row for the index "
-            f"of type {type(df.index).__name__} without an explicit index value. "
-            "Row addition skipped."
+            "of type %s without an explicit index value. Row addition skipped.",
+            type(df.index).__name__,
         )
 
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -375,8 +375,9 @@ class AppSession:
             # sometimes stays open.
             if fragment_id and not self._fragment_storage.contains(fragment_id):
                 _LOGGER.info(
-                    f"The fragment with id {fragment_id} does not exist anymore - "
-                    "it might have been removed during a preceding full-app rerun."
+                    "The fragment with id %s does not exist anymore - "
+                    "it might have been removed during a preceding full-app rerun.",
+                    fragment_id,
                 )
                 return
 
@@ -954,9 +955,10 @@ def _populate_theme_msg(msg: CustomThemeConfig, section: str = "theme") -> None:
     if base is not None:
         if base not in base_map:
             _LOGGER.warning(
-                f'"{base}" is an invalid value for theme.base.'
-                f" Allowed values include {list(base_map.keys())}."
-                ' Setting theme.base to "light".'
+                '"%s" is an invalid value for theme.base. Allowed values include %s. '
+                'Setting theme.base to "light".',
+                base,
+                list(base_map.keys()),
             )
         else:
             msg.base = base_map[base]
@@ -976,8 +978,8 @@ def _populate_theme_msg(msg: CustomThemeConfig, section: str = "theme") -> None:
             font_faces = json.loads(font_faces)
         except Exception as e:
             _LOGGER.warning(
-                "Failed to parse the theme.fontFaces config option with json.loads: "
-                f"{font_faces}.",
+                "Failed to parse the theme.fontFaces config option with json.loads: %s.",
+                font_faces,
                 exc_info=e,
             )
             font_faces = None
@@ -988,7 +990,8 @@ def _populate_theme_msg(msg: CustomThemeConfig, section: str = "theme") -> None:
                 msg.font_faces.append(ParseDict(font_face, FontFace()))
             except Exception as e:  # noqa: PERF203
                 _LOGGER.warning(
-                    f"Failed to parse the theme.fontFaces config option: {font_face}.",
+                    "Failed to parse the theme.fontFaces config option: %s.",
+                    font_face,
                     exc_info=e,
                 )
 

--- a/lib/streamlit/runtime/caching/storage/local_disk_cache_storage.py
+++ b/lib/streamlit/runtime/caching/storage/local_disk_cache_storage.py
@@ -109,9 +109,9 @@ class LocalDiskCacheStorageManager(CacheStorageManager):
             and not math.isinf(context.ttl_seconds)
         ):
             _LOGGER.warning(
-                f"The cached function '{context.function_display_name}' has a TTL "
-                "that will be ignored. Persistent cached functions currently don't "
-                "support TTL."
+                "The cached function '%s' has a TTL that will be ignored. "
+                "Persistent cached functions currently don't support TTL.",
+                context.function_display_name,
             )
 
 

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -79,8 +79,8 @@ def serialize_forward_msg(msg: ForwardMsg) -> bytes:
 
         msg_size_error = MessageSizeError(msg_str)
         _LOGGER.warning(
-            "Websocket message size limit exceeded. "
-            f"Showing error to the user: {msg_size_error}"
+            "Websocket message size limit exceeded. Showing error to the user: %s",
+            msg_size_error,
         )
         exception.marshall(msg.delta.new_element.exception, msg_size_error)
         # Deactivate caching for this error message:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -639,13 +639,14 @@ class ScriptRunner:
                                 # (see https://github.com/streamlit/streamlit/issues/9080).
                                 if not rerun_data.is_auto_rerun:
                                     _LOGGER.warning(
-                                        f"Couldn't find fragment with id {fragment_id}."
+                                        "Couldn't find fragment with id %s."
                                         " This can happen if the fragment does not"
                                         " exist anymore when this request is processed,"
                                         " for example because a full app rerun happened"
                                         " that did not register the fragment."
                                         " Usually this doesn't happen or no action is"
-                                        " required, so its mainly for debugging."
+                                        " required, so its mainly for debugging.",
+                                        fragment_id,
                                     )
                             except (RerunException, StopException):
                                 # The wrapped_fragment function is executed

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -258,7 +258,7 @@ def get_module_paths(module: ModuleType) -> set[str]:
             pass
         except Exception:
             _LOGGER.warning(
-                f"Examining the path of {module.__name__} raised:", exc_info=True
+                "Examining the path of %s raised:", module.__name__, exc_info=True
             )
 
         all_paths.update(

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -154,7 +154,9 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
                 else None
             )
             _LOGGER.error(
-                f"""Error during authentication: {sanitized_error}. Error description: {sanitized_error_description}""",
+                "Error during authentication: %s. Error description: %s",
+                sanitized_error,
+                sanitized_error_description,
             )
             self.redirect_to_base()
             return

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -1346,10 +1346,7 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         new_session_msg = msg.new_session
         app_session._populate_theme_msg(new_session_msg.custom_theme)
 
-        patched_logger.warning.assert_called_once_with(
-            '"blah" is an invalid value for theme.base.'
-            " Allowed values include ['light', 'dark']. Setting theme.base to \"light\"."
-        )
+        patched_logger.warning.assert_called_once()
 
 
 @patch.object(

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -174,8 +174,9 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         fob.assert_called_once()  # Just __init__.py
 
         # Check that the warning was called with the expected message
-        patched_logger.warning.assert_any_call(
-            "Examining the path of MisbehavedModule raised:",
+        patched_logger.warning.assert_called_once_with(
+            "Examining the path of %s raised:",
+            "MisbehavedModule",
             exc_info=True,
         )
 


### PR DESCRIPTION
## Describe your changes

Using template strings and passing the log message arguments to the logging module is preferred over `f-strings`  (see [here](https://docs.astral.sh/ruff/rules/logging-f-string/)). This PR activates `G004` which prevents f-strings in all logging calls.  

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
