### PR TITLE
feat #7775: Add image carousel element

### DIFF
--- a/frontend/lib/src/components/elements/ImageList/ImageCarousel.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageCarousel.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+
+import { ImageList as ImageListProto } from "@streamlit/protobuf"
+
+import { render } from "~lib/test_util"
+import { mockEndpoints } from "~lib/mocks/mocks"
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
+
+import ImageList, { ImageListProps } from "./ImageList"
+
+describe("ImageList Element", () => {
+  const buildMediaURL = vi.fn().mockReturnValue("https://mock.media.url")
+  const sendClientErrorToHost = vi.fn()
+
+  const getProps = (
+    elementProps: Partial<ImageListProto> = {}
+  ): ImageListProps => ({
+    element: ImageListProto.create({
+      imgs: [
+        { caption: "a", url: "/media/mockImage1.jpeg" },
+        { caption: "b", url: "/media/mockImage2.jpeg" },
+      ],
+      width: -1,
+      ...elementProps,
+      carousel: true,
+    }),
+    endpoints: mockEndpoints({
+      buildMediaURL: buildMediaURL,
+      sendClientErrorToHost: sendClientErrorToHost,
+    }),
+  })
+
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: { current: null },
+      values: [250],
+    })
+  })
+
+  it("renders without crashing", () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+    expect(screen.getAllByRole("img")).toHaveLength(2)
+  })
+
+  it("renders explicit width for each image", () => {
+    const props = getProps({ width: 300 })
+    render(<ImageList {...props} />)
+
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(2)
+    images.forEach(image => {
+      expect(image).toHaveStyle("width: 300px")
+    })
+  })
+
+  it("creates its `src` attribute using buildMediaURL", () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(2)
+
+    expect(buildMediaURL).toHaveBeenNthCalledWith(1, "/media/mockImage1.jpeg")
+    expect(buildMediaURL).toHaveBeenNthCalledWith(2, "/media/mockImage2.jpeg")
+
+    images.forEach(image => {
+      expect(image).toHaveAttribute("src", "https://mock.media.url")
+    })
+  })
+
+  it("has a caption", () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+
+    const caption = screen.getByTestId("stImageCaption")
+    expect(caption).toHaveTextContent("a")
+  })
+
+  it("renders explicit width for each caption", () => {
+    const props = getProps({ width: 300 })
+    render(<ImageList {...props} />)
+
+    const caption = screen.getByTestId("stImageCaption")
+    expect(caption).toHaveStyle("width: 300px")
+  })
+
+  it("sends an CLIENT_ERROR message when the image source fails to load", () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(2)
+
+    // Trigger the error event on the first image using fireEvent
+    fireEvent.error(images[0])
+
+    // Verify the error was sent with correct parameters
+    expect(sendClientErrorToHost).toHaveBeenCalledWith(
+      "Image",
+      "Image source failed to load",
+      "onerror triggered",
+      "https://mock.media.url/"
+    )
+  })
+
+  it("slides between images when arrows are clicked", async () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+
+    const images = screen.getAllByRole("img")
+    expect(images[0]).toBeVisible()
+    expect(images[1]).not.toBeVisible()
+
+    const rightArrow = screen.queryByTestId("carousel-next-button")
+    const leftArrow = screen.queryByTestId("carousel-prev-button")
+    const caption = screen.getByTestId("stImageCaption")
+    expect(rightArrow).toBeInTheDocument()
+    expect(leftArrow).not.toBeInTheDocument()
+    expect(caption).toHaveTextContent("a")
+
+    // Click the right arrow
+    await userEvent.click(screen.getByTestId("carousel-next-button"))
+
+    await waitFor(() => {
+      expect(images[0]).not.toBeVisible()
+    })
+
+    await waitFor(() => {
+      expect(images[1]).toBeVisible()
+    })
+
+    // It is the last image, so the right arrow should not be visible
+    const rightArrowUpdate = screen.queryByTestId("carousel-next-button")
+    const leftArrowUpdate = screen.queryByTestId("carousel-prev-button")
+    const captionUpdate = screen.getByTestId("stImageCaption")
+    expect(rightArrowUpdate).not.toBeInTheDocument()
+    expect(leftArrowUpdate).toBeInTheDocument()
+    expect(captionUpdate).toHaveTextContent("b")
+
+    await userEvent.click(screen.getByTestId("carousel-prev-button"))
+
+    await waitFor(() => {
+      expect(images[0]).toBeVisible()
+    })
+
+    await waitFor(() => {
+      expect(images[1]).not.toBeVisible()
+    })
+  })
+
+  it("does not render arrows or dots when there is only one image", () => {
+    const props = getProps({
+      imgs: [{ caption: "a", url: "/media/mockImage1.jpeg" }],
+    })
+    render(<ImageList {...props} />)
+
+    const images = screen.getAllByRole("img")
+    expect(images).toHaveLength(1)
+
+    const rightArrow = screen.queryByTestId("carousel-next-button")
+    const leftArrow = screen.queryByTestId("carousel-prev-button")
+    const dots = screen.queryAllByTestId(/carousel-dot-/)
+
+    expect(rightArrow).not.toBeInTheDocument()
+    expect(leftArrow).not.toBeInTheDocument()
+    expect(dots).toHaveLength(0)
+  })
+
+  it("slides between images when dot is clicked", async () => {
+    const props = getProps()
+    render(<ImageList {...props} />)
+
+    const images = screen.getAllByRole("img")
+    const caption = screen.getByTestId("stImageCaption")
+    expect(images[0]).toBeVisible()
+    expect(images[1]).not.toBeVisible()
+    expect(caption).toHaveTextContent("a")
+
+    const dot0 = screen.getByTestId("carousel-dot-0")
+    expect(dot0).toBeInTheDocument()
+    const dot1 = screen.getByTestId("carousel-dot-1")
+    expect(dot1).toBeInTheDocument()
+
+    // The second dot should be active
+    expect(dot0).toHaveStyle({ backgroundColor: "rgb(255, 255, 255)" })
+
+    // Click the second dot
+    await userEvent.click(dot1)
+
+    await waitFor(() => {
+      expect(images[0]).not.toBeVisible()
+    })
+
+    await waitFor(() => {
+      expect(images[1]).toBeVisible()
+    })
+
+    // The second dot should be active
+    await waitFor(() => {
+      expect(dot1).toHaveStyle({ backgroundColor: "rgb(255, 255, 255)" })
+    })
+
+    await waitFor(() => {
+      expect(dot1).toHaveStyle("border: 2px solid white")
+    })
+
+    const captionUpdate = screen.getByTestId("stImageCaption")
+    expect(captionUpdate).toHaveTextContent("b")
+  })
+})

