### PR TITLE
[fix] Make toolbar still show custom menu items when in MINIMAL mode

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4287,4 +4287,140 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       connectionManager.incrementMessageCacheRunCount
     ).not.toHaveBeenCalled()
   })
+
+  describe("Toolbar visibility in minimal mode", () => {
+    beforeEach(() => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      vi.mocked(isToolbarDisplayed).mockReturnValue(false)
+    })
+
+    it("shows toolbar in minimal mode when app-defined About menu item exists", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Set About menu item via pageConfigChanged
+      sendForwardMessage("pageConfigChanged", {
+        menuItems: {
+          aboutSectionMd: "Version X",
+        },
+      })
+
+      // The toolbar should be visible because there's an About menu item
+      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+    })
+
+    it("shows toolbar in minimal mode when app-defined Get Help menu item exists", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Set Get Help menu item via pageConfigChanged
+      sendForwardMessage("pageConfigChanged", {
+        menuItems: {
+          getHelpUrl: "https://example.com/help",
+          hideGetHelp: false,
+        },
+      })
+
+      // The toolbar should be visible because there's a Get Help menu item
+      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+    })
+
+    it("shows toolbar in minimal mode when app-defined Report a Bug menu item exists", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Set Report a Bug menu item via pageConfigChanged
+      sendForwardMessage("pageConfigChanged", {
+        menuItems: {
+          reportABugUrl: "https://example.com/bug",
+          hideReportABug: false,
+        },
+      })
+
+      // The toolbar should be visible because there's a Report a Bug menu item
+      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+    })
+
+    it("hides toolbar in minimal mode when no menu items exist", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to minimal with no menu items
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // The toolbar should not be visible because there are no menu items
+      expect(screen.queryByTestId("stMainMenu")).not.toBeInTheDocument()
+    })
+
+    it("hides toolbar in minimal mode when menu items are hidden", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Set menu items but hide them
+      sendForwardMessage("pageConfigChanged", {
+        menuItems: {
+          getHelpUrl: "https://example.com/help",
+          hideGetHelp: true,
+          reportABugUrl: "https://example.com/bug",
+          hideReportABug: true,
+        },
+      })
+
+      // The toolbar should not be visible because all menu items are hidden
+      expect(screen.queryByTestId("stMainMenu")).not.toBeInTheDocument()
+    })
+
+    it("shows toolbar in non-minimal modes regardless of menu items", () => {
+      renderApp(getProps())
+
+      // Set toolbar mode to VIEWER (non-minimal)
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.VIEWER,
+        },
+      })
+
+      // The toolbar should be visible even without menu items
+      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3611,7 +3611,7 @@ describe("App", () => {
         ],
       })
 
-      expect(screen.getByTestId("stToolbarActionButton")).toBeInTheDocument()
+      expect(screen.getByTestId("stToolbarActionButton")).toBeVisible()
     })
 
     it("sets hideSidebarNav based on the server config option and host setting", () => {
@@ -3670,6 +3670,62 @@ describe("App", () => {
       })
 
       expect(screen.queryByTestId("stAppDeployButton")).not.toBeInTheDocument()
+    })
+
+    it("shows toolbar in minimal mode when host menu items exist", () => {
+      prepareHostCommunicationManager()
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Initially no toolbar in minimal mode
+      expect(screen.queryByTestId("stMainMenu")).not.toBeInTheDocument()
+
+      // Add host menu items
+      fireWindowPostMessage({
+        type: "SET_MENU_ITEMS",
+        items: [{ label: "Host menu item", key: "host-item", type: "text" }],
+      })
+
+      // Toolbar should now be visible
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
+    })
+
+    it("shows toolbar in minimal mode when host toolbar items exist", () => {
+      prepareHostCommunicationManager()
+
+      // Set toolbar mode to minimal
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.MINIMAL,
+        },
+      })
+
+      // Initially no toolbar actions in minimal mode
+      expect(screen.queryByTestId("stToolbarActions")).not.toBeInTheDocument()
+
+      // Add host toolbar items
+      fireWindowPostMessage({
+        type: "SET_TOOLBAR_ITEMS",
+        items: [
+          {
+            key: "favorite",
+            icon: "star.svg",
+          },
+        ],
+      })
+
+      // Toolbar actions should now be visible
+      expect(screen.getByTestId("stToolbarActions")).toBeVisible()
+      expect(screen.getByTestId("stToolbarActionButton")).toBeVisible()
     })
 
     it("does not relay custom parent messages by default", () => {
@@ -4314,7 +4370,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       })
 
       // The toolbar should be visible because there's an About menu item
-      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
     })
 
     it("shows toolbar in minimal mode when app-defined Get Help menu item exists", () => {
@@ -4338,7 +4394,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       })
 
       // The toolbar should be visible because there's a Get Help menu item
-      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
     })
 
     it("shows toolbar in minimal mode when app-defined Report a Bug menu item exists", () => {
@@ -4362,7 +4418,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       })
 
       // The toolbar should be visible because there's a Report a Bug menu item
-      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
     })
 
     it("hides toolbar in minimal mode when no menu items exist", () => {
@@ -4420,7 +4476,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       })
 
       // The toolbar should be visible even without menu items
-      expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
+      expect(screen.getByTestId("stMainMenu")).toBeVisible()
     })
   })
 })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2066,6 +2066,18 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
+   * Checks if there are any app-defined menu items configured via st.set_page_config
+   */
+  private hasAppDefinedMenuItems = (): boolean => {
+    const { menuItems } = this.state
+    return Boolean(
+      menuItems?.aboutSectionMd ||
+        (menuItems?.getHelpUrl && !menuItems?.hideGetHelp) ||
+        (menuItems?.reportABugUrl && !menuItems?.hideReportABug)
+    )
+  }
+
+  /**
    * Determines whether the toolbar should be visible based on embed mode,
    * toolbar mode settings, and availability of host menu/toolbar items.
    */
@@ -2076,11 +2088,18 @@ export class App extends PureComponent<Props, State> {
     // Show toolbar if not embedded or if specifically configured to display in embed mode
     const isToolbarAllowedInEmbed = !isEmbed() || isToolbarDisplayed()
 
-    // Show toolbar if not in minimal mode or if there are host items to display
-    const hasContentToShow =
-      this.state.toolbarMode !== Config.ToolbarMode.MINIMAL ||
-      hostMenuItems.length > 0 ||
-      hostToolbarItems.length > 0
+    // Determine if toolbar has content to show based on toolbar mode
+    let hasContentToShow: boolean
+    if (this.state.toolbarMode === Config.ToolbarMode.MINIMAL) {
+      // In minimal mode, only show toolbar if there are menu items to display
+      hasContentToShow =
+        hostMenuItems.length > 0 ||
+        hostToolbarItems.length > 0 ||
+        this.hasAppDefinedMenuItems()
+    } else {
+      // In non-minimal modes, always show the toolbar
+      hasContentToShow = true
+    }
 
     return isToolbarAllowedInEmbed && hasContentToShow
   }


### PR DESCRIPTION
## Describe your changes

Updated the App component to include a method for checking app-defined menu items, affecting toolbar visibility logic.

This enhances the user experience by ensuring the toolbar behaves correctly based on the configuration of menu items.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)
Closes #12083

## Testing Plan

I added unit tests for this.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
