### PR TITLE
[fix] Utilize moduleResolution: bundler

### DIFF
--- a/frontend/app/tsconfig.json
+++ b/frontend/app/tsconfig.json
@@ -8,10 +8,7 @@
       "@streamlit/app": ["./src"],
       "@streamlit/connection": ["../connection/src"],
       "@streamlit/protobuf": ["../protobuf/src"],
-      "@streamlit/utils": ["../utils/src"],
-      // TODO: #moduleResolutionBundler
-      // We need to change tsconfig.json to use "moduleResolution": "bundler" to properly handle this. When we do that, we can remove this.
-      "vega-embed": ["../node_modules/vega-embed/build/embed.d.ts"]
+      "@streamlit/utils": ["../utils/src"]
     }
   },
   "include": ["src/**/*", "../lib/declarations.d.ts", "../lib/emotion.d.ts"]

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -17,7 +17,6 @@ import { defineConfig } from "vite"
 import { version } from "./package.json"
 
 import react from "@vitejs/plugin-react-swc"
-import path from "path"
 import viteTsconfigPaths from "vite-tsconfig-paths"
 
 const BASE = "./"
@@ -73,15 +72,6 @@ export default defineConfig({
       {
         find: "react-syntax-highlighter",
         replacement: "react-syntax-highlighter/dist/cjs/index.js",
-      },
-      // TODO: #moduleResolutionBundler
-      // Fix for vega-embed v7 ES module structure
-      {
-        find: "vega-embed",
-        replacement: path.resolve(
-          __dirname,
-          "../node_modules/vega-embed/build/embed.js"
-        ),
       },
       ...profilerAliases,
     ],

--- a/frontend/connection/package.json
+++ b/frontend/connection/package.json
@@ -12,7 +12,8 @@
     ".": {
       "require": "./dist/streamlit-connection.cjs.js",
       "import": "./dist/streamlit-connection.es.js",
-      "default": "./dist/streamlit-connection.umd.js"
+      "default": "./dist/streamlit-connection.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -12,7 +12,8 @@
     ".": {
       "require": "./dist/streamlit-lib.cjs.js",
       "import": "./dist/streamlit-lib.es.js",
-      "default": "./dist/streamlit-lib.umd.js"
+      "default": "./dist/streamlit-lib.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "sideEffects": [

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -16,9 +16,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 
-import { PickingInfo, ViewStateChangeParameters } from "@deck.gl/core"
-// eslint-disable-next-line import/no-unresolved
-import { TooltipContent } from "@deck.gl/core/dist/lib/tooltip"
+import {
+  type DeckProps,
+  PickingInfo,
+  ViewStateChangeParameters,
+} from "@deck.gl/core"
 import { parseToRgba } from "color2k"
 import JSON5 from "json5"
 import isEqual from "lodash/isEqual"
@@ -47,6 +49,14 @@ import {
   LAYER_TYPE_TO_FILL_FUNCTION,
 } from "./utils/colors"
 import { jsonConverter } from "./utils/jsonConverter"
+
+/**
+ * Extracted type from the DeckGL library since it is not exported correctly.
+ */
+type TooltipContent =
+  NonNullable<DeckProps["getTooltip"]> extends (info: PickingInfo) => infer R
+    ? R
+    : never
 
 type UseDeckGlShape = {
   createTooltip: (info: PickingInfo | null) => TooltipContent

--- a/frontend/lib/tsconfig.json
+++ b/frontend/lib/tsconfig.json
@@ -13,10 +13,7 @@
       "@streamlit/app": ["./src"],
       "@streamlit/connection": ["../connection/src"],
       "@streamlit/protobuf": ["../protobuf/src"],
-      "@streamlit/utils": ["../utils/src"],
-      // TODO: #moduleResolutionBundler
-      // We need to change tsconfig.json to use "moduleResolution": "bundler" to properly handle this. When we do that, we can remove this.
-      "vega-embed": ["../node_modules/vega-embed/build/embed.d.ts"]
+      "@streamlit/utils": ["../utils/src"]
     }
   },
   "include": ["src/**/*", "declarations.d.ts", "emotion.d.ts"],

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -63,12 +63,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "~lib": path.resolve(__dirname, "../lib/src"),
-      // TODO: #moduleResolutionBundler
-      // Fix for vega-embed v7 ES module structure
-      "vega-embed": path.resolve(
-        __dirname,
-        "../node_modules/vega-embed/build/embed.js"
-      ),
     },
   },
   test: {

--- a/frontend/typescript-config/base.tsconfig.json
+++ b/frontend/typescript-config/base.tsconfig.json
@@ -12,7 +12,7 @@
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,

--- a/frontend/utils/package.json
+++ b/frontend/utils/package.json
@@ -12,7 +12,8 @@
     ".": {
       "require": "./dist/streamlit-utils.cjs.js",
       "import": "./dist/streamlit-utils.es.js",
-      "default": "./dist/streamlit-utils.umd.js"
+      "default": "./dist/streamlit-utils.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Describe your changes

- Updates our `tsconfig` to utilize `moduleResolution: bundler`, which is [the expected value](https://www.typescriptlang.org/tsconfig/#moduleResolution) to use when using a build tool like we do (Vite).
- Fixes some internal `package.json` files to properly export `types` in order to support this `moduleResolution` property
- Removes the workarounds from the Vega major version update https://github.com/streamlit/streamlit/pull/11580

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Existing tests cover this

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
