### PR TITLE
[perf] Remove react-device-detect dependency

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -14362,32 +14362,6 @@ IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: react-device-detect. A copy of the source code may be downloaded from https://github.com/duskload/react-device-detect/. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2017 duskload
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: react-dropzone. A copy of the source code may be downloaded from https://github.com/react-dropzone/react-dropzone.git. This software contains the following license and notice below:
 
 The MIT License (MIT)

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -46,7 +46,6 @@
     "rc-overflow": "^1.4.1",
     "re-resizable": "^6.11.2",
     "react": "^18.2.0",
-    "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
     "react-hot-keys": "^2.7.3",
@@ -137,7 +136,7 @@
     "query-string": "^8.1.0",
     "set-value": "^4.0.1",
     "static-eval": "^2.0.5",
-    "ua-parser-js": "^1.0.33",
+    "ua-parser-js": "^1.0.40",
     "ws": "^8.11.0",
     "y18n": "^5.0.8"
   },

--- a/frontend/app/src/components/Navigation/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.test.tsx
@@ -16,9 +16,9 @@
 
 import React from "react"
 
-import * as reactDeviceDetect from "react-device-detect"
 import { screen } from "@testing-library/react"
 
+import * as isMobile from "@streamlit/lib"
 import { mockEndpoints, render } from "@streamlit/lib"
 import { IAppPage, PageConfig } from "@streamlit/protobuf"
 import { AppContextProps } from "@streamlit/app/src/components/AppContext"
@@ -81,11 +81,11 @@ describe("SidebarNav", () => {
     vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
       getContextOutput({})
     )
+
+    vi.spyOn(isMobile, "isMobile").mockReturnValue(false)
   })
 
   afterEach(() => {
-    // @ts-expect-error
-    reactDeviceDetect.isMobile = false
     window.localStorage.clear()
   })
 

--- a/frontend/app/src/components/Navigation/SidebarNav.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.tsx
@@ -24,10 +24,8 @@ import React, {
 } from "react"
 
 import groupBy from "lodash/groupBy"
-// We import react-device-detect in this way so that tests can mock its
-// isMobile field sanely.
-import * as reactDeviceDetect from "react-device-detect"
 
+import { isMobile } from "@streamlit/lib"
 import { localStorageAvailable } from "@streamlit/utils"
 import { StreamlitEndpoints } from "@streamlit/connection"
 import { IAppPage } from "@streamlit/protobuf"
