### PR TITLE
PoC showing how many e2e tests fail when react strict mode is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ frontend-with-profiler:
 	# Build frontend dependent libraries (excluding app and lib):
 	cd frontend/ ; yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological run build
 	# Build the app with the profiler enabled:
-	cd frontend/ ; FORCE_STRICT_MODE=1 yarn workspace @streamlit/app buildWithProfiler
+	cd frontend/ ; VITE_MODE=development FORCE_STRICT_MODE=1 yarn workspace @streamlit/app buildWithProfiler
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ frontend-with-profiler:
 	# Build frontend dependent libraries (excluding app and lib):
 	cd frontend/ ; yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological run build
 	# Build the app with the profiler enabled:
-	cd frontend/ ; yarn workspace @streamlit/app buildWithProfiler
+	cd frontend/ ; FORCE_STRICT_MODE=1 yarn workspace @streamlit/app buildWithProfiler
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 

--- a/frontend/app/src/StrictModeVerifier.tsx
+++ b/frontend/app/src/StrictModeVerifier.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from "react"
+
+let renderCount = 0
+
+export function StrictModeVerifier(): null {
+  const isFirstRender = useRef(true)
+
+  // In StrictMode, this effect will run twice on mount
+  useEffect(() => {
+    renderCount++
+
+    // Only log on the very first render of the app
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+
+      // Log with a unique marker that we can grep for in CI logs
+      // eslint-disable-next-line no-console
+      console.log(
+        `🔍 STRICT_MODE_VERIFICATION: Component rendered ${renderCount} time(s). ` +
+          `StrictMode is ${renderCount > 1 ? "ACTIVE ✅" : "NOT ACTIVE ❌"}`
+      )
+
+      // Also add a data attribute to the DOM for e2e tests to check
+      const marker = document.createElement("div")
+      marker.setAttribute("data-testid", "strict-mode-marker")
+      marker.setAttribute("data-strict-mode-active", String(renderCount > 1))
+      marker.style.display = "none"
+      document.body.appendChild(marker)
+    }
+  }, [])
+
+  return null
+}

--- a/frontend/app/src/ThemedApp.tsx
+++ b/frontend/app/src/ThemedApp.tsx
@@ -25,6 +25,7 @@ import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclarati
 
 import AppWithScreencast from "./App"
 import { useThemeManager } from "./util/useThemeManager"
+import { StrictModeVerifier } from "./StrictModeVerifier"
 
 export interface ThemedAppProps {
   streamlitExecutionStartedAt: number
@@ -38,6 +39,7 @@ const ThemedApp = ({
 
   return (
     <RootStyleProvider theme={activeTheme}>
+      <StrictModeVerifier />
       <WindowDimensionsProvider>
         {/* The data grid requires one root level portal element for rendering cell overlays */}
         <PortalProvider>

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -40,10 +40,15 @@ if (!rootDomNode) {
 
 const reactRoot = createRoot(rootDomNode)
 
-reactRoot.render(
-  <StrictMode>
-    <StyletronProvider value={engine}>
-      <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
-    </StyletronProvider>
-  </StrictMode>
+// Force StrictMode for e2e tests when FORCE_STRICT_MODE is set
+const shouldUseStrictMode =
+  process.env.FORCE_STRICT_MODE === "1" ||
+  process.env.NODE_ENV === "development"
+
+const app = (
+  <StyletronProvider value={engine}>
+    <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
+  </StyletronProvider>
 )
+
+reactRoot.render(shouldUseStrictMode ? <StrictMode>{app}</StrictMode> : app)

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -40,15 +40,10 @@ if (!rootDomNode) {
 
 const reactRoot = createRoot(rootDomNode)
 
-// Force StrictMode for e2e tests when FORCE_STRICT_MODE is set
-const shouldUseStrictMode =
-  process.env.FORCE_STRICT_MODE === "1" ||
-  process.env.NODE_ENV === "development"
-
-const app = (
-  <StyletronProvider value={engine}>
-    <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
-  </StyletronProvider>
+reactRoot.render(
+  <StrictMode>
+    <StyletronProvider value={engine}>
+      <ThemedApp streamlitExecutionStartedAt={streamlitExecutionStartedAt} />
+    </StyletronProvider>
+  </StrictMode>
 )
-
-reactRoot.render(shouldUseStrictMode ? <StrictMode>{app}</StrictMode> : app)

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -57,6 +57,9 @@ export default defineConfig({
     PACKAGE_METADATA: {
       version,
     },
+    "process.env.FORCE_STRICT_MODE": JSON.stringify(
+      process.env.FORCE_STRICT_MODE || ""
+    ),
   },
   plugins: [
     react({


### PR DESCRIPTION
- Updated the Makefile to set `FORCE_STRICT_MODE=1` when building the app with the profiler.
- Modified `vite.config.ts` to include `process.env.FORCE_STRICT_MODE` in the build configuration.
- Adjusted `index.tsx` to conditionally wrap the app in `StrictMode` based on the `FORCE_STRICT_MODE` environment variable, enhancing support for end-to-end tests.

These changes improve the development and testing experience by allowing stricter checks during the build process.

## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
