### PR TITLE
Deprecate `st.bokeh_chart` in favour of `streamlit-bokeh` component

### DIFF
--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -289,16 +289,6 @@ fig = px.scatter(
 )
 st.plotly_chart(fig, use_container_width=True)
 
-"st.bokeh_chart"
-if st.toggle("Show Bokeh chart (has some issues)", False):
-    from bokeh.plotting import figure
-
-    x = [1, 2, 3, 4, 5]
-    y = [6, 7, 2, 4, 5]
-    p = figure(title="simple line example", x_axis_label="x", y_axis_label="y")
-    p.line(x, y, legend_label="Trend", line_width=2)
-    st.bokeh_chart(p, use_container_width=True)
-
 "st.pydeck_chart"
 data = pd.DataFrame(
     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4], columns=["lat", "lon"]

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -52,8 +52,8 @@ class BokehMixin:
         wherever you would call Bokeh's ``show``.
 
         .. Important::
-            Bokeh chart is deprecated. Please use our custom component,
-            |streamlit-bokeh|_ custom component instead.
+            Bokeh chart is deprecated and will be removed in a future version.
+            Please use our custom component, |streamlit-bokeh|_ instead.
 
         .. |streamlit-bokeh| replace:: ``streamlit-bokeh``
         .. _streamlit-bokeh: https://github.com/streamlit/streamlit-bokeh

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Final, cast
 
+from streamlit.deprecation_util import (
+    show_deprecation_warning,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.BokehChart_pb2 import BokehChart as BokehChartProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -49,11 +52,8 @@ class BokehMixin:
         wherever you would call Bokeh's ``show``.
 
         .. Important::
-            You must install ``bokeh==2.4.3`` and ``numpy<2`` to use this
-            command.
-
-            If you need a newer version of Bokeh, use our |streamlit-bokeh|_
-            custom component instead.
+            Bokeh chart is deprecated. Please use our custom component,
+            |streamlit-bokeh|_ custom component instead.
 
         .. |streamlit-bokeh| replace:: ``streamlit-bokeh``
         .. _streamlit-bokeh: https://github.com/streamlit/streamlit-bokeh
@@ -101,6 +101,12 @@ class BokehMixin:
                 f"[streamlit-bokeh](https://github.com/streamlit/streamlit-bokeh)."
             )
 
+        show_deprecation_warning(
+            "st.bokeh_chart is deprecated and will be removed in a future version. "
+            "Please use our custom component, "
+            "[streamlit-bokeh](https://github.com/streamlit/streamlit-bokeh), "
+            "instead."
+        )
         # Generate element ID from delta path
         delta_path = self.dg._get_delta_path_str()
 

--- a/lib/tests/streamlit/elements/bokeh_test.py
+++ b/lib/tests/streamlit/elements/bokeh_test.py
@@ -60,6 +60,23 @@ class BokehTest(DeltaGeneratorTestCase):
             with pytest.raises(StreamlitAPIException):
                 st.bokeh_chart(plot)
 
+    @unittest.skipIf(
+        is_version_less_than(np.__version__, "2.0.0") is False,
+        "This test only runs if numpy is < 2.0.0. The bokeh version supported "
+        "by Streamlit is not compatible with numpy 2.x.",
+    )
+    @patch("streamlit.elements.bokeh_chart.show_deprecation_warning")
+    def test_calling_fragment_does_not_show_warning(
+        self, patched_show_deprecation_warning
+    ):
+        from bokeh.plotting import figure
+
+        plot = figure()
+        plot.line([1], [1])
+        st.bokeh_chart(plot)
+
+        patched_show_deprecation_warning.assert_not_called()
+
 
 class BokehMissingTest(DeltaGeneratorTestCase):
     """Test that appropriate error is raised when bokeh is not installed."""

--- a/lib/tests/streamlit/elements/bokeh_test.py
+++ b/lib/tests/streamlit/elements/bokeh_test.py
@@ -66,7 +66,7 @@ class BokehTest(DeltaGeneratorTestCase):
         "by Streamlit is not compatible with numpy 2.x.",
     )
     @patch("streamlit.elements.bokeh_chart.show_deprecation_warning")
-    def test_calling_fragment_does_not_show_warning(
+    def test_calling_bokeh_chart_shows_deprecation_warning(
         self, patched_show_deprecation_warning
     ):
         from bokeh.plotting import figure
@@ -75,7 +75,7 @@ class BokehTest(DeltaGeneratorTestCase):
         plot.line([1], [1])
         st.bokeh_chart(plot)
 
-        patched_show_deprecation_warning.assert_not_called()
+        patched_show_deprecation_warning.assert_called_once()
 
 
 class BokehMissingTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

Deprecates the outdated `st.bokeh_chart` command in favour of [streamlit-bokeh custom component](https://github.com/streamlit/streamlit-bokeh).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
