### PR TITLE
`st.set_page_config`: enable sidebar/layout configs to be None

### DIFF
--- a/e2e_playwright/st_set_page_config.py
+++ b/e2e_playwright/st_set_page_config.py
@@ -169,3 +169,19 @@ def set_page_config_menu_items_overwrite():
 
 st.button("Set Initial Menu Items", on_click=set_initial_menu_items)
 st.button("Menu Items Overwrite", on_click=set_page_config_menu_items_overwrite)
+
+
+def set_page_config_layout_additive():
+    st.set_page_config(page_title="Initial", layout="wide")
+    st.set_page_config(page_title="Updated", layout=None)
+
+
+st.button("Layout Additive", on_click=set_page_config_layout_additive)
+
+
+def set_page_config_sidebar_additive():
+    st.set_page_config(page_title="Initial", initial_sidebar_state="collapsed")
+    st.set_page_config(page_title="Updated", initial_sidebar_state=None)
+
+
+st.button("Sidebar Additive", on_click=set_page_config_sidebar_additive)

--- a/e2e_playwright/st_set_page_config_test.py
+++ b/e2e_playwright/st_set_page_config_test.py
@@ -196,6 +196,24 @@ def test_set_page_config_properties_additive(app: Page):
     expect(app_view_container).to_have_attribute("data-layout", "wide")
 
 
+def test_set_page_config_layout_additive(app: Page):
+    click_button(app, "Layout Additive")
+    expect_no_exception(app)
+    expect(app).to_have_title("Updated")
+    app_view_container = app.get_by_test_id("stAppViewContainer")
+    # Layout set to None should inherit config from previous call
+    expect(app_view_container).to_have_attribute("data-layout", "wide")
+
+
+def test_set_page_config_sidebar_additive(app: Page):
+    click_button(app, "Sidebar Additive")
+    expect_no_exception(app)
+    expect(app).to_have_title("Updated")
+    sidebar = app.get_by_test_id("stSidebar")
+    # Sidebar set to None should inherit config from previous call
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
+
+
 # Webkit (safari) doesn't support screencast on linux machines, so menu item
 # indices not the same as other browsers
 @pytest.mark.skip_browser("webkit")

--- a/e2e_playwright/st_set_page_config_test.py
+++ b/e2e_playwright/st_set_page_config_test.py
@@ -26,6 +26,10 @@ from e2e_playwright.shared.react18_utils import wait_for_react_stability
 
 
 def test_wide_layout(app: Page):
+    """Test the default layout is centered and calling set_page_config with
+    layout="wide" sets the layout to wide.
+    """
+
     app_view_container = app.get_by_test_id("stAppViewContainer")
     # The default layout is "centered":
     expect(app_view_container).to_have_attribute("data-layout", "narrow")
@@ -81,6 +85,9 @@ def test_wide_layout_with_small_viewport(app: Page):
 
 
 def test_centered_layout(app: Page):
+    """Test that calling set_page_config with layout="centered" sets the layout
+    to centered.
+    """
     click_button(app, "Centered Layout")
     expect(app).to_have_title("Centered Layout")
     app_view_container = app.get_by_test_id("stAppViewContainer")
@@ -97,6 +104,9 @@ def test_allows_preceding_command_in_callback(app: Page):
 
 
 def test_with_collapsed_sidebar(app: Page):
+    """Test that calling set_page_config with initial_sidebar_state="collapsed"
+    sets the sidebar to collapsed.
+    """
     click_button(app, "Collapsed Sidebar")
     expect(app).to_have_title("Collapsed Sidebar")
     sidebar = app.get_by_test_id("stSidebar")
@@ -105,6 +115,9 @@ def test_with_collapsed_sidebar(app: Page):
 
 
 def test_with_expanded_sidebar(app: Page):
+    """Test that calling set_page_config with initial_sidebar_state="expanded"
+    sets the sidebar to expanded.
+    """
     click_button(app, "Expanded Sidebar")
     expect(app).to_have_title("Expanded Sidebar")
     sidebar = app.get_by_test_id("stSidebar")
@@ -113,6 +126,9 @@ def test_with_expanded_sidebar(app: Page):
 
 
 def test_page_icon_with_emoji_shortcode(app: Page):
+    """Test that calling set_page_config with page_icon=":shark:" sets
+    the page icon to a shark emoji.
+    """
     click_button(app, "Page Config With Emoji Shortcode")
     expect(app).to_have_title("With Emoji Shortcode")
     favicon = app.locator("link[rel='shortcut icon']")
