### PR TITLE
Serve manifest.json from static asset handler

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -131,8 +131,13 @@ jobs:
         timeout-minutes: 120
         run: |
           sudo apt update
-          sudo apt install rsync
+          sudo apt install rsync jq
           make package
+          INDEX_NAME=$(jq '."index.html".name' lib/streamlit/static/manifest.json)
+          if [ "${INDEX_NAME}" != "index-testFailure" ]:
+            echo 'manifest.json file is missing or malformatted'
+            exit 1
+          fi
       - name: Store Whl File
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -133,9 +133,10 @@ jobs:
           sudo apt update
           sudo apt install rsync jq
           make package
-          INDEX_NAME=$(jq '."index.html".name' lib/streamlit/static/manifest.json)
-          if [ "${INDEX_NAME}" != "index-testFailure" ]:
-            echo 'manifest.json file is missing or malformatted'
+          INDEX_NAME=$(jq '."index.html".name' lib/streamlit/static/manifest.json | tr -d '"')
+          if [[ "${INDEX_NAME}" != "index" ]]
+          then
+            echo 'lib/streamlit/static/manifest.json is missing or malformatted!'
             exit 1
           fi
       - name: Store Whl File

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,9 @@ frontend:
 	cd frontend/ ; yarn workspaces foreach --all --topological run build
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
+	# Move manifest.json to a location that can actually be served by the Tornado
+	# server's static asset handler.
+	mv lib/streamlit/static/.vite/manifest.json lib/streamlit/static
 
 .PHONY: frontend-dependencies
 # Build frontend dependent libraries (excluding app and lib)

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -115,6 +115,7 @@ export default defineConfig({
     outDir: "build",
     assetsDir: "static",
     sourcemap: DEV_BUILD,
+    manifest: true,
     rollupOptions: {
       output: {
         // Customize the chunk file naming pattern to match static/js/[name].[hash].js


### PR DESCRIPTION
## Describe your changes

We need to be able to know the file paths to some of our static assets (in particular
our js and css entrypoints) in our deployments where our `index.html` isn't served
by the Tornado server.

This can be done with nearly no work on our end by tweaking our vite config to generate
a manifest when building the frontend, then serving this file using the existing static asset
handler.

## GitHub Issue Link (if applicable)

## Testing Plan

- Manual tests
   - Built the package, ran the Streamlit server, and verified that running `curl localhost:8501/manifest.json`
      returns the manifest file as expected.
- Also added a simple test in the PR preview CI stage to check that the file exists and some expected
   keys are in the JSON object

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
