### PR TITLE
Type annotations for the `.clear()` method on cached functions

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -334,6 +334,11 @@ class CachedFunc(Protocol[P, T_co]):
     @overload
     def clear(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
 
+    # Currently we can't define the "all-optional" argument overload with `P.args` and `P.kwargs` in Python.
+    # So we use `Any` as a fallback.
+    @overload
+    def clear(self, *args: Any, **kwargs: Any) -> None: ...
+
 
 class CacheDataAPI:
     """Implements the public st.cache_data API: the @st.cache_data decorator, and

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -24,13 +24,14 @@ from typing import (
     Callable,
     Final,
     Literal,
+    Protocol,
     TypeVar,
     Union,
     cast,
     overload,
 )
 
-from typing_extensions import TypeAlias
+from typing_extensions import ParamSpec, TypeAlias
 
 import streamlit as st
 from streamlit import runtime
@@ -318,7 +319,20 @@ def get_data_cache_stats_provider() -> CacheStatsProvider:
 
 # Type-annotate the decorator function.
 # (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
-F = TypeVar("F", bound=Callable[..., Any])
+P = ParamSpec("P")
+T_co = TypeVar("T_co", covariant=True)
+
+
+class CachedFunc(Protocol[P, T_co]):
+    """Protocol for cached functions that preserve the original function's signature and add a clear method."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co: ...
+
+    @overload
+    def clear(self) -> None: ...
+
+    @overload
+    def clear(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 
 class CacheDataAPI:
@@ -343,7 +357,7 @@ class CacheDataAPI:
 
     # Bare decorator usage
     @overload
-    def __call__(self, func: F) -> F: ...
+    def __call__(self, func: Callable[P, T_co]) -> CachedFunc[P, T_co]: ...
 
     # Decorator with arguments
     @overload
@@ -356,11 +370,11 @@ class CacheDataAPI:
         persist: CachePersistType | bool = None,
         experimental_allow_widgets: bool = False,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> Callable[[F], F]: ...
+    ) -> Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]: ...
 
     def __call__(
         self,
-        func: F | None = None,
+        func: Callable[P, T_co] | None = None,
         *,
         ttl: float | timedelta | str | None = None,
         max_entries: int | None = None,
@@ -368,7 +382,7 @@ class CacheDataAPI:
         persist: CachePersistType | bool = None,
         experimental_allow_widgets: bool = False,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> F | Callable[[F], F]:
+    ) -> CachedFunc[P, T_co] | Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]:
         return self._decorator(
             func,
             ttl=ttl,
@@ -381,7 +395,7 @@ class CacheDataAPI:
 
     def _decorator(
         self,
-        func: F | None = None,
+        func: Callable[P, T_co] | None = None,
         *,
         ttl: float | timedelta | str | None,
         max_entries: int | None,
@@ -389,7 +403,7 @@ class CacheDataAPI:
         persist: CachePersistType | bool,
         experimental_allow_widgets: bool,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> F | Callable[[F], F]:
+    ) -> CachedFunc[P, T_co] | Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]:
         """Decorator to cache functions that return data (e.g. dataframe transforms, database queries, ML inference).
 
         Cached objects are stored in "pickled" form, which means that the return
@@ -567,9 +581,9 @@ class CacheDataAPI:
         if experimental_allow_widgets:
             show_widget_replay_deprecation("cache_data")
 
-        def wrapper(f: F) -> F:
+        def wrapper(f: Callable[P, T_co]) -> CachedFunc[P, T_co]:
             return cast(
-                "F",
+                "CachedFunc[P, T_co]",
                 make_cached_func_wrapper(
                     CachedDataFuncInfo(
                         func=f,  # type: ignore

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -210,6 +210,11 @@ class CachedFunc(Protocol[P, T_co]):
     @overload
     def clear(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
 
+    # Currently we can't define the "all-optional" argument overload with `P.args` and `P.kwargs` in Python.
+    # So we use `Any` as a fallback.
+    @overload
+    def clear(self, *args: Any, **kwargs: Any) -> None: ...
+
 
 class CacheResourceAPI:
     """Implements the public st.cache_resource API: the @st.cache_resource decorator,

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -18,10 +18,19 @@ from __future__ import annotations
 
 import math
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Final, TypeVar, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Final,
+    Protocol,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from cachetools import TTLCache
-from typing_extensions import TypeAlias
+from typing_extensions import ParamSpec, TypeAlias
 
 import streamlit as st
 from streamlit.logger import get_logger
@@ -184,6 +193,24 @@ class CachedResourceFuncInfo(CachedFuncInfo):
         )
 
 
+# Type-annotate the decorator function.
+# (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
+P = ParamSpec("P")
+T_co = TypeVar("T_co", covariant=True)
+
+
+class CachedFunc(Protocol[P, T_co]):
+    """Protocol for cached functions that preserve the original function's signature and add a clear method."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co: ...
+
+    @overload
+    def clear(self) -> None: ...
+
+    @overload
+    def clear(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+
 class CacheResourceAPI:
     """Implements the public st.cache_resource API: the @st.cache_resource decorator,
     and st.cache_resource.clear().
@@ -202,14 +229,9 @@ class CacheResourceAPI:
         # (Ignore spurious mypy complaints - https://github.com/python/mypy/issues/2427)
         self._decorator = gather_metrics(decorator_metric_name, self._decorator)  # type: ignore
 
-    # Type-annotate the decorator function.
-    # (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
-
-    F = TypeVar("F", bound=Callable[..., Any])
-
     # Bare decorator usage
     @overload
