### PR TITLE
Lower log level from info to debug when Arrow serialization fails

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -820,7 +820,7 @@ def convert_pandas_df_to_arrow_bytes(df: DataFrame) -> bytes:
     try:
         table = pa.Table.from_pandas(df)
     except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
-        _LOGGER.info(
+        _LOGGER.debug(
             "Serialization of dataframe to Arrow table was unsuccessful. "
             "Applying automatic fixes for column types to make the dataframe "
             "Arrow-compatible.",


### PR DESCRIPTION
## Describe your changes

In one of my streamlit apps, I display many DataFrames with mixed types, and the existing log at the INFO level for Arrow serialization fallback is cluttering my log history, even though the automatic type fixes work perfectly and don’t require attention. I propose lowering this log level from INFO to DEBUG to reduce noise in production environments while still retaining useful debug information for developers when needed. This change keeps the logs cleaner without affecting functionality, aligning with logging best practices where DEBUG is used for technical details and INFO is reserved for higher-level operational messages.

## GitHub Issue Link (if applicable)

#11389
