### PR TITLE
Fix confusing `no running event loop` logs

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -62,6 +62,7 @@ from streamlit.web.server.stats_request_handler import StatsRequestHandler
 from streamlit.web.server.upload_file_request_handler import UploadFileRequestHandler
 
 if TYPE_CHECKING:
+    import asyncio
     from collections.abc import Awaitable
     from ssl import SSLContext
 
@@ -239,6 +240,11 @@ class Server:
         self.initialize_mimetypes()
 
         self._main_script_path = main_script_path
+
+        # The task that runs the server if an event loop is already running.
+        # We need to save a reference to it so that it doesn't get
+        # garbage collected while running.
+        self._bootstrap_task: asyncio.Task[None] | None = None
 
         # Initialize MediaFileStorage and its associated endpoint
         media_file_storage = MemoryMediaFileStorage(MEDIA_ENDPOINT)


### PR DESCRIPTION
## Describe your changes

This improves our bootstrap logic and prevents the confusing `RuntimeError: no running event loop` message from being displayed on unrelated errors. In the current state, if `asyncio.run(main())` throws an uncaught exception, it will always show as:

```
RuntimeError: no running event loop

During handling of the above exception, another exception occurred:
```

since the exception is thrown within the `except RuntimeError` block. This is confusing since the RuntimeError is expected.

## Testing Plan

- Existing logic should cover this well.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
