### PR TITLE
Fix cache spinner test flakiness

### DIFF
--- a/lib/tests/streamlit/elements/cache_spinner_test.py
+++ b/lib/tests/streamlit/elements/cache_spinner_test.py
@@ -20,6 +20,9 @@ import streamlit as st
 from streamlit.elements.spinner import DELAY_SECS
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
+# Wait needs to be longer than the spinner delay timeout:
+TEST_DELAY_SECS = DELAY_SECS + 0.2
+
 
 @st.cache_data(show_spinner=False)
 def function_without_spinner():
@@ -56,7 +59,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_data(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
-            time.sleep(DELAY_SECS + 0.2)
+            time.sleep(TEST_DELAY_SECS)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
             return 3
@@ -68,7 +71,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_data(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
-            time.sleep(DELAY_SECS + 0.2)
+            time.sleep(TEST_DELAY_SECS)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
             return 3
@@ -80,7 +83,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_resource(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
-            time.sleep(DELAY_SECS + 0.2)
+            time.sleep(TEST_DELAY_SECS)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
             return 3
@@ -92,7 +95,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_resource(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
-            time.sleep(DELAY_SECS + 0.2)
+            time.sleep(TEST_DELAY_SECS)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
             return 3

--- a/lib/tests/streamlit/elements/cache_spinner_test.py
+++ b/lib/tests/streamlit/elements/cache_spinner_test.py
@@ -17,6 +17,7 @@
 import time
 
 import streamlit as st
+from streamlit.elements.spinner import DELAY_SECS
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -55,10 +56,9 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_data(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
-            time.sleep(0.5)
+            time.sleep(DELAY_SECS + 0.2)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
-            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_time()
@@ -68,10 +68,9 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_data(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
-            time.sleep(0.5)
+            time.sleep(DELAY_SECS + 0.2)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
-            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_no_time()
@@ -81,10 +80,9 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_resource(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
-            time.sleep(0.5)
+            time.sleep(DELAY_SECS + 0.2)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
-            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_time()
@@ -94,10 +92,9 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
 
         @st.cache_resource(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
-            time.sleep(0.5)
+            time.sleep(DELAY_SECS + 0.2)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
-            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_no_time()

--- a/lib/tests/streamlit/elements/cache_spinner_test.py
+++ b/lib/tests/streamlit/elements/cache_spinner_test.py
@@ -58,6 +58,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.5)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
+            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_time()
@@ -70,6 +71,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.5)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
+            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_no_time()
@@ -82,6 +84,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.5)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is True
+            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_time()
@@ -94,6 +97,7 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.5)
             el = self.get_delta_from_queue().new_element
             assert el.spinner.show_time is False
+            time.sleep(0.5)
             return 3
 
         function_with_spinner_and_no_time()


### PR DESCRIPTION
## Describe your changes

Attempt to fix some flakiness with the cache spinner unit tests, e.g. https://github.com/streamlit/streamlit/actions/runs/16268056240/job/45928342989?pr=11928#step:7:5839

The spinner has a delay (currently 0.5s). To resolve flakiness, we need to use a sleep value above the spinner delay.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
