### PR TITLE
Fix wrong parameter in flaky decorator

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -269,7 +269,7 @@ def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port
     )
 
 
-@pytest.mark.flaky(max_runs=4)
+@pytest.mark.flaky(reruns=4)
 def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that logos display properly in sidebar and main sections."""
 
@@ -303,7 +303,7 @@ def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     assert_snapshot(collapsed_logo_image, name="collapsed-header-logo")
 
 
-@pytest.mark.flaky(max_runs=4)
+@pytest.mark.flaky(reruns=4)
 def test_renders_small_logos(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that small logos display properly in sidebar and main sections."""
 
@@ -320,7 +320,7 @@ def test_renders_small_logos(app: Page, assert_snapshot: ImageCompareFunction):
     assert_snapshot(app.get_by_test_id("stSidebar"), name="small-sidebar-logo")
 
 
-@pytest.mark.flaky(max_runs=4)
+@pytest.mark.flaky(reruns=4)
 def test_renders_large_logos(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that large logos display properly in sidebar and main sections."""
 


### PR DESCRIPTION
## Describe your changes

The rerun parameter is named based on the [`flaky` plugin](https://pypi.org/project/flaky/). However, we are using the  `pytest-rerunfailures` plugin which calls this parameter `reruns`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
