### PR TITLE
[feat] Simplify all copy to clipboard handling

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -2796,32 +2796,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: clipboard. A copy of the source code may be downloaded from git+https://github.com/zenorocha/clipboard.js.git. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Zeno Rocha
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: cliui. A copy of the source code may be downloaded from git+https://github.com/yargs/cliui.git. This software contains the following license and notice below:
 
 Copyright (c) 2015, Contributors
@@ -14512,32 +14486,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: tiny-emitter. A copy of the source code may be downloaded from https://github.com/scottcorgan/tiny-emitter.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Scott Corgan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -563,6 +563,21 @@ def browser_type_launch_args(
     return browser_type_launch_args
 
 
+@pytest.fixture(scope="session")
+def browser_context_args(
+    browser_context_args: dict[str, Any], browser_name: str
+) -> dict[str, Any]:
+    """Fixture that adds clipboard permissions to the browser context for Chromium."""
+    # Clipboard permissions are only supported in Chromium-based browsers
+    if browser_name == "chromium":
+        return {
+            **browser_context_args,
+            "permissions": ["clipboard-read", "clipboard-write"],
+        }
+
+    return browser_context_args
+
+
 @pytest.fixture(params=["light_theme", "dark_theme"])
 def app_theme(request: pytest.FixtureRequest) -> str:
     """Fixture that returns the theme name."""

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -370,10 +370,8 @@ def test_dialogs_have_different_fragment_ids(app: Page):
 def test_dialog_copy_buttons_work(app: Page):
     """Test that the copy buttons in the dialog work as expected.
 
-    We paste the copied content into an input field. We could use
-    playwright's app.evaluate("navigator.clipboard.readText()") to get
-    the copied text, but then we have to grant permission to the user
-    agent to allow accessing the clipboard.
+    We paste the copied content into an input field to verify that the copy
+    button works.
     """
 
     open_dialog_with_copy_buttons(app)

