### PR TITLE
[fix] CameraInput width/height styles simplification.

### DIFF
--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -48,7 +48,6 @@ import {
   UploadFileInfo,
   UploadingStatus,
 } from "~lib/components/widgets/FileUploader/UploadFileInfo"
-import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 
 import CameraInputButton from "./CameraInputButton"
 import { FacingMode } from "./SwitchFacingModeButton"
@@ -65,7 +64,6 @@ export interface Props {
   widgetMgr: WidgetStateManager
   uploadClient: FileUploadClient
   disabled: boolean
-  width: number
   fragmentId?: string
   // Allow for unit testing
   testOverride?: WebcamPermission
@@ -352,7 +350,7 @@ class CameraInput extends PureComponent<Props, State> {
   }
 
   public override render(): React.ReactNode {
-    const { element, widgetMgr, disabled, width } = this.props
+    const { element, widgetMgr, disabled } = this.props
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -381,7 +379,7 @@ class CameraInput extends PureComponent<Props, State> {
         </WidgetLabel>
         {this.state.imgSrc ? (
           <>
-            <StyledBox width={width}>
+            <StyledBox>
               {this.state.imgSrc !== this.RESTORED_FROM_WIDGET_STRING && (
                 <StyledImg
                   src={this.state.imgSrc}
@@ -391,8 +389,6 @@ class CameraInput extends PureComponent<Props, State> {
                       ? "50%"
                       : "100%"
                   }
-                  width={width}
-                  height={(width * 9) / 16}
                 />
               )}
             </StyledBox>
@@ -414,7 +410,6 @@ class CameraInput extends PureComponent<Props, State> {
           <WebcamComponent
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             handleCapture={this.handleCapture}
-            width={width}
             disabled={disabled}
             clearPhotoInProgress={this.state.clearPhotoInProgress}
             setClearPhotoInProgress={this.setClearPhotoInProgress}
@@ -596,9 +591,4 @@ function urltoFile(url: string, filename: string): Promise<File> {
     .then(buf => new File([buf], filename, { type: "image/jpeg" }))
 }
 
-/**
- * This component should be refactored to remove the width calculation from JS
- * entirely and instead utilize width: 100%; height: 100%; aspect-ratio: 16 / 9;
- * on the StyledBox CSS instead.
- */
-export default withCalculatedWidth(CameraInput)
+export default CameraInput

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -35,7 +35,6 @@ vi.mock("react-device-detect", () => {
 const getProps = (props: Partial<Props> = {}): Props => {
   return {
     handleCapture: vi.fn(),
-    width: 500,
     disabled: false,
     setClearPhotoInProgress: vi.fn(),
     clearPhotoInProgress: false,

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import React, { memo, ReactElement, useRef, useState } from "react"
 
 import { Video } from "@emotion-icons/open-iconic"
 import { isMobile } from "react-device-detect"
 import Webcam from "react-webcam"
 
-import { debounce } from "~lib/util/utils"
 import Icon from "~lib/components/shared/Icon"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import themeColors from "~lib/theme/emotionBaseTheme/themeColors"
@@ -44,7 +36,6 @@ import {
 
 export interface Props {
   handleCapture: (capturedPhoto: string | null) => void
-  width: number
   disabled: boolean
   clearPhotoInProgress: boolean
   setClearPhotoInProgress: (clearPhotoInProgress: boolean) => void
@@ -60,15 +51,9 @@ export enum WebcamPermission {
   ERROR = "error",
 }
 
-interface AskForCameraPermissionProps {
-  width: number
-}
-
-export const AskForCameraPermission = ({
-  width,
-}: AskForCameraPermissionProps): ReactElement => {
+export const AskForCameraPermission = (): ReactElement => {
   return (
-    <StyledBox width={width}>
+    <StyledBox>
       <Icon size="threeXL" color={themeColors.gray60} content={Video} />
       <StyledDescription>
         This app would like to use your camera.
@@ -86,7 +71,6 @@ export const AskForCameraPermission = ({
 
 const WebcamComponent = ({
   handleCapture,
-  width,
   disabled,
   clearPhotoInProgress,
   setClearPhotoInProgress,
@@ -98,20 +82,6 @@ const WebcamComponent = ({
     testOverride || WebcamPermission.PENDING
   )
   const videoRef = useRef<Webcam>(null)
-
-  const [debouncedWidth, setDebouncedWidth] = useState(width)
-
-  // TODO: Update to match React best practices
-  // eslint-disable-next-line react-hooks/react-compiler
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedSetDebouncedCallback = useCallback(
-    debounce(1000, setDebouncedWidth),
-    []
-  )
-
-  useEffect(() => {
-    memoizedSetDebouncedCallback(width)
-  }, [width, memoizedSetDebouncedCallback])
 
   function capture(): void {
     if (videoRef.current !== null) {
@@ -127,7 +97,7 @@ const WebcamComponent = ({
       {webcamPermission !== WebcamPermission.SUCCESS &&
       !disabled &&
       !clearPhotoInProgress ? (
-        <AskForCameraPermission width={debouncedWidth} />
+        <AskForCameraPermission />
       ) : (
         isMobile && <SwitchFacingModeButton switchFacingMode={setFacingMode} />
       )}
@@ -138,7 +108,6 @@ const WebcamComponent = ({
           !disabled &&
           !clearPhotoInProgress
         }
-        width={debouncedWidth}
       >
         {!disabled && (
           <Webcam
@@ -146,12 +115,11 @@ const WebcamComponent = ({
             ref={videoRef}
             screenshotFormat="image/jpeg"
             screenshotQuality={1}
-            width={debouncedWidth}
-            // We keep Aspect ratio of container always equal 16 / 9.
-            // The aspect ration of video stream may be different depending on a camera.
-            height={(debouncedWidth * 9) / 16}
             style={{
               borderRadius: `${theme.radii.default} ${theme.radii.default} 0 0`,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
             }}
             onUserMediaError={() => {
               setWebcamPermissionState(WebcamPermission.ERROR)
@@ -161,7 +129,6 @@ const WebcamComponent = ({
               setClearPhotoInProgress(false)
             }}
             videoConstraints={{
-              width: { ideal: debouncedWidth },
               facingMode,
             }}
           />

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -69,15 +69,11 @@ export const StyledCameraInput = styled.div({
   objectFit: "contain",
 })
 
-export interface StyledBoxProps {
-  width: number
-}
-
-export const StyledBox = styled.div<StyledBoxProps>(({ theme, width }) => ({
+export const StyledBox = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.secondaryBg,
   borderRadius: `${theme.radii.default} ${theme.radii.default} 0 0`,
   width: "100%",
-  height: (width * 9) / 16,
+  aspectRatio: "16 / 9",
   display: "flex",
   flexDirection: "column",
   justifyContent: "center",
@@ -96,6 +92,8 @@ export interface StyledImgProps {
 export const StyledImg = styled.img<StyledImgProps>(({ theme, opacity }) => ({
   borderRadius: `${theme.radii.default} ${theme.radii.default} 0 0`,
   objectFit: "contain",
+  width: "100%",
+  height: "100%",
   opacity,
 }))
 


### PR DESCRIPTION
## Describe your changes

After some previous refactors of width handling by @sfc-gh-bnisco and @sfc-gh-lwilby , we can simplify the width styling in CameraInput to use CSS styles instead of calculating the width via `withCalculatedWidth`. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Coverage with existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
