### PR TITLE
Fix runtime error with event based watcher

### DIFF
--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import threading
 import unittest
 from unittest import mock
 
@@ -43,9 +44,14 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         self.mock_util = self.util_patcher.start()
 
     def tearDown(self):
-        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
-        fo._observer.start.reset_mock()
-        fo._observer.schedule.reset_mock()
+        # The test suite patches MultiPathWatcher. We need to close
+        # any existing watcher instance here to not break other tests.
+        if event_based_path_watcher._MultiPathWatcher._singleton is not None:
+            fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+            fo.close()
+            fo._observer.start.reset_mock()
+            fo._observer.schedule.reset_mock()
+            event_based_path_watcher._MultiPathWatcher._singleton = None
 
         self.observer_class_patcher.stop()
         self.util_patcher.stop()
@@ -384,3 +390,92 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         # should not have increased.
         assert cb1.call_count == 1
         assert cb2.call_count == 2
+
+    @mock.patch("os.path.isdir")
+    def test_dir_watcher_file_event_precedence(self, mock_is_dir):
+        """Test that file-specific watchers are prioritized for file events.
+
+        If we're watching both a directory and a file inside that directory,
+        an event on the file should be handled by the file's watcher, not the
+        directory's.
+        """
+        dir_path = "/this/is/my/dir"
+        file_path = "/this/is/my/dir/file.py"
+        mock_is_dir.side_effect = lambda path: path == dir_path
+
+        dir_cb = mock.Mock()
+        event_based_path_watcher.EventBasedPathWatcher(dir_path, dir_cb)
+
+        file_cb = mock.Mock()
+        event_based_path_watcher.EventBasedPathWatcher(file_path, file_cb)
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = next(iter(fo._folder_handlers.values()))
+
+        self.mock_util.path_modification_time = lambda *args: 102.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+
+        ev = events.FileSystemEvent(file_path)
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        dir_cb.assert_not_called()
+        file_cb.assert_called_once()
+
+    @mock.patch("os.path.isdir")
+    def test_no_race_condition_on_path_change(self, mock_is_dir):
+        """Test for race condition when modifying watchers during event handling.
+
+        This test creates two threads:
+        1. Simulates file modification events, which reads from _watched_paths.
+        2. Adds and removes watchers, which writes to _watched_paths.
+
+        Without a lock, this would cause a "dictionary changed size during
+        iteration" RuntimeError.
+        """
+        dir_path = "/this/is/my/dir"
+        mock_is_dir.side_effect = lambda path: path == dir_path
+
+        # Initial watcher for the directory
+        event_based_path_watcher.EventBasedPathWatcher(dir_path, mock.Mock())
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = next(iter(fo._folder_handlers.values()))
+
+        # Mock fs-related utils to avoid disk access and to ensure
+        # that we always proceed past the mtime/md5 checks.
+        self.mock_util.calc_md5_with_blocking_retries.return_value = "md5"
+        mod_time = [1.0]
+
+        def mock_mod_time(*args, **kwargs):
+            mod_time[0] += 1.0
+            return mod_time[0]
+
+        self.mock_util.path_modification_time.side_effect = mock_mod_time
+
+        def event_handler_thread():
+            ev = events.FileSystemEvent(f"{dir_path}/some_file.py")
+            ev.event_type = events.EVENT_TYPE_MODIFIED
+            for _ in range(50):
+                folder_handler.on_modified(ev)
+
+        def watcher_management_thread():
+            for i in range(50):
+                path = f"{dir_path}/file_{i}.py"
+                watcher = event_based_path_watcher.EventBasedPathWatcher(
+                    path, mock.Mock()
+                )
+                watcher.close()
+
+        t1 = threading.Thread(target=event_handler_thread)
+        t2 = threading.Thread(target=watcher_management_thread)
+
+        t1.start()
+        t2.start()
+
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # The test succeeds if no exceptions were thrown.
+        assert t1.is_alive() is False
+        assert t2.is_alive() is False


### PR DESCRIPTION
## Describe your changes

Fix an sporadic error - `RuntimeError: dictionary changed size during iteration` - that comes up with the event path watcher. Reason is that it didn't correctly apply the lock mechanism when accessing the watched paths.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11691

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
