### PR TITLE
[fix] Remove traces of experimental_fragment in tests

### DIFF
--- a/e2e_playwright/st_feedback.py
+++ b/e2e_playwright/st_feedback.py
@@ -52,7 +52,7 @@ with st.form(key="my_form", clear_on_submit=True):
 st.write("feedback-in-form:", str(sentiment))
 
 
-@st.experimental_fragment()
+@st.fragment
 def test_fragment():
     sentiment = st.feedback(key="fragment_feedback")
     st.write("feedback-in-fragment:", str(sentiment))

--- a/e2e_playwright/st_file_uploader.py
+++ b/e2e_playwright/st_file_uploader.py
@@ -109,7 +109,7 @@ st.file_uploader(
 st.text(st.session_state.counter)
 
 
-@st.experimental_fragment()
+@st.fragment
 def test_file_fragment():
     file_uploader_in_fragment = st.file_uploader(label="file uploader")
     st.write("File uploader in Fragment:", bool(file_uploader_in_fragment))

--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -116,7 +116,7 @@ st.write(
 st.header("Pills in fragment")
 
 
-@st.experimental_fragment()
+@st.fragment
 def test_fragment():
     s5 = st.pills(
         "Elements", ["Water", "Fire", "Earth", "Air"], key="pills_in_fragment"

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -147,6 +147,7 @@ st.write(
 st.header("Segmented Control in fragment", anchor="segmented-control-in-fragment")
 
 
+@st.fragment
 def test_fragment():
     s5 = st.segmented_control(
         "Select an emotion:",

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -147,7 +147,6 @@ st.write(
 st.header("Segmented Control in fragment", anchor="segmented-control-in-fragment")
 
 
-@st.experimental_fragment()
 def test_fragment():
     s5 = st.segmented_control(
         "Select an emotion:",


### PR DESCRIPTION
## Describe your changes

- Removes `st.experimental_fragment()` in favor of the non-experimental syntax `st.fragment`

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Updates e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
