### PR TITLE
[feat] Add JSON5 validation in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -192,6 +192,18 @@ repos:
           /vendor/
           |^vendor/
           |^component-lib/declarations/apache-arrow
+  - repo: https://gitlab.com/bmares/check-json5
+    rev: v1.0.0
+    hooks:
+      # Check JSON files that are allowed to have comments
+      - id: check-json5
+        # Note that this should be the same as the check-json hook's exclude
+        # property
+        files: |
+          (?x)
+          ^\.vscode/.*\.json$
+          |tsconfig.*\.json$
+          |.*tsconfig\.json$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -204,12 +216,13 @@ repos:
           |\.snap$
       - id: check-added-large-files
       - id: check-json
+        # Note that this should be the same as the check-json5 hook's files
+        # property
         exclude: |
           (?x)
-          |^.vscode/launch\.json$
-          |^.vscode/settings\.json$
-          |^frontend/app/tsconfig.json
-          |^frontend/lib/tsconfig.json
+          ^\.vscode/.*\.json$
+          |tsconfig.*\.json$
+          |.*tsconfig\.json$
       - id: check-toml
       - id: check-yaml
         exclude: lib/conda-recipe/meta.yaml


### PR DESCRIPTION
## Describe your changes

- Follow up from https://github.com/streamlit/streamlit/pull/11580
- There are some JSON files that are allowed to have comments in them (VSCode settings, tsconfig)
- Rather than skipping them, we can parse them with JSON5 to get a stronger sense that they are well-formatted
- _Technically speaking_ JSON5 is a superset of JSON with comments. I was unable to find a solid JSON with comments parser, JSON5 is more well supported in the ecosystem. I figure this is a fine tradeoff as they effectively are interchangeable for our purposes.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
