### PR TITLE
[feat] Implement configurable trusted headers.

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging
 import os
 import secrets
@@ -964,6 +965,27 @@ _create_option(
     """,
     default_val=120,
     type_=int,
+)
+
+_create_option(
+    "server.trustedUserHeaders",
+    description="""
+        HTTP headers to embed in st.user.
+
+        Configures HTTP headers whose values, on websocket connect, will be saved in
+        st.user. Each key is the header name to map, and each value is the key in
+        st.user to save the value under.
+
+        If configured using an environment variable or CLI option, it should be a
+        single JSON-formatted dict of string-to-string.
+
+        Note: This is an experimental API subject to change.
+    """,
+    default_val={},
+    # This is used by click. We accept a JSON string, so this is a str.
+    type_=str,
+    # Hide until API is finalized.
+    visibility="hidden",
 )
 
 # Config Section: Browser #
@@ -1987,6 +2009,41 @@ def _set_development_mode() -> None:
     development.is_development_mode = get_option("global.developmentMode")
 
 
+def _parse_trusted_user_headers() -> None:
+    """Convert string-valued server.trustedUserHeaders to a dict.
+
+    If server.trustedUserHeaders is configured from an environment variable or from
+    the CLI, it will be a JSON string. Parse this and set the value to the resulting
+    dict, after validation.
+    """
+    options = get_config_options()
+    trusted_user_headers = options["server.trustedUserHeaders"]
+    if isinstance(trusted_user_headers.value, str):
+        try:
+            parsed_value = json.loads(trusted_user_headers.value)
+            # Validate that this is an object with string values.
+            if not isinstance(parsed_value, dict):
+                # Config validation is using RuntimeError deliberately; ingore warning
+                # about making this TypeError.
+                # ruff: noqa: TRY004
+                raise RuntimeError("server.trustedUserHeaders JSON must be an object")
+            for json_key, json_value in parsed_value.items():
+                if not isinstance(json_value, str):
+                    raise RuntimeError(
+                        "server.trustedUserHeaders JSON must only have string values. "
+                        f'got bad value for key "{json_key}": {json_value}'
+                    )
+            set_option(
+                "server.trustedUserHeaders",
+                parsed_value,
+                where_defined=trusted_user_headers.where_defined,
+            )
+        except json.decoder.JSONDecodeError as jde:
+            raise RuntimeError(
+                f"bad JSON value for server.trustedUserHeaders: {jde.msg}"
+            )
+
+
 def on_config_parsed(
     func: Callable[[], None], force_connect: bool = False, lock: bool = False
 ) -> Callable[[], None]:
@@ -2046,3 +2103,6 @@ def on_config_parsed(
 # may edit config options based on the values of other config options.
 on_config_parsed(_check_conflicts, lock=True)
 on_config_parsed(_set_development_mode)
+# Update server.trustedUserHeaders from any JSON string that was set. Take out the
+# lock, since this is mutating the config.
+on_config_parsed(_parse_trusted_user_headers, lock=True)

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2038,7 +2038,7 @@ def _parse_trusted_user_headers() -> None:
                 parsed_value,
                 where_defined=trusted_user_headers.where_defined,
             )
-        except json.decoder.JSONDecodeError as jde:
+        except json.JSONDecodeError as jde:
             raise RuntimeError(
                 f"bad JSON value for server.trustedUserHeaders: {jde.msg}"
             )

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -974,7 +974,10 @@ _create_option(
 
         Configures HTTP headers whose values, on websocket connect, will be saved in
         st.user. Each key is the header name to map, and each value is the key in
-        st.user to save the value under.
+        st.user to save the value under. If the configured header occurs multiple times
+        in the request, the first value will be used. Multiple headers may not point to
+        the same user key, and an error will be thrown on initialization if this is
+        done.
 
         If configured using an environment variable or CLI option, it should be a
         single JSON-formatted dict of string-to-string.
@@ -2042,6 +2045,21 @@ def _parse_trusted_user_headers() -> None:
             raise RuntimeError(
                 f"bad JSON value for server.trustedUserHeaders: {jde.msg}"
             )
+
+    # Fetch the latest value, since we might've updated it from JSON.
+    final_config_value = options["server.trustedUserHeaders"].value
+    # Ensure no user keys are duplicated.
+    values = set()
+    bad_keys = []
+    for user_key in final_config_value.values():
+        if user_key in values:
+            bad_keys.append(user_key)
+        values.add(user_key)
+
+    if bad_keys:
+        raise RuntimeError(
+            f"server.trustedUserHeaders had multiple mappings for user key(s) {bad_keys}"
+        )
 
 
 def on_config_parsed(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2023,7 +2023,7 @@ def _parse_trusted_user_headers() -> None:
             parsed_value = json.loads(trusted_user_headers.value)
             # Validate that this is an object with string values.
             if not isinstance(parsed_value, dict):
-                # Config validation is using RuntimeError deliberately; ingore warning
+                # Config validation is using RuntimeError deliberately; ignore warning
                 # about making this TypeError.
                 # ruff: noqa: TRY004
                 raise RuntimeError("server.trustedUserHeaders JSON must be an object")

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -180,6 +180,21 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             # extract it from the Sec-Websocket-Protocol header.
             pass
 
+        # Map in any user-configured headers. Note that these override anything coming
+        # from the auth cookie.
+        mapping_config = config.get_option("server.trustedUserHeaders")
+        for header_name, user_info_key in mapping_config.items():
+            header_values = self.request.headers.get_list(header_name)
+            if header_values:
+                # If there's at least one value, use the first value.
+                # NOTE: Tornado doesn't document the order of these values, so it's
+                # possible this won't be the first value that was received by the
+                # server.
+                user_info[user_info_key] = header_values[0]
+            else:
+                # Default to explicit None.
+                user_info[user_info_key] = None
+
         self._session_id = self._runtime.connect_session(
             client=self,
             user_info=user_info,

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -682,6 +682,18 @@ class ConfigTest(unittest.TestCase):
             "value_two": "v2",
         }
 
+    def test_parse_trusted_user_headers_forbids_duplicate_user_keys(self):
+        config._set_option(
+            "server.trustedUserHeaders",
+            {"hdr-one": "duplicate", "hdr-two": "duplicate", "hdr-three": "unique"},
+            "test",
+        )
+        with pytest.raises(
+            RuntimeError,
+            match="had multiple mappings.*duplicate",
+        ):
+            config._parse_trusted_user_headers()
+
     def test_maybe_convert_to_number(self):
         assert config._maybe_convert_to_number("1234") == 1234
         assert config._maybe_convert_to_number("1234.5678") == 1234.5678

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -391,6 +391,36 @@ class ConfigTest(unittest.TestCase):
         assert config.get_option("_test.tomlTest") == DESIRED_VAL
         assert config.get_where_defined("_test.tomlTest") == DUMMY_DEFINITION
 
+    def test_parsing_to_map(self):
+        """Test that we can parse into a dict-valued option."""
+        DUMMY_DEFINITION = "<test definition>"
+        DEFAULT_VAL = {}
+        # Create a dummy default option.
+        config._create_option(
+            "_test.tomlTest",
+            description="This option tests the TOML parser.",
+            default_val=DEFAULT_VAL,
+        )
+        config.get_config_options(force_reparse=True)
+        assert config.get_option("_test.tomlTest") == DEFAULT_VAL
+        assert (
+            config.get_where_defined("_test.tomlTest")
+            == ConfigOption.DEFAULT_DEFINITION
+        )
+
+        # Validate that we can set nested values and get back a dict.
+        NEW_TOML = """
+            [_test.tomlTest]
+            one-value = "one"
+            two-value = "two"
+        """
+        config._update_config_with_toml(NEW_TOML, DUMMY_DEFINITION)
+        assert config.get_option("_test.tomlTest") == {
+            "one-value": "one",
+            "two-value": "two",
+        }
+        assert config.get_where_defined("_test.tomlTest") == DUMMY_DEFINITION
+
     def test_parsing_sensitive_options(self):
         """Test config._update_config_with_sensitive_env_var()."""
         # Some useful variables.
@@ -548,31 +578,32 @@ class ConfigTest(unittest.TestCase):
                 "magic.displayLastExprIfNoSemicolon",
                 "mapbox.token",
                 "secrets.files",
+                "server.address",
+                "server.allowRunOnSave",
                 "server.baseUrlPath",
-                "server.customComponentBaseUrlPath",
-                "server.enableCORS",
                 "server.cookieSecret",
                 "server.corsAllowedOrigins",
-                "server.scriptHealthCheckEnabled",
+                "server.customComponentBaseUrlPath",
+                "server.disconnectedSessionTTL",
+                "server.enableArrowTruncation",
+                "server.enableCORS",
+                "server.enableStaticServing",
                 "server.enableWebsocketCompression",
                 "server.websocketPingInterval",
                 "server.enableXsrfProtection",
                 "server.fileWatcherType",
-                "server.folderWatchList",
                 "server.folderWatchBlacklist",
+                "server.folderWatchList",
                 "server.headless",
-                "server.showEmailPrompt",
-                "server.address",
-                "server.allowRunOnSave",
+                "server.maxMessageSize",
+                "server.maxUploadSize",
                 "server.port",
                 "server.runOnSave",
-                "server.maxUploadSize",
-                "server.maxMessageSize",
-                "server.enableStaticServing",
-                "server.enableArrowTruncation",
+                "server.scriptHealthCheckEnabled",
+                "server.showEmailPrompt",
                 "server.sslCertFile",
                 "server.sslKeyFile",
-                "server.disconnectedSessionTTL",
+                "server.trustedUserHeaders",
                 "ui.hideTopBar",
             ]
         )
@@ -604,6 +635,52 @@ class ConfigTest(unittest.TestCase):
             match="browser.serverPort does not work when global.developmentMode is true.",
         ):
             config._check_conflicts()
+
+    def test_parse_trusted_user_headers_handles_bad_json(self):
+        # JSON that fails to parse.
+        config._set_option("server.trustedUserHeaders", "{123:}", "test")
+        with pytest.raises(
+            RuntimeError,
+            match="bad JSON value",
+        ):
+            config._parse_trusted_user_headers()
+
+    def test_parse_trusted_user_headers_handles_non_objects(self):
+        # Non-object values.
+        for value in ("[]", "null", "123", "false", '"str"'):
+            config._set_option("server.trustedUserHeaders", value, "test")
+            with pytest.raises(
+                RuntimeError,
+                match="JSON must be an object",
+            ):
+                config._parse_trusted_user_headers()
+
+    def test_parse_trusted_user_headers_handles_non_string_entries(self):
+        # Non-string object values.
+        for value in (
+            '{"key": null}',
+            '{"key": 123}',
+            '{"key": []}',
+            '{"good_key": "value", "bad_key": false}',
+        ):
+            config._set_option("server.trustedUserHeaders", value, "test")
+            with pytest.raises(
+                RuntimeError,
+                match="JSON must only have string values",
+            ):
+                config._parse_trusted_user_headers()
+
+    def test_parse_trusted_user_headers_parses_good_json(self):
+        config._set_option(
+            "server.trustedUserHeaders",
+            '{"value_one": "val", "value_two": "v2"}',
+            "test",
+        )
+        config._parse_trusted_user_headers()
+        assert config.get_option("server.trustedUserHeaders") == {
+            "value_one": "val",
+            "value_two": "v2",
+        }
 
     def test_maybe_convert_to_number(self):
         assert config._maybe_convert_to_number("1234") == 1234


### PR DESCRIPTION
## Describe your changes

Add a `server.trustedUserHeaders` config option to allow users to configure HTTP headers which will be mapped to `st.user` keys.

This allows hosting Streamlit in an environment where authorization is handled by a proxy, like when using [Istio external authorization](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/).

Since Streamlit's `ConfigOption` integrates directly with Click, and Click does not natively support map-valued options, use a JSON string for overrides, but native TOML map ("table") support for config files.

## Testing Plan

Config changes are covered by unit tests.

The websocket handler does not have existing unit tests. This layer is _not_ tested, but manual testing was performed:
- run streamlit app with `--server.trustedUserHeaders '{"user-agent": "userAgent", "fake-header": "fakeHeader"}'
- verify that `st.user["userAgent"]` holds the browser's user agent
- verify that `st.user["fakeHeader"]` holds `None`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
