### PR TITLE
Add new CUSTOM_COMPONENT_CLIENT_ID global

### DIFF
--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -99,10 +99,17 @@ function getSrc(
   }
 
   // Add streamlitUrl query parameter to src
+  const customComponentClientId =
+    window.__streamlit?.CUSTOM_COMPONENT_CLIENT_ID
   const currentUrl = new URL(window.location.href)
   src = queryString.stringifyUrl({
     url: src,
-    query: { streamlitUrl: currentUrl.origin + currentUrl.pathname },
+    query: {
+      streamlitUrl: currentUrl.origin + currentUrl.pathname,
+      ...(customComponentClientId && {
+        __streamlit_parent_client_id: customComponentClientId,
+      }),
+    },
   })
   return src
 }

--- a/frontend/utils/src/types/index.ts
+++ b/frontend/utils/src/types/index.ts
@@ -46,6 +46,16 @@ export interface StreamlitWindowObject {
   // works.
   MAIN_PAGE_BASE_URL?: string
 
+  // When our Streamlit app is embedded in an iframe, this can be set by the
+  // parent frame of the app so that the Streamlit app is aware of its own
+  // Service Worker clientId. This has to be done when using Custom Components
+  // in an app deployed in a context where we use a Service Worker as `fetch`
+  // requests sent from the component iframe set `resultingClientId` but not
+  // `replacesClientId`, which means that without this we would be unable to
+  // associate a `fetch` request from a custom component iframe with its parent
+  // frame.
+  CUSTOM_COMPONENT_CLIENT_ID?: string
+
   // Theme related settings.
   LIGHT_THEME?: ICustomThemeConfig
   DARK_THEME?: ICustomThemeConfig


### PR DESCRIPTION
## Describe your changes

When a Streamlit app is deployed in a context where it is one of potentially
several apps running on a given browser/machine and a service worker is being
used, some difficulty arises if a `fetch` request is sent from a custom component
iframe. In this situation, the request has a `resultingClientId` (the ID of the
custom component iframe) set but not a `replacesClientId` (the ID of the parent
app), which means we're unable to determine which corresponding
parent Streamlit app to send a message to if necessary.

We fix this by adding a new `__streamlit.CUSTOM_COMPONENT_CLIENT_ID`
window variable and passing this value as a query param to the component
instance so that the service worker has enough information to match component
iframes with their parents.

## Testing Plan

- Unit Tests (JS and/or Python)
   - Added a new JS unit test 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
