### PR TITLE
Add `corepack enable` to makefile along with `corepack install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,14 +260,15 @@ protobuf:
 .PHONY: react-init
 # Install all frontend dependencies.
 react-init:
-	cd frontend/ ; \
-	if command -v "corepack" > /dev/null; then \
-		if ! command -v "yarn" > /dev/null; then \
-			corepack enable ; \
-		fi ; \
-		corepack install ; \
-	fi ; \
-	yarn install --immutable
+	@cd frontend/ && { \
+		corepack enable yarn; \
+		if [ $$? -ne 0 ]; then \
+			echo "Error: 'corepack' command not found or failed to enable."; \
+			echo "Please ensure you are running the expected version of Node.js as defined in '.nvmrc'."; \
+			exit 1; \
+		fi; \
+		corepack install && yarn install --immutable; \
+	}
 
 .PHONY: frontend
 # Build frontend into static files.

--- a/Makefile
+++ b/Makefile
@@ -262,8 +262,11 @@ protobuf:
 react-init:
 	cd frontend/ ; \
 	if command -v "corepack" > /dev/null; then \
-		corepack enable; corepack install ; \
-	fi;\
+		if ! command -v "yarn" > /dev/null; then \
+			corepack enable ; \
+		fi ; \
+		corepack install ; \
+	fi ; \
 	yarn install --immutable
 
 .PHONY: frontend

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ protobuf:
 react-init:
 	cd frontend/ ; \
 	if command -v "corepack" > /dev/null; then \
-		corepack install ; \
+		corepack enable; corepack install ; \
 	fi;\
 	yarn install --immutable
 


### PR DESCRIPTION
## Describe your changes

Previously, I raised the issue #10754, which was, ultimately, a feature request about not having to manually activate the yarn functionality of corepack. The way you enable that is by running `corepack enable; corepack install`. The commit https://github.com/streamlit/streamlit/commit/1ef4bba5d42ca7684e7e8e419b66f03dc192dc8c#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R265 added the `corepack install` part. This adds the `corepack enable` part.

If `corepack enable` was omitted to avoid overriding the user's version of yarn if they have a non-corepack edition of yarn already in use, then maybe the `corepack enable` I'm adding here should be wrapped in an `if command -v "yarn" > /dev/null; then`...`fi`? I have done so in the second of the two commits in this PR; the first may be cherry-picked instead if that wasn't desirable.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/10754

## Testing Plan

The software will fail to build if this is wrong, so the current CI/CD is likely sufficient.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
