### PR TITLE
Expose OIDC tokens

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -205,7 +205,7 @@ def set_cookie_with_chunks(
     signed_value = create_signed_value_fn(cookie_name, serialized_cookie_value)
 
     # Cookie format: "name=value" + COOKIE_ATTRIBUTES
-    actual_cookie_size = len(cookie_name) + len(signed_value) + COOKIE_ATTR_SIZE
+    actual_cookie_size = len(cookie_name) + 1 + len(signed_value) + COOKIE_ATTR_SIZE
 
     # Check if cookie needs to be split
     if actual_cookie_size > MAX_COOKIE_BYTES:
@@ -347,7 +347,7 @@ def get_cookie_with_chunks(
         chunk_name = f"{cookie_name}_{i + 1}"
         chunk_value = get_single_cookie_fn(chunk_name)
         if chunk_value is None:
-            _LOGGER.exception("Missing chunk %d for cookie '%s'", i, cookie_name)
+            _LOGGER.exception("Missing chunk %d for cookie '%s'", i + 1, cookie_name)
             return None
         chunks.append(chunk_value)
 

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -14,19 +14,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import json
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
 
 from streamlit import config
 from streamlit.errors import StreamlitAuthError
+from streamlit.logger import get_logger
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
+
+_LOGGER: Final = get_logger(__name__)
 
 if TYPE_CHECKING:
 
     class ProviderTokenPayload(TypedDict):
         provider: str
         exp: int
+
+
+MAX_COOKIE_BYTES: Final = 4096
+APPROX_COOKIE_ATTR_SIZE: Final = 31
 
 
 class AuthCache:
@@ -94,14 +102,19 @@ def get_expose_tokens_config() -> list[str]:
     auth_section = get_secrets_auth_section()
     expose_tokens = auth_section.get("expose_tokens")
 
-    if expose_tokens is None:
+    if isinstance(expose_tokens, str):
+        res = [expose_tokens]
+    elif isinstance(expose_tokens, list):
+        res = [str(token) for token in expose_tokens]
+    else:
         return []
 
-    if isinstance(expose_tokens, str):
-        return [expose_tokens]
-    if isinstance(expose_tokens, list):
-        return [str(token) for token in expose_tokens]
-    return []
+    if set(res) - {"id", "access"}:
+        raise StreamlitAuthError(
+            "Invalid expose_tokens configuration. Only 'id' and 'access' are allowed."
+        )
+
+    return res
 
 
 def encode_provider_token(provider: str) -> str:
@@ -162,6 +175,176 @@ def generate_default_provider_section(auth_section: AttrDict) -> dict[str, Any]:
             "AttrDict", auth_section.get("client_kwargs", AttrDict({}))
         ).to_dict()
     return default_provider_section
+
+
+def set_cookie_with_chunks(
+    set_single_cookie_fn: Callable[[str, str], None],
+    create_signed_value_fn: Callable[[str, str], bytes],
+    cookie_name: str,
+    value: dict[str, Any],
+) -> None:
+    """Set a cookie, splitting into multiple cookies if necessary.
+
+    Args:
+        set_single_cookie_fn: Function to set a single cookie (cookie_name, value)
+        create_signed_value_fn: Function to create a signed cookie value (cookie_name, value)
+        cookie_name: Name of the cookie
+        value: Dictionary value to serialize and store
+    """
+    serialized_cookie_value = json.dumps(value)
+
+    # Calculate actual cookie size using the provided signing function
+    signed_value = create_signed_value_fn(cookie_name, serialized_cookie_value)
+
+    # Cookie format: "name=value; HttpOnly; Path=/"
+    actual_cookie_size = len(cookie_name) + len(signed_value) + APPROX_COOKIE_ATTR_SIZE
+
+    # Check if cookie needs to be split
+    if actual_cookie_size > MAX_COOKIE_BYTES:
+        _LOGGER.debug(
+            "Cookie size (%d bytes) exceeds browser limit. Splitting into multiple cookies.",
+            actual_cookie_size,
+        )
+        _set_split_cookie(set_single_cookie_fn, cookie_name, serialized_cookie_value)
+    else:
+        set_single_cookie_fn(cookie_name, serialized_cookie_value)
+
+
+def _set_split_cookie(
+    set_single_cookie_fn: Callable[[str, str], None],
+    cookie_name: str,
+    value: str,
+) -> None:
+    """Split a large cookie value into multiple smaller cookies.
+
+    The main cookie always exists and contains the first chunk.
+    Additional chunks are stored as cookie_name_1, cookie_name_2, etc.
+
+    Args:
+        set_single_cookie_fn: Function to set a single cookie (cookie_name, value)
+        cookie_name: Name of the cookie
+        value: Serialized string value to split and store
+    """
+
+    # Maximum size for a single cookie chunk (conservatively set to allow for overhead)
+    # Overhead seems to be around 110 bytes, but depends on Tornado internals, so having a safe 3x margin
+    cookie_space = 3800 - len(
+        cookie_name
+    )  # Account for cookie name + fix-length overhead (timestamp etc)
+    chunk_size = (
+        cookie_space * 3
+    ) // 4  # Account for base64 encoding overhead of 4/3 ratio
+    chunks = []
+    for i in range(0, len(value), chunk_size):
+        chunk = value[i : i + chunk_size]
+        chunks.append(chunk)
+
+    # Store number of chunks in a metadata cookie
+    set_single_cookie_fn(f"{cookie_name}_count", str(len(chunks)))
+
+    # Store first chunk in the main cookie
+    set_single_cookie_fn(cookie_name, chunks[0])
+
+    # Store remaining chunks as cookie_name_1, cookie_name_2, etc.
+    for i in range(1, len(chunks)):
+        chunk_name = f"{cookie_name}_{i}"
+        set_single_cookie_fn(chunk_name, chunks[i])
+
+    _LOGGER.info(
+        "Split cookie '%s' into %d chunks",
+        cookie_name,
+        len(chunks),
+    )
+
+
+def get_cookie_with_chunks(
+    get_single_cookie_fn: Callable[[str], bytes | None],
+    cookie_name: str,
+) -> bytes | None:
+    """Get a cookie, reconstructing from chunks if it was split.
+
+    If a count cookie exists, the main cookie contains the first chunk,
+    and additional chunks are in cookie_name_1, cookie_name_2, etc.
+    If no count cookie exists, the main cookie contains the entire value.
+
+    Args:
+        get_single_cookie_fn: Function to get a single cookie (cookie_name) -> bytes | None
+        cookie_name: Name of the cookie
+
+    Returns
+    -------
+        Cookie value as bytes, or None if not found
+    """
+    # Check if there's a count cookie indicating split cookies
+    count_cookie_name = f"{cookie_name}_count"
+    count_value = get_single_cookie_fn(count_cookie_name)
+
+    # If no count cookie, just return the main cookie
+    if count_value is None:
+        return get_single_cookie_fn(cookie_name)
+
+    # Parse chunk count
+    try:
+        chunk_count = int(count_value)
+    except (ValueError, TypeError):
+        _LOGGER.exception("Invalid chunk count for cookie '%s'", cookie_name)
+        return None
+
+    # Reconstruct the original value from chunks
+    # First chunk is in the main cookie
+    chunks = []
+    main_chunk = get_single_cookie_fn(cookie_name)
+    if main_chunk is None:
+        _LOGGER.exception("Missing main cookie (chunk 0) for '%s'", cookie_name)
+        return None
+    chunks.append(main_chunk)
+
+    # Remaining chunks are in cookie_name_1, cookie_name_2, etc.
+    for i in range(1, chunk_count):
+        chunk_name = f"{cookie_name}_{i}"
+        chunk_value = get_single_cookie_fn(chunk_name)
+        if chunk_value is None:
+            _LOGGER.exception("Missing chunk %d for cookie '%s'", i, cookie_name)
+            return None
+        chunks.append(chunk_value)
+
+    reconstructed_value = b"".join(chunks)
+    return reconstructed_value
+
+
+def clear_cookie_and_chunks(
+    get_single_cookie_fn: Callable[[str], bytes | None],
+    clear_single_cookie_fn: Callable[[str], None],
+    cookie_name: str,
+) -> None:
+    """Clear a cookie and any associated chunk cookies.
+
+    The main cookie always exists. If there are chunks, also clear
+    cookie_name_1, cookie_name_2, etc., and the count cookie.
+
+    Args:
+        get_single_cookie_fn: Function to get a single cookie (cookie_name) -> bytes | None
+        clear_single_cookie_fn: Function to clear a single cookie (cookie_name)
+        cookie_name: Name of the cookie
+    """
+    # Clear the main cookie (always exists)
+    clear_single_cookie_fn(cookie_name)
+
+    # Check if there's a count cookie indicating split cookies
+    count_cookie_name = f"{cookie_name}_count"
+    count_value = get_single_cookie_fn(count_cookie_name)
+
+    if count_value:
+        try:
+            chunk_count = int(count_value)
+            # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
+            for i in range(1, chunk_count):
+                clear_single_cookie_fn(f"{cookie_name}_{i}")
+            # Clear the count cookie
+            clear_single_cookie_fn(count_cookie_name)
+        except (ValueError, TypeError):
+            # If count is invalid, just clear the count cookie
+            clear_single_cookie_fn(count_cookie_name)
 
 
 def validate_auth_credentials(provider: str) -> None:

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -259,7 +259,7 @@ def _set_split_cookie(
     )
 
 
-chunks_regex = re.compile(rb"chunks-(\d+)")
+_chunks_regex = re.compile(rb"chunks-(\d+)")
 
 
 def get_cookie_with_chunks(
@@ -284,7 +284,7 @@ def get_cookie_with_chunks(
     if cookie_value is None:
         return cookie_value
 
-    match = chunks_regex.match(cookie_value)
+    match = _chunks_regex.match(cookie_value)
     if match is None:
         return cookie_value
 
@@ -330,7 +330,7 @@ def clear_cookie_and_chunks(
     if cookie_value is None:
         return
 
-    match = chunks_regex.match(cookie_value)
+    match = _chunks_regex.match(cookie_value)
     if match is None:
         return
 

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -41,6 +41,8 @@ COOKIE_ATTR_SIZE: Final = len(COOKIE_ATTRIBUTES)
 # Safety buffer for signing overhead to account for edge cases, rounding, and potential
 # variations in signing implementations (e.g., longer timestamps after year 2286)
 SIGNING_OVERHEAD_SAFETY_BUFFER: Final = 50
+# Base64 encoding of 1 byte = 4 bytes, so overhead = total - 4
+SINGLE_BYTE_BASE64_SIZE: Final = 4
 
 
 class AuthCache:
@@ -242,8 +244,7 @@ def _calculate_signing_overhead(
     """
     test_value = "x"  # Minimal test value (1 byte)
     signed = create_signed_value_fn(cookie_name, test_value)
-    # base64 encoding of 1 byte = 4 bytes, so overhead = total - 4
-    return len(signed) - 4
+    return len(signed) - SINGLE_BYTE_BASE64_SIZE
 
 
 def _set_split_cookie(
@@ -277,6 +278,11 @@ def _set_split_cookie(
 
     # Space available for the base64-encoded value (after subtracting signing overhead)
     available_for_base64_value = available_for_signed_value - signing_overhead
+
+    # If there is not enough space for the base64-encoded value, raise an error.
+    # We need at least 4 bytes for a minimal base64-encoded value.
+    if available_for_base64_value < SINGLE_BYTE_BASE64_SIZE:
+        raise StreamlitAuthError("Not enough space available for the signed value.")
 
     # Convert from base64 space to raw value space (base64 has 4/3 expansion ratio)
     chunk_size = (available_for_base64_value * 3) // 4

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -35,7 +35,12 @@ if TYPE_CHECKING:
 
 
 MAX_COOKIE_BYTES: Final = 4096
-APPROX_COOKIE_ATTR_SIZE: Final = 31
+# Cookie attributes added by Tornado: "; Path=/; HttpOnly"
+COOKIE_ATTRIBUTES: Final = "; Path=/; HttpOnly"
+COOKIE_ATTR_SIZE: Final = len(COOKIE_ATTRIBUTES)
+# Safety buffer for signing overhead to account for edge cases, rounding, and potential
+# variations in signing implementations (e.g., longer timestamps after year 2286)
+SIGNING_OVERHEAD_SAFETY_BUFFER: Final = 50
 
 
 class AuthCache:
@@ -175,6 +180,8 @@ def generate_default_provider_section(auth_section: AttrDict) -> dict[str, Any]:
         default_provider_section["client_kwargs"] = cast(
             "AttrDict", auth_section.get("client_kwargs", AttrDict({}))
         ).to_dict()
+    if auth_section.get("expose_tokens"):
+        default_provider_section["expose_tokens"] = auth_section.get("expose_tokens")
     return default_provider_section
 
 
@@ -197,8 +204,8 @@ def set_cookie_with_chunks(
     # Calculate actual cookie size using the provided signing function
     signed_value = create_signed_value_fn(cookie_name, serialized_cookie_value)
 
-    # Cookie format: "name=value; HttpOnly; Path=/"
-    actual_cookie_size = len(cookie_name) + len(signed_value) + APPROX_COOKIE_ATTR_SIZE
+    # Cookie format: "name=value" + COOKIE_ATTRIBUTES
+    actual_cookie_size = len(cookie_name) + len(signed_value) + COOKIE_ATTR_SIZE
 
     # Check if cookie needs to be split
     if actual_cookie_size > MAX_COOKIE_BYTES:
@@ -206,35 +213,73 @@ def set_cookie_with_chunks(
             "Cookie size (%d bytes) exceeds browser limit. Splitting into multiple cookies.",
             actual_cookie_size,
         )
-        _set_split_cookie(set_single_cookie_fn, cookie_name, serialized_cookie_value)
+        _set_split_cookie(
+            set_single_cookie_fn,
+            create_signed_value_fn,
+            cookie_name,
+            serialized_cookie_value,
+        )
     else:
         set_single_cookie_fn(cookie_name, serialized_cookie_value)
 
 
+def _calculate_signing_overhead(
+    create_signed_value_fn: Callable[[str, str], bytes],
+    cookie_name: str,
+) -> int:
+    """Calculate the server's signing overhead by measuring the size difference.
+
+    This empirically measures the overhead added by the signing function (e.g., Tornado's
+    create_signed_value) by signing a minimal test value and computing the difference.
+
+    Args:
+        create_signed_value_fn: Function to create a signed cookie value
+        cookie_name: Name of the cookie (affects overhead due to length prefix)
+
+    Returns
+    -------
+        The number of bytes added by signing (excluding the base64-encoded value)
+    """
+    test_value = "x"  # Minimal test value (1 byte)
+    signed = create_signed_value_fn(cookie_name, test_value)
+    # base64 encoding of 1 byte = 4 bytes, so overhead = total - 4
+    return len(signed) - 4
+
+
 def _set_split_cookie(
     set_single_cookie_fn: Callable[[str, str], None],
+    create_signed_value_fn: Callable[[str, str], bytes],
     cookie_name: str,
     value: str,
 ) -> None:
     """Split a large cookie value into multiple smaller cookies.
 
-    The main cookie always exists and contains the first chunk.
+    The main cookie always exists and either contains the whole value or the chunk count.
     Additional chunks are stored as cookie_name_1, cookie_name_2, etc.
 
     Args:
         set_single_cookie_fn: Function to set a single cookie (cookie_name, value)
+        create_signed_value_fn: Function to create a signed cookie value
         cookie_name: Name of the cookie
         value: Serialized string value to split and store
     """
+    # Calculate overhead empirically from the actual signing function, plus safety buffer
+    signing_overhead = (
+        _calculate_signing_overhead(create_signed_value_fn, cookie_name)
+        + SIGNING_OVERHEAD_SAFETY_BUFFER
+    )
 
-    # Maximum size for a single cookie chunk (conservatively set to allow for overhead)
-    # Overhead seems to be around 110 bytes, but depends on Tornado internals, so having a safe 3x margin
-    cookie_space = 3800 - len(
-        cookie_name
-    )  # Account for cookie name + fix-length overhead (timestamp etc)
-    chunk_size = (
-        cookie_space * 3
-    ) // 4  # Account for base64 encoding overhead of 4/3 ratio
+    # Available space for the signed value:
+    # MAX_COOKIE_BYTES - cookie_name - "=" (1 byte) - cookie attributes
+    available_for_signed_value = (
+        MAX_COOKIE_BYTES - len(cookie_name) - 1 - COOKIE_ATTR_SIZE
+    )
+
+    # Space available for the base64-encoded value (after subtracting signing overhead)
+    available_for_base64_value = available_for_signed_value - signing_overhead
+
+    # Convert from base64 space to raw value space (base64 has 4/3 expansion ratio)
+    chunk_size = (available_for_base64_value * 3) // 4
     chunks = []
     for i in range(0, len(value), chunk_size):
         chunk = value[i : i + chunk_size]

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -84,6 +84,26 @@ def get_secrets_auth_section() -> AttrDict:
     return auth_section
 
 
+def get_expose_tokens_config() -> list[str]:
+    """Get the expose_tokens configuration from secrets.toml.
+
+    Returns a list of token types to expose. Accepts both string and list formats:
+    - expose_tokens = "id" -> ["id"]
+    - expose_tokens = ["id", "access"] -> ["id", "access"]
+    """
+    auth_section = get_secrets_auth_section()
+    expose_tokens = auth_section.get("expose_tokens")
+
+    if expose_tokens is None:
+        return []
+
+    if isinstance(expose_tokens, str):
+        return [expose_tokens]
+    if isinstance(expose_tokens, list):
+        return [str(token) for token in expose_tokens]
+    return []
+
+
 def encode_provider_token(provider: str) -> str:
     """Returns a signed JWT token with the provider and expiration time."""
     try:

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
@@ -87,7 +88,7 @@ def get_secrets_auth_section() -> AttrDict:
     auth_section = AttrDict({})
     """Get the 'auth' section of the secrets.toml."""
     if secrets_singleton.load_if_toml_exists():
-        auth_section = cast("AttrDict", secrets_singleton.get("auth"))
+        auth_section = cast("AttrDict", secrets_singleton.get("auth", AttrDict({})))
 
     return auth_section
 
@@ -239,15 +240,16 @@ def _set_split_cookie(
         chunk = value[i : i + chunk_size]
         chunks.append(chunk)
 
-    # Store number of chunks in a metadata cookie
-    set_single_cookie_fn(f"{cookie_name}_count", str(len(chunks)))
+    if len(chunks) == 1:
+        set_single_cookie_fn(cookie_name, chunks[0])
+        return
 
-    # Store first chunk in the main cookie
-    set_single_cookie_fn(cookie_name, chunks[0])
+    # Store count in the main cookie
+    set_single_cookie_fn(cookie_name, f"chunks-{len(chunks)}")
 
     # Store remaining chunks as cookie_name_1, cookie_name_2, etc.
-    for i in range(1, len(chunks)):
-        chunk_name = f"{cookie_name}_{i}"
+    for i in range(len(chunks)):
+        chunk_name = f"{cookie_name}_{i + 1}"
         set_single_cookie_fn(chunk_name, chunks[i])
 
     _LOGGER.info(
@@ -255,6 +257,9 @@ def _set_split_cookie(
         cookie_name,
         len(chunks),
     )
+
+
+chunks_regex = re.compile(rb"chunks-(\d+)")
 
 
 def get_cookie_with_chunks(
@@ -275,33 +280,26 @@ def get_cookie_with_chunks(
     -------
         Cookie value as bytes, or None if not found
     """
-    # Check if there's a count cookie indicating split cookies
-    count_cookie_name = f"{cookie_name}_count"
-    count_value = get_single_cookie_fn(count_cookie_name)
+    cookie_value = get_single_cookie_fn(cookie_name)
+    if cookie_value is None:
+        return cookie_value
 
-    # If no count cookie, just return the main cookie
-    if count_value is None:
-        return get_single_cookie_fn(cookie_name)
+    match = chunks_regex.match(cookie_value)
+    if match is None:
+        return cookie_value
 
     # Parse chunk count
     try:
-        chunk_count = int(count_value)
+        chunk_count = int(match.group(1))
     except (ValueError, TypeError):
         _LOGGER.exception("Invalid chunk count for cookie '%s'", cookie_name)
         return None
 
     # Reconstruct the original value from chunks
-    # First chunk is in the main cookie
     chunks = []
-    main_chunk = get_single_cookie_fn(cookie_name)
-    if main_chunk is None:
-        _LOGGER.exception("Missing main cookie (chunk 0) for '%s'", cookie_name)
-        return None
-    chunks.append(main_chunk)
 
-    # Remaining chunks are in cookie_name_1, cookie_name_2, etc.
-    for i in range(1, chunk_count):
-        chunk_name = f"{cookie_name}_{i}"
+    for i in range(chunk_count):
+        chunk_name = f"{cookie_name}_{i + 1}"
         chunk_value = get_single_cookie_fn(chunk_name)
         if chunk_value is None:
             _LOGGER.exception("Missing chunk %d for cookie '%s'", i, cookie_name)
@@ -327,24 +325,24 @@ def clear_cookie_and_chunks(
         clear_single_cookie_fn: Function to clear a single cookie (cookie_name)
         cookie_name: Name of the cookie
     """
-    # Clear the main cookie (always exists)
+    cookie_value = get_single_cookie_fn(cookie_name)
     clear_single_cookie_fn(cookie_name)
+    if cookie_value is None:
+        return
 
-    # Check if there's a count cookie indicating split cookies
-    count_cookie_name = f"{cookie_name}_count"
-    count_value = get_single_cookie_fn(count_cookie_name)
+    match = chunks_regex.match(cookie_value)
+    if match is None:
+        return
 
-    if count_value:
-        try:
-            chunk_count = int(count_value)
-            # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
-            for i in range(1, chunk_count):
-                clear_single_cookie_fn(f"{cookie_name}_{i}")
-            # Clear the count cookie
-            clear_single_cookie_fn(count_cookie_name)
-        except (ValueError, TypeError):
-            # If count is invalid, just clear the count cookie
-            clear_single_cookie_fn(count_cookie_name)
+    try:
+        chunk_count = int(match.group(1))
+        # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
+        for i in range(1, chunk_count + 1):
+            clear_single_cookie_fn(f"{cookie_name}_{i}")
+    except (ValueError, TypeError):
+        # If count is invalid, but we already cleared the main cookie
+        # so we can ignore it
+        pass
 
 
 def validate_auth_credentials(provider: str) -> None:

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -34,6 +34,7 @@ from streamlit.type_util import (
     is_pydantic_model,
     is_sequence_of_pydantic_models,
 )
+from streamlit.user_info import UserInfoProxy
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -111,7 +112,10 @@ class JsonMixin:
         """
 
         if is_custom_dict(body):
+            is_user = isinstance(body, UserInfoProxy)
             body = body.to_dict()  # ty: ignore[unresolved-attribute]
+            if is_user and "tokens" in body:
+                body["tokens"] = dict.fromkeys(body["tokens"], "***")
 
         if is_namedtuple(body):
             body = body._asdict()  # ty: ignore[unresolved-attribute]

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from streamlit.proto.BackMsg_pb2 import BackMsg, DeferredFileRequest
     from streamlit.runtime.script_data import ScriptData
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfoType
     from streamlit.runtime.state import SessionState
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
     from streamlit.source_util import PageHash, PageInfo
@@ -92,7 +93,7 @@ class AppSession:
         uploaded_file_manager: UploadedFileManager,
         script_cache: ScriptCache,
         message_enqueued_callback: Callable[[], None] | None,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         session_id_override: str | None = None,
     ) -> None:
         """Initialize the AppSession.

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from streamlit.proto.BackMsg_pb2 import BackMsg
     from streamlit.runtime.caching.storage import CacheStorageManager
     from streamlit.runtime.media_file_storage import MediaFileStorage
+    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfoType
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 # Wait for the script run result for 60s and if no result is available give up
@@ -362,7 +363,7 @@ class Runtime:
     def connect_session(
         self,
         client: SessionClient,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
@@ -425,7 +426,7 @@ class Runtime:
     def create_session(
         self,
         client: SessionClient,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -51,6 +51,7 @@ from streamlit.runtime.scriptrunner_utils.script_requests import (
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ScriptRunContext,
+    UserInfoType,
     add_script_run_ctx,
     get_script_run_ctx,
 )
@@ -174,7 +175,7 @@ class ScriptRunner:
         uploaded_file_mgr: UploadedFileManager,
         script_cache: ScriptCache,
         initial_rerun_data: RerunData,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         fragment_storage: FragmentStorage,
         pages_manager: PagesManager,
     ) -> None:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 _LOGGER: Final = get_logger(__name__)
 
-UserInfo: TypeAlias = dict[str, str | bool | None]
+UserInfoType: TypeAlias = dict[str, str | bool | dict[str, str] | None]
 
 
 # If true, it indicates that we are in a cached function that disallows the usage of
@@ -82,7 +82,7 @@ class ScriptRunContext:
     session_state: SafeSessionState
     uploaded_file_mgr: UploadedFileManager
     main_script_path: str
-    user_info: UserInfo
+    user_info: UserInfoType
     fragment_storage: FragmentStorage
     pages_manager: PagesManager
 

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.app_session import AppSession
     from streamlit.runtime.script_data import ScriptData
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfoType
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 
@@ -238,7 +239,7 @@ class SessionManager(Protocol):
         self,
         client: SessionClient,
         script_data: ScriptData,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
     from streamlit.runtime.script_data import ScriptData
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfoType
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 _LOGGER: Final = get_logger(__name__)
@@ -89,7 +90,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         self,
         client: SessionClient,
         script_data: ScriptData,
-        user_info: dict[str, str | bool | None],
+        user_info: UserInfoType,
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -378,6 +378,37 @@ def _get_user_info() -> UserInfo:
     return context_user_info
 
 
+class TokensProxy(Mapping[str, str]):
+    """A read-only, dict-like object for accessing exposed tokens."""
+
+    def __init__(self, tokens: dict[str, str]) -> None:
+        self._tokens = tokens
+
+    def __getitem__(self, key: str) -> str:
+        return self._tokens[key]
+
+    def __getattr__(self, key: str) -> str:
+        try:
+            return self._tokens[key]
+        except KeyError:
+            raise AttributeError(f'Token "{key}" is not exposed or does not exist.')
+
+    def __setattr__(self, name: str, value: str | None) -> NoReturn:
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+        else:
+            raise StreamlitAPIException("st.user.tokens cannot be modified")
+
+    def __setitem__(self, name: str, value: str | None) -> NoReturn:
+        raise StreamlitAPIException("st.user.tokens cannot be modified")
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._tokens)
+
+    def __len__(self) -> int:
+        return len(self._tokens)
+
+
 class UserInfoProxy(Mapping[str, str | bool | None]):
     """
     A read-only, dict-like object for accessing information about the current\
@@ -489,13 +520,17 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
     >>> }
     """
 
-    def __getitem__(self, key: str) -> str | bool | None:
+    def __getitem__(self, key: str) -> str | bool | None | TokensProxy:
+        if key == "tokens":
+            return self.tokens
         try:
             return _get_user_info()[key]
         except KeyError:
             raise KeyError(f'st.user has no key "{key}".')
 
-    def __getattr__(self, key: str) -> str | bool | None:
+    def __getattr__(self, key: str) -> str | bool | None | TokensProxy:
+        if key == "tokens":
+            return self.tokens
         try:
             return _get_user_info()[key]
         except KeyError:
@@ -527,6 +562,12 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
             A dictionary of the current user's information.
         """
         return _get_user_info()
+
+    @property
+    def tokens(self) -> TokensProxy:
+        """Access exposed tokens via a dict-like object."""
+        user_info = _get_user_info()
+        return TokensProxy(user_info.get("tokens", {}))
 
 
 has_shown_experimental_user_warning = False

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -441,32 +441,6 @@ class TokensProxy(Mapping[str, str]):
     >>>         st.success("ID token retrieved successfully")
     >>>     except KeyError:
     >>>         st.warning("ID token not available")
-
-    **Example 2: Expose multiple tokens with a named provider**
-
-    To expose both ID and access tokens, provide a list to ``expose_tokens``.
-    This example uses a named provider configuration.
-
-    ``.streamlit/secrets.toml``:
-
-    >>> [auth]
-    >>> redirect_uri = "http://localhost:8501/oauth2callback"
-    >>> cookie_secret = "xxx"
-    >>>
-    >>> [auth.google]
-    >>> client_id = "xxx"
-    >>> client_secret = "xxx"
-    >>> server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"  # fmt: skip
-    >>> expose_tokens = ["id", "access"]
-
-    Your app code:
-
-    >>> import streamlit as st
-    >>>
-    >>> if st.user.is_logged_in:
-    >>>     st.write("Available tokens:")
-    >>>     for token_name in st.user.tokens:
-    >>>         st.write(f"- {token_name}")
     """
 
     def __init__(self, tokens: dict[str, str]) -> None:

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -68,8 +68,7 @@ def login(provider: str | None = None) -> None:
     is an extension of OAuth 2.0, you can't use generic OAuth providers.
     Streamlit parses the user's identity token and surfaces its attributes in
     ``st.user``. If the provider returns an access token, that
-    token is ignored. Therefore, this command will not allow your app to act on
-    behalf of a user in a secure system.
+    token is ignored unless you explicitly expose it.
 
     For all providers, there are two shared settings, ``redirect_uri`` and
     ``cookie_secret``, which you must specify in an ``[auth]`` dictionary

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -652,6 +652,7 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         return _get_user_info()
 
     @property
+    @gather_metrics("user.tokens")
     def tokens(self) -> TokensProxy:
         """Access exposed tokens via a dict-like object."""
         user_info = _get_user_info()

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -20,6 +20,7 @@ from typing import (
     Any,
     Final,
     NoReturn,
+    cast,
 )
 
 from streamlit import config, logger, runtime
@@ -42,7 +43,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 from streamlit.url_util import make_url_path
 
 if TYPE_CHECKING:
-    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfo
+    from streamlit.runtime.scriptrunner_utils.script_run_context import UserInfoType
 
 
 _LOGGER: Final = logger.get_logger(__name__)
@@ -361,7 +362,7 @@ def generate_login_redirect_url(provider: str) -> str:
     return f"{login_path}?provider={provider_token}"
 
 
-def _get_user_info() -> UserInfo:
+def _get_user_info() -> UserInfoType:
     ctx = _get_script_run_ctx()
     if ctx is None:
         _LOGGER.warning(
@@ -480,13 +481,13 @@ class TokensProxy(Mapping[str, str]):
         except KeyError:
             raise AttributeError(f'Token "{key}" is not exposed or does not exist.')
 
-    def __setattr__(self, name: str, value: str | None) -> None:
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
             super().__setattr__(name, value)
         else:
             raise StreamlitAPIException("st.user.tokens cannot be modified")
 
-    def __setitem__(self, name: str, value: str | None) -> None:
+    def __setitem__(self, name: str, value: Any) -> None:
         raise StreamlitAPIException("st.user.tokens cannot be modified")
 
     def __iter__(self) -> Iterator[str]:
@@ -496,7 +497,7 @@ class TokensProxy(Mapping[str, str]):
         return len(self._tokens)
 
 
-class UserInfoProxy(Mapping[str, str | bool | None]):
+class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
     """
     A read-only, dict-like object for accessing information about the current\
     user.
@@ -611,7 +612,7 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
         if key == "tokens":
             return self.tokens
         try:
-            return _get_user_info()[key]
+            return cast("str | bool | None", _get_user_info()[key])
         except KeyError:
             raise KeyError(f'st.user has no key "{key}".')
 
@@ -619,7 +620,7 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
         if key == "tokens":
             return self.tokens
         try:
-            return _get_user_info()[key]
+            return cast("str | bool | None", _get_user_info()[key])
         except KeyError:
             raise AttributeError(f'st.user has no attribute "{key}".')
 
@@ -635,7 +636,7 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
     def __len__(self) -> int:
         return len(_get_user_info())
 
-    def to_dict(self) -> UserInfo:
+    def to_dict(self) -> UserInfoType:
         """
         Get user info as a dictionary.
 
@@ -654,7 +655,7 @@ class UserInfoProxy(Mapping[str, str | bool | None]):
     def tokens(self) -> TokensProxy:
         """Access exposed tokens via a dict-like object."""
         user_info = _get_user_info()
-        return TokensProxy(user_info.get("tokens", {}))
+        return TokensProxy(cast("dict[str, str]", user_info.get("tokens", {})))
 
 
 has_shown_experimental_user_warning = False

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -379,7 +379,94 @@ def _get_user_info() -> UserInfo:
 
 
 class TokensProxy(Mapping[str, str]):
-    """A read-only, dict-like object for accessing exposed tokens."""
+    """
+    A read-only, dict-like object for accessing exposed tokens from the
+    identity provider.
+
+    This class provides access to tokens that have been explicitly exposed via
+    the ``expose_tokens`` setting in your authentication configuration. Tokens
+    are accessed through ``st.user.tokens`` and contain sensitive credentials
+    that your app can use to authenticate with external services on behalf of
+    the logged-in user.
+
+    To expose tokens, add the ``expose_tokens`` parameter to your authentication
+    configuration in ``.streamlit/secrets.toml``. You can specify a single token
+    type as a string or multiple token types as a list. Streamlit supports
+    exposing ``"id"`` tokens (identity tokens) and ``"access"`` tokens (access
+    tokens). If ``expose_tokens`` is not configured, ``st.user.tokens`` will be
+    empty.
+
+    .. Warning::
+        Tokens are sensitive credentials that should be handled securely. Never
+        expose tokens in your app's UI, logs, or error messages. Only use tokens
+        for server-side API calls, and be mindful of token expiration times.
+        Only expose tokens if your app needs them for specific API integrations.
+
+    You can access token values using either key notation (``st.user.tokens["id"]``)
+    or attribute notation (``st.user.tokens.id``). The object is read-only to
+    prevent accidental modification of sensitive credentials.
+
+    .. Note::
+        If no tokens are exposed or if the user is not logged in,
+        ``st.user.tokens`` will be an empty dict-like object. Attempting to
+        access a non-existent token will raise a ``KeyError`` (for key notation)
+        or ``AttributeError`` (for attribute notation).
+
+    Examples
+    --------
+    **Example 1: Expose the ID token**
+
+    To expose only the identity token, add ``expose_tokens`` to your
+    authentication configuration. This example uses an unnamed default provider.
+
+    ``.streamlit/secrets.toml``:
+
+    >>> [auth]
+    >>> redirect_uri = "http://localhost:8501/oauth2callback"
+    >>> cookie_secret = "xxx"
+    >>> client_id = "xxx"
+    >>> client_secret = "xxx"
+    >>> server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"  # fmt: skip
+    >>> expose_tokens = "id"
+
+    Your app code:
+
+    >>> import streamlit as st
+    >>>
+    >>> if st.user.is_logged_in:
+    >>>     try:
+    >>>         id_token = st.user.tokens["id"]
+    >>> # Use the token for API verification (never display it!)
+    >>>         st.success("ID token retrieved successfully")
+    >>>     except KeyError:
+    >>>         st.warning("ID token not available")
+
+    **Example 2: Expose multiple tokens with a named provider**
+
+    To expose both ID and access tokens, provide a list to ``expose_tokens``.
+    This example uses a named provider configuration.
+
+    ``.streamlit/secrets.toml``:
+
+    >>> [auth]
+    >>> redirect_uri = "http://localhost:8501/oauth2callback"
+    >>> cookie_secret = "xxx"
+    >>>
+    >>> [auth.google]
+    >>> client_id = "xxx"
+    >>> client_secret = "xxx"
+    >>> server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"  # fmt: skip
+    >>> expose_tokens = ["id", "access"]
+
+    Your app code:
+
+    >>> import streamlit as st
+    >>>
+    >>> if st.user.is_logged_in:
+    >>>     st.write("Available tokens:")
+    >>>     for token_name in st.user.tokens:
+    >>>         st.write(f"- {token_name}")
+    """
 
     def __init__(self, tokens: dict[str, str]) -> None:
         self._tokens = tokens
@@ -393,13 +480,13 @@ class TokensProxy(Mapping[str, str]):
         except KeyError:
             raise AttributeError(f'Token "{key}" is not exposed or does not exist.')
 
-    def __setattr__(self, name: str, value: str | None) -> NoReturn:
+    def __setattr__(self, name: str, value: str | None) -> None:
         if name.startswith("_"):
             super().__setattr__(name, value)
         else:
             raise StreamlitAPIException("st.user.tokens cannot be modified")
 
-    def __setitem__(self, name: str, value: str | None) -> NoReturn:
+    def __setitem__(self, name: str, value: str | None) -> None:
         raise StreamlitAPIException("st.user.tokens cannot be modified")
 
     def __iter__(self) -> Iterator[str]:

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -28,6 +28,7 @@ from tornado.escape import utf8
 from tornado.websocket import WebSocketHandler
 
 from streamlit import config
+from streamlit.auth_util import get_expose_tokens_config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.runtime import Runtime, SessionClient, SessionClientDisconnectedError
@@ -175,8 +176,17 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                     # Also read in tokens if token cookie exists
                     raw_token_cookie_value = self.get_signed_cookie(TOKENS_COOKIE_NAME)
                     if raw_token_cookie_value:
-                        tokens = json.loads(raw_token_cookie_value)
-                        user_info["tokens"] = tokens
+                        all_tokens = json.loads(raw_token_cookie_value)
+
+                        # Filter tokens based on expose_tokens configuration
+                        expose_tokens = get_expose_tokens_config()
+                        filtered_tokens = {}
+                        for token_type in expose_tokens:
+                            token_key = f"{token_type}_token"
+                            if token_key in all_tokens:
+                                filtered_tokens[token_type] = all_tokens[token_key]
+
+                        user_info["tokens"] = filtered_tokens
 
             if len(ws_protocols) >= 3:
                 # See the NOTE in the docstring of the `select_subprotocol` method above

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -34,6 +34,7 @@ from streamlit.runtime import Runtime, SessionClient, SessionClientDisconnectedE
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.web.server.server_util import (
     AUTH_COOKIE_NAME,
+    TOKENS_COOKIE_NAME,
     is_url_from_allowed_origins,
     is_xsrf_enabled,
 )
@@ -170,6 +171,12 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
 
                 if self._validate_xsrf_token(csrf_protocol_value):
                     user_info.update(self._parse_user_cookie(raw_cookie_value))
+
+                    # Also read in tokens if token cookie exists
+                    raw_token_cookie_value = self.get_signed_cookie(TOKENS_COOKIE_NAME)
+                    if raw_token_cookie_value:
+                        tokens = json.loads(raw_token_cookie_value)
+                        user_info["tokens"] = tokens
 
             if len(ws_protocols) >= 3:
                 # See the NOTE in the docstring of the `select_subprotocol` method above

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -28,7 +28,7 @@ from tornado.escape import utf8
 from tornado.websocket import WebSocketHandler
 
 from streamlit import config
-from streamlit.auth_util import get_expose_tokens_config
+from streamlit.auth_util import get_cookie_with_chunks, get_expose_tokens_config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.runtime import Runtime, SessionClient, SessionClientDisconnectedError
@@ -62,6 +62,9 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         if is_xsrf_enabled():
             _ = self.xsrf_token
 
+        # Do this once instead of on every open
+        self.expose_tokens = get_expose_tokens_config()
+
     def get_signed_cookie(
         self,
         name: str,
@@ -69,15 +72,25 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         max_age_days: float = 31,
         min_version: int | None = None,
     ) -> bytes | None:
-        """Get a signed cookie from the request. Added for compatibility with
-        Tornado < 6.3.0.
+        """Get a signed cookie from the request, reconstructing from chunks if needed.
+
+        Added for compatibility with Tornado < 6.3.0. Also handles chunked cookies
+        automatically.
 
         See release notes: https://www.tornadoweb.org/en/stable/releases/v6.3.0.html#deprecation-notices
         """
-        try:
-            return super().get_signed_cookie(name, value, max_age_days, min_version)
-        except AttributeError:
-            return super().get_secure_cookie(name, value, max_age_days, min_version)
+
+        def get_single_cookie(cookie_name: str) -> bytes | None:
+            try:
+                return super(BrowserWebSocketHandler, self).get_signed_cookie(
+                    cookie_name, value, max_age_days, min_version
+                )
+            except AttributeError:
+                return super(BrowserWebSocketHandler, self).get_secure_cookie(
+                    cookie_name, value, max_age_days, min_version
+                )
+
+        return get_cookie_with_chunks(get_single_cookie, name)
 
     def check_origin(self, origin: str) -> bool:
         """Set up CORS."""
@@ -157,7 +170,7 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         return None
 
     def open(self, *args: Any, **kwargs: Any) -> Awaitable[None] | None:
-        user_info: dict[str, str | bool | None] = {}
+        user_info: dict[str, dict[str, str] | str | bool | None] = {}
 
         existing_session_id = None
         try:
@@ -179,9 +192,8 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                         all_tokens = json.loads(raw_token_cookie_value)
 
                         # Filter tokens based on expose_tokens configuration
-                        expose_tokens = get_expose_tokens_config()
-                        filtered_tokens = {}
-                        for token_type in expose_tokens:
+                        filtered_tokens: dict[str, str] = {}
+                        for token_type in self.expose_tokens:
                             token_key = f"{token_type}_token"
                             if token_key in all_tokens:
                                 filtered_tokens[token_type] = all_tokens[token_key]

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -112,14 +112,16 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
         try:
             return self.create_signed_value(cookie_name, value)
         except AttributeError:
-            return self.create_secure_cookie_value(cookie_name, value)
+            # Default to the older method for compatibility with Tornado < 6.3.0
+            return cast("bytes", self.create_secure_cookie_value(cookie_name, value))  # type: ignore[attr-defined]
 
     def _get_signed_cookie(self, cookie_name: str) -> bytes | None:
         """Get a signed cookie."""
         try:
-            return self.get_signed_cookie(cookie_name)
+            return cast("bytes", self.get_signed_cookie(cookie_name))
         except AttributeError:
-            return self.get_secure_cookie(cookie_name)
+            # Default to the older method for compatibility with Tornado < 6.3.0
+            return cast("bytes", self.get_secure_cookie(cookie_name))
         except Exception:
             # Handle cases where cookie_secret is not configured or other errors
             return None
@@ -213,11 +215,7 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         user = cast("dict[str, Any]", token.get("userinfo"))
 
         cookie_value = dict(user, origin=origin, is_logged_in=True)
-        tokens = {
-            k: v
-            for k, v in token.items()
-            if k in ["id_token", "access_token", "refresh_token"]
-        }
+        tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
 
         if user:
             self.set_auth_cookie(cookie_value, tokens)

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -29,7 +29,7 @@ from streamlit.errors import StreamlitAuthError
 from streamlit.logger import get_logger
 from streamlit.url_util import make_url_path
 from streamlit.web.server.oidc_mixin import TornadoOAuth, TornadoOAuth2App
-from streamlit.web.server.server_util import AUTH_COOKIE_NAME
+from streamlit.web.server.server_util import AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -72,33 +72,40 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
     def redirect_to_base(self) -> None:
         self.redirect(make_url_path(self.base_url, "/"))
 
-    def set_auth_cookie(self, user_info: dict[str, Any]) -> None:
-        serialized_cookie_value = json.dumps(user_info)
+    def set_auth_cookie(
+        self, user_info: dict[str, Any], tokens: dict[str, Any]
+    ) -> None:
+        self.set_serialized_cookie(AUTH_COOKIE_NAME, user_info)
+        self.set_serialized_cookie(TOKENS_COOKIE_NAME, tokens)
+
+    def set_serialized_cookie(self, cookie_name: str, value: dict[str, Any]) -> None:
+        """Set a serialized cookie with a value that is less than 4096 bytes."""
+        serialized_cookie_value = json.dumps(value)
 
         # log error if cookie value is larger than 4096 bytes
         if len(serialized_cookie_value.encode()) > 4096:
             _LOGGER.error(
-                "Authentication cookie size exceeds maximum browser limit of 4096 bytes. Authentication may fail."
+                "Cookie size exceeds maximum browser limit of 4096 bytes. Authentication may fail."
             )
-
         try:
             # We don't specify Tornado secure flag here because it leads to missing cookie on Safari.
             # The OIDC flow should work only on secure context anyway (localhost or HTTPS),
             # so specifying the secure flag here will not add anything in terms of security.
             self.set_signed_cookie(
-                AUTH_COOKIE_NAME,
+                cookie_name,
                 serialized_cookie_value,
                 httpOnly=True,
             )
         except AttributeError:
             self.set_secure_cookie(
-                AUTH_COOKIE_NAME,
+                cookie_name,
                 serialized_cookie_value,
                 httponly=True,
             )
 
     def clear_auth_cookie(self) -> None:
         self.clear_cookie(AUTH_COOKIE_NAME)
+        self.clear_cookie(TOKENS_COOKIE_NAME)
 
 
 class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):
@@ -176,8 +183,11 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         user = cast("dict[str, Any]", token.get("userinfo"))
 
         cookie_value = dict(user, origin=origin, is_logged_in=True)
+        tokens = {k: v for k, v in token.items() if k.endswith("_token")}
+
         if user:
-            self.set_auth_cookie(cookie_value)
+            self.set_auth_cookie(cookie_value, tokens)
+            # Keep tokens in a separate cookie to avoid hitting the size limit
         else:
             _LOGGER.error(
                 "Error, missing user info.",

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import json
 from typing import Any, Final, cast
 from urllib.parse import urlparse
 
@@ -21,9 +20,11 @@ import tornado.web
 
 from streamlit.auth_util import (
     AuthCache,
+    clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
     get_secrets_auth_section,
+    set_cookie_with_chunks,
 )
 from streamlit.errors import StreamlitAuthError
 from streamlit.logger import get_logger
@@ -75,37 +76,66 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
     def set_auth_cookie(
         self, user_info: dict[str, Any], tokens: dict[str, Any]
     ) -> None:
-        self.set_serialized_cookie(AUTH_COOKIE_NAME, user_info)
-        self.set_serialized_cookie(TOKENS_COOKIE_NAME, tokens)
+        set_cookie_with_chunks(
+            self._set_single_cookie,
+            self._create_signed_value,
+            AUTH_COOKIE_NAME,
+            user_info,
+        )
+        set_cookie_with_chunks(
+            self._set_single_cookie,
+            self._create_signed_value,
+            TOKENS_COOKIE_NAME,
+            tokens,
+        )
 
-    def set_serialized_cookie(self, cookie_name: str, value: dict[str, Any]) -> None:
-        """Set a serialized cookie with a value that is less than 4096 bytes."""
-        serialized_cookie_value = json.dumps(value)
-
-        # log error if cookie value is larger than 4096 bytes
-        if len(serialized_cookie_value.encode()) > 4096:
-            _LOGGER.error(
-                "Cookie size exceeds maximum browser limit of 4096 bytes. Authentication may fail."
-            )
+    def _set_single_cookie(self, cookie_name: str, value: str) -> None:
+        """Set a single cookie."""
         try:
             # We don't specify Tornado secure flag here because it leads to missing cookie on Safari.
             # The OIDC flow should work only on secure context anyway (localhost or HTTPS),
             # so specifying the secure flag here will not add anything in terms of security.
             self.set_signed_cookie(
                 cookie_name,
-                serialized_cookie_value,
+                value,
                 httpOnly=True,
             )
         except AttributeError:
             self.set_secure_cookie(
                 cookie_name,
-                serialized_cookie_value,
+                value,
                 httponly=True,
             )
 
+    def _create_signed_value(self, cookie_name: str, value: str) -> bytes:
+        """Create a signed cookie value."""
+        try:
+            return self.create_signed_value(cookie_name, value)
+        except AttributeError:
+            return self.create_secure_cookie_value(cookie_name, value)
+
+    def _get_signed_cookie(self, cookie_name: str) -> bytes | None:
+        """Get a signed cookie."""
+        try:
+            return self.get_signed_cookie(cookie_name)
+        except AttributeError:
+            return self.get_secure_cookie(cookie_name)
+        except Exception:
+            # Handle cases where cookie_secret is not configured or other errors
+            return None
+
     def clear_auth_cookie(self) -> None:
-        self.clear_cookie(AUTH_COOKIE_NAME)
-        self.clear_cookie(TOKENS_COOKIE_NAME)
+        """Clear auth cookies, including any split cookie chunks."""
+        clear_cookie_and_chunks(
+            self._get_signed_cookie,
+            self.clear_cookie,
+            AUTH_COOKIE_NAME,
+        )
+        clear_cookie_and_chunks(
+            self._get_signed_cookie,
+            self.clear_cookie,
+            TOKENS_COOKIE_NAME,
+        )
 
 
 class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):
@@ -183,7 +213,11 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         user = cast("dict[str, Any]", token.get("userinfo"))
 
         cookie_value = dict(user, origin=origin, is_logged_in=True)
-        tokens = {k: v for k, v in token.items() if k.endswith("_token")}
+        tokens = {
+            k: v
+            for k, v in token.items()
+            if k in ["id_token", "access_token", "refresh_token"]
+        }
 
         if user:
             self.set_auth_cookie(cookie_value, tokens)

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 DEVELOPMENT_PORT: Final = 3000
 
 AUTH_COOKIE_NAME: Final = "_streamlit_user"
+TOKENS_COOKIE_NAME: Final = "_streamlit_user_tokens"
 
 
 def allowlisted_origins() -> set[str]:

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import unittest
 from typing import Any
@@ -23,6 +24,7 @@ import pytest
 
 from streamlit.auth_util import (
     AuthCache,
+    _calculate_signing_overhead,
     clear_cookie_and_chunks,
     get_cookie_with_chunks,
     get_expose_tokens_config,
@@ -30,6 +32,21 @@ from streamlit.auth_util import (
     set_cookie_with_chunks,
 )
 from streamlit.errors import StreamlitAuthError
+
+# Simulates realistic Tornado cookie signing overhead (~100 bytes for signature, timestamp, etc.)
+MOCK_SIGNING_OVERHEAD = 100
+
+
+def create_realistic_signed_value(name: str, value: str) -> bytes:
+    """Mock that simulates realistic Tornado cookie signing behavior.
+
+    Returns base64-encoded value plus a fixed overhead to simulate signing.
+    """
+    base64_value = base64.b64encode(value.encode()).decode()
+    # Simulate: "2|1:0|10:timestamp|{name_len}:{name}|{val_len}:{base64_value}||{signature}" noqa: ERA001
+    overhead = "x" * MOCK_SIGNING_OVERHEAD
+    return f"{overhead}{base64_value}".encode()
+
 
 CONFIG_MOCK: dict[str, Any] = {}
 
@@ -184,6 +201,15 @@ class ExposeTokensConfigTest(unittest.TestCase):
 class CookieChunkingTest(unittest.TestCase):
     """Test cookie chunking functionality."""
 
+    def test_calculate_signing_overhead(self):
+        """Test that signing overhead is calculated correctly from the signing function."""
+        # The overhead should be the signed size minus base64 size of the test value
+        # base64("x") = "eA==" which is 4 bytes
+        overhead = _calculate_signing_overhead(
+            create_realistic_signed_value, "test_cookie"
+        )
+        assert overhead == MOCK_SIGNING_OVERHEAD
+
     def test_set_cookie_with_chunks_small_cookie(self):
         """Test that small cookies are set without chunking."""
         cookies: dict[str, str] = {}
@@ -191,14 +217,10 @@ class CookieChunkingTest(unittest.TestCase):
         def mock_set_cookie(name: str, value: str) -> None:
             cookies[name] = value
 
-        def mock_create_signed_value(name: str, value: str) -> bytes:
-            # Simulate a signed value that's similar in size
-            return f"signed_{value}".encode()
-
         small_data = {"key": "value"}
         set_cookie_with_chunks(
             mock_set_cookie,
-            mock_create_signed_value,
+            create_realistic_signed_value,
             "test_cookie",
             small_data,
         )
@@ -216,25 +238,23 @@ class CookieChunkingTest(unittest.TestCase):
         def mock_set_cookie(name: str, value: str) -> None:
             cookies[name] = value
 
-        def mock_create_signed_value(name: str, value: str) -> bytes:
-            # Simulate a very large signed value that exceeds the limit
-            return ("x" * 5000).encode()
-
-        large_data = {"key": "x" * 10000}
+        # Create data large enough to exceed the 4096 byte cookie limit after signing
+        # With ~100 byte overhead and base64 expansion (4/3), we need ~3000+ raw bytes
+        large_data = {"key": "x" * 5000}
         set_cookie_with_chunks(
             mock_set_cookie,
-            mock_create_signed_value,
+            create_realistic_signed_value,
             "test_cookie",
             large_data,
         )
 
-        # Main cookie should exist (contains first chunk)
+        # Main cookie should exist (contains chunk count marker)
         assert "test_cookie" in cookies
         chunk_count = int(cookies["test_cookie"].split("-")[1])
         assert chunk_count > 1  # Should have multiple chunks
 
-        # Verify additional chunks exist (1, 2, 3, etc.)
-        for i in range(1, chunk_count):
+        # Verify all chunks exist (1, 2, ..., chunk_count)
+        for i in range(1, chunk_count + 1):
             assert f"test_cookie_{i}" in cookies
 
     def test_get_cookie_with_chunks_single_cookie(self):
@@ -378,15 +398,12 @@ class CookieChunkingTest(unittest.TestCase):
         def mock_get_cookie(name: str) -> bytes | None:
             return cookies.get(name)
 
-        def mock_create_signed_value(name: str, value: str) -> bytes:
-            return f"signed_{value}".encode()
-
         data = {"user": "john", "email": "john@example.com"}
 
         # Set the cookie
         set_cookie_with_chunks(
             mock_set_cookie,
-            mock_create_signed_value,
+            create_realistic_signed_value,
             "auth_cookie",
             data,
         )
@@ -406,17 +423,13 @@ class CookieChunkingTest(unittest.TestCase):
         def mock_get_cookie(name: str) -> bytes | None:
             return cookies.get(name)
 
-        def mock_create_signed_value(name: str, value: str) -> bytes:
-            # Simulate a large signed value
-            return ("x" * 5000).encode()
-
-        # Create large data
-        data = {"token": "x" * 10000}
+        # Create large data that will require chunking
+        data = {"token": "x" * 5000}
 
         # Set the cookie (should chunk it)
         set_cookie_with_chunks(
             mock_set_cookie,
-            mock_create_signed_value,
+            create_realistic_signed_value,
             "auth_cookie",
             data,
         )

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -19,6 +19,8 @@ import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from streamlit.auth_util import (
     AuthCache,
     clear_cookie_and_chunks,
@@ -27,6 +29,7 @@ from streamlit.auth_util import (
     get_signing_secret,
     set_cookie_with_chunks,
 )
+from streamlit.errors import StreamlitAuthError
 
 CONFIG_MOCK: dict[str, Any] = {}
 
@@ -155,6 +158,28 @@ class ExposeTokensConfigTest(unittest.TestCase):
             result = get_expose_tokens_config()
             assert result == []
 
+    def test_expose_tokens_invalid_value_raises_error(self):
+        """Test expose_tokens with invalid token value raises StreamlitAuthError."""
+        with patch(
+            "streamlit.auth_util.secrets_singleton",
+            MagicMock(
+                load_if_toml_exists=MagicMock(return_value=True),
+                get=MagicMock(
+                    return_value={
+                        "redirect_uri": "http://localhost:8501/oauth2callback",
+                        "cookie_secret": "test_cookie_secret",
+                        "expose_tokens": ["id", "invalid"],  # Invalid token value
+                    }
+                ),
+            ),
+        ):
+            with pytest.raises(StreamlitAuthError) as exc_info:
+                get_expose_tokens_config()
+            assert (
+                "Invalid expose_tokens configuration. Only 'id' and 'access' are allowed."
+                in str(exc_info.value)
+            )
+
 
 class CookieChunkingTest(unittest.TestCase):
     """Test cookie chunking functionality."""
@@ -205,8 +230,7 @@ class CookieChunkingTest(unittest.TestCase):
 
         # Main cookie should exist (contains first chunk)
         assert "test_cookie" in cookies
-        assert "test_cookie_count" in cookies
-        chunk_count = int(cookies["test_cookie_count"])
+        chunk_count = int(cookies["test_cookie"].split("-")[1])
         assert chunk_count > 1  # Should have multiple chunks
 
         # Verify additional chunks exist (1, 2, 3, etc.)
@@ -228,13 +252,13 @@ class CookieChunkingTest(unittest.TestCase):
     def test_get_cookie_with_chunks_chunked_cookie(self):
         """Test retrieving a chunked cookie."""
         original_value = '{"key": "value123"}'
-        chunk0 = '{"key": '  # Main cookie contains first chunk
-        chunk1 = '"value123"}'
+        chunk1 = '{"key": '  # Main cookie contains first chunk
+        chunk2 = '"value123"}'
 
         cookies: dict[str, bytes] = {
-            "test_cookie_count": b"2",
-            "test_cookie": chunk0.encode(),  # Main cookie is first chunk
-            "test_cookie_1": chunk1.encode(),
+            "test_cookie": b"chunks-2",
+            "test_cookie_1": chunk1.encode(),  # Main cookie is first chunk
+            "test_cookie_2": chunk2.encode(),
         }
 
         def mock_get_cookie(name: str) -> bytes | None:
@@ -255,10 +279,10 @@ class CookieChunkingTest(unittest.TestCase):
     def test_get_cookie_with_chunks_missing_chunk(self):
         """Test retrieving a chunked cookie with a missing chunk."""
         cookies: dict[str, bytes] = {
-            "test_cookie_count": b"3",
-            "test_cookie": b"chunk0",  # Main cookie is first chunk
-            # test_cookie_1 is missing
-            "test_cookie_2": b"chunk2",
+            "test_cookie": b"chunks-3",
+            "test_cookie_1": b"chunk0",  # Main cookie is first chunk
+            # test_cookie_2 is missing
+            "test_cookie_3": b"chunk2",
         }
 
         def mock_get_cookie(name: str) -> bytes | None:
@@ -270,14 +294,14 @@ class CookieChunkingTest(unittest.TestCase):
     def test_get_cookie_with_chunks_invalid_count(self):
         """Test retrieving a chunked cookie with invalid count."""
         cookies: dict[str, bytes] = {
-            "test_cookie_count": b"invalid",
+            "test_cookie": b"chunks-invalid",
         }
 
         def mock_get_cookie(name: str) -> bytes | None:
             return cookies.get(name)
 
         result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
-        assert result is None
+        assert result == b"chunks-invalid"
 
     def test_clear_cookie_and_chunks_single_cookie(self):
         """Test clearing a single (non-chunked) cookie."""
@@ -301,10 +325,10 @@ class CookieChunkingTest(unittest.TestCase):
     def test_clear_cookie_and_chunks_chunked_cookie(self):
         """Test clearing a chunked cookie."""
         cookies: dict[str, bytes] = {
-            "test_cookie_count": b"3",
-            "test_cookie": b"chunk0",  # Main cookie is first chunk
+            "test_cookie": b"chunks-3",
             "test_cookie_1": b"chunk1",
             "test_cookie_2": b"chunk2",
+            "test_cookie_3": b"chunk3",
         }
         cleared: list[str] = []
 
@@ -321,13 +345,13 @@ class CookieChunkingTest(unittest.TestCase):
         assert "test_cookie" in cleared
         assert "test_cookie_1" in cleared
         assert "test_cookie_2" in cleared
-        assert "test_cookie_count" in cleared
-        assert len(cleared) == 4  # main, 1, 2, count
+        assert "test_cookie_3" in cleared
+        assert len(cleared) == 4  # main, 1, 2, 3
 
     def test_clear_cookie_and_chunks_invalid_count(self):
         """Test clearing a chunked cookie with invalid count."""
         cookies: dict[str, bytes] = {
-            "test_cookie_count": b"invalid",
+            "test_cookie": b"chunks-invalid",
         }
         cleared: list[str] = []
 
@@ -342,8 +366,7 @@ class CookieChunkingTest(unittest.TestCase):
 
         # Should clear the main cookie and the count cookie
         assert "test_cookie" in cleared
-        assert "test_cookie_count" in cleared
-        assert len(cleared) == 2
+        assert len(cleared) == 1
 
     def test_round_trip_small_cookie(self):
         """Test setting and getting a small cookie."""
@@ -399,7 +422,7 @@ class CookieChunkingTest(unittest.TestCase):
         )
 
         # Verify chunks were created
-        assert "auth_cookie_count" in cookies
+        assert "auth_cookie" in cookies
 
         # Get the cookie (should reconstruct it)
         result = get_cookie_with_chunks(mock_get_cookie, "auth_cookie")

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -18,7 +18,7 @@ import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from streamlit.auth_util import AuthCache, get_signing_secret
+from streamlit.auth_util import AuthCache, get_expose_tokens_config, get_signing_secret
 
 CONFIG_MOCK: dict[str, Any] = {}
 
@@ -71,3 +71,78 @@ class AuthUtilTest(unittest.TestCase):
         """Get the cookie signing secret from the configuration or secrets.toml."""
         x = get_signing_secret()
         assert x == "your_cookie_secret_here"
+
+
+class ExposeTokensConfigTest(unittest.TestCase):
+    """Test expose_tokens configuration parsing."""
+
+    def test_expose_tokens_string_config(self):
+        """Test expose_tokens as a string."""
+        with patch(
+            "streamlit.auth_util.secrets_singleton",
+            MagicMock(
+                load_if_toml_exists=MagicMock(return_value=True),
+                get=MagicMock(
+                    return_value={
+                        "redirect_uri": "http://localhost:8501/oauth2callback",
+                        "cookie_secret": "test_cookie_secret",
+                        "expose_tokens": "id",
+                    }
+                ),
+            ),
+        ):
+            result = get_expose_tokens_config()
+            assert result == ["id"]
+
+    def test_expose_tokens_list_config(self):
+        """Test expose_tokens as a list."""
+        with patch(
+            "streamlit.auth_util.secrets_singleton",
+            MagicMock(
+                load_if_toml_exists=MagicMock(return_value=True),
+                get=MagicMock(
+                    return_value={
+                        "redirect_uri": "http://localhost:8501/oauth2callback",
+                        "cookie_secret": "test_cookie_secret",
+                        "expose_tokens": ["id", "access"],
+                    }
+                ),
+            ),
+        ):
+            result = get_expose_tokens_config()
+            assert result == ["id", "access"]
+
+    def test_expose_tokens_no_config(self):
+        """Test when expose_tokens is not configured."""
+        with patch(
+            "streamlit.auth_util.secrets_singleton",
+            MagicMock(
+                load_if_toml_exists=MagicMock(return_value=True),
+                get=MagicMock(
+                    return_value={
+                        "redirect_uri": "http://localhost:8501/oauth2callback",
+                        "cookie_secret": "test_cookie_secret",
+                    }
+                ),
+            ),
+        ):
+            result = get_expose_tokens_config()
+            assert result == []
+
+    def test_expose_tokens_invalid_type(self):
+        """Test expose_tokens with invalid type."""
+        with patch(
+            "streamlit.auth_util.secrets_singleton",
+            MagicMock(
+                load_if_toml_exists=MagicMock(return_value=True),
+                get=MagicMock(
+                    return_value={
+                        "redirect_uri": "http://localhost:8501/oauth2callback",
+                        "cookie_secret": "test_cookie_secret",
+                        "expose_tokens": 123,  # Invalid type
+                    }
+                ),
+            ),
+        ):
+            result = get_expose_tokens_config()
+            assert result == []

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -14,11 +14,19 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from streamlit.auth_util import AuthCache, get_expose_tokens_config, get_signing_secret
+from streamlit.auth_util import (
+    AuthCache,
+    clear_cookie_and_chunks,
+    get_cookie_with_chunks,
+    get_expose_tokens_config,
+    get_signing_secret,
+    set_cookie_with_chunks,
+)
 
 CONFIG_MOCK: dict[str, Any] = {}
 
@@ -146,3 +154,254 @@ class ExposeTokensConfigTest(unittest.TestCase):
         ):
             result = get_expose_tokens_config()
             assert result == []
+
+
+class CookieChunkingTest(unittest.TestCase):
+    """Test cookie chunking functionality."""
+
+    def test_set_cookie_with_chunks_small_cookie(self):
+        """Test that small cookies are set without chunking."""
+        cookies: dict[str, str] = {}
+
+        def mock_set_cookie(name: str, value: str) -> None:
+            cookies[name] = value
+
+        def mock_create_signed_value(name: str, value: str) -> bytes:
+            # Simulate a signed value that's similar in size
+            return f"signed_{value}".encode()
+
+        small_data = {"key": "value"}
+        set_cookie_with_chunks(
+            mock_set_cookie,
+            mock_create_signed_value,
+            "test_cookie",
+            small_data,
+        )
+
+        # Should only have the main cookie, no chunks
+        assert "test_cookie" in cookies
+        assert "test_cookie_count" not in cookies
+        assert "test_cookie_0" not in cookies
+        assert json.loads(cookies["test_cookie"]) == small_data
+
+    def test_set_cookie_with_chunks_large_cookie(self):
+        """Test that large cookies are split into chunks."""
+        cookies: dict[str, str] = {}
+
+        def mock_set_cookie(name: str, value: str) -> None:
+            cookies[name] = value
+
+        def mock_create_signed_value(name: str, value: str) -> bytes:
+            # Simulate a very large signed value that exceeds the limit
+            return ("x" * 5000).encode()
+
+        large_data = {"key": "x" * 10000}
+        set_cookie_with_chunks(
+            mock_set_cookie,
+            mock_create_signed_value,
+            "test_cookie",
+            large_data,
+        )
+
+        # Main cookie should exist (contains first chunk)
+        assert "test_cookie" in cookies
+        assert "test_cookie_count" in cookies
+        chunk_count = int(cookies["test_cookie_count"])
+        assert chunk_count > 1  # Should have multiple chunks
+
+        # Verify additional chunks exist (1, 2, 3, etc.)
+        for i in range(1, chunk_count):
+            assert f"test_cookie_{i}" in cookies
+
+    def test_get_cookie_with_chunks_single_cookie(self):
+        """Test retrieving a single (non-chunked) cookie."""
+        cookies: dict[str, bytes] = {
+            "test_cookie": b'{"key": "value"}',
+        }
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
+        assert result == b'{"key": "value"}'
+
+    def test_get_cookie_with_chunks_chunked_cookie(self):
+        """Test retrieving a chunked cookie."""
+        original_value = '{"key": "value123"}'
+        chunk0 = '{"key": '  # Main cookie contains first chunk
+        chunk1 = '"value123"}'
+
+        cookies: dict[str, bytes] = {
+            "test_cookie_count": b"2",
+            "test_cookie": chunk0.encode(),  # Main cookie is first chunk
+            "test_cookie_1": chunk1.encode(),
+        }
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
+        assert result == original_value.encode()
+
+    def test_get_cookie_with_chunks_missing_cookie(self):
+        """Test retrieving a non-existent cookie."""
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return None
+
+        result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
+        assert result is None
+
+    def test_get_cookie_with_chunks_missing_chunk(self):
+        """Test retrieving a chunked cookie with a missing chunk."""
+        cookies: dict[str, bytes] = {
+            "test_cookie_count": b"3",
+            "test_cookie": b"chunk0",  # Main cookie is first chunk
+            # test_cookie_1 is missing
+            "test_cookie_2": b"chunk2",
+        }
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
+        assert result is None
+
+    def test_get_cookie_with_chunks_invalid_count(self):
+        """Test retrieving a chunked cookie with invalid count."""
+        cookies: dict[str, bytes] = {
+            "test_cookie_count": b"invalid",
+        }
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
+        assert result is None
+
+    def test_clear_cookie_and_chunks_single_cookie(self):
+        """Test clearing a single (non-chunked) cookie."""
+        cookies: dict[str, bytes] = {
+            "test_cookie": b'{"key": "value"}',
+        }
+        cleared: list[str] = []
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        def mock_clear_cookie(name: str) -> None:
+            cleared.append(name)
+            cookies.pop(name, None)
+
+        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
+
+        assert "test_cookie" in cleared
+        assert len(cleared) == 1
+
+    def test_clear_cookie_and_chunks_chunked_cookie(self):
+        """Test clearing a chunked cookie."""
+        cookies: dict[str, bytes] = {
+            "test_cookie_count": b"3",
+            "test_cookie": b"chunk0",  # Main cookie is first chunk
+            "test_cookie_1": b"chunk1",
+            "test_cookie_2": b"chunk2",
+        }
+        cleared: list[str] = []
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        def mock_clear_cookie(name: str) -> None:
+            cleared.append(name)
+            cookies.pop(name, None)
+
+        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
+
+        # Should clear the main cookie, additional chunks (1, 2), and the count cookie
+        assert "test_cookie" in cleared
+        assert "test_cookie_1" in cleared
+        assert "test_cookie_2" in cleared
+        assert "test_cookie_count" in cleared
+        assert len(cleared) == 4  # main, 1, 2, count
+
+    def test_clear_cookie_and_chunks_invalid_count(self):
+        """Test clearing a chunked cookie with invalid count."""
+        cookies: dict[str, bytes] = {
+            "test_cookie_count": b"invalid",
+        }
+        cleared: list[str] = []
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        def mock_clear_cookie(name: str) -> None:
+            cleared.append(name)
+            cookies.pop(name, None)
+
+        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
+
+        # Should clear the main cookie and the count cookie
+        assert "test_cookie" in cleared
+        assert "test_cookie_count" in cleared
+        assert len(cleared) == 2
+
+    def test_round_trip_small_cookie(self):
+        """Test setting and getting a small cookie."""
+        cookies: dict[str, bytes] = {}
+
+        def mock_set_cookie(name: str, value: str) -> None:
+            cookies[name] = value.encode()
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        def mock_create_signed_value(name: str, value: str) -> bytes:
+            return f"signed_{value}".encode()
+
+        data = {"user": "john", "email": "john@example.com"}
+
+        # Set the cookie
+        set_cookie_with_chunks(
+            mock_set_cookie,
+            mock_create_signed_value,
+            "auth_cookie",
+            data,
+        )
+
+        # Get the cookie
+        result = get_cookie_with_chunks(mock_get_cookie, "auth_cookie")
+        assert result is not None
+        assert json.loads(result) == data
+
+    def test_round_trip_large_cookie(self):
+        """Test setting and getting a large cookie that requires chunking."""
+        cookies: dict[str, bytes] = {}
+
+        def mock_set_cookie(name: str, value: str) -> None:
+            cookies[name] = value.encode()
+
+        def mock_get_cookie(name: str) -> bytes | None:
+            return cookies.get(name)
+
+        def mock_create_signed_value(name: str, value: str) -> bytes:
+            # Simulate a large signed value
+            return ("x" * 5000).encode()
+
+        # Create large data
+        data = {"token": "x" * 10000}
+
+        # Set the cookie (should chunk it)
+        set_cookie_with_chunks(
+            mock_set_cookie,
+            mock_create_signed_value,
+            "auth_cookie",
+            data,
+        )
+
+        # Verify chunks were created
+        assert "auth_cookie_count" in cookies
+
+        # Get the cookie (should reconstruct it)
+        result = get_cookie_with_chunks(mock_get_cookie, "auth_cookie")
+        assert result is not None
+        assert json.loads(result) == data

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import StreamlitInvalidWidthError
+from streamlit.user_info import UserInfoProxy
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
@@ -116,3 +120,46 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidWidthError) as e:
             st.json('{"some": "json"}', width=width)
         assert "Invalid width" in str(e.value)
+
+    def test_st_json_masks_user_info_tokens(self):
+        """Test that st.json masks token values when displaying UserInfoProxy."""
+        with patch(
+            "streamlit.user_info._get_user_info",
+            return_value={
+                "email": "test@example.com",
+                "name": "Test User",
+                "tokens": {
+                    "id": "secret_id_token_value",
+                    "access": "secret_access_token_value",
+                },
+            },
+        ):
+            user = UserInfoProxy()
+
+            st.json(user)
+
+            el = self.get_delta_from_queue().new_element
+            body = json.loads(el.json.body)
+            assert body["email"] == "test@example.com"
+            assert body["name"] == "Test User"
+            assert body["tokens"]["id"] == "***"
+            assert body["tokens"]["access"] == "***"
+
+    def test_st_json_user_info_without_tokens(self):
+        """Test that st.json handles UserInfoProxy without tokens correctly."""
+        with patch(
+            "streamlit.user_info._get_user_info",
+            return_value={
+                "email": "test@example.com",
+                "name": "Test User",
+            },
+        ):
+            user = UserInfoProxy()
+
+            st.json(user)
+
+            el = self.get_delta_from_queue().new_element
+            body = json.loads(el.json.body)
+            assert body["email"] == "test@example.com"
+            assert body["name"] == "Test User"
+            assert "tokens" not in body

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -286,7 +286,7 @@ class UserInfoAuthTest(DeltaGeneratorTestCase):
         assert c.url.startswith("/auth/logout")
 
 
-class TokensProxyTest:
+class TestTokensProxy:
     """Test TokensProxy class functionality."""
 
     def test_tokens_proxy_access(self):

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import json
 import threading
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,7 @@ from streamlit.runtime.scriptrunner import (
     get_script_run_ctx,
 )
 from streamlit.runtime.state import SafeSessionState, SessionState
+from streamlit.user_info import TokensProxy
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 SECRETS_MOCK = {
@@ -282,3 +284,111 @@ class UserInfoAuthTest(DeltaGeneratorTestCase):
         c = self.get_message_from_queue().auth_redirect
 
         assert c.url.startswith("/auth/logout")
+
+
+class TokensProxyTest:
+    """Test TokensProxy class functionality."""
+
+    def test_tokens_proxy_access(self):
+        """Test token access via key and attribute notation."""
+        proxy = TokensProxy({"id": "token1", "access": "token2"})
+
+        assert proxy["id"] == "token1"
+        assert proxy.id == "token1"
+        assert proxy["access"] == "token2"
+        assert proxy.access == "token2"
+
+    def test_tokens_proxy_empty(self):
+        """Test TokensProxy with no tokens."""
+        proxy = TokensProxy({})
+
+        assert len(proxy) == 0
+        with pytest.raises(KeyError):
+            assert proxy["id"]
+        with pytest.raises(AttributeError):
+            assert proxy.id
+
+    def test_tokens_proxy_readonly(self):
+        """Test that tokens cannot be modified."""
+        proxy = TokensProxy({"id": "test"})
+
+        with pytest.raises(StreamlitAPIException):
+            proxy.id = "modified"
+        with pytest.raises(StreamlitAPIException):
+            proxy["id"] = "modified"
+
+
+class UserInfoTokensTest(DeltaGeneratorTestCase):
+    """Test st.user.tokens functionality."""
+
+    @contextmanager
+    def _with_user_context(self, user_info):
+        """Helper to set up user context for testing."""
+        orig_report_ctx = get_script_run_ctx()
+        forward_msg_queue = ForwardMsgQueue()
+
+        try:
+            add_script_run_ctx(
+                threading.current_thread(),
+                ScriptRunContext(
+                    session_id="test session id",
+                    _enqueue=forward_msg_queue.enqueue,
+                    query_string="",
+                    session_state=SafeSessionState(SessionState(), lambda: None),
+                    uploaded_file_mgr=None,
+                    main_script_path="",
+                    user_info=user_info,
+                    fragment_storage=MemoryFragmentStorage(),
+                    pages_manager=PagesManager(""),
+                ),
+            )
+            yield
+        finally:
+            add_script_run_ctx(threading.current_thread(), orig_report_ctx)
+
+    def test_user_tokens_property_access(self):
+        """Test that st.user.tokens returns a TokensProxy."""
+        user_info = {
+            "email": "test@example.com",
+            "tokens": {"id": "token1", "access": "token2"},
+        }
+
+        with self._with_user_context(user_info):
+            tokens = st.user.tokens
+            assert isinstance(tokens, TokensProxy)
+            assert tokens.id == "token1"
+            assert tokens.access == "token2"
+
+    def test_user_tokens_key_access(self):
+        """Test that st.user['tokens'] returns a TokensProxy."""
+        user_info = {
+            "email": "test@example.com",
+            "tokens": {"id": "token1", "access": "token2"},
+        }
+
+        with self._with_user_context(user_info):
+            tokens = st.user["tokens"]
+            assert isinstance(tokens, TokensProxy)
+            assert tokens.id == "token1"
+            assert tokens.access == "token2"
+
+    def test_user_tokens_empty(self):
+        """Test st.user.tokens when no tokens are present."""
+        user_info = {"email": "test@example.com"}
+
+        with self._with_user_context(user_info):
+            tokens = st.user.tokens
+            assert isinstance(tokens, TokensProxy)
+            assert len(tokens) == 0
+
+    def test_user_tokens_consistency(self):
+        """Test that st.user.tokens and st.user['tokens'] return the same type."""
+        user_info = {"email": "test@example.com", "tokens": {"id": "test_token"}}
+
+        with self._with_user_context(user_info):
+            tokens_prop = st.user.tokens
+            tokens_key = st.user["tokens"]
+
+            assert isinstance(tokens_prop, TokensProxy)
+            assert isinstance(tokens_key, TokensProxy)
+            assert tokens_prop.id == tokens_key.id

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -228,7 +228,6 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
             },
             {
                 "access_token": "test_access_token",
-                "refresh_token": "test_refresh_token",
                 "id_token": "test_id_token",
             },
         )

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -153,7 +153,8 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     AuthLogoutHandler,
                     {"base_url": ""},
                 )
