### PR TITLE
feat: Add add_script_run_ctx to ensure Streamlit context for all callback methods

### DIFF
--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -51,6 +51,7 @@ from langchain.callbacks.base import (
 )
 
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
 
 if TYPE_CHECKING:
     from langchain.schema import (
@@ -325,6 +326,7 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
         self._expand_new_thoughts = expand_new_thoughts
         self._collapse_completed_thoughts = collapse_completed_thoughts
         self._thought_labeler = thought_labeler or LLMThoughtLabeler()
+        self._ctx = get_script_run_ctx()
 
     def _require_current_thought(self) -> LLMThought:
         """Return our current LLMThought. Raise an error if we have no current
@@ -352,6 +354,7 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
     def on_llm_start(
         self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any
     ) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         if self._current_thought is None:
             self._current_thought = LLMThought(
                 parent_container=self._parent_container,
@@ -366,17 +369,21 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
         # be visible until it has a child.
 
     def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_llm_new_token(token, **kwargs)
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_llm_end(response, **kwargs)
 
     def on_llm_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_llm_error(error, **kwargs)
 
     def on_tool_start(
         self, serialized: dict[str, Any], input_str: str, **kwargs: Any
     ) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_tool_start(serialized, input_str, **kwargs)
 
     def on_tool_end(
@@ -387,22 +394,26 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
         llm_prefix: str | None = None,
         **kwargs: Any,
     ) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_tool_end(
             output, color, observation_prefix, llm_prefix, **kwargs
         )
         self._complete_current_thought()
 
     def on_tool_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_tool_error(error, **kwargs)
 
     def on_agent_action(
         self, action: AgentAction, color: str | None = None, **kwargs: Any
     ) -> Any:
+        add_script_run_ctx(ctx=self._ctx)
         self._require_current_thought().on_agent_action(action, color, **kwargs)
 
     def on_agent_finish(
         self, finish: AgentFinish, color: str | None = None, **kwargs: Any
     ) -> None:
+        add_script_run_ctx(ctx=self._ctx)
         if self._current_thought is not None:
             self._current_thought.complete(
                 self._thought_labeler.get_final_agent_thought_label()


### PR DESCRIPTION
## Describe your changes

Added proper context to langchain callback. This prevents NoSessionContext errors when using LangChain callbacks in Streamlit applications

## GitHub Issue Link (if applicable)

Fixes #12051 
Fixed langchain-ai/langgraph#101

## Manual Testing Done

### Code for Testing

```py
# pip install langchain langchain-openai streamlit langgraph
import streamlit as st
from langchain.agents import create_react_agent
from langchain_openai import ChatOpenAI
from langchain_core.tools import tool
from langgraph.prebuilt import create_react_agent
from streamlit.external.langchain import StreamlitCallbackHandler
import getpass, os

os.environ["OPENAI_API_KEY"] = getpass.getpass("Enter your OpenAI API key: ")

@tool
def multiply(a: int, b: int) -> int:
    """Multiply two numbers."""
    return a * b


agent = create_react_agent(
    model=ChatOpenAI(
        model="gpt-4.1",
        temperature=0.0,
        streaming=True,
        stream_usage=True,
    ),
    tools=[multiply],
)

output_container = st.empty()
user_input = "Multiply 31243 and 4413"
output_container = output_container.container()
output_container.chat_message("user").write(user_input)
answer_container = output_container.chat_message("assistant", avatar="🦜")
st_callback = StreamlitCallbackHandler(
    answer_container,
    expand_new_thoughts=True,
    collapse_completed_thoughts=True,
    max_thought_containers=100,
)

answer = agent.invoke(
    {"messages": [{"role": "user", "content": user_input}]},
    {"callbacks": [st_callback]},
)

answer_container.write(answer["messages"][-1].content)
```

### Old Output (Existing streamlit)

```
  You can now view your Streamlit app in your browser.

  Local URL: http://localhost:8501
  Network URL: http://192.168.0.104:8501

  For better performance, install the Watchdog module:

  $ xcode-select --install
  $ pip install watchdog
            
2025-07-29 08:33:05.912 Thread 'ThreadPoolExecutor-3_0': missing ScriptRunContext! This warning can be ignored when running in bare mode.
Error in StreamlitCallbackHandler.on_tool_start callback: NoSessionContext()
2025-07-29 08:33:05.914 Thread 'ThreadPoolExecutor-3_0': missing ScriptRunContext! This warning can be ignored when running in bare mode.
2025-07-29 08:33:05.914 Thread 'ThreadPoolExecutor-3_0': missing ScriptRunContext! This warning can be ignored when running in bare mode.
2025-07-29 08:33:05.914 Thread 'ThreadPoolExecutor-3_0': missing ScriptRunContext! This warning can be ignored when running in bare mode.
Error in StreamlitCallbackHandler.on_tool_end callback: NoSessionContext()
```

### New Output (Updated streamlit)

```
You can now view your Streamlit app in your browser.

Local URL: http://localhost:8501
Network URL: http://192.168.0.104:8501

For better performance, install the Watchdog module:

$ xcode-select --install
$ pip install watchdog
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.