### PR TITLE
Support proxying requests to fetch custom component assets

### DIFF
--- a/lib/streamlit/components/types/base_custom_component.py
+++ b/lib/streamlit/components/types/base_custom_component.py
@@ -41,10 +41,8 @@ class BaseCustomComponent(ABC):
         url: str | None = None,
         module_name: str | None = None,
     ) -> None:
-        if (path is None and url is None) or (path is not None and url is not None):
-            raise StreamlitAPIException(
-                "Either 'path' or 'url' must be set, but not both."
-            )
+        if path is None and url is None:
+            raise StreamlitAPIException("Either 'path' or 'url' must be set.")
 
         self._name = name
         self._path = path

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.runtime import get_instance
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -77,12 +78,15 @@ def declare_component(
         The path to serve the component's frontend files from. The path should
         be absolute. If ``path`` is ``None`` (default), Streamlit will serve
         the component from the location in ``url``. Either ``path`` or ``url``
-        must be specified, but not both.
+        must be specified. If both are specified, then ``url`` will take
+        precedence.
 
     url: str or None
         The URL that the component is served from. If ``url`` is ``None``
         (default), Streamlit will serve the component from the location in
-        ``path``. Either ``path`` or ``url`` must be specified, but not both.
+        ``path``. Either ``path`` or ``url`` must be specified. If both are
+        specified, then ``url`` will take precedence.
+
 
     Returns
     -------
@@ -108,6 +112,15 @@ def declare_component(
 
     # Build the component name.
     component_name = f"{module_name}.{name}"
+
+    # NOTE: We intentionally don't mention this behavior in this function's
+    # docstring as we're only using it internally for now (the config option
+    # is also hidden). This should be properly documented if/when we do decide
+    # to expose it more publicly.
+    if not url and (
+        component_base_path := config.get_option("server.customComponentBaseUrlPath")
+    ):
+        url = f"{component_base_path}/{component_name}/"
 
     # Create our component object, and register it.
     component = CustomComponent(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -812,6 +812,19 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "server.customComponentBaseUrlPath",
+    description="""
+        The base path for the URL where Streamlit should serve custom
+        components. If this config var is set and a call to ``declare_component``
+        does not specify a URL, the component's URL will be set to
+        ``f"{server.customComponentBaseUrlPath}/{component_name}/"``.
+    """,
+    default_val="",
+    type_=str,
+    visibility="hidden",
+)
+
 # TODO: Rename to server.enableCorsProtection.
 _create_option(
     "server.enableCORS",

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -534,6 +534,7 @@ class ConfigTest(unittest.TestCase):
                 "mapbox.token",
                 "secrets.files",
                 "server.baseUrlPath",
+                "server.customComponentBaseUrlPath",
                 "server.enableCORS",
                 "server.cookieSecret",
                 "server.corsAllowedOrigins",


### PR DESCRIPTION
## Describe your changes

In some of our deployments of Streamlit in Snowflake, we need to be able to proxy requests
to fetch custom component assets through another service (for authentication / origin reasons)
but still rely on the Streamlit server's endpoints to server custom component assets. This can't
be done today as we explicitly disallow setting both a `url` and `path` for a component at once,
but it seems like this restriction was put in place at the time because we didn't expect people
to ever want to do this. Now that we have a good reason to do so, it shouldn't hurt to remove
the code preventing it.

We also add a new `server.customComponentBaseUrlPath` config option that makes it
possible to automatically set URLs for a component to be
`{server.customComponentBaseUrlPath}/{component_name}` when set. For now, the new
config option is kept hidden so that the API can change freely if needed, but if we see demand
from elsewhere in the community to do this kind of thing, we may publicly expose it.

## Testing Plan

- Unit Tests (JS and/or Python)
   - Updated both JS and Python tests where needed
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
