### PR TITLE
Clean-up pytest warnings

### DIFF
--- a/lib/pytest.ini
+++ b/lib/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_default_fixture_loop_scope = function
 markers =
     slow: marks tests as slow
     require_integration: marks tests that require integration dependencies

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -36,6 +36,10 @@ class ConnectionUtilTest(unittest.TestCase):
         assert extracted == {"k1": "v1", "k2": "v2"}
         assert d == {"k3": "v3", "k4": "v4"}
 
+    @pytest.mark.filterwarnings("ignore:pkg_resources is deprecated")
+    @pytest.mark.filterwarnings(
+        "ignore:Deprecated call to `pkg_resources.declare_namespace"
+    )
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -615,6 +615,7 @@ class ScriptRunnerTest(AsyncTestCase):
             assert call_kwargs["uncaught_exception"] == "AttributeError"
 
     @parameterized.expand([(True,), (False,)])
+    @patch("streamlit.runtime.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_runtime_error(self, show_error_details: bool):
         """Tests that we correctly handle scripts with runtime errors."""
         with testutil.patch_config_options(


### PR DESCRIPTION
## Describe your changes

Having unnecessary noise in logs that are read by AI agents can eat up context window and create worse results. This PR cleans up all of the pytest warnings. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
