### PR TITLE
fix: excess margin at top of page (#6336)

### DIFF
--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -148,8 +148,10 @@ export const StyledAppViewBlockContainer =
       let topPadding = littlePadding // Default: 2.25rem
 
       if (!embedded) {
-        // Non-embedded apps always get 6rem or 8rem
-        topPadding = hasTopNav ? "8rem" : "6rem"
+        // Non-embedded apps always get:
+        //     - 8rem if hasTopNav
+        //     - 2.25rem (default) if no topNav
+        topPadding = hasTopNav ? "8rem" : littlePadding
       } else if (showPadding || showToolbar) {
         // 6rem if embedded with show_padding or show_toolbar
         topPadding = "6rem"


### PR DESCRIPTION
## Describe your changes

This reduces the excess margin at the top of the app. 

## GitHub Issue Link (if applicable)

Possible fix for: #6336

## Testing Plan

No testing required since `littlePadding` is hard coded.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
