### PR TITLE
[Fix] Reconcile date & time input placeholder colors

### DIFF
--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -421,6 +421,10 @@ function DateInput({
                     paddingTop: spacing.sm,
                     lineHeight: lineHeights.inputWidget,
 
+                    "::placeholder": {
+                      color: theme.colors.fadedText60,
+                    },
+
                     // Change input value text color in error state - matches st.error in light and dark mode
                     ...(error && {
                       color: hasLightBackgroundColor(theme)

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -145,6 +145,13 @@ function TimeInput({
               },
             },
           },
+
+          Placeholder: {
+            style: () => ({
+              color: theme.colors.fadedText60,
+            }),
+          },
+
           SelectArrow: {
             component: ChevronDown,
 


### PR DESCRIPTION
## Describe your changes
Explicit specification of widget placeholder color (`fadedtext60`)

**Before:**
<img width="500" alt="Screenshot 2025-06-12 at 4 40 08 p m" src="https://github.com/user-attachments/assets/7664c542-eb3b-42b7-85da-de29be97a1aa" />

**After:**
<img width="500" alt="Screenshot 2025-06-12 at 4 40 28 p m" src="https://github.com/user-attachments/assets/61e7d6b2-3b09-44bf-803c-2215647299eb" />

## GitHub Issue Link (if applicable)
Addresses https://github.com/streamlit/streamlit/issues/11611