@@ -125,6 +141,9 @@ def test_page_icon_with_emoji_shortcode(app: Page):
 
 
 def test_page_icon_with_emoji_symbol(app: Page):
+    """Test that calling set_page_config with page_icon="🐦‍🔥" sets
+    the page icon to a phoenix emoji.
+    """
     click_button(app, "Page Config With Emoji Symbol")
     expect(app).to_have_title("With Emoji Symbol")
     favicon = app.locator("link[rel='shortcut icon']")
@@ -136,6 +155,9 @@ def test_page_icon_with_emoji_symbol(app: Page):
 
 
 def test_page_icon_with_local_icon_str(app: Page):
+    """Test that calling set_page_config with a local icon string for page_icon
+    sets as expected.
+    """
     click_button(app, "Page Config With Local Icon Str")
     expect(app).to_have_title("With Local Icon Str")
     favicon_element = app.locator("link[rel='shortcut icon']")
@@ -145,6 +167,9 @@ def test_page_icon_with_local_icon_str(app: Page):
 
 
 def test_page_icon_with_local_icon(app: Page):
+    """Test that calling set_page_config with a local icon path for page_icon
+    sets as expected.
+    """
     click_button(app, "Page Config With Local Icon Path")
     expect(app).to_have_title("With Local Icon Path")
     favicon_element = app.locator("link[rel='shortcut icon']")
@@ -154,6 +179,9 @@ def test_page_icon_with_local_icon(app: Page):
 
 
 def test_page_icon_with_material_icon(app: Page):
+    """Test that calling set_page_config with a material icon for page_icon
+    sets as expected.
+    """
     click_button(app, "Page Config With Material Icon")
     expect(app).to_have_title("With Material Icon")
     favicon = app.locator("link[rel='shortcut icon']")
@@ -166,12 +194,18 @@ def test_page_icon_with_material_icon(app: Page):
 
 # Tests for removal of set page config restrictions:
 def test_allow_double_set_page_config(app: Page):
+    """Test that calling set_page_config multiple times no longer triggers
+    an error.
+    """
     click_button(app, "Double Set Page Config")
     expect_no_exception(app)
     expect(app).to_have_title("Page Config 2")
 
 
 def test_allow_set_page_config_not_first_command(app: Page):
