### PR TITLE
Make crossorigin property configurable for media elements

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -478,6 +478,7 @@ export class App extends PureComponent<Props, State> {
           enforceDownloadInNewTab,
           metricsUrl,
           blockErrorDialogs,
+          setAnonymousCrossOriginPropertyOnMediaElements,
         } = response
 
         const appConfig: AppConfig = {
@@ -490,6 +491,7 @@ export class App extends PureComponent<Props, State> {
           mapboxToken,
           disableFullscreenMode,
           enforceDownloadInNewTab,
+          setAnonymousCrossOriginPropertyOnMediaElements,
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -479,6 +479,7 @@ export class App extends PureComponent<Props, State> {
           metricsUrl,
           blockErrorDialogs,
           setAnonymousCrossOriginPropertyOnMediaElements,
+          resourceCrossOriginMode,
         } = response
 
         const appConfig: AppConfig = {
@@ -491,7 +492,11 @@ export class App extends PureComponent<Props, State> {
           mapboxToken,
           disableFullscreenMode,
           enforceDownloadInNewTab,
-          setAnonymousCrossOriginPropertyOnMediaElements,
+          resourceCrossOriginMode:
+            (resourceCrossOriginMode ??
+            setAnonymousCrossOriginPropertyOnMediaElements)
+              ? "anonymous"
+              : undefined,
         }
 
         // Set the metrics configuration:

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -183,6 +183,13 @@ export type LibConfig = {
   disableFullscreenMode?: boolean
 
   enforceDownloadInNewTab?: boolean
+
+  /**
+   * Whether to set the `crossOrigin` property to `anonymous` on media elements (img, video, audio).
+   * If it is set to false, the `crossOrigin` property will not be set on media elements at all.
+   * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
+   */
+  setAnonymousCrossOriginPropertyOnMediaElements?: boolean
 }
 
 /**

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -185,10 +185,13 @@ export type LibConfig = {
   enforceDownloadInNewTab?: boolean
 
   /**
-   * Whether to set the `crossOrigin` property to `anonymous` on media elements (img, video, audio).
-   * If it is set to false, the `crossOrigin` property will not be set on media elements at all.
+   * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
+   * If it is set to undefined, the `crossOrigin` property will not be set on media elements at all.
    * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
    */
+  resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
+
+  /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
   setAnonymousCrossOriginPropertyOnMediaElements?: boolean
 }
 

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -41,11 +41,11 @@ export type LibConfig = {
   enforceDownloadInNewTab?: boolean
 
   /**
-   * Whether to set the `crossOrigin` property to `anonymous` on media elements (img, video, audio).
-   * If it is set to false, the `crossOrigin` property will not be set on media elements at all.
+   * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
+   * If it is set to undefined, the `crossOrigin` property will not be set on media elements at all.
    * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
    */
-  setAnonymousCrossOriginPropertyOnMediaElements?: boolean
+  resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
 }
 
 export interface LibContextProps {

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -39,6 +39,13 @@ export type LibConfig = {
   disableFullscreenMode?: boolean
 
   enforceDownloadInNewTab?: boolean
+
+  /**
+   * Whether to set the `crossOrigin` property to `anonymous` on media elements (img, video, audio).
+   * If it is set to false, the `crossOrigin` property will not be set on media elements at all.
+   * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
+   */
+  setAnonymousCrossOriginPropertyOnMediaElements?: boolean
 }
 
 export interface LibContextProps {

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -20,7 +20,7 @@ import { fireEvent, screen } from "@testing-library/react"
 
 import { Audio as AudioProto } from "@streamlit/protobuf"
 
-import { render } from "~lib/test_util"
+import { render, renderWithContexts } from "~lib/test_util"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
@@ -144,5 +144,34 @@ describe("Audio Element", () => {
       "onerror triggered",
       "https://mock.media.url/"
     )
+  })
+
+  describe("crossOrigin attribute", () => {
+    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+      const props = getProps()
+      renderWithContexts(<Audio {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+      })
+      const audioElement = screen.getByTestId("stAudio")
+      expect(audioElement).toHaveAttribute("crossOrigin", "anonymous")
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+      const props = getProps()
+      renderWithContexts(<Audio {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+      })
+      const audioElement = screen.getByTestId("stAudio")
+      expect(audioElement).not.toHaveAttribute("crossOrigin")
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", () => {
+      const props = getProps()
+      renderWithContexts(<Audio {...props} />, {
+        libConfig: {},
+      })
+      const audioElement = screen.getByTestId("stAudio")
+      expect(audioElement).not.toHaveAttribute("crossOrigin")
+    })
   })
 })

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -147,25 +147,34 @@ describe("Audio Element", () => {
   })
 
   describe("crossOrigin attribute", () => {
-    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+    it("sets crossOrigin to 'anonymous' when resourceCrossOriginMode is 'anonymous'", () => {
       const props = getProps()
       renderWithContexts(<Audio {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+        libConfig: { resourceCrossOriginMode: "anonymous" },
       })
       const audioElement = screen.getByTestId("stAudio")
       expect(audioElement).toHaveAttribute("crossOrigin", "anonymous")
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+    it("sets crossOrigin to 'use-credentials' when resourceCrossOriginMode is 'use-credentials'", () => {
       const props = getProps()
       renderWithContexts(<Audio {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+        libConfig: { resourceCrossOriginMode: "use-credentials" },
+      })
+      const audioElement = screen.getByTestId("stAudio")
+      expect(audioElement).toHaveAttribute("crossOrigin", "use-credentials")
+    })
+
+    it("does not set crossOrigin attribute when resourceCrossOriginMode is undefined", () => {
+      const props = getProps()
+      renderWithContexts(<Audio {...props} />, {
+        libConfig: { resourceCrossOriginMode: undefined },
       })
       const audioElement = screen.getByTestId("stAudio")
       expect(audioElement).not.toHaveAttribute("crossOrigin")
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", () => {
+    it("does not set crossOrigin attribute when libConfig is empty", () => {
       const props = getProps()
       renderWithContexts(<Audio {...props} />, {
         libConfig: {},

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react"
 
 import { getLogger } from "loglevel"
 
 import { Audio as AudioProto } from "@streamlit/protobuf"
 
+import { LibContext } from "~lib/components/core/LibContext"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
@@ -37,6 +45,8 @@ function Audio({
   endpoints,
   elementMgr,
 }: Readonly<AudioProps>): ReactElement {
+  const { libConfig } = useContext(LibContext)
+
   const audioRef = useRef<HTMLAudioElement>(null)
 
   const { startTime, endTime, loop, autoplay } = element
@@ -175,6 +185,12 @@ function Audio({
         autoPlay={autoplay && !preventAutoplay}
         src={uri}
         onError={handleAudioError}
+        crossOrigin={
+          libConfig.setAnonymousCrossOriginPropertyOnMediaElements
+            ? "anonymous"
+            : // Setting it to undefined will not set the crossOrigin property in the DOM
+              undefined
+        }
       />
     </StyledAudioContainer>
   )

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -185,12 +185,7 @@ function Audio({
         autoPlay={autoplay && !preventAutoplay}
         src={uri}
         onError={handleAudioError}
-        crossOrigin={
-          libConfig.setAnonymousCrossOriginPropertyOnMediaElements
-            ? "anonymous"
-            : // Setting it to undefined will not set the crossOrigin property in the DOM
-              undefined
-        }
+        crossOrigin={libConfig.resourceCrossOriginMode}
       />
     </StyledAudioContainer>
   )

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -20,7 +20,7 @@ import { fireEvent, screen } from "@testing-library/react"
 
 import { ImageList as ImageListProto } from "@streamlit/protobuf"
 
-import { render } from "~lib/test_util"
+import { render, renderWithContexts } from "~lib/test_util"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 
@@ -122,5 +122,43 @@ describe("ImageList Element", () => {
       "onerror triggered",
       "https://mock.media.url/"
     )
+  })
+
+  describe("crossOrigin attribute", () => {
+    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+      const props = getProps()
+      renderWithContexts(<ImageList {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+      })
+      const images = screen.getAllByRole("img")
+      expect(images).toHaveLength(2)
+      images.forEach(image => {
+        expect(image).toHaveAttribute("crossOrigin", "anonymous")
+      })
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+      const props = getProps()
+      renderWithContexts(<ImageList {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+      })
+      const images = screen.getAllByRole("img")
+      expect(images).toHaveLength(2)
+      images.forEach(image => {
+        expect(image).not.toHaveAttribute("crossOrigin")
+      })
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", () => {
+      const props = getProps()
+      renderWithContexts(<ImageList {...props} />, {
+        libConfig: {},
+      })
+      const images = screen.getAllByRole("img")
+      expect(images).toHaveLength(2)
+      images.forEach(image => {
+        expect(image).not.toHaveAttribute("crossOrigin")
+      })
+    })
   })
 })

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -125,10 +125,10 @@ describe("ImageList Element", () => {
   })
 
   describe("crossOrigin attribute", () => {
-    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+    it("sets crossOrigin to 'anonymous' when resourceCrossOriginMode is 'anonymous'", () => {
       const props = getProps()
       renderWithContexts(<ImageList {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+        libConfig: { resourceCrossOriginMode: "anonymous" },
       })
       const images = screen.getAllByRole("img")
       expect(images).toHaveLength(2)
@@ -137,10 +137,22 @@ describe("ImageList Element", () => {
       })
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+    it("sets crossOrigin to 'use-credentials' when resourceCrossOriginMode is 'use-credentials'", () => {
       const props = getProps()
       renderWithContexts(<ImageList {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+        libConfig: { resourceCrossOriginMode: "use-credentials" },
+      })
+      const images = screen.getAllByRole("img")
+      expect(images).toHaveLength(2)
+      images.forEach(image => {
+        expect(image).toHaveAttribute("crossOrigin", "use-credentials")
+      })
+    })
+
+    it("does not set crossOrigin attribute when resourceCrossOriginMode is undefined", () => {
+      const props = getProps()
+      renderWithContexts(<ImageList {...props} />, {
+        libConfig: { resourceCrossOriginMode: undefined },
       })
       const images = screen.getAllByRole("img")
       expect(images).toHaveLength(2)
@@ -149,7 +161,7 @@ describe("ImageList Element", () => {
       })
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", () => {
+    it("does not set crossOrigin attribute when libConfig is empty", () => {
       const props = getProps()
       renderWithContexts(<ImageList {...props} />, {
         libConfig: {},

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -165,12 +165,7 @@ function ImageList({
                 src={endpoints.buildMediaURL(image.url)}
                 alt={idx.toString()}
                 onError={handleImageError}
-                crossOrigin={
-                  libConfig.setAnonymousCrossOriginPropertyOnMediaElements
-                    ? "anonymous"
-                    : // Setting it to undefined will not set the crossOrigin property in the DOM
-                      undefined
-                }
+                crossOrigin={libConfig.resourceCrossOriginMode}
               />
               {image.caption && (
                 <StyledCaption data-testid="stImageCaption" style={imgStyle}>

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { CSSProperties, memo, ReactElement } from "react"
+import React, { CSSProperties, memo, ReactElement, useContext } from "react"
 
 import { getLogger } from "loglevel"
 
@@ -31,6 +31,7 @@ import Toolbar, {
   StyledToolbarElementContainer,
 } from "~lib/components/shared/Toolbar"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+import { LibContext } from "~lib/components/core/LibContext"
 
 import {
   StyledCaption,
@@ -75,6 +76,7 @@ function ImageList({
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
+  const { libConfig } = useContext(LibContext)
 
   // The width of the element is the width of the container, not necessarily the image.
   const elementWidth = width || 0
@@ -163,6 +165,12 @@ function ImageList({
                 src={endpoints.buildMediaURL(image.url)}
                 alt={idx.toString()}
                 onError={handleImageError}
+                crossOrigin={
+                  libConfig.setAnonymousCrossOriginPropertyOnMediaElements
+                    ? "anonymous"
+                    : // Setting it to undefined will not set the crossOrigin property in the DOM
+                      undefined
+                }
               />
               {image.caption && (
                 <StyledCaption data-testid="stImageCaption" style={imgStyle}>

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -253,25 +253,34 @@ describe("Video Element", () => {
   })
 
   describe("crossOrigin attribute", () => {
-    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", async () => {
+    it("sets crossOrigin to 'anonymous' when resourceCrossOriginMode is 'anonymous'", async () => {
       const props = getProps()
       renderWithContexts(<Video {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+        libConfig: { resourceCrossOriginMode: "anonymous" },
       })
       const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", async () => {
+    it("sets crossOrigin to 'use-credentials' when resourceCrossOriginMode is 'use-credentials'", async () => {
       const props = getProps()
       renderWithContexts(<Video {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+        libConfig: { resourceCrossOriginMode: "use-credentials" },
+      })
+      const videoElement = await screen.findByTestId("stVideo")
+      expect(videoElement).toHaveAttribute("crossOrigin", "use-credentials")
+    })
+
+    it("does not set crossOrigin attribute when resourceCrossOriginMode is undefined", async () => {
+      const props = getProps()
+      renderWithContexts(<Video {...props} />, {
+        libConfig: { resourceCrossOriginMode: undefined },
       })
       const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).not.toHaveAttribute("crossOrigin")
     })
 
-    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", async () => {
+    it("does not set crossOrigin attribute when libConfig is empty", async () => {
       const props = getProps()
       renderWithContexts(<Video {...props} />, {
         libConfig: {},
@@ -280,7 +289,7 @@ describe("Video Element", () => {
       expect(videoElement).not.toHaveAttribute("crossOrigin")
     })
 
-    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is false but dev mode with subtitles", async () => {
+    it("sets crossOrigin to 'anonymous' when in dev mode with subtitles regardless of resourceCrossOriginMode", async () => {
       // Store original NODE_ENV
       const originalNodeEnv = process.env.NODE_ENV
       process.env.NODE_ENV = "development"
@@ -289,7 +298,7 @@ describe("Video Element", () => {
         subtitles: [{ url: "https://mock.subtitle.url" }],
       })
       renderWithContexts(<Video {...props} />, {
-        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+        libConfig: { resourceCrossOriginMode: undefined },
       })
       const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -20,7 +20,7 @@ import { fireEvent, screen } from "@testing-library/react"
 
 import { Video as VideoProto } from "@streamlit/protobuf"
 
-import { render } from "~lib/test_util"
+import { render, renderWithContexts } from "~lib/test_util"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
@@ -249,6 +249,53 @@ describe("Video Element", () => {
       const props = getProps()
       render(<Video {...props} />)
       expect(props.endpoints.checkSourceUrlResponse).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("crossOrigin attribute", () => {
+    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", async () => {
+      const props = getProps()
+      renderWithContexts(<Video {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: true },
+      })
+      const videoElement = await screen.findByTestId("stVideo")
+      expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", async () => {
+      const props = getProps()
+      renderWithContexts(<Video {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+      })
+      const videoElement = await screen.findByTestId("stVideo")
+      expect(videoElement).not.toHaveAttribute("crossOrigin")
+    })
+
+    it("does not set crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is undefined", async () => {
+      const props = getProps()
+      renderWithContexts(<Video {...props} />, {
+        libConfig: {},
+      })
+      const videoElement = await screen.findByTestId("stVideo")
+      expect(videoElement).not.toHaveAttribute("crossOrigin")
+    })
+
+    it("sets crossOrigin to 'anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is false but dev mode with subtitles", async () => {
+      // Store original NODE_ENV
+      const originalNodeEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = "development"
+
+      const props = getProps({
+        subtitles: [{ url: "https://mock.subtitle.url" }],
+      })
+      renderWithContexts(<Video {...props} />, {
+        libConfig: { setAnonymousCrossOriginPropertyOnMediaElements: false },
+      })
+      const videoElement = await screen.findByTestId("stVideo")
+      expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")
+
+      // Restore original NODE_ENV
+      process.env.NODE_ENV = originalNodeEnv
     })
   })
 })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react"
 
 import { getLogger } from "loglevel"
 
 import { ISubtitleTrack, Video as VideoProto } from "@streamlit/protobuf"
 
+import { LibContext } from "~lib/components/core/LibContext"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
@@ -44,6 +52,8 @@ function Video({
   endpoints,
   elementMgr,
 }: Readonly<VideoProps>): ReactElement {
+  const { libConfig } = useContext(LibContext)
+
   const videoRef = useRef<HTMLVideoElement>(null)
 
   /* Element may contain "url" or "data" property. */
@@ -256,7 +266,8 @@ function Video({
       src={endpoints.buildMediaURL(url)}
       style={VIDEO_STYLE}
       crossOrigin={
-        process.env.NODE_ENV === "development" && subtitles.length > 0
+        (process.env.NODE_ENV === "development" && subtitles.length > 0) ||
+        libConfig.setAnonymousCrossOriginPropertyOnMediaElements
           ? "anonymous"
           : undefined
       }

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -266,10 +266,9 @@ function Video({
       src={endpoints.buildMediaURL(url)}
       style={VIDEO_STYLE}
       crossOrigin={
-        (process.env.NODE_ENV === "development" && subtitles.length > 0) ||
-        libConfig.setAnonymousCrossOriginPropertyOnMediaElements
+        process.env.NODE_ENV === "development" && subtitles.length > 0
           ? "anonymous"
-          : undefined
+          : libConfig.resourceCrossOriginMode
       }
       onError={handleVideoError}
     >

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -618,16 +618,16 @@ describe("CustomMediaTag", () => {
 
   // Create minimal mock for LibContext focusing only on what CustomMediaTag needs
   const createMockLibContextValue = (
-    setAnonymousCrossOriginPropertyOnMediaElements: boolean
+    resourceCrossOriginMode: undefined | "anonymous" | "use-credentials"
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any => {
     return {
-      libConfig: { setAnonymousCrossOriginPropertyOnMediaElements },
+      libConfig: { resourceCrossOriginMode },
     }
   }
 
   it("should render img element with crossOrigin='anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
-    const mockContextValue = createMockLibContextValue(true)
+    const mockContextValue = createMockLibContextValue("anonymous")
     render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={mockNode} {...mockProps} />
@@ -641,7 +641,7 @@ describe("CustomMediaTag", () => {
   })
 
   it("should render img element without crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
-    const mockContextValue = createMockLibContextValue(false)
+    const mockContextValue = createMockLibContextValue(undefined)
     render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={mockNode} {...mockProps} />
@@ -662,7 +662,7 @@ describe("CustomMediaTag", () => {
       controls: true,
     }
 
-    const mockContextValue = createMockLibContextValue(true)
+    const mockContextValue = createMockLibContextValue("anonymous")
     const { container } = render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={videoNode} {...videoProps} />
@@ -683,7 +683,7 @@ describe("CustomMediaTag", () => {
       controls: true,
     }
 
-    const mockContextValue = createMockLibContextValue(false)
+    const mockContextValue = createMockLibContextValue(undefined)
     const { container } = render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={videoNode} {...videoProps} />
@@ -704,7 +704,7 @@ describe("CustomMediaTag", () => {
       controls: true,
     }
 
-    const mockContextValue = createMockLibContextValue(true)
+    const mockContextValue = createMockLibContextValue("anonymous")
     const { container } = render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={audioNode} {...audioProps} />
@@ -725,7 +725,7 @@ describe("CustomMediaTag", () => {
       controls: true,
     }
 
-    const mockContextValue = createMockLibContextValue(false)
+    const mockContextValue = createMockLibContextValue(undefined)
     const { container } = render(
       <LibContext.Provider value={mockContextValue}>
         <CustomMediaTag node={audioNode} {...audioProps} />

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -25,11 +25,13 @@ import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { colors } from "~lib/theme/primitives/colors"
 import IsDialogContext from "~lib/components/core/IsDialogContext"
 import { mockTheme } from "~lib/mocks/mockTheme"
+import { LibContext } from "~lib/components/core/LibContext"
 
 import StreamlitMarkdown, {
   createAnchorFromText,
   CustomCodeTag,
   CustomCodeTagProps,
+  CustomMediaTag,
   CustomPreTag,
   LinkWithTargetBlank,
 } from "./StreamlitMarkdown"
@@ -603,5 +605,136 @@ describe("CustomPreTag", () => {
     expect(preTag).toHaveTextContent(
       'import streamlit as st st.write("Hello")'
     )
+  })
+})
+
+describe("CustomMediaTag", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockNode = { tagName: "img" } as any
+  const mockProps = {
+    src: "test-image.jpg",
+    alt: "Test image",
+  }
+
+  // Create minimal mock for LibContext focusing only on what CustomMediaTag needs
+  const createMockLibContextValue = (
+    setAnonymousCrossOriginPropertyOnMediaElements: boolean
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): any => {
+    return {
+      libConfig: { setAnonymousCrossOriginPropertyOnMediaElements },
+    }
+  }
+
+  it("should render img element with crossOrigin='anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+    const mockContextValue = createMockLibContextValue(true)
+    render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={mockNode} {...mockProps} />
+      </LibContext.Provider>
+    )
+
+    const imgElement = screen.getByRole("img")
+    expect(imgElement).toHaveAttribute("crossOrigin", "anonymous")
+    expect(imgElement).toHaveAttribute("src", "test-image.jpg")
+    expect(imgElement).toHaveAttribute("alt", "Test image")
+  })
+
+  it("should render img element without crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+    const mockContextValue = createMockLibContextValue(false)
+    render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={mockNode} {...mockProps} />
+      </LibContext.Provider>
+    )
+
+    const imgElement = screen.getByRole("img")
+    expect(imgElement).not.toHaveAttribute("crossOrigin")
+    expect(imgElement).toHaveAttribute("src", "test-image.jpg")
+    expect(imgElement).toHaveAttribute("alt", "Test image")
+  })
+
+  it("should render video element with crossOrigin='anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const videoNode = { tagName: "video" } as any
+    const videoProps = {
+      src: "test-video.mp4",
+      controls: true,
+    }
+
+    const mockContextValue = createMockLibContextValue(true)
+    const { container } = render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={videoNode} {...videoProps} />
+      </LibContext.Provider>
+    )
+
+    const videoElement = container.querySelector("video")
+    expect(videoElement).toBeTruthy()
+    expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")
+    expect(videoElement).toHaveAttribute("src", "test-video.mp4")
+  })
+
+  it("should render video element without crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const videoNode = { tagName: "video" } as any
+    const videoProps = {
+      src: "test-video.mp4",
+      controls: true,
+    }
+
+    const mockContextValue = createMockLibContextValue(false)
+    const { container } = render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={videoNode} {...videoProps} />
+      </LibContext.Provider>
+    )
+
+    const videoElement = container.querySelector("video")
+    expect(videoElement).toBeTruthy()
+    expect(videoElement).not.toHaveAttribute("crossOrigin")
+    expect(videoElement).toHaveAttribute("src", "test-video.mp4")
+  })
+
+  it("should render audio element with crossOrigin='anonymous' when setAnonymousCrossOriginPropertyOnMediaElements is true", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const audioNode = { tagName: "audio" } as any
+    const audioProps = {
+      src: "test-audio.mp3",
+      controls: true,
+    }
+
+    const mockContextValue = createMockLibContextValue(true)
+    const { container } = render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={audioNode} {...audioProps} />
+      </LibContext.Provider>
+    )
+
+    const audioElement = container.querySelector("audio")
+    expect(audioElement).toBeTruthy()
+    expect(audioElement).toHaveAttribute("crossOrigin", "anonymous")
+    expect(audioElement).toHaveAttribute("src", "test-audio.mp3")
+  })
+
+  it("should render audio element without crossOrigin attribute when setAnonymousCrossOriginPropertyOnMediaElements is false", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const audioNode = { tagName: "audio" } as any
+    const audioProps = {
+      src: "test-audio.mp3",
+      controls: true,
+    }
+
+    const mockContextValue = createMockLibContextValue(false)
+    const { container } = render(
+      <LibContext.Provider value={mockContextValue}>
+        <CustomMediaTag node={audioNode} {...audioProps} />
+      </LibContext.Provider>
+    )
+
+    const audioElement = container.querySelector("audio")
+    expect(audioElement).toBeTruthy()
+    expect(audioElement).not.toHaveAttribute("crossOrigin")
+    expect(audioElement).toHaveAttribute("src", "test-audio.mp3")
   })
 })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -47,6 +47,7 @@ import remarkEmoji from "remark-emoji"
 import remarkGfm from "remark-gfm"
 import { findAndReplace } from "mdast-util-find-and-replace"
 
+import { LibContext } from "~lib/components/core/LibContext"
 import StreamlitSyntaxHighlighter from "~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter"
 import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
 import IsDialogContext from "~lib/components/core/IsDialogContext"
@@ -373,6 +374,23 @@ export const CustomPreTag: FC<ReactMarkdownProps> = ({ children }) => {
   )
 }
 
+export const CustomMediaTag: FC<
+  JSX.IntrinsicElements["img" | "video" | "audio"] &
+    ReactMarkdownProps & { node: Element }
+> = ({ node, ...props }) => {
+  const { libConfig } = useContext(LibContext)
+
+  const Tag = node.tagName
+  const attributes = {
+    ...props,
+    crossOrigin: libConfig.setAnonymousCrossOriginPropertyOnMediaElements
+      ? "anonymous"
+      : // Setting it to undefined will not set the crossOrigin property in the DOM
+        undefined,
+  }
+  return <Tag {...attributes} />
+}
+
 // These are common renderers that don't depend on props or context
 const BASE_RENDERERS = {
   pre: CustomPreTag,
@@ -383,6 +401,9 @@ const BASE_RENDERERS = {
   h4: CustomHeading,
   h5: CustomHeading,
   h6: CustomHeading,
+  img: CustomMediaTag,
+  video: CustomMediaTag,
+  audio: CustomMediaTag,
 }
 
 /**

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -383,10 +383,7 @@ export const CustomMediaTag: FC<
   const Tag = node.tagName
   const attributes = {
     ...props,
-    crossOrigin: libConfig.setAnonymousCrossOriginPropertyOnMediaElements
-      ? "anonymous"
-      : // Setting it to undefined will not set the crossOrigin property in the DOM
-        undefined,
+    crossOrigin: libConfig.resourceCrossOriginMode,
   }
   return <Tag {...attributes} />
 }

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -243,7 +243,9 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
                 "blockErrorDialogs": False,
-                "setAnonymousCrossOriginPropertyOnMediaElements": False,
+                # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if
+                #   so with which value. One of None, "anonymous", "use-credentials".
+                "resourceCrossOriginMode": None,
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -243,6 +243,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "enforceDownloadInNewTab": False,
                 "metricsUrl": "",
                 "blockErrorDialogs": False,
+                "setAnonymousCrossOriginPropertyOnMediaElements": False,
             }
         )
         self.set_status(200)

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -291,6 +291,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "enforceDownloadInNewTab": False,
             "metricsUrl": "",
             "blockErrorDialogs": False,
+            "setAnonymousCrossOriginPropertyOnMediaElements": False,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -291,7 +291,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "enforceDownloadInNewTab": False,
             "metricsUrl": "",
             "blockErrorDialogs": False,
-            "setAnonymousCrossOriginPropertyOnMediaElements": False,
+            "resourceCrossOriginMode": None,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]


### PR DESCRIPTION
## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->

This PR adds a new field to the `/host-config` endpoint: `resourceCrossOriginMode `
If this field is set to `"anonymous"`, the `crossOrigin="anonymous"` (see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin) is added to the media elements `img`, `audio`, and `video` including when rendered via markdown.
This allows those elements to render when loaded from a cross origin target, though the browser does not add any credentials automatically to the request.
If the value is undefined, the `crossOrigin` property is not set at all.

For testing reasons, the server can also send the `setAnonymousCrossOriginPropertyOnMediaElements: true` field. This field can be removed in a few weeks.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Added unit tests to ensure that the attribute `crossOrigin` is set based on the new lib context
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
