### PR TITLE
Update altair dependency constraints in setup.py to exclude problematic versions 5.4.0 and 5.4.1 due to compatibility issues with the narwhals library.

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -31,7 +31,10 @@ VERSION = "1.47.1"  # PEP-440
 # - Always include the lower bound as >= VERSION, to keep testing min versions easy
 # - And include an upper bound that's < NEXT_MAJOR_VERSION
 INSTALL_REQUIRES = [
-    "altair>=4.0, <6",
+    # Altair 5.4.0 and 5.4.1 have compatibility issues with narwhals library
+    # that cause st.line_chart and other built-in charts to fail rendering.
+    # See: https://github.com/streamlit/streamlit/issues/12064
+    "altair>=4.0, <6, !=5.4.0, !=5.4.1",
     "blinker>=1.5.0, <2",
     "cachetools>=4.0, <7",
     "click>=7.0, <9",


### PR DESCRIPTION
## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->
This updates altair dependency constraints in setup.py to exclude problematic versions 5.4.0 and 5.4.1 due to compatibility issues with the narwhals library.

## GitHub Issue Link (if applicable)

Fixes #12064 

## Testing Plan

If CI passes, we should be good.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