--- a/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
@@ -130,6 +130,7 @@ describe("Opened ThemeCreatorDialog", () => {
 
   it("should copy to clipboard", async () => {
     const user = userEvent.setup()
+    // eslint-disable-next-line no-restricted-properties -- This is fine in tests
     const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText")
 
     const props = getProps()

--- a/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -94,9 +94,6 @@ const ThemeCreatorDialog = (props: Props): ReactElement => {
   const { activeTheme, addThemes, setTheme } = useContext(LibContext)
 
   const themeInput = toThemeInput(activeTheme.emotion)
-  const config = toMinimalToml(themeInput)
-
-  const { isCopied, copyToClipboard } = useCopyToClipboard({ text: config })
 
   const updateTheme = (customTheme: ThemeConfig): void => {
     addThemes([customTheme])
@@ -111,11 +108,15 @@ const ThemeCreatorDialog = (props: Props): ReactElement => {
     updateTheme(customTheme)
   }
 
+  const config = toMinimalToml(themeInput)
+
+  const { isCopied, copyToClipboard } = useCopyToClipboard()
+
   const copyConfig = (): void => {
     props.metricsMgr.enqueue("menuClick", {
       label: "copyThemeToClipboard",
     })
-    copyToClipboard()
+    copyToClipboard(config)
   }
 
   const onClickedBack = (): void => {

--- a/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useCallback, useContext, useState } from "react"
+import React, { ReactElement, useCallback, useContext } from "react"
 
 import { Check } from "@emotion-icons/material-outlined"
 
@@ -37,6 +37,7 @@ import {
   StreamlitMarkdown,
   ThemeConfig,
   toThemeInput,
+  useCopyToClipboard,
 } from "@streamlit/lib"
 
 import {
@@ -90,10 +91,12 @@ export interface Props {
 }
 
 const ThemeCreatorDialog = (props: Props): ReactElement => {
-  const [copied, updateCopied] = useState(false)
   const { activeTheme, addThemes, setTheme } = useContext(LibContext)
 
   const themeInput = toThemeInput(activeTheme.emotion)
+  const config = toMinimalToml(themeInput)
+
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ text: config })
 
   const updateTheme = (customTheme: ThemeConfig): void => {
     addThemes([customTheme])
@@ -106,22 +109,13 @@ const ThemeCreatorDialog = (props: Props): ReactElement => {
       [key]: newVal,
     })
     updateTheme(customTheme)
-    updateCopied(false)
   }
 
-  const config = toMinimalToml(themeInput)
-
-  const copyConfig = async (): Promise<void> => {
+  const copyConfig = (): void => {
     props.metricsMgr.enqueue("menuClick", {
       label: "copyThemeToClipboard",
     })
-    try {
-      await navigator.clipboard.writeText(config)
-      updateCopied(true)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
-      updateCopied(false)
-    }
+    copyToClipboard()
   }
 
   const onClickedBack = (): void => {
@@ -204,7 +198,7 @@ To save your changes, copy your custom theme into the clipboard and paste it int
           <StyledFullRow>
             <div>
               <BaseButton onClick={copyConfig} kind={BaseButtonKind.SECONDARY}>
-                {copied ? (
+                {isCopied ? (
                   <React.Fragment>
                     {"Copied to clipboard "}
                     <Icon

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -204,6 +204,11 @@ export default tseslint.config([
           property: "innerHeight",
           message: "Please use the `useWindowDimensionsContext` hook instead.",
         },
+        {
+          object: "navigator",
+          property: "clipboard",
+          message: "Please use the `useCopyToClipboard` hook instead.",
+        },
       ],
       // Imports should be `import "./FooModule"`, not `import "./FooModule.js"`
       // We need to configure this to check our .tsx files, see:

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -63,7 +63,6 @@
     "axios": "^1.11.0",
     "baseui": "12.2.0",
     "classnames": "^2.3.2",
-    "clipboard": "^2.0.11",
     "color2k": "^2.0.2",
     "d3": "^7.9.0",
     "d3-graphviz": "^5.6.0",

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.test.tsx
@@ -29,6 +29,7 @@ Object.assign(navigator, {
 })
 
 describe("CopyButton Element", () => {
+  // eslint-disable-next-line no-restricted-properties -- This is fine in tests
   const mockWriteText = vi.mocked(navigator.clipboard.writeText)
 
   beforeEach(() => {

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.test.tsx
@@ -14,62 +14,122 @@
  * limitations under the License.
  */
 
-import React from "react"
-
-import { screen } from "@testing-library/react"
-import Clipboard from "clipboard"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
 import { render } from "~lib/test_util"
 
 import CopyButton from "./CopyButton"
 
-vi.mock("clipboard")
+// Mock navigator.clipboard
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn(),
+  },
+})
 
 describe("CopyButton Element", () => {
+  const mockWriteText = vi.mocked(navigator.clipboard.writeText)
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it("renders without crashing", () => {
+  it("renders a button with copy icon and correct accessibility attributes", () => {
+    render(<CopyButton text="test code" />)
+
+    const button = screen.getByRole("button", {
+      name: "Copy to clipboard",
+    })
+    expect(button).toBeVisible()
+    expect(button).toHaveAttribute("title", "Copy to clipboard")
+
+    // Verify copy icon is present initially
+    expect(screen.getByTestId("stCodeCopyButton")).toBeVisible()
+  })
+
+  it("copies text to clipboard when clicked", async () => {
+    const testText = "console.log('Hello World')"
+    mockWriteText.mockResolvedValue()
+
+    render(<CopyButton text={testText} />)
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy to clipboard",
+    })
+    await userEvent.click(copyButton)
+
+    expect(mockWriteText).toHaveBeenCalledWith(testText)
+  })
+
+  it("shows check icon temporarily after successful copy", async () => {
+    mockWriteText.mockResolvedValue()
+
     render(<CopyButton text="test" />)
-    expect(screen.getByTestId("stCodeCopyButton")).toBeInTheDocument()
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy to clipboard",
+    })
+    await userEvent.click(copyButton)
+
+    // The icon should change to check (we can't easily test the specific icon,
+    // but we can verify the button is still present and functional)
+    expect(copyButton).toBeVisible()
+    expect(mockWriteText).toHaveBeenCalledWith("test")
   })
 
-  describe("attributes", () => {
-    it("should have title", () => {
-      render(<CopyButton text="test" />)
-      expect(screen.getByTestId("stCodeCopyButton")).toHaveAttribute(
-        "title",
-        "Copy to clipboard"
-      )
-    })
+  it("reverts to copy icon after timeout", async () => {
+    mockWriteText.mockResolvedValue()
 
-    it("should have clipboard text", () => {
-      render(<CopyButton text="test" />)
-      expect(screen.getByTestId("stCodeCopyButton")).toHaveAttribute(
-        "data-clipboard-text",
-        "test"
-      )
+    render(<CopyButton text="test" />)
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy to clipboard",
     })
+    await userEvent.click(copyButton)
+
+    expect(mockWriteText).toHaveBeenCalledWith("test")
+
+    // Wait for the timeout to reset the state (default is 2 seconds)
+    await waitFor(
+      () => {
+        // We can't easily test the icon change, but we can verify the button remains functional
+        expect(copyButton).toBeVisible()
+      },
+      { timeout: 3000 }
+    )
   })
 
-  describe("calling clipboard", () => {
-    it("should be called on did mount", () => {
-      render(<CopyButton text="test" />)
+  it("handles copy failure gracefully", async () => {
+    mockWriteText.mockRejectedValue(new Error("Copy failed"))
 
-      expect(Clipboard).toHaveBeenCalled()
+    render(<CopyButton text="test" />)
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy to clipboard",
     })
 
-    it("should be called on unmount", () => {
-      const { unmount } = render(<CopyButton text="test" />)
+    // Should not throw even if clipboard operation fails
+    await userEvent.click(copyButton)
 
-      unmount()
+    expect(mockWriteText).toHaveBeenCalledWith("test")
+    expect(copyButton).toBeVisible()
+  })
 
-      // @ts-expect-error
-      const mockClipboard = Clipboard.mock.instances[0]
-      const mockDestroy = mockClipboard.destroy
+  it("can be clicked multiple times", async () => {
+    mockWriteText.mockResolvedValue()
 
-      expect(mockDestroy).toHaveBeenCalled()
+    render(<CopyButton text="test code" />)
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy to clipboard",
     })
+
+    await userEvent.click(copyButton)
+    await userEvent.click(copyButton)
+    await userEvent.click(copyButton)
+
+    expect(mockWriteText).toHaveBeenCalledTimes(3)
+    expect(mockWriteText).toHaveBeenCalledWith("test code")
   })
 })

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, useRef } from "react"
+import React, { memo, useCallback, useRef } from "react"
 
 import { Check as CheckIcon, Copy as CopyIcon } from "react-feather"
 
@@ -32,14 +32,18 @@ const CopyButton: React.FC<Props> = ({ text }) => {
   const theme = useEmotionTheme()
   const buttonRef = useRef<HTMLButtonElement>(null)
 
-  const { isCopied, copyToClipboard } = useCopyToClipboard({ text })
+  const { isCopied, copyToClipboard } = useCopyToClipboard()
+
+  const handleCopy = useCallback(() => {
+    copyToClipboard(text)
+  }, [copyToClipboard, text])
 
   return (
     <StyledCopyButton
       data-testid="stCodeCopyButton"
       title="Copy to clipboard"
       ref={buttonRef}
-      onClick={copyToClipboard}
+      onClick={handleCopy}
     >
       {/* Convert size to px because using rem works but logs a console error (at least on webkit) */}
       {isCopied ? (

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import React, { memo, useEffect, useRef } from "react"
+import React, { memo, useRef } from "react"
 
-import Clipboard from "clipboard"
-import { Copy as CopyIcon } from "react-feather"
+import { Check as CheckIcon, Copy as CopyIcon } from "react-feather"
 
+import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { convertRemToPx } from "~lib/theme"
 
@@ -31,39 +31,22 @@ interface Props {
 const CopyButton: React.FC<Props> = ({ text }) => {
   const theme = useEmotionTheme()
   const buttonRef = useRef<HTMLButtonElement>(null)
-  const clipboardRef = useRef<Clipboard | null>(null)
 
-  useEffect(() => {
-    const node = buttonRef.current
-
-    if (node !== null) {
-      clipboardRef.current = new Clipboard(node, {
-        // Set the container so that copying also works in dialogs.
-        // Otherwise, the copy event is swallowed somehow.
-        container: node.parentElement ?? undefined,
-      })
-    }
-
-    return () => {
-      if (clipboardRef.current !== null) {
-        clipboardRef.current.destroy()
-      }
-    }
-  }, [])
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ text })
 
   return (
     <StyledCopyButton
       data-testid="stCodeCopyButton"
       title="Copy to clipboard"
       ref={buttonRef}
-      data-clipboard-text={text}
-      style={{
-        top: 0,
-        right: 0,
-      }}
+      onClick={copyToClipboard}
     >
       {/* Convert size to px because using rem works but logs a console error (at least on webkit) */}
-      <CopyIcon size={convertRemToPx(theme.iconSizes.base)} />
+      {isCopied ? (
+        <CheckIcon size={convertRemToPx(theme.iconSizes.base)} />
+      ) : (
+        <CopyIcon size={convertRemToPx(theme.iconSizes.base)} />
+      )}
     </StyledCopyButton>
   )
 }

--- a/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
@@ -242,6 +242,8 @@ export const StyledCopyButton = styled.button(({ theme }) => ({
   backgroundColor: theme.colors.transparent,
   color: theme.colors.fadedText60,
   transform: "scale(0)",
+  top: 0,
+  right: 0,
 
   [`${StyledCodeBlock}:hover &, &:active, &:focus, &:hover`]: {
     opacity: 1,

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import React, { memo, ReactElement, useCallback } from "react"
 
 import { getLogger } from "loglevel"
 
@@ -25,6 +25,7 @@ import { StyledCode } from "~lib/components/elements/CodeBlock/styled-components
 import AlertContainer, { Kind } from "~lib/components/shared/AlertContainer"
 import { StyledStackTrace } from "~lib/components/shared/ErrorElement/styled-components"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
+import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { notNullOrUndefined } from "~lib/util/utils"
 
 import {
@@ -130,11 +131,11 @@ function ExceptionElement({
     formattedExceptionFull
   )}`
 
-  const onCopyClick = (): void => {
-    navigator.clipboard.writeText(formattedExceptionFull).catch(error => {
-      LOG.error("Failed to copy exception details to clipboard:", error)
-    })
-  }
+  const { copyToClipboard } = useCopyToClipboard()
+
+  const handleCopy = useCallback(() => {
+    copyToClipboard(formattedExceptionFull)
+  }, [copyToClipboard, formattedExceptionFull])
 
   return (
     <div className="stException" data-testid="stException">
@@ -152,7 +153,7 @@ function ExceptionElement({
           ) : null}
           {isLocalhost() && (
             <StyledExceptionLinks>
-              <StyledExceptionCopyButton onClick={onCopyClick}>
+              <StyledExceptionCopyButton onClick={handleCopy}>
                 Copy
               </StyledExceptionCopyButton>
               <a href={searchUrl} target="_blank" rel="noopener noreferrer">

--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useRef } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
-import Clipboard from "clipboard"
 import JSON5 from "json5"
-import ReactJson from "react-json-view"
+import ReactJson, { OnCopyProps } from "react-json-view"
 
 import { Json as JsonProto } from "@streamlit/protobuf"
 
 import ErrorElement from "~lib/components/shared/ErrorElement"
+import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { hasLightBackgroundColor } from "~lib/theme"
 import { ensureError } from "~lib/util/ErrorHandling"
@@ -39,7 +39,14 @@ export interface JsonProps {
 function Json({ element }: Readonly<JsonProps>): ReactElement {
   const theme = useEmotionTheme()
 
-  const elementRef = useRef<HTMLDivElement>(null)
+  const { copyToClipboard } = useCopyToClipboard()
+
+  const handleCopy = useCallback(
+    (copy: OnCopyProps): void => {
+      copyToClipboard(JSON.stringify(copy.src))
+    },
+    [copyToClipboard]
+  )
 
   let bodyObject
   try {
@@ -62,22 +69,8 @@ function Json({ element }: Readonly<JsonProps>): ReactElement {
   // theme's background is light or dark.
   const jsonTheme = hasLightBackgroundColor(theme) ? "rjv-default" : "monokai"
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const handleCopy = (copy: any): void => {
-    // we use ClipboardJS to do the copying, because it allows
-    // us to specify a container element. This is necessary because
-    // otherwise copying doesn't work in dialogs.
-    Clipboard.copy(JSON.stringify(copy.src), {
-      container: elementRef.current ?? undefined,
-    })
-  }
-
   return (
-    <StyledJsonWrapper
-      className="stJson"
-      data-testid="stJson"
-      ref={elementRef}
-    >
+    <StyledJsonWrapper className="stJson" data-testid="stJson">
       <ReactJson
         src={bodyObject}
         collapsed={element.maxExpandDepth ?? !element.expanded}

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -236,11 +236,11 @@ function ComponentInstance(props: Props): ReactElement {
   const onBackMsgRef = useRef<IframeMessageHandlerProps>()
 
   // Show a log in the console as a soft-warning to the developer before showing the more disrupting warning element
-  const clearTimeoutLog = useTimeout(
+  const { clear: clearTimeoutLog } = useTimeout(
     () => LOG.warn(getWarnMessage(componentName, url)),
     COMPONENT_READY_WARNING_TIME_MS / 4
   )
-  const clearTimeoutWarningElement = useTimeout(() => {
+  const { clear: clearTimeoutWarningElement } = useTimeout(() => {
     /* eslint-disable-next-line @eslint-react/dom/no-flush-sync -- To keep
      * behavior the same as before introducing `createRoot` and after, we ensure
      * that the state updates are flushed immediately.

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.tsx
@@ -14,19 +14,13 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useState,
-} from "react"
+import { memo, ReactElement, useCallback, useEffect, useState } from "react"
 
 import { ACCESSIBILITY_TYPE, PLACEMENT, Popover } from "baseui/popover"
-import { getLogger } from "loglevel"
 
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import { BaseColumn } from "~lib/components/widgets/DataFrame/columns"
+import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { convertRemToPx, hasLightBackgroundColor } from "~lib/theme"
 
@@ -41,8 +35,6 @@ import {
   StyledMenuListItem,
   StyledTypeIconContainer,
 } from "./styled-components"
-
-const LOG = getLogger("ColumnMenu")
 
 export interface ColumnMenuProps {
   // The top position of the menu
@@ -90,6 +82,8 @@ function ColumnMenu({
   const [formatMenuOpen, setFormatMenuOpen] = useState(false)
   const { colors, fontSizes, radii, fontWeights } = theme
 
+  const { copyToClipboard } = useCopyToClipboard()
+
   // Disable page scrolling while the menu is open to keep the menu und
   // column header aligned.
   // This is done by preventing defaults on wheel and touch events:
@@ -112,14 +106,8 @@ function ColumnMenu({
   }, [onCloseMenu])
 
   const handleCopyNameToClipboard = useCallback((): void => {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(column.title).catch(error => {
-        LOG.error("Failed to copy column name to clipboard:", error)
-      })
-    } else {
-      LOG.error("Clipboard API not supported.")
-    }
-  }, [column.title])
+    copyToClipboard(column.title)
+  }, [column.title, copyToClipboard])
 
   return (
     <Popover

--- a/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 
 import { useCopyToClipboard } from "./useCopyToClipboard"
 
@@ -28,8 +28,13 @@ Object.assign(navigator, {
 
 describe("useCopyToClipboard", () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     mockWriteText.mockReset()
     mockWriteText.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("should copy text to clipboard and reset after timeout", async () => {
@@ -49,9 +54,10 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(true)
 
     // Wait for timeout to reset
-    await waitFor(() => expect(result.current.isCopied).toBe(false), {
-      timeout: timeout * 2,
+    act(() => {
+      vi.advanceTimersByTime(timeout)
     })
+    expect(result.current.isCopied).toBe(false)
   })
 
   it("should restart timeout on multiple rapid clicks", async () => {
@@ -67,7 +73,9 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(true)
 
     // Wait for half the timeout, then copy again
-    await new Promise(r => setTimeout(r, timeout / 2))
+    act(() => {
+      vi.advanceTimersByTime(timeout / 2)
+    })
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       result.current.copyToClipboard()
@@ -75,7 +83,9 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(true)
 
     // Wait for half the timeout again, then copy one more time
-    await new Promise(r => setTimeout(r, timeout / 2))
+    act(() => {
+      vi.advanceTimersByTime(timeout / 2)
+    })
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       result.current.copyToClipboard()
@@ -84,13 +94,16 @@ describe("useCopyToClipboard", () => {
 
     // Now wait for the full timeout from the last copy
     // Should still be copied after the original timeout would have expired
-    await new Promise(r => setTimeout(r, timeout / 2))
+    act(() => {
+      vi.advanceTimersByTime(timeout / 2)
+    })
     expect(result.current.isCopied).toBe(true)
 
     // But should reset after the full timeout from the last copy
-    await waitFor(() => expect(result.current.isCopied).toBe(false), {
-      timeout: timeout,
+    act(() => {
+      vi.advanceTimersByTime(timeout / 2)
     })
+    expect(result.current.isCopied).toBe(false)
 
     expect(mockWriteText).toHaveBeenCalledTimes(3)
   })

--- a/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
@@ -122,21 +122,7 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(false)
   })
 
-  it("should not copy when no text is provided", async () => {
-    const { result } = renderHook(() => useCopyToClipboard())
-
-    expect(result.current.isCopied).toBe(false)
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      result.current.copyToClipboard()
-    })
-
-    expect(mockWriteText).not.toHaveBeenCalled()
-    expect(result.current.isCopied).toBe(false)
-  })
-
-  it("should not copy when empty text is provided", async () => {
+  it("should copy empty text", async () => {
     const { result } = renderHook(() => useCopyToClipboard())
 
     expect(result.current.isCopied).toBe(false)
@@ -146,7 +132,7 @@ describe("useCopyToClipboard", () => {
       result.current.copyToClipboard("")
     })
 
-    expect(mockWriteText).not.toHaveBeenCalled()
-    expect(result.current.isCopied).toBe(false)
+    expect(mockWriteText).toHaveBeenCalledWith("")
+    expect(result.current.isCopied).toBe(true)
   })
 })

--- a/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react"
+
+import { useCopyToClipboard } from "./useCopyToClipboard"
+
+// Mock navigator.clipboard
+const mockWriteText = vi.fn()
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+})
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => {
+    mockWriteText.mockReset()
+    mockWriteText.mockResolvedValue(undefined)
+  })
+
+  it("should copy text to clipboard and reset after timeout", async () => {
+    const text = "Hello World"
+    const timeout = 100
+    const { result } = renderHook(() => useCopyToClipboard({ text, timeout }))
+
+    expect(result.current.isCopied).toBe(false)
+
+    // Perform copy
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard()
+    })
+
+    expect(mockWriteText).toHaveBeenCalledWith(text)
+    expect(result.current.isCopied).toBe(true)
+
+    // Wait for timeout to reset
+    await waitFor(() => expect(result.current.isCopied).toBe(false), {
+      timeout: timeout * 2,
+    })
+  })
+
+  it("should restart timeout on multiple rapid clicks", async () => {
+    const text = "Hello World"
+    const timeout = 200
+    const { result } = renderHook(() => useCopyToClipboard({ text, timeout }))
+
+    // First copy
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard()
+    })
+    expect(result.current.isCopied).toBe(true)
+
+    // Wait for half the timeout, then copy again
+    await new Promise(r => setTimeout(r, timeout / 2))
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard()
+    })
+    expect(result.current.isCopied).toBe(true)
+
+    // Wait for half the timeout again, then copy one more time
+    await new Promise(r => setTimeout(r, timeout / 2))
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard()
+    })
+    expect(result.current.isCopied).toBe(true)
+
+    // Now wait for the full timeout from the last copy
+    // Should still be copied after the original timeout would have expired
+    await new Promise(r => setTimeout(r, timeout / 2))
+    expect(result.current.isCopied).toBe(true)
+
+    // But should reset after the full timeout from the last copy
+    await waitFor(() => expect(result.current.isCopied).toBe(false), {
+      timeout: timeout,
+    })
+
+    expect(mockWriteText).toHaveBeenCalledTimes(3)
+  })
+
+  it("should handle clipboard write failure", async () => {
+    const text = "Hello World"
+    mockWriteText.mockRejectedValue(new Error("Clipboard write failed"))
+
+    const { result } = renderHook(() => useCopyToClipboard({ text }))
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard()
+    })
+
+    expect(result.current.isCopied).toBe(false)
+  })
+})

--- a/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/lib/src/hooks/useCopyToClipboard.test.tsx
@@ -40,14 +40,14 @@ describe("useCopyToClipboard", () => {
   it("should copy text to clipboard and reset after timeout", async () => {
     const text = "Hello World"
     const timeout = 100
-    const { result } = renderHook(() => useCopyToClipboard({ text, timeout }))
+    const { result } = renderHook(() => useCopyToClipboard({ timeout }))
 
     expect(result.current.isCopied).toBe(false)
 
     // Perform copy
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
-      result.current.copyToClipboard()
+      result.current.copyToClipboard(text)
     })
 
     expect(mockWriteText).toHaveBeenCalledWith(text)
@@ -63,12 +63,12 @@ describe("useCopyToClipboard", () => {
   it("should restart timeout on multiple rapid clicks", async () => {
     const text = "Hello World"
     const timeout = 200
-    const { result } = renderHook(() => useCopyToClipboard({ text, timeout }))
+    const { result } = renderHook(() => useCopyToClipboard({ timeout }))
 
     // First copy
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
-      result.current.copyToClipboard()
+      result.current.copyToClipboard(text)
     })
     expect(result.current.isCopied).toBe(true)
 
@@ -78,7 +78,7 @@ describe("useCopyToClipboard", () => {
     })
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
-      result.current.copyToClipboard()
+      result.current.copyToClipboard(text)
     })
     expect(result.current.isCopied).toBe(true)
 
@@ -88,7 +88,7 @@ describe("useCopyToClipboard", () => {
     })
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
-      result.current.copyToClipboard()
+      result.current.copyToClipboard(text)
     })
     expect(result.current.isCopied).toBe(true)
 
@@ -112,13 +112,41 @@ describe("useCopyToClipboard", () => {
     const text = "Hello World"
     mockWriteText.mockRejectedValue(new Error("Clipboard write failed"))
 
-    const { result } = renderHook(() => useCopyToClipboard({ text }))
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard(text)
+    })
+
+    expect(result.current.isCopied).toBe(false)
+  })
+
+  it("should not copy when no text is provided", async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    expect(result.current.isCopied).toBe(false)
 
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       result.current.copyToClipboard()
     })
 
+    expect(mockWriteText).not.toHaveBeenCalled()
+    expect(result.current.isCopied).toBe(false)
+  })
+
+  it("should not copy when empty text is provided", async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    expect(result.current.isCopied).toBe(false)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.copyToClipboard("")
+    })
+
+    expect(mockWriteText).not.toHaveBeenCalled()
     expect(result.current.isCopied).toBe(false)
   })
 })

--- a/frontend/lib/src/hooks/useCopyToClipboard.ts
+++ b/frontend/lib/src/hooks/useCopyToClipboard.ts
@@ -20,7 +20,7 @@ import useTimeout from "./useTimeout"
 
 export type UseCopyToClipboardResult = {
   isCopied: boolean
-  copyToClipboard: () => void
+  copyToClipboard: (inlineText?: string) => void
 }
 
 export const useCopyToClipboard = ({
@@ -30,13 +30,13 @@ export const useCopyToClipboard = ({
   /**
    * The text to copy to the clipboard.
    */
-  text: string
+  text?: string
   /**
    * The (optional) timeout in milliseconds to reset the copied state. Default
    * is 2 seconds.
    */
   timeout?: number
-}): UseCopyToClipboardResult => {
+} = {}): UseCopyToClipboardResult => {
   const [isCopied, setIsCopied] = useState(false)
 
   const { restart } = useTimeout(
@@ -46,22 +46,30 @@ export const useCopyToClipboard = ({
     isCopied ? timeout : null
   )
 
-  const copyToClipboard = useCallback(() => {
-    const performCopy = async (): Promise<void> => {
-      try {
-        await navigator.clipboard.writeText(text)
-        setIsCopied(true)
-        // Restart the timeout on each successful copy to reset the timer
-        restart()
-      } catch {
-        setIsCopied(false)
+  const copyToClipboard = useCallback(
+    (inlineText?: string) => {
+      const textToCopy = inlineText ?? text
+      if (!textToCopy) {
+        return
       }
-    }
 
-    // Call the async function but don't return the promise to make passing the
-    // callback into `onClick` pass the type-checker
-    void performCopy()
-  }, [text, restart])
+      const performCopy = async (): Promise<void> => {
+        try {
+          await navigator.clipboard.writeText(textToCopy)
+          setIsCopied(true)
+          // Restart the timeout on each successful copy to reset the timer
+          restart()
+        } catch {
+          setIsCopied(false)
+        }
+      }
+
+      // Call the async function but don't return the promise to make passing the
+      // callback into `onClick` pass the type-checker
+      void performCopy()
+    },
+    [text, restart]
+  )
 
   return { isCopied, copyToClipboard }
 }

--- a/frontend/lib/src/hooks/useCopyToClipboard.ts
+++ b/frontend/lib/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useState } from "react"
+
+import useTimeout from "./useTimeout"
+
+export type UseCopyToClipboardResult = {
+  isCopied: boolean
+  copyToClipboard: () => void
+}
+
+export const useCopyToClipboard = ({
+  text,
+  timeout = 2_000,
+}: {
+  /**
+   * The text to copy to the clipboard.
+   */
+  text: string
+  /**
+   * The (optional) timeout in milliseconds to reset the copied state. Default
+   * is 2 seconds.
+   */
+  timeout?: number
+}): UseCopyToClipboardResult => {
+  const [isCopied, setIsCopied] = useState(false)
+
+  const { restart } = useTimeout(
+    useCallback(() => {
+      setIsCopied(false)
+    }, []),
+    isCopied ? timeout : null
+  )
+
+  const copyToClipboard = useCallback(() => {
+    const performCopy = async (): Promise<void> => {
+      try {
+        await navigator.clipboard.writeText(text)
+        setIsCopied(true)
+        // Restart the timeout on each successful copy to reset the timer
+        restart()
+      } catch {
+        setIsCopied(false)
+      }
+    }
+
+    // Call the async function but don't return the promise to make passing the
+    // callback into `onClick` pass the type-checker
+    void performCopy()
+  }, [text, restart])
+
+  return { isCopied, copyToClipboard }
+}

--- a/frontend/lib/src/hooks/useCopyToClipboard.ts
+++ b/frontend/lib/src/hooks/useCopyToClipboard.ts
@@ -24,7 +24,7 @@ const LOG = getLogger("useCopyToClipboard")
 
 export type UseCopyToClipboardResult = {
   isCopied: boolean
-  copyToClipboard: (text?: string) => void
+  copyToClipboard: (text: string) => void
 }
 
 export const useCopyToClipboard = ({
@@ -46,11 +46,7 @@ export const useCopyToClipboard = ({
   )
 
   const copyToClipboard = useCallback(
-    (text?: string) => {
-      if (!text) {
-        return
-      }
-
+    (text: string) => {
       const performCopy = async (): Promise<void> => {
         try {
           // eslint-disable-next-line no-restricted-properties -- This is the only expected usage of navigator.clipboard
@@ -59,7 +55,7 @@ export const useCopyToClipboard = ({
           // Restart the timeout on each successful copy to reset the timer
           restart()
         } catch (error) {
-          LOG.error("Failed to copy exception details to clipboard:", error)
+          LOG.error("Failed to copy text to clipboard:", error)
           setIsCopied(false)
         }
       }

--- a/frontend/lib/src/hooks/useCopyToClipboard.ts
+++ b/frontend/lib/src/hooks/useCopyToClipboard.ts
@@ -16,21 +16,20 @@
 
 import { useCallback, useState } from "react"
 
+import { getLogger } from "loglevel"
+
 import useTimeout from "./useTimeout"
+
+const LOG = getLogger("useCopyToClipboard")
 
 export type UseCopyToClipboardResult = {
   isCopied: boolean
-  copyToClipboard: (inlineText?: string) => void
+  copyToClipboard: (text?: string) => void
 }
 
 export const useCopyToClipboard = ({
-  text,
   timeout = 2_000,
 }: {
-  /**
-   * The text to copy to the clipboard.
-   */
-  text?: string
   /**
    * The (optional) timeout in milliseconds to reset the copied state. Default
    * is 2 seconds.
@@ -47,19 +46,20 @@ export const useCopyToClipboard = ({
   )
 
   const copyToClipboard = useCallback(
-    (inlineText?: string) => {
-      const textToCopy = inlineText ?? text
-      if (!textToCopy) {
+    (text?: string) => {
+      if (!text) {
         return
       }
 
       const performCopy = async (): Promise<void> => {
         try {
-          await navigator.clipboard.writeText(textToCopy)
+          // eslint-disable-next-line no-restricted-properties -- This is the only expected usage of navigator.clipboard
+          await navigator.clipboard.writeText(text)
           setIsCopied(true)
           // Restart the timeout on each successful copy to reset the timer
           restart()
-        } catch {
+        } catch (error) {
+          LOG.error("Failed to copy exception details to clipboard:", error)
           setIsCopied(false)
         }
       }
@@ -68,7 +68,7 @@ export const useCopyToClipboard = ({
       // callback into `onClick` pass the type-checker
       void performCopy()
     },
-    [text, restart]
+    [restart]
   )
 
   return { isCopied, copyToClipboard }

--- a/frontend/lib/src/hooks/useTimeout.test.ts
+++ b/frontend/lib/src/hooks/useTimeout.test.ts
@@ -14,39 +14,48 @@
  * limitations under the License.
  */
 
-import { renderHook, waitFor } from "@testing-library/react"
+import { renderHook } from "@testing-library/react"
 
 import useTimeout from "./useTimeout"
 
 describe("timeout function", () => {
-  it("should call the callback function after timeout", async () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("should call the callback function after timeout", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 50
     renderHook(() => useTimeout(callback, timeoutDelayMs))
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 2 * timeoutDelayMs,
-    })
+
+    expect(callback).toHaveBeenCalledTimes(0)
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it("should not call the callback function when cancel timeout", async () => {
+  it("should not call the callback function when cancel timeout", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 100
     const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
     const { clear } = result.current
     clear()
-    await new Promise(r => setTimeout(r, 2 * timeoutDelayMs))
+    vi.advanceTimersByTime(2 * timeoutDelayMs)
     expect(callback).toHaveBeenCalledTimes(0)
   })
 
-  it("should not call the callback when timeoutMs is null", async () => {
+  it("should not call the callback when timeoutMs is null", () => {
     const callback = vi.fn()
     renderHook(() => useTimeout(callback, null))
     // Wait longer than a typical timeout to ensure callback isn't called
-    await new Promise(r => setTimeout(r, 200))
+    vi.advanceTimersByTime(200)
     expect(callback).toHaveBeenCalledTimes(0)
   })
 
-  it("should start timeout when timeoutMs changes from null to a number", async () => {
+  it("should start timeout when timeoutMs changes from null to a number", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 50
     let timeoutMs: number | null = null
@@ -54,7 +63,7 @@ describe("timeout function", () => {
     const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
 
     // Initially no timeout should be set
-    await new Promise(r => setTimeout(r, 100))
+    vi.advanceTimersByTime(100)
     expect(callback).toHaveBeenCalledTimes(0)
 
     // Change timeoutMs to a number
@@ -62,12 +71,11 @@ describe("timeout function", () => {
     rerender()
 
     // Now callback should be called after the timeout
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 2 * timeoutDelayMs,
-    })
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it("should clear timeout when timeoutMs changes from a number to null", async () => {
+  it("should clear timeout when timeoutMs changes from a number to null", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 100
     let timeoutMs: number | null = timeoutDelayMs
@@ -79,11 +87,11 @@ describe("timeout function", () => {
     rerender()
 
     // Wait longer than the original timeout to ensure callback isn't called
-    await new Promise(r => setTimeout(r, 2 * timeoutDelayMs))
+    vi.advanceTimersByTime(2 * timeoutDelayMs)
     expect(callback).toHaveBeenCalledTimes(0)
   })
 
-  it("should handle multiple transitions between null and number values", async () => {
+  it("should handle multiple transitions between null and number values", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 50
     let timeoutMs: number | null = null
@@ -91,28 +99,26 @@ describe("timeout function", () => {
     const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
 
     // Start with null - no callback
-    await new Promise(r => setTimeout(r, 100))
+    vi.advanceTimersByTime(100)
     expect(callback).toHaveBeenCalledTimes(0)
 
     // Change to number - should trigger callback
     timeoutMs = timeoutDelayMs
     rerender()
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 2 * timeoutDelayMs,
-    })
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(1)
 
     // Change back to null - no more callbacks
     timeoutMs = null
     rerender()
-    await new Promise(r => setTimeout(r, 100))
+    vi.advanceTimersByTime(100)
     expect(callback).toHaveBeenCalledTimes(1)
 
     // Change to number again - should trigger callback again
     timeoutMs = timeoutDelayMs
     rerender()
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(2), {
-      timeout: 2 * timeoutDelayMs,
-    })
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(2)
   })
 
   it("should clear timeout using the clear function when timeoutMs is null", () => {
@@ -124,7 +130,7 @@ describe("timeout function", () => {
     expect(() => clear()).not.toThrow()
   })
 
-  it("should handle changing from one number to another", async () => {
+  it("should handle changing from one number to another", () => {
     const callback = vi.fn()
     let timeoutMs = 200 // Long initial timeout
 
@@ -135,22 +141,21 @@ describe("timeout function", () => {
     rerender()
 
     // Should only call callback once with the new shorter timeout
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 100,
-    })
+    vi.advanceTimersByTime(50)
+    expect(callback).toHaveBeenCalledTimes(1)
 
     // Ensure it doesn't call again after the original longer timeout
-    await new Promise(r => setTimeout(r, 200))
+    vi.advanceTimersByTime(200)
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it("should restart timeout when restart function is called", async () => {
+  it("should restart timeout when restart function is called", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 100
     const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
 
     // Wait for half the timeout duration, then restart
-    await new Promise(r => setTimeout(r, timeoutDelayMs / 2))
+    vi.advanceTimersByTime(timeoutDelayMs / 2)
     const { restart } = result.current
     restart()
 
@@ -158,32 +163,30 @@ describe("timeout function", () => {
     expect(callback).toHaveBeenCalledTimes(0)
 
     // Wait for the full timeout duration from restart
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 2 * timeoutDelayMs,
-    })
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it("should handle multiple restarts before timeout fires", async () => {
+  it("should handle multiple restarts before timeout fires", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 80
     const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
     const { restart } = result.current
 
     // Restart multiple times rapidly
-    await new Promise(r => setTimeout(r, 20))
+    vi.advanceTimersByTime(20)
     restart()
-    await new Promise(r => setTimeout(r, 20))
+    vi.advanceTimersByTime(20)
     restart()
-    await new Promise(r => setTimeout(r, 20))
+    vi.advanceTimersByTime(20)
     restart()
 
     // Should not have called callback yet
     expect(callback).toHaveBeenCalledTimes(0)
 
     // Wait for the timeout from the last restart
-    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-      timeout: 2 * timeoutDelayMs,
-    })
+    vi.advanceTimersByTime(timeoutDelayMs)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
   it("should not restart timeout when timeoutMs is null", () => {
@@ -195,8 +198,7 @@ describe("timeout function", () => {
     expect(() => restart()).not.toThrow()
 
     // Wait a bit and ensure callback was never called
-    setTimeout(() => {
-      expect(callback).toHaveBeenCalledTimes(0)
-    }, 100)
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(0)
   })
 })

--- a/frontend/lib/src/hooks/useTimeout.test.ts
+++ b/frontend/lib/src/hooks/useTimeout.test.ts
@@ -32,9 +32,171 @@ describe("timeout function", () => {
     const callback = vi.fn()
     const timeoutDelayMs = 100
     const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
-    const clear = result.current
+    const { clear } = result.current
     clear()
     await new Promise(r => setTimeout(r, 2 * timeoutDelayMs))
     expect(callback).toHaveBeenCalledTimes(0)
+  })
+
+  it("should not call the callback when timeoutMs is null", async () => {
+    const callback = vi.fn()
+    renderHook(() => useTimeout(callback, null))
+    // Wait longer than a typical timeout to ensure callback isn't called
+    await new Promise(r => setTimeout(r, 200))
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
+
+  it("should start timeout when timeoutMs changes from null to a number", async () => {
+    const callback = vi.fn()
+    const timeoutDelayMs = 50
+    let timeoutMs: number | null = null
+
+    const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
+
+    // Initially no timeout should be set
+    await new Promise(r => setTimeout(r, 100))
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    // Change timeoutMs to a number
+    timeoutMs = timeoutDelayMs
+    rerender()
+
+    // Now callback should be called after the timeout
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 2 * timeoutDelayMs,
+    })
+  })
+
+  it("should clear timeout when timeoutMs changes from a number to null", async () => {
+    const callback = vi.fn()
+    const timeoutDelayMs = 100
+    let timeoutMs: number | null = timeoutDelayMs
+
+    const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
+
+    // Change timeoutMs to null before the timeout fires
+    timeoutMs = null
+    rerender()
+
+    // Wait longer than the original timeout to ensure callback isn't called
+    await new Promise(r => setTimeout(r, 2 * timeoutDelayMs))
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
+
+  it("should handle multiple transitions between null and number values", async () => {
+    const callback = vi.fn()
+    const timeoutDelayMs = 50
+    let timeoutMs: number | null = null
+
+    const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
+
+    // Start with null - no callback
+    await new Promise(r => setTimeout(r, 100))
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    // Change to number - should trigger callback
+    timeoutMs = timeoutDelayMs
+    rerender()
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 2 * timeoutDelayMs,
+    })
+
+    // Change back to null - no more callbacks
+    timeoutMs = null
+    rerender()
+    await new Promise(r => setTimeout(r, 100))
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Change to number again - should trigger callback again
+    timeoutMs = timeoutDelayMs
+    rerender()
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(2), {
+      timeout: 2 * timeoutDelayMs,
+    })
+  })
+
+  it("should clear timeout using the clear function when timeoutMs is null", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useTimeout(callback, null))
+
+    // Should be able to call clear function without errors even when no timeout is set
+    const { clear } = result.current
+    expect(() => clear()).not.toThrow()
+  })
+
+  it("should handle changing from one number to another", async () => {
+    const callback = vi.fn()
+    let timeoutMs = 200 // Long initial timeout
+
+    const { rerender } = renderHook(() => useTimeout(callback, timeoutMs))
+
+    // Change to a shorter timeout before the first one fires
+    timeoutMs = 50
+    rerender()
+
+    // Should only call callback once with the new shorter timeout
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 100,
+    })
+
+    // Ensure it doesn't call again after the original longer timeout
+    await new Promise(r => setTimeout(r, 200))
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it("should restart timeout when restart function is called", async () => {
+    const callback = vi.fn()
+    const timeoutDelayMs = 100
+    const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
+
+    // Wait for half the timeout duration, then restart
+    await new Promise(r => setTimeout(r, timeoutDelayMs / 2))
+    const { restart } = result.current
+    restart()
+
+    // Should not have called callback yet
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    // Wait for the full timeout duration from restart
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 2 * timeoutDelayMs,
+    })
+  })
+
+  it("should handle multiple restarts before timeout fires", async () => {
+    const callback = vi.fn()
+    const timeoutDelayMs = 80
+    const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
+    const { restart } = result.current
+
+    // Restart multiple times rapidly
+    await new Promise(r => setTimeout(r, 20))
+    restart()
+    await new Promise(r => setTimeout(r, 20))
+    restart()
+    await new Promise(r => setTimeout(r, 20))
+    restart()
+
+    // Should not have called callback yet
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    // Wait for the timeout from the last restart
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 2 * timeoutDelayMs,
+    })
+  })
+
+  it("should not restart timeout when timeoutMs is null", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useTimeout(callback, null))
+    const { restart } = result.current
+
+    // Should be able to call restart without errors even when timeoutMs is null
+    expect(() => restart()).not.toThrow()
+
+    // Wait a bit and ensure callback was never called
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledTimes(0)
+    }, 100)
   })
 })

--- a/frontend/lib/src/hooks/useTimeout.tsx
+++ b/frontend/lib/src/hooks/useTimeout.tsx
@@ -16,17 +16,30 @@
 
 import { useCallback, useEffect, useRef } from "react"
 
+export type UseTimeoutReturn = {
+  clear: () => void
+  restart: () => void
+}
+
 /**
- * Call setTimeout with the passed callback and timeout in milliseconds.
- * The timeout can be cleared by calling the returned clear-function.
+ * Call setTimeout with the passed callback and timeout in milliseconds. The
+ * timeout can be cleared by calling the returned clear function or restarted
+ * by calling the returned restart function.
  *
- * A new timeout will be set when the passed timeoutMs changes.
+ * A new timeout will be set when the passed timeoutMs changes. If timeoutMs is
+ * null, no timeout will be set. If timeoutMs changes from null to a number, the
+ * timeout will start. If timeoutMs changes from a number to null, the timeout
+ * will be cleared.
  *
  * @param callback to be called when the timeout delay is over
- * @param timeoutMs the delay in milliseconds after which the timeout callback is called
- * @returns a memoized clear (stable reference across re-runs) function to stop the timeout
+ * @param timeoutMs the delay in milliseconds after which the timeout callback
+ * is called, or null to disable timeout
+ * @returns an object with clear and restart functions to control the timeout
  */
-function useTimeout(callback: () => void, timeoutMs: number): () => void {
+function useTimeout(
+  callback: () => void,
+  timeoutMs: number | null
+): UseTimeoutReturn {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const callbackRef = useRef<() => void>(callback)
 
@@ -35,27 +48,50 @@ function useTimeout(callback: () => void, timeoutMs: number): () => void {
   }, [callback])
 
   useEffect(() => {
-    timeoutRef.current = setTimeout(() => {
-      callbackRef.current()
-    }, timeoutMs)
-
-    return () => {
-      if (!timeoutRef.current) {
-        return
-      }
+    // Clear any existing timeout
+    if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
       timeoutRef.current = null
+    }
+
+    // Only set timeout if timeoutMs is not null
+    if (timeoutMs !== null) {
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current()
+      }, timeoutMs)
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
     }
   }, [timeoutMs])
 
   const clear = useCallback(() => {
-    if (!timeoutRef.current) {
-      return
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
     }
-    clearTimeout(timeoutRef.current)
   }, [])
 
-  return clear
+  const restart = useCallback(() => {
+    // Clear any existing timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+
+    // Set new timeout if timeoutMs is not null
+    if (timeoutMs !== null) {
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current()
+      }, timeoutMs)
+    }
+  }, [timeoutMs])
+
+  return { clear, restart }
 }
 
 export default useTimeout

--- a/frontend/lib/src/hooks/useTimeout.tsx
+++ b/frontend/lib/src/hooks/useTimeout.tsx
@@ -47,7 +47,7 @@ function useTimeout(
     callbackRef.current = callback
   }, [callback])
 
-  useEffect(() => {
+  const setupTimeout = useCallback(() => {
     // Clear any existing timeout
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
@@ -60,6 +60,10 @@ function useTimeout(
         callbackRef.current()
       }, timeoutMs)
     }
+  }, [timeoutMs])
+
+  useEffect(() => {
+    setupTimeout()
 
     return () => {
       if (timeoutRef.current) {
@@ -67,7 +71,7 @@ function useTimeout(
         timeoutRef.current = null
       }
     }
-  }, [timeoutMs])
+  }, [setupTimeout])
 
   const clear = useCallback(() => {
     if (timeoutRef.current) {
@@ -77,19 +81,8 @@ function useTimeout(
   }, [])
 
   const restart = useCallback(() => {
-    // Clear any existing timeout
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = null
-    }
-
-    // Set new timeout if timeoutMs is not null
-    if (timeoutMs !== null) {
-      timeoutRef.current = setTimeout(() => {
-        callbackRef.current()
-      }, timeoutMs)
-    }
-  }, [timeoutMs])
+    setupTimeout()
+  }, [setupTimeout])
 
   return { clear, restart }
 }

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -66,6 +66,7 @@ export { useWindowDimensionsContext } from "./components/shared/WindowDimensions
 export { ComponentRegistry } from "./components/widgets/CustomComponent"
 export { Quiver } from "./dataframes/Quiver"
 export { FileUploadClient } from "./FileUploadClient"
+export { useCopyToClipboard } from "./hooks/useCopyToClipboard"
 export { useEmotionTheme } from "./hooks/useEmotionTheme"
 export { useExecuteWhenChanged } from "./hooks/useExecuteWhenChanged"
 export { useRequiredContext } from "./hooks/useRequiredContext"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3701,7 +3701,6 @@ __metadata:
     axios-mock-adapter: "npm:^2.1.0"
     baseui: "npm:12.2.0"
     classnames: "npm:^2.3.2"
-    clipboard: "npm:^2.0.11"
     color2k: "npm:^2.0.2"
     d3: "npm:^7.9.0"
     d3-graphviz: "npm:^5.6.0"
@@ -7555,17 +7554,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipboard@npm:^2.0.11":
-  version: 2.0.11
-  resolution: "clipboard@npm:2.0.11"
-  dependencies:
-    good-listener: "npm:^1.2.2"
-    select: "npm:^1.1.2"
-    tiny-emitter: "npm:^2.0.0"
-  checksum: 10c0/23bdf16b875bd2dd101eeefae3c25a2fbd990b613fad3d227ca6719d1b81a3c6f69701b494393fdecd07d98380024f82d045f464124dbbafbcf0557f2921978f
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -9265,13 +9253,6 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
-  languageName: node
-  linkType: hard
-
-"delegate@npm:^3.1.2":
-  version: 3.2.0
-  resolution: "delegate@npm:3.2.0"
-  checksum: 10c0/f8512633514f375b8675018088fdd679d92b84246ad6ba1de9fbc4ea7630f7fb0ff8772ac86c37a68233885f58c6b8b70676d7366f38cb2dcbf7baa474e2362d
   languageName: node
   linkType: hard
 
@@ -11860,15 +11841,6 @@ __metadata:
   bin:
     glslify: bin.js
   checksum: 10c0/ccf277220047752ee9ddfb8e1398846a747ca8eb6601a71c4e34278b2e15845affbb52d4ef0023cb21bb0f52785b585c5af9189cc2f0abfca1ffab15c1b3f6f6
-  languageName: node
-  linkType: hard
-
-"good-listener@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "good-listener@npm:1.2.2"
-  dependencies:
-    delegate: "npm:^3.1.2"
-  checksum: 10c0/5c532f2e223f1f3a12504077d6d960986979a7923fb428a26bde012b88ac57ffba1b28507f95bd16a73c1ae805fdb38d26d9442d538dd559fad159a7f58243fe
   languageName: node
   linkType: hard
 
@@ -17899,13 +17871,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"select@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "select@npm:1.1.2"
-  checksum: 10c0/5dbd871c03a52aa70ce29ab46e9115d26cb34404717e7e705e678b3b4d535bacfa0a4c4c2d32262acec7b6fdfb6827e8980ea4ef969a8681f8a0b752331a0a02
-  languageName: node
-  linkType: hard
-
 "semver@npm:^5.3.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -19005,13 +18970,6 @@ __metadata:
   version: 1.3.6
   resolution: "timezone-mock@npm:1.3.6"
   checksum: 10c0/7e554f9378531258330ada94bc4101bb4ece6e501f9e210652fb57751cf2e5d4aeab3dd9fd840a6534316db757ac6bb39338730c5d3f72dcbd4cb315ea482101
-  languageName: node
-  linkType: hard
-
-"tiny-emitter@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "tiny-emitter@npm:2.1.0"
-  checksum: 10c0/459c0bd6e636e80909898220eb390e1cba2b15c430b7b06cec6ac29d87acd29ef618b9b32532283af749f5d37af3534d0e3bde29fdf6bcefbf122784333c953d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

**Technical changes:**
- This PR introduces a centralized `useCopyToClipboard` hook, which encapsulates
  - The logic for copying something to clipboard
  - Handling a boolean state `isCopied`
    - This is reset from `true -> false` after 2 seconds automatically
    - The timeout is also properly handled when the copy action is triggered multiple times
  - Handles logging on errors
- Removes the external `clipboard` dependency since as of June 2024, the built-in `navigator.clipboard` API is supported in all browsers that we support (see https://caniuse.com/async-clipboard)
- Updates the `useTimeout` hook to be more powerful to support the above requirements
- Bans the direct usage of `navigator.clipboard` and suggests people use the shared hook

**2 user-facing changes:**
1. The CopyButton now shows a visual affordance when copying a value to clipboard. Note both the check mark and the reset back to the copy icon after 2 seconds:

https://github.com/user-attachments/assets/e0ed2ad8-3ce8-4c84-bab4-ca57dcc46759

2. The ThemeCreatorDialog also uses the new shared `useCopyToClipboard` logic. It used to maintain its own `isCopied` state, which was only reset when theme items were changed. This now just resets on the same 2 second clock as all the other instances. This is super minor, but is technically a behavior change so I wanted to call it out.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
