### PR TITLE
[Fix] Flicker on facet altair charts.

### DIFF
--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -35,6 +35,19 @@ import {
 import { useVegaElementPreprocessor } from "./useVegaElementPreprocessor"
 import { useVegaEmbed } from "./useVegaEmbed"
 
+function isFacetChart(spec: any): boolean {
+  // Check for top-level facet property
+  if ("facet" in spec) return true
+  // Check for row/column encoding
+  if (
+    spec.encoding &&
+    (spec.encoding.row !== undefined || spec.encoding.column !== undefined)
+  ) {
+    return true
+  }
+  return false
+}
+
 export interface Props {
   element: VegaLiteChartElement
   widgetMgr: WidgetStateManager
@@ -77,6 +90,11 @@ const ArrowVegaLiteChart: FC<Props> = ({
     fragmentId
   )
 
+  // Facet charts need the container element to have a width.
+  // We want to target this styling to facet charts since it
+  // causes the toolbar to be on the far right.
+  const isFacet = isFacetChart(element.spec)
+
   const { data, datasets, spec } = element
 
   // Create the view once the container is ready and re-create
@@ -106,7 +124,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
   return (
     <StyledToolbarElementContainer
       height={height}
-      useContainerWidth={element.useContainerWidth}
+      useContainerWidth={element.useContainerWidth || isFacet}
     >
       <Toolbar
         target={StyledToolbarElementContainer}
@@ -119,7 +137,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
       <StyledVegaLiteChartContainer
         data-testid="stVegaLiteChart"
         className="stVegaLiteChart"
-        useContainerWidth={element.useContainerWidth}
+        useContainerWidth={element.useContainerWidth || isFacet}
         isFullScreen={isFullScreen}
         ref={containerRef}
       />

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -41,6 +41,9 @@ function isFacetChart(spec: string | object): boolean {
 
     return !!(
       parsedSpec.facet ||
+      // TODO (lawilby): do some tests for row/column
+      // shorthand facet charts to confirm they work with
+      // sizing in the same way.
       parsedSpec.encoding?.row ||
       parsedSpec.encoding?.column ||
       parsedSpec.encoding?.facet

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -86,6 +86,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
   const element = useVegaElementPreprocessor(
     inputElement,
     isFullScreen,
+    // Facet charts enter a loop when using the width from the StyledVegaLiteChartContainer.
     isFacet ? (fullScreenWidth ?? 0) : width,
     height ?? 0
   )
@@ -111,6 +112,9 @@ const ArrowVegaLiteChart: FC<Props> = ({
     }
 
     return finalizeView
+    // We can't use width in this dependency array because it causes facet charts to enter a loop.
+    // TODO(lawilby): Do we need width/height in this dependency array? It seems any changes
+    // Are the changes in the spec enough?
   }, [createView, finalizeView, spec, fullScreenWidth, height, containerRef])
 
   // The references to data and datasets will always change each rerun

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -36,17 +36,19 @@ import { useVegaElementPreprocessor } from "./useVegaElementPreprocessor"
 import { useVegaEmbed } from "./useVegaEmbed"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function isFacetChart(spec: any): boolean {
-  // Check for top-level facet property
-  if ("facet" in spec) return true
-  // Check for row/column encoding
-  if (
-    spec.encoding &&
-    (spec.encoding.row !== undefined || spec.encoding.column !== undefined)
-  ) {
-    return true
+function isFacetChart(spec: string | object): boolean {
+  try {
+    const parsedSpec = typeof spec === "string" ? JSON.parse(spec) : spec
+
+    return !!(
+      parsedSpec.facet ||
+      parsedSpec.encoding?.row ||
+      parsedSpec.encoding?.column ||
+      parsedSpec.encoding?.facet
+    )
+  } catch {
+    return false
   }
-  return false
 }
 export interface Props {
   element: VegaLiteChartElement
@@ -64,10 +66,16 @@ const ArrowVegaLiteChart: FC<Props> = ({
   const {
     expanded: isFullScreen,
     height,
+    width: fullScreenWidth,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
   const [width, containerRef] = useCalculatedWidth()
+
+  // Facet charts need the container element to have a width and also
+  // do not work well with stretch/container width
+  // so they cannot use the width from the StyledVegaLiteChartContainer.
+  const isFacet = isFacetChart(inputElement.spec)
 
   // We preprocess the input vega element to do a two things:
   // 1. Update the spec to handle Streamlit specific configurations such as
@@ -78,7 +86,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
   const element = useVegaElementPreprocessor(
     inputElement,
     isFullScreen,
-    width,
+    isFacet ? (fullScreenWidth ?? 0) : width,
     height ?? 0
   )
 
@@ -92,11 +100,6 @@ const ArrowVegaLiteChart: FC<Props> = ({
 
   const { data, datasets, spec } = element
 
-  // Facet charts need the container element to have a width.
-  // We want to target this styling to facet charts since it
-  // causes the toolbar to be on the far right.
-  const isFacet = isFacetChart(spec)
-
   // Create the view once the container is ready and re-create
   // if the spec changes or the dimensions change.
   // We utilize useLayoutEffect to ensure that the view is created
@@ -108,7 +111,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
     }
 
     return finalizeView
-  }, [createView, finalizeView, spec, width, height, containerRef])
+  }, [createView, finalizeView, spec, fullScreenWidth, height, containerRef])
 
   // The references to data and datasets will always change each rerun
   // because the forward message always produces new references, so
@@ -124,7 +127,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
   return (
     <StyledToolbarElementContainer
       height={height}
-      useContainerWidth={element.useContainerWidth || isFacet}
+      useContainerWidth={element.useContainerWidth}
     >
       <Toolbar
         target={StyledToolbarElementContainer}
@@ -137,7 +140,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
       <StyledVegaLiteChartContainer
         data-testid="stVegaLiteChart"
         className="stVegaLiteChart"
-        useContainerWidth={element.useContainerWidth || isFacet}
+        useContainerWidth={element.useContainerWidth}
         isFullScreen={isFullScreen}
         ref={containerRef}
       />

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -35,6 +35,7 @@ import {
 import { useVegaElementPreprocessor } from "./useVegaElementPreprocessor"
 import { useVegaEmbed } from "./useVegaEmbed"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function isFacetChart(spec: any): boolean {
   // Check for top-level facet property
   if ("facet" in spec) return true
@@ -47,7 +48,6 @@ function isFacetChart(spec: any): boolean {
   }
   return false
 }
-
 export interface Props {
   element: VegaLiteChartElement
   widgetMgr: WidgetStateManager
@@ -90,12 +90,12 @@ const ArrowVegaLiteChart: FC<Props> = ({
     fragmentId
   )
 
+  const { data, datasets, spec } = element
+
   // Facet charts need the container element to have a width.
   // We want to target this styling to facet charts since it
   // causes the toolbar to be on the far right.
-  const isFacet = isFacetChart(element.spec)
-
-  const { data, datasets, spec } = element
+  const isFacet = isFacetChart(spec)
 
   // Create the view once the container is ready and re-create
   // if the spec changes or the dimensions change.

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -35,7 +35,6 @@ import {
 import { useVegaElementPreprocessor } from "./useVegaElementPreprocessor"
 import { useVegaEmbed } from "./useVegaEmbed"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 function isFacetChart(spec: string | object): boolean {
   try {
     const parsedSpec = typeof spec === "string" ? JSON.parse(spec) : spec

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
@@ -101,6 +101,7 @@ export const StyledVegaLiteChartContainer =
     ({ theme, useContainerWidth, isFullScreen }) => ({
       width: useContainerWidth || isFullScreen ? "100%" : "auto",
       height: isFullScreen ? "100%" : "auto",
+      overflow: "auto",
       // These styles come from VegaLite Library
       "&.vega-embed": {
         position: "relative",

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
@@ -101,7 +101,6 @@ export const StyledVegaLiteChartContainer =
     ({ theme, useContainerWidth, isFullScreen }) => ({
       width: useContainerWidth || isFullScreen ? "100%" : "auto",
       height: isFullScreen ? "100%" : "auto",
-      overflow: "auto",
       // These styles come from VegaLite Library
       "&.vega-embed": {
         position: "relative",

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -296,8 +296,20 @@ def _prepare_vega_lite_spec(
         # on vconcat with use_container_width=True as there are unintended
         # consequences of changing the default autosize for all charts.
         # fit-x fits the width and height can be adjusted.
+        is_facet_chart = "facet" in spec or (
+            "encoding" in spec
+            and (any(x in spec["encoding"] for x in ["row", "column", "facet"]))
+        )
         if "vconcat" in spec and use_container_width:
             spec["autosize"] = {"type": "fit-x", "contains": "padding"}
+
+        elif is_facet_chart:
+            spec["autosize"] = {
+                "type": "pad",
+                "contains": "padding",
+                "resize": False,
+            }
+
         else:
             spec["autosize"] = {"type": "fit", "contains": "padding"}
 

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -304,11 +304,7 @@ def _prepare_vega_lite_spec(
             spec["autosize"] = {"type": "fit-x", "contains": "padding"}
 
         elif is_facet_chart:
-            spec["autosize"] = {
-                "type": "pad",
-                "contains": "padding",
-                "resize": False,
-            }
+            spec["autosize"] = {"type": "pad", "contains": "padding"}
 
         else:
             spec["autosize"] = {"type": "fit", "contains": "padding"}


### PR DESCRIPTION
## Describe your changes

There are a few issues with facet charts that this PR fixes:

- Autosize does not work with facet charts. Currently, it seems we are mainly seeing a warning and it is not directly causing the flicker, but this is a source of chart issues and it's better to remove it. 
- Using `fit-content` on the parent containers of the facet chart seems to cause a loop where the spec is altered leading to a loop. It seems the trigger for this was the change to use the `width` measured from `StyledVegaLiteChartContainer` instead of from `StyledFullScreenFrame` introduced [here](https://github.com/streamlit/streamlit/commit/50c7ecc633c58059b7f4e49088c2a42a9de37f04#diff-92f0e57b8f2d70900bd5b548ed97c7fb579f2880d48faaea8b7cfac004d479c0). Although the `width` is only added to the spec when the chart is full screen (which is a trigger for flickering), this width is also part of the dependency array. So it seems there is a loop where because the parent container's width is dependent on the chart, the chart must also be dependent on the parent width in the vega code (we are not using it outside of full screen) and we enter a loop. This seems only applicable to the facet charts, so there must be something different about how vega handles dimensions with these charts leading to the loop.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
