### PR TITLE
Accept lists for callback args

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -60,9 +60,9 @@ st.write("value 7:", v7)
 
 if runtime.exists():
 
-    def on_change(x: int, y: int):
+    def on_change(x: int, y: int, z: int):
         st.session_state.selectbox_changed = True
-        st.text(f"Selectbox widget callback triggered: args={x}, kwargs={y}")
+        st.text(f"Selectbox widget callback triggered: x={x}, y={y}, z={z}")
 
     st.selectbox(
         "selectbox 8 (with callback, help)",
@@ -70,8 +70,8 @@ if runtime.exists():
         1,
         key="selectbox8",
         on_change=on_change,
-        args=["1"],
-        kwargs={"y": 2},
+        args=["1", "2"],
+        kwargs={"y": 3},
         help="Help text",
     )
     st.write("value 8:", st.session_state.selectbox8)

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -60,9 +60,9 @@ st.write("value 7:", v7)
 
 if runtime.exists():
 
-    def on_change():
+    def on_change(x: int, y: int):
         st.session_state.selectbox_changed = True
-        st.text("Selectbox widget callback triggered")
+        st.text(f"Selectbox widget callback triggered: args={x}, kwargs={y}")
 
     st.selectbox(
         "selectbox 8 (with callback, help)",
@@ -70,6 +70,8 @@ if runtime.exists():
         1,
         key="selectbox8",
         on_change=on_change,
+        args=["1"],
+        kwargs={"y": 2},
         help="Help text",
     )
     st.write("value 8:", st.session_state.selectbox8)

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -70,7 +70,7 @@ if runtime.exists():
         1,
         key="selectbox8",
         on_change=on_change,
-        args=[1, "2"],
+        args=[1, 2],
         kwargs={"y": 3},
         help="Help text",
     )

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -71,7 +71,7 @@ if runtime.exists():
         key="selectbox8",
         on_change=on_change,
         args=[1, 2],
-        kwargs={"y": 3},
+        kwargs={"z": 3},
         help="Help text",
     )
     st.write("value 8:", st.session_state.selectbox8)

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -70,7 +70,7 @@ if runtime.exists():
         1,
         key="selectbox8",
         on_change=on_change,
-        args=["1", "2"],
+        args=[1, "2"],
         kwargs={"y": 3},
         help="Help text",
     )

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -15,7 +15,10 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
+from e2e_playwright.shared.app_utils import (
+    check_top_level_class,
+    get_element_by_key,
+)
 
 
 def test_selectbox_widget_rendering(
@@ -183,6 +186,9 @@ def test_handles_callback_on_change_correctly(app: Page):
     expect(app.get_by_test_id("stMarkdown").nth(8)).to_have_text(
         "selectbox changed: True", use_inner_text=True
     )
+    expect(
+        app.get_by_text("Selectbox widget callback triggered: args=1, kwargs=2")
+    ).to_be_visible()
 
     # Change different input to trigger delta path change
     empty_selectbox_input = app.get_by_test_id("stSelectbox").locator("input").first

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -187,7 +187,7 @@ def test_handles_callback_on_change_correctly(app: Page):
         "selectbox changed: True", use_inner_text=True
     )
     expect(
-        app.get_by_text("Selectbox widget callback triggered: args=1, kwargs=2")
+        app.get_by_text("Selectbox widget callback triggered: x=1, y=2, z=3")
     ).to_be_visible()
 
     # Change different input to trigger delta path change

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -287,8 +287,8 @@ class FormMixin:
             parameter of ``st.markdown``.
         on_click : callable
             An optional callback invoked when this button is clicked.
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
         type : "primary", "secondary", or "tertiary"

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -143,8 +143,8 @@ class AudioInputMixin:
             An optional callback invoked when this audio input's value
             changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -138,8 +138,8 @@ class ButtonMixin:
         on_click : callable
             An optional callback invoked when this button is clicked.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -359,8 +359,8 @@ class ButtonMixin:
             - ``None``: This is same as ``on_click="rerun"``. This value exists
               for backwards compatibility and shouldn't be used.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -339,8 +339,8 @@ class ButtonGroupMixin:
             An optional callback invoked when this feedback widget's value
             changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -561,8 +561,8 @@ class ButtonGroupMixin:
         on_change : callable
             An optional callback invoked when this widget's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -787,8 +787,8 @@ class ButtonGroupMixin:
         on_change : callable
             An optional callback invoked when this widget's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -143,8 +143,8 @@ class CameraInputMixin:
             An optional callback invoked when this camera_input's value
             changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -478,8 +478,8 @@ class ChatMixin:
         on_submit : callable
             An optional callback invoked when the chat input's value is submitted.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -123,8 +123,8 @@ class CheckboxMixin:
         on_change : callable
             An optional callback invoked when this checkbox's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -249,8 +249,8 @@ class CheckboxMixin:
         on_change : callable
             An optional callback invoked when this toggle's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -126,8 +126,8 @@ class ColorPickerMixin:
             An optional callback invoked when this color_picker's value
             changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -726,8 +726,8 @@ class DataEditorMixin:
         on_change : callable
             An optional callback invoked when this data_editor's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -326,8 +326,8 @@ class FileUploaderMixin:
             An optional callback invoked when this file_uploader's value
             changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -255,7 +255,7 @@ class MultiSelectMixin:
 
         Parameters
         ----------
