### PR TITLE
Add `styleOverrides` param to `useLayoutStyles`

### DIFF
--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -29,10 +29,40 @@ export const StyledElementContainerLayoutWrapper: FC<
     node: ElementNode
   }
 > = ({ node, ...rest }) => {
+  let styleOverrides = {}
+  if (node.element.type === "imgs") {
+    // The st.image element is potentially a list of images, so we always want
+    // the enclosing container to be full width. The size of individual
+    // images is managed in the ImageList component.
+    styleOverrides = {
+      width: "100%",
+    }
+  } else if (node.element.type === "textArea") {
+    // The st.text_area element has a legacy implementation where the height
+    // is measuring only the input box so the pixel height must be set in the element
+    // and the container must be allowed to expand.
+    // The difference between content and stretch is so that this element will
+    // behave correctly inside containers.
+    styleOverrides = {
+      height: node.element.heightConfig?.useContent ? "auto" : "100%",
+    }
+  } else if (
+    node.element.type === "iframe" ||
+    node.element.type === "deckGlJsonChart" ||
+    node.element.type === "arrowDataFrame"
+  ) {
+    // TODO(lwilby): Some elements need overflow to be visible in webkit. Will investigate
+    // if we can remove this custom handling in future layouts work.
+    styleOverrides = {
+      overflow: "visible",
+    }
+  }
+
   const styles = useLayoutStyles({
     element: node.element,
     subElement:
       (node.element?.type && node.element[node.element.type]) || undefined,
+    styleOverrides,
   })
 
   return <StyledElementContainer {...rest} {...styles} />

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -40,11 +40,13 @@ export const StyledElementContainerLayoutWrapper: FC<
   } else if (node.element.type === "textArea") {
     // The st.text_area element has a legacy implementation where the height
     // is measuring only the input box so the pixel height must be set in the element
-    // and the container must be allowed to expand.
-    // The difference between content and stretch is so that this element will
-    // behave correctly inside containers.
+    // and the container must be allowed to expand. Additionally, we don't want the
+    // flex with height to be set on the element container.
+    // TODO(lawilby): The PR expanding the height of text_area elements will
+    // make st.text_area consistent with the other elements and we can remove this.
     styleOverrides = {
-      height: "100%",
+      height: "auto",
+      flex: "",
     }
   } else if (
     node.element.type === "iframe" ||

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import React, { FC, useMemo } from "react"
 
 import { useLayoutStyles } from "~lib/components/core/Layout/useLayoutStyles"
 import type { ElementNode } from "~lib/AppNode"
@@ -29,36 +29,39 @@ export const StyledElementContainerLayoutWrapper: FC<
     node: ElementNode
   }
 > = ({ node, ...rest }) => {
-  let styleOverrides = {}
-  if (node.element.type === "imgs") {
-    // The st.image element is potentially a list of images, so we always want
-    // the enclosing container to be full width. The size of individual
-    // images is managed in the ImageList component.
-    styleOverrides = {
-      width: "100%",
+  const styleOverrides = useMemo(() => {
+    if (node.element.type === "imgs") {
+      // The st.image element is potentially a list of images, so we always want
+      // the enclosing container to be full width. The size of individual
+      // images is managed in the ImageList component.
+      return {
+        width: "100%",
+      }
+    } else if (node.element.type === "textArea") {
+      // The st.text_area element has a legacy implementation where the height
+      // is measuring only the input box so the pixel height must be set in the element
+      // and the container must be allowed to expand. Additionally, we don't want the
+      // flex with height to be set on the element container.
+      // TODO(lawilby): The PR expanding the height of text_area elements will
+      // make st.text_area consistent with the other elements and we can remove this.
+      return {
+        height: "auto",
+        flex: "",
+      }
+    } else if (
+      node.element.type === "iframe" ||
+      node.element.type === "deckGlJsonChart" ||
+      node.element.type === "arrowDataFrame"
+    ) {
+      // TODO(lwilby): Some elements need overflow to be visible in webkit. Will investigate
+      // if we can remove this custom handling in future layouts work.
+      return {
+        overflow: "visible",
+      }
     }
-  } else if (node.element.type === "textArea") {
-    // The st.text_area element has a legacy implementation where the height
-    // is measuring only the input box so the pixel height must be set in the element
-    // and the container must be allowed to expand. Additionally, we don't want the
-    // flex with height to be set on the element container.
-    // TODO(lawilby): The PR expanding the height of text_area elements will
-    // make st.text_area consistent with the other elements and we can remove this.
-    styleOverrides = {
-      height: "auto",
-      flex: "",
-    }
-  } else if (
-    node.element.type === "iframe" ||
-    node.element.type === "deckGlJsonChart" ||
-    node.element.type === "arrowDataFrame"
-  ) {
-    // TODO(lwilby): Some elements need overflow to be visible in webkit. Will investigate
-    // if we can remove this custom handling in future layouts work.
-    styleOverrides = {
-      overflow: "visible",
-    }
-  }
+
+    return {}
+  }, [node.element.type])
 
   const styles = useLayoutStyles({
     element: node.element,

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -37,6 +37,15 @@ export const StyledElementContainerLayoutWrapper: FC<
     styleOverrides = {
       width: "100%",
     }
+  } else if (node.element.type === "textArea") {
+    // The st.text_area element has a legacy implementation where the height
+    // is measuring only the input box so the pixel height must be set in the element
+    // and the container must be allowed to expand.
+    // The difference between content and stretch is so that this element will
+    // behave correctly inside containers.
+    styleOverrides = {
+      height: node.element.heightConfig?.useContent ? "auto" : "100%",
+    }
   } else if (
     node.element.type === "iframe" ||
     node.element.type === "deckGlJsonChart" ||

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -44,7 +44,7 @@ export const StyledElementContainerLayoutWrapper: FC<
     // The difference between content and stretch is so that this element will
     // behave correctly inside containers.
     styleOverrides = {
-      height: node.element.heightConfig?.useContent ? "auto" : "100%",
+      height: "100%",
     }
   } else if (
     node.element.type === "iframe" ||

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -37,15 +37,6 @@ export const StyledElementContainerLayoutWrapper: FC<
     styleOverrides = {
       width: "100%",
     }
-  } else if (node.element.type === "textArea") {
-    // The st.text_area element has a legacy implementation where the height
-    // is measuring only the input box so the pixel height must be set in the element
-    // and the container must be allowed to expand.
-    // The difference between content and stretch is so that this element will
-    // behave correctly inside containers.
-    styleOverrides = {
-      height: node.element.heightConfig?.useContent ? "auto" : "100%",
-    }
   } else if (
     node.element.type === "iframe" ||
     node.element.type === "deckGlJsonChart" ||

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -658,6 +658,7 @@ describe("#useLayoutStyles", () => {
           width: "50%",
           height: "150px",
           overflow: "hidden",
+          flex: "0 0 150px",
         }
 
         const { result } = renderHook(() =>
@@ -665,9 +666,10 @@ describe("#useLayoutStyles", () => {
         )
 
         expect(result.current).toEqual({
-          width: "50%", // overridden from calculated "200px"
-          height: "150px", // overridden from calculated "300px"
-          overflow: "hidden", // overridden from calculated "auto"
+          width: "50%",
+          height: "150px",
+          overflow: "hidden",
+          flex: "0 0 150px",
         })
       })
 
@@ -686,9 +688,10 @@ describe("#useLayoutStyles", () => {
         )
 
         expect(result.current).toEqual({
-          width: "75%", // overridden
-          height: "300px", // computed value preserved
-          overflow: "auto", // computed value preserved
+          width: "75%",
+          height: "300px",
+          overflow: "auto",
+          flex: "0 0 300px",
         })
       })
 

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -54,7 +54,7 @@ describe("#useLayoutStyles", () => {
         [0, getDefaultStyles({})],
         [-100, getDefaultStyles({})],
         [NaN, getDefaultStyles({})],
-        [100, getDefaultStyles({ width: 100 })],
+        [100, getDefaultStyles({ width: "100px" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = new MockElement()
         const subElement = { width, useContainerWidth }
@@ -76,25 +76,6 @@ describe("#useLayoutStyles", () => {
         [100, getDefaultStyles({ width: "100%" })],
       ])("and with a width value of %s, returns %o", (width, expected) => {
         const element = new MockElement()
-        const subElement = { width, useContainerWidth }
-        const { result } = renderHook(() =>
-          useLayoutStyles({ element, subElement })
-        )
-        expect(result.current).toEqual(expected)
-      })
-    })
-
-    describe("that is an image list", () => {
-      const useContainerWidth = false
-
-      it.each([
-        [undefined, getDefaultStyles({ width: "100%" })],
-        [0, getDefaultStyles({ width: "100%" })],
-        [-100, getDefaultStyles({ width: "100%" })],
-        [NaN, getDefaultStyles({ width: "100%" })],
-        [100, getDefaultStyles({ width: "100%" })],
-      ])("and with a width value of %s, returns %o", (width, expected) => {
-        const element = new MockElement({ type: "imgs" })
         const subElement = { width, useContainerWidth }
         const { result } = renderHook(() =>
           useLayoutStyles({ element, subElement })
@@ -128,7 +109,7 @@ describe("#useLayoutStyles", () => {
         [
           new streamlit.WidthConfig({ pixelWidth: 100 }),
           false,
-          getDefaultStyles({ width: 100 }),
+          getDefaultStyles({ width: "100px" }),
         ],
         [
           new streamlit.WidthConfig({ pixelWidth: 100 }),
@@ -153,7 +134,7 @@ describe("#useLayoutStyles", () => {
         [0, false, getDefaultStyles({})],
         [-100, false, getDefaultStyles({})],
         [NaN, false, getDefaultStyles({})],
-        [100, false, getDefaultStyles({ width: 100 })],
+        [100, false, getDefaultStyles({ width: "100px" })],
         [0, true, getDefaultStyles({ width: "100%" })],
         [-100, true, getDefaultStyles({ width: "100%" })],
         [NaN, true, getDefaultStyles({ width: "100%" })],
@@ -219,7 +200,7 @@ describe("#useLayoutStyles", () => {
             width: 100,
           },
           false,
-          getDefaultStyles({ width: 200 }),
+          getDefaultStyles({ width: "200px" }),
         ],
         [
           {
@@ -275,13 +256,13 @@ describe("#useLayoutStyles", () => {
 
     describe("with width defined on subElement but element.widthConfig is null or undefined", () => {
       it.each([
-        [100, false, null, getDefaultStyles({ width: 100 })],
-        [200, false, null, getDefaultStyles({ width: 200 })],
+        [100, false, null, getDefaultStyles({ width: "100px" })],
+        [200, false, null, getDefaultStyles({ width: "200px" })],
         [100, true, null, getDefaultStyles({ width: "100%" })],
         [0, false, null, getDefaultStyles({})],
         [-100, false, null, getDefaultStyles({})],
-        [100, false, undefined, getDefaultStyles({ width: 100 })],
-        [200, false, undefined, getDefaultStyles({ width: 200 })],
+        [100, false, undefined, getDefaultStyles({ width: "100px" })],
+        [200, false, undefined, getDefaultStyles({ width: "200px" })],
         [100, true, undefined, getDefaultStyles({ width: "100%" })],
         [0, false, undefined, getDefaultStyles({})],
         [-100, false, undefined, getDefaultStyles({})],
@@ -318,7 +299,7 @@ describe("#useLayoutStyles", () => {
         [
           new streamlit.HeightConfig({ pixelHeight: 100 }),
           getDefaultStyles({
-            height: 100,
+            height: "100px",
             overflow: "auto",
             flex: "0 0 100px",
           }),
@@ -356,7 +337,7 @@ describe("#useLayoutStyles", () => {
           100,
           null,
           getDefaultStyles({
-            height: 100,
+            height: "100px",
             overflow: "auto",
             flex: "0 0 100px",
           }),
@@ -365,7 +346,7 @@ describe("#useLayoutStyles", () => {
           200,
           null,
           getDefaultStyles({
-            height: 200,
+            height: "200px",
             overflow: "auto",
             flex: "0 0 200px",
           }),
@@ -377,7 +358,7 @@ describe("#useLayoutStyles", () => {
           100,
           undefined,
           getDefaultStyles({
-            height: 100,
+            height: "100px",
             overflow: "auto",
             flex: "0 0 100px",
           }),
@@ -386,7 +367,7 @@ describe("#useLayoutStyles", () => {
           200,
           undefined,
           getDefaultStyles({
-            height: 200,
+            height: "200px",
             overflow: "auto",
             flex: "0 0 200px",
           }),
@@ -422,7 +403,7 @@ describe("#useLayoutStyles", () => {
         [
           100,
           getDefaultStyles({
-            height: 100,
+            height: "100px",
             overflow: "auto",
             flex: "0 0 100px",
           }),
@@ -433,33 +414,6 @@ describe("#useLayoutStyles", () => {
         const { result } = renderHook(() =>
           useLayoutStyles({ element, subElement })
         )
-        expect(result.current).toEqual(expected)
-      })
-    })
-
-    describe("with text area element type", () => {
-      it.each([
-        [
-          new streamlit.HeightConfig({ useStretch: true }),
-          getDefaultStyles({ height: "100%" }),
-        ],
-        [
-          new streamlit.HeightConfig({ useContent: true }),
-          getDefaultStyles({ height: "auto" }),
-        ],
-        [
-          new streamlit.HeightConfig({ pixelHeight: 100 }),
-          getDefaultStyles({ height: "auto" }),
-        ],
-        [null, getDefaultStyles({ height: "auto" })],
-        [undefined, getDefaultStyles({ height: "auto" })],
-      ])("and with heightConfig %s, returns %o", (heightConfig, expected) => {
-        const element = new MockElement({
-          type: "textArea",
-          heightConfig,
-        })
-
-        const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current).toEqual(expected)
       })
     })
@@ -486,7 +440,7 @@ describe("#useLayoutStyles", () => {
             height: 100,
           },
           getDefaultStyles({
-            height: 200,
+            height: "200px",
             overflow: "auto",
             flex: "0 0 200px",
           }),
@@ -536,8 +490,8 @@ describe("#useLayoutStyles", () => {
             heightConfig: new streamlit.HeightConfig({ pixelHeight: 300 }),
           },
           getDefaultStyles({
-            width: 200,
-            height: 300,
+            width: "200px",
+            height: "300px",
             overflow: "auto",
             flex: "0 0 300px",
           }),
@@ -568,8 +522,8 @@ describe("#useLayoutStyles", () => {
         [
           { width: 200, height: 300 },
           getDefaultStyles({
-            width: 200,
-            height: 300,
+            width: "200px",
+            height: "300px",
             overflow: "auto",
             flex: "0 0 300px",
           }),
@@ -578,14 +532,17 @@ describe("#useLayoutStyles", () => {
           { width: 0, height: 100 },
           getDefaultStyles({
             width: "auto",
-            height: 100,
+            height: "100px",
             overflow: "auto",
             flex: "0 0 100px",
           }),
         ],
         [
           { width: 100, height: 0 },
-          getDefaultStyles({ width: 100, height: "auto" }),
+          getDefaultStyles({
+            width: "100px",
+            height: "auto",
+          }),
         ],
       ])(
         "and with subElement props %o, returns %o",
@@ -623,7 +580,7 @@ describe("#useLayoutStyles", () => {
               pixelWidth: 150,
             }),
           },
-          getDefaultStyles({ width: 150, height: "auto" }),
+          getDefaultStyles({ width: "150px", height: "auto" }),
         ],
       ])(
         "and with subElement widthConfig %o, returns %o",
@@ -687,6 +644,86 @@ describe("#useLayoutStyles", () => {
         const element = new MockElement({ heightConfig })
         const { result } = renderHook(() => useLayoutStyles({ element }))
         expect(result.current.flex).toBeUndefined()
+      })
+    })
+
+    describe("with styleOverrides", () => {
+      it("applies style overrides to computed styles", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ pixelWidth: 200 }),
+          heightConfig: new streamlit.HeightConfig({ pixelHeight: 300 }),
+        })
+
+        const styleOverrides = {
+          width: "50%",
+          height: "150px",
+          overflow: "hidden",
+        }
+
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, styleOverrides })
+        )
+
+        expect(result.current).toEqual({
+          width: "50%", // overridden from calculated "200px"
+          height: "150px", // overridden from calculated "300px"
+          overflow: "hidden", // overridden from calculated "auto"
+        })
+      })
+
+      it("partially overrides computed styles", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ pixelWidth: 200 }),
+          heightConfig: new streamlit.HeightConfig({ pixelHeight: 300 }),
+        })
+
+        const styleOverrides = {
+          width: "75%",
+        }
+
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, styleOverrides })
+        )
+
+        expect(result.current).toEqual({
+          width: "75%", // overridden
+          height: "300px", // computed value preserved
+          overflow: "auto", // computed value preserved
+        })
+      })
+
+      it("handles empty styleOverrides", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ pixelWidth: 100 }),
+        })
+
+        const styleOverrides = {}
+
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, styleOverrides })
+        )
+
+        expect(result.current).toEqual({
+          width: "100px",
+          height: "auto",
+          overflow: "visible",
+        })
+      })
+
+      it("handles undefined styleOverrides", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ pixelWidth: 100 }),
+        })
+
+        const { result } = renderHook(() =>
+          useLayoutStyles({ element, styleOverrides: undefined })
+        )
+
+        expect(result.current).toEqual({
+          width: "100px",
+          height: "auto",
+          overflow: "visible",
+        })
       })
     })
   })

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -27,11 +27,18 @@ type SubElement = {
   widthConfig?: streamlit.IWidthConfig | null | undefined
 }
 
+type StyleOverrides = {
+  height?: string
+  width?: string
+  overflow?: string
+}
+
 export type UseLayoutStylesArgs = {
   element: Element | BlockProto
-  // subElement supports older config where the height is set on the lower
-  // level element. This will be the proto corresponding to the element type, e.g. "textArea".
+  // subElement supports older config where the width/height is set on the lower
+  // level element.
   subElement?: SubElement
+  styleOverrides?: StyleOverrides
 }
 
 const isNonZeroPositiveNumber = (value: unknown): value is number =>
@@ -148,6 +155,7 @@ export type UseLayoutStylesShape = {
 export const useLayoutStyles = ({
   element,
   subElement,
+  styleOverrides,
 }: UseLayoutStylesArgs): UseLayoutStylesShape => {
   // Note: Consider rounding the width to the nearest pixel so we don't have
   // subpixel widths, which leads to blurriness on screen
@@ -161,21 +169,15 @@ export const useLayoutStyles = ({
     }
     let flex: React.CSSProperties["flex"] = undefined
 
-    // The st.image element is potentially a list of images, so we always want
-    // the enclosing container to be full width. The size of individual
-    // images is managed in the ImageList component.
-    const isImgList = element.type === "imgs"
-
     const { pixels: commandWidth, type: widthType } = getWidth(
       element,
       subElement
     )
     let width: React.CSSProperties["width"] = "auto"
-
-    if (widthType === DimensionType.STRETCH || isImgList) {
+    if (widthType === DimensionType.STRETCH) {
       width = "100%"
     } else if (widthType === DimensionType.PIXEL) {
-      width = commandWidth
+      width = `${commandWidth}px`
     } else if (widthType === DimensionType.CONTENT) {
       width = "fit-content"
     }
@@ -187,37 +189,30 @@ export const useLayoutStyles = ({
     let height: React.CSSProperties["height"] = "auto"
     let overflow: React.CSSProperties["overflow"] = "visible"
 
-    // The st.text_area element has a legacy implementation where the height
-    // is measuring only the input box so the pixel height must be set in the element
-    // and the container must be allowed to expand.
-    const isTextArea = element.type === "textArea"
-
-    // TODO(lwilby): Some elements need overflow to be visible in webkit. Will investigate
-    // if we can remove this custom handling in future layouts work.
-    const skipOverflow =
-      element.type === "iframe" ||
-      element.type === "deckGlJsonChart" ||
-      element.type === "arrowDataFrame"
-
     if (heightType === DimensionType.STRETCH) {
       height = "100%"
-    } else if (heightType === DimensionType.CONTENT || isTextArea) {
+    } else if (heightType === DimensionType.CONTENT) {
       height = "auto"
     } else if (heightType === DimensionType.PIXEL) {
-      height = commandHeight
-      overflow = skipOverflow ? "visible" : "auto"
+      height = `${commandHeight}px`
+      overflow = "auto"
       // TODO (lawilby): We only have vertical containers currently, but this will be
       // modified to handle horizontal containers when direction on containers is implemented.
       flex = `0 0 ${commandHeight}px`
     }
 
-    return {
+    const calculated_styles = {
       width,
       height,
       overflow,
       flex,
     }
-  }, [element, subElement])
+
+    return {
+      ...calculated_styles,
+      ...styleOverrides,
+    }
+  }, [element, subElement, styleOverrides])
 
   return layoutStyles
 }

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -28,7 +28,7 @@ type SubElement = {
 }
 
 type StyleOverrides = Partial<
-  Pick<UseLayoutStylesShape, "height" | "width" | "overflow">
+  Pick<UseLayoutStylesShape, "height" | "width" | "overflow" | "flex">
 >
 
 export type UseLayoutStylesArgs = {

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -27,11 +27,9 @@ type SubElement = {
   widthConfig?: streamlit.IWidthConfig | null | undefined
 }
 
-type StyleOverrides = {
-  height?: string
-  width?: string
-  overflow?: string
-}
+type StyleOverrides = Partial<
+  Pick<UseLayoutStylesShape, "height" | "width" | "overflow">
+>
 
 export type UseLayoutStylesArgs = {
   element: Element | BlockProto
@@ -201,7 +199,7 @@ export const useLayoutStyles = ({
       flex = `0 0 ${commandHeight}px`
     }
 
-    const calculated_styles = {
+    const calculatedStyles = {
       width,
       height,
       overflow,
@@ -209,7 +207,7 @@ export const useLayoutStyles = ({
     }
 
     return {
-      ...calculated_styles,
+      ...calculatedStyles,
       ...styleOverrides,
     }
   }, [element, subElement, styleOverrides])


### PR DESCRIPTION
## Describe your changes

Some light refactoring to allow for customization of the styles returned from `useLayoutStyles` via injection instead of with case carve-outs inside of the function. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Unit Tests (JS and/or Python) ✅

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