+    """Test that calling set_page_config after the first command does not trigger
+    an error.
+    """
     click_button(app, "Page Config not first command")
     favicon = app.locator("link[rel='shortcut icon']")
     expect(favicon).to_have_attribute(
@@ -184,6 +218,9 @@ def test_allow_set_page_config_not_first_command(app: Page):
 
 
 def test_set_page_config_properties_additive(app: Page):
+    """Test that calling set_page_config multiple times with different properties
+    sets as expected (properties are additive).
+    """
     click_button(app, "Set Page Config Properties Additive")
     expect_no_exception(app)
     expect(app).to_have_title("Page Config Additive")
@@ -197,6 +234,9 @@ def test_set_page_config_properties_additive(app: Page):
 
 
 def test_set_page_config_layout_additive(app: Page):
+    """Test that calling set_page_config multiple times with different layout
+    configs sets as expected (properties are additive).
+    """
     click_button(app, "Layout Additive")
     expect_no_exception(app)
     expect(app).to_have_title("Updated")
@@ -206,6 +246,9 @@ def test_set_page_config_layout_additive(app: Page):
 
 
 def test_set_page_config_sidebar_additive(app: Page):
+    """Test that calling set_page_config multiple times with different sidebar
+    configs sets as expected (properties are additive).
+    """
     click_button(app, "Sidebar Additive")
     expect_no_exception(app)
     expect(app).to_have_title("Updated")
@@ -218,6 +261,9 @@ def test_set_page_config_sidebar_additive(app: Page):
 # indices not the same as other browsers
 @pytest.mark.skip_browser("webkit")
 def test_set_page_config_menu_items_additive(app: Page):
+    """Test that calling set_page_config multiple times with different menu
+    items sets as expected (properties are additive).
+    """
     click_button(app, "Set Page Config Menu Items Additive")
     expect_no_exception(app)
 
@@ -232,6 +278,9 @@ def test_set_page_config_menu_items_additive(app: Page):
 
 @pytest.mark.skip_browser("webkit")
 def test_set_page_config_menu_items_overwrites(app: Page):
+    """Test that menu items can be overwritten by calling set_page_config
+    multiple times.
+    """
     # Set the initial menu items:
     click_button(app, "Set Initial Menu Items")
     expect_no_exception(app)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -906,7 +906,10 @@ export class App extends PureComponent<Props, State> {
 
     // Only change layout/sidebar when the page config has changed.
     // This preserves the user's previous choice/default, and prevents extra re-renders.
-    if (layout !== this.state.layout && layout !== PageConfig.Layout.UNSET) {
+    if (
+      layout !== this.state.layout &&
+      layout !== PageConfig.Layout.LAYOUT_UNSET
+    ) {
       this.setState((prevState: State) => ({
         layout,
         userSettings: {
@@ -918,7 +921,7 @@ export class App extends PureComponent<Props, State> {
 
     if (
       initialSidebarState !== this.state.initialSidebarState &&
-      initialSidebarState !== PageConfig.SidebarState.NONE
+      initialSidebarState !== PageConfig.SidebarState.SIDEBAR_UNSET
     ) {
       this.setState(() => ({
         initialSidebarState,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -905,8 +905,8 @@ export class App extends PureComponent<Props, State> {
     }
 
     // Only change layout/sidebar when the page config has changed.
-    // This preserves the user's previous choice, and prevents extra re-renders.
-    if (layout !== this.state.layout) {
+    // This preserves the user's previous choice/default, and prevents extra re-renders.
+    if (layout !== this.state.layout && layout !== PageConfig.Layout.UNSET) {
       this.setState((prevState: State) => ({
         layout,
         userSettings: {
@@ -915,7 +915,11 @@ export class App extends PureComponent<Props, State> {
         },
       }))
     }
-    if (initialSidebarState !== this.state.initialSidebarState) {
+
+    if (
+      initialSidebarState !== this.state.initialSidebarState &&
+      initialSidebarState !== PageConfig.SidebarState.NONE
+    ) {
       this.setState(() => ({
         initialSidebarState,
       }))

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -110,8 +110,8 @@ def _get_favicon_string(page_icon: PageIcon) -> str:
 def set_page_config(
     page_title: str | None = None,
     page_icon: PageIcon | None = None,
-    layout: Layout = "centered",
-    initial_sidebar_state: InitialSideBarState = "auto",
+    layout: Layout | None = None,
+    initial_sidebar_state: InitialSideBarState | None = None,
     menu_items: MenuItems | None = None,
 ) -> None:
     """
@@ -218,6 +218,9 @@ def set_page_config(
         pb_layout = PageConfigProto.CENTERED
     elif layout == "wide":
         pb_layout = PageConfigProto.WIDE
+    elif layout is None:
+        # Allows for multiple (additive) calls to set_page_config
+        pb_layout = PageConfigProto.UNSET
     else:
         # Note: Pylance incorrectly notes this error as unreachable
         raise StreamlitInvalidPageLayoutError(layout=layout)
@@ -231,6 +234,9 @@ def set_page_config(
         pb_sidebar_state = PageConfigProto.EXPANDED
     elif initial_sidebar_state == "collapsed":
         pb_sidebar_state = PageConfigProto.COLLAPSED
+    elif initial_sidebar_state is None:
+        # Allows for multiple (additive) calls to set_page_config
+        pb_sidebar_state = PageConfigProto.NONE
     else:
         # Note: Pylance incorrectly notes this error as unreachable
         raise StreamlitInvalidSidebarStateError(

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -220,7 +220,7 @@ def set_page_config(
         pb_layout = PageConfigProto.WIDE
     elif layout is None:
         # Allows for multiple (additive) calls to set_page_config
-        pb_layout = PageConfigProto.UNSET
+        pb_layout = PageConfigProto.LAYOUT_UNSET
     else:
         # Note: Pylance incorrectly notes this error as unreachable
         raise StreamlitInvalidPageLayoutError(layout=layout)
@@ -236,7 +236,7 @@ def set_page_config(
         pb_sidebar_state = PageConfigProto.COLLAPSED
     elif initial_sidebar_state is None:
         # Allows for multiple (additive) calls to set_page_config
-        pb_sidebar_state = PageConfigProto.NONE
+        pb_sidebar_state = PageConfigProto.SIDEBAR_UNSET
     else:
         # Note: Pylance incorrectly notes this error as unreachable
         raise StreamlitInvalidSidebarStateError(

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -88,6 +88,11 @@ class PageConfigTest(DeltaGeneratorTestCase):
         c = self.get_message_from_queue().page_config_changed
         assert c.layout == PageConfigProto.CENTERED
 
+    def test_set_page_config_layout_none(self):
+        st.set_page_config(layout=None)
+        c = self.get_message_from_queue().page_config_changed
+        assert c.layout == PageConfigProto.UNSET
+
     def test_set_page_config_layout_invalid(self):
         with pytest.raises(StreamlitAPIException):
             st.set_page_config(layout="invalid")
@@ -106,6 +111,11 @@ class PageConfigTest(DeltaGeneratorTestCase):
         st.set_page_config(initial_sidebar_state="collapsed")
         c = self.get_message_from_queue().page_config_changed
         assert c.initial_sidebar_state == PageConfigProto.COLLAPSED
+
+    def test_set_page_config_sidebar_none(self):
+        st.set_page_config(initial_sidebar_state=None)
+        c = self.get_message_from_queue().page_config_changed
+        assert c.initial_sidebar_state == PageConfigProto.NONE
 
     def test_set_page_config_sidebar_invalid(self):
         with pytest.raises(StreamlitInvalidSidebarStateError):

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -91,7 +91,7 @@ class PageConfigTest(DeltaGeneratorTestCase):
     def test_set_page_config_layout_none(self):
         st.set_page_config(layout=None)
         c = self.get_message_from_queue().page_config_changed
-        assert c.layout == PageConfigProto.UNSET
+        assert c.layout == PageConfigProto.LAYOUT_UNSET
 
     def test_set_page_config_layout_invalid(self):
         with pytest.raises(StreamlitAPIException):
@@ -115,7 +115,7 @@ class PageConfigTest(DeltaGeneratorTestCase):
     def test_set_page_config_sidebar_none(self):
         st.set_page_config(initial_sidebar_state=None)
         c = self.get_message_from_queue().page_config_changed
-        assert c.initial_sidebar_state == PageConfigProto.NONE
+        assert c.initial_sidebar_state == PageConfigProto.SIDEBAR_UNSET
 
     def test_set_page_config_sidebar_invalid(self):
         with pytest.raises(StreamlitInvalidSidebarStateError):

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -43,6 +43,10 @@ message PageConfig {
 
     // Use the full browser width to render elements.
     WIDE = 1;
+
+    // Unset distinguishes whether property explicitly set - on initial call, will
+    // will set to centered as default. Otherwise, inherit value from previous call
+    UNSET = 2;
   }
 
   enum SidebarState {
@@ -54,5 +58,9 @@ message PageConfig {
 
     // Force the sidebar to be hidden.
     COLLAPSED = 2;
+
+    // None distinguishes whether property explicitly set - on initial call, will
+    // will set to auto as default. Otherwise, inherit value from previous call
+    NONE = 3;
   }
 }

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -44,8 +44,8 @@ message PageConfig {
     // Use the full browser width to render elements.
     WIDE = 1;
 
-    // Unset distinguishes whether property explicitly set - on initial call, will
-    // will set to centered as default. Otherwise, inherit value from previous call
+    // Unset distinguishes that config was not provided - on initial call, will
+    // set to centered as default. Otherwise, inherit value from previous call
     UNSET = 2;
   }
 
@@ -59,8 +59,8 @@ message PageConfig {
     // Force the sidebar to be hidden.
     COLLAPSED = 2;
 
-    // None distinguishes whether property explicitly set - on initial call, will
-    // will set to auto as default. Otherwise, inherit value from previous call
+    // None distinguishes that config was not provided - on initial call, will
+    // set to auto as default. Otherwise, inherit value from previous call
     NONE = 3;
   }
 }

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -46,7 +46,7 @@ message PageConfig {
 
     // Unset distinguishes that config was not provided - on initial call, will
     // set to centered as default. Otherwise, inherit value from previous call
-    UNSET = 2;
+    LAYOUT_UNSET = 2;
   }
 
   enum SidebarState {
@@ -59,8 +59,8 @@ message PageConfig {
     // Force the sidebar to be hidden.
     COLLAPSED = 2;
 
-    // None distinguishes that config was not provided - on initial call, will
+    // Unset distinguishes that config was not provided - on initial call, will
     // set to auto as default. Otherwise, inherit value from previous call
-    NONE = 3;
+    SIDEBAR_UNSET = 3;
   }
 }


### PR DESCRIPTION
## Describe your changes
To better enable additive calls to `st.set_page_config` now that restrictions have been removed (https://github.com/streamlit/streamlit/pull/11286), make params `layout` & `initial_sidebar_state` default to `None` if not set so they inherit the behavior of the previous call. 

If there is no previous call (1st `st.set_page_config` call), these will be set by the FE to the defaults - values `"centered"` & `"auto"` respectively.

## Testing Plan
- Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 
