### PR TITLE
[Fix] `st.number_input` styling

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/styled-components.ts
@@ -73,10 +73,6 @@ export const StyledInputControl = styled.button(({ theme }) => ({
     outline: "none",
     border: "none",
   },
-  "&:last-of-type": {
-    borderTopRightRadius: theme.radii.default,
-    borderBottomRightRadius: theme.radii.default,
-  },
   "&:disabled": {
     cursor: "not-allowed",
     color: theme.colors.fadedText40,


### PR DESCRIPTION
## Describe your changes
Fixes visual gap in `st.number_input` styling. Note this is a small enough difference that it doesn't pick up in snaps

**Before:**
<img width="300" height="200" alt="Screenshot 2025-06-09 at 11 38 34 p m" src="https://github.com/user-attachments/assets/92626678-4ccf-4d93-88fd-08afe2f339a4" />

**After:**
<img width="300" height="200" alt="Screenshot 2025-06-09 at 11 39 30 p m" src="https://github.com/user-attachments/assets/6808dd91-6200-4e3f-b7e4-2e0e42cac21a" />


## GitHub Issue Link (if applicable)
Closes #11569 

## Testing Plan
- Manual Testing: ✅ 