### PR TITLE
[fix] Maintain tracked directory with make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ clean:
 	rm -rf ~/.cache/pre-commit
 	rm -rf e2e_playwright/test-results
 	rm -rf e2e_playwright/performance-results
-	find . -name .streamlit -not -path './e2e_playwright/.streamlit' -type d -exec rm -rfv {} \; || true
+	find . -name .streamlit -not \( -path './e2e_playwright/.streamlit' -o -path './e2e_playwright/config/.streamlit' \) -type d -exec rm -rfv {} \; || true
 	cd lib; rm -rf .coverage .coverage\.*
 
 .PHONY: protobuf


### PR DESCRIPTION
## Describe your changes

- Fixes an issue where `make clean` would unexpectedly delete tracked files in the `./e2e_playwright/config/.streamlit` directory.

## GitHub Issue Link (if applicable)

Fixes #11570

## Testing Plan

- Manually tested

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
