### PR TITLE
Add timeouts to e2e test workflows

### DIFF
--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   playwright-e2e-tests-changed-files:
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 20
 
     defaults:
       run:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   playwright-e2e-tests:
     runs-on: ubuntu-latest-32-cores
+    timeout-minutes: 30
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

The e2e tests can sometimes run for a very long time if something goes wrong. This PR configures some reasonable timeout limits. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
