### PR TITLE
[feat] Add configurable websocket ping interval to fix proxy connection drops

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -926,6 +926,24 @@ _create_option(
 )
 
 _create_option(
+    "server.websocketPingInterval",
+    description="""
+        The interval (in seconds) at which the server pings the client to keep
+        the websocket connection alive.
+
+        The default value should work for most deployments. However, if you're
+        experiencing frequent disconnections in certain proxy setups (e.g.,
+        "Connection error" messages), you may want to try adjusting this value.
+
+        Note: When you set this option, Streamlit automatically sets the ping
+        timeout to match this interval. For Tornado >=6.5, a value less than 30
+        may cause connection issues.
+    """,
+    default_val=None,
+    type_=int,
+)
+
+_create_option(
     "server.enableStaticServing",
     description="""
         Enable serving files from a `static` directory in the running app's

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -64,20 +64,58 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
-TORNADO_SETTINGS = {
-    # Gzip HTTP responses.
-    "compress_response": True,
-    # Ping every 30s to keep WS alive.
-    # With recent versions of Tornado, this value must be greater than or
-    # equal to websocket_ping_timeout.
-    # For details, see https://github.com/tornadoweb/tornado/pull/3376
-    # For compatibility with older versions of Tornado, we set the value to 1.
-    "websocket_ping_interval": 1 if is_tornado_version_less_than("6.5.0") else 30,
-    # If we don't get a ping response within 30s, the connection
-    # is timed out.
-    "websocket_ping_timeout": 30,
-    "xsrf_cookie_name": "_streamlit_xsrf",
-}
+
+def _get_websocket_ping_interval() -> int:
+    """Get the websocket ping interval from config or default based on Tornado version."""
+    configured_interval = config.get_option("server.websocketPingInterval")
+    if configured_interval is not None:
+        # User has explicitly set a value
+        # Warn if using Tornado 6.5+ with low interval
+        if not is_tornado_version_less_than("6.5.0") and configured_interval < 30:
+            _LOGGER.warning(
+                "You have set server.websocketPingInterval to %s, but Tornado >= 6.5 "
+                "requires websocket_ping_interval >= websocket_ping_timeout (30s). "
+                "This may cause connection issues. See "
+                "https://github.com/tornadoweb/tornado/pull/3376#issuecomment-2984887076 "
+                "for more information.",
+                configured_interval,
+            )
+        return int(configured_interval)
+    # Use default behavior
+    return 1 if is_tornado_version_less_than("6.5.0") else 30
+
+
+def get_tornado_settings() -> dict[str, Any]:
+    """Get Tornado settings for the server.
+
+    This is a function to allow for testing and dynamic configuration.
+    """
+    ping_interval = _get_websocket_ping_interval()
+
+    # Determine timeout based on configuration
+    configured_interval = config.get_option("server.websocketPingInterval")
+    if configured_interval is not None:
+        # If user configured the interval, set timeout to match
+        ping_timeout = ping_interval
+    else:
+        # Default case: always use 30s timeout (original behavior)
+        ping_timeout = 30
+
+    return {
+        # Gzip HTTP responses.
+        "compress_response": True,
+        # Ping interval for websocket keepalive.
+        # With recent versions of Tornado, this value must be greater than or
+        # equal to websocket_ping_timeout.
+        # For details, see https://github.com/tornadoweb/tornado/pull/3376
+        # For compatibility with older versions of Tornado, we set the value to 1.
+        "websocket_ping_interval": ping_interval,
+        # If we don't get a ping response within this time, the connection
+        # is timed out.
+        "websocket_ping_timeout": ping_timeout,
+        "xsrf_cookie_name": "_streamlit_xsrf",
+    }
+
 
 # When server.port is not available it will look for the next available port
 # up to MAX_PORT_SEARCH_RETRIES.
@@ -450,7 +488,7 @@ class Server:
             xsrf_cookies=is_xsrf_enabled(),
             # Set the websocket message size. The default value is too low.
             websocket_max_message_size=get_max_message_size_bytes(),
-            **TORNADO_SETTINGS,  # type: ignore[arg-type]
+            **get_tornado_settings(),
         )
 
     @property

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -65,24 +65,36 @@ if TYPE_CHECKING:
 _LOGGER: Final = get_logger(__name__)
 
 
-def _get_websocket_ping_interval() -> int:
-    """Get the websocket ping interval from config or default based on Tornado version."""
+def _get_websocket_ping_interval_and_timeout() -> tuple[int, int]:
+    """Get the websocket ping interval and timeout from config or defaults.
+
+    Returns
+    -------
+        tuple: (ping_interval, ping_timeout)
+    """
     configured_interval = config.get_option("server.websocketPingInterval")
+
     if configured_interval is not None:
         # User has explicitly set a value
+        interval = int(configured_interval)
+
         # Warn if using Tornado 6.5+ with low interval
-        if not is_tornado_version_less_than("6.5.0") and configured_interval < 30:
+        if not is_tornado_version_less_than("6.5.0") and interval < 30:
             _LOGGER.warning(
                 "You have set server.websocketPingInterval to %s, but Tornado >= 6.5 "
-                "requires websocket_ping_interval >= websocket_ping_timeout (30s). "
-                "This may cause connection issues. See "
-                "https://github.com/tornadoweb/tornado/pull/3376#issuecomment-2984887076 "
-                "for more information.",
-                configured_interval,
+                "requires websocket_ping_interval >= websocket_ping_timeout. "
+                "To comply, we are setting both the ping interval and ping timeout to %s. "
+                "Depending on the specific deployment setup, this may cause connection issues.",
+                interval,
+                interval,
             )
-        return int(configured_interval)
-    # Use default behavior
-    return 1 if is_tornado_version_less_than("6.5.0") else 30
+
+        # When user configures interval, set timeout to match
+        return interval, interval
+
+    # Default behavior: respect Tornado version for interval, always 30s timeout
+    default_interval = 1 if is_tornado_version_less_than("6.5.0") else 30
+    return default_interval, 30
 
 
 def get_tornado_settings() -> dict[str, Any]:
@@ -90,16 +102,7 @@ def get_tornado_settings() -> dict[str, Any]:
 
     This is a function to allow for testing and dynamic configuration.
     """
-    ping_interval = _get_websocket_ping_interval()
-
-    # Determine timeout based on configuration
-    configured_interval = config.get_option("server.websocketPingInterval")
-    if configured_interval is not None:
-        # If user configured the interval, set timeout to match
-        ping_timeout = ping_interval
-    else:
-        # Default case: always use 30s timeout (original behavior)
-        ping_timeout = 30
+    ping_interval, ping_timeout = _get_websocket_ping_interval_and_timeout()
 
     return {
         # Gzip HTTP responses.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -555,6 +555,7 @@ class ConfigTest(unittest.TestCase):
                 "server.corsAllowedOrigins",
                 "server.scriptHealthCheckEnabled",
                 "server.enableWebsocketCompression",
+                "server.websocketPingInterval",
                 "server.enableXsrfProtection",
                 "server.fileWatcherType",
                 "server.folderWatchList",

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -293,13 +293,15 @@ class ServerTest(ServerTestCase):
     async def test_websocket_ping_interval_custom_config(self):
         """Test that custom websocket ping interval is respected."""
         from streamlit.web.server.server import (
-            _get_websocket_ping_interval,
+            _get_websocket_ping_interval_and_timeout,
             get_tornado_settings,
         )
 
         # Test custom configuration that's valid for all versions
         config._set_option("server.websocketPingInterval", 45, "test")
-        assert _get_websocket_ping_interval() == 45
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 45
+        assert timeout == 45
         settings = get_tornado_settings()
         assert settings["websocket_ping_interval"] == 45
         assert (
@@ -308,7 +310,9 @@ class ServerTest(ServerTestCase):
 
         # Test high value
         config._set_option("server.websocketPingInterval", 120, "test")
-        assert _get_websocket_ping_interval() == 120
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 120
+        assert timeout == 120
         settings = get_tornado_settings()
         assert settings["websocket_ping_interval"] == 120
         assert (
@@ -323,7 +327,7 @@ class ServerTest(ServerTestCase):
     async def test_websocket_ping_interval_tornado_old(self, mock_version_check):
         """Test websocket ping interval with Tornado < 6.5."""
         from streamlit.web.server.server import (
-            _get_websocket_ping_interval,
+            _get_websocket_ping_interval_and_timeout,
             get_tornado_settings,
         )
 
@@ -332,7 +336,9 @@ class ServerTest(ServerTestCase):
 
         # Test default with old Tornado
         config._set_option("server.websocketPingInterval", None, "test")
-        assert _get_websocket_ping_interval() == 1
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 1
+        assert timeout == 30
         settings = get_tornado_settings()
         assert settings["websocket_ping_interval"] == 1
         assert (
@@ -341,7 +347,9 @@ class ServerTest(ServerTestCase):
 
         # Test low values are accepted
         config._set_option("server.websocketPingInterval", 5, "test")
-        assert _get_websocket_ping_interval() == 5
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 5
+        assert timeout == 5
         settings = get_tornado_settings()
         assert settings["websocket_ping_interval"] == 5
         assert (
@@ -355,22 +363,28 @@ class ServerTest(ServerTestCase):
     @patch("streamlit.web.server.server.is_tornado_version_less_than")
     async def test_websocket_ping_interval_tornado_new(self, mock_version_check):
         """Test websocket ping interval with Tornado >= 6.5."""
-        from streamlit.web.server.server import _get_websocket_ping_interval
+        from streamlit.web.server.server import _get_websocket_ping_interval_and_timeout
 
         # Mock new Tornado version
         mock_version_check.return_value = False
 
         # Test default with new Tornado
         config._set_option("server.websocketPingInterval", None, "test")
-        assert _get_websocket_ping_interval() == 30
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 30
+        assert timeout == 30
 
         # Test that low values are respected
         config._set_option("server.websocketPingInterval", 10, "test")
-        assert _get_websocket_ping_interval() == 10
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 10
+        assert timeout == 10
 
         # Test that values >= 30 are kept as-is
         config._set_option("server.websocketPingInterval", 60, "test")
-        assert _get_websocket_ping_interval() == 60
+        interval, timeout = _get_websocket_ping_interval_and_timeout()
+        assert interval == 60
+        assert timeout == 60
 
         # Reset config
         config._set_option("server.websocketPingInterval", None, "test")

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -271,16 +271,109 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_tornado_settings_applied(self):
         """Test that TORNADO_SETTINGS are properly applied to the app."""
-        from streamlit.web.server.server import TORNADO_SETTINGS
+        from streamlit.web.server.server import get_tornado_settings
 
+        # Reset config to test default behavior
+        config._set_option("server.websocketPingInterval", None, "test")
+
+        tornado_settings = get_tornado_settings()
         assert (
             self.app_settings["websocket_ping_interval"]
-            == TORNADO_SETTINGS["websocket_ping_interval"]
+            == tornado_settings["websocket_ping_interval"]
         )
         assert (
             self.app_settings["websocket_ping_timeout"]
-            == TORNADO_SETTINGS["websocket_ping_timeout"]
+            == tornado_settings["websocket_ping_timeout"]
         )
+
+        # In default case, timeout should always be 30
+        assert tornado_settings["websocket_ping_timeout"] == 30
+
+    @tornado.testing.gen_test
+    async def test_websocket_ping_interval_custom_config(self):
+        """Test that custom websocket ping interval is respected."""
+        from streamlit.web.server.server import (
+            _get_websocket_ping_interval,
+            get_tornado_settings,
+        )
+
+        # Test custom configuration that's valid for all versions
+        config._set_option("server.websocketPingInterval", 45, "test")
+        assert _get_websocket_ping_interval() == 45
+        settings = get_tornado_settings()
+        assert settings["websocket_ping_interval"] == 45
+        assert (
+            settings["websocket_ping_timeout"] == 45
+        )  # Timeout matches interval when configured
+
+        # Test high value
+        config._set_option("server.websocketPingInterval", 120, "test")
+        assert _get_websocket_ping_interval() == 120
+        settings = get_tornado_settings()
+        assert settings["websocket_ping_interval"] == 120
+        assert (
+            settings["websocket_ping_timeout"] == 120
+        )  # Timeout matches interval when configured
+
+        # Reset config for other tests
+        config._set_option("server.websocketPingInterval", None, "test")
+
+    @tornado.testing.gen_test
+    @patch("streamlit.web.server.server.is_tornado_version_less_than")
+    async def test_websocket_ping_interval_tornado_old(self, mock_version_check):
+        """Test websocket ping interval with Tornado < 6.5."""
+        from streamlit.web.server.server import (
+            _get_websocket_ping_interval,
+            get_tornado_settings,
+        )
+
+        # Mock old Tornado version
+        mock_version_check.return_value = True
+
+        # Test default with old Tornado
+        config._set_option("server.websocketPingInterval", None, "test")
+        assert _get_websocket_ping_interval() == 1
+        settings = get_tornado_settings()
+        assert settings["websocket_ping_interval"] == 1
+        assert (
+            settings["websocket_ping_timeout"] == 30
+        )  # Timeout still 30 in default case!
+
+        # Test low values are accepted
+        config._set_option("server.websocketPingInterval", 5, "test")
+        assert _get_websocket_ping_interval() == 5
+        settings = get_tornado_settings()
+        assert settings["websocket_ping_interval"] == 5
+        assert (
+            settings["websocket_ping_timeout"] == 5
+        )  # Timeout matches when configured
+
+        # Reset config
+        config._set_option("server.websocketPingInterval", None, "test")
+
+    @tornado.testing.gen_test
+    @patch("streamlit.web.server.server.is_tornado_version_less_than")
+    async def test_websocket_ping_interval_tornado_new(self, mock_version_check):
+        """Test websocket ping interval with Tornado >= 6.5."""
+        from streamlit.web.server.server import _get_websocket_ping_interval
+
+        # Mock new Tornado version
+        mock_version_check.return_value = False
+
+        # Test default with new Tornado
+        config._set_option("server.websocketPingInterval", None, "test")
+        assert _get_websocket_ping_interval() == 30
+
+        # Test that low values are respected
+        config._set_option("server.websocketPingInterval", 10, "test")
+        assert _get_websocket_ping_interval() == 10
+
+        # Test that values >= 30 are kept as-is
+        config._set_option("server.websocketPingInterval", 60, "test")
+        assert _get_websocket_ping_interval() == 60
+
+        # Reset config
+        config._set_option("server.websocketPingInterval", None, "test")
 
 
 class PortRotateAHundredTest(unittest.TestCase):


### PR DESCRIPTION
## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->

Added a new configuration option `server.websocketPingInterval` to allow users to customize the websocket ping interval. This addresses connection drops experienced by users with certain proxy setups after upgrading to Streamlit `1.47.0` (which includes Tornado 6.5.1).

## GitHub Issue Link (if applicable)

Fixes #12108


## Testing Plan

  - Added unit tests covering all scenarios:
    - Default behavior for both Tornado versions
    - Custom configuration behavior
    - Version-specific constraints using mocking
  - All existing tests pass
  - Linting checks pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

