### PR TITLE
clear the script cache when all file watchers are disconnected

### DIFF
--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -138,7 +138,7 @@ class WebsocketSessionManager(SessionManager):
             del self._active_session_info_by_id[session_id]
 
         if not self._active_session_info_by_id:
-            # this is to avoid stale cached scripts when all file watchers are closed
+            # Avoid stale cached scripts when all file watchers and sessions are disconnected
             self._script_cache.clear()
 
     def get_active_session_info(self, session_id: str) -> ActiveSessionInfo | None:

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -137,6 +137,10 @@ class WebsocketSessionManager(SessionManager):
             )
             del self._active_session_info_by_id[session_id]
 
+        if not self._active_session_info_by_id:
+            # this is to avoid stale cached scripts when all file watchers are closed
+            self._script_cache.clear()
+
     def get_active_session_info(self, session_id: str) -> ActiveSessionInfo | None:
         return self._active_session_info_by_id.get(session_id)
 


### PR DESCRIPTION
## Describe your changes

The script cache will be stale and have invalid code when all websocket sessions are disconnected.
This is because all file watchers are disconnected, so nobody is picking up on script file changes.
When a new websocket session connects, the same stale script cache will be used, and the run will be incorrect.

Fix this by clearing the script cache when all websocket sessions are disconnected.
The next websocket session will start from a clean cache without stale entry and load the correct app code.
This is because a cleared cache will reload the script bytecode from disk again.


## Testing Plan
- Run streamlit server
- Open app in browser
- Close browser completely
- Edit script
- Reopen app in browser
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
