### PR TITLE
[fix] Enforce React Context display names

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -111,6 +111,8 @@ export default tseslint.config([
       "@eslint-react/hooks-extra/no-direct-set-state-in-use-effect": "off",
       // We don't want to warn about empty fragments
       "@eslint-react/no-useless-fragment": "off",
+      // We want to enforce display names for context providers for better debugging
+      "@eslint-react/no-missing-context-display-name": "error",
       // TypeScript rules with type-checking
       // We want to use these, but we have far too many instances of these rules
       // for it to be realistic right now. Over time, we should fix these.

--- a/frontend/lib/src/components/core/IsDialogContext.ts
+++ b/frontend/lib/src/components/core/IsDialogContext.ts
@@ -20,4 +20,7 @@
 
 import { createContext } from "react"
 
-export default createContext(false)
+const IsDialogContext = createContext(false)
+IsDialogContext.displayName = "IsDialogContext"
+
+export default IsDialogContext

--- a/frontend/lib/src/components/core/IsSidebarContext.ts
+++ b/frontend/lib/src/components/core/IsSidebarContext.ts
@@ -16,4 +16,7 @@
 
 import { createContext } from "react"
 
-export default createContext(false)
+const IsSidebarContext = createContext(false)
+IsSidebarContext.displayName = "IsSidebarContext"
+
+export default IsSidebarContext

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -170,3 +170,4 @@ export const LibContext = createContext<LibContextProps>({
   // This should be overwritten
   componentRegistry: new ComponentRegistry(noOpEndpoints),
 })
+LibContext.displayName = "LibContext"

--- a/frontend/lib/src/components/core/Portal/PortalContext.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalContext.tsx
@@ -18,3 +18,4 @@ import { createContext } from "react"
 export const PortalContext = createContext<(() => HTMLElement | null) | null>(
   null
 )
+PortalContext.displayName = "PortalContext"


### PR DESCRIPTION
## Describe your changes

- Leverages a new eslint rule to improve the developer experience when working with React Contexts

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ This is a lint change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
