### PR TITLE
Make sure that no loading skeletons exist before running e2e tests

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -46,6 +46,7 @@ from playwright.sync_api import (
     Page,
     Response,
     Route,
+    expect,
 )
 from typing_extensions import Self
 
@@ -953,6 +954,10 @@ def wait_for_app_run(
         timeout=25000,
         state="attached",
     )
+
+    # Wait for all element skeletons to be removed.
+    # This is useful to make sure that all elements have been rendered.
+    expect(page_or_locator.get_by_test_id("stSkeleton")).to_have_count(0, timeout=25000)
 
     if wait_delay > 0:
         # Give the app a little more time to render everything

--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -15,7 +15,6 @@
 from playwright.sync_api import Page, Route, expect
 
 from e2e_playwright.conftest import wait_until
-from e2e_playwright.shared.app_utils import goto_app
 
 # The timeout value from ComponentInstance.tsx
 COMPONENT_READY_WARNING_TIME_MS = 60000  # 60 seconds
@@ -43,7 +42,7 @@ def test_component_source_failure(page: Page, app_port: int):
     page.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(page, f"http://localhost:{app_port}")
+    page.goto(f"http://localhost:{app_port}")
 
     # Expect the iframe to be attached
     expect(page.get_by_test_id("stCustomComponentV1")).to_be_attached()

--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -71,7 +71,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     page.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(page, f"http://localhost:{app_port}")
+    page.goto(f"http://localhost:{app_port}")
 
     # Expect the iframe to be attached
     expect(page.get_by_test_id("stCustomComponentV1")).to_be_attached()

--- a/e2e_playwright/st_components_v1.py
+++ b/e2e_playwright/st_components_v1.py
@@ -36,11 +36,12 @@ components.iframe(src, width=200, height=100, scrolling=True, tab_index=-1)
 # Zero tab_index
 components.iframe(src, width=200, height=100, scrolling=True, tab_index=0)
 
-# Set a query parameter to ensure that it doesn't affect the path of the custom component,
-# since that would trigger a reload if the query param changes
-st.query_params["hello"] = "world"
+if st.toggle("Show custom component"):
+    # Set a query parameter to ensure that it doesn't affect the path of the custom component,
+    # since that would trigger a reload if the query param changes
+    st.query_params["hello"] = "world"
 
-url = "http://not.a.real.url"
-test_component = components.declare_component("test_component", url=url)
+    url = "http://not.a.real.url"
+    test_component = components.declare_component("test_component", url=url)
 
-test_component(key="component_1")
+    test_component(key="component_1")

--- a/e2e_playwright/st_components_v1_test.py
+++ b/e2e_playwright/st_components_v1_test.py
@@ -20,6 +20,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
+    get_checkbox,
     get_element_by_key,
 )
 
@@ -100,6 +101,9 @@ def test_iframe_tab_index_attributes(app: Page):
 def test_declare_component_correctly_sets_attr(app: Page):
     """Test that components.declare_component correctly sets attributes and rendered size."""
 
+    checkbox_element = get_checkbox(app, "Show custom component")
+    checkbox_element.locator("label").click()
+
     declare_component = app.locator("iframe").nth(6)
 
     expect(declare_component).to_have_attribute(
@@ -115,11 +119,17 @@ def test_declare_component_correctly_sets_attr(app: Page):
 
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
+    checkbox_element = get_checkbox(app, "Show custom component")
+    checkbox_element.locator("label").click()
+
     check_top_level_class(app, "stCustomComponentV1")
 
 
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
+    checkbox_element = get_checkbox(app, "Show custom component")
+    checkbox_element.locator("label").click()
+
     expect(get_element_by_key(app, "component_1")).to_be_visible()
 
 

--- a/e2e_playwright/st_components_v1_test.py
+++ b/e2e_playwright/st_components_v1_test.py
@@ -24,6 +24,8 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
 )
 
+NUM_IFRAMES = 6
+
 
 def test_components_iframe_rendering(
     themed_app: Page, assert_snapshot: ImageCompareFunction
@@ -31,7 +33,7 @@ def test_components_iframe_rendering(
     """Test that our components v1 API correctly renders elements via screenshot matching."""
 
     elements = themed_app.locator("iframe")
-    expect(elements).to_have_count(7)
+    expect(elements).to_have_count(NUM_IFRAMES)
 
     # Only doing a snapshot of the html component, since the iframe one
     # does not use a valid URL.


### PR DESCRIPTION
## Describe your changes

This adds a check to `wait_for_app_run` to ensure that there aren't any loading skeletons shown in the app before declaring an app run to be finished. This is an attempt to stabilize our e2e tests.  

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
