### PR TITLE
[fix] Stabilize flaky markdown snapshot test + mark pydeck as flaky

### DIFF
--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -186,6 +186,9 @@ def test_match_snapshot_for_column_beside_widget(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test that the st.markdown columns beside widget snapshot is correct."""
+    # Wait for the labels to be visible, or else the snapshot tests will flake
+    expect(app.get_by_text("This is a label")).to_have_count(2)
+
     container = _get_container_of_text(app, "Headers in column beside widget")
     assert_snapshot(container, name="st_markdown-headers_beside_widget")
 

--- a/e2e_playwright/st_pydeck_chart_select_test.py
+++ b/e2e_playwright/st_pydeck_chart_select_test.py
@@ -179,6 +179,7 @@ def test_pydeck_chart_multiselect_interactions_and_return_values(app: Page):
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_single_select_interactions_and_return_values(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
@@ -232,6 +233,7 @@ def test_pydeck_chart_single_select_interactions_and_return_values(
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_multiselect_has_consistent_visuals(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
@@ -287,6 +289,7 @@ def test_pydeck_chart_multiselect_has_consistent_visuals(
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_selection_state_remains_after_unmounting(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
@@ -348,6 +351,7 @@ def test_pydeck_chart_selection_callback(app: Page):
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_selection_in_form(app: Page):
     """Test the selection functionality of a PyDeck chart within a form."""
     _select_chart_type(app, "form")
@@ -389,6 +393,7 @@ def test_pydeck_chart_selection_in_form(app: Page):
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.flaky(reruns=4)
 def test_pydeck_chart_selection_in_fragment(app: Page):
     """Test the selection functionality of a PyDeck chart within a fragment."""
     _select_chart_type(app, "fragment")


### PR DESCRIPTION
## Describe your changes

- The markdown test has been flaking due to a render race condition.
  - The failure case: ![actual_st_markdown-headers_beside_widget webkit](https://github.com/user-attachments/assets/d55544a8-ddb0-4260-9ff3-0fc2d86d1839)
  - The expected case: ![expected_st_markdown-headers_beside_widget webkit](https://github.com/user-attachments/assets/f3905ded-9620-41f8-a22e-3c39c5addb25)
  - This PR asserts that the label is there before moving on to snapshotting
- This PR also adds flaky markers to all tests in pydeck, since they are traditionally flaky due to webgl constraints.



## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Updates an e2e test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
