### PR TITLE
Remove unnecessary pass

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -438,7 +438,6 @@ class Secrets(Mapping[str, Any]):
                     # A user may only have one secrets.toml file defined, so we'd expect
                     # exceptions to be raised when attempting to install a
                     # watcher on the nonexistent ones.
-                    pass
 
             # We set file_watchers_installed to True even if the installation attempt
             # failed to avoid repeatedly trying to install it.


### PR DESCRIPTION
Potential fix for [https://github.com/streamlit/streamlit/security/code-scanning/10677](https://github.com/streamlit/streamlit/security/code-scanning/10677)

To fix the issue, the unnecessary `pass` statement on line 441 should be removed. This will simplify the code while maintaining its functionality. No additional changes, imports, or definitions are required, as the logging statement already provides the necessary behavior for the `except` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
