### PR TITLE
[Fix] Remove unused link button code

### DIFF
--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
@@ -27,7 +27,6 @@ import {
   StyledHeaderButton,
   StyledHeaderNoPaddingButton,
   StyledIconButton,
-  StyledLinkButton,
   StyledMinimalButton,
   StyledPillsButton,
   StyledPillsButtonActive,
@@ -60,8 +59,6 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
     ComponentType = StyledTertiaryButton
   } else if (kind === BaseButtonKind.GHOST) {
     ComponentType = StyledGhostButton
-  } else if (kind === BaseButtonKind.LINK) {
-    ComponentType = StyledLinkButton
   } else if (kind === BaseButtonKind.ICON) {
     ComponentType = StyledIconButton
   } else if (kind === BaseButtonKind.PILLS) {

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -26,7 +26,6 @@ export enum BaseButtonKind {
   SECONDARY = "secondary",
   TERTIARY = "tertiary",
   GHOST = "ghost",
-  LINK = "link",
   ICON = "icon",
   BORDERLESS_ICON = "borderlessIcon",
   BORDERLESS_ICON_ACTIVE = "borderlessIconActive",
@@ -219,28 +218,6 @@ export const StyledGhostButton = styled(
   "&:focus:not(:active)": {
     borderColor: theme.colors.transparent,
     color: theme.colors.primary,
-  },
-  "&:disabled, &:disabled:hover, &:disabled:active": {
-    backgroundColor: theme.colors.lightGray,
-    borderColor: theme.colors.transparent,
-    color: theme.colors.gray,
-  },
-}))
-
-export const StyledLinkButton = styled(
-  StyledBaseButton
-)<RequiredBaseButtonProps>(({ theme }) => ({
-  backgroundColor: theme.colors.transparent,
-  padding: theme.spacing.none,
-  border: "none",
-  color: theme.colors.primary,
-  "&:hover": {
-    textDecoration: "underline",
-  },
-  "&:active": {
-    backgroundColor: theme.colors.transparent,
-    color: theme.colors.primary,
-    textDecoration: "underline",
   },
   "&:disabled, &:disabled:hover, &:disabled:active": {
     backgroundColor: theme.colors.lightGray,


### PR DESCRIPTION
## Describe your changes
Remove unused link button styling/component code from `BaseButton` as we handle this with `BaseLinkButton` in `components/elements/LinkButton/LinkButton.tsx`