-            ]
+            ],
+            cookie_secret="test_secret",
         )
 
     def test_logout_success(self):

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -200,7 +200,14 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
         return_value=(
             MagicMock(
                 authorize_access_token=MagicMock(
-                    return_value={"userinfo": {"email": "test@example.com"}}
+                    return_value={
+                        "userinfo": {"email": "test@example.com"},
+                        "access_token": "test_access_token",
+                        "refresh_token": "test_refresh_token",
+                        "id_token": "test_id_token",
+                        "token_type": "Bearer",
+                        "expires_in": 3600,
+                    }
                 )
             ),
             MagicMock(),
@@ -217,6 +224,11 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "email": "test@example.com",
                 "origin": "http://localhost:8501",
                 "is_logged_in": True,
+            },
+            {
+                "access_token": "test_access_token",
+                "refresh_token": "test_refresh_token",
+                "id_token": "test_id_token",
             }
         )
 

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -229,7 +229,7 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "access_token": "test_access_token",
                 "refresh_token": "test_refresh_token",
                 "id_token": "test_id_token",
-            }
+            },
         )
 
         assert response.code == 302


### PR DESCRIPTION
## Describe your changes

Store the  OIDC auth response in a cookie and expose them to users for API calls

Currently, from user perspective, `st.user` gets an extra field called "tokens" that is a dict of all the tokens that were made available - most often the triplet of acces_token, id_token, refresh_token

This is useful for multiple use cases (see the issues below).

To achieve (a) reliably, the tokens are stored in a separate cookie from user info. This is because cookies are limited to be <4096 bytes and I ran into that limit in my own testing already if I combined the two dictionaries. Additionally, both cookies can now be chunked so as a by-product, this now supports login systems with larger userdata.

I have tested it to work in my own use case and it seems to be performing as intended. But it is just one use case and I may well be missing some others. so any proposals to improve this are very welcome. 

Originally, also contained st.user_refresh command, but that got it's own PR: https://github.com/streamlit/streamlit/pull/12696

## GitHub Issue Link (if applicable)

Closes #10378 

Exposing access_token: https://github.com/streamlit/streamlit/issues/10378
Too large usedata for current login system: https://github.com/streamlit/streamlit/issues/12518

Need to provide id token hint at logout: https://github.com/streamlit/streamlit/issues/12144#issuecomment-3172828767 -> PR https://github.com/streamlit/streamlit/pull/12693
Need for user refresh: https://github.com/streamlit/streamlit/issues/12043 -> PR https://github.com/streamlit/streamlit/pull/12696

## Testing Plan

- Unit tests present
- Manually tested to work for my own use case

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
