### PR TITLE
[refactor] Remove axios CancelToken in favor of AbortSignal

### DIFF
--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -256,7 +256,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .reply(() => [200, 1])
 
       const mockOnUploadProgress = vi.fn()
-      const mockCancelToken = axios.CancelToken.source().token
+      const mockAbortController = new AbortController()
 
       await expect(
         endpoints.uploadFileUploaderFile(
@@ -264,7 +264,7 @@ describe("DefaultStreamlitEndpoints", () => {
           MOCK_FILE,
           "mockSessionId",
           mockOnUploadProgress,
-          mockCancelToken
+          mockAbortController.signal
         )
       ).resolves.toBeUndefined()
 
@@ -281,7 +281,7 @@ describe("DefaultStreamlitEndpoints", () => {
       // expect(actualRequestConfig.method?.toUpperCase()).toBe("PUT");
       expect(actualRequestConfig.responseType).toBe("text")
       expect(actualRequestConfig.data).toEqual(expectedData)
-      expect(actualRequestConfig.cancelToken).toBe(mockCancelToken)
+      expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
 
@@ -291,7 +291,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .reply(() => [200, 1])
 
       const mockOnUploadProgress = vi.fn()
-      const mockCancelToken = axios.CancelToken.source().token
+      const mockAbortController = new AbortController()
 
       await expect(
         endpoints.uploadFileUploaderFile(
@@ -299,7 +299,7 @@ describe("DefaultStreamlitEndpoints", () => {
           MOCK_FILE,
           "mockSessionId",
           mockOnUploadProgress,
-          mockCancelToken
+          mockAbortController.signal
         )
       ).resolves.toBeUndefined()
 
@@ -314,7 +314,7 @@ describe("DefaultStreamlitEndpoints", () => {
       )
       expect(actualRequestConfig.responseType).toBe("text")
       expect(actualRequestConfig.data).toEqual(expectedData)
-      expect(actualRequestConfig.cancelToken).toBe(mockCancelToken)
+      expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
 
@@ -324,7 +324,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .reply(() => [200, 1])
 
       const mockOnUploadProgress = vi.fn()
-      const mockCancelToken = axios.CancelToken.source().token
+      const mockAbortController = new AbortController()
 
       endpoints.setFileUploadClientConfig({
         prefix: "http://example.com/someprefix/",
@@ -340,7 +340,7 @@ describe("DefaultStreamlitEndpoints", () => {
           MOCK_FILE,
           "mockSessionId",
           mockOnUploadProgress,
-          mockCancelToken
+          mockAbortController.signal
         )
       ).resolves.toBeUndefined()
 
@@ -363,7 +363,7 @@ describe("DefaultStreamlitEndpoints", () => {
           header2: "header2value",
         })
       )
-      expect(actualRequestConfig.cancelToken).toBe(mockCancelToken)
+      expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
 

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import axios, { AxiosRequestConfig, AxiosResponse, CancelToken } from "axios"
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
 import { getLogger } from "loglevel"
 
 import { IAppPage } from "@streamlit/protobuf"
@@ -249,7 +249,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     _sessionId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
-    cancelToken?: CancelToken
+    signal?: AbortSignal
   ): Promise<void> {
     const form = new FormData()
     const { name, webkitRelativePath } = file
@@ -263,7 +263,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
     try {
       await this.csrfRequest<number>(uploadUrl, {
-        cancelToken,
+        signal,
         method: "PUT",
         data: form,
         responseType: "text",

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -20,8 +20,6 @@
  * Returns a promise with the index of the URI that worked.
  */
 
-import { CancelToken } from "axios"
-
 import { IAppPage } from "@streamlit/protobuf"
 import type { StreamlitWindowObject } from "@streamlit/utils"
 
@@ -145,7 +143,7 @@ export interface StreamlitEndpoints {
    * @param file The file to upload.
    * @param sessionId the current sessionID. The file will be associated with this ID.
    * @param onUploadProgress optional function that will be called repeatedly with progress events during the upload.
-   * @param cancelToken optional axios CancelToken that can be used to cancel the in-progress upload.
+   * @param signal optional AbortSignal that can be used to cancel the in-progress upload.
    *
    * @return a Promise<number> that resolves with the file's unique ID, as assigned by the server.
    */
@@ -155,7 +153,7 @@ export interface StreamlitEndpoints {
     sessionId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
-    cancelToken?: CancelToken
+    signal?: AbortSignal
   ): Promise<void>
 
   /**

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -304,6 +304,12 @@ export default tseslint.config([
                 "Please use the useEmotionTheme hook instead of useTheme for type-safety",
               importNames: ["useTheme"],
             },
+            {
+              name: "axios",
+              importNames: ["CancelToken"],
+              message:
+                "Please use the `AbortController` API instead of `CancelToken`",
+            },
           ],
         },
       ],

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CancelToken } from "axios"
 import isEqual from "lodash/isEqual"
 import { getLogger } from "loglevel"
 import { v4 as uuidv4 } from "uuid"
@@ -95,7 +94,7 @@ export class FileUploadClient {
    * @param fileUploadUrl: the URL to upload the file to.
    * @param file: the files to upload.
    * @param onUploadProgress: an optional function that will be called repeatedly with progress events during the upload.
-   * @param cancelToken: an optional axios CancelToken that can be used to cancel the in-progress upload.
+   * @param signal: an optional AbortSignal that can be used to cancel the in-progress upload.
    *
    * @return a Promise<void> that resolves with a void promise when the upload is complete.
    */
@@ -105,7 +104,7 @@ export class FileUploadClient {
     file: File,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
-    cancelToken?: CancelToken
+    signal?: AbortSignal
   ): Promise<void> {
     this.offsetPendingRequestCount(widget.formId, 1)
     return this.endpoints
@@ -114,7 +113,7 @@ export class FileUploadClient {
         file,
         this.sessionInfo.current.sessionId,
         onUploadProgress,
-        cancelToken
+        signal
       )
       .finally(() => this.offsetPendingRequestCount(widget.formId, -1))
   }

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { CancelToken } from "axios"
-
 import { IAppPage } from "@streamlit/protobuf"
 
 export type FileUploadClientConfig = {
@@ -107,7 +105,7 @@ export interface StreamlitEndpoints {
    * @param file The file to upload.
    * @param sessionId the current sessionID. The file will be associated with this ID.
    * @param onUploadProgress optional function that will be called repeatedly with progress events during the upload.
-   * @param cancelToken optional axios CancelToken that can be used to cancel the in-progress upload.
+   * @param signal optional AbortSignal that can be used to cancel the in-progress upload.
    *
    * @return a Promise<number> that resolves with the file's unique ID, as assigned by the server.
    */
@@ -117,7 +115,7 @@ export interface StreamlitEndpoints {
     sessionId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
     onUploadProgress?: (progressEvent: any) => void,
-    cancelToken?: CancelToken
+    signal?: AbortSignal
   ): Promise<void>
 
   /**

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -154,7 +154,7 @@ function ChatInput({
           // Cancel request as the file hasn't been uploaded.
           // However, it may have been received by the server so we'd still
           // send out a request to delete it.
-          file.status.cancelToken.cancel()
+          file.status.abortController.abort()
         }
 
         if (
@@ -220,7 +220,7 @@ function ChatInput({
             fileId,
             file.setStatus({
               type: "uploading",
-              cancelToken: file.status.cancelToken,
+              abortController: file.status.abortController,
               progress: newProgress,
             }),
             prevFiles

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createFileUploadHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createFileUploadHandler.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import axios from "axios"
-
 import { IFileURLs } from "@streamlit/protobuf"
 
 import { UploadFileInfo } from "~lib/components/widgets/FileUploader/UploadFileInfo"
@@ -44,14 +42,14 @@ export const createUploadFileHandler =
   }: CreateUploadFileParams) =>
   (fileURLs: IFileURLs, file: File): void => {
     // Create an UploadFileInfo for this file and add it to our state.
-    const cancelToken = axios.CancelToken.source()
+    const abortController = new AbortController()
     const uploadingFileInfo = new UploadFileInfo(
       file.name,
       file.size,
       getNextLocalFileId(),
       {
         type: "uploading",
-        cancelToken,
+        abortController,
         progress: 1,
       }
     )
@@ -66,13 +64,13 @@ export const createUploadFileHandler =
         fileURLs.uploadUrl as string,
         file,
         e => onUploadProgress(e, uploadingFileInfo.id),
-        cancelToken.token
+        abortController.signal
       )
       .then(() => onUploadComplete(uploadingFileInfo.id, fileURLs))
       .catch(err => {
-        // If this was a cancel error, we don't show the user an error -
+        // If this was an abort error, we don't show the user an error -
         // the cancellation was in response to an action they took.
-        if (!axios.isCancel(err)) {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
           updateFile(
             uploadingFileInfo.id,
             uploadingFileInfo.setStatus({

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -16,7 +16,6 @@
 
 import React, { memo, PureComponent } from "react"
 
-import axios from "axios"
 import isEqual from "lodash/isEqual"
 import zip from "lodash/zip"
 import { flushSync } from "react-dom"
@@ -366,7 +365,7 @@ class FileUploader extends PureComponent<InnerProps, State> {
 
   public uploadFile = (fileURLs: IFileURLs, file: File): void => {
     // Create an UploadFileInfo for this file and add it to our state.
-    const cancelToken = axios.CancelToken.source()
+    const abortController = new AbortController()
 
     // For directory uploads, use the relative path to preserve directory structure
     const fileName = file.webkitRelativePath || file.name
@@ -377,7 +376,7 @@ class FileUploader extends PureComponent<InnerProps, State> {
       this.nextLocalFileId(),
       {
         type: "uploading",
-        cancelToken,
+        abortController,
         progress: 1,
       }
     )
@@ -389,13 +388,13 @@ class FileUploader extends PureComponent<InnerProps, State> {
         fileURLs.uploadUrl as string,
         file,
         e => this.onUploadProgress(e, uploadingFileInfo.id),
-        cancelToken.token
+        abortController.signal
       )
       .then(() => this.onUploadComplete(uploadingFileInfo.id, fileURLs))
       .catch(err => {
-        // If this was a cancel error, we don't show the user an error -
+        // If this was an abort error, we don't show the user an error -
         // the cancellation was in response to an action they took.
-        if (!axios.isCancel(err)) {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
           this.updateFile(
             uploadingFileInfo.id,
             uploadingFileInfo.setStatus({
@@ -449,7 +448,7 @@ class FileUploader extends PureComponent<InnerProps, State> {
       // The file hasn't been uploaded. Let's cancel the request.
       // However, it may have been received by the server so we'll still
       // send out a request to delete.
-      file.status.cancelToken.cancel()
+      file.status.abortController.abort()
     }
 
     if (file.status.type === "uploaded" && file.status.fileUrls.deleteUrl) {
@@ -539,7 +538,7 @@ class FileUploader extends PureComponent<InnerProps, State> {
       fileId,
       file.setStatus({
         type: "uploading",
-        cancelToken: file.status.cancelToken,
+        abortController: file.status.abortController,
         progress: newProgress,
       })
     )

--- a/frontend/lib/src/components/widgets/FileUploader/UploadFileInfo.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadFileInfo.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-import { CancelTokenSource } from "axios"
-
 import { IFileURLs } from "@streamlit/protobuf"
 
 export interface UploadingStatus {
   type: "uploading"
-  cancelToken: CancelTokenSource
+  abortController: AbortController
   progress: number
 }
 

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -18,7 +18,6 @@ import React from "react"
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
-import { CancelTokenSource } from "axios"
 
 import { render } from "~lib/test_util"
 
@@ -34,7 +33,7 @@ describe("FileStatus widget", () => {
   it("shows progress bar when uploading", () => {
     const props = getProps({
       type: "uploading",
-      cancelToken: null as unknown as CancelTokenSource,
+      abortController: new AbortController(),
       progress: 40,
     })
     render(<UploadedFileStatus {...props} />)


### PR DESCRIPTION
## Describe your changes

- Axios `CancelToken` is deprecated, since the built-in `AbortSignal` is a the standardized implementation: https://axios-http.com/docs/cancellation
- This PR migrates instances to `AbortSignal`

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Updates unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
