### PR TITLE
Makes st.navigation(position='top') use "stTopNavLink" instead of "stSidebarNavLink" for data-testid's

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
@@ -28,7 +28,7 @@ def test_desktop_top_nav(app: Page):
 
     # The top nav is rendered using rc-overflow component
     # Check that navigation links exist and are visible
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links).to_have_count(3)  # 3 pages
 
     # Verify no sidebar is visible
@@ -61,7 +61,7 @@ def test_mobile_fallback_to_sidebar(app: Page):
     expect(sidebar).to_be_visible()
 
     # Wait for sidebar to expand by checking if links are visible
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links.first).to_be_visible()
 
     # The sidebar might have overflow or positioning issues on mobile
@@ -83,7 +83,7 @@ def test_overflow_behavior(app: Page):
     app.set_viewport_size({"width": 800, "height": 600})
 
     # Verify we have 5 nav links total
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links).to_have_count(5)
 
     # Note: Due to our mock of rc-overflow in the JS tests, all links will be visible
@@ -137,7 +137,7 @@ def test_hidden_navigation_mode(app: Page):
     expect(app.get_by_test_id("stSidebar")).not_to_be_visible()
 
     # No nav links should be visible
-    expect(app.get_by_test_id("stSidebarNavLink")).not_to_be_visible()
+    expect(app.get_by_test_id("stTopNavLink")).not_to_be_visible()
 
     # Only first page content should be visible - check header
     expect(app.get_by_test_id("stHeading").filter(has_text="Page 1")).to_be_visible()
@@ -166,7 +166,7 @@ def test_switching_navigation_modes(app: Page):
 
     # Verify switched to top nav - sidebar hidden, nav links visible at top
     expect(app.get_by_test_id("stSidebar")).not_to_be_visible()
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links).to_have_count(3)
     expect(nav_links.first).to_be_visible()
 
@@ -186,7 +186,7 @@ def test_top_nav_visual_regression(app: Page, assert_snapshot: ImageCompareFunct
     wait_for_app_run(app)
 
     # Wait for app to stabilize
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links.first).to_be_visible()
 
     # Take screenshot of the navigation area
@@ -226,7 +226,7 @@ def test_mobile_sidebar_overlay_visual(
     expect(sidebar).to_be_visible()
 
     # Verify navigation has moved into the sidebar
-    nav_links = app.get_by_test_id("stSidebarNavLink")
+    nav_links = app.get_by_test_id("stTopNavLink")
     expect(nav_links).to_have_count(3)
     expect(nav_links.first).to_be_visible()
 

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
@@ -61,7 +61,7 @@ def test_mobile_fallback_to_sidebar(app: Page):
     expect(sidebar).to_be_visible()
 
     # Wait for sidebar to expand by checking if links are visible
-    nav_links = app.get_by_test_id("stTopNavLink")
+    nav_links = app.get_by_test_id("stSidebarNavLink")
     expect(nav_links.first).to_be_visible()
 
     # The sidebar might have overflow or positioning issues on mobile
@@ -226,7 +226,7 @@ def test_mobile_sidebar_overlay_visual(
     expect(sidebar).to_be_visible()
 
     # Verify navigation has moved into the sidebar
-    nav_links = app.get_by_test_id("stTopNavLink")
+    nav_links = app.get_by_test_id("stSidebarNavLink")
     expect(nav_links).to_have_count(3)
     expect(nav_links.first).to_be_visible()
 

--- a/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
@@ -145,7 +145,7 @@ describe("SidebarNavLink", () => {
     it("renders successfully with isTopNav prop", () => {
       render(<SidebarNavLink {...getProps({ isTopNav: true })} />)
 
-      const sidebarNavLink = screen.getByTestId("stSidebarNavLink")
+      const sidebarNavLink = screen.getByTestId("stTopNavLink")
       expect(sidebarNavLink).toHaveTextContent("Test")
     })
 
@@ -154,7 +154,7 @@ describe("SidebarNavLink", () => {
         <SidebarNavLink {...getProps({ isTopNav: true, isActive: true })} />
       )
 
-      const sidebarNavLink = screen.getByTestId("stSidebarNavLink")
+      const sidebarNavLink = screen.getByTestId("stTopNavLink")
       expect(sidebarNavLink).toHaveAttribute("aria-current", "page")
     })
 
@@ -166,8 +166,8 @@ describe("SidebarNavLink", () => {
 
       render(<SidebarNavLink {...getProps({ isTopNav: true })} />)
 
-      screen.getByTestId("stSidebarNavLinkContainer")
-      const sidebarNavLink = screen.getByTestId("stSidebarNavLink")
+      screen.getByTestId("stTopNavLinkContainer")
+      const sidebarNavLink = screen.getByTestId("stTopNavLink")
       expect(sidebarNavLink).toHaveStyle("pointer-events: none")
     })
   })

--- a/frontend/app/src/components/Navigation/SidebarNavLink.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNavLink.tsx
@@ -48,13 +48,18 @@ const SidebarNavLink = ({
   // disable sidebar nav links
   const { widgetsDisabled: disableSidebarNavLinks } = useAppContext()
 
+  const navLinkTestId = isTopNav ? "stTopNavLink" : "stSidebarNavLink"
+  const navLinkContainerTestId = isTopNav
+    ? "stTopNavLinkContainer"
+    : "stSidebarNavLinkContainer"
+
   return (
     <StyledSidebarNavLinkContainer
       disabled={disableSidebarNavLinks}
-      data-testid="stSidebarNavLinkContainer"
+      data-testid={navLinkContainerTestId}
     >
       <StyledSidebarNavLink
-        data-testid="stSidebarNavLink"
+        data-testid={navLinkTestId}
         isActive={isActive}
         disabled={disableSidebarNavLinks}
         href={pageUrl}


### PR DESCRIPTION
## Describe your changes

It was pointed out that it would be nice for these `data-testid`'s to be more semantically correct. Since we're sharing the component with sidebar nav, the top nav links were showing up as `stSidebarNavLink`'s. Now they will correctly render as `stTopNavLink`'s.

## GitHub Issue Link (if applicable)

none

## Testing Plan

The unit and e2e tests were updated to reflect these changes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