@@ -181,7 +179,7 @@ const SidebarNav = ({
           onClick={e => {
             e.preventDefault()
             onPageChange(page.pageScriptHash as string)
-            if (reactDeviceDetect.isMobile) {
+            if (isMobile()) {
               collapseSidebar()
             }
           }}

--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -16,10 +16,10 @@
 
 import React from "react"
 
-import * as reactDeviceDetect from "react-device-detect"
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
+import * as isMobile from "@streamlit/lib"
 import { mockEndpoints, render } from "@streamlit/lib"
 import { IAppPage, PageConfig } from "@streamlit/protobuf"
 import { AppContextProps } from "@streamlit/app/src/components/AppContext"
@@ -83,11 +83,11 @@ describe("SidebarNav", () => {
     vi.spyOn(StreamlitContextProviderModule, "useAppContext").mockReturnValue(
       getContextOutput({})
     )
+
+    vi.spyOn(isMobile, "isMobile").mockReturnValue(false)
   })
 
   afterEach(() => {
-    // @ts-expect-error
-    reactDeviceDetect.isMobile = false
     window.localStorage.clear()
   })
 
@@ -509,8 +509,7 @@ describe("SidebarNav", () => {
   it("collapses sidebar on page change when on mobile", async () => {
     const onPageChange = vi.fn()
     const user = userEvent.setup()
-    // @ts-expect-error
-    reactDeviceDetect.isMobile = true
+    vi.spyOn(isMobile, "isMobile").mockReturnValue(true)
 
     const props = getProps({ onPageChange })
     render(<SidebarNav {...props} />)

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -90,7 +90,6 @@
     "re-resizable": "^6.11.2",
     "react-color": "^2.18.1",
     "react-debounce-render": "^8.0.2",
-    "react-device-detect": "^2.2.2",
     "react-dropzone": "^14.3.8",
     "react-feather": "^2.0.10",
     "react-json-view": "^1.19.1",
@@ -110,6 +109,7 @@
     "sprintf-js": "^1.1.3",
     "styletron-react": "^6.1.0",
     "typed-signals": "^3.0.0",
+    "ua-parser-js": "^1.0.40",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "urlpattern-polyfill": "^10.1.0",
@@ -153,6 +153,7 @@
     "@types/react-syntax-highlighter": "^15.5.5",
     "@types/react-window": "~1.8.8",
     "@types/sprintf-js": "^1.1.4",
+    "@types/ua-parser-js": "^0.7.39",
     "@types/uuid": "^10.0.0",
     "@types/wavesurfer.js": "^6.0.12",
     "@types/xxhashjs": "^0.2.2",
@@ -173,5 +174,8 @@
     "vitest": "^3.2.4",
     "vitest-canvas-mock": "^0.3.3",
     "vitest-fetch-mock": "^0.4.5"
+  },
+  "resolutions": {
+    "ua-parser-js": "^1.0.40"
   }
 }

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -23,7 +23,6 @@ import React, {
   useState,
 } from "react"
 
-import { isMobile } from "react-device-detect"
 import { ChevronDown } from "baseui/icon"
 import {
   type OnChangeParams,
@@ -43,6 +42,7 @@ import {
   WidgetLabel,
 } from "~lib/components/widgets/BaseWidget"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { isMobile } from "~lib/util/isMobile"
 
 export interface Props {
   value: string | null
@@ -269,7 +269,8 @@ const Selectbox: React.FC<Props> = ({
           Input: {
             props: {
               // Change the 'readonly' prop to hide the mobile keyboard if options < 10
-              readOnly: isMobile && !showKeyboardOnMobile ? "readonly" : null,
+              readOnly:
+                isMobile() && !showKeyboardOnMobile ? "readonly" : null,
             },
             style: () => ({
               lineHeight: theme.lineHeights.inputWidget,

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -26,9 +26,9 @@ import WebcamComponent, { Props, WebcamPermission } from "./WebcamComponent"
 
 vi.mock("react-webcam")
 
-vi.mock("react-device-detect", () => {
+vi.mock("~lib/util/isMobile", () => {
   return {
-    isMobile: true,
+    isMobile: () => true,
   }
 })
 

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -24,9 +24,9 @@ import React, {
 } from "react"
 
 import { Video } from "@emotion-icons/open-iconic"
-import { isMobile } from "react-device-detect"
 import Webcam from "react-webcam"
 
+import { isMobile } from "~lib/util/isMobile"
 import { debounce } from "~lib/util/utils"
 import Icon from "~lib/components/shared/Icon"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
@@ -129,7 +129,9 @@ const WebcamComponent = ({
       !clearPhotoInProgress ? (
         <AskForCameraPermission width={debouncedWidth} />
       ) : (
-        isMobile && <SwitchFacingModeButton switchFacingMode={setFacingMode} />
+        isMobile() && (
+          <SwitchFacingModeButton switchFacingMode={setFacingMode} />
+        )
       )}
       <StyledBox
         data-testid="stCameraInputWebcamStyledBox"

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -24,10 +24,10 @@ import {
   Select as UISelect,
 } from "baseui/select"
 import without from "lodash/without"
-import { isMobile } from "react-device-detect"
 
 import { MultiSelect as MultiSelectProto } from "@streamlit/protobuf"
 
+import { isMobile } from "~lib/util/isMobile"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { VirtualDropdown } from "~lib/components/shared/Dropdown"
 import { fuzzyFilterSelectOptions } from "~lib/components/shared/Dropdown/Selectbox"
@@ -423,7 +423,7 @@ const Multiselect: FC<Props> = props => {
               props: {
                 // Change the 'readonly' prop to hide the mobile keyboard if options < 10
                 readOnly:
-                  isMobile && showKeyboardOnMobile === false
+                  isMobile() && showKeyboardOnMobile === false
                     ? "readonly"
                     : null,
               },

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -111,6 +111,7 @@ export { default as emotionLightTheme } from "./theme/emotionLightTheme"
 export { fonts, spacing } from "./theme/primitives"
 export { ensureError } from "./util/ErrorHandling"
 export { useIsOverflowing } from "./util/Hooks"
+export { isMobile } from "./util/isMobile"
 export {
   mark,
   measure,

--- a/frontend/lib/src/util/isMobile.ts
+++ b/frontend/lib/src/util/isMobile.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UAParser from "ua-parser-js"
+
+const parser = new UAParser()
+
+/**
+ * Utilizes user agent to determine if the user is on a mobile device.
+ * Note: This is a simple heuristic and may not be 100% accurate.
+ *
+ * @returns true if the user is on a mobile device, false otherwise
+ */
+export function isMobile(): boolean {
+  const result = parser.getResult()
+  return result.device.type === "mobile"
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3225,7 +3225,6 @@ __metadata:
     rc-overflow: "npm:^1.4.1"
     re-resizable: "npm:^6.11.2"
     react: "npm:^18.2.0"
-    react-device-detect: "npm:^2.2.2"
     react-dom: "npm:^18.2.0"
     react-feather: "npm:^2.0.10"
     react-hot-keys: "npm:^2.7.3"
@@ -3325,6 +3324,7 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:^15.5.5"
     "@types/react-window": "npm:~1.8.8"
     "@types/sprintf-js": "npm:^1.1.4"
+    "@types/ua-parser-js": "npm:^0.7.39"
     "@types/uuid": "npm:^10.0.0"
     "@types/wavesurfer.js": "npm:^6.0.12"
     "@types/xxhashjs": "npm:^0.2.2"
@@ -3367,7 +3367,6 @@ __metadata:
     re-resizable: "npm:^6.11.2"
     react-color: "npm:^2.18.1"
     react-debounce-render: "npm:^8.0.2"
-    react-device-detect: "npm:^2.2.2"
     react-dropzone: "npm:^14.3.8"
     react-feather: "npm:^2.0.10"
     react-json-view: "npm:^1.19.1"
@@ -3390,6 +3389,7 @@ __metadata:
     tsc-alias: "npm:^1.8.16"
     typed-signals: "npm:^3.0.0"
     typesync: "npm:^0.14.3"
+    ua-parser-js: "npm:^1.0.40"
     unified: "npm:^11.0.5"
     unist-util-visit: "npm:^5.0.0"
     urlpattern-polyfill: "npm:^10.1.0"
@@ -16426,18 +16426,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-device-detect@npm:^2.2.2":
-  version: 2.2.3
-  resolution: "react-device-detect@npm:2.2.3"
-  dependencies:
-    ua-parser-js: "npm:^1.0.33"
-  peerDependencies:
-    react: ">= 0.14.0"
-    react-dom: ">= 0.14.0"
-  checksum: 10c0/396bbeeab0cb21da084c67434d204c9cf502fad6c683903313084d3f6487950a36a34f9bf67ccf5c1772a1bb5b79a2a4403fcfe6b51d93877db4c2d9f3a3a925
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^18.2.0":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
@@ -19296,7 +19284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.33, ua-parser-js@npm:^1.0.35":
+"ua-parser-js@npm:^1.0.35":
   version: 1.0.39
   resolution: "ua-parser-js@npm:1.0.39"
   bin:


### PR DESCRIPTION
## Describe your changes

- Noticed that we had 2 dependencies that kind of do the same thing. This removes `react-device-detect` in favor of standardizing on `ua-parser-js`
- While not super significant, this removes 13kb from the wheel file. This will also reduce the size of our bundles sent to the user's browser at run time.

## GitHub Issue Link (if applicable)

## Testing Plan

- Updates unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
