### PR TITLE
Use CSS class naming pattern in markdown

### DIFF
--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -33,6 +33,7 @@ alwaysApply: false
 - Utilize props in styled components to display elements that may have some interactivity.
   - Avoid the need to target other components.
 - When using BaseWeb, be sure to import our theme via `useTheme` and use those values in overrides.
+- Use the following pattern for naming custom CSS classes and test IDs: `stComponentSubcomponent`, for example: `stTextInputIcon`.
 
 ## Yarn Workspaces
 

--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -146,7 +146,9 @@ def test_colored_text_hover(app: Page):
     """Test that the colored text is correctly rendered and changes color on hover."""
     # Check hover behavior for colored text in primary button
     primary_button_element = app.get_by_test_id("stButton").nth(22)
-    expect(primary_button_element.locator("span")).to_have_class("colored-text")
+    expect(primary_button_element.locator("span")).to_have_class(
+        "stMarkdownColoredText"
+    )
     expect(primary_button_element.locator("span")).to_have_css(
         "color", "rgb(0, 104, 201)"
     )
@@ -158,7 +160,9 @@ def test_colored_text_hover(app: Page):
 
     # Check hover behavior for colored text in secondary button
     secondary_button_element = app.get_by_test_id("stButton").nth(23)
-    expect(secondary_button_element.locator("span")).to_have_class("colored-text")
+    expect(secondary_button_element.locator("span")).to_have_class(
+        "stMarkdownColoredText"
+    )
     expect(secondary_button_element.locator("span")).to_have_css(
         "color", "rgb(0, 104, 201)"
     )
@@ -170,7 +174,9 @@ def test_colored_text_hover(app: Page):
 
     # Check hover behavior for colored text in tertiary button
     tertiary_button_element = app.get_by_test_id("stButton").nth(24)
-    expect(tertiary_button_element.locator("span")).to_have_class("colored-text")
+    expect(tertiary_button_element.locator("span")).to_have_class(
+        "stMarkdownColoredText"
+    )
     expect(tertiary_button_element.locator("span")).to_have_css(
         "color", "rgb(0, 104, 201)"
     )

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -111,7 +111,7 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
         // override text color on hover for colored text - note since text color applied
         // as inline style (highest specificity) we need to use !important
         // use inherit to handle all button types
-        "span.colored-text": {
+        "span.stMarkdownColoredText": {
           color: "inherit !important",
         },
       },

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -410,7 +410,7 @@ describe("StreamlitMarkdown", () => {
       const tagName = markdown.nodeName.toLowerCase()
       expect(tagName).toBe("span")
       expect(markdown).toHaveStyle(`color: ${style}`)
-      expect(markdown).toHaveClass("colored-text")
+      expect(markdown).toHaveClass("stMarkdownColoredText")
 
       // Removes rendered StreamlitMarkdown component before next case run
       cleanup()

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -467,7 +467,7 @@ function createRemarkColoringAndSmall(
           const data = node.data || (node.data = {})
           data.hName = "span"
           data.hProperties = data.hProperties || {}
-          data.hProperties.className = "is-badge"
+          data.hProperties.className = "stMarkdownBadge"
           data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`
           return
         }
@@ -482,13 +482,13 @@ function createRemarkColoringAndSmall(
         data.hProperties.style = style
         // Add class name specific to colored text used for button hover selector
         // to override text color
-        data.hProperties.className = "colored-text"
+        data.hProperties.className = "stMarkdownColoredText"
         // Add class for background color for custom styling
         if (
           style &&
           (/background-color:/.test(style) || /background:/.test(style))
         ) {
-          data.hProperties.className = "has-background-color"
+          data.hProperties.className = "stMarkdownColoredBackground"
         }
         return
       }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -256,13 +256,13 @@ export const StyledStreamlitMarkdown =
           border: `${theme.sizes.borderWidth} solid ${theme.colors.dataframeBorderColor}`,
         },
 
-        "span.has-background-color": {
+        "span.stMarkdownColoredBackground": {
           borderRadius: theme.radii.md,
           padding: `${theme.spacing.threeXS} ${theme.spacing.twoXS}`,
           margin: theme.spacing.none,
         },
 
-        "span.is-badge": {
+        "span.stMarkdownBadge": {
           borderRadius: theme.radii.md,
           // Since we're using inline-block below, we're not using vertical padding here,
           // because inline-block already makes the element look a bit taller.


### PR DESCRIPTION
## Describe your changes

We have been using a prefixed naming pattern for all custom CSS classes and test IDs: `stComponentSubcomponent`. This PR migrates some custom css classnames in `StreamlitMarkdown` to this pattern and adds a hint to our cursor rules.

## Testing Plan

- Updated tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
