### PR TITLE
Fix pandas deprecation warning in test

### DIFF
--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -28,6 +28,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.dataframe_util import (
     convert_arrow_bytes_to_pandas_df,
+    is_pandas_version_less_than,
 )
 from streamlit.elements.lib.column_config_utils import INDEX_IDENTIFIER
 from streamlit.errors import StreamlitAPIException
@@ -363,9 +364,15 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
             success = "Success status"
 
         df = pd.DataFrame({"pipeline": ["Success"], "status": [Status.success]})
-        styler = df.style.map(
-            lambda v: "color: red" if v == Status.success else "", subset=["status"]
-        )
+
+        def apply_color(v: Status) -> str:
+            return "color: red" if v == Status.success else ""
+
+        if is_pandas_version_less_than("2.2.0"):
+            styler = df.style.applymap(apply_color, subset=["status"])
+        else:
+            styler = df.style.map(apply_color, subset=["status"])
+
         st.dataframe(styler)
 
         expected = pd.DataFrame(

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -363,7 +363,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
             success = "Success status"
 
         df = pd.DataFrame({"pipeline": ["Success"], "status": [Status.success]})
-        styler = df.style.applymap(
+        styler = df.style.map(
             lambda v: "color: red" if v == Status.success else "", subset=["status"]
         )
         st.dataframe(styler)


### PR DESCRIPTION
## Describe your changes

Fixes a deprecation warning triggered in our tests:

<img width="867" alt="image" src="https://github.com/user-attachments/assets/1bb9f2de-d7d8-48d2-863a-168d963d85f4" />

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
