### PR TITLE
if we're using uv, then use the right python to run playwright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,15 @@ python-init:
 	if command -v "uv" > /dev/null; then \
 		echo "Running command: uv pip install $${pip_args[@]}"; \
 		uv pip install $${pip_args[@]}; \
+		if [ "${INSTALL_TEST_REQS}" = "true" ] ; then\
+			uv run python -m playwright install --with-deps; \
+		fi;\
 	else \
 		echo "Running command: pip install $${pip_args[@]}"; \
 		pip install $${pip_args[@]}; \
-	fi;\
-	if [ "${INSTALL_TEST_REQS}" = "true" ] ; then\
-		python -m playwright install --with-deps; \
+		if [ "${INSTALL_TEST_REQS}" = "true" ] ; then\
+			python -m playwright install --with-deps; \
+		fi;\
 	fi;\
 
 .PHONY: pylint


### PR DESCRIPTION
## Describe your changes

This prevents an error where playwright is not detected as installed, since we just uv installed it but then regular invoke it!

## GitHub Issue Link (if applicable)

## Testing Plan

I did not write any additional tests for this, but manually tested it. If it breaks the current building path (which presumably must be different than how I installed it) then the current CI will fail.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
