### PR TITLE
Feat/st tabs default tab (new version)

### DIFF
--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -76,6 +76,14 @@ describe("st.tabs", () => {
     })
   })
 
+  it("sets the correct default tab index", () => {
+    const node = makeTabsNode(3)
+    node.deltaBlock.tabContainer = { defaultTabIndex: 2 }
+    render(<Tabs {...getProps({ node })} />)
+    const tabs = screen.getAllByRole("tab")
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true")
+  })
+
   it("doesn't disable tabs when widgets are disabled", () => {
     render(<Tabs {...getProps({ widgetsDisabled: true })} />)
     const tabs = screen.getAllByRole("tab")

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -48,12 +48,13 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
   const { widgetsDisabled, node, isStale, width } = props
   const { fragmentIdsThisRun, scriptRunState, scriptRunId } =
     useContext(LibContext)
+  const defaultTabIndex = node.deltaBlock?.tabContainer?.defaultTabIndex ?? 0
 
   let allTabLabels: string[] = []
-  const [activeTabKey, setActiveTabKey] = useState<React.Key>(0)
+  const [activeTabKey, setActiveTabKey] = useState<React.Key>(defaultTabIndex)
   const [activeTabName, setActiveTabName] = useState<string>(
     // @ts-expect-error
-    node.children[0].deltaBlock.tab.label || "0"
+    node.children[defaultTabIndex].deltaBlock.tab.label || "0"
   )
 
   const tabListRef = useRef<HTMLUListElement>(null)
@@ -65,8 +66,8 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
   useEffect(() => {
     const newTabKey = allTabLabels.indexOf(activeTabName)
     if (newTabKey === -1) {
-      setActiveTabKey(0)
-      setActiveTabName(allTabLabels[0])
+      setActiveTabKey(defaultTabIndex)
+      setActiveTabName(allTabLabels[defaultTabIndex])
     }
     // TODO: Update to match React best practices
     // eslint-disable-next-line react-hooks/react-compiler
@@ -85,8 +86,8 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
       setActiveTabKey(newTabKey)
       setActiveTabName(allTabLabels[newTabKey])
     } else {
-      setActiveTabKey(0)
-      setActiveTabName(allTabLabels[0])
+      setActiveTabKey(defaultTabIndex)
+      setActiveTabName(allTabLabels[defaultTabIndex])
     }
 
     // TODO: Update to match React best practices

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -523,9 +523,10 @@ class LayoutsMixin:
         tab_container = self.dg._block(block_proto)
 
         default_index = tabs.index(default) if default else 0
+
         block_proto.tab_container.default_tab_index = default_index
 
-        return tuple(tab_container._block(tab_proto(tab_label)) for tab_label in tabs)
+        return tuple(tab_container._block(tab_proto(tab)) for tab in tabs)
 
     @gather_metrics("expander")
     def expander(

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -520,11 +520,12 @@ class LayoutsMixin:
         block_proto.tab_container.SetInParent()
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
-        tab_container = self.dg._block(block_proto)
 
         default_index = tabs.index(default) if default else 0
 
         block_proto.tab_container.default_tab_index = default_index
+
+        tab_container = self.dg._block(block_proto)
 
         return tuple(tab_container._block(tab_proto(tab)) for tab in tabs)
 

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -409,6 +409,7 @@ class LayoutsMixin:
     def tabs(
         self,
         tabs: Sequence[str],
+        default: str | None = None,
         *,
         width: WidthWithoutContent = "stretch",
     ) -> Sequence[DeltaGenerator]:
@@ -499,6 +500,11 @@ class LayoutsMixin:
                 "The input argument to st.tabs must contain at least one tab label."
             )
 
+        if default and default not in tabs:
+            raise StreamlitAPIException(
+                f"The default tab '{default}' is not in the list of tabs."
+            )
+
         if any(not isinstance(tab, str) for tab in tabs):
             raise StreamlitAPIException(
                 "The tabs input list to st.tabs is only allowed to contain strings."
@@ -515,6 +521,10 @@ class LayoutsMixin:
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
         tab_container = self.dg._block(block_proto)
+
+        default_index = tabs.index(default) if default else 0
+        block_proto.tab_container.default_tab_index = default_index
+
         return tuple(tab_container._block(tab_proto(tab_label)) for tab_label in tabs)
 
     @gather_metrics("expander")

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -630,17 +630,37 @@ class TabsTest(DeltaGeneratorTestCase):
 
         for tab in tabs:
             with tab:
-                # Noop
                 pass
 
         all_deltas = self.get_all_deltas_from_queue()
 
         tabs_block = all_deltas[1:]
-        # 6 elements will be created: 1 horizontal block, 5 tabs
         assert len(all_deltas) == 6
         assert len(tabs_block) == 5
         for index, tab_block in enumerate(tabs_block):
             assert tab_block.add_block.tab.label == f"tab {index}"
+
+    def test_default_tab_index_first_tab(self):
+        """Test that the default tab index is 0 when default is not specified."""
+        tabs = ["Tab 1", "Tab 2", "Tab 3"]
+        st.tabs(tabs)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+
+        assert tab_container_block.add_block.tab_container.default_tab_index == 0
+
+    def test_invalid_default_tab(self):
+        """Test that an exception is raised if the default tab is not in the list."""
+        tabs = ["Tab 1", "Tab 2", "Tab 3"]
+        default_tab = "Tab 4"
+
+        with pytest.raises(StreamlitAPIException) as context:
+            st.tabs(tabs, default=default_tab)
+
+        assert "The default tab 'Tab 4' is not in the list of tabs." in str(
+            context.value
+        )
 
 
 class DialogTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -662,6 +662,37 @@ class TabsTest(DeltaGeneratorTestCase):
             context.value
         )
 
+    def test_valid_default_tab(self):
+        """Test that a valid default tab sets the correct index."""
+        tabs = ["Home", "Profile", "Settings"]
+        default = "Profile"
+        st.tabs(tabs, default=default)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+
+        assert tab_container_block.add_block.tab_container.default_tab_index == 1
+
+    def test_tab_labels_with_whitespace(self):
+        """Test that labels with leading/trailing spaces are accepted and preserved."""
+        tabs = ["  Tab 1", "Tab 2  ", "  Tab 3  "]
+        st.tabs(tabs)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        labels = [delta.add_block.tab.label for delta in all_deltas[1:]]
+
+        assert labels == tabs
+
+    def test_duplicate_tab_labels(self):
+        """Test that duplicate tab labels are allowed."""
+        tabs = ["Tab", "Tab", "Tab"]
+        st.tabs(tabs)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        labels = [delta.add_block.tab.label for delta in all_deltas[1:]]
+
+        assert labels == tabs
+
 
 class DialogTest(DeltaGeneratorTestCase):
     """Run unit tests for the non-public delta-generator dialog and also the dialog

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -111,6 +111,7 @@ message Block {
   }
 
   message TabContainer {
+    int32 default_tab_index = 1;
   }
 
   message Tab {


### PR DESCRIPTION
## Describe your changes
Messed up while rebasing PR #11267 so I made a new branch with the same changes.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)
#10910 

## Testing Plan
Added Python unit tests to verify that:
The correct tab index is set when using a label.
The correct tab index is set when using an index.
The default behavior is preserved when default is not provided.
Verified that the feature works via manual inspection of all_deltas.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
