### PR TITLE
Hide quickselect in `date_input` if min date is more than 2 years ago

### DIFF
--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -469,7 +469,7 @@ describe("DateInput widget", () => {
   })
 
   describe("quick select feature", () => {
-    it("shows quick select for range date inputs if minDate is within 2 years", async () => {
+    it("hides quick select for range date inputs if minDate is within 2 years", async () => {
       const user = userEvent.setup()
       const recentMinDate = moment().subtract(1, "year").format("YYYY/MM/DD")
       const props = getProps({
@@ -486,12 +486,11 @@ describe("DateInput widget", () => {
       const dateInput = screen.getByTestId("stDateInputField")
       await user.click(dateInput)
 
-      // Quick select should be visible for range inputs
-      const quickSelect = screen.getByRole("combobox")
-      expect(quickSelect).toBeVisible()
+      // Quick select should not be visible
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
     })
 
-    it("hides quick select for range date inputs if minDate is older than 2 years", async () => {
+    it("shows quick select for range date inputs if minDate is older than 2 years", async () => {
       const user = userEvent.setup()
       const oldMinDate = "2020/01/01"
       const props = getProps({
@@ -508,11 +507,12 @@ describe("DateInput widget", () => {
       const dateInput = screen.getByTestId("stDateInputField")
       await user.click(dateInput)
 
-      // Quick select should not be visible
-      expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+      // Quick select should be visible
+      const quickSelect = screen.getByRole("combobox")
+      expect(quickSelect).toBeVisible()
     })
 
-    it("hides quick select by default because minDate is 1970", async () => {
+    it("shows quick select by default because minDate is 1970", async () => {
       const user = userEvent.setup()
       const props = getProps({
         isRange: true,
@@ -524,8 +524,9 @@ describe("DateInput widget", () => {
       const dateInput = screen.getByTestId("stDateInputField")
       await user.click(dateInput)
 
-      // Quick select should NOT be visible for range inputs with old minDate
-      expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+      // Quick select should be visible for range inputs with old minDate
+      const quickSelect = screen.getByRole("combobox")
+      expect(quickSelect).toBeVisible()
     })
 
     it("does not show quick select for single date inputs", async () => {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -18,6 +18,7 @@ import React from "react"
 
 import { act, fireEvent, screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
+import moment from "moment"
 
 import {
   DateInput as DateInputProto,
@@ -468,7 +469,50 @@ describe("DateInput widget", () => {
   })
 
   describe("quick select feature", () => {
-    it("shows quick select for range date inputs", async () => {
+    it("shows quick select for range date inputs if minDate is within 2 years", async () => {
+      const user = userEvent.setup()
+      const recentMinDate = moment().subtract(1, "year").format("YYYY/MM/DD")
+      const props = getProps({
+        isRange: true,
+        min: recentMinDate,
+        default: [
+          recentMinDate,
+          moment(recentMinDate).add(1, "day").format("YYYY/MM/DD"),
+        ],
+      })
+
+      render(<DateInput {...props} />)
+
+      const dateInput = screen.getByTestId("stDateInputField")
+      await user.click(dateInput)
+
+      // Quick select should be visible for range inputs
+      const quickSelect = screen.getByRole("combobox")
+      expect(quickSelect).toBeVisible()
+    })
+
+    it("hides quick select for range date inputs if minDate is older than 2 years", async () => {
+      const user = userEvent.setup()
+      const oldMinDate = "2020/01/01"
+      const props = getProps({
+        isRange: true,
+        min: oldMinDate,
+        default: [
+          oldMinDate,
+          moment(oldMinDate).add(1, "day").format("YYYY/MM/DD"),
+        ],
+      })
+
+      render(<DateInput {...props} />)
+
+      const dateInput = screen.getByTestId("stDateInputField")
+      await user.click(dateInput)
+
+      // Quick select should not be visible
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    })
+
+    it("hides quick select by default because minDate is 1970", async () => {
       const user = userEvent.setup()
       const props = getProps({
         isRange: true,
@@ -480,9 +524,8 @@ describe("DateInput widget", () => {
       const dateInput = screen.getByTestId("stDateInputField")
       await user.click(dateInput)
 
-      // Quick select should be visible for range inputs
-      const quickSelect = screen.getByRole("combobox")
-      expect(quickSelect).toBeVisible()
+      // Quick select should NOT be visible for range inputs with old minDate
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
     })
 
     it("does not show quick select for single date inputs", async () => {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -125,6 +125,17 @@ function DateInput({
 
   const maxDate = useMemo(() => getMaxDate(element), [element])
 
+  const enableQuickSelect = useMemo(() => {
+    if (!element.isRange) {
+      return false
+    }
+
+    // Since quick select allows to select the past 2 years,
+    // we need to disable it if the min date is smaller than 2 years ago.
+    const twoYearsAgo = moment().subtract(2, "years").toDate()
+    return minDate > twoYearsAgo
+  }, [element.isRange, minDate])
+
   const clearable = element.default.length === 0 && !disabled
 
   // We need to extract the mask and format (date-fns notation) from the provided format string
@@ -243,7 +254,7 @@ function DateInput({
         disabled={disabled}
         onChange={handleChange}
         onClose={handleClose}
-        quickSelect={element.isRange}
+        quickSelect={enableQuickSelect}
         overrides={{
           Popover: {
             props: {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -130,10 +130,10 @@ function DateInput({
       return false
     }
 
-    // Since quick select allows to select the past 2 years,
-    // we need to disable it if the min date is smaller than 2 years ago.
+    // Since quick select allows to select ranges up to the past 2 years,
+    // we should only enable it if the min date is older than 2 years ago.
     const twoYearsAgo = moment().subtract(2, "years").toDate()
-    return minDate > twoYearsAgo
+    return minDate < twoYearsAgo
   }, [element.isRange, minDate])
 
   const clearable = element.default.length === 0 && !disabled


### PR DESCRIPTION
## Describe your changes

Quickselect in date input is allowing to go back to up to 2 years. In order to comply with the configured min date, we are only activating quickselect if the min date is at least 2 years ago

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11939

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
