### PR TITLE
[fix] Mark a number of e2e tests as flaky

### DIFF
--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import FilePayload, Locator, Page, expect
 
 from e2e_playwright.conftest import (
@@ -365,6 +366,7 @@ def test_file_upload_error_message_file_too_large(app: Page):
     expect(app.get_by_text("File must be 1.0MB or smaller.")).to_be_visible()
 
 
+@pytest.mark.flaky(reruns=4)
 def test_single_file_upload_button_tooltip(app: Page):
     """Test that the single file upload button tooltip renders correctly."""
     chat_input = app.get_by_test_id("stChatInput").nth(3)
@@ -372,6 +374,7 @@ def test_single_file_upload_button_tooltip(app: Page):
     expect(app.get_by_text("Upload or drag and drop a file")).to_be_visible()
 
 
+@pytest.mark.flaky(reruns=4)
 def test_multi_file_upload_button_tooltip(app: Page):
     """Test that the single file upload button tooltip renders correctly."""
     chat_input = app.get_by_test_id("stChatInput").nth(4)

--- a/e2e_playwright/st_dataframe_interactions_test.py
+++ b/e2e_playwright/st_dataframe_interactions_test.py
@@ -415,6 +415,7 @@ def test_csv_download_button(
     _test_csv_download(app, app.locator("body"), click_enter_on_file_picker)
 
 
+@pytest.mark.flaky(reruns=4)
 def test_csv_download_button_in_iframe(iframed_app: IframedPage):
     """Test that the csv download button works in an iframe.
 

--- a/e2e_playwright/st_download_button_test.py
+++ b/e2e_playwright/st_download_button_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_until
@@ -189,6 +190,7 @@ def test_custom_css_class_via_key(app: Page):
     expect(get_element_by_key(app, "download_button")).to_be_visible()
 
 
+@pytest.mark.flaky(reruns=4)
 def test_download_button_source_error(app: Page, app_port: int):
     """Test that the download button source error is correctly logged."""
     # Ensure download source request return a 404 status

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -113,6 +113,7 @@ def test_box_select_on_stacked_bar_chart_displays_a_df(app: Page):
 @pytest.mark.only_browser(
     "chromium"
 )  # Flaky on WebKit and Firefox, but manually tested
+@pytest.mark.flaky(reruns=4)
 def test_lasso_select_on_histogram_chart_displays_a_df_and_resets_when_double_clicked(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/e2e_playwright/st_pydeck_chart_select_test.py
+++ b/e2e_playwright/st_pydeck_chart_select_test.py
@@ -135,6 +135,7 @@ def _click_point_and_verify_selection(
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_multiselect_interactions_and_return_values(app: Page):
     """
     Test single selection, multi selection, and deselection all function
@@ -322,6 +323,7 @@ def test_pydeck_chart_selection_state_remains_after_unmounting(
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_selection_callback(app: Page):
     """Test the callback functionality of a PyDeck chart."""
     _select_chart_type(app, "callback")

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
@@ -89,6 +90,7 @@ def test_radio_has_correct_default_values(app: Page):
         expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
 
 
+@pytest.mark.flaky(reruns=4)
 def test_set_value_correctly_when_click(app: Page):
     """Test that st.radio returns the correct values when the selection is changed."""
     wait_for_app_run(app)


### PR DESCRIPTION
## Describe your changes

- Takes the top [8 known flaky tests](https://issues.streamlit.app/Flaky_Tests) and allows them to rerun up to 4 times in an attempt to prevent full test suite failures

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Modifies e2e test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
