### PR TITLE
Pin mypy to 1.15 to resolve CI issue

### DIFF
--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,7 +1,9 @@
 pre-commit
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.11.11
-mypy>=1.15
+# We are pinning the upper version to not break our CI on updates,
+# and have dependabot handle the updates instead.
+mypy>=1.15,<1.16
 mypy-protobuf>=3.2
 semver>=3
 setuptools>=65.5.1


### PR DESCRIPTION
## Describe your changes

The mypy 1.16 update broke our CI. I prepared a mypy update in https://github.com/streamlit/streamlit/pull/11484. However, there are a couple of regressions with mypy impacting our codebase -> need to wait for a patch to update to 1.16.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
