### PR TITLE
Add cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
 
+    # Use cooldown to avoid updating dependencies too frequently
+    # and minimize risk of supply chain attacks.
+    cooldown:
+      default-days: 5
+
     labels:
       - "change:chore"
       - "impact:internal"
@@ -67,19 +72,13 @@ updates:
           - "unified"
       eslint:
         patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@typescript-eslint/*"
-          - "@eslint-react/*"
+          - "*eslint*"
       emotion:
         patterns:
-          - "@emotion/*"
-          - "@emotion-icons/*"
+          - "*emotion*"
       vitest:
         patterns:
-          - "vitest"
-          - "vitest-*"
-          - "@vitest/*"
+          - "*vitest*"
       vite:
         patterns:
           - "vite"
@@ -97,6 +96,11 @@ updates:
     # Allow a limited number of update PRs at a time
     # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
+
+    # Use cooldown to avoid updating dependencies too frequently
+    # and minimize risk of supply chain attacks.
+    cooldown:
+      default-days: 5
 
     labels:
       - "change:chore"


### PR DESCRIPTION
## Describe your changes

Use [cooldown of 5 days](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) for dependency updates by dependabot to avoid updating dependencies too frequently and minimize risk of supply chain attacks (we will wait at least 5 days before getting a version update PR)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
