### PR TITLE
[fix] flaky video end test

### DIFF
--- a/e2e_playwright/st_video_test.py
+++ b/e2e_playwright/st_video_test.py
@@ -128,9 +128,22 @@ def test_video_end_time(app: Page, video_option_label: str):
     video_element = _select_video_to_show(app, video_option_label)
     _wait_until_video_has_data(app, video_element)
     video_element.evaluate("el => el.play()")
-    # Wait until video will reach end_time
-    app.wait_for_timeout(3000)
-    expect(video_element).to_have_js_property("paused", True)
+
+    # Wait for the video to actually start playing
+    wait_until(
+        app,
+        lambda: video_element.evaluate("el => !el.paused") is True,
+        timeout=2000,
+    )
+
+    # Wait until video reaches end_time and pauses
+    wait_until(
+        app,
+        lambda: video_element.evaluate("el => el.paused") is True,
+        timeout=5000,
+    )
+
+    # Verify the video stopped at the expected end_time (33 seconds)
     wait_until(app, lambda: int(video_element.evaluate("el => el.currentTime")) == 33)
 
 


### PR DESCRIPTION
## Describe your changes

Attempt to reduce flakiness by introducing new waits and a bit longer timeouts. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Test only.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
