### PR TITLE
[WIP] Prevent resetting page title on rerun

### DIFF
--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -98,9 +98,6 @@ export class AppNavigation {
       this.hideSidebarNav = newSession.config?.hideSidebarNav ?? null
     }
 
-    // We do not know the page name, so use an empty string version
-    document.title = getTitle("")
-
     return [
       {
         // Set current page script hash to handle SPA case


### PR DESCRIPTION
## Describe your changes

The page title currently gets reset on every rerun (new session message). This can lead to unexpected results, like the title getting reset until a callback finishes:

```python
import time

import streamlit as st

st.set_page_config(page_title="Callback Test")

st.title("Callback Test")


def _sleep_and_show_spinner():
    time.sleep(3)


st.button("Sleep in callback", on_click=_sleep_and_show_spinner)

if st.button("Sleep inline"):
    time.sleep(3)
```

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
