### PR TITLE
[Fix] Utilize userEvent in ColorPicker tests

### DIFF
--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { ColorPicker as ColorPickerProto } from "@streamlit/protobuf"
@@ -103,13 +103,17 @@ describe("ColorPicker widget", () => {
 
     const newColor = "#e91e63"
     const colorBlock = screen.getByTestId("stColorPickerBlock")
+    // Open the color picker
     await user.click(colorBlock)
 
-    // Our widget should be updated.
+    // Change the color
     const colorInput = screen.getByRole("textbox")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(colorInput, { target: { value: newColor } })
+    // Remove existing color characters (6 backspaces) to leave the #
+    // and then enter the newColor code
+    await user.type(
+      colorInput,
+      `{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}e91e63"`
+    )
     // Close out of the popover
     await user.click(colorBlock)
 
@@ -134,16 +138,20 @@ describe("ColorPicker widget", () => {
     // Choose a new color
     const newColor = "#e91e63"
     const colorBlock = screen.getByTestId("stColorPickerBlock")
+    // Open the color picker
     await user.click(colorBlock)
 
     const colorInput = screen.getByRole("textbox")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(colorInput, { target: { value: newColor } })
+    // Remove existing color characters (6 backspaces) to leave the #
+    // and then enter the newColor code
+    await user.type(
+      colorInput,
+      `{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}e91e63"`
+    )
     // Close out of the popover
     await user.click(colorBlock)
 
-    expect(colorInput).toHaveValue(newColor)
+    expect(colorInput).toHaveValue(newColor.toUpperCase())
     expect(colorBlock).toHaveStyle(`background-color: ${newColor}`)
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
       props.element,

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -101,19 +101,19 @@ describe("ColorPicker widget", () => {
 
     render(<ColorPicker {...props} />)
 
-    const newColor = "#e91e63"
-    const colorBlock = screen.getByTestId("stColorPickerBlock")
     // Open the color picker
+    const colorBlock = screen.getByTestId("stColorPickerBlock")
     await user.click(colorBlock)
 
-    // Change the color
+    // Clear the color input text field
     const colorInput = screen.getByRole("textbox")
-    // Remove existing color characters (6 backspaces) to leave the #
-    // and then enter the newColor code
-    await user.type(
-      colorInput,
-      `{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}e91e63"`
-    )
+    await user.tripleClick(colorInput)
+    await user.keyboard("{backspace}")
+
+    // Enter the new color in the input field
+    const newColor = "#e91e63"
+    await user.type(colorInput, newColor)
+
     // Close out of the popover
     await user.click(colorBlock)
 
@@ -135,17 +135,17 @@ describe("ColorPicker widget", () => {
 
     render(<ColorPicker {...props} />)
 
-    // Choose a new color
-    const newColor = "#e91e63"
-    const colorBlock = screen.getByTestId("stColorPickerBlock")
     // Open the color picker
+    const colorBlock = screen.getByTestId("stColorPickerBlock")
     await user.click(colorBlock)
 
+    // Clear the color input text field
     const colorInput = screen.getByRole("textbox")
-    // Remove existing color characters (6 backspaces) to leave the #
-    // and then enter the newColor code
     await user.tripleClick(colorInput)
     await user.keyboard("{backspace}")
+
+    // Enter the new color in the input field
+    const newColor = "#e91e63"
     await user.type(colorInput, newColor)
 
     // Close out of the popover

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -144,10 +144,10 @@ describe("ColorPicker widget", () => {
     const colorInput = screen.getByRole("textbox")
     // Remove existing color characters (6 backspaces) to leave the #
     // and then enter the newColor code
-    await user.type(
-      colorInput,
-      `{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}e91e63"`
-    )
+    await user.tripleClick(colorInput)
+    await user.keyboard("{backspace}")
+    await user.type(colorInput, newColor)
+
     // Close out of the popover
     await user.click(colorBlock)
 


### PR DESCRIPTION
## Describe your changes
Test best practices - move to `userEvent` instead of `fireEvent` for color picker