### PR TITLE
[fix] No more sidebar flickering when initial_sidebar_state="collapsed"

### DIFF
--- a/e2e_playwright/hello_app_test.py
+++ b/e2e_playwright/hello_app_test.py
@@ -170,6 +170,10 @@ def test_app_print_mode_portrait_with_sidebar_closed(
     """
     app = themed_app
 
+    # Note: this was moved up to the top because the sidebar has logic that when
+    # resizing the window could cause the sidebar to be open or closed
+    _set_portrait_dimensions(app)
+
     _load_dataframe_demo_page(app)
     # close sidebar. Must be done before print-mode, because we hide the close button
     # when printing
@@ -179,7 +183,6 @@ def test_app_print_mode_portrait_with_sidebar_closed(
     expect(sidebar_element).not_to_be_visible()
 
     app.emulate_media(media="print", forced_colors="active")
-    _set_portrait_dimensions(app)
     _evaluate_match_media_print(app)
 
     assert_snapshot(app, name="hello_app-print_media-portrait-sidebar_closed")
@@ -211,6 +214,10 @@ def test_app_print_mode_landscape_with_sidebar_closed(
     """
     app = themed_app
 
+    # Note: this was moved up to the top because the sidebar has logic that when
+    # resizing the window could cause the sidebar to be open or closed
+    _set_landscape_dimensions(app)
+
     _load_dataframe_demo_page(app)
     # close sidebar. Must be done before print-mode, because we hide the close button
     # when printing
@@ -220,7 +227,6 @@ def test_app_print_mode_landscape_with_sidebar_closed(
     expect(sidebar_element).not_to_be_visible()
 
     app.emulate_media(media="print", forced_colors="active")
-    _set_landscape_dimensions(app)
     _evaluate_match_media_print(app)
 
     assert_snapshot(app, name="hello_app-print_media-landscape-sidebar_closed")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
@@ -56,17 +56,21 @@ def test_mobile_fallback_to_sidebar(app: Page):
 
     wait_for_app_run(app)
 
-    # On mobile, should show sidebar, not top nav
+    # On mobile with AUTO state, sidebar should be collapsed by default
     sidebar = app.get_by_test_id("stSidebar")
-    expect(sidebar).to_be_visible()
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
 
-    # Wait for sidebar to expand by checking if links are visible
+    # Expand the sidebar to access navigation
+    expand_button = app.get_by_test_id("stExpandSidebarButton")
+    expand_button.click()
+
+    # Wait for sidebar to expand and nav links to be visible
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
     nav_links = app.get_by_test_id("stSidebarNavLink")
     expect(nav_links.first).to_be_visible()
 
-    # The sidebar might have overflow or positioning issues on mobile
-    # Try clicking the link directly without worrying about viewport
-    nav_links.nth(2).click(force=True)
+    # Test navigation functionality
+    nav_links.nth(2).click()
     wait_for_app_run(app)
 
     # Verify content updated - be specific
@@ -221,11 +225,19 @@ def test_mobile_sidebar_overlay_visual(
 
     wait_for_app_run(app)
 
-    # Verify sidebar is visible on mobile
+    # On mobile with AUTO state, sidebar should be collapsed by default
     sidebar = app.get_by_test_id("stSidebar")
-    expect(sidebar).to_be_visible()
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
 
-    # Verify navigation has moved into the sidebar
+    # Take screenshot of initial collapsed state
+    assert_snapshot(app, name="st_navigation-mobile_sidebar_overlay_collapsed")
+
+    # Expand the sidebar to test overlay behavior
+    expand_button = app.get_by_test_id("stExpandSidebarButton")
+    expand_button.click()
+
+    # Wait for sidebar to expand and verify navigation is visible
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
     nav_links = app.get_by_test_id("stSidebarNavLink")
     expect(nav_links).to_have_count(3)
     expect(nav_links.first).to_be_visible()
@@ -242,9 +254,6 @@ def test_mobile_sidebar_overlay_visual(
     # Wait for sidebar to collapse
     # The sidebar aria-expanded attribute should be false
     expect(sidebar).to_have_attribute("aria-expanded", "false")
-
-    # Take screenshot of collapsed state showing more content visible
-    assert_snapshot(app, name="st_navigation-mobile_sidebar_overlay_collapsed")
 
     # Test navigation interaction
     # Expand sidebar again using the expand button in the header

--- a/e2e_playwright/st_sidebar_flicker.py
+++ b/e2e_playwright/st_sidebar_flicker.py
@@ -1,0 +1,52 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+# Get the test mode from query params
+test_mode = st.query_params.get("test_mode", "collapsed")
+
+# Configure page based on test mode
+if test_mode == "collapsed":
+    st.set_page_config(
+        page_title="Sidebar Flicker Test - Collapsed", initial_sidebar_state="collapsed"
+    )
+elif test_mode == "expanded":
+    st.set_page_config(
+        page_title="Sidebar Flicker Test - Expanded", initial_sidebar_state="expanded"
+    )
+elif test_mode == "auto":
+    st.set_page_config(
+        page_title="Sidebar Flicker Test - Auto", initial_sidebar_state="auto"
+    )
+elif test_mode == "no_config":
+    # Don't call set_page_config at all
+    pass
+else:
+    st.error(f"Unknown test mode: {test_mode}")
+
+# Main content
+st.title("Sidebar Flicker Test")
+st.write(f"Test mode: {test_mode}")
+
+# Add some sidebar content
+with st.sidebar:
+    st.header("Sidebar Content")
+    st.write("This is sidebar content")
+    st.button("Sidebar Button")
+    st.selectbox("Sidebar Select", ["Option 1", "Option 2", "Option 3"])
+
+# Add main content
+st.write("This is main content")
+st.button("Main Button")

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -42,13 +42,7 @@ def test_sidebar_no_flicker_on_initial_load(
     else:  # auto
         expected_final_state = "collapsed" if viewport == "mobile" else "expanded"
 
-        # Use CDP to capture sidebar state changes during page load
-    client = page.context.new_cdp_session(page)
-
-    # Enable runtime domain to execute JavaScript early
-    client.send("Runtime.enable")
-
-    # Script to inject that will monitor sidebar
+        # Use add_init_script to capture sidebar state changes during page load (works across all browsers)
     monitor_script = """
     window.__sidebarStates = [];
     window.__monitorStarted = Date.now();
@@ -91,8 +85,8 @@ def test_sidebar_no_flicker_on_initial_load(
     });
     """
 
-    # Inject the script before page loads
-    client.send("Page.addScriptToEvaluateOnNewDocument", {"source": monitor_script})
+    # Inject the script before page loads (works across all browsers)
+    page.add_init_script(monitor_script)
 
     # Navigate to the page
     page.goto(f"http://localhost:{app_port}/?test_mode={initial_sidebar_state}")
@@ -138,10 +132,7 @@ def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
 
     Should default to auto behavior (expanded on desktop).
     """
-    # Track sidebar states
-    client = page.context.new_cdp_session(page)
-    client.send("Runtime.enable")
-
+    # Track sidebar states (works across all browsers)
     monitor_script = """
     window.__sidebarStates = [];
     window.__monitorStarted = Date.now();
@@ -168,7 +159,7 @@ def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
     });
     """
 
-    client.send("Page.addScriptToEvaluateOnNewDocument", {"source": monitor_script})
+    page.add_init_script(monitor_script)
 
     page.goto(f"http://localhost:{app_port}/?test_mode=no_config")
     wait_for_app_loaded(page)

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -15,35 +15,39 @@
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded
+from e2e_playwright.conftest import wait_for_app_loaded, wait_until
 
 
-@pytest.mark.parametrize("viewport", ["desktop", "mobile"])
-@pytest.mark.parametrize("initial_sidebar_state", ["collapsed", "expanded", "auto"])
-def test_sidebar_no_flicker_on_initial_load(
-    page: Page, app_port: int, viewport: str, initial_sidebar_state: str
-):
-    """Test that sidebar doesn't flicker when initial_sidebar_state is set.
-
-    This test should fail when the bug is present and pass when fixed.
-    """
-
-    # Set viewport size
-    if viewport == "mobile":
+def setup_viewport(page: Page, viewport_type: str) -> None:
+    """Set up viewport for testing."""
+    if viewport_type == "mobile":
         page.set_viewport_size({"width": 640, "height": 800})
     else:
         page.set_viewport_size({"width": 1280, "height": 720})
 
-    # Determine expected final state
-    if initial_sidebar_state == "collapsed":
-        expected_final_state = "collapsed"
-    elif initial_sidebar_state == "expanded":
-        expected_final_state = "expanded"
-    else:  # auto
-        expected_final_state = "collapsed" if viewport == "mobile" else "expanded"
 
-        # Use add_init_script to capture sidebar state changes during page load (works across all browsers)
-    monitor_script = """
+def get_expected_sidebar_state(initial_state: str, viewport: str) -> str:
+    """Calculate expected sidebar state based on config and viewport."""
+    if initial_state == "collapsed":
+        return "collapsed"
+    if initial_state == "expanded":
+        return "expanded"
+
+    return "collapsed" if viewport == "mobile" else "expanded"
+
+
+def verify_sidebar_state(page: Page, expected_state: str) -> None:
+    """Verify sidebar exists and has expected expanded state."""
+    sidebar = page.get_by_test_id("stSidebar")
+    expect(sidebar).to_be_attached()
+
+    expected_expanded = "true" if expected_state == "expanded" else "false"
+    expect(sidebar).to_have_attribute("aria-expanded", expected_expanded)
+
+
+def create_sidebar_monitor_script() -> str:
+    """Create JavaScript to monitor sidebar state changes during page load."""
+    return """
     window.__sidebarStates = [];
     window.__monitorStarted = Date.now();
 
@@ -61,7 +65,7 @@ def test_sidebar_no_flicker_on_initial_load(
     };
 
     // Monitor DOM mutations
-    const observer = new MutationObserver((mutations) => {
+    const observer = new MutationObserver(() => {
         const sidebar = document.querySelector('[data-testid="stSidebar"]');
         if (sidebar) {
             const ariaExpanded = sidebar.getAttribute('aria-expanded');
@@ -85,30 +89,35 @@ def test_sidebar_no_flicker_on_initial_load(
     });
     """
 
-    # Inject the script before page loads (works across all browsers)
-    page.add_init_script(monitor_script)
 
-    # Navigate to the page
-    page.goto(f"http://localhost:{app_port}/?test_mode={initial_sidebar_state}")
-
-    # Wait for app to load
-    wait_for_app_loaded(page)
-
-    # Get all captured states
+def check_for_sidebar_flicker(page: Page, initial_state: str) -> None:
+    """Check captured sidebar states for any flickering behavior."""
     states = page.evaluate("window.__sidebarStates || []")
 
-    # Check final state is correct
-    sidebar = page.get_by_test_id("stSidebar")
-    expect(sidebar).to_have_attribute(
-        "aria-expanded", "true" if expected_final_state == "expanded" else "false"
-    )
+    if not states:
+        return  # No state changes captured
 
-    # Analyze states for flicker
-    if initial_sidebar_state == "collapsed" and len(states) > 0:
-        # For collapsed state, check if it ever was expanded
-        for _, state in enumerate(states):
+    # Check for flicker in collapsed state (most common issue)
+    if initial_state == "collapsed":
+        for state in states:
             if state["ariaExpanded"] == "true":
-                # Found a flicker - sidebar was expanded before becoming collapsed
+                # Found flicker - sidebar was expanded when it should stay collapsed
+                states_str = "\n".join(
+                    [
+                        f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']} (via {s['method']})"
+                        for s in states
+                    ]
+                )
+                # Use pytest.fail for custom error message
+                pytest.fail(
+                    f"Sidebar flickered! Started expanded then collapsed.\nState changes:\n{states_str}"
+                )
+
+    # Check for flicker in expanded state
+    elif initial_state == "expanded":
+        for state in states:
+            if state["ariaExpanded"] == "false":
+                # Found flicker - sidebar was collapsed when it should stay expanded
                 states_str = "\n".join(
                     [
                         f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']} (via {s['method']})"
@@ -116,15 +125,136 @@ def test_sidebar_no_flicker_on_initial_load(
                     ]
                 )
                 pytest.fail(
-                    f"Sidebar flickered! Started expanded then collapsed.\n"
-                    f"State changes:\n{states_str}"
+                    f"Sidebar flickered! Started collapsed then expanded.\nState changes:\n{states_str}"
                 )
 
-    # For debugging - print states if test passes but we want to see what happened
-    if states:
-        print(f"\nSidebar states for {initial_sidebar_state} on {viewport}:")
-        for state in states:
-            print(f"  {state['timestamp']}ms: aria-expanded={state['ariaExpanded']}")
+
+def verify_no_sidebar_flicker(
+    page: Page, initial_state: str, expected_final_state: str
+) -> None:
+    """Verify that sidebar doesn't flicker during page load.
+
+    This checks both that the final state is correct AND that no
+    intermediate flickering occurred during the loading process.
+    """
+    # Wait for sidebar to be stable in expected state
+    wait_for_sidebar_stable(page, expected_final_state)
+
+    # Verify final state is correct
+    verify_sidebar_state(page, expected_final_state)
+
+    # Check for any flicker that occurred during loading
+    check_for_sidebar_flicker(page, initial_state)
+
+
+def wait_for_sidebar_stable(
+    page: Page, expected_state: str, timeout: int = 3000
+) -> None:
+    """Wait for sidebar to reach stable state without flickering."""
+    sidebar = page.get_by_test_id("stSidebar")
+    expected_expanded = "true" if expected_state == "expanded" else "false"
+
+    def check_stable_state() -> bool:
+        current_state = sidebar.get_attribute("aria-expanded")
+        return current_state == expected_expanded
+
+    wait_until(page, check_stable_state, timeout=timeout)
+
+
+@pytest.mark.parametrize("viewport", ["desktop", "mobile"])
+@pytest.mark.parametrize("initial_sidebar_state", ["collapsed", "expanded", "auto"])
+def test_sidebar_no_flicker_on_initial_load(
+    page: Page, app_port: int, viewport: str, initial_sidebar_state: str
+):
+    """Test that sidebar doesn't flicker during initial page load.
+
+    Verifies that when initial_sidebar_state is configured, the sidebar
+    maintains the correct state throughout the page load process without
+    flickering between expanded and collapsed states.
+    """
+    # Set up viewport
+    setup_viewport(page, viewport)
+
+    # Determine expected final state
+    expected_final_state = get_expected_sidebar_state(initial_sidebar_state, viewport)
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    # Navigate to the page
+    page.goto(f"http://localhost:{app_port}/?test_mode={initial_sidebar_state}")
+
+    # Wait for app to load
+    wait_for_app_loaded(page)
+
+    # Verify sidebar state without flicker
+    verify_no_sidebar_flicker(page, initial_sidebar_state, expected_final_state)
+
+
+def test_sidebar_collapsed_state_no_flicker(page: Page, app_port: int):
+    """Test that sidebar stays collapsed when configured as collapsed.
+
+    This focused test ensures that a sidebar configured as collapsed
+    never shows an expanded state during page load.
+    """
+    setup_viewport(page, "desktop")
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=collapsed")
+    wait_for_app_loaded(page)
+
+    verify_no_sidebar_flicker(page, "collapsed", "collapsed")
+
+
+def test_sidebar_expanded_state_no_flicker(page: Page, app_port: int):
+    """Test that sidebar stays expanded when configured as expanded.
+
+    This focused test ensures that a sidebar configured as expanded
+    maintains its expanded state during page load.
+    """
+    setup_viewport(page, "desktop")
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=expanded")
+    wait_for_app_loaded(page)
+
+    verify_no_sidebar_flicker(page, "expanded", "expanded")
+
+
+def test_sidebar_auto_state_desktop(page: Page, app_port: int):
+    """Test that sidebar auto state works correctly on desktop.
+
+    On desktop, auto state should result in an expanded sidebar.
+    """
+    setup_viewport(page, "desktop")
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=auto")
+    wait_for_app_loaded(page)
+
+    verify_no_sidebar_flicker(page, "auto", "expanded")
+
+
+def test_sidebar_auto_state_mobile(page: Page, app_port: int):
+    """Test that sidebar auto state works correctly on mobile.
+
+    On mobile, auto state should result in a collapsed sidebar.
+    """
+    setup_viewport(page, "mobile")
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=auto")
+    wait_for_app_loaded(page)
+
+    verify_no_sidebar_flicker(page, "auto", "collapsed")
 
 
 def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
@@ -132,48 +262,72 @@ def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
 
     Should default to auto behavior (expanded on desktop).
     """
-    # Track sidebar states (works across all browsers)
-    monitor_script = """
-    window.__sidebarStates = [];
-    window.__monitorStarted = Date.now();
+    setup_viewport(page, "desktop")
 
-    const observer = new MutationObserver(() => {
-        const sidebar = document.querySelector('[data-testid="stSidebar"]');
-        if (sidebar) {
-            const ariaExpanded = sidebar.getAttribute('aria-expanded');
-            const lastState = window.__sidebarStates[window.__sidebarStates.length - 1];
-
-            if (!lastState || lastState.ariaExpanded !== ariaExpanded) {
-                window.__sidebarStates.push({
-                    timestamp: Date.now() - window.__monitorStarted,
-                    ariaExpanded: ariaExpanded
-                });
-            }
-        }
-    });
-
-    observer.observe(document.documentElement, {
-        childList: true,
-        subtree: true,
-        attributes: true
-    });
-    """
-
-    page.add_init_script(monitor_script)
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
 
     page.goto(f"http://localhost:{app_port}/?test_mode=no_config")
     wait_for_app_loaded(page)
 
-    # Verify final state
-    sidebar = page.get_by_test_id("stSidebar")
-    expect(sidebar).to_have_attribute("aria-expanded", "true")
+    # Without page config, should behave like auto (expanded on desktop)
+    verify_sidebar_state(page, "expanded")
 
-    # Get states
+    # Also check that no flicker occurred during load
     states = page.evaluate("window.__sidebarStates || []")
+    if states:
+        # Check for any unexpected state changes
+        for state in states:
+            if state["ariaExpanded"] == "false":
+                states_str = "\n".join(
+                    [
+                        f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']} (via {s['method']})"
+                        for s in states
+                    ]
+                )
+                pytest.fail(
+                    f"Sidebar unexpectedly collapsed during load.\nState changes:\n{states_str}"
+                )
 
-    # Check for unexpected state changes
-    if len(states) > 1:
+
+def test_sidebar_stability_after_initial_load(page: Page, app_port: int):
+    """Test that sidebar state remains stable after initial load.
+
+    Verifies that the sidebar doesn't change state unexpectedly
+    after the page has finished loading.
+    """
+    setup_viewport(page, "desktop")
+
+    # Inject monitoring script before page loads
+    page.add_init_script(create_sidebar_monitor_script())
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=collapsed")
+    wait_for_app_loaded(page)
+
+    # Verify initial state
+    verify_sidebar_state(page, "collapsed")
+
+    # Clear previous state tracking and monitor for additional changes
+    page.evaluate("window.__sidebarStates = []; window.__monitorStarted = Date.now();")
+
+    # Wait a bit more and verify state hasn't changed
+    page.wait_for_timeout(1000)
+    verify_sidebar_state(page, "collapsed")
+
+    # Check that no state changes occurred during the wait
+    states = page.evaluate("window.__sidebarStates || []")
+    if states:
         states_str = "\n".join(
-            [f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']}" for s in states]
+            [
+                f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']} (via {s['method']})"
+                for s in states
+            ]
         )
-        print(f"\nMultiple state changes detected:\n{states_str}")
+        pytest.fail(
+            f"Sidebar state changed after initial load.\nState changes:\n{states_str}"
+        )
+
+    # Verify sidebar is still attached and stable
+    sidebar = page.get_by_test_id("stSidebar")
+    expect(sidebar).to_be_attached()
+    expect(sidebar).to_have_attribute("aria-expanded", "false")

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -1,0 +1,188 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_loaded
+
+
+@pytest.mark.parametrize("viewport", ["desktop", "mobile"])
+@pytest.mark.parametrize("initial_sidebar_state", ["collapsed", "expanded", "auto"])
+def test_sidebar_no_flicker_on_initial_load(
+    page: Page, app_port: int, viewport: str, initial_sidebar_state: str
+):
+    """Test that sidebar doesn't flicker when initial_sidebar_state is set.
+
+    This test should fail when the bug is present and pass when fixed.
+    """
+
+    # Set viewport size
+    if viewport == "mobile":
+        page.set_viewport_size({"width": 640, "height": 800})
+    else:
+        page.set_viewport_size({"width": 1280, "height": 720})
+
+    # Determine expected final state
+    if initial_sidebar_state == "collapsed":
+        expected_final_state = "collapsed"
+    elif initial_sidebar_state == "expanded":
+        expected_final_state = "expanded"
+    else:  # auto
+        expected_final_state = "collapsed" if viewport == "mobile" else "expanded"
+
+        # Use CDP to capture sidebar state changes during page load
+    client = page.context.new_cdp_session(page)
+
+    # Enable runtime domain to execute JavaScript early
+    client.send("Runtime.enable")
+
+    # Script to inject that will monitor sidebar
+    monitor_script = """
+    window.__sidebarStates = [];
+    window.__monitorStarted = Date.now();
+
+    // Override setAttribute to catch aria-expanded changes
+    const originalSetAttribute = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = function(name, value) {
+        if (this.dataset && this.dataset.testid === 'stSidebar' && name === 'aria-expanded') {
+            window.__sidebarStates.push({
+                timestamp: Date.now() - window.__monitorStarted,
+                ariaExpanded: value,
+                method: 'setAttribute'
+            });
+        }
+        return originalSetAttribute.call(this, name, value);
+    };
+
+    // Monitor DOM mutations
+    const observer = new MutationObserver((mutations) => {
+        const sidebar = document.querySelector('[data-testid="stSidebar"]');
+        if (sidebar) {
+            const ariaExpanded = sidebar.getAttribute('aria-expanded');
+            const lastState = window.__sidebarStates[window.__sidebarStates.length - 1];
+
+            if (!lastState || lastState.ariaExpanded !== ariaExpanded) {
+                window.__sidebarStates.push({
+                    timestamp: Date.now() - window.__monitorStarted,
+                    ariaExpanded: ariaExpanded,
+                    method: 'mutation'
+                });
+            }
+        }
+    });
+
+    observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-expanded']
+    });
+    """
+
+    # Inject the script before page loads
+    client.send("Page.addScriptToEvaluateOnNewDocument", {"source": monitor_script})
+
+    # Navigate to the page
+    page.goto(f"http://localhost:{app_port}/?test_mode={initial_sidebar_state}")
+
+    # Wait for app to load
+    wait_for_app_loaded(page)
+
+    # Get all captured states
+    states = page.evaluate("window.__sidebarStates || []")
+
+    # Check final state is correct
+    sidebar = page.get_by_test_id("stSidebar")
+    expect(sidebar).to_have_attribute(
+        "aria-expanded", "true" if expected_final_state == "expanded" else "false"
+    )
+
+    # Analyze states for flicker
+    if initial_sidebar_state == "collapsed" and len(states) > 0:
+        # For collapsed state, check if it ever was expanded
+        for _, state in enumerate(states):
+            if state["ariaExpanded"] == "true":
+                # Found a flicker - sidebar was expanded before becoming collapsed
+                states_str = "\n".join(
+                    [
+                        f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']} (via {s['method']})"
+                        for s in states
+                    ]
+                )
+                pytest.fail(
+                    f"Sidebar flickered! Started expanded then collapsed.\n"
+                    f"State changes:\n{states_str}"
+                )
+
+    # For debugging - print states if test passes but we want to see what happened
+    if states:
+        print(f"\nSidebar states for {initial_sidebar_state} on {viewport}:")
+        for state in states:
+            print(f"  {state['timestamp']}ms: aria-expanded={state['ariaExpanded']}")
+
+
+def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
+    """Test sidebar behavior when set_page_config is not called.
+
+    Should default to auto behavior (expanded on desktop).
+    """
+    # Track sidebar states
+    client = page.context.new_cdp_session(page)
+    client.send("Runtime.enable")
+
+    monitor_script = """
+    window.__sidebarStates = [];
+    window.__monitorStarted = Date.now();
+
+    const observer = new MutationObserver(() => {
+        const sidebar = document.querySelector('[data-testid="stSidebar"]');
+        if (sidebar) {
+            const ariaExpanded = sidebar.getAttribute('aria-expanded');
+            const lastState = window.__sidebarStates[window.__sidebarStates.length - 1];
+
+            if (!lastState || lastState.ariaExpanded !== ariaExpanded) {
+                window.__sidebarStates.push({
+                    timestamp: Date.now() - window.__monitorStarted,
+                    ariaExpanded: ariaExpanded
+                });
+            }
+        }
+    });
+
+    observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true
+    });
+    """
+
+    client.send("Page.addScriptToEvaluateOnNewDocument", {"source": monitor_script})
+
+    page.goto(f"http://localhost:{app_port}/?test_mode=no_config")
+    wait_for_app_loaded(page)
+
+    # Verify final state
+    sidebar = page.get_by_test_id("stSidebar")
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
+
+    # Get states
+    states = page.evaluate("window.__sidebarStates || []")
+
+    # Check for unexpected state changes
+    if len(states) > 1:
+        states_str = "\n".join(
+            [f"  {s['timestamp']}ms: aria-expanded={s['ariaExpanded']}" for s in states]
+        )
+        print(f"\nMultiple state changes detected:\n{states_str}")

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -1100,8 +1100,10 @@ describe("AppView element", () => {
 
       const { rerender } = render(<AppView {...props} />)
 
-      // Sidebar should not be rendered when initialSidebarState is AUTO
-      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+      // Sidebar should be rendered and expanded when initialSidebarState is AUTO
+      const sidebarDOMElement = screen.getByTestId("stSidebar")
+      expect(sidebarDOMElement).toBeInTheDocument()
+      expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
 
       // Now simulate receiving page config with collapsed state
       vi.spyOn(
@@ -1231,8 +1233,10 @@ describe("AppView element", () => {
         />
       )
 
-      // Sidebar should not be rendered initially
-      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+      // Sidebar should be rendered and expanded initially
+      const sidebarDOMElement = screen.getByTestId("stSidebar")
+      expect(sidebarDOMElement).toBeInTheDocument()
+      expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
     })
 
     it("sidebar shows after first script run when no page config is set", () => {
@@ -1271,9 +1275,11 @@ describe("AppView element", () => {
         ),
       })
 
-      // Initially AUTO state, no sidebar
+      // Initially AUTO state, sidebar should be rendered and expanded
       render(<AppView {...props} />)
-      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+      const sidebarDOMElement = screen.getByTestId("stSidebar")
+      expect(sidebarDOMElement).toBeInTheDocument()
+      expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
 
       // Simulate script finished event without page config change
       // This tests the showSidebarOverride logic would apply

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -1059,4 +1059,229 @@ describe("AppView element", () => {
       expect(screen.getByTestId("toolbar-actions")).toBeInTheDocument()
     })
   })
+
+  describe("sidebar flicker prevention", () => {
+    it("does not render sidebar when initialSidebarState is AUTO on initial render", () => {
+      // Mock the context with AUTO state
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.AUTO,
+        })
+      )
+
+      const sidebarElement = new ElementNode(
+        makeElementWithInfoText("sidebar content"),
+        ForwardMsgMetadata.create({}),
+        "no script run id",
+        FAKE_SCRIPT_HASH
+      )
+
+      const sidebar = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [sidebarElement],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const empty = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const props = getProps({
+        elements: new AppRoot(
+          FAKE_SCRIPT_HASH,
+          new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+        ),
+      })
+
+      const { rerender } = render(<AppView {...props} />)
+
+      // Sidebar should not be rendered when initialSidebarState is AUTO
+      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+
+      // Now simulate receiving page config with collapsed state
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+        })
+      )
+
+      rerender(<AppView {...props} />)
+
+      // Now sidebar should be rendered but collapsed
+      const sidebarAfterConfig = screen.getByTestId("stSidebar")
+      expect(sidebarAfterConfig).toBeInTheDocument()
+      expect(sidebarAfterConfig).toHaveAttribute("aria-expanded", "false")
+    })
+
+    it("renders sidebar immediately when initialSidebarState is COLLAPSED", () => {
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+        })
+      )
+
+      const sidebarElement = new ElementNode(
+        makeElementWithInfoText("sidebar content"),
+        ForwardMsgMetadata.create({}),
+        "no script run id",
+        FAKE_SCRIPT_HASH
+      )
+
+      const sidebar = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [sidebarElement],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const empty = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const props = getProps({
+        elements: new AppRoot(
+          FAKE_SCRIPT_HASH,
+          new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+        ),
+      })
+
+      render(<AppView {...props} />)
+
+      // Sidebar should be rendered immediately when state is known
+      const sidebarDOMElement = screen.getByTestId("stSidebar")
+      expect(sidebarDOMElement).toBeInTheDocument()
+      expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "false")
+    })
+
+    it("renders sidebar immediately when initialSidebarState is EXPANDED", () => {
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.EXPANDED,
+        })
+      )
+
+      const sidebarElement = new ElementNode(
+        makeElementWithInfoText("sidebar content"),
+        ForwardMsgMetadata.create({}),
+        "no script run id",
+        FAKE_SCRIPT_HASH
+      )
+
+      const sidebar = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [sidebarElement],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const empty = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const props = getProps({
+        elements: new AppRoot(
+          FAKE_SCRIPT_HASH,
+          new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+        ),
+      })
+
+      render(<AppView {...props} />)
+
+      // Sidebar should be rendered immediately when state is known
+      const sidebarDOMElement = screen.getByTestId("stSidebar")
+      expect(sidebarDOMElement).toBeInTheDocument()
+      expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
+    })
+
+    it("shows sidebar when multiple pages exist even with AUTO state", () => {
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.AUTO,
+        })
+      )
+
+      render(
+        <AppView
+          {...getProps({
+            appPages: [
+              { pageName: "page1", pageScriptHash: "hash1" },
+              { pageName: "page2", pageScriptHash: "hash2" },
+            ],
+            navigationPosition: Navigation.Position.SIDEBAR,
+          })}
+        />
+      )
+
+      // Sidebar should not be rendered initially
+      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+    })
+
+    it("sidebar shows after first script run when no page config is set", () => {
+      vi.spyOn(
+        StreamlitContextProviderModule,
+        "useAppContext"
+      ).mockReturnValue(
+        getContextOutput({
+          initialSidebarState: PageConfig.SidebarState.AUTO,
+        })
+      )
+
+      const sidebarElement = new ElementNode(
+        makeElementWithInfoText("sidebar content"),
+        ForwardMsgMetadata.create({}),
+        "no script run id",
+        FAKE_SCRIPT_HASH
+      )
+
+      const sidebar = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [sidebarElement],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const empty = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        new BlockProto({ allowEmpty: true })
+      )
+
+      const props = getProps({
+        elements: new AppRoot(
+          FAKE_SCRIPT_HASH,
+          new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+        ),
+      })
+
+      // Initially AUTO state, no sidebar
+      render(<AppView {...props} />)
+      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+
+      // Simulate script finished event without page config change
+      // This tests the showSidebarOverride logic would apply
+      // (In the real app, this would be handled by scriptFinishedHandler)
+
+      // Since we can't easily trigger the script finished handler in the test,
+      // we'll verify the initial behavior is correct (no sidebar with AUTO)
+      // The actual fix will ensure sidebar shows after script finishes
+    })
+  })
 })

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -20,7 +20,6 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
-  useRef,
   useState,
 } from "react"
 
@@ -33,6 +32,7 @@ import {
   IGuestToHostMessage,
   LibContext,
   Profiler,
+  useWindowDimensionsContext,
   WidgetStateManager,
 } from "@streamlit/lib"
 import { IAppPage, Logo, Navigation } from "@streamlit/protobuf"
@@ -145,6 +145,8 @@ function AppView(props: AppViewProps): ReactElement {
     activeTheme,
   } = useContext(LibContext)
 
+  const { innerWidth } = useWindowDimensionsContext()
+
   const layout = wideMode ? "wide" : "narrow"
   const hasSidebarElements = !elements.sidebar.isEmpty
   const hasEventElements = !elements.event.isEmpty
@@ -202,21 +204,23 @@ function AppView(props: AppViewProps): ReactElement {
 
   const [isSidebarCollapsed, setSidebarIsCollapsed] = useState<boolean>(true)
 
-  const hasInitializedWidthRef = useRef(false)
-
   // Initialize sidebar state once after stable width is achieved
   useLayoutEffect(() => {
     if (showSidebar) {
       setSidebarIsCollapsed(
         shouldCollapse(
           initialSidebarState,
-          parseInt(activeTheme.emotion.breakpoints.md, 10)
+          parseInt(activeTheme.emotion.breakpoints.md, 10),
+          innerWidth
         )
       )
     }
-
-    hasInitializedWidthRef.current = true
-  }, [initialSidebarState, activeTheme.emotion.breakpoints.md, showSidebar])
+  }, [
+    initialSidebarState,
+    activeTheme.emotion.breakpoints.md,
+    showSidebar,
+    innerWidth,
+  ])
 
   // Handle updates to initialSidebarState after set_page_config
 

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -19,7 +19,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useState,
 } from "react"
 
@@ -32,6 +31,7 @@ import {
   IGuestToHostMessage,
   LibContext,
   Profiler,
+  useExecuteWhenChanged,
   useWindowDimensionsContext,
   WidgetStateManager,
 } from "@streamlit/lib"
@@ -155,11 +155,12 @@ function AppView(props: AppViewProps): ReactElement {
   const [showSidebarOverride, setShowSidebarOverride] = useState(false)
 
   const showSidebar =
-    hasSidebarElements ||
-    (navigationPosition === Navigation.Position.SIDEBAR &&
-      !hideSidebarNav &&
-      appPages.length > 1) ||
-    showSidebarOverride
+    innerWidth > 0 &&
+    (hasSidebarElements ||
+      (navigationPosition === Navigation.Position.SIDEBAR &&
+        !hideSidebarNav &&
+        appPages.length > 1) ||
+      showSidebarOverride)
 
   useEffect(() => {
     // Handle sidebar flicker/unmount with MPA & hideSidebarNav
@@ -204,9 +205,9 @@ function AppView(props: AppViewProps): ReactElement {
 
   const [isSidebarCollapsed, setSidebarIsCollapsed] = useState<boolean>(true)
 
-  // Initialize sidebar state once after stable width is achieved
-  useLayoutEffect(() => {
-    if (showSidebar) {
+  // Update sidebar state when innerWidth changes and is > 0
+  useExecuteWhenChanged(() => {
+    if (innerWidth > 0 && showSidebar) {
       setSidebarIsCollapsed(
         shouldCollapse(
           initialSidebarState,
@@ -216,10 +217,10 @@ function AppView(props: AppViewProps): ReactElement {
       )
     }
   }, [
+    innerWidth,
+    showSidebar,
     initialSidebarState,
     activeTheme.emotion.breakpoints.md,
-    showSidebar,
-    innerWidth,
   ])
 
   // Handle updates to initialSidebarState after set_page_config

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -223,8 +223,6 @@ function AppView(props: AppViewProps): ReactElement {
     activeTheme.emotion.breakpoints.md,
   ])
 
-  // Handle updates to initialSidebarState after set_page_config
-
   const toggleSidebar = useCallback(() => {
     setSidebarIsCollapsed(prev => !prev)
   }, [])

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -24,6 +24,7 @@ import React, {
   useState,
 } from "react"
 
+import { StreamlitEndpoints } from "@streamlit/connection"
 import {
   AppRoot,
   BlockNode,
@@ -32,11 +33,8 @@ import {
   IGuestToHostMessage,
   LibContext,
   Profiler,
-  useExecuteWhenChanged,
-  useWindowDimensionsContext,
   WidgetStateManager,
 } from "@streamlit/lib"
-import { StreamlitEndpoints } from "@streamlit/connection"
 import { IAppPage, Logo, Navigation } from "@streamlit/protobuf"
 import ThemedSidebar from "@streamlit/app/src/components/Sidebar"
 import { shouldCollapse } from "@streamlit/app/src/components/Sidebar/utils"
@@ -147,14 +145,12 @@ function AppView(props: AppViewProps): ReactElement {
     activeTheme,
   } = useContext(LibContext)
 
-  const { innerWidth } = useWindowDimensionsContext()
-
   const layout = wideMode ? "wide" : "narrow"
   const hasSidebarElements = !elements.sidebar.isEmpty
   const hasEventElements = !elements.event.isEmpty
   const hasBottomElements = !elements.bottom.isEmpty
 
-  const [showSidebarOverride, setShowSidebarOverride] = useState(() => false)
+  const [showSidebarOverride, setShowSidebarOverride] = useState(false)
 
   const showSidebar =
     hasSidebarElements ||
@@ -204,44 +200,25 @@ function AppView(props: AppViewProps): ReactElement {
     />
   )
 
-  const [isSidebarCollapsed, setSidebarIsCollapsed] = useState<boolean>(() =>
-    shouldCollapse(
-      initialSidebarState,
-      parseInt(activeTheme.emotion.breakpoints.md, 10),
-      innerWidth
-    )
-  )
+  const [isSidebarCollapsed, setSidebarIsCollapsed] = useState<boolean>(true)
 
   const hasInitializedWidthRef = useRef(false)
 
   // Initialize sidebar state once after stable width is achieved
   useLayoutEffect(() => {
-    if (!hasInitializedWidthRef.current && innerWidth > 0) {
+    if (showSidebar) {
       setSidebarIsCollapsed(
         shouldCollapse(
           initialSidebarState,
-          parseInt(activeTheme.emotion.breakpoints.md, 10),
-          innerWidth
+          parseInt(activeTheme.emotion.breakpoints.md, 10)
         )
       )
-      hasInitializedWidthRef.current = true
     }
-  }, [initialSidebarState, activeTheme.emotion.breakpoints.md, innerWidth])
+
+    hasInitializedWidthRef.current = true
+  }, [initialSidebarState, activeTheme.emotion.breakpoints.md, showSidebar])
 
   // Handle updates to initialSidebarState after set_page_config
-  useExecuteWhenChanged(() => {
-    if (!hasInitializedWidthRef.current) {
-      return
-    }
-
-    setSidebarIsCollapsed(
-      shouldCollapse(
-        initialSidebarState,
-        parseInt(activeTheme.emotion.breakpoints.md, 10),
-        innerWidth
-      )
-    )
-  }, [initialSidebarState, activeTheme.emotion.breakpoints.md])
 
   const toggleSidebar = useCallback(() => {
     setSidebarIsCollapsed(prev => !prev)
@@ -270,6 +247,15 @@ function AppView(props: AppViewProps): ReactElement {
     shouldShowExpandButton ||
     shouldShowNavigation ||
     showToolbar
+
+  console.log({
+    initialSidebarState,
+    isSidebarCollapsed,
+    showSidebar,
+    hasSidebarElements,
+    hideSidebarNav,
+    showSidebarOverride,
+  })
 
   // The tabindex is required to support scrolling by arrow keys.
   return (

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -252,15 +252,6 @@ function AppView(props: AppViewProps): ReactElement {
     shouldShowNavigation ||
     showToolbar
 
-  console.log({
-    initialSidebarState,
-    isSidebarCollapsed,
-    showSidebar,
-    hasSidebarElements,
-    hideSidebarNav,
-    showSidebarOverride,
-  })
-
   // The tabindex is required to support scrolling by arrow keys.
   return (
     <>


### PR DESCRIPTION
## Describe your changes

This change fixes the bug linked below and adds a bunch of testing to ensure this doesn't happen again without us catching it. Additionally, it was discovered that there were some tests that were locking in this buggy behavior, so those have been updated as well.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

This PR fixes #11848 

## Testing Plan

Added a new e2e test file as I felt it was merited to ensure this functionality doesn't regress. The test injects some javascript to look for any transient flickers that might occur that could be missed by playwright.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
