### PR TITLE
remove the obsolete `install` make target, which no longer exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help:
 
 .PHONY: all
 # Get dependencies, build frontend, install Streamlit into Python environment.
-all: init frontend install
+all: init frontend
 
 .PHONY: all-devel
 # Get dependencies and install Streamlit into Python environment -- but do not build the frontend.


### PR DESCRIPTION
Fixes #11725

## Describe your changes

This change removes an invocation of the make target `install` which no longer exists.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/11725

## Testing Plan

This only removes a harmless error `make: *** No rule to make target 'install', needed by 'all'. Stop.` that occurred at the end of make runs, and no further tests are presumably required. I have manually verified that streamlit in fact installs when using `all`, etc, and the current CI should catch if that fails for any reason.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
