### PR TITLE
Fix code text sizing in tooltips

### DIFF
--- a/e2e_playwright/help_tooltip.py
+++ b/e2e_playwright/help_tooltip.py
@@ -26,6 +26,12 @@ with st.sidebar:
 
 
 columns_ = st.columns([9, 1.5, 1.5])
+
+with columns_[0]:
+    st.number_input(
+        "Tooltip with code test", 0, 10, 1, help="Tooltip `with some code` in it"
+    )
+
 with columns_[1].popover("Some popover"):
     pass
 

--- a/e2e_playwright/help_tooltip_test.py
+++ b/e2e_playwright/help_tooltip_test.py
@@ -88,3 +88,27 @@ def test_tooltip_does_not_overflow_on_the_right_side(app: Page):
         lambda: (bbox := tooltip.bounding_box()) is not None
         and bbox["x"] + bbox["width"] <= viewport_width,
     )
+
+
+def test_tooltip_with_code(app: Page):
+    """Test that a help tooltip with code displays correctly."""
+    # Get the number input widget
+    number_input = app.get_by_test_id("stNumberInput")
+    # Hover over the tooltip target (?) to display the tooltip
+    hover_target = number_input.get_by_test_id("stTooltipHoverTarget")
+    hover_target.hover()
+
+    # Wait for tooltip to appear and stabilize
+    app.wait_for_timeout(200)
+
+    # Get the tooltip content
+    tooltip = app.get_by_test_id("stTooltipContent")
+    expect(tooltip).to_be_visible()
+    expect(tooltip).to_contain_text("Tooltip with some code in it")
+
+    # General tooltip text should have a size of 14px
+    expect(tooltip.get_by_text("Tooltip")).to_have_css("font-size", "14px")
+
+    # Inline code text should be set to 0.75em (which with tooltip font size
+    # of 14px translates to 10.5px)
+    expect(tooltip.get_by_role("code")).to_have_css("font-size", "10.5px")

--- a/frontend/lib/src/components/shared/Tooltip/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/styled-components.tsx
@@ -44,6 +44,6 @@ export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
     maxWidth: "100%",
   },
   "*": {
-    fontSize: `${theme.fontSizes.sm} !important`,
+    fontSize: theme.fontSizes.sm,
   },
 }))


### PR DESCRIPTION
## Describe your changes
Removing the unnecessary `!important` specification for tooltip content overrides the inline code font sizing

**Before:**
<img width="630" alt="Screenshot 2025-07-07 at 4 12 31 p m" src="https://github.com/user-attachments/assets/8439b749-e813-4723-939d-e43217e5f4e1" />

**After:**
<img width="630" alt="Screenshot 2025-07-07 at 4 13 14 p m" src="https://github.com/user-attachments/assets/105d625f-acf5-47a7-9d7b-303fca14b4ed" />

## Testing Plan
- E2E Tests: Added ✅ 
- Manual Testing: ✅ 