### PR TITLE
[fix] Correct package.json exports ordering

### DIFF
--- a/frontend/connection/package.json
+++ b/frontend/connection/package.json
@@ -10,10 +10,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/streamlit-connection.cjs.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/streamlit-connection.es.js",
-      "default": "./dist/streamlit-connection.umd.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/streamlit-connection.cjs.js",
+      "default": "./dist/streamlit-connection.umd.js"
     }
   },
   "scripts": {

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -10,10 +10,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/streamlit-lib.cjs.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/streamlit-lib.es.js",
-      "default": "./dist/streamlit-lib.umd.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/streamlit-lib.cjs.js",
+      "default": "./dist/streamlit-lib.umd.js"
     }
   },
   "sideEffects": [

--- a/frontend/utils/package.json
+++ b/frontend/utils/package.json
@@ -10,10 +10,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/streamlit-utils.cjs.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/streamlit-utils.es.js",
-      "default": "./dist/streamlit-utils.umd.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/streamlit-utils.cjs.js",
+      "default": "./dist/streamlit-utils.umd.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Describe your changes

- Updates the order of `package.json` exports to follow the recommendation by [Nodejs documentation](https://nodejs.org/api/packages.html#conditional-exports) and [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
- This also fixes a warning in the console we were seeing in vite/vitest about the improper order

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
