### PR TITLE
[Fix]: Playwright artifact upload SHA ordering issue

### DIFF
--- a/.github/workflows/playwright-custom-components.yml
+++ b/.github/workflows/playwright-custom-components.yml
@@ -45,14 +45,6 @@ jobs:
         run: python -m playwright install --with-deps
       - name: Run make frontend-fast
         run: make frontend-fast
-      - name: Run custom component playwright tests
-        run: |
-          source venv/bin/activate
-          cd e2e_playwright
-          echo "Installing custom components"
-          uv pip install -r ./custom_components/components-e2e-requirements.txt
-          rm -rf ./test-results
-          pytest ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1
       - name: Get short SHA
         id: short_sha
         run: |
@@ -61,6 +53,14 @@ jobs:
           else
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
           fi
+      - name: Run custom component playwright tests
+        run: |
+          source venv/bin/activate
+          cd e2e_playwright
+          echo "Installing custom components"
+          uv pip install -r ./custom_components/components-e2e-requirements.txt
+          rm -rf ./test-results
+          pytest ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1
       - name: Upload failed test results
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Description

This PR fixes an issue in the playwright-custom-components workflow where the short SHA generation step was placed after the test execution. This caused the artifact upload to fail when tests failed, as the SHA variable wasn't available for the artifact name.

## Problem
- In `playwright-custom-components.yml`, the "Get short SHA" step was positioned after the test execution
- When tests failed, the workflow would skip to the upload step (with `if: always()`)
- The upload step would reference `steps.short_sha.outputs.sha_short` which wouldn't exist
- This resulted in incomplete artifact names when tests failed
<img width="1323" height="128" alt="image" src="https://github.com/user-attachments/assets/37f71d67-6f7e-4647-9143-b4b60b91da29" />
<img width="1186" height="170" alt="image" src="https://github.com/user-attachments/assets/4f66ea14-0e6c-4ddf-bc73-c314a4d8c262" />


## Solution
- Moved the "Get short SHA" step to execute before the test runs
- This ensures the SHA is always available for artifact naming, regardless of test results
- Aligns with the pattern used in other playwright workflows (`playwright.yml` and `playwright-changed-files.yml`)

## Testing
- The change is a simple reordering of workflow steps
- No functional changes to the tests themselves
- Artifact uploads will now work correctly even when tests fail

## Type of change
- 🐛 Bug fix (non-breaking change which fixes an issue)