### PR TITLE
[fix] Attempt to stabilize some flaky e2e tests

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -26,6 +26,7 @@ from e2e_playwright.shared.app_utils import (
     get_segment_button,
     goto_app,
 )
+from e2e_playwright.shared.react18_utils import take_stable_snapshot
 
 
 def test_loads_main_script_on_initial_page_load(app: Page):
@@ -283,7 +284,12 @@ def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(
         "href", "https://www.example.com"
     )
-    assert_snapshot(app.get_by_test_id("stSidebar"), name="sidebar-logo")
+    take_stable_snapshot(
+        app,
+        app.get_by_test_id("stSidebar"),
+        assert_snapshot,
+        name="sidebar-logo",
+    )
 
     # Collapse the sidebar
     app.get_by_test_id("stSidebarContent").hover()
@@ -300,7 +306,12 @@ def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
 
     collapsed_logo_image = logo_link_element.get_by_test_id("stHeaderLogo")
     expect(collapsed_logo_image).to_be_visible()
-    assert_snapshot(collapsed_logo_image, name="collapsed-header-logo")
+    take_stable_snapshot(
+        app,
+        collapsed_logo_image,
+        assert_snapshot,
+        name="collapsed-header-logo",
+    )
 
 
 @pytest.mark.flaky(reruns=4)
@@ -334,7 +345,12 @@ def test_renders_large_logos(app: Page, assert_snapshot: ImageCompareFunction):
     expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(
         "href", "https://www.example.com"
     )
-    assert_snapshot(app.get_by_test_id("stSidebar"), name="large-sidebar-logo")
+    take_stable_snapshot(
+        app,
+        app.get_by_test_id("stSidebar"),
+        assert_snapshot,
+        name="large-sidebar-logo",
+    )
 
     # Collapse the sidebar
     app.get_by_test_id("stSidebarContent").hover()
@@ -354,7 +370,12 @@ def test_renders_large_logos(app: Page, assert_snapshot: ImageCompareFunction):
 
     collapsed_logo_image = logo_link_element.get_by_test_id("stHeaderLogo")
     expect(collapsed_logo_image).to_be_visible()
-    assert_snapshot(collapsed_logo_image, name="large-collapsed-header-logo")
+    take_stable_snapshot(
+        app,
+        collapsed_logo_image,
+        assert_snapshot,
+        name="large-collapsed-header-logo",
+    )
 
 
 def test_completes_script_lifecycle(app: Page):

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -94,10 +94,14 @@ def test_number_input_shows_instructions_when_dirty(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Test that st.number_input shows the instructions correctly when dirty."""
-    first_number_input = app.get_by_test_id("stNumberInput").first
-    first_number_input.locator("input").fill("10")
+    first_number_input = app.get_by_label("number input 1 (default)")
+    first_number_input.fill("10")
+    # Find the container of the number input to snapshot
+    first_number_input_field = app.locator("[data-testid='stNumberInput']").filter(
+        has=first_number_input
+    )
 
-    assert_snapshot(first_number_input, name="st_number_input-input_instructions")
+    assert_snapshot(first_number_input_field, name="st_number_input-input_instructions")
 
 
 def test_number_input_updates_value_correctly_on_enter(app: Page):
@@ -142,9 +146,7 @@ def test_number_input_has_correct_value_on_increment_click(app: Page):
 
 def test_number_input_has_correct_value_on_arrow_up(app: Page):
     """Test that st.number_input has the correct value on arrow up."""
-    first_number_input_field = (
-        app.get_by_test_id("stNumberInput").nth(0).locator("input")
-    )
+    first_number_input_field = app.get_by_label("number input 1 (default)")
     first_number_input_field.press("ArrowUp")
 
     expect(app.get_by_test_id("stMarkdown").nth(0)).to_have_text(
@@ -155,9 +157,7 @@ def test_number_input_has_correct_value_on_arrow_up(app: Page):
 def test_number_input_has_correct_value_on_blur(app: Page):
     """Test that st.number_input has the correct value on blur."""
 
-    first_number_input_field = (
-        app.get_by_test_id("stNumberInput").nth(0).locator("input")
-    )
+    first_number_input_field = app.get_by_label("number input 1 (default)")
     first_number_input_field.focus()
     first_number_input_field.fill("10")
     first_number_input_field.blur()


### PR DESCRIPTION
## Describe your changes

- Utilize accessible selectors using actual text content to prevent race conditions in `st_number_input_test.py`
- Utilize `take_stable_snapshot` in `mpa_basics_test.py`
  - Note: I don't think this is a 100% perfect fix as I saw one of the tests still flake in webkit on this run: https://github.com/streamlit/streamlit/actions/runs/15886864078/job/44800849878?pr=11768 It passed after re-running, which is why I left the `flaky` pytest marker.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Updates e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
