### PR TITLE
Document file upload `type` as best-effort check

### DIFF
--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -33,8 +33,8 @@ TYPE_PAIRS = [
 
 def _get_main_filename_and_extension(filename: str) -> tuple[str, str]:
     """Returns the main part of a filename and its extension."""
-    # Handle NTFS Alternate Data Streams (ADS), e.g: "file.txt:ads" -> ("file.txt", ".txt")
-    if ":" in filename:
+    # Handle NTFS Alternate Data Streams (ADS) on Windows, e.g: "file.txt:ads" -> ("file.txt", ".txt")
+    if os.name == "nt" and ":" in filename:
         main_filename, ads_part = filename.split(":", 1)
         # We only treat it as an ADS if the part after the colon has an extension.
         if os.path.splitext(ads_part)[1]:

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -31,6 +31,18 @@ TYPE_PAIRS = [
 ]
 
 
+def _get_main_filename_and_extension(filename: str) -> tuple[str, str]:
+    """Returns the main part of a filename and its extension."""
+    # Handle NTFS Alternate Data Streams (ADS), e.g: "file.txt:ads" -> ("file.txt", ".txt")
+    if ":" in filename:
+        main_filename, ads_part = filename.split(":", 1)
+        # We only treat it as an ADS if the part after the colon has an extension.
+        if os.path.splitext(ads_part)[1]:
+            return main_filename, os.path.splitext(main_filename)[1]
+
+    return filename, os.path.splitext(filename)[1]
+
+
 def normalize_upload_file_type(file_type: str | Sequence[str]) -> Sequence[str]:
     if isinstance(file_type, str):
         file_type = [file_type]
@@ -59,8 +71,9 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     enforce file type check by extension on the frontend, but we check it on backend
     before returning file to the user to protect ourselves.
     """
-    normalized_filename = filename.lower()
-    base_name, extension = os.path.splitext(normalized_filename)
+    main_filename, extension = _get_main_filename_and_extension(filename)
+    normalized_filename = main_filename.lower()
+
     normalized_allowed_types = [allowed_type.lower() for allowed_type in allowed_types]
 
     if not any(

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -71,6 +71,12 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     enforce file type check by extension on the frontend, but we check it on backend
     before returning file to the user to protect ourselves.
     """
+
+    # Ensure that there isn't a null byte in a filename
+    # since this could be a workaround to bypass the file type check.
+    if "\0" in filename:
+        raise StreamlitAPIException("Filename cannot contain null bytes.")
+
     main_filename, extension = _get_main_filename_and_extension(filename)
     normalized_filename = main_filename.lower()
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -464,6 +464,12 @@ class ChatMixin:
               example, to only accept JPG/JPEG and PNG files, use
               ``["jpg", "jpeg", "png"]``.
 
+            .. note::
+                This is a best-effort check, but doesn't provide a
+                security guarantee against users uploading files of other types
+                or type extensions. The correct handling of uploaded files is
+                part of the app developer's responsibility.
+
         disabled : bool
             Whether the chat input should be disabled. This defaults to
             ``False``.

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -296,6 +296,12 @@ class FileUploaderMixin:
               example, to only accept JPG/JPEG and PNG files, use
               ``["jpg", "jpeg", "png"]``.
 
+            .. note::
+                This is a best-effort check, but doesn't provide a
+                security guarantee against users uploading files of other types
+                or type extensions. The correct handling of uploaded files is
+                part of the app developer's responsibility.
+
         accept_multiple_files : bool
             Whether to accept more than one file in a submission. If this is
             ``False`` (default), the user can only submit one file at a time.

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import unittest
 from typing import TYPE_CHECKING
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -70,6 +71,9 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
                 True,
             ),
             ("extension_is_uppercase", "document.CSV", [".csv"], True),
