### PR TITLE
Remove stretch height from public api

### DIFF
--- a/e2e_playwright/st_form.py
+++ b/e2e_playwright/st_form.py
@@ -213,14 +213,3 @@ with st.form("form_16", height="content"):
     )
     if submitted_16:
         st.write("Form submitted")
-
-with st.form("form_17", height="stretch"):
-    st.write("Inside form 17")
-    st.write("Form height: stretch")
-    text_input = st.text_input("Form 17 - Text Input")
-    submitted_17 = st.form_submit_button(
-        "Form 17 - Submit",
-        help="Submit by clicking",
-    )
-    if submitted_17:
-        st.write("Form submitted")

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -304,7 +304,3 @@ def test_form_height_configurations(app: Page, assert_snapshot: ImageCompareFunc
     form_16 = app.get_by_test_id("stForm").nth(15)
     expect(form_16.get_by_test_id("stFormSubmitButton").first).to_be_visible()
     assert_snapshot(form_16, name="st_form-content_height")
-
-    form_17 = app.get_by_test_id("stForm").nth(16)
-    expect(form_17.get_by_test_id("stFormSubmitButton").first).to_be_visible()
-    assert_snapshot(form_17, name="st_form-stretch_height")

--- a/lib/streamlit/elements/code.py
+++ b/lib/streamlit/elements/code.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit.elements.lib.layout_utils import (
-    Height,
     LayoutConfig,
     WidthWithoutContent,
     validate_height,
@@ -41,7 +40,7 @@ class CodeMixin:
         *,
         line_numbers: bool = False,
         wrap_lines: bool = False,
-        height: Height = "content",
+        height: int | Literal["content"] = "content",
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display a code block with optional syntax highlighting.

--- a/lib/streamlit/elements/code.py
+++ b/lib/streamlit/elements/code.py
@@ -40,7 +40,7 @@ class CodeMixin:
         *,
         line_numbers: bool = False,
         wrap_lines: bool = False,
-        height: int | Literal["content"] = "content",
+        height: int | Literal["content"] | None = "content",
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display a code block with optional syntax highlighting.
@@ -117,7 +117,10 @@ class CodeMixin:
         code_proto.show_line_numbers = line_numbers
         code_proto.wrap_lines = wrap_lines
 
-        validate_height(height, allow_content=True)
+        if height is None:
+            height = "content"
+        else:
+            validate_height(height, allow_content=True)
         validate_width(width)
         layout_config = LayoutConfig(height=height, width=width)
 

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit.elements.lib.form_utils import FormData, current_form_id, is_in_form
 from streamlit.elements.lib.layout_utils import (
-    Height,
     Width,
     get_height_config,
     get_width_config,
@@ -76,7 +75,7 @@ class FormMixin:
         enter_to_submit: bool = True,
         border: bool = True,
         width: Width = "stretch",
-        height: Height = "content",
+        height: int | Literal["content"] = "content",
     ) -> DeltaGenerator:
         """Create a form that batches elements together with a "Submit" button.
 

--- a/lib/tests/streamlit/elements/code_test.py
+++ b/lib/tests/streamlit/elements/code_test.py
@@ -212,15 +212,7 @@ class CodeElement(DeltaGeneratorTestCase):
         )
         assert element.height_config.use_content
 
-    @parameterized.expand(
-        [
-            "invalid",
-            -100,
-            0,
-            100.5,
-            None,
-        ]
-    )
+    @parameterized.expand(["invalid", -100, 0, 100.5])
     def test_st_code_with_invalid_height(self, height):
         """Test st.code with invalid height values."""
         code = "print('My string = %d' % my_value)"

--- a/lib/tests/streamlit/elements/code_test.py
+++ b/lib/tests/streamlit/elements/code_test.py
@@ -212,19 +212,6 @@ class CodeElement(DeltaGeneratorTestCase):
         )
         assert element.height_config.use_content
 
-    def test_st_code_with_height_stretch(self):
-        """Test st.code with stretch height."""
-        code = "print('My string = %d' % my_value)"
-        st.code(code, height="stretch")
-
-        element = self.get_delta_from_queue().new_element
-        assert element.code.code_text == code
-        assert (
-            element.height_config.WhichOneof("height_spec")
-            == HeightConfigFields.USE_STRETCH.value
-        )
-        assert element.height_config.use_stretch
-
     @parameterized.expand(
         [
             "invalid",

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -478,16 +478,6 @@ class FormDimensionsTest(DeltaGeneratorTestCase):
         assert form_proto.form.form_id == "form_with_content"
         assert form_proto.height_config.use_content
 
-    def test_form_with_stretch_height(self):
-        """Test form with stretch height."""
-        with st.form("form_with_stretch", height="stretch"):
-            st.text_input("Input")
-            st.form_submit_button("Submit")
-
-        form_proto = self.get_delta_from_queue(0).add_block
-        assert form_proto.form.form_id == "form_with_stretch"
-        assert form_proto.height_config.use_stretch
-
     @parameterized.expand(
         [
             ("invalid", "invalid"),


### PR DESCRIPTION
## Describe your changes

Since `height=100%` requires some changes that may break some apps and we don't want to release them until the entire flexBox feature is available so that users can migrate their code, we will remove these from the public API for now to avoid confusion. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
