### PR TITLE
[chore] Add a timeout to the Performance Suite GH Workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   performance:
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 25
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

This pull request makes a minor update to the GitHub Actions workflow by increasing the timeout for the performance job to 25 minutes.

## GitHub Issue Link (if applicable)

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