+            # On non-Windows, a colon is a valid filename character.
+            ("colon_in_filename_valid", "my:file.txt", [".txt"], True),
+            ("colon_in_filename_invalid", "my:file.txt", [".log"], False),
             # Invalid cases
             ("invalid_single_extension", "document.docx", [".pdf", ".png"], False),
             (
@@ -81,6 +85,18 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
             ("no_extension", "file_without_extension", [".pdf", ".png"], False),
             ("empty_filename", "", [".pdf", ".tar.gz"], False),
             ("filename_is_period", ".", [".pdf", ".tar.gz"], False),
+        ]
+    )
+    def test_filename_valid(self, _, filename, allowed_types, expected_valid):
+        """Test whether filenames are valid against allowed extensions."""
+        actual_valid = is_filename_valid(filename, allowed_types)
+        assert actual_valid == expected_valid
+
+
+@mock.patch("streamlit.elements.lib.file_uploader_utils.os.name", "nt")
+class EnforceFilenameRestrictionWindowsTest(unittest.TestCase):
+    @parameterized.expand(
+        [
             (
                 "ads_bypass_attempt",
                 "file.txt:$fakeStream.pdf",
@@ -114,7 +130,9 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
             ),
         ]
     )
-    def test_filename_valid(self, _, filename, allowed_types, expected_valid):
-        """Test whether filenames are valid against allowed extensions."""
+    def test_filename_valid_on_windows(
+        self, _, filename, allowed_types, expected_valid
+    ):
+        """Test NTFS alternate data stream cases on Windows."""
         actual_valid = is_filename_valid(filename, allowed_types)
         assert actual_valid == expected_valid

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -81,6 +81,37 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
             ("no_extension", "file_without_extension", [".pdf", ".png"], False),
             ("empty_filename", "", [".pdf", ".tar.gz"], False),
             ("filename_is_period", ".", [".pdf", ".tar.gz"], False),
+            (
+                "ads_bypass_attempt",
+                "file.txt:$fakeStream.pdf",
+                [".pdf", ".png"],
+                False,
+            ),
+            (
+                "ads_valid_extension",
+                "document.pdf:$fakeStream.txt",
+                [".pdf", ".png"],
+                True,
+            ),
+            (
+                "regular_filename_with_colon_no_ads_extension",
+                "config.ini:section",
+                [".ini"],
+                False,
+            ),
+            (
+                "ads_no_main_extension",
+                "file:$fakeStream.pdf",
+                [".pdf"],
+                False,
+            ),
+            ("filename_starts_with_colon", ":foo.txt", [".txt"], False),
+            (
+                "multiple_colons_in_filename",
+                "file.pdf:stream1.txt:stream2.log",
+                [".pdf"],
+                True,
+            ),
         ]
     )
     def test_filename_valid(self, _, filename, allowed_types, expected_valid):

--- a/lib/tests/streamlit/file_uploader_utils_test.py
+++ b/lib/tests/streamlit/file_uploader_utils_test.py
@@ -85,6 +85,8 @@ class EnforceFilenameRestrictionTest(unittest.TestCase):
             ("no_extension", "file_without_extension", [".pdf", ".png"], False),
             ("empty_filename", "", [".pdf", ".tar.gz"], False),
             ("filename_is_period", ".", [".pdf", ".tar.gz"], False),
+            # Null byte injection
+            ("null_byte_injection", "file.txt\0.pdf", [".pdf"], False),
         ]
     )
     def test_filename_valid(self, _, filename, allowed_types, expected_valid):


### PR DESCRIPTION
## Describe your changes

This PR makes it more prominent that our `type` config for file uploading is only a best-effort check and not a technical guarantee. The correct handling of uploaded files is part of the app developer's responsibility. This PR also improves this check to handle a specific scenario with NTFS and to prevent filenames with null bytes.

- Related feature request: https://github.com/streamlit/streamlit/issues/7024
- https://github.com/streamlit/streamlit/pull/10509#issuecomment-2787052441

- Closes https://github.com/streamlit/streamlit/issues/11883

## Testing Plan

- Updated unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
