### PR TITLE
Add files generated in CI to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,10 @@ frontend/cypress/snapshots/linux/1x
 
 # Performance suite output
 **/.benchmarks/
+
+
+########################################################################
+# Files during CI runs
+########################################################################
+./protoc-*-linux-x86_64.zip
+./python_cache_key.md5


### PR DESCRIPTION
## Describe your changes

Adds two files that get generated/downloaded during the CI execution to our gitignore file to improve how it works with copilot agent (which reuses our GitHub Action build action).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
