### PR TITLE
[feat]: Add new widget json_editor

### DIFF
--- a/e2e_playwright/st_json_editor.py
+++ b/e2e_playwright/st_json_editor.py
@@ -1,0 +1,142 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import streamlit as st
+from streamlit import runtime
+
+st.subheader("Simple dict:")
+st.json_editor({"foo": "bar"})
+
+st.subheader("Collapsed")
+st.json_editor({"json": "collapsed"}, expanded=False)
+
+st.subheader("Keep whitespaces:")
+st.json_editor({"Hello     World": "Foo    Bar"})
+
+st.subheader("Complex dict:")
+st.json_editor(
+    {
+        "array": [1, 2],
+        "boolean": True,
+        "null": None,
+        "integer": 123,
+        "float": 123.45,
+        "object": {"a": "b", "c": "d"},
+        "string": "Hello World",
+    }
+)
+
+st.subheader("Simple List:")
+st.json_editor(["a", "b"])
+
+st.subheader("Empty dict:")
+st.json_editor({})
+
+st.subheader("Expand to depth of 2:")
+st.json_editor(
+    {
+        "level1": {
+            "level2": {"level3": {"a": "b"}},
+            "c": "d",
+            "list": [{"list_item": "value"}],
+        },
+        "string": "Hello World",
+    },
+    expanded=2,
+)
+
+st.subheader("Edit json disabled:")
+st.json_editor({"cant": "edit this"}, disabled=True)
+
+st.subheader("Width tests:")
+st.json_editor(
+    {
+        "width": "stretch",
+        "description": "This JSON element will stretch to fill the container width",
+        "nested": {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "a": "This is a very long string that should wrap when the width is set to stretch",
+                        "b": "Another long string to demonstrate wrapping behavior",
+                    }
+                }
+            }
+        },
+    },
+    width="stretch",
+)
+
+st.json_editor(
+    {
+        "width": 300,
+        "description": "This JSON element has a fixed width of 300 pixels",
+        "nested": {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "a": "This is a very long string that should not wrap when the width is fixed",
+                        "b": "Another long string to demonstrate fixed width behavior",
+                    }
+                }
+            }
+        },
+    },
+    width=300,
+)
+
+
+st.subheader("Keeps container bounds:")
+
+col1, col2 = st.container(key="container_with_json_editor").columns(2)
+
+with col1.container(border=True):
+    st.json_editor(
+        {
+            "foo": "a" * 100,
+            "bar": "this is a very long string that will not fit in the column and will cause it to wrap",
+        }
+    )
+
+
+if runtime.exists():
+
+    def on_change():
+        st.session_state.json_editor_changed = True
+        st.text("Text input changed callback")
+
+    st.json_editor(
+        {
+            "Car": [
+                "Chevrolet",
+                "Impala",
+                "1967",
+            ]
+        },
+        on_change=on_change,
+        key="json_editor_input_1",
+    )
+    st.write("value : ", json.dumps(st.session_state.json_editor_input_1))
+    st.write("text input changed:", st.session_state.get("json_editor_changed") is True)
+    st.session_state.json_editor_changed = False
+
+st.subheader("Simple json to edit:")
+edited_json = st.json_editor({"car": "BMW"})
+st.write("value :", json.dumps(edited_json))
+
+st.subheader("Simple json to view:")
+edited_json = st.json_editor({"MotorBike": "Kawasaki"}, disabled=True)
+st.write("value :", json.dumps(edited_json))

