### PR TITLE
Add context info to switch page rerun

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -236,6 +236,7 @@ def switch_page(page: str | Path | StreamlitPage) -> NoReturn:  # type: ignore[m
             query_string=ctx.query_string,
             page_script_hash=page_script_hash,
             cached_message_hashes=ctx.cached_message_hashes,
+            context_info=ctx.context_info,
         )
     )
     # Force a yield point so the runner can do the rerun

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -17,8 +17,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from streamlit.commands.execution_control import _new_fragment_id_queue, rerun
+from streamlit.commands.execution_control import (
+    _new_fragment_id_queue,
+    rerun,
+    switch_page,
+)
 from streamlit.errors import StreamlitAPIException
+from streamlit.navigation.page import StreamlitPage
 from streamlit.runtime.scriptrunner import RerunData
 
 
@@ -108,3 +113,35 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_true(patched_get_script_run_ctx)
 def test_st_rerun_invalid_scope_throws_error():
     with pytest.raises(StreamlitAPIException):
         rerun(scope="foo")
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_st_switch_page_context_info(patched_get_script_run_ctx):
+    """Test that context_info is passed to RerunData in st.switch_page."""
+    ctx = MagicMock()
+    ctx.pages_manager = MagicMock()  # Ensure pages_manager is present
+    ctx.main_script_path = "/some/path/your_app.py"
+    ctx.query_string = ""
+    ctx.page_script_hash = "some_hash"  # This is for the current page, not the target
+    ctx.cached_message_hashes = MagicMock()
+    ctx.context_info = {"test_key": "test_value"}  # Set a specific context_info
+
+    patched_get_script_run_ctx.return_value = ctx
+
+    # Mock the StreamlitPage object and its _script_hash attribute
+    mock_page = MagicMock(spec=StreamlitPage)
+    mock_page._script_hash = "target_page_hash"
+
+    with patch(
+        "streamlit.commands.execution_control.get_main_script_directory",
+        return_value="/some/path",
+    ):
+        switch_page(mock_page)
+
+    ctx.script_requests.request_rerun.assert_called_once()
+    call_args = ctx.script_requests.request_rerun.call_args[0][0]
+    assert isinstance(call_args, RerunData)
+    assert call_args.page_script_hash == "target_page_hash"
+    assert call_args.context_info == {"test_key": "test_value"}
+    # check that query_params.clear() was called
+    ctx.session_state.query_params.assert_called_once()


### PR DESCRIPTION
## Describe your changes

Fixes an issue with `st.switch_page` clearing all context info when it gets called.
 
## GitHub Issue Link (if applicable)

- Closes #11507 

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