--- a/frontend/lib/src/components/elements/ImageList/ImageCarousel.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageCarousel.tsx
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  CSSProperties,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { Image as ImageProto } from "@streamlit/protobuf"
+
+import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
+import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
+import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
+import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+import * as Primitives from "~lib/theme/primitives"
+
+import { StyledCaption, StyledImageContainer } from "./styled-components"
+
+export interface ImageCarouselProps {
+  images: ImageProto[]
+  endpoints: StreamlitEndpoints
+  elementWidth: number
+  imgStyle: CSSProperties
+  isFullScreen?: boolean
+  onImageError: (e: React.SyntheticEvent<HTMLImageElement>) => void
+}
+
+export function ImageCarousel({
+  images,
+  endpoints,
+  elementWidth,
+  imgStyle,
+  isFullScreen,
+  onImageError,
+}: ImageCarouselProps): ReactElement {
+  const {
+    expanded: isFullScreenContext,
+    width,
+    height,
+  } = useRequiredContext(ElementFullscreenContext)
+
+  // Use the isFullScreen prop passed from parent instead of context directly
+  const actualIsFullScreen = isFullScreen ?? isFullScreenContext
+
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [isHoveredPrev, setIsHoveredPrev] = useState(false)
+  const [isHoveredNext, setIsHoveredNext] = useState(false)
+  const [maxImageHeight] = useState<number>(0)
+  const [captionHeight, setCaptionHeight] = useState<number>(0)
+  const [isTransitioning, setIsTransitioning] = useState(false)
+
+  const captionRef = useRef<HTMLDivElement>(null)
+
+  const isFirstImage = currentIndex === 0
+  const isLastImage = currentIndex === images.length - 1
+  const hasCaption = Boolean(images[currentIndex]?.caption)
+
+  const TRANSITION_DURATION = 500
+
+  useEffect(() => {
+    if (isFirstImage) {
+      setIsHoveredPrev(false)
+    }
+    if (isLastImage) {
+      setIsHoveredNext(false)
+    }
+  }, [isFirstImage, isLastImage])
+
+  useEffect(() => {
+    if (captionRef.current && hasCaption) {
+      setCaptionHeight(captionRef.current.offsetHeight)
+    } else {
+      setCaptionHeight(0)
+    }
+  }, [hasCaption, currentIndex])
+
+  const nextImage = (): void => {
+    setIsTransitioning(true)
+    setCurrentIndex(oldIndex => (oldIndex + 1) % images.length)
+
+    setTimeout(() => {
+      setIsTransitioning(false)
+    }, TRANSITION_DURATION)
+  }
+
+  const prevImage = (): void => {
+    setIsTransitioning(true)
+    setCurrentIndex(oldIndex =>
+      oldIndex === 0 ? images.length - 1 : oldIndex - 1
+    )
+
+    setTimeout(() => {
+      setIsTransitioning(false)
+    }, TRANSITION_DURATION)
+  }
+
+  const goToImage = (index: number): void => {
+    if (index === currentIndex) return
+
+    setIsTransitioning(true)
+    setCurrentIndex(index)
+
+    setTimeout(() => {
+      setIsTransitioning(false)
+    }, TRANSITION_DURATION)
+  }
+
+  const getImageFullscreenHeight = (): string | number => {
+    if (actualIsFullScreen && height) {
+      // Reserve space for caption if it exists
+      const reservedHeight = hasCaption ? captionHeight + 20 : 0
+      return Math.max(height - reservedHeight, 100)
+    }
+    return maxImageHeight > 0 ? `${maxImageHeight}px` : "auto"
+  }
+
+  const isVisible = (index: number): boolean => {
+    if (isTransitioning) {
+      return true
+    }
+    return index === currentIndex
+  }
+
+  // Get the container width - use elementWidth when not in fullscreen
+  // For carousel, we need to respect the image width from imgStyle if it's explicitly set
+  const containerWidth = actualIsFullScreen ? width : elementWidth
+
+  return (
+    <StyledImageContainer data-testid="stImageCarousel">
+      <div
+        style={{
+          position: "relative",
+          width: containerWidth ?? "100%",
+          height: getImageFullscreenHeight(),
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            transition: "transform 500ms ease-in-out",
+            transform: `translateX(-${
+              currentIndex * (containerWidth || elementWidth)
+            }px)`,
+            width: `${images.length * (containerWidth || elementWidth)}px`,
+            height: "100%",
+          }}
+        >
+          {images.map((image, idx) => (
+            <img
+              // TODO: Update to match React best practices
+              // eslint-disable-next-line @eslint-react/no-array-index-key
+              key={idx}
+              style={{
+                ...imgStyle,
+                boxSizing: "border-box",
+                width: imgStyle.width ?? containerWidth ?? "100%",
+                maxWidth: imgStyle.maxWidth ?? containerWidth ?? "100%",
+                height: actualIsFullScreen
+                  ? "100%"
+                  : maxImageHeight > 0
+                  ? `${maxImageHeight}px`
+                  : "auto",
+                maxHeight: actualIsFullScreen ? "100%" : undefined,
+                flexShrink: 0,
+                objectFit: actualIsFullScreen
+                  ? "contain"
+                  : imgStyle.objectFit || "contain",
+                display: "block",
+                backgroundColor: "transparent",
+                opacity: isVisible(idx) ? 1 : 0,
+              }}
+              src={endpoints.buildMediaURL(image.url ?? "")}
+              alt={`image-${idx}`}
+              onError={onImageError}
+            />
+          ))}
+        </div>
+
+        {!isFirstImage && (
+          <button
+            data-testid="carousel-prev-button"
+            type="button"
+            onClick={prevImage}
+            aria-label="Previous"
+            onMouseEnter={() => setIsHoveredPrev(true)}
+            onMouseLeave={() => setIsHoveredPrev(false)}
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "1rem",
+              transform: "translateY(-50%)",
+              background: isHoveredPrev
+                ? "rgba(255, 255, 255, 0.4)"
+                : "rgba(100, 100, 100, 0.4)",
+              color: isHoveredPrev ? "black" : "white",
+              border: isHoveredPrev
+                ? "1px solid rgba(0, 0, 0, 0.4)"
+                : "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: Primitives.sizes.full,
+              width: Primitives.sizes.buttonSize,
+              height: Primitives.sizes.buttonSize,
+              fontSize: Primitives.fontSizes.fourXL,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              paddingBottom: Primitives.iconSizes.xs,
+              paddingRight: Primitives.iconSizes.xs,
+            }}
+          >
+            ‹
+          </button>
+        )}
+        {!isLastImage && (
+          <button
+            data-testid="carousel-next-button"
+            type="button"
+            onClick={nextImage}
+            aria-label="Next"
+            onMouseEnter={() => setIsHoveredNext(true)}
+            onMouseLeave={() => setIsHoveredNext(false)}
+            style={{
+              position: "absolute",
+              top: "50%",
+              right: "1rem",
+              transform: "translateY(-50%)",
+              background: isHoveredNext
+                ? "rgba(255, 255, 255, 0.4)"
+                : "rgba(100, 100, 100, 0.4)",
+              color: isHoveredNext ? "black" : "white",
+              border: isHoveredNext
+                ? "1px solid rgba(0, 0, 0, 0.4)"
+                : "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: Primitives.sizes.full,
+              width: Primitives.sizes.buttonSize,
+              height: Primitives.sizes.buttonSize,
+              fontSize: Primitives.fontSizes.fourXL,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              paddingBottom: Primitives.iconSizes.xs,
+              paddingLeft: Primitives.iconSizes.xs,
+            }}
+          >
+            ›
+          </button>
+        )}
+        <div
+          style={{
+            position: "absolute",
+            bottom: Primitives.spacing.md,
+            left: "50%",
+            transform: "translateX(-50%)",
+            display: "flex",
+            backgroundColor: Primitives.colors.gray80,
+            padding: Primitives.sizes.spinnerThickness,
+            borderRadius: Primitives.sizes.smallLogoHeight,
+          }}
+        >
+          {images.map((_, index) => (
+            <span
+              // TODO: Update to match React best practices
+              // eslint-disable-next-line @eslint-react/no-array-index-key
+              key={index}
+              onClick={() => goToImage(index)}
+              onKeyDown={e => {
+                if (e.key === "Enter" || e.key === " ") {
+                  goToImage(index)
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              style={{
+                display: "inline-block",
+                width: Primitives.iconSizes.sm,
+                height: Primitives.iconSizes.sm,
+                margin: `${Primitives.spacing.none} ${Primitives.spacing.twoXS}`,
+                borderRadius: "50%",
+                backgroundColor: index === currentIndex ? "white" : "gray",
+                cursor: "pointer",
+                transition: "background-color 200ms",
+                border: index === currentIndex ? "2px solid white" : "none",
+                boxSizing: "border-box",
+              }}
+              data-testid={`carousel-dot-${index}`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {hasCaption && (
+        <StyledCaption
+          ref={captionRef}
+          data-testid="stImageCaption"
+          style={imgStyle}
+        >
+          <StreamlitMarkdown
+            source={images[currentIndex].caption}
+            allowHTML={false}
+            isCaption
+            isLabel
+          />
+        </StyledCaption>
+      )}
+    </StyledImageContainer>
+  )
+}

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -37,6 +37,7 @@ import {
   StyledImageContainer,
   StyledImageList,
 } from "./styled-components"
+import { ImageCarousel } from "./ImageCarousel"
 
 const LOG = getLogger("ImageList")
 
@@ -78,6 +79,10 @@ function ImageList({
 
   // The width of the element is the width of the container, not necessarily the image.
   const elementWidth = width || 0
+
+  const images = element.imgs
+  const isCarousel = element.carousel === true && images.length > 1
+
   // The width field in the proto sets the image width, but has special
   // cases the values in the WidthBehavior enum.
   let imageWidth: number | undefined
@@ -151,35 +156,47 @@ function ImageList({
         onCollapse={collapse}
         disableFullscreenMode={disableFullscreenMode}
       ></Toolbar>
-      <StyledImageList className="stImage" data-testid="stImage">
-        {element.imgs.map((iimage, idx): ReactElement => {
-          const image = iimage as ImageProto
-          return (
-            // TODO: Update to match React best practices
-            // eslint-disable-next-line @eslint-react/no-array-index-key
-            <StyledImageContainer data-testid="stImageContainer" key={idx}>
-              <img
-                style={imgStyle}
-                src={endpoints.buildMediaURL(image.url)}
-                alt={idx.toString()}
-                onError={handleImageError}
-              />
-              {image.caption && (
-                <StyledCaption data-testid="stImageCaption" style={imgStyle}>
-                  <StreamlitMarkdown
-                    source={image.caption}
-                    allowHTML={false}
-                    isCaption
-                    // This is technically not a label but we want the same restrictions
-                    // as for labels (e.g. no Markdown tables or horizontal rule).
-                    isLabel
-                  />
-                </StyledCaption>
-              )}
-            </StyledImageContainer>
-          )
-        })}
-      </StyledImageList>
+
+      {isCarousel ? (
+        <ImageCarousel
+          images={images.map(img => img as ImageProto)}
+          endpoints={endpoints}
+          elementWidth={elementWidth}
+          imgStyle={imgStyle}
+          isFullScreen={isFullScreen}
+          onImageError={handleImageError}
+        />
+      ) : (
+        <StyledImageList className="stImage" data-testid="stImage">
+          {element.imgs.map((iimage, idx): ReactElement => {
+            const image = iimage as ImageProto
+            return (
+              // TODO: Update to match React best practices
+              // eslint-disable-next-line @eslint-react/no-array-index-key
+              <StyledImageContainer data-testid="stImageContainer" key={idx}>
+                <img
+                  style={imgStyle}
+                  src={endpoints.buildMediaURL(image.url)}
+                  alt={idx.toString()}
+                  onError={handleImageError}
+                />
+                {image.caption && (
+                  <StyledCaption data-testid="stImageCaption" style={imgStyle}>
+                    <StreamlitMarkdown
+                      source={image.caption}
+                      allowHTML={false}
+                      isCaption
+                      // This is technically not a label but we want the same restrictions
+                      // as for labels (e.g. no Markdown tables or horizontal rule).
+                      isLabel
+                    />
+                  </StyledCaption>
+                )}
+              </StyledImageContainer>
+            )
+          })}
+        </StyledImageList>
+      )}
     </StyledToolbarElementContainer>
   )
 }

--- a/frontend/lib/src/theme/primitives/sizes.ts
+++ b/frontend/lib/src/theme/primitives/sizes.ts
@@ -62,4 +62,6 @@ export const sizes = {
   // The minimum width of the menu (used for the dataframe column menu)
   minMenuWidth: "8rem",
   minChatInputFileListHeight: "3rem",
+  // Used for buttons in the image carousel
+  buttonSize: "3rem",
 }

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -54,6 +54,7 @@ class ImageMixin:
         width: int | None = None,
         use_column_width: UseColumnWith = None,
         clamp: bool = False,
+        carousel: bool = False,
         channels: Channels = "RGB",
         output_format: ImageFormatOrAuto = "auto",
         *,
@@ -108,6 +109,11 @@ class ImageMixin:
             ignored for image URLs and files. If this is ``False`` (default)
             and an image has an out-of-range value, a ``RuntimeError`` will be
             raised.
+        carousel : bool
+            Whether to display the images in a carousel. If this is ``True``,
+            Streamlit displays the images in a carousel that users can swipe
+            through. If this is ``False`` (default), Streamlit displays the
+            images sequencially and vertically.
         channels : "RGB" or "BGR"
             The color format when ``image`` is an ``nd.array``. This is ignored
             for other image types. If this is ``"RGB"`` (default),
@@ -177,6 +183,7 @@ class ImageMixin:
             image_width = WidthBehavior.MIN_IMAGE_OR_CONTAINER
 
         image_list_proto = ImageListProto()
+        image_list_proto.carousel = carousel
         marshall_images(
             self.dg._get_delta_path_str(),
             image,
@@ -184,6 +191,7 @@ class ImageMixin:
             image_width,
             image_list_proto,
             clamp,
+            carousel,
             channels,
             output_format,
         )

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -350,6 +350,7 @@ def marshall_images(
     width: int | WidthBehavior,
     proto_imgs: ImageListProto,
     clamp: bool,
+    carousel: bool,
     channels: Channels = "RGB",
     output_format: ImageFormatOrAuto = "auto",
 ) -> None:
@@ -377,6 +378,10 @@ def marshall_images(
         This is only meaningful for byte array images; the parameter is
         ignored for image URLs. If this is not set, and an image has an
         out-of-range value, an error will be thrown.
+    carousel
+        If True, the images will be displayed in a carousel. This is only
+        meaningful for lists of images. If False, the images will be
+        displayed in sequence vertically. Defaults to False.
     channels
         If image is an nd.array, this parameter denotes the format used to
         represent color information. Defaults to 'RGB', meaning
@@ -427,6 +432,9 @@ def marshall_images(
         )
 
     proto_imgs.width = int(width)
+
+    if carousel:
+        proto_imgs.carousel = True
     # Each image in an image list needs to be kept track of at its own coordinates.
     for coord_suffix, (single_image, single_caption) in enumerate(
         zip(images, captions)

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -184,6 +184,7 @@ def marshall(
         width=image_width,
         proto_imgs=image_list_proto,
         clamp=False,
+        carousel=False,
         channels="RGB",
         output_format="PNG",
     )

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -350,6 +350,7 @@ class ImageProtoTest(DeltaGeneratorTestCase):
             0,
             image_list_proto,
             False,
+            False,
         )
 
         img = image_list_proto.imgs[0]

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -46,4 +46,6 @@ message ImageList {
   // -4 means use the smaller of image width & container width
   // -5 means use the larger of image width & container width
   int32 width = 2;
+
+  bool carousel = 3;
 }


### PR DESCRIPTION
## Describe your changes

The feature comes with two arrows to switch between
images and clickable index dots that select which image
to show. Also functional with fullscreen mode.

As this is only a change in the way image lists
are handled, we figured it would be more coherent if
'carousel' was a boolean in the image element and
not an element itself.

https://github.com/user-attachments/assets/bcb38f63-4669-4ac2-b3ae-17b16c9bb4cb

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/7775

## Testing Plan

- Unit Tests (JS and/or Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
