### PR TITLE
Allow usage of 3000 as app port

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1673,7 +1673,7 @@ def _check_conflicts() -> None:
     # When using the Node server, we must always connect to 8501 (this is
     # hard-coded in JS). Otherwise, the browser would decide what port to
     # connect to based on window.location.port, which in dev is going
-    # to be (3000)
+    # to be 3000.
 
     # Import logger locally to prevent circular references
     from streamlit.logger import get_logger

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -774,8 +774,6 @@ _create_option(
     "server.port",
     description="""
         The port where the server will listen for browser connections.
-
-        Don't use port 3000 which is reserved for internal development.
     """,
     default_val=8501,
     type_=int,
@@ -954,8 +952,7 @@ def _browser_server_port() -> int:
     - Open the browser automatically (part of `streamlit run`).
 
     This option is for advanced use cases. To change the port of your app, use
-    `server.Port` instead. Don't use port 3000 which is reserved for internal
-    development.
+    `server.Port` instead.
 
     Default: whatever value is set in server.port.
     """

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -53,7 +53,6 @@ from streamlit.web.server.routes import (
     StaticFileHandler,
 )
 from streamlit.web.server.server_util import (
-    DEVELOPMENT_PORT,
     get_cookie_secret,
     is_xsrf_enabled,
     make_url_path_regex,
@@ -203,14 +202,6 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
         address = config.get_option("server.address")
         port = config.get_option("server.port")
 
-        if int(port) == DEVELOPMENT_PORT:
-            _LOGGER.warning(
-                "Port %s is reserved for internal development. "
-                "It is strongly recommended to select an alternative port "
-                "for `server.port`.",
-                DEVELOPMENT_PORT,
-            )
-
         try:
             http_server.listen(port, address)
             break  # It worked! So let's break out of the loop.
@@ -225,9 +216,6 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
                         "Port %s already in use, trying to use the next one.", port
                     )
                     port += 1
-                    # Don't use the development port here:
-                    if port == DEVELOPMENT_PORT:
-                        port += 1
 
                     config.set_option(
                         "server.port", port, ConfigOption.STREAMLIT_DEFINITION

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -25,7 +25,7 @@ from streamlit.runtime.secrets import secrets_singleton
 if TYPE_CHECKING:
     from tornado.web import RequestHandler
 
-# The port reserved for internal development.
+# The port used for internal development.
 DEVELOPMENT_PORT: Final = 3000
 
 AUTH_COOKIE_NAME: Final = "_streamlit_user"


### PR DESCRIPTION
## Describe your changes

Removes all warnings about using 3000 as app port. 3000 was historically blocked as our internal development port. However, with the change to vite we changed how we detect that we are in development mode. This allowed us to make 3000 also usable by users.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/8149

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
