### PR TITLE
Make Download URL configurable & allow preventing download attribute

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -480,7 +480,7 @@ export class App extends PureComponent<Props, State> {
           blockErrorDialogs,
           setAnonymousCrossOriginPropertyOnMediaElements,
           resourceCrossOriginMode,
-          setDownloadAttributeOnLinkElements,
+          preventDownloadAttribute,
         } = response
 
         const appConfig: AppConfig = {
@@ -498,7 +498,7 @@ export class App extends PureComponent<Props, State> {
             setAnonymousCrossOriginPropertyOnMediaElements)
               ? "anonymous"
               : undefined,
-          setDownloadAttributeOnLinkElements,
+          preventDownloadAttribute,
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -480,6 +480,7 @@ export class App extends PureComponent<Props, State> {
           blockErrorDialogs,
           setAnonymousCrossOriginPropertyOnMediaElements,
           resourceCrossOriginMode,
+          setDownloadAttributeOnLinkElements,
         } = response
 
         const appConfig: AppConfig = {
@@ -497,6 +498,7 @@ export class App extends PureComponent<Props, State> {
             setAnonymousCrossOriginPropertyOnMediaElements)
               ? "anonymous"
               : undefined,
+          setDownloadAttributeOnLinkElements,
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -480,7 +480,6 @@ export class App extends PureComponent<Props, State> {
           blockErrorDialogs,
           setAnonymousCrossOriginPropertyOnMediaElements,
           resourceCrossOriginMode,
-          preventDownloadAttribute,
         } = response
 
         const appConfig: AppConfig = {
@@ -489,6 +488,7 @@ export class App extends PureComponent<Props, State> {
           enableCustomParentMessages,
           blockErrorDialogs,
         }
+
         const libConfig: LibConfig = {
           mapboxToken,
           disableFullscreenMode,
@@ -498,7 +498,6 @@ export class App extends PureComponent<Props, State> {
             setAnonymousCrossOriginPropertyOnMediaElements)
               ? "anonymous"
               : undefined,
-          preventDownloadAttribute,
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -78,6 +78,10 @@ class Endpoints implements StreamlitEndpoints {
     return url
   }
 
+  public buildDownloadUrl(url: string): string {
+    return url
+  }
+
   public buildFileUploadURL(url: string): string {
     return url
   }

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -31,6 +31,7 @@ const mockEndpoints = {
     (componentName: string, path: string) => `${componentName}/${path}`
   ),
   buildMediaURL: vi.fn((url: string) => url),
+  buildDownloadUrl: vi.fn((url: string) => url),
   buildAppPageURL: vi.fn((_baseUrl, page) => page.pageName || ""),
   uploadFileUploaderFile: vi.fn(),
 }

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -236,7 +236,6 @@ export class ConnectionManager {
 
   private connectToRunningServer(): WebsocketConnection {
     const baseUriPartsList = getPossibleBaseUris()
-
     return new WebsocketConnection({
       getLastSessionId: this.props.getLastSessionId,
       endpoints: this.props.endpoints,

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -119,6 +119,41 @@ describe("DefaultStreamlitEndpoints", () => {
     })
   })
 
+  describe("buildDownloadUrl", () => {
+    const endpoints = new DefaultStreamlitEndpoints({
+      getServerUri: () => MOCK_SERVER_URI,
+      csrfEnabled: false,
+      sendClientError: vi.fn(),
+    })
+
+    beforeEach(() => {
+      // Reset window.__streamlit before each test
+      window.__streamlit = undefined
+    })
+
+    it("builds URL correctly for streamlit-served media when DOWNLOAD_ASSETS_BASE_URL is not set", () => {
+      const url = endpoints.buildDownloadUrl("/media/1234567890.pdf")
+      expect(url).toBe(
+        "http://streamlit.mock:80/mock/base/path/media/1234567890.pdf"
+      )
+    })
+
+    it("builds URL correctly when DOWNLOAD_ASSETS_BASE_URL is set", () => {
+      window.__streamlit = {
+        DOWNLOAD_ASSETS_BASE_URL: "https://downloads.example.com/assets",
+      }
+      const url = endpoints.buildDownloadUrl("/media/1234567890.pdf")
+      expect(url).toBe(
+        "https://downloads.example.com/assets/media/1234567890.pdf"
+      )
+    })
+
+    it("passes through non-media URLs unchanged", () => {
+      const url = endpoints.buildDownloadUrl("https://example.com/file.pdf")
+      expect(url).toBe("https://example.com/file.pdf")
+    })
+  })
+
   describe("buildFileUploadURL", () => {
     const endpoints = new DefaultStreamlitEndpoints({
       getServerUri: () => MOCK_SERVER_URI,

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -26,6 +26,7 @@ import {
 } from "@streamlit/utils"
 
 import { FileUploadClientConfig, StreamlitEndpoints } from "./types"
+import { parseUriIntoBaseParts } from "./utils"
 
 const LOG = getLogger("DefaultStreamlitEndpoints")
 
@@ -177,6 +178,25 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       return buildHttpUri(this.requireServerUri(), url)
     }
     return url
+  }
+
+  /**
+   * Construct a URL for a download file.
+   * @param url a relative or absolute URL. If `url` is absolute, it will be
+   * returned unchanged. Otherwise, the return value will be a URL for fetching
+   * the media file from the connected Streamlit instance. The target server can
+   * be changed by setting window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL.
+   */
+  public buildDownloadUrl(url: string): string {
+    if (!url.startsWith(MEDIA_ENDPOINT)) {
+      return url
+    }
+
+    // The url is relative, so we need to build the full URL.
+    const downloadAssetBaseUrl = window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL
+    return downloadAssetBaseUrl
+      ? buildHttpUri(parseUriIntoBaseParts(downloadAssetBaseUrl), url)
+      : buildHttpUri(this.requireServerUri(), url)
   }
 
   /**

--- a/frontend/connection/src/testUtils.ts
+++ b/frontend/connection/src/testUtils.ts
@@ -28,6 +28,7 @@ export function mockEndpoints(
     checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
+    buildDownloadUrl: vi.fn(),
     buildFileUploadURL: vi.fn(),
     buildAppPageURL: vi
       .fn()

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -115,6 +115,14 @@ export interface StreamlitEndpoints {
   buildMediaURL(url: string): string
 
   /**
+   * Construct a URL for a download file.
+   * @param url a relative or absolute URL. If `url` is absolute, it will be
+   * returned unchanged. Otherwise, the return value will be a URL for fetching
+   * the media file from the connected Streamlit instance.
+   */
+  buildDownloadUrl(url: string): string
+
+  /**
    * Construct a URL for uploading a file.
    * @param url a relative or absolute URL. If `url` is absolute, it will be
    * returned unchanged. Otherwise, the return value will be a URL for fetching

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -201,13 +201,6 @@ export type LibConfig = {
 
   /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
   setAnonymousCrossOriginPropertyOnMediaElements?: boolean
-
-  /** When set to true, the download attribute will not be set on the link element. This is mainly for scenarios
-   * where a service worker is in the play, as the service worker will not intercept the download request otherwise
-   * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
-   * Content-Disposition header.
-   */
-  preventDownloadAttribute?: boolean
 }
 
 /**

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -193,6 +193,13 @@ export type LibConfig = {
 
   /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
   setAnonymousCrossOriginPropertyOnMediaElements?: boolean
+
+  /** When set to false, the download attribute will not be set on the link element. This is mainly for scenarios
+   * where a service worker is in the play, as the service worker will not intercept the download request otherwise
+   * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
+   * Content-Disposition header.
+   */
+  setDownloadAttributeOnLinkElements?: boolean
 }
 
 /**

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -194,12 +194,12 @@ export type LibConfig = {
   /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
   setAnonymousCrossOriginPropertyOnMediaElements?: boolean
 
-  /** When set to false, the download attribute will not be set on the link element. This is mainly for scenarios
+  /** When set to true, the download attribute will not be set on the link element. This is mainly for scenarios
    * where a service worker is in the play, as the service worker will not intercept the download request otherwise
    * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
    * Content-Disposition header.
    */
-  setDownloadAttributeOnLinkElements?: boolean
+  preventDownloadAttribute?: boolean
 }
 
 /**

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -25,10 +25,6 @@ const INITIAL_SLASH_RE = /^\/+/
 export function parseUriIntoBaseParts(url?: string): URL {
   const currentUrl = new URL(url ?? window.location.href)
 
-  if (!currentUrl.port) {
-    currentUrl.port = currentUrl.protocol === "https:" ? "443" : "80"
-  }
-
   currentUrl.pathname = currentUrl.pathname
     .replace(FINAL_SLASH_RE, "")
     .replace(INITIAL_SLASH_RE, "")

--- a/frontend/lib/src/FileUploadClient.test.ts
+++ b/frontend/lib/src/FileUploadClient.test.ts
@@ -41,6 +41,7 @@ describe("FileUploadClient Upload", () => {
         checkSourceUrlResponse: vi.fn(),
         buildComponentURL: vi.fn(),
         buildMediaURL: vi.fn(),
+        buildDownloadUrl: vi.fn(),
         buildFileUploadURL: vi.fn(),
         buildAppPageURL: vi.fn(),
         uploadFileUploaderFile: uploadFileUploaderFile,

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -77,6 +77,14 @@ export interface StreamlitEndpoints {
   buildMediaURL(url: string): string
 
   /**
+   * Construct a URL for a download file.
+   * @param url a relative or absolute URL. If `url` is absolute, it will be
+   * returned unchanged. Otherwise, the return value will be a URL for fetching
+   * the media file from the connected Streamlit instance.
+   */
+  buildDownloadUrl(url: string): string
+
+  /**
    * Construct a URL for uploading a file.
    * @param url a relative or absolute URL. If `url` is absolute, it will be
    * returned unchanged. Otherwise, the return value will be a URL for fetching

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -40,12 +40,12 @@ export type LibConfig = {
 
   enforceDownloadInNewTab?: boolean
 
-  /** When set to false, the download attribute will not be set on the link element. This is mainly for scenarios
+  /** When set to true, the download attribute will not be set on the link element. This is mainly for scenarios
    * where a service worker is in the play, as the service worker will not intercept the download request otherwise
    * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
    * Content-Disposition header.
    */
-  setDownloadAttributeOnLinkElements?: boolean
+  preventDownloadAttribute?: boolean
 
   /**
    * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -40,6 +40,13 @@ export type LibConfig = {
 
   enforceDownloadInNewTab?: boolean
 
+  /** When set to false, the download attribute will not be set on the link element. This is mainly for scenarios
+   * where a service worker is in the play, as the service worker will not intercept the download request otherwise
+   * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
+   * Content-Disposition header.
+   */
+  setDownloadAttributeOnLinkElements?: boolean
+
   /**
    * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
    * It is only applied when window.__streamlit.BACKEND_BASE_URL is set.

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -40,13 +40,6 @@ export type LibConfig = {
 
   enforceDownloadInNewTab?: boolean
 
-  /** When set to true, the download attribute will not be set on the link element. This is mainly for scenarios
-   * where a service worker is in the play, as the service worker will not intercept the download request otherwise
-   * (see https://issues.chromium.org/issues/40410035). The browser will still set the file name based on the server's
-   * Content-Disposition header.
-   */
-  preventDownloadAttribute?: boolean
-
   /**
    * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
    * It is only applied when window.__streamlit.BACKEND_BASE_URL is set.

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -159,6 +159,7 @@ const noOpEndpoints: StreamlitEndpoints = {
   checkSourceUrlResponse: () => Promise.resolve(),
   buildComponentURL: () => "",
   buildMediaURL: () => "",
+  buildDownloadUrl: () => "",
   buildFileUploadURL: () => "",
   buildAppPageURL: () => "",
   uploadFileUploaderFile: () =>

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -15,8 +15,8 @@
  */
 import { getLogger } from "loglevel"
 
-import { isNullOrUndefined } from "~lib/util/utils"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
+import { isNullOrUndefined } from "~lib/util/utils"
 
 import { ComponentMessageType } from "./enums"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -194,6 +194,7 @@ function useDataExporter(
           enforceDownloadInNewTab,
           url,
           filename: suggestedName,
+          setDownloadAttribute: true,
         })
 
         link.style.display = "none"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -194,9 +194,6 @@ function useDataExporter(
           enforceDownloadInNewTab,
           url,
           filename: suggestedName,
-          // The download attribute can be set here because the file is created in the browser,
-          // and does not need to go through a service worker.
-          setDownloadAttribute: true,
         })
 
         link.style.display = "none"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -19,11 +19,11 @@ import { useCallback } from "react"
 import { DataEditorProps } from "@glideapps/glide-data-grid"
 import { getLogger } from "loglevel"
 
-import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 import {
   BaseColumn,
   toSafeString,
 } from "~lib/components/widgets/DataFrame/columns"
+import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 import { isNullOrUndefined } from "~lib/util/utils"
 
 // Delimiter between cells
@@ -194,6 +194,8 @@ function useDataExporter(
           enforceDownloadInNewTab,
           url,
           filename: suggestedName,
+          // The download attribute can be set here because the file is created in the browser,
+          // and does not need to go through a service worker.
           setDownloadAttribute: true,
         })
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -26,7 +26,7 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 
-import DownloadButton, { getDownloadUrl, Props } from "./DownloadButton"
+import DownloadButton, { Props } from "./DownloadButton"
 
 vi.mock("~lib/WidgetStateManager")
 vi.mock("~lib/StreamlitEndpoints")
@@ -113,7 +113,7 @@ describe("DownloadButton widget", () => {
         undefined
       )
 
-      expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(
+      expect(props.endpoints.buildDownloadUrl).toHaveBeenCalledWith(
         "/media/mockDownloadURL"
       )
     })
@@ -164,41 +164,6 @@ describe("DownloadButton widget", () => {
       expect(linkWithoutDownload.getAttribute("download")).toBeNull()
     })
 
-    describe("getDownloadUrl", () => {
-      beforeEach(() => {
-        // Reset window.__streamlit before each test
-        window.__streamlit = undefined
-      })
-
-      it("returns buildMediaURL result when no DOWNLOAD_ASSETS_BASE_URL is set", () => {
-        const props = getProps()
-        const url = "/test/file.pdf"
-        getDownloadUrl(props.endpoints, url)
-        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(url)
-      })
-
-      it("uses DOWNLOAD_ASSETS_BASE_URL when available", () => {
-        const props = getProps()
-
-        window.__streamlit = {
-          DOWNLOAD_ASSETS_BASE_URL: "https://assets.example.com",
-        }
-        const url = "/test/file.pdf"
-        getDownloadUrl(props.endpoints, url)
-        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(
-          "https://assets.example.com:/test/file.pdf"
-        )
-      })
-
-      it("handles empty url", () => {
-        const props = getProps()
-
-        const url = ""
-        getDownloadUrl(props.endpoints, url)
-        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith("")
-      })
-    })
-
     it("can set fragmentId on click", async () => {
       const user = userEvent.setup()
       const props = getProps(undefined, { fragmentId: "myFragmentId" })
@@ -225,7 +190,7 @@ describe("DownloadButton widget", () => {
 
   it("triggers checkSourceUrlResponse to check download url", () => {
     const props = getProps()
-    props.endpoints.buildMediaURL = vi.fn(url => url)
+    props.endpoints.buildDownloadUrl = vi.fn(url => url)
     render(<DownloadButton {...props} />)
 
     expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledWith(

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -24,8 +24,9 @@ import { DownloadButton as DownloadButtonProto } from "@streamlit/protobuf"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { mockEndpoints } from "~lib/mocks/mocks"
+import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 
-import DownloadButton, { createDownloadLink, Props } from "./DownloadButton"
+import DownloadButton, { getDownloadUrl, Props } from "./DownloadButton"
 
 vi.mock("~lib/WidgetStateManager")
 vi.mock("~lib/StreamlitEndpoints")
@@ -119,19 +120,83 @@ describe("DownloadButton widget", () => {
 
     it("has a correct new tab behaviour download link", () => {
       const props = getProps()
-      const sameTabLink = createDownloadLink(
-        props.endpoints,
-        props.element.url,
-        false
-      )
+      const sameTabLink = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: props.element.url,
+        filename: "",
+        setDownloadAttribute: true,
+      })
       expect(sameTabLink.getAttribute("target")).toBe("_self")
 
-      const newTabLink = createDownloadLink(
-        props.endpoints,
-        props.element.url,
-        true
-      )
+      const newTabLink = createDownloadLinkElement({
+        enforceDownloadInNewTab: true,
+        url: props.element.url,
+        filename: "",
+        setDownloadAttribute: true,
+      })
       expect(newTabLink.getAttribute("target")).toBe("_blank")
+    })
+
+    it("sets download attribute correctly", () => {
+      const props = getProps()
+      const linkWithoutFilename = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: props.element.url,
+        filename: "",
+        setDownloadAttribute: true,
+      })
+      expect(linkWithoutFilename.getAttribute("download")).toBe("")
+
+      const linkWithFilename = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: props.element.url,
+        filename: "test.pdf",
+        setDownloadAttribute: true,
+      })
+      expect(linkWithFilename.getAttribute("download")).toBe("test.pdf")
+
+      const linkWithoutDownload = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: props.element.url,
+        filename: "test.pdf",
+        setDownloadAttribute: false,
+      })
+      expect(linkWithoutDownload.getAttribute("download")).toBeNull()
+    })
+
+    describe("getDownloadUrl", () => {
+      beforeEach(() => {
+        // Reset window.__streamlit before each test
+        window.__streamlit = undefined
+      })
+
+      it("returns buildMediaURL result when no DOWNLOAD_ASSETS_BASE_URL is set", () => {
+        const props = getProps()
+        const url = "/test/file.pdf"
+        getDownloadUrl(props.endpoints, url)
+        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(url)
+      })
+
+      it("uses DOWNLOAD_ASSETS_BASE_URL when available", () => {
+        const props = getProps()
+
+        window.__streamlit = {
+          DOWNLOAD_ASSETS_BASE_URL: "https://assets.example.com",
+        }
+        const url = "/test/file.pdf"
+        getDownloadUrl(props.endpoints, url)
+        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(
+          "https://assets.example.com:/test/file.pdf"
+        )
+      })
+
+      it("handles empty url", () => {
+        const props = getProps()
+
+        const url = ""
+        getDownloadUrl(props.endpoints, url)
+        expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith("")
+      })
     })
 
     it("can set fragmentId on click", async () => {
@@ -160,6 +225,7 @@ describe("DownloadButton widget", () => {
 
   it("triggers checkSourceUrlResponse to check download url", () => {
     const props = getProps()
+    props.endpoints.buildMediaURL = vi.fn(url => url)
     render(<DownloadButton {...props} />)
 
     expect(props.endpoints.checkSourceUrlResponse).toHaveBeenCalledWith(

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -124,7 +124,6 @@ describe("DownloadButton widget", () => {
         enforceDownloadInNewTab: false,
         url: props.element.url,
         filename: "",
-        setDownloadAttribute: true,
       })
       expect(sameTabLink.getAttribute("target")).toBe("_self")
 
@@ -132,51 +131,144 @@ describe("DownloadButton widget", () => {
         enforceDownloadInNewTab: true,
         url: props.element.url,
         filename: "",
-        setDownloadAttribute: true,
       })
       expect(newTabLink.getAttribute("target")).toBe("_blank")
     })
 
-    it("sets download attribute correctly", () => {
-      const props = getProps()
-      const linkWithoutFilename = createDownloadLinkElement({
-        enforceDownloadInNewTab: false,
-        url: props.element.url,
-        filename: "",
-        setDownloadAttribute: true,
+    describe("download attribute", () => {
+      it("sets download attribute with empty filename", () => {
+        const props = getProps()
+        const link = createDownloadLinkElement({
+          enforceDownloadInNewTab: false,
+          url: props.element.url,
+          filename: "",
+        })
+        expect(link.getAttribute("download")).toBe("")
       })
-      expect(linkWithoutFilename.getAttribute("download")).toBe("")
 
-      const linkWithFilename = createDownloadLinkElement({
-        enforceDownloadInNewTab: false,
-        url: props.element.url,
-        filename: "test.pdf",
-        setDownloadAttribute: true,
+      it("sets download attribute with filename", () => {
+        const props = getProps()
+        const link = createDownloadLinkElement({
+          enforceDownloadInNewTab: false,
+          url: props.element.url,
+          filename: "test.pdf",
+        })
+        expect(link.getAttribute("download")).toBe("test.pdf")
       })
-      expect(linkWithFilename.getAttribute("download")).toBe("test.pdf")
 
-      const linkWithoutDownload = createDownloadLinkElement({
-        enforceDownloadInNewTab: false,
-        url: props.element.url,
-        filename: "test.pdf",
-        setDownloadAttribute: false,
+      it("omits download attribute for service worker compatibility in Chromium browsers", () => {
+        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+        const originalStreamlit = window.__streamlit
+        window.__streamlit = {
+          ...window.__streamlit,
+          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+        }
+
+        // Mock user agent to be a Chromium-based browser (not Firefox)
+        const originalUserAgent = Object.getOwnPropertyDescriptor(
+          window.navigator,
+          "userAgent"
+        )
+        Object.defineProperty(window.navigator, "userAgent", {
+          value:
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+          configurable: true,
+        })
+
+        try {
+          const link = createDownloadLinkElement({
+            enforceDownloadInNewTab: false,
+            url: "https://download.streamlit.app/file.pdf",
+            filename: "test.pdf",
+          })
+          expect(link.getAttribute("download")).toBeNull()
+        } finally {
+          // Cleanup
+          window.__streamlit = originalStreamlit
+          if (originalUserAgent) {
+            Object.defineProperty(
+              window.navigator,
+              "userAgent",
+              originalUserAgent
+            )
+          }
+        }
       })
-      expect(linkWithoutDownload.getAttribute("download")).toBeNull()
-    })
 
-    it("can set fragmentId on click", async () => {
-      const user = userEvent.setup()
-      const props = getProps(undefined, { fragmentId: "myFragmentId" })
-      render(<DownloadButton {...props} />)
+      it("sets download attribute in Firefox even with DOWNLOAD_ASSETS_BASE_URL", () => {
+        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+        const originalStreamlit = window.__streamlit
+        window.__streamlit = {
+          ...window.__streamlit,
+          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+        }
 
-      const downloadButton = screen.getByRole("button")
-      await user.click(downloadButton)
+        // Mock user agent to be Firefox
+        const originalUserAgent = Object.getOwnPropertyDescriptor(
+          window.navigator,
+          "userAgent"
+        )
+        Object.defineProperty(window.navigator, "userAgent", {
+          value:
+            "Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0",
+          configurable: true,
+        })
 
-      expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
-        props.element,
-        { fromUi: true },
-        "myFragmentId"
-      )
+        try {
+          const link = createDownloadLinkElement({
+            enforceDownloadInNewTab: false,
+            url: "https://download.streamlit.app/file.pdf",
+            filename: "test.pdf",
+          })
+          expect(link.getAttribute("download")).toBe("test.pdf")
+        } finally {
+          // Cleanup
+          window.__streamlit = originalStreamlit
+          if (originalUserAgent) {
+            Object.defineProperty(
+              window.navigator,
+              "userAgent",
+              originalUserAgent
+            )
+          }
+        }
+      })
+
+      it("sets download attribute when URL does not match DOWNLOAD_ASSETS_BASE_URL", () => {
+        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+        const originalStreamlit = window.__streamlit
+        window.__streamlit = {
+          ...window.__streamlit,
+          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+        }
+
+        try {
+          const link = createDownloadLinkElement({
+            enforceDownloadInNewTab: false,
+            url: "https://different-domain.com/file.pdf",
+            filename: "test.pdf",
+          })
+          expect(link.getAttribute("download")).toBe("test.pdf")
+        } finally {
+          // Cleanup
+          window.__streamlit = originalStreamlit
+        }
+      })
+
+      it("can set fragmentId on click", async () => {
+        const user = userEvent.setup()
+        const props = getProps(undefined, { fragmentId: "myFragmentId" })
+        render(<DownloadButton {...props} />)
+
+        const downloadButton = screen.getByRole("button")
+        await user.click(downloadButton)
+
+        expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+          props.element,
+          { fromUi: true },
+          "myFragmentId"
+        )
+      })
     })
 
     it("handles the disabled prop", () => {

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -135,140 +135,19 @@ describe("DownloadButton widget", () => {
       expect(newTabLink.getAttribute("target")).toBe("_blank")
     })
 
-    describe("download attribute", () => {
-      it("sets download attribute with empty filename", () => {
-        const props = getProps()
-        const link = createDownloadLinkElement({
-          enforceDownloadInNewTab: false,
-          url: props.element.url,
-          filename: "",
-        })
-        expect(link.getAttribute("download")).toBe("")
-      })
+    it("can set fragmentId on click", async () => {
+      const user = userEvent.setup()
+      const props = getProps(undefined, { fragmentId: "myFragmentId" })
+      render(<DownloadButton {...props} />)
 
-      it("sets download attribute with filename", () => {
-        const props = getProps()
-        const link = createDownloadLinkElement({
-          enforceDownloadInNewTab: false,
-          url: props.element.url,
-          filename: "test.pdf",
-        })
-        expect(link.getAttribute("download")).toBe("test.pdf")
-      })
+      const downloadButton = screen.getByRole("button")
+      await user.click(downloadButton)
 
-      it("omits download attribute for service worker compatibility in Chromium browsers", () => {
-        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
-        const originalStreamlit = window.__streamlit
-        window.__streamlit = {
-          ...window.__streamlit,
-          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
-        }
-
-        // Mock user agent to be a Chromium-based browser (not Firefox)
-        const originalUserAgent = Object.getOwnPropertyDescriptor(
-          window.navigator,
-          "userAgent"
-        )
-        Object.defineProperty(window.navigator, "userAgent", {
-          value:
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-          configurable: true,
-        })
-
-        try {
-          const link = createDownloadLinkElement({
-            enforceDownloadInNewTab: false,
-            url: "https://download.streamlit.app/file.pdf",
-            filename: "test.pdf",
-          })
-          expect(link.getAttribute("download")).toBeNull()
-        } finally {
-          // Cleanup
-          window.__streamlit = originalStreamlit
-          if (originalUserAgent) {
-            Object.defineProperty(
-              window.navigator,
-              "userAgent",
-              originalUserAgent
-            )
-          }
-        }
-      })
-
-      it("sets download attribute in Firefox even with DOWNLOAD_ASSETS_BASE_URL", () => {
-        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
-        const originalStreamlit = window.__streamlit
-        window.__streamlit = {
-          ...window.__streamlit,
-          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
-        }
-
-        // Mock user agent to be Firefox
-        const originalUserAgent = Object.getOwnPropertyDescriptor(
-          window.navigator,
-          "userAgent"
-        )
-        Object.defineProperty(window.navigator, "userAgent", {
-          value:
-            "Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0",
-          configurable: true,
-        })
-
-        try {
-          const link = createDownloadLinkElement({
-            enforceDownloadInNewTab: false,
-            url: "https://download.streamlit.app/file.pdf",
-            filename: "test.pdf",
-          })
-          expect(link.getAttribute("download")).toBe("test.pdf")
-        } finally {
-          // Cleanup
-          window.__streamlit = originalStreamlit
-          if (originalUserAgent) {
-            Object.defineProperty(
-              window.navigator,
-              "userAgent",
-              originalUserAgent
-            )
-          }
-        }
-      })
-
-      it("sets download attribute when URL does not match DOWNLOAD_ASSETS_BASE_URL", () => {
-        // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
-        const originalStreamlit = window.__streamlit
-        window.__streamlit = {
-          ...window.__streamlit,
-          DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
-        }
-
-        try {
-          const link = createDownloadLinkElement({
-            enforceDownloadInNewTab: false,
-            url: "https://different-domain.com/file.pdf",
-            filename: "test.pdf",
-          })
-          expect(link.getAttribute("download")).toBe("test.pdf")
-        } finally {
-          // Cleanup
-          window.__streamlit = originalStreamlit
-        }
-      })
-
-      it("can set fragmentId on click", async () => {
-        const user = userEvent.setup()
-        const props = getProps(undefined, { fragmentId: "myFragmentId" })
-        render(<DownloadButton {...props} />)
-
-        const downloadButton = screen.getByRole("button")
-        await user.click(downloadButton)
-
-        expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
-          props.element,
-          { fromUi: true },
-          "myFragmentId"
-        )
-      })
+      expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+        props.element,
+        { fromUi: true },
+        "myFragmentId"
+      )
     })
 
     it("handles the disabled prop", () => {

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useContext, useEffect } from "react"
+import React, {
+  memo,
+  ReactElement,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react"
 
 import { DownloadButton as DownloadButtonProto } from "@streamlit/protobuf"
+import { parseUriIntoBaseParts } from "@streamlit/connection"
+import { buildHttpUri } from "@streamlit/utils"
 
 import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 import BaseButton, {
@@ -37,64 +45,74 @@ export interface Props {
   fragmentId?: string
 }
 
-export function createDownloadLink(
+export function getDownloadUrl(
   endpoints: StreamlitEndpoints,
-  url: string,
-  enforceDownloadInNewTab: boolean
-): HTMLAnchorElement {
-  return createDownloadLinkElement({
-    enforceDownloadInNewTab,
-    url: endpoints.buildMediaURL(url),
-    filename: "",
-  })
+  url: string
+): string {
+  const downloadAssetBaseUrl = window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL
+  const downloadAssetsUriParts = downloadAssetBaseUrl
+    ? buildHttpUri(parseUriIntoBaseParts(downloadAssetBaseUrl), url)
+    : url
+  return endpoints.buildMediaURL(downloadAssetsUriParts)
 }
 
 function DownloadButton(props: Props): ReactElement {
   const { disabled, element, widgetMgr, endpoints, fragmentId } = props
+  const { help, label, icon, ignoreRerun, type, url, useContainerWidth } =
+    element
 
   const {
-    libConfig: { enforceDownloadInNewTab = false }, // Default to false, if no libConfig, e.g. for tests
+    libConfig: {
+      enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
+      setDownloadAttributeOnLinkElements = true,
+    },
   } = useContext(LibContext)
 
   let kind = BaseButtonKind.SECONDARY
-  if (element.type === "primary") {
+  if (type === "primary") {
     kind = BaseButtonKind.PRIMARY
-  } else if (element.type === "tertiary") {
+  } else if (type === "tertiary") {
     kind = BaseButtonKind.TERTIARY
   }
+
+  const downloadUrl = useMemo(
+    () => getDownloadUrl(endpoints, url),
+    [endpoints, url]
+  )
 
   useEffect(() => {
     // Since we use a hidden link to download, we can't use the onerror event
     // to catch src url load errors. Catch with direct check instead.
-    void endpoints.checkSourceUrlResponse(element.url, "Download Button")
-  }, [element.url, endpoints])
+    void endpoints.checkSourceUrlResponse(downloadUrl, "Download Button")
+  }, [downloadUrl])
 
   const handleDownloadClick: () => void = () => {
-    if (!element.ignoreRerun) {
+    if (!ignoreRerun) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Fix this
       widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
     }
     // Downloads are only done on links, so create a hidden one and click it
     // for the user.
-    const link = createDownloadLink(
-      endpoints,
-      element.url,
-      enforceDownloadInNewTab
-    )
+    const link = createDownloadLinkElement({
+      filename: "",
+      url: downloadUrl,
+      enforceDownloadInNewTab,
+      setDownloadAttribute: setDownloadAttributeOnLinkElements,
+    })
     link.click()
   }
 
   return (
     <div className="stDownloadButton" data-testid="stDownloadButton">
-      <BaseButtonTooltip help={element.help} containerWidth={true}>
+      <BaseButtonTooltip help={help} containerWidth={useContainerWidth}>
         <BaseButton
           kind={kind}
           size={BaseButtonSize.SMALL}
           disabled={disabled}
           onClick={handleDownloadClick}
-          containerWidth={true}
+          containerWidth={useContainerWidth}
         >
-          <DynamicButtonLabel icon={element.icon} label={element.label} />
+          <DynamicButtonLabel icon={icon} label={label} />
         </BaseButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -23,8 +23,6 @@ import React, {
 } from "react"
 
 import { DownloadButton as DownloadButtonProto } from "@streamlit/protobuf"
-import { parseUriIntoBaseParts } from "@streamlit/connection"
-import { buildHttpUri } from "@streamlit/utils"
 
 import createDownloadLinkElement from "~lib/util/createDownloadLinkElement"
 import BaseButton, {
@@ -45,17 +43,6 @@ export interface Props {
   fragmentId?: string
 }
 
-export function getDownloadUrl(
-  endpoints: StreamlitEndpoints,
-  url: string
-): string {
-  const downloadAssetBaseUrl = window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL
-  const downloadAssetsUriParts = downloadAssetBaseUrl
-    ? buildHttpUri(parseUriIntoBaseParts(downloadAssetBaseUrl), url)
-    : url
-  return endpoints.buildMediaURL(downloadAssetsUriParts)
-}
-
 function DownloadButton(props: Props): ReactElement {
   const { disabled, element, widgetMgr, endpoints, fragmentId } = props
   const { help, label, icon, ignoreRerun, type, url, useContainerWidth } =
@@ -64,7 +51,7 @@ function DownloadButton(props: Props): ReactElement {
   const {
     libConfig: {
       enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
-      setDownloadAttributeOnLinkElements = true,
+      preventDownloadAttribute = false,
     },
   } = useContext(LibContext)
 
@@ -76,7 +63,7 @@ function DownloadButton(props: Props): ReactElement {
   }
 
   const downloadUrl = useMemo(
-    () => getDownloadUrl(endpoints, url),
+    () => endpoints.buildDownloadUrl(url),
     [endpoints, url]
   )
 
@@ -84,7 +71,7 @@ function DownloadButton(props: Props): ReactElement {
     // Since we use a hidden link to download, we can't use the onerror event
     // to catch src url load errors. Catch with direct check instead.
     void endpoints.checkSourceUrlResponse(downloadUrl, "Download Button")
-  }, [downloadUrl])
+  }, [downloadUrl, endpoints])
 
   const handleDownloadClick: () => void = () => {
     if (!ignoreRerun) {
@@ -97,7 +84,7 @@ function DownloadButton(props: Props): ReactElement {
       filename: "",
       url: downloadUrl,
       enforceDownloadInNewTab,
-      setDownloadAttribute: setDownloadAttributeOnLinkElements,
+      setDownloadAttribute: !preventDownloadAttribute,
     })
     link.click()
   }

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -50,7 +50,6 @@ function DownloadButton(props: Props): ReactElement {
   const {
     libConfig: {
       enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
-      preventDownloadAttribute = false,
     },
   } = useContext(LibContext)
 
@@ -83,7 +82,6 @@ function DownloadButton(props: Props): ReactElement {
       filename: "",
       url: downloadUrl,
       enforceDownloadInNewTab,
-      setDownloadAttribute: !preventDownloadAttribute,
     })
     link.click()
   }

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -45,8 +45,7 @@ export interface Props {
 
 function DownloadButton(props: Props): ReactElement {
   const { disabled, element, widgetMgr, endpoints, fragmentId } = props
-  const { help, label, icon, ignoreRerun, type, url, useContainerWidth } =
-    element
+  const { help, label, icon, ignoreRerun, type, url } = element
 
   const {
     libConfig: {
@@ -91,13 +90,13 @@ function DownloadButton(props: Props): ReactElement {
 
   return (
     <div className="stDownloadButton" data-testid="stDownloadButton">
-      <BaseButtonTooltip help={help} containerWidth={useContainerWidth}>
+      <BaseButtonTooltip help={help} containerWidth={true}>
         <BaseButton
           kind={kind}
           size={BaseButtonSize.SMALL}
           disabled={disabled}
           onClick={handleDownloadClick}
-          containerWidth={useContainerWidth}
+          containerWidth={true}
         >
           <DynamicButtonLabel icon={icon} label={label} />
         </BaseButton>

--- a/frontend/lib/src/hooks/useDownloadUrl.ts
+++ b/frontend/lib/src/hooks/useDownloadUrl.ts
@@ -26,7 +26,7 @@ const useDownloadUrl = (
   const {
     libConfig: {
       enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
-      setDownloadAttributeOnLinkElements = true, // Default to true to retain existing behavior
+      preventDownloadAttribute = false, // Default to true to retain existing behavior
     },
   } = useContext(LibContext)
 
@@ -37,14 +37,14 @@ const useDownloadUrl = (
       enforceDownloadInNewTab,
       url,
       filename,
-      setDownloadAttribute: setDownloadAttributeOnLinkElements,
+      setDownloadAttribute: !preventDownloadAttribute,
     })
 
     link.style.display = "none"
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-  }, [url, enforceDownloadInNewTab, filename])
+  }, [url, enforceDownloadInNewTab, filename, preventDownloadAttribute])
 
   return downloadUrl
 }

--- a/frontend/lib/src/hooks/useDownloadUrl.ts
+++ b/frontend/lib/src/hooks/useDownloadUrl.ts
@@ -24,7 +24,10 @@ const useDownloadUrl = (
   filename: string
 ): (() => void) => {
   const {
-    libConfig: { enforceDownloadInNewTab = false }, // Default to false, if no libConfig, e.g. for tests
+    libConfig: {
+      enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
+      setDownloadAttributeOnLinkElements = true, // Default to true to retain existing behavior
+    },
   } = useContext(LibContext)
 
   const downloadUrl = useCallback(() => {
@@ -34,6 +37,7 @@ const useDownloadUrl = (
       enforceDownloadInNewTab,
       url,
       filename,
+      setDownloadAttribute: setDownloadAttributeOnLinkElements,
     })
 
     link.style.display = "none"

--- a/frontend/lib/src/hooks/useDownloadUrl.ts
+++ b/frontend/lib/src/hooks/useDownloadUrl.ts
@@ -26,7 +26,6 @@ const useDownloadUrl = (
   const {
     libConfig: {
       enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
-      preventDownloadAttribute = false, // Default to false to retain existing behavior
     },
   } = useContext(LibContext)
 
@@ -37,14 +36,13 @@ const useDownloadUrl = (
       enforceDownloadInNewTab,
       url,
       filename,
-      setDownloadAttribute: !preventDownloadAttribute,
     })
 
     link.style.display = "none"
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-  }, [url, enforceDownloadInNewTab, filename, preventDownloadAttribute])
+  }, [url, enforceDownloadInNewTab, filename])
 
   return downloadUrl
 }

--- a/frontend/lib/src/hooks/useDownloadUrl.ts
+++ b/frontend/lib/src/hooks/useDownloadUrl.ts
@@ -26,7 +26,7 @@ const useDownloadUrl = (
   const {
     libConfig: {
       enforceDownloadInNewTab = false, // Default to false, if no libConfig, e.g. for tests
-      preventDownloadAttribute = false, // Default to true to retain existing behavior
+      preventDownloadAttribute = false, // Default to false to retain existing behavior
     },
   } = useContext(LibContext)
 

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -59,6 +59,7 @@ export function mockEndpoints(
     checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
+    buildDownloadUrl: vi.fn(),
     buildFileUploadURL: vi.fn(),
     buildAppPageURL: vi
       .fn()

--- a/frontend/lib/src/util/createDownloadLinkElement.test.ts
+++ b/frontend/lib/src/util/createDownloadLinkElement.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import createDownloadLinkElement from "./createDownloadLinkElement"
+
+describe("download attribute", () => {
+  const url = "/media/mockDownloadURL"
+
+  it("sets download attribute with empty filename", () => {
+    const link = createDownloadLinkElement({
+      enforceDownloadInNewTab: false,
+      url: url,
+      filename: "",
+    })
+    expect(link.getAttribute("download")).toBe("")
+  })
+
+  it("sets download attribute with filename", () => {
+    const link = createDownloadLinkElement({
+      enforceDownloadInNewTab: false,
+      url: url,
+      filename: "test.pdf",
+    })
+    expect(link.getAttribute("download")).toBe("test.pdf")
+  })
+
+  it("omits download attribute for service worker compatibility in Chromium browsers", () => {
+    // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+    const originalStreamlit = window.__streamlit
+    window.__streamlit = {
+      ...window.__streamlit,
+      DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+    }
+
+    // Mock user agent to be a Chromium-based browser (not Firefox)
+    const originalUserAgent = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "userAgent"
+    )
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      configurable: true,
+    })
+
+    try {
+      const link = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: "https://download.streamlit.app/file.pdf",
+        filename: "test.pdf",
+      })
+      expect(link.getAttribute("download")).toBeNull()
+    } finally {
+      // Cleanup
+      window.__streamlit = originalStreamlit
+      if (originalUserAgent) {
+        Object.defineProperty(window.navigator, "userAgent", originalUserAgent)
+      }
+    }
+  })
+
+  it("sets download attribute in Firefox even with DOWNLOAD_ASSETS_BASE_URL", () => {
+    // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+    const originalStreamlit = window.__streamlit
+    window.__streamlit = {
+      ...window.__streamlit,
+      DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+    }
+
+    // Mock user agent to be Firefox
+    const originalUserAgent = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "userAgent"
+    )
+    Object.defineProperty(window.navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0",
+      configurable: true,
+    })
+
+    try {
+      const link = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: "https://download.streamlit.app/file.pdf",
+        filename: "test.pdf",
+      })
+      expect(link.getAttribute("download")).toBe("test.pdf")
+    } finally {
+      // Cleanup
+      window.__streamlit = originalStreamlit
+      if (originalUserAgent) {
+        Object.defineProperty(window.navigator, "userAgent", originalUserAgent)
+      }
+    }
+  })
+
+  it("sets download attribute when URL does not match DOWNLOAD_ASSETS_BASE_URL", () => {
+    // Mock the global streamlit object with DOWNLOAD_ASSETS_BASE_URL
+    const originalStreamlit = window.__streamlit
+    window.__streamlit = {
+      ...window.__streamlit,
+      DOWNLOAD_ASSETS_BASE_URL: "https://download.streamlit.app",
+    }
+
+    try {
+      const link = createDownloadLinkElement({
+        enforceDownloadInNewTab: false,
+        url: "https://different-domain.com/file.pdf",
+        filename: "test.pdf",
+      })
+      expect(link.getAttribute("download")).toBe("test.pdf")
+    } finally {
+      // Cleanup
+      window.__streamlit = originalStreamlit
+    }
+  })
+})

--- a/frontend/lib/src/util/createDownloadLinkElement.ts
+++ b/frontend/lib/src/util/createDownloadLinkElement.ts
@@ -36,10 +36,12 @@ const createDownloadLinkElement = ({
   // We don't set the download attribute when the window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL variable is set
   // and the passed url is a request to that origin. The reason is that there is a bug for service workers where they
   // don't intercept the download request otherwise (see https://issues.chromium.org/issues/40410035). Firefox does not have
-  // the same problem.
+  // the same problem, so we always set the download attribute for Firefox. SiS is using a service worker, so without this logic
+  // download requests wouldn't work right now.
+  const downloadBaseUrl = window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL
   if (
-    !window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL ||
-    !url.startsWith(window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL) ||
+    !downloadBaseUrl ||
+    !url.startsWith(downloadBaseUrl) ||
     window.navigator.userAgent.includes("Firefox")
   ) {
     link.setAttribute("download", filename)

--- a/frontend/lib/src/util/createDownloadLinkElement.ts
+++ b/frontend/lib/src/util/createDownloadLinkElement.ts
@@ -18,14 +18,12 @@ interface DownloadLinkElementParameters {
   enforceDownloadInNewTab: boolean
   url: string
   filename: string
-  setDownloadAttribute: boolean
 }
 
 const createDownloadLinkElement = ({
   enforceDownloadInNewTab,
   url,
   filename,
-  setDownloadAttribute,
 }: DownloadLinkElementParameters): HTMLAnchorElement => {
   const link = document.createElement("a")
   link.setAttribute("href", url)
@@ -35,7 +33,15 @@ const createDownloadLinkElement = ({
     link.setAttribute("target", "_self")
   }
 
-  if (setDownloadAttribute) {
+  // We don't set the download attribute when the window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL variable is set
+  // and the passed url is a request to that origin. The reason is that there is a bug for service workers where they
+  // don't intercept the download request otherwise (see https://issues.chromium.org/issues/40410035). Firefox does not have
+  // the same problem.
+  if (
+    !window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL ||
+    !url.startsWith(window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL) ||
+    window.navigator.userAgent.includes("Firefox")
+  ) {
     link.setAttribute("download", filename)
   }
 

--- a/frontend/lib/src/util/createDownloadLinkElement.ts
+++ b/frontend/lib/src/util/createDownloadLinkElement.ts
@@ -18,12 +18,14 @@ interface DownloadLinkElementParameters {
   enforceDownloadInNewTab: boolean
   url: string
   filename: string
+  setDownloadAttribute: boolean
 }
 
 const createDownloadLinkElement = ({
   enforceDownloadInNewTab,
   url,
   filename,
+  setDownloadAttribute,
 }: DownloadLinkElementParameters): HTMLAnchorElement => {
   const link = document.createElement("a")
   link.setAttribute("href", url)
@@ -32,7 +34,10 @@ const createDownloadLinkElement = ({
   } else {
     link.setAttribute("target", "_self")
   }
-  link.setAttribute("download", filename)
+
+  if (setDownloadAttribute) {
+    link.setAttribute("download", filename)
+  }
 
   return link
 }

--- a/frontend/utils/src/types/index.ts
+++ b/frontend/utils/src/types/index.ts
@@ -41,6 +41,8 @@ export interface StreamlitWindowObject {
   BACKEND_BASE_URL?: string
   // URL pointing to where the _stcore/host-config endpoint is being served.
   HOST_CONFIG_BASE_URL?: string
+  // URL pointing to where the /media assets are being served from for download only.
+  DOWNLOAD_ASSETS_BASE_URL?: string
   // URL pointing to the main page of this Streamlit app. Setting this is needed
   // when setting BACKEND_BASE_URL so that handling page URLs in multipage apps
   // works.

--- a/frontend/utils/src/uri/index.ts
+++ b/frontend/utils/src/uri/index.ts
@@ -25,7 +25,7 @@ export function buildHttpUri(
   path: string
 ): string {
   const fullPath = makePath(pathname, path)
-  return `${protocol}//${hostname}:${port}/${fullPath}`
+  return `${protocol}//${hostname}${port ? `:${port}` : ""}/${fullPath}`
 }
 
 export function makePath(basePath: string, subPath: string): string {

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -246,7 +246,6 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if
                 #   so with which value. One of None, "anonymous", "use-credentials".
                 "resourceCrossOriginMode": None,
-                "preventDownloadAttribute": False,
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -246,6 +246,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if
                 #   so with which value. One of None, "anonymous", "use-credentials".
                 "resourceCrossOriginMode": None,
+                "setDownloadAttributeOnLinkElements": True,
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -246,7 +246,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if
                 #   so with which value. One of None, "anonymous", "use-credentials".
                 "resourceCrossOriginMode": None,
-                "setDownloadAttributeOnLinkElements": True,
+                "preventDownloadAttribute": True,
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -246,7 +246,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if
                 #   so with which value. One of None, "anonymous", "use-credentials".
                 "resourceCrossOriginMode": None,
-                "preventDownloadAttribute": True,
+                "preventDownloadAttribute": False,
             }
         )
         self.set_status(200)

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -292,6 +292,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "metricsUrl": "",
             "blockErrorDialogs": False,
             "resourceCrossOriginMode": None,
+            "setDownloadAttributeOnLinkElements": True,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -292,7 +292,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "metricsUrl": "",
             "blockErrorDialogs": False,
             "resourceCrossOriginMode": None,
-            "preventDownloadAttribute": True,
+            "preventDownloadAttribute": False,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -292,7 +292,7 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "metricsUrl": "",
             "blockErrorDialogs": False,
             "resourceCrossOriginMode": None,
-            "setDownloadAttributeOnLinkElements": True,
+            "preventDownloadAttribute": True,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -292,7 +292,6 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "metricsUrl": "",
             "blockErrorDialogs": False,
             "resourceCrossOriginMode": None,
-            "preventDownloadAttribute": False,
         }
         # Check that localhost NOT appended/allowed outside dev mode
         assert "http://localhost" not in response_body["allowedOrigins"]


### PR DESCRIPTION
## Describe your changes

This PR adds following changes:
- Makes the download URL configurable via a new `window.__streamlit.DOWNLOAD_ASSETS_BASE_URL` variable
- The `download` attribute from the download link anchor element is not set when the browser is different than Firefox and `window.__streamlit.DOWNLOAD_ASSETS_BASE_URL` is set and the url to create the download link for is starting with that `window.__streamlit.DOWNLOAD_ASSETS_BASE_URL`
- The download button's `endpoints.checkSourceUrlResponse` call checks the finally built URL after going through `buildMediaUrl` etc. instead of using the raw `element.url`

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
   - Updated the `DownloadButton.test.tsx` to cover the new functionality
   - Updated `routes_test.py` for the new `/host-config` field
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
