### PR TITLE
[Fix] Mark wrap as transient prop

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -186,7 +186,7 @@ export const FlexBoxContainer = (
       props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
       streamlit.GapSize.SMALL,
     direction: direction,
-    // This is also backwards capatible since previously wrap was not added
+    // This is also backwards compatible since previously wrap was not added
     // to the flex container.
     $flexWrap: props.node.deltaBlock.flexContainer?.wrap ?? false,
     height,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -188,7 +188,7 @@ export const FlexBoxContainer = (
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
-    $flexWrap: props.node.deltaBlock.flexContainer?.wrap ?? false,
+    $wrap: props.node.deltaBlock.flexContainer?.wrap ?? false,
     height,
     flex,
     border: getBorderBackwardsCompatible(props.node.deltaBlock),

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -188,7 +188,7 @@ export const FlexBoxContainer = (
     direction: direction,
     // This is also backwards capatible since previously wrap was not added
     // to the flex container.
-    wrap: props.node.deltaBlock.flexContainer?.wrap ?? false,
+    $flexWrap: props.node.deltaBlock.flexContainer?.wrap ?? false,
     height,
     flex,
     border: getBorderBackwardsCompatible(props.node.deltaBlock),

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -155,7 +155,7 @@ export interface StyledFlexContainerBlockProps {
   gap?: streamlit.GapSize | undefined
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
-  // not passed to the DOM. It overlaps with a valid attibute
+  // not passed to the DOM. It overlaps with a valid attribute
   // so passing it to the DOM will cause an error in the console.
   $wrap?: boolean
   height?: React.CSSProperties["height"]

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -154,6 +154,9 @@ export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
   flex?: React.CSSProperties["flex"]
+  // This marks the prop as a transient property so it is
+  // not passed to the DOM. It overlaps with a valid attibute
+  // so passing it to the DOM will cause an error in the console.
   $wrap?: boolean
   height?: React.CSSProperties["height"]
   border: boolean

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -154,14 +154,14 @@ export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
   flex?: React.CSSProperties["flex"]
-  wrap?: boolean
+  $flexWrap?: boolean
   height?: React.CSSProperties["height"]
   border: boolean
 }
 
 export const StyledFlexContainerBlock =
   styled.div<StyledFlexContainerBlockProps>(
-    ({ theme, direction, gap, flex, wrap, height, border }) => {
+    ({ theme, direction, gap, flex, $flexWrap, height, border }) => {
       let gapWidth
       if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
@@ -176,7 +176,7 @@ export const StyledFlexContainerBlock =
         overflow: isInteger(height) ? "auto" : "visible",
         flexDirection: direction,
         flex,
-        flexWrap: wrap ? "wrap" : "nowrap",
+        flexWrap: $flexWrap ? "wrap" : "nowrap",
         ...(border && {
           border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
           borderRadius: theme.radii.default,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -154,14 +154,14 @@ export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
   flex?: React.CSSProperties["flex"]
-  $flexWrap?: boolean
+  $wrap?: boolean
   height?: React.CSSProperties["height"]
   border: boolean
 }
 
 export const StyledFlexContainerBlock =
   styled.div<StyledFlexContainerBlockProps>(
-    ({ theme, direction, gap, flex, $flexWrap, height, border }) => {
+    ({ theme, direction, gap, flex, $wrap, height, border }) => {
       let gapWidth
       if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
@@ -176,7 +176,7 @@ export const StyledFlexContainerBlock =
         overflow: isInteger(height) ? "auto" : "visible",
         flexDirection: direction,
         flex,
-        flexWrap: $flexWrap ? "wrap" : "nowrap",
+        flexWrap: $wrap ? "wrap" : "nowrap",
         ...(border && {
           border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
           borderRadius: theme.radii.default,


### PR DESCRIPTION
## Describe your changes

The wrap prop was being passed by emotion to the div, but it is a boolean so this causes an error in the console.
We convert it into the correct style inside the StyledComponent. Since the style is still passed correctly as well, I don't expect there are any regressions due to this.  

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

- Existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
