### PR TITLE
Use private token in `st.map`

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -230,23 +230,8 @@ class MapMixin:
            height: 600px
 
         """
-        # This feature was turned off while we investigate why different
-        # map styles cause DeckGL to crash.
-        #
-        # For reference, this was the docstring for map_style:
-        #
-        #   map_style : str, None
-        #       One of Mapbox's map style URLs. A full list can be found here:
-        #       https://docs.mapbox.com/api/maps/styles/#mapbox-styles
-        #
-        #       This feature requires a Mapbox token. See the top of these docs
-        #       for information on how to get one and set it up in Streamlit.
-        #
-        map_style = None
         map_proto = DeckGlJsonChartProto()
-        deck_gl_json = to_deckgl_json(
-            data, latitude, longitude, size, color, map_style, zoom
-        )
+        deck_gl_json = to_deckgl_json(data, latitude, longitude, size, color, zoom)
         marshall(
             map_proto, deck_gl_json, use_container_width, width=width, height=height
         )
@@ -264,7 +249,6 @@ def to_deckgl_json(
     lon: str | None,
     size: None | str | float,
     color: None | str | Collection[float],
-    map_style: str | None,
     zoom: int | None,
 ) -> str:
     if data is None:
@@ -317,14 +301,6 @@ def to_deckgl_json(
             "data": df.to_dict("records"),
         }
     ]
-
-    if map_style:
-        if not config.get_option("mapbox.token"):
-            raise StreamlitAPIException(
-                "You need a Mapbox token in order to select a map type. "
-                "Refer to the docs for st.map for more information."
-            )
-        default["mapStyle"] = map_style
 
     return json.dumps(default)
 
@@ -502,3 +478,7 @@ def marshall(
         pydeck_proto.height = height
 
     pydeck_proto.id = ""
+
+    mapbox_token = config.get_option("mapbox.token")
+    if mapbox_token:
+        pydeck_proto.mapbox_token = mapbox_token

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -27,6 +27,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.elements.map import _DEFAULT_MAP, _DEFAULT_ZOOM_LEVEL
 from streamlit.errors import StreamlitAPIException
+from streamlit.testing.v1.util import patch_config_options
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 mock_df = pd.DataFrame({"lat": [1, 2, 3, 4], "lon": [10, 20, 30, 40]})
@@ -341,3 +342,11 @@ class StMapTest(DeltaGeneratorTestCase):
         st.map(mock_df, width=240)
         c = self.get_delta_from_queue().new_element.deck_gl_json_chart
         assert c.width == 240
+
+    def test_mapbox_token_is_set_in_proto(self):
+        """Test that mapbox token is set in proto if configured."""
+
+        with patch_config_options({"mapbox.token": "test_mapbox_token"}):
+            st.map(mock_df)
+            c = self.get_delta_from_queue().new_element.deck_gl_json_chart
+            assert c.mapbox_token == "test_mapbox_token"


### PR DESCRIPTION
## Describe your changes

The configured mapbox token is currently only used with `st.pydeck_chart`. This also adds the token to the proto (if configured) for `st.map`.

## GitHub Issue Link (if applicable)

- Close https://github.com/streamlit/streamlit/issues/11399

## Testing Plan

- Added unit test. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
