### PR TITLE
fix: Deduplicate equivalent file extensions in file uploader UI display

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
@@ -61,4 +61,22 @@ describe("FileDropzoneInstructions widget", () => {
     render(<FileDropzoneInstructions {...props} />)
     expect(screen.getByText(/• JPG, CSV.GZ, PNG, TAR.GZ/)).toBeInTheDocument()
   })
+
+  it("deduplicates equivalent extensions (shows only JPG when both JPG and JPEG are present)", () => {
+    const props = getProps({
+      acceptedExtensions: [".jpg", ".jpeg", ".png"],
+    })
+    render(<FileDropzoneInstructions {...props} />)
+    expect(screen.getByText(/• JPG, PNG/)).toBeInTheDocument()
+    // Should not show JPEG
+    expect(screen.queryByText(/JPEG/)).not.toBeInTheDocument()
+  })
+
+  it("shows JPEG when only JPEG is present (no JPG)", () => {
+    const props = getProps({
+      acceptedExtensions: [".jpeg", ".png"],
+    })
+    render(<FileDropzoneInstructions {...props} />)
+    expect(screen.getByText(/• JPEG, PNG/)).toBeInTheDocument()
+  })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -35,6 +35,43 @@ export interface Props {
   maxSizeBytes: number
 }
 
+
+const deduplicateExtensionsForDisplay = (extensions: string[]): string[] => {
+  const extensionPairs = [
+    [".jpg", ".jpeg"],
+    [".mpg", ".mpeg"],
+    [".mp4", ".mpeg4"],
+    [".tif", ".tiff"],
+    [".htm", ".html"],
+  ]
+
+
+  const normalizedExtensions = extensions.map(ext => ext.toLowerCase())
+
+
+  const preferredExtensions = new Set<string>()
+
+
+  for (const [first, second] of extensionPairs) {
+    if (normalizedExtensions.includes(first)) {
+      preferredExtensions.add(first)
+    }
+  }
+
+  // Filter out extensions that have a preferred alternative
+  return extensions.filter(ext => {
+    const normalizedExt = ext.toLowerCase()
+
+    for (const [first, second] of extensionPairs) {
+      if (normalizedExt === second && preferredExtensions.has(first)) {
+        return false
+      }
+    }
+
+    return true
+  })
+}
+
 const FileDropzoneInstructions = ({
   multiple,
   acceptedExtensions,
@@ -51,7 +88,7 @@ const FileDropzoneInstructions = ({
       <Small>
         {`Limit ${getSizeDisplay(maxSizeBytes, FileSize.Byte, 0)} per file`}
         {acceptedExtensions.length
-          ? ` • ${acceptedExtensions
+          ? ` • ${deduplicateExtensionsForDisplay(acceptedExtensions)
               .map(ext => ext.replace(/^\./, "").toUpperCase())
               .join(", ")}`
           : null}


### PR DESCRIPTION
#11991

### Describe your changes

- I fixed redundant display of equivalent file extensions in `st.file_uploader` UI. When both JPG and JPEG extensions are present (due to backend auto-expansion), the UI now shows only "JPG" instead of "JPG, JPEG". This applies to all equivalent extension pairs: JPG/JPEG, MPG/MPEG, MP4/MPEG4, TIF/TIFF, and HTM/HTML.

**Before**: `st.file_uploader(type=["jpg"])` displayed "PNG, JPG, JPEG"  
**After**: `st.file_uploader(type=["jpg"])` displays "PNG, JPG"

### GitHub Issue Link (if applicable)

- Fixes the issue described in the bug report about redundant JPG/JPEG display in file uploader UI.

## Testing Plan

- **Unit Tests**: Added comprehensive tests in `FileDropzoneInstructions.test.tsx` covering JPG/JPEG deduplication scenarios
- **Manual Testing**: Verified the logic handles all edge cases including mixed extensions and single extension scenarios
- **No additional tests needed**: The existing file uploader functionality remains unchanged; only the display logic was modified