### PR TITLE
Add support for setting the column config width to pixels

### DIFF
--- a/e2e_playwright/st_dataframe_config.py
+++ b/e2e_playwright/st_dataframe_config.py
@@ -136,7 +136,7 @@ st.dataframe(
     column_config={
         "col_0": st.column_config.NumberColumn(
             "Number column",
-            width="medium",
+            width=200,
             help="This is a number column",
             required=True,  # Should be ignored
             disabled=False,  # Should be ignored
@@ -625,7 +625,7 @@ st.dataframe(
         },
     ),
     column_config={
-        "col_0": st.column_config.TextColumn("Text", width="large"),
+        "col_0": st.column_config.TextColumn("Text", width=400),
         "col_1": st.column_config.ImageColumn("Logo", width="medium"),
     },
     row_height=100,

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict, Union
 
 from typing_extensions import NotRequired, TypeAlias
 
@@ -42,7 +42,7 @@ NumberFormat: TypeAlias = Literal[
     "bytes",
 ]
 
-ColumnWidth: TypeAlias = Literal["small", "medium", "large"]
+ColumnWidth: TypeAlias = Union[Literal["small", "medium", "large"], int]
 
 # Type alias that represents all available column types
 # which are configurable by the user.
@@ -169,7 +169,7 @@ class ColumnConfig(TypedDict, total=False):
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -177,6 +177,7 @@ class ColumnConfig(TypedDict, total=False):
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -273,7 +274,7 @@ def Column(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -281,6 +282,7 @@ def Column(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -377,7 +379,7 @@ def NumberColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -385,6 +387,7 @@ def NumberColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -535,7 +538,7 @@ def TextColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -543,6 +546,7 @@ def TextColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -657,7 +661,7 @@ def LinkColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -665,6 +669,7 @@ def LinkColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -815,7 +820,7 @@ def CheckboxColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -823,6 +828,7 @@ def CheckboxColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -923,7 +929,7 @@ def SelectboxColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -931,6 +937,7 @@ def SelectboxColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1046,7 +1053,7 @@ def BarChartColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1054,6 +1061,7 @@ def BarChartColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1142,7 +1150,7 @@ def LineChartColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1150,6 +1158,7 @@ def LineChartColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1239,7 +1248,7 @@ def AreaChartColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1247,6 +1256,7 @@ def AreaChartColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1342,7 +1352,7 @@ def ImageColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1350,6 +1360,7 @@ def ImageColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1424,7 +1435,7 @@ def ListColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1432,6 +1443,7 @@ def ListColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1517,7 +1529,7 @@ def DatetimeColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1525,6 +1537,7 @@ def DatetimeColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1679,7 +1692,7 @@ def TimeColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1687,6 +1700,7 @@ def TimeColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1832,7 +1846,7 @@ def DateColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1840,6 +1854,7 @@ def DateColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -1982,7 +1997,7 @@ def ProgressColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -1990,6 +2005,7 @@ def ProgressColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If
@@ -2104,7 +2120,7 @@ def JsonColumn(
         The label shown at the top of the column. If this is ``None``
         (default), the column name is used.
 
-    width: "small", "medium", "large", or None
+    width: "small", "medium", "large", int, or None
         The display width of the column. If this is ``None`` (default), the
         column will be sized to fit the cell contents. Otherwise, this can be
         one of the following:
@@ -2112,6 +2128,7 @@ def JsonColumn(
         - ``"small"``: 75px wide
         - ``"medium"``: 200px wide
         - ``"large"``: 400px wide
+        - An integer specifying the width in pixels.
 
     help: str or None
         A tooltip that gets displayed when hovering over the column label. If

--- a/lib/tests/streamlit/elements/lib/column_types_test.py
+++ b/lib/tests/streamlit/elements/lib/column_types_test.py
@@ -70,7 +70,7 @@ class ColumnTypesTest(unittest.TestCase):
         assert remove_none_values(
             NumberColumn(
                 "Col1",
-                width="small",
+                width=100,
                 help="Help text",
                 disabled=False,
                 required=True,
@@ -83,7 +83,7 @@ class ColumnTypesTest(unittest.TestCase):
             )
         ) == {
             "label": "Col1",
-            "width": "small",
+            "width": 100,
             "help": "Help text",
             "disabled": False,
             "required": True,


### PR DESCRIPTION
## Describe your changes

Setting dataframe column width via pixels was already supported technically for quite some time. This PR adapts our typing and docstring to make this an official feature. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10019
- Closes https://github.com/streamlit/streamlit/issues/8346

## Testing Plan

- Added width as pixels to unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
