### PR TITLE
[fix] Make the topPadding also look to see if there's a sidebar so that it stays consistent

### DIFF
--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -386,6 +386,42 @@ describe("AppView element", () => {
         const style = getMainBlockContainerStyle()
         expect(style.paddingTop).toEqual("6rem")
       })
+
+      it("uses 6rem top padding regardless of sidebar content (hasSidebar does not affect non-embedded)", () => {
+        const sidebarElement = new ElementNode(
+          makeElementWithInfoText("sidebar!"),
+          ForwardMsgMetadata.create({}),
+          "no script run id",
+          FAKE_SCRIPT_HASH
+        )
+
+        const sidebar = new BlockNode(
+          FAKE_SCRIPT_HASH,
+          [sidebarElement],
+          new BlockProto({ allowEmpty: true })
+        )
+
+        const empty = new BlockNode(
+          FAKE_SCRIPT_HASH,
+          [],
+          new BlockProto({ allowEmpty: true })
+        )
+
+        render(
+          <AppView
+            {...getProps({
+              elements: new AppRoot(
+                FAKE_SCRIPT_HASH,
+                new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+              ),
+              embedded: false, // Non-embedded
+              appPages: [{ pageName: "page1", pageScriptHash: "hash1" }], // Single page, no top nav
+            })}
+          />
+        )
+        const style = getMainBlockContainerStyle()
+        expect(style.paddingTop).toEqual("6rem") // Should be 6rem, not affected by sidebar
+      })
     })
 
     describe("embedded apps", () => {

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -613,6 +613,47 @@ describe("AppView element", () => {
           expect(style.paddingTop).toEqual("4.5rem")
           expect(style.paddingBottom).toEqual("1rem")
         })
+
+        it("uses 4.5rem top padding when sidebar content exists (hasSidebar=true)", () => {
+          const sidebarElement = new ElementNode(
+            makeElementWithInfoText("sidebar!"),
+            ForwardMsgMetadata.create({}),
+            "no script run id",
+            FAKE_SCRIPT_HASH
+          )
+
+          const sidebar = new BlockNode(
+            FAKE_SCRIPT_HASH,
+            [sidebarElement],
+            new BlockProto({ allowEmpty: true })
+          )
+
+          const empty = new BlockNode(
+            FAKE_SCRIPT_HASH,
+            [],
+            new BlockProto({ allowEmpty: true })
+          )
+
+          vi.spyOn(
+            StreamlitContextProviderModule,
+            "useAppContext"
+          ).mockReturnValue(getContextOutput({ showToolbar: false }))
+
+          const props = getProps({
+            elements: new AppRoot(
+              FAKE_SCRIPT_HASH,
+              new BlockNode(FAKE_SCRIPT_HASH, [empty, sidebar, empty, empty])
+            ),
+            embedded: true,
+            showPadding: false,
+            appLogo: null, // No header content, only sidebar
+          })
+
+          render(<AppView {...props} />)
+          const style = getMainBlockContainerStyle()
+          expect(style.paddingTop).toEqual("4.5rem")
+          expect(style.paddingBottom).toEqual("1rem")
+        })
       })
     })
 

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -316,6 +316,7 @@ function AppView(props: AppViewProps): ReactElement {
                 showPadding={showPadding}
                 hasBottom={hasBottomElements}
                 hasHeader={hasHeaderUserContent}
+                hasSidebar={showSidebar}
                 showToolbar={showToolbar}
                 hasTopNav={shouldShowNavigation}
                 embedded={embedded}

--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -125,6 +125,7 @@ export interface StyledAppViewBlockContainerProps {
   hasHeader: boolean
   showToolbar: boolean
   hasTopNav: boolean
+  hasSidebar: boolean
   embedded: boolean
 }
 
@@ -137,6 +138,7 @@ export const StyledAppViewBlockContainer =
       hasHeader,
       showToolbar,
       hasTopNav,
+      hasSidebar,
       embedded,
       theme,
     }) => {
@@ -151,7 +153,7 @@ export const StyledAppViewBlockContainer =
       } else if (showPadding || showToolbar) {
         // 6rem if embedded with show_padding or show_toolbar
         topPadding = "6rem"
-      } else if (hasHeader) {
+      } else if (hasHeader || hasSidebar) {
         // 4.5rem if embedded with header but no padding/toolbar
         topPadding = "4.5rem"
       }


### PR DESCRIPTION
## Describe your changes

This update introduces the hasSidebar prop to the AppView component, allowing for conditional rendering based on the sidebar's visibility. Additionally, the styled-components interface has been updated to accommodate this new prop, ensuring proper styling adjustments when the sidebar is present.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

This fixes https://github.com/streamlit/streamlit/issues/11912

## Testing Plan

Added a js test for this.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