-    def __call__(self, func: F) -> F: ...
+    def __call__(self, func: Callable[P, T_co]) -> CachedFunc[P, T_co]: ...
 
     # Decorator with arguments
     @overload
@@ -222,11 +244,11 @@ class CacheResourceAPI:
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> Callable[[F], F]: ...
+    ) -> Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]: ...
 
     def __call__(
         self,
-        func: F | None = None,
+        func: Callable[P, T_co] | None = None,
         *,
         ttl: float | timedelta | str | None = None,
         max_entries: int | None = None,
@@ -234,7 +256,7 @@ class CacheResourceAPI:
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> F | Callable[[F], F]:
+    ) -> CachedFunc[P, T_co] | Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]:
         return self._decorator(
             func,
             ttl=ttl,
@@ -247,7 +269,7 @@ class CacheResourceAPI:
 
     def _decorator(
         self,
-        func: F | None,
+        func: Callable[P, T_co] | None,
         *,
         ttl: float | timedelta | str | None,
         max_entries: int | None,
@@ -255,7 +277,7 @@ class CacheResourceAPI:
         validate: ValidateFunc | None,
         experimental_allow_widgets: bool,
         hash_funcs: HashFuncsDict | None = None,
-    ) -> F | Callable[[F], F]:
+    ) -> CachedFunc[P, T_co] | Callable[[Callable[P, T_co]], CachedFunc[P, T_co]]:
         """Decorator to cache functions that return global resources (e.g. database connections, ML models).
 
         Cached objects are shared across all users, sessions, and reruns. They

--- a/lib/tests/streamlit/typing/cache_types.py
+++ b/lib/tests/streamlit/typing/cache_types.py
@@ -31,8 +31,21 @@ if TYPE_CHECKING:
 
     assert_type(cached_data_fn(1, "2"), bool)
     assert_type(cached_data_fn.clear(), None)
+    assert_type(cached_data_fn.clear(1), None)
+    assert_type(cached_data_fn.clear(1, "2"), None)
+    assert_type(cached_data_fn.clear(1, arg2="2"), None)
+    assert_type(cached_data_fn.clear(arg1=1), None)
+    assert_type(cached_data_fn.clear(arg2="2"), None)
+    assert_type(cached_data_fn.clear(arg1=1, arg2="2"), None)
+
     assert_type(cached_data_fn_with_decorator_args(1, "2"), bool)
     assert_type(cached_data_fn_with_decorator_args.clear(), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(1), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(1, "2"), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(1, arg2="2"), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(arg1=1), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(arg2="2"), None)
+    assert_type(cached_data_fn_with_decorator_args.clear(arg1=1, arg2="2"), None)
 
     @st.cache_resource
     def cached_resource_fn(arg1: int, arg2: str) -> bool:
@@ -44,5 +57,18 @@ if TYPE_CHECKING:
 
     assert_type(cached_resource_fn(1, "2"), bool)
     assert_type(cached_resource_fn.clear(), None)
+    assert_type(cached_resource_fn.clear(1), None)
+    assert_type(cached_resource_fn.clear(1, "2"), None)
+    assert_type(cached_resource_fn.clear(1, arg2="2"), None)
+    assert_type(cached_resource_fn.clear(arg1=1), None)
+    assert_type(cached_resource_fn.clear(arg2="2"), None)
+    assert_type(cached_resource_fn.clear(arg1=1, arg2="2"), None)
+
     assert_type(cached_resource_fn_with_decorator_args(1, "2"), bool)
     assert_type(cached_resource_fn_with_decorator_args.clear(), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(1), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(1, "2"), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(1, arg2="2"), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(arg1=1), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(arg2="2"), None)
+    assert_type(cached_resource_fn_with_decorator_args.clear(arg1=1, arg2="2"), None)

--- a/lib/tests/streamlit/typing/cache_types.py
+++ b/lib/tests/streamlit/typing/cache_types.py
@@ -1,0 +1,48 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    import streamlit as st
+
+    @st.cache_data
+    def cached_data_fn(arg1: int, arg2: str) -> bool:
+        return True
+
+    @st.cache_data(ttl=1)
+    def cached_data_fn_with_decorator_args(arg1: int, arg2: str) -> bool:
+        return True
+
+    assert_type(cached_data_fn(1, "2"), bool)
+    assert_type(cached_data_fn.clear(), None)
+    assert_type(cached_data_fn_with_decorator_args(1, "2"), bool)
+    assert_type(cached_data_fn_with_decorator_args.clear(), None)
+
+    @st.cache_resource
+    def cached_resource_fn(arg1: int, arg2: str) -> bool:
+        return True
+
+    @st.cache_resource(ttl=1)
+    def cached_resource_fn_with_decorator_args(arg1: int, arg2: str) -> bool:
+        return True
+
+    assert_type(cached_resource_fn(1, "2"), bool)
+    assert_type(cached_resource_fn.clear(), None)
+    assert_type(cached_resource_fn_with_decorator_args(1, "2"), bool)
+    assert_type(cached_resource_fn_with_decorator_args.clear(), None)


### PR DESCRIPTION
## Describe your changes

I wanted type hints on the `.clear()` method on cached functions for better developer experience such as auto-completion.

```python
@st.cache_data
def fn():
    return 42

fn.clear()  # The type of `clear()` should be inferred as `() -> None`.
```

## GitHub Issue Link (if applicable)

## Testing Plan

Unit Tests (Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