--- a/e2e_playwright/st_json_editor_test.py
+++ b/e2e_playwright/st_json_editor_test.py
@@ -1,0 +1,138 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
+
+
+def test_st_json_editor_displays_correctly(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test st.json renders the data correctly."""
+    json_elements = app.get_by_test_id("stJsonEditor")
+    expect(json_elements).to_have_count(14)
+
+    assert_snapshot(json_elements.nth(0), name="st_json_editor-simple_dict")
+    assert_snapshot(json_elements.nth(1), name="st_json_editor-collapsed")
+    assert_snapshot(json_elements.nth(2), name="st_json_editor-with_white_spaces")
+    # The complex dict is  tested in the themed test below
+    assert_snapshot(json_elements.nth(4), name="st_json_editor-simple_list")
+    assert_snapshot(json_elements.nth(5), name="st_json_editor-empty_dict")
+    assert_snapshot(json_elements.nth(6), name="st_json_editor-expanded_2")
+    # The disabled edit json test is  tested in another test below
+    # Width tests
+    assert_snapshot(json_elements.nth(8), name="st_json_editor-width_stretch")
+    assert_snapshot(json_elements.nth(9), name="st_json_editor-width_pixels")
+
+    # The container bounds test is  tested in another test below
+    # The onChange function test is  tested in another test below
+    # Edit and view tests are tested in another tests below
+
+
+def test_st_json_editor_keeps_container_bounds(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test st.json_editor keeps the container bounds."""
+    container_with_json_editor = get_element_by_key(app, "container_with_json_editor")
+    expect(container_with_json_editor.get_by_test_id("stJsonEditor")).to_have_count(1)
+    assert_snapshot(container_with_json_editor, name="st_json-keep_bounds")
+
+
+def test_st_json_editor_displays_correctly_when_themed(
+    themed_app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test st.json_editor renders the data correctly with different themes."""
+    json_elements = themed_app.get_by_test_id("stJsonEditor")
+    assert_snapshot(json_elements.nth(3), name="st_json_editor-complex_dict")
+
+
+def test_check_top_level_class(app: Page):
+    """Check that the top level class is correctly set."""
+    check_top_level_class(app, "stJsonEditor")
+
+
+def test_shows_copy_icon(themed_app: Page, assert_snapshot: ImageCompareFunction):
+    """Test that the copy icon is shown by hovering over the element."""
+    json_element = themed_app.get_by_test_id("stJsonEditor").nth(7)
+    expect(json_element).to_be_visible()
+    hover_target = json_element.locator(".jer-value-string")
+    hover_target.hover()
+
+    assert_snapshot(
+        json_element, name="st_json_editor-copy_icon_on_hover_edit_disabled"
+    )
+
+
+def test_shows_edit_icon_on_hovering(
+    themed_app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that the copy icon is shown by hovering over the element."""
+    json_element = themed_app.get_by_test_id("stJsonEditor").nth(0)
+    expect(json_element).to_be_visible()
+    hover_target = json_element.locator(".jer-value-string")
+    hover_target.hover()
+
+    assert_snapshot(json_element, name="st_json_editor-edit_icon_on_hover")
+
+
+def test_json_editor_has_correct_value_when_edited(app: Page):
+    """Test that st.json_edit has the correct value when edited."""
+
+    json_element = app.get_by_test_id("stJsonEditor").nth(12)
+    expect(json_element).to_be_visible()
+    click_target = json_element.locator("#car_display")
+    fill_target = json_element.locator("#car_textarea")
+    click_target.dblclick()
+    fill_target.fill("Renault")
+    fill_target.press("Enter")
+
+    expect(app.get_by_test_id("stMarkdown").nth(2)).to_have_text(
+        'value : {"car": "Renault"}'
+    )
+
+
+def test_json_editor_has_correct_value_when_not_edited(app: Page):
+    """Test that st.json_edit has the correct value when NOT edited because edit is disabled."""
+
+    json_element = app.get_by_test_id("stJsonEditor").nth(13)
+    expect(json_element).to_be_visible()
+    click_target = json_element.locator("#MotorBike_display")
+    click_target.dblclick()
+
+    expect(app.get_by_test_id("stMarkdown").nth(3)).to_have_text(
+        'value : {"MotorBike": "Kawasaki"}'
+    )
+
+
+def test_calls_callback_on_change(app: Page):
+    """Test that it correctly calls the callback on change."""
+
+    json_element = app.get_by_test_id("stJsonEditor").nth(11)
+    expect(json_element).to_be_visible()
+    click_target = json_element.locator("#Car\\.2_display")
+    fill_target = json_element.locator("#Car\\.2_textarea")
+    click_target.dblclick()
+    fill_target.fill("1964")
+    fill_target.press("Enter")
+
+    expect(app.get_by_test_id("stMarkdown").nth(0)).to_have_text(
+        'value : {"Car": ["Chevrolet", "Impala", "1964"]}',
+        use_inner_text=True,
+    )
+    expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text(
+        "text input changed: True",
+        use_inner_text=True,
+    )

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -71,7 +71,7 @@
     "@types/iframe-resizer": "~4.0.0",
     "@types/jsdom": "~21.1.7",
     "@types/lodash": "^4.17.16",
-    "@types/node": "^22.15.18",
+    "@types/node": "^22.15.19",
     "@types/prop-types": "~15.7.14",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -72,6 +72,7 @@
     "dompurify": "^3.2.5",
     "hoist-non-react-statics": "^3.3.2",
     "immer": "^9.0.19",
+    "json-edit-react": "^1.26.2",
     "json5": "^2.2.3",
     "katex": "^0.16.22",
     "lodash": "^4.17.21",

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -150,6 +150,7 @@ const Checkbox = lazy(() => import("~lib/components/widgets/Checkbox"))
 const ColorPicker = lazy(() => import("~lib/components/widgets/ColorPicker"))
 const DateInput = lazy(() => import("~lib/components/widgets/DateInput"))
 const Html = lazy(() => import("~lib/components/elements/Html"))
+const JsonEditor = lazy(() => import("~lib/components/widgets/JsonEditor"))
 const Multiselect = lazy(() => import("~lib/components/widgets/Multiselect"))
 const Progress = lazy(() => import("~lib/components/elements/Progress"))
 const Spinner = lazy(() => import("~lib/components/elements/Spinner"))
@@ -570,6 +571,18 @@ const RawElementNodeRenderer = (
           key={fileUploaderProto.id}
           element={fileUploaderProto}
           uploadClient={props.uploadClient}
+          {...widgetProps}
+        />
+      )
+    }
+
+    case "jsonEditor": {
+      const jsonEditorProto = node.element.jsonEditor as JsonProto
+      widgetProps.disabled = widgetProps.disabled || jsonEditorProto.disabled
+      return (
+        <JsonEditor
+          key={jsonEditorProto.id}
+          element={jsonEditorProto}
           {...widgetProps}
         />
       )

--- a/frontend/lib/src/components/widgets/JsonEditor/JsonEditor.test.tsx
+++ b/frontend/lib/src/components/widgets/JsonEditor/JsonEditor.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { act, screen } from "@testing-library/react"
+
+import { Json as JsonProto } from "@streamlit/protobuf"
+
+import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+import * as getColors from "~lib/theme/getColors"
+
+import JsonEditor, { JsonProps } from "./JsonEditor"
+
+const getProps = (
+  elementProps: Partial<JsonProto> = {},
+  widgetProps: Partial<JsonProps> = {}
+): JsonProps => ({
+  element: JsonProto.create({
+    body:
+      '{ "proper": [1,2,3],' +
+      '  "nested": { "thing1": "cat", "thing2": "hat" },' +
+      '  "json": "structure" }',
+    ...elementProps,
+  }),
+  disabled: false,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  }),
+  ...widgetProps,
+})
+
+describe("JsonEditor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders JSON editor as expected", () => {
+    const props = getProps()
+    render(<JsonEditor {...props} />)
+
+    const jsonElement = screen.getByTestId("stJsonEditor")
+    expect(jsonElement).toBeInTheDocument()
+    expect(jsonElement).toHaveClass("stJsonEditor")
+  })
+
+  it("should show an error with invalid JSON", () => {
+    const props = getProps({ body: "invalid JSON" })
+    render(<JsonEditor {...props} />)
+
+    expect(screen.getByTestId("stAlertContainer")).toBeInTheDocument()
+  })
+
+  it("renders JSON with NaN and Infinity values", () => {
+    const props = getProps({
+      body: `{
+        "numbers":[ -1e27, NaN, Infinity, -Infinity, 2.2822022, -2.2702775 ]
+      }`,
+    })
+    render(<JsonEditor {...props} />)
+
+    expect(screen.getByTestId("stJsonEditor")).toBeInTheDocument()
+  })
+
+  describe("getJsonTheme", () => {
+    it("picks a reasonable theme when the background is light", () => {
+      vi.spyOn(getColors, "hasLightBackgroundColor").mockReturnValue(true)
+      render(<JsonEditor {...getProps({ expanded: true })} />)
+      expect(screen.getAllByText("}")[0]).toHaveStyle("color: rgb(0, 128, 46)")
+    })
+
+    it("picks a reasonable theme when the background is dark", () => {
+      vi.spyOn(getColors, "hasLightBackgroundColor").mockReturnValue(false)
+      render(<JsonEditor {...getProps({ expanded: true })} />)
+      expect(screen.getAllByText("}")[0]).toHaveStyle(
+        "color: rgb(86, 211, 100)"
+      )
+    })
+  })
+
+  describe("editing JSON", () => {
+    it("updates the JSON and calls setStringValue", () => {
+      const setStringValue = vi.fn()
+
+      const props = getProps({
+        body: '{ "a": 1 }',
+        expanded: true,
+      })
+      props.widgetMgr.setStringValue = setStringValue
+
+      render(<JsonEditor {...props} />)
+
+      const updatedData = { a: 1, b: 2 }
+
+      act(() => {
+        props.widgetMgr.setStringValue(
+          expect.any(Object),
+          JSON.stringify(updatedData),
+          { fromUi: true },
+          undefined
+        )
+      })
+
+      expect(setStringValue).toHaveBeenCalledWith(
+        props.element,
+        JSON.stringify(updatedData),
+        { fromUi: true },
+        undefined
+      )
+
+      const updatedValue = setStringValue.mock.calls[1][1]
+      expect(JSON.parse(updatedValue)).toEqual({ a: 1, b: 2 })
+    })
+
+    it("updates the JSON correctly when a key is deleted", () => {
+      const setStringValue = vi.fn()
+
+      const props = getProps({ expanded: true })
+      props.widgetMgr.setStringValue = setStringValue
+
+      render(<JsonEditor {...props} />)
+
+      const initialJson = {
+        proper: [1, 2, 3],
+        nested: { thing1: "cat", thing2: "hat" },
+        json: "structure",
+      }
+
+      // Simulate initial value being set
+      act(() => {
+        props.widgetMgr.setStringValue(
+          props.element,
+          JSON.stringify(initialJson),
+          { fromUi: false },
+          undefined
+        )
+      })
+
+      const updatedJson = {
+        proper: [1, 2, 3],
+        json: "structure",
+      }
+
+      act(() => {
+        props.widgetMgr.setStringValue(
+          props.element,
+          JSON.stringify(updatedJson),
+          { fromUi: true },
+          undefined
+        )
+      })
+
+      expect(setStringValue).toHaveBeenCalledWith(
+        props.element,
+        JSON.stringify(updatedJson),
+        { fromUi: true },
+        undefined
+      )
+
+      const updatedValue = setStringValue.mock.calls[2][1]
+
+      expect(JSON.parse(updatedValue)).toEqual({
+        proper: [1, 2, 3],
+        json: "structure",
+      })
+    })
+
+    it("updates the JSON correctly when a key is added", () => {
+      const setStringValue = vi.fn()
+
+      const props = getProps({ expanded: true })
+      props.widgetMgr.setStringValue = setStringValue
+
+      render(<JsonEditor {...props} />)
+
+      const updatedJson = {
+        proper: [1, 2, 3],
+        nested: { thing1: "cat", thing2: "hat" },
+        json: "structure",
+      }
+
+      const initialJson = {
+        proper: [1, 2, 3],
+        json: "structure",
+      }
+
+      // Simulate initial value being set
+      act(() => {
+        props.widgetMgr.setStringValue(
+          props.element,
+          JSON.stringify(initialJson),
+          { fromUi: false },
+          undefined
+        )
+      })
+
+      act(() => {
+        props.widgetMgr.setStringValue(
+          props.element,
+          JSON.stringify(updatedJson),
+          { fromUi: true },
+          undefined
+        )
+      })
+
+      expect(setStringValue).toHaveBeenCalledWith(
+        props.element,
+        JSON.stringify(updatedJson),
+        { fromUi: true },
+        undefined
+      )
+
+      const updatedValue = setStringValue.mock.calls[2][1]
+
+      expect(JSON.parse(updatedValue)).toEqual({
+        proper: [1, 2, 3],
+        nested: { thing1: "cat", thing2: "hat" },
+        json: "structure",
+      })
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/JsonEditor/JsonEditor.tsx
+++ b/frontend/lib/src/components/widgets/JsonEditor/JsonEditor.tsx
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  memo,
+  ReactElement,
+  useCallback,
+  useRef,
+  useState,
+} from "react"
+
+import JSON5 from "json5"
+import {
+  githubDarkTheme,
+  githubLightTheme,
+  JsonEditor as ReactJsonEditor,
+  UpdateFunctionProps,
+} from "json-edit-react"
+import Clipboard from "clipboard"
+import { useTheme } from "@emotion/react"
+
+import { Json as JsonProto } from "@streamlit/protobuf"
+
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+import {
+  useBasicWidgetState,
+  ValueWithSource,
+} from "~lib/hooks/useBasicWidgetState"
+import ErrorElement from "~lib/components/shared/ErrorElement"
+import { EmotionTheme, hasLightBackgroundColor } from "~lib/theme"
+import { ensureError } from "~lib/util/ErrorHandling"
+
+import { StyledJsonWrapper } from "./styled-components"
+
+export interface JsonProps {
+  disabled: boolean
+  element: JsonProto
+  widgetMgr: WidgetStateManager
+  fragmentId?: string
+}
+
+/**
+ * Functional element representing JSON structured text.
+ */
+function JsonEditor({
+  disabled,
+  element,
+  widgetMgr,
+  fragmentId,
+}: JsonProps): ReactElement {
+  const [value, setValueWithSource] = useBasicWidgetState<
+    string | null,
+    JsonProto
+  >({
+    getStateFromWidgetMgr,
+    getDefaultStateFromProto,
+    getCurrStateFromProto,
+    updateWidgetMgrState,
+    element,
+    widgetMgr,
+    fragmentId,
+  })
+
+  const theme: EmotionTheme = useTheme()
+
+  const elementRef = useRef<HTMLDivElement>(null)
+
+  let bodyObject
+  try {
+    bodyObject = JSON.parse(element.body)
+  } catch (e) {
+    const error = ensureError(e)
+    try {
+      // eslint-disable-next-line import/no-named-as-default-member
+      bodyObject = JSON5.parse(element.body)
+    } catch (json5Error) {
+      // If content fails to parse as Json, rebuild the error message
+      // to show where the problem occurred.
+      const pos = parseInt(error.message.replace(/[^0-9]/g, ""), 10)
+      error.message += `\n${element.body.substring(0, pos + 1)} ← here`
+      return <ErrorElement name={"Json Parse Error"} message={error.message} />
+    }
+  }
+
+  const darkTheme = [
+    githubDarkTheme,
+    {
+      input: ["#ffffff", { fontSize: "90%" }],
+      inputHighlight: "#acb0b5",
+    },
+  ]
+
+  const lightTheme = [
+    githubLightTheme,
+    {
+      string: "rgb(203, 75, 22)",
+      number: "rgb(38, 139, 210)",
+    },
+  ]
+
+  const [jsonData, setJsonData] = useState(bodyObject)
+
+  // Try to pick a reasonable ReactJson theme based on whether the streamlit
+  // theme's background is light or dark.
+  const jsonTheme = hasLightBackgroundColor(theme) ? lightTheme : darkTheme
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  const handleCopy = (copy: any): void => {
+    // we use ClipboardJS to do the copying, because it allows
+    // us to specify a container element. This is necessary because
+    // otherwise copying doesn't work in dialogs.
+    Clipboard.copy(JSON.stringify(copy.src), {
+      container: elementRef.current ?? undefined,
+    })
+  }
+
+  return (
+    <StyledJsonWrapper
+      className="stJsonEditor"
+      data-testid="stJsonEditor"
+      ref={elementRef}
+    >
+      <ReactJsonEditor
+        data={jsonData}
+        setData={setJsonData}
+        enableClipboard={handleCopy}
+        viewOnly={disabled}
+        collapse={element.maxExpandDepth ?? !element.expanded}
+        theme={jsonTheme}
+        rootName=""
+        onUpdate={useCallback(
+          (update: UpdateFunctionProps): void => {
+            const newJson: string | null =
+              update.newData === null ? null : JSON.stringify(update.newData)
+            setValueWithSource({ value: newJson, fromUi: true })
+            setJsonData(value) //updates state with new data
+          },
+          [value, setValueWithSource]
+        )}
+      />
+    </StyledJsonWrapper>
+  )
+}
+
+function getStateFromWidgetMgr(
+  widgetMgr: WidgetStateManager,
+  element: JsonProto
+): string | null {
+  return widgetMgr.getStringValue(element) ?? null
+}
+
+function getDefaultStateFromProto(): string | null {
+  return ""
+}
+
+function getCurrStateFromProto(element: JsonProto): string | null {
+  return element.value ?? null
+}
+
+function updateWidgetMgrState(
+  element: JsonProto,
+  widgetMgr: WidgetStateManager,
+  vws: ValueWithSource<string | null>,
+  fragmentId?: string
+): void {
+  widgetMgr.setStringValue(
+    element,
+    vws.value,
+    { fromUi: vws.fromUi },
+    fragmentId
+  )
+}
+
+export default memo(JsonEditor)

--- a/frontend/lib/src/components/widgets/JsonEditor/index.ts
+++ b/frontend/lib/src/components/widgets/JsonEditor/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./JsonEditor"

--- a/frontend/lib/src/components/widgets/JsonEditor/styled-components.ts
+++ b/frontend/lib/src/components/widgets/JsonEditor/styled-components.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+export const StyledJsonWrapper = styled.div(({ theme }) => ({
+  overflowY: "auto",
+  ".react-json-view .copy-icon svg": {
+    // Make the copy icon responsive to the root font size.
+    fontSize: `1em !important`,
+    marginRight: `${theme.spacing.threeXS} !important`,
+    verticalAlign: "middle !important",
+  },
+}))

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3195,7 +3195,7 @@ __metadata:
     "@types/iframe-resizer": "npm:~4.0.0"
     "@types/jsdom": "npm:~21.1.7"
     "@types/lodash": "npm:^4.17.16"
-    "@types/node": "npm:^22.15.18"
+    "@types/node": "npm:^22.15.19"
     "@types/prop-types": "npm:~15.7.14"
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
@@ -3363,6 +3363,7 @@ __metadata:
     eslint-plugin-vitest: "npm:^0.5.4"
     hoist-non-react-statics: "npm:^3.3.2"
     immer: "npm:^9.0.19"
+    json-edit-react: "npm:^1.26.2"
     json5: "npm:^2.2.3"
     katex: "npm:^0.16.22"
     lodash: "npm:^4.17.21"
@@ -4717,12 +4718,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.15.18":
-  version: 22.15.18
-  resolution: "@types/node@npm:22.15.18"
+"@types/node@npm:^22.15.19":
+  version: 22.15.19
+  resolution: "@types/node@npm:22.15.19"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/e23178c568e2dc6b93b6aa3b8dfb45f9556e527918c947fe7406a4c92d2184c7396558912400c3b1b8d0fa952ec63819aca2b8e4d3545455fc6f1e9623e09ca6
+  checksum: 10c0/8ef52fa1a91b1c8891616d46f3921a9f3c65ad1c6bb62db7899c8c28643c13bf9d607a2403b1e5aceb3e6fa6749efc9e0ba5c39618a4872da6946437b0edbfbe
   languageName: node
   linkType: hard
 
@@ -12804,6 +12805,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-edit-react@npm:^1.26.2":
+  version: 1.26.2
+  resolution: "json-edit-react@npm:1.26.2"
+  dependencies:
+    object-property-assigner: "npm:^1.3.5"
+    object-property-extractor: "npm:^1.0.13"
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: 10c0/2df6922b860794e56ab31ed134fa1e0348db6301e079a22bc1b79f5ab36335fc3328bfa2eabaebfd39a2523fb32a699ce2647605689a5d0b9a2c4be51c9a4119
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -15089,6 +15102,20 @@ __metadata:
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
   checksum: 10c0/b11f7ccdbc6d406d1f186cdadb9d54738e347b2692a14439ca5ac70c225fa6db46db809711b78589866d47b25fc3e8dee0b4c722ac751e11180f9380e3d8601d
+  languageName: node
+  linkType: hard
+
+"object-property-assigner@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "object-property-assigner@npm:1.3.5"
+  checksum: 10c0/144ecbc656c1ea25aac074a41ee32b1aa2935dcbb126750a0f7dc4d454af835e19c43931ed230b966f624b846cf92e4e524719d87eecc9deadb7602b1168906b
+  languageName: node
+  linkType: hard
+
+"object-property-extractor@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "object-property-extractor@npm:1.0.13"
+  checksum: 10c0/53c1de766f313dbdb0f169b04b641add3397a32dec71e780794bbc6dadd0235e6e194e9e829b78c497a3229079e66f8fc1737ec4e1da85fa1a79f0400991965b
   languageName: node
   linkType: hard
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -203,6 +203,7 @@ html = _main.html
 image = _main.image
 info = _main.info
 json = _main.json
+json_editor = _main.json_editor
 latex = _main.latex
 line_chart = _main.line_chart
 link_button = _main.link_button

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -83,6 +83,7 @@ from streamlit.elements.widgets.checkbox import CheckboxMixin
 from streamlit.elements.widgets.color_picker import ColorPickerMixin
 from streamlit.elements.widgets.data_editor import DataEditorMixin
 from streamlit.elements.widgets.file_uploader import FileUploaderMixin
+from streamlit.elements.widgets.json_editor import JsonEditorMixin
 from streamlit.elements.widgets.multiselect import MultiSelectMixin
 from streamlit.elements.widgets.number_input import NumberInputMixin
 from streamlit.elements.widgets.radio import RadioMixin
@@ -200,6 +201,7 @@ class DeltaGenerator(
     SelectSliderMixin,
     SliderMixin,
     SnowMixin,
+    JsonEditorMixin,
     JsonMixin,
     TextMixin,
     TextWidgetsMixin,

--- a/lib/streamlit/elements/widgets/json_editor.py
+++ b/lib/streamlit/elements/widgets/json_editor.py
@@ -1,0 +1,242 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import types
+from collections import ChainMap, UserDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from streamlit.elements.lib.form_utils import current_form_id
+from streamlit.elements.lib.layout_utils import WidthWithoutContent, validate_width
+from streamlit.elements.lib.policies import check_widget_policies
+from streamlit.elements.lib.utils import Key, compute_and_register_element_id, to_key
+from streamlit.proto.Json_pb2 import Json as JsonProto
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state import (
+    WidgetArgs,
+    WidgetCallback,
+    WidgetKwargs,
+    register_widget,
+)
+from streamlit.type_util import (
+    is_custom_dict,
+    is_list_like,
+    is_namedtuple,
+    is_pydantic_model,
+)
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+@dataclass
+class JsonEditorSerde:
+    """JsonEditorSerde is used to serialize and deserialize the json editor state."""
+
+    body: object | str | None
+
+    def set_body(self, new_body: str | None) -> None:
+        self.body = new_body
+
+    def serialize(self, body: object) -> str:
+        return json.dumps(body, default=self._ensure_serialization)
+
+    def deserialize(self, ui_value: str | None) -> object:
+        if ui_value == "":
+            return ""
+        if ui_value is None:  # first case
+            ui_value = json.dumps(self.body, default=self._ensure_serialization)
+        return json.loads(ui_value)
+
+    def _ensure_serialization(self, o: object) -> str | list[Any]:
+        """A repr function for json.dumps default arg, which tries to serialize sets
+        as lists.
+        """
+        return list(o) if isinstance(o, set) else repr(o)
+
+
+class JsonEditorMixin:
+    @gather_metrics("json_editor")
+    def json_editor(
+        self,
+        body: object,
+        *,  # keyword-only arguments:
+        expanded: bool | int = True,
+        width: WidthWithoutContent = "stretch",
+        disabled: bool = False,
+        key: Key | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+    ) -> object:
+        """Display an object or string as a pretty-printed, interactive and editable JSON string.
+
+        Parameters
+        ----------
+        body : object or str
+            The object to print as JSON. All referenced objects should be
+            serializable to JSON as well. If object is a string, we assume it
+            contains serialized JSON.
+
+        expanded : bool or int
+            The initial expansion state of the JSON element. This can be one
+            of the following:
+
+            - ``True`` (default): The element is fully expanded.
+            - ``False``: The element is fully collapsed.
+            - An integer: The element is expanded to the depth specified. The
+              integer must be non-negative. ``expanded=0`` is equivalent to
+              ``expanded=False``.
+
+            Regardless of the initial expansion state, users can collapse or
+            expand any key-value pair to show or hide any part of the object.
+
+        width : "stretch" or int
+            The width of the JSON element. This can be either:
+            - "stretch" (default): The element will stretch to fill the container width
+            - An integer: The element will have a fixed width in pixels
+
+        disabled : bool
+            An optional boolean that disables the json edit if set to
+            ``True``. The default is ``False``.
+
+        key : str or int
+            An optional string or integer to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+        on_change : callable
+            An optional callback invoked when this json input's value changes.
+
+        args : tuple
+            An optional tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
+
+        Example
+        -------
+        >>> import streamlit as st
+        >>>
+        >>> st.json_editor(
+        ...     {
+        ...         "My": "Json",
+        ...         "Car": [
+        ...             "Chevrolet",
+        ...             "Impala",
+        ...             "1967",
+        ...         ],
+        ...         "level 1": {"level 2": {"level3": {"Honda": "CB650R"}}},
+        ...     },
+        ...     expanded=2,
+        ... )
+
+
+        """
+        key = to_key(key)
+
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=None,
+            writes_allowed=False,
+        )
+
+        if is_custom_dict(body):
+            body = body.to_dict()
+
+        if is_namedtuple(body):
+            body = body._asdict()
+
+        if isinstance(
+            body, (ChainMap, types.MappingProxyType, UserDict)
+        ) or is_pydantic_model(body):
+            body = dict(body)  # type: ignore
+
+        if is_list_like(body):
+            body = list(body)
+
+        serde = JsonEditorSerde(body)
+
+        if not isinstance(body, str):
+            try:
+                # Serialize body to string and try to interpret sets as lists
+                body = serde.serialize(body)
+            except TypeError as err:
+                self.dg.warning(
+                    "Warning: this data structure was not fully serializable as "
+                    f"JSON due to one or more unexpected keys.  (Error was: {err})"
+                )
+                body = json.dumps(
+                    body, skipkeys=True, default=serde._ensure_serialization
+                )
+                serde.body = body
+
+        ctx = get_script_run_ctx()
+        element_id = compute_and_register_element_id(
+            "json_editor",
+            user_key=key,
+            form_id=current_form_id(self.dg),
+            data=body,
+        )
+
+        json_proto = JsonProto()  # uses the same proto as st.json
+        json_proto.body = body
+        json_proto.id = element_id
+
+        if isinstance(expanded, bool):
+            json_proto.expanded = expanded
+        elif isinstance(expanded, int):
+            json_proto.expanded = True
+            json_proto.max_expand_depth = expanded
+        else:
+            raise TypeError(
+                f"The type {type(expanded)} of `expanded` is not supported"
+                ", must be bool or int."
+            )
+
+        validate_width(width)
+        if isinstance(width, int):
+            json_proto.width_config.pixel_width = width
+        else:
+            json_proto.width_config.use_stretch = True
+
+        json_proto.disabled = disabled
+        json_proto.form_id = current_form_id(self.dg)
+        json_proto.value = body
+
+        widget_state = register_widget(
+            json_proto.id,
+            on_change_handler=on_change,
+            args=args,
+            kwargs=kwargs,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
+            ctx=ctx,
+            value_type="string_value",
+        )
+
+        self.dg._enqueue("json_editor", json_proto)
+
+        return widget_state.value
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -62,6 +62,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("toggle", lambda: st.toggle("Toggle me")),
     # arrows
     ("data_editor", lambda: st.data_editor(pd.DataFrame())),
+    ("json_editor", lambda: st.json_editor({})),
     ("dataframe", lambda: st.dataframe(pd.DataFrame(), on_select="rerun")),
     # other widgets
     ("color_picker", lambda: st.color_picker("Pick a color")),

--- a/lib/tests/streamlit/elements/json_editor_test.py
+++ b/lib/tests/streamlit/elements/json_editor_test.py
@@ -1,0 +1,187 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import numpy as np
+import pytest
+from parameterized import parameterized
+
+import streamlit as st
+from streamlit.elements.widgets.json_editor import JsonEditorSerde
+from streamlit.errors import StreamlitInvalidWidthError
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.streamlit.elements.layout_test_utils import WidthConfigFields
+
+
+class StjsonEditorAPITest(DeltaGeneratorTestCase):
+    """Test Public Streamlit Public APIs."""
+
+    def test_st_json_editor(self):
+        """Test st.json_editor."""
+        st.json_editor('{"some": "json_editor"}')
+
+        el = self.get_delta_from_queue().new_element
+        assert el.json_editor.body == '{"some": "json_editor"}'
+        assert el.json_editor.expanded is True
+        assert el.json_editor.HasField("max_expand_depth") is False
+        assert (
+            el.json_editor.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.json_editor.width_config.use_stretch is True
+
+        # Test that an object containing non-json_editor-friendly keys can still
+        # be displayed.  Resultant json_editor body will be missing those keys.
+
+        n = np.array([1, 2, 3, 4, 5])
+        data = {n[0]: "this key will not render as json_editor", "array": n}
+        st.json_editor(data)
+
+        el = self.get_delta_from_queue().new_element
+        assert el.json_editor.body == '{"array": "array([1, 2, 3, 4, 5])"}'
+        assert (
+            el.json_editor.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.json_editor.width_config.use_stretch is True
+
+    def test_expanded_param(self):
+        """Test expanded parameter for `st.json_editor`"""
+        st.json_editor(
+            {
+                "level1": {"level2": {"level3": {"a": "b"}}, "c": "d"},
+            },
+            expanded=2,
+            key="json_editor",
+        )
+
+        el = self.get_delta_from_queue().new_element
+        assert el.json_editor.expanded is True
+        assert el.json_editor.max_expand_depth == 2
+        assert (
+            el.json_editor.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.json_editor.width_config.use_stretch is True
+
+        with self.assertRaises(TypeError):
+            st.json_editor(
+                {
+                    "level1": {"level2": {"level3": {"a": "b"}}, "c": "d"},
+                },
+                expanded=["foo"],  # type: ignore
+            )
+
+    def test_st_json_editor_with_width_pixels(self):
+        """Test st.json_editor with width in pixels."""
+        st.json_editor('{"some": "json_editor"}', width=500)
+
+        el = self.get_delta_from_queue().new_element
+        assert (
+            el.json_editor.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.PIXEL_WIDTH.value
+        )
+        assert el.json_editor.width_config.pixel_width == 500
+
+    def test_st_json_editor_with_width_stretch(self):
+        """Test st.json_editor with stretch width."""
+        st.json_editor('{"some": "json_editor"}', width="stretch")
+
+        el = self.get_delta_from_queue().new_element
+        assert (
+            el.json_editor.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.json_editor.width_config.use_stretch is True
+
+    @parameterized.expand(
+        [
+            "invalid",
+            -100,
+            0,
+            100.5,
+            None,
+        ]
+    )
+    def test_st_json_editor_with_invalid_width(self, width):
+        """Test st.json_editor with invalid width values."""
+        with pytest.raises(StreamlitInvalidWidthError) as e:
+            st.json_editor('{"some": "json_editor"}', width=width)
+        assert "Invalid width" in str(e.value)
+
+    def test_st_json_editor_with_key(self):
+        """Test st.json_editor with a unique key."""
+        st.json_editor('{"keyed": "value"}', key="unique_json_editor")
+        el = self.get_delta_from_queue().new_element
+        assert el.json_editor.body == '{"keyed": "value"}'
+
+    def test_st_json_editor_with_nested_dict(self):
+        """Test st.json_editor with a deeply nested dictionary."""
+        data = {"level1": {"level2": {"level3": {"value": 42, "list": [1, 2, 3]}}}}
+        st.json_editor(data)
+        el = self.get_delta_from_queue().new_element
+        assert '"value": 42' in el.json_editor.body
+        assert '"list": [1, 2, 3]' in el.json_editor.body
+
+    def test_st_json_editor_with_list_input(self):
+        """Test st.json_editor with a list as top-level input."""
+        st.json_editor([{"item": 1}, {"item": 2}])
+        el = self.get_delta_from_queue().new_element
+        assert el.json_editor.body.startswith("[")
+        assert '"item": 1' in el.json_editor.body
+
+    def test_deserialize_with_valid_edited_json(self):
+        serde = JsonEditorSerde(body={"name": "Alice"})
+        edited = '{"name": "Bob"}'
+        result = serde.deserialize(edited)
+        assert result == {"name": "Bob"}
+
+    def test_deserialize_with_none_uses_original_body(self):
+        body = {"foo": "bar"}
+        serde = JsonEditorSerde(body=body)
+        result = serde.deserialize(None)
+        assert result == body
+
+    def test_deserialize_with_empty_string_returns_empty_string(self):
+        serde = JsonEditorSerde(body={"foo": "bar"})
+        result = serde.deserialize("")
+        assert result == ""
+
+    def test_deserialize_with_list_and_types(self):
+        edited = '[1, "two", true, null]'
+        serde = JsonEditorSerde(body=[])
+        result = serde.deserialize(edited)
+        assert result == [1, "two", True, None]
+
+    def test_serialize_set_to_list(self):
+        serde = JsonEditorSerde(body=None)
+        result = serde.serialize({"items": {1, 2}})
+        # JSON string should have list, not set
+        assert json.loads(result)["items"] == [1, 2] or json.loads(result)["items"] == [
+            2,
+            1,
+        ]
+
+    def test_deserialize_nested_object_edit(self):
+        original = {"Item1": {"Item2": "a", "Item3": "b"}}
+        edited = '{"Item1": {"Item2": "c", "Item3": "d"}}'
+        serde = JsonEditorSerde(body=original)
+        result = serde.deserialize(edited)
+        assert result == {"Item1": {"Item2": "c", "Item3": "d"}}
+
+    def test_deserialize_invalid_json_raises(self):
+        serde = JsonEditorSerde(body={})
+        with pytest.raises(json.JSONDecodeError):
+            serde.deserialize('{"name": "Bob"')

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -108,6 +108,7 @@ message Element {
     IFrame iframe = 38;
     ImageList imgs = 6;
     Json json = 31;
+    Json json_editor = 57;
     LinkButton link_button = 51;
     Markdown markdown = 29;
     Metric metric = 42;
@@ -132,7 +133,7 @@ message Element {
     Video video = 14;
     Heading heading = 47;
     Code code = 48;
-    // Next ID: 57
+    // Next ID: 58
   }
 
   reserved 9;

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -31,4 +31,13 @@ message Json {
   optional int32 max_expand_depth = 3;
   // Width configuration
   streamlit.WidthConfig width_config = 4;
+  // deactivates editing
+  bool disabled = 5;
+  // The form ID of the widget, required if json is editable
+  string form_id = 6;
+  // The id of the widget, required if json is editable
+  string id = 7;
+  // string for the current value of the json
+  string value = 8;
+  bool set_value = 9;
 }


### PR DESCRIPTION

## Describe your changes

Added `st.json_editor()` widget.
This new widget allows user to dynamically edit jsonData directly on browser.
To create the editor in frontend, we integrated the following React component as a new project dependency:
https://github.com/CarlosNZ/json-edit-react
When the jsonData is edited the new json is returned, similar to what happens in the widget `st.text_input()`.
It is also possible to deactivate the editing by setting the parameter `disabled` to true (default is false).

**Example usage:**
```
import streamlit as st

st.subheader("Simple json to edit:")
edited_json = st.json_editor({"car": "BMW"})
st.write("value :", edited_json)
```

![WhatsApp Image 2025-06-12 at 18 28 54](https://github.com/user-attachments/assets/56164cb3-9db3-4240-9413-a874b867fde4)
![WhatsApp Image 2025-06-12 at 18 29 17](https://github.com/user-attachments/assets/8c1a658e-9feb-4b4f-989c-1cc1ac0be970)
![WhatsApp Image 2025-06-12 at 18 30 04](https://github.com/user-attachments/assets/7a13ed49-4b8f-4988-92c1-a2a9bd978189)

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)
Fixes streamlit#10819

## Testing Plan

New unit, integration and e2e tests were added and `st.json()` widget tests were replicated to ensure the new widget works properly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
