### PR TITLE
Update ty type checker version

### DIFF
--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,6 +1,6 @@
 pre-commit
 # We fix ty to a version since its still in preview and likely breaks our CI on updates:
-ty==0.0.1a16
+ty==0.0.1a17
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.12.7
 # We are pinning the upper version to not break our CI on updates,

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -316,7 +316,7 @@ def _navigation(
     else:
         nav_sections = {
             section: [convert_to_streamlit_page(p) for p in section_pages]
-            for section, section_pages in pages.items()
+            for section, section_pages in pages.items()  # ty: ignore[possibly-unbound-attribute]
         }
     page_list = pages_from_nav_sections(nav_sections)
 

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -85,7 +85,7 @@ class WebsocketSessionManager(SessionManager):
             and self._session_storage.get(existing_session_id)
         )
 
-        if session_info:
+        if isinstance(session_info, SessionInfo):
             existing_session = session_info.session
             existing_session.register_file_watchers()
 


### PR DESCRIPTION
## Describe your changes

Updates the ty type checker to `0.0.1a17` and type issues.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