-        label: str
+        label : str
             A short label explaining to the user what this select widget is for.
             The label can optionally contain GitHub-flavored Markdown of the
             following types: Bold, Italics, Strikethroughs, Inline Code, Links,
@@ -277,27 +277,27 @@ class MultiSelectMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        options: Iterable
+        options : Iterable
             Labels for the select options in an ``Iterable``. This can be a
             ``list``, ``set``, or anything supported by ``st.dataframe``. If
             ``options`` is dataframe-like, the first column will be used. Each
             label will be cast to ``str`` internally by default.
 
-        default: Iterable of V, V, or None
+        default : Iterable of V, V, or None
             List of default values. Can also be a single value.
 
-        format_func: function
+        format_func : function
             Function to modify the display of the options. It receives
             the raw option as an argument and should output the label to be
             shown for that option. This has no impact on the return value of
             the command.
 
-        key: str or int
+        key : str or int
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-        help: str or None
+        help : str or None
             A tooltip that gets displayed next to the widget label. Streamlit
             only displays the tooltip when ``label_visibility="visible"``. If
             this is ``None`` (default), no tooltip is displayed.
@@ -306,19 +306,19 @@ class MultiSelectMixin:
             including the Markdown directives described in the ``body``
             parameter of ``st.markdown``.
 
-        on_change: callable
+        on_change : callable
             An optional callback invoked when this widget's value changes.
 
-        args: tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
-        kwargs: dict
+        kwargs : dict
             An optional dict of kwargs to pass to the callback.
 
-        max_selections: int
+        max_selections : int
             The max selections that can be selected at a time.
 
-        placeholder: str or  None
+        placeholder : str or  None
             A string to display when no options are selected.
             If this is ``None`` (default), the widget displays placeholder text
             based on the widget's configuration:
@@ -333,17 +333,17 @@ class MultiSelectMixin:
               and ``accept_new_options=False``. The widget is also disabled in
               this case.
 
-        disabled: bool
+        disabled : bool
             An optional boolean that disables the multiselect widget if set
             to ``True``. The default is ``False``.
 
-        label_visibility: "visible", "hidden", or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. The default is ``"visible"``. If this
             is ``"hidden"``, Streamlit displays an empty spacer instead of the
             label, which can help keep the widget aligned with other widgets.
             If this is ``"collapsed"``, Streamlit displays no label or spacer.
 
-        accept_new_options: bool
+        accept_new_options : bool
             Whether the user can add selections that aren't included in ``options``.
             If this is ``False`` (default), the user can only select from the
             items in ``options``. If this is ``True``, the user can enter new

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -317,8 +317,8 @@ class NumberInputMixin:
         on_change : callable
             An optional callback invoked when this number_input's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -229,8 +229,8 @@ class RadioMixin:
         on_change : callable
             An optional callback invoked when this radio's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -231,8 +231,8 @@ class SelectSliderMixin:
         on_change : callable
             An optional callback invoked when this select_slider's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -346,8 +346,8 @@ class SelectboxMixin:
         on_change : callable
             An optional callback invoked when this selectbox's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -555,8 +555,8 @@ class SliderMixin:
         on_change : callable
             An optional callback invoked when this slider's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -206,8 +206,8 @@ class TextWidgetsMixin:
         on_change : callable
             An optional callback invoked when this text input's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -535,8 +535,8 @@ class TextWidgetsMixin:
         on_change : callable
             An optional callback invoked when this text_area's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -420,8 +420,8 @@ class TimeWidgetsMixin:
         on_change : callable
             An optional callback invoked when this time_input's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
@@ -753,8 +753,8 @@ class TimeWidgetsMixin:
         on_change : callable
             An optional callback invoked when this date_input's value changes.
 
-        args : tuple
-            An optional tuple of args to pass to the callback.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
 
         kwargs : dict
             An optional dict of kwargs to pass to the callback.

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -24,6 +24,7 @@ from typing import (
     Generic,
     Literal,
     TypeVar,
+    Union,
     cast,
     get_args,
 )
@@ -43,7 +44,7 @@ T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
 
-WidgetArgs: TypeAlias = tuple[Any, ...] | list[Any]
+WidgetArgs: TypeAlias = Union[tuple[Any, ...], list[Any]]
 WidgetKwargs: TypeAlias = dict[str, Any]
 WidgetCallback: TypeAlias = Callable[..., None]
 

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -43,7 +43,7 @@ T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
 
-WidgetArgs: TypeAlias = tuple[Any, ...]
+WidgetArgs: TypeAlias = tuple[Any, ...] | list[Any]
 WidgetKwargs: TypeAlias = dict[str, Any]
 WidgetCallback: TypeAlias = Callable[..., None]
 


### PR DESCRIPTION
## Describe your changes
Callback args are formally typed as tuples, but lists work and can be a little more readable in some contexts.

This adds lists into the type hinting for callback args.

## GitHub Issue Link (if applicable)
streamlit/docs#1315

## Testing Plan
None.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
