### PR TITLE
Use previous websocket ping interval for old tornado version

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -54,6 +54,7 @@ from streamlit.web.server.routes import (
 )
 from streamlit.web.server.server_util import (
     get_cookie_secret,
+    is_tornado_version_less_than,
     is_xsrf_enabled,
     make_url_path_regex,
 )
@@ -73,7 +74,8 @@ TORNADO_SETTINGS = {
     # With recent versions of Tornado, this value must be greater than or
     # equal to websocket_ping_timeout.
     # For details, see https://github.com/tornadoweb/tornado/pull/3376
-    "websocket_ping_interval": 30,
+    # For compatibility with older versions of Tornado, we set the value to 1.
+    "websocket_ping_interval": 1 if is_tornado_version_less_than("6.5.0") else 30,
     # If we don't get a ping response within 30s, the connection
     # is timed out.
     "websocket_ping_timeout": 30,

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -21,6 +21,7 @@ from urllib.parse import urljoin
 
 from streamlit import config, net_util, url_util
 from streamlit.runtime.secrets import secrets_singleton
+from streamlit.type_util import is_version_less_than
 
 if TYPE_CHECKING:
     from tornado.web import RequestHandler
@@ -33,6 +34,29 @@ AUTH_COOKIE_NAME: Final = "_streamlit_user"
 
 def allowlisted_origins() -> set[str]:
     return {origin.strip() for origin in config.get_option("server.corsAllowedOrigins")}
+
+
+def is_tornado_version_less_than(v: str) -> bool:
+    """Return True if the current Tornado version is less than the input version.
+
+    Parameters
+    ----------
+    v : str
+        Version string, e.g. "0.25.0"
+
+    Returns
+    -------
+    bool
+
+
+    Raises
+    ------
+    InvalidVersion
+        If the version strings are not valid.
+    """
+    import tornado
+
+    return is_version_less_than(tornado.version, v)
 
 
 def is_url_from_allowed_origins(url: str) -> bool:


### PR DESCRIPTION
## Describe your changes

The new websocket ping interval & ping timeout settings do not work well with older tornado versions, causing the websocket to lose connection in the recurring interval. Therefore, we are only applying the new settings for tornado >= 6.5:

<img width="844" alt="Screenshot 2025-06-26 at 13 33 15" src="https://github.com/user-attachments/assets/fff5fd1a-5a19-488c-af72-5572089ab326" />

## Testing Plan

- The existing test should test this also via our min dependency check. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
