### PR TITLE
Enforce max line length in unit tests

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -124,7 +124,6 @@ extend-safe-fixes = ["TC002", "TC003"]
   "ARG",
   "S",
   "TRY",
-  "E501",
   "ANN",
   "NPY002",
 ]

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -147,9 +147,9 @@ class PageConfigTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as e:
             menu_items = {"invalid": "fdsa"}
             st.set_page_config(menu_items=menu_items)
-        assert (
-            str(e.value)
-            == 'We only accept the keys: `"Get help"`, `"Report a bug"`, and `"About"` (`"invalid"` is not a valid key.)'
+        assert str(e.value) == (
+            'We only accept the keys: `"Get help"`, `"Report a bug"`, and `"About"` '
+            '(`"invalid"` is not a valid key.)'
         )
 
     def test_set_page_config_menu_items_empty_dict(self):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -613,7 +613,8 @@ class ConfigTest(unittest.TestCase):
             config._set_option("not.defined", "no.value", "test")
         # cm.output is a list of messages and there shouldn't be any other messages besides one created by this test
         assert (
-            '"not.defined" is not a valid config option. If you previously had this config option set, it may have been removed.'
+            '"not.defined" is not a valid config option. '
+            "If you previously had this config option set, it may have been removed."
             in cm.output[0]
         )
 
@@ -771,7 +772,8 @@ class ConfigTest(unittest.TestCase):
                 config._set_option(f"theme.sidebar.{option}", True, "test")
             # cm.output is a list of messages and there shouldn't be any other messages besides one created by this test
             assert (
-                f'"theme.sidebar.{option}" is not a valid config option. If you previously had this config option set, it may have been removed.'
+                f'"theme.sidebar.{option}" is not a valid config option. '
+                "If you previously had this config option set, it may have been removed."
                 in cm.output[0]
             )
 

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -64,9 +64,9 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         with pytest.raises(AttributeError) as e:
             MockConnection("my_mock_connection").some_raw_connection_method()
 
-        assert (
-            str(e.value)
-            == "`some_raw_connection_method` doesn't exist here, but you can call `._instance.some_raw_connection_method` instead"
+        assert str(e.value) == (
+            "`some_raw_connection_method` doesn't exist here, but you can call "
+            "`._instance.some_raw_connection_method` instead"
         )
         assert (
             MockConnection("my_mock_connection")._instance.some_raw_connection_method()

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -520,8 +520,9 @@ class DeltaGeneratorWithTest(DeltaGeneratorTestCase):
         st.markdown("Object 1b") |
                                  | st.markdown("Object 2")
 
-        In this scenario, Task 2 should inherit the container1 context from Task 1 when it is created, so Objects 1a and 1b
-        will both go in container 1, and object 2 will go in container 2.
+        In this scenario, Task 2 should inherit the container1 context from Task 1
+        when it is created, so Objects 1a and 1b will both go in container 1,
+        and object 2 will go in container 2.
         """
         container1 = st.container()
         container2 = st.container()

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -151,9 +151,9 @@ class AudioTest(DeltaGeneratorTestCase):
             fake_audio_np_array, sample_rate=sample_rate
         )
 
-        assert (
-            computed_bytes
-            == b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00D\xac\x00\x00\x88X\x01\x00\x02\x00\x10\x00data\x00\x00\x00\x00"
+        assert computed_bytes == (
+            b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00D\xac\x00\x00\x88X\x01\x00\x02\x00\x10\x00data"
+            b"\x00\x00\x00\x00"
         )
 
     def test_maybe_convert_to_wave_numpy_arr_mono(self):
@@ -165,9 +165,9 @@ class AudioTest(DeltaGeneratorTestCase):
             fake_audio_np_array, sample_rate=sample_rate
         )
 
-        assert (
-            computed_bytes
-            == b"RIFF(\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x07\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x10\x00data\x04\x00\x00\x008\x0e\xff\x7f"
+        assert computed_bytes == (
+            b"RIFF(\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x07\x00\x00\x00\x0e\x00\x00\x00"
+            b"\x02\x00\x10\x00data\x04\x00\x00\x008\x0e\xff\x7f"
         )
 
     def test_maybe_convert_to_wave_numpy_arr_stereo(self):
@@ -182,9 +182,9 @@ class AudioTest(DeltaGeneratorTestCase):
             fake_audio_np_array, sample_rate=sample_rate
         )
 
-        assert (
-            computed_bytes
-            == b"RIFF,\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00D\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00data\x08\x00\x00\x008\x0eTU\xff\x7f8\x0e"
+        assert computed_bytes == (
+            b"RIFF,\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00D\xac\x00\x00\x10\xb1\x02\x00"
+            b"\x04\x00\x10\x00data\x08\x00\x00\x008\x0eTU\xff\x7f8\x0e"
         )
 
     def test_maybe_convert_to_wave_bytes_with_sample_rate(self):

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -79,9 +79,9 @@ class StHelpTest(DeltaGeneratorTestCase):
 
         ds = self.get_delta_from_queue().new_element.doc_string
         assert ds.name == "my_func"
-        assert (
-            ds.value
-            == "tests.streamlit.elements.help_test.StHelpTest.test_basic_func_with_doc.<locals>.my_func(some_param, another_param=123)"
+        assert ds.value == (
+            "tests.streamlit.elements.help_test.StHelpTest.test_basic_func_with_doc.<locals>.my_func(some_param, "
+            "another_param=123)"
         )
         assert ds.type == "function"
         assert ds.doc_string == "This is the doc"
@@ -97,9 +97,9 @@ class StHelpTest(DeltaGeneratorTestCase):
 
         ds = self.get_delta_from_queue().new_element.doc_string
         assert ds.name == "my_func"
-        assert (
-            ds.value
-            == "tests.streamlit.elements.help_test.StHelpTest.test_basic_func_without_doc.<locals>.my_func(some_param, another_param=123)"
+        assert ds.value == (
+            "tests.streamlit.elements.help_test.StHelpTest.test_basic_func_without_doc.<locals>.my_func(some_param, "
+            "another_param=123)"
         )
         assert ds.type == "function"
         assert ds.doc_string == ""
@@ -114,7 +114,11 @@ class StHelpTest(DeltaGeneratorTestCase):
         assert ds.name == "st.audio"
         assert ds.type == "method"
 
-        signature = "(data: 'MediaData', format: 'str' = 'audio/wav', start_time: 'MediaTime' = 0, *, sample_rate: 'int | None' = None, end_time: 'MediaTime | None' = None, loop: 'bool' = False, autoplay: 'bool' = False, width: 'WidthWithoutContent' = 'stretch') -> 'DeltaGenerator'"
+        signature = (
+            "(data: 'MediaData', format: 'str' = 'audio/wav', start_time: 'MediaTime' = 0, *, "
+            "sample_rate: 'int | None' = None, end_time: 'MediaTime | None' = None, loop: 'bool' = False, "
+            "autoplay: 'bool' = False, width: 'WidthWithoutContent' = 'stretch') -> 'DeltaGenerator'"
+        )
 
         assert f"streamlit.delta_generator.MediaMixin.audio{signature}" == ds.value
         assert ds.doc_string.startswith("Display an audio player")

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: E501
+
 """Unit tests for st.image and other image.py utility code."""
 
 from __future__ import annotations

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -88,7 +88,7 @@ class LinkButtonTest(DeltaGeneratorTestCase):
         """Test that an error is raised if an invalid icon is provided."""
         with pytest.raises(StreamlitAPIException) as e:
             st.link_button("the label", url="https://streamlit.io", icon="invalid")
-        assert (
-            str(e.value)
-            == 'The value "invalid" is not a valid emoji. Shortcodes are not allowed, please use a single character instead.'
+        assert str(e.value) == (
+            'The value "invalid" is not a valid emoji. '
+            "Shortcodes are not allowed, please use a single character instead."
         )

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -187,9 +187,9 @@ class MetricTest(DeltaGeneratorTestCase):
         with pytest.raises(TypeError) as exc:
             st.metric(123, "-321")
 
-        assert (
-            str(exc.value)
-            == "'123' is of type <class 'int'>, which is not an accepted type. label only accepts: str. Please convert the label to an accepted type."
+        assert str(exc.value) == (
+            "'123' is of type <class 'int'>, which is not an accepted type. "
+            "label only accepts: str. Please convert the label to an accepted type."
         )
 
     def test_invalid_label_visibility(self):
@@ -217,18 +217,20 @@ class MetricTest(DeltaGeneratorTestCase):
         with pytest.raises(TypeError) as exc:
             st.metric("Testing", [1, 2, 3])
 
-        assert (
-            str(exc.value)
-            == "'[1, 2, 3]' is of type <class 'list'>, which is not an accepted type. value only accepts: int, float, str, or None. Please convert the value to an accepted type."
+        assert str(exc.value) == (
+            "'[1, 2, 3]' is of type <class 'list'>, which is not an accepted type. "
+            "value only accepts: int, float, str, or None. "
+            "Please convert the value to an accepted type."
         )
 
     def test_invalid_delta(self):
         with pytest.raises(TypeError) as exc:
             st.metric("Testing", "123", [123])
 
-        assert (
-            str(exc.value)
-            == "'[123]' is of type <class 'list'>, which is not an accepted type. delta only accepts: int, float, str, or None. Please convert the value to an accepted type."
+        assert str(exc.value) == (
+            "'[123]' is of type <class 'list'>, which is not an accepted type. "
+            "delta only accepts: int, float, str, or None. "
+            "Please convert the value to an accepted type."
         )
 
     def test_invalid_delta_color(self):

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -59,9 +59,9 @@ class PyDeckTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.plotly_chart(fig, theme="bad_theme")
 
-        assert (
-            str(exc.value)
-            == 'You set theme="bad_theme" while Streamlit charts only support theme=”streamlit” or theme=None to fallback to the default library theme.'
+        assert str(exc.value) == (
+            'You set theme="bad_theme" while Streamlit charts only support '
+            "theme=”streamlit” or theme=None to fallback to the default library theme."
         )
 
     def test_st_plotly_chart_simple(self):

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: E501
+
 from __future__ import annotations
 
 import json

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -128,7 +128,9 @@ class CacheDataTest(unittest.TestCase):
         class TestClass:
             @st.cache_data(
                 hash_funcs={
-                    "tests.streamlit.runtime.caching.cache_data_api_test.CacheDataTest.test_cached_member_function_with_hash_func.<locals>.TestClass": id
+                    "tests.streamlit.runtime.caching.cache_data_api_test."
+                    "CacheDataTest.test_cached_member_function_with_hash_func."
+                    "<locals>.TestClass": id
                 }
             )
             def member_func(self):
@@ -212,7 +214,7 @@ Object of type tests.streamlit.runtime.caching.cache_data_api_test.CacheDataTest
 ```
 
 If you think this is actually a Streamlit bug, please
-[file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""
+[file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""  # noqa: E501
         assert str(ctx.value) == expected_message
 
     def test_cached_st_function_clear_args(self):

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -104,7 +104,9 @@ class CacheResourceTest(unittest.TestCase):
         class TestClass:
             @st.cache_resource(
                 hash_funcs={
-                    "tests.streamlit.runtime.caching.cache_resource_api_test.CacheResourceTest.test_cached_member_function_with_hash_func.<locals>.TestClass": id
+                    "tests.streamlit.runtime.caching.cache_resource_api_test."
+                    "CacheResourceTest.test_cached_member_function_with_hash_func."
+                    "<locals>.TestClass": id
                 }
             )
             def member_func(self):
@@ -177,7 +179,7 @@ Object of type tests.streamlit.runtime.caching.cache_resource_api_test.CacheReso
 ```
 
 If you think this is actually a Streamlit bug, please
-[file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""
+[file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""  # noqa: E501
         assert str(ctx.value) == expected_message
 
     def test_cached_st_function_clear_args(self):

--- a/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
+++ b/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
@@ -114,8 +114,8 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
 
             output = "".join(logs.output)
             assert (
-                "The cached function 'func-display-name' has a TTL that will be ignored. Persistent cached functions currently don't support TTL."
-                in output
+                "The cached function 'func-display-name' has a TTL that will be ignored. "
+                "Persistent cached functions currently don't support TTL." in output
             )
 
     def test_check_context_without_persist(self):
@@ -145,8 +145,8 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
 
             output = "".join(logs.output)
             assert (
-                "The cached function 'func-display-name' has a TTL that will be ignored. Persistent cached functions currently don't support TTL."
-                not in output
+                "The cached function 'func-display-name' has a TTL that will be ignored. "
+                "Persistent cached functions currently don't support TTL." not in output
             )
 
     @patch("shutil.rmtree", wraps=shutil.rmtree)

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -577,7 +577,8 @@ def get_test_tuples(
     app_functions : list[APP_FUNCTION]
         Functions that run Streamlit elements like they are an app.
     elements : list[tuple[str, Callable[[], DeltaGenerator]]]
-        Tuples of (name, element-producer) where name describes the produced element and element_producer is a function that executes a Streamlit element.
+        Tuples of (name, element-producer) where name describes the produced element and element_producer
+        is a function that executes a Streamlit element.
     """
     return [
         (_element_producer[0], _app, _element_producer[1])

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: E501
+
 """Unit tests for MediaFileManager"""
 
 from __future__ import annotations

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -62,7 +62,9 @@ class TestSecretErrorMessages(unittest.TestCase):
         messages = SecretErrorMessages()
         assert (
             messages.get_missing_attr_message("attr")
-            == 'st.secrets has no attribute "attr". Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings on Streamlit Cloud? More info: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management'
+            == 'st.secrets has no attribute "attr". Did you forget to add it to secrets.toml, '
+            "mount it to secret directory, or the app settings on Streamlit Cloud? More info: "
+            "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
         )
 
         messages.set_missing_attr_message(

--- a/lib/tests/streamlit/toast_test.py
+++ b/lib/tests/streamlit/toast_test.py
@@ -50,7 +50,7 @@ class ToastTest(DeltaGeneratorTestCase):
         """Test that an error is raised if an invalid icon is provided."""
         with pytest.raises(StreamlitAPIException) as e:
             st.toast("toast text", icon="invalid")
-        assert (
-            str(e.value)
-            == 'The value "invalid" is not a valid emoji. Shortcodes are not allowed, please use a single character instead.'
+        assert str(e.value) == (
+            'The value "invalid" is not a valid emoji. Shortcodes '
+            "are not allowed, please use a single character instead."
         )

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -360,7 +360,9 @@ class SslServerTest(unittest.TestCase):
         ):
             start_listening(mock.MagicMock())
         assert logs.output == [
-            "ERROR:streamlit.web.server.server:Options 'server.sslCertFile' and 'server.sslKeyFile' must be set together. Set missing options or delete existing options."
+            "ERROR:streamlit.web.server.server:Options 'server.sslCertFile' and "
+            "'server.sslKeyFile' must be set together. Set missing options or delete "
+            "existing options."
         ]
 
     @parameterized.expand(["server.sslCertFile", "server.sslKeyFile"])
@@ -447,7 +449,8 @@ class SslServerTest(unittest.TestCase):
 
             start_listening(mock.MagicMock())
         assert re.search(
-            r"ERROR:streamlit\.web\.server\.server:Failed to load SSL certificate\. Make sure cert file '.+' and key file '.+' are correct\.",
+            r"ERROR:streamlit\.web\.server\.server:Failed to load SSL certificate\. Make "
+            r"sure cert file '.+' and key file '.+' are correct\.",
             logs.output[0],
         )
 


### PR DESCRIPTION
## Describe your changes

Enforces the max line length of 120 chars in our unit tests and removes the E501 rule ignore. There are a couple of files where its not very practical to enforce this rule, added a module-level ignore in those files.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
