### PR TITLE
[WIP] Using React Portals to ensure that the toolbar stays outside of containers (`st.container`, `st.form`)

### DIFF
--- a/e2e_playwright/st_container.py
+++ b/e2e_playwright/st_container.py
@@ -87,3 +87,6 @@ with col2:
         st.write("Inside container 7")
     with st.container(height=100, border=True):
         st.write("Inside container 8")
+
+with st.container(height=200, border=True):
+    st.dataframe([1, 2, 3])

--- a/e2e_playwright/st_form.py
+++ b/e2e_playwright/st_form.py
@@ -253,3 +253,7 @@ with st.container(height=600, border=True):
         st.form_submit_button(
             help="Submit by clicking",
         )
+
+with st.form("my_form"):
+    st.dataframe([1, 2, 3])
+    st.form_submit_button("Submit")

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
@@ -89,6 +89,12 @@ export interface ToolbarProps {
   onCollapse?: () => void
   isFullScreen?: boolean
   locked?: boolean
+  isVisible?: boolean
+  // The position of the toolbar can be passed in to allow it to be rendered in a portal.
+  position?: {
+    top: number
+    right: number
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   target?: StyledComponent<any, any, any>
   disableFullscreenMode?: boolean
@@ -99,6 +105,8 @@ const Toolbar: React.FC<React.PropsWithChildren<ToolbarProps>> = ({
   onCollapse,
   isFullScreen,
   locked,
+  isVisible = false,
+  position,
   children,
   target,
   disableFullscreenMode,
@@ -113,7 +121,9 @@ const Toolbar: React.FC<React.PropsWithChildren<ToolbarProps>> = ({
       className="stElementToolbar"
       data-testid="stElementToolbar"
       locked={locked || isFullScreen}
+      isVisible={isVisible}
       target={target}
+      position={position}
     >
       <StyledToolbar data-testid="stElementToolbarButtonContainer">
         {children}

--- a/frontend/lib/src/components/shared/Toolbar/styled-components.ts
+++ b/frontend/lib/src/components/shared/Toolbar/styled-components.ts
@@ -22,31 +22,29 @@ export const TOP_DISTANCE = "-2.65rem"
 
 export interface StyledToolbarWrapperProps {
   locked?: boolean
+  isVisible?: boolean
+  position?: {
+    top: number
+    right: number
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   target?: StyledComponent<any, any, any>
 }
 
 export const StyledToolbarWrapper = styled.div<StyledToolbarWrapperProps>(
-  ({ theme, locked, target }) => ({
+  ({ theme, locked, isVisible, target, position }) => ({
     padding: `${theme.spacing.sm} 0 ${theme.spacing.sm} ${theme.spacing.sm}`,
-    position: "absolute",
-    top: locked ? TOP_DISTANCE : "-1rem",
-    right: theme.spacing.none,
-    transition: "none",
-    ...(!locked && {
-      opacity: 0,
-      "&:active, &:focus-visible, &:hover": {
-        transition: "opacity 150ms 100ms, top 100ms 100ms",
-        opacity: 1,
-        top: TOP_DISTANCE,
-      },
-      ...(target && {
-        [`${target}:hover &, ${target}:active &, ${target}:focus-visible &`]: {
-          transition: "opacity 150ms 100ms, top 100ms 100ms",
-          opacity: 1,
-          top: TOP_DISTANCE,
-        },
-      }),
+    position: position ? "fixed" : "absolute",
+    right: position ? position.right : theme.spacing.none,
+    transition: "opacity 150ms 100ms, top 100ms 100ms",
+
+    opacity: locked || isVisible ? 1 : 0,
+
+    ...(!position && {
+      top: locked || isVisible ? TOP_DISTANCE : "-1rem",
+    }),
+    ...(position && {
+      top: `calc(${position.top}px + ${TOP_DISTANCE})`,
     }),
   })
 )

--- a/frontend/lib/src/hooks/useElementPosition.ts
+++ b/frontend/lib/src/hooks/useElementPosition.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, RefObject, useCallback, useEffect } from "react"
+
+export interface ElementPosition {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+/**
+ * Custom hook that returns the position of a DOM element.
+ *
+ * @param elementRef - A ref to the element.
+ *
+ * @returns The position of the element, or undefined if the element is not yet available.
+ */
+export function useElementPosition(
+  elementRef: RefObject<HTMLElement>
+): ElementPosition | undefined {
+  const [position, setPosition] = useState<ElementPosition | undefined>(
+    undefined
+  )
+
+  const updatePosition = useCallback(() => {
+    if (elementRef.current) {
+      const rect = elementRef.current.getBoundingClientRect()
+      setPosition({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      })
+    }
+  }, [elementRef])
+
+  useEffect(() => {
+    // We want to set the position immediately on mount.
+    updatePosition()
+
+    // We also use a MutationObserver to detect when the element's position
+    // might have changed due to other elements being added or removed.
+    const observer = new MutationObserver(updatePosition)
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true, // For changes that might affect layout
+    })
+
+    window.addEventListener("resize", updatePosition)
+    return () => {
+      window.removeEventListener("resize", updatePosition)
+      observer.disconnect()
+    }
+  }, [updatePosition])
+
+  return position
+}


### PR DESCRIPTION
## Describe your changes

In containers like `st.container` and `st.form`, when the container is set to a fixed width or height, we want content inside the container to scroll and not overflow. The exception is the toolbar on certain elements like dataframes, which should overflow the container when visible. 

This PR uses a react portal to render the toolbar outside of the container. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

#11704

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
