### PR TITLE
Refactor multiselect e2e test

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -90,6 +90,36 @@ def get_selectbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator
     return element
 
 
+def get_multiselect(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
+    """Get a multiselect with the given label.
+
+    Parameters
+    ----------
+    locator : Locator | Page
+        The locator to search for the element.
+
+    label : str or Pattern[str]
+        The label of the element to get.
+
+    Returns
+    -------
+    Locator
+        The element.
+    """
+    # Prefer matching the widget label exactly to avoid substring collisions
+    # like "multiselect 1" also matching "multiselect 11".
+    if isinstance(label, Pattern):
+        label_locator = locator.get_by_test_id("stWidgetLabel").filter(has_text=label)
+    else:
+        label_locator = locator.get_by_test_id("stWidgetLabel").get_by_text(
+            label, exact=True
+        )
+
+    element = locator.get_by_test_id("stMultiSelect").filter(has=label_locator)
+    expect(element).to_be_visible()
+    return element
+
+
 def get_checkbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
     """Get a checkbox widget with the given label.
 
@@ -406,6 +436,24 @@ def expect_markdown(
         .filter(has_text=expected_message)
     )
     expect(markdown_el).to_be_visible()
+
+
+def expect_text(
+    locator: Locator | Page,
+    expected_message: str | Pattern[str],
+) -> None:
+    """Expect a st.text element with the given message to be visible.
+
+    Parameters
+    ----------
+    locator : Locator | Page
+        The locator to search for the text element.
+
+    expected_message : str or Pattern[str]
+        The expected message to be displayed in the text element.
+    """
+    text_el = locator.get_by_test_id("stText").filter(has_text=expected_message)
+    expect(text_el).to_be_visible()
 
 
 def expect_exception(

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -50,6 +50,7 @@ def del_from_multiselect(page: Page, label: str, option_text: str) -> None:
     ms.locator(
         f'span[data-baseweb="tag"] span[title="{option_text}"] + span[role="presentation"]'
     ).first.click()
+    wait_for_app_run(page)
 
 
 def test_multiselect_on_load(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -338,7 +339,6 @@ def test_multiselect_accept_new_options(app: Page):
 
     # Remove one option
     del_from_multiselect(app, "multiselect 14 - accept new options", "mango")
-    wait_for_app_run(app)
 
     # Verify we can add another option after removing one
     multiselect_elem.locator("input").click()
@@ -398,7 +398,6 @@ def test_multiselect_empty_options_with_accept_new_options(app: Page):
     del_from_multiselect(
         app, "multiselect 16 - empty options with accept_new_options", "strawberry"
     )
-    wait_for_app_run(app)
 
     # Verify one option was removed
     expect_text(app, "value 16: ['blueberry']")

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -12,144 +12,161 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
-from playwright.sync_api import Page, expect
+import re
+
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_checkbox,
     expect_help_tooltip,
+    expect_text,
     get_element_by_key,
+    get_multiselect,
 )
 
 MULTISELECT_COUNT = 19
 
 
-def select_for_kth_multiselect(
-    page: Page, option_text: str, k: int, close_after_selecting: bool
+def _get_multiselect_input(locator: Locator | Page, label: str) -> Locator:
+    return get_multiselect(locator, label).locator("input").first
+
+
+def select_for_multiselect(
+    page: Page, label: str, option_text: str, close_after_selecting: bool
 ) -> None:
-    """Select an option from a multiselect widget.
-
-    Parameters
-    ----------
-    page : Page
-        The playwright page to use.
-    option_text : str
-        The text of the option to select.
-    k : int
-        The index of the multiselect widget to select from.
-    close_after_selecting : bool
-        Whether to close the dropdown after selecting the option.
-    """
-
-    multiselect_elem = page.get_by_test_id("stMultiSelect").nth(k)
-    multiselect_elem.locator("input").click()
+    """Select an option from a multiselect widget identified by its label."""
+    ms = get_multiselect(page, label)
+    ms.locator("input").click()
     page.locator("li").filter(has_text=option_text).first.click()
     if close_after_selecting:
         page.keyboard.press("Escape")
     wait_for_app_run(page)
 
 
-def del_from_kth_multiselect(page: Page, option_text: str, k: int):
-    """Delete an option from a multiselect widget.
-
-    Parameters
-    ----------
-    page : Page
-        The playwright page to use.
-    option_text : str
-        The text of the option to delete.
-    k : int
-        The index of the multiselect widget to delete from.
-    """
-    multiselect_elem = page.get_by_test_id("stMultiSelect").nth(k)
-    multiselect_elem.locator(
+def del_from_multiselect(page: Page, label: str, option_text: str) -> None:
+    ms = get_multiselect(page, label)
+    ms.locator(
         f'span[data-baseweb="tag"] span[title="{option_text}"] + span[role="presentation"]'
     ).first.click()
 
 
 def test_multiselect_on_load(themed_app: Page, assert_snapshot: ImageCompareFunction):
     """Should show widgets correctly when loaded."""
-    multiselect_elements = themed_app.get_by_test_id("stMultiSelect")
-    expect(multiselect_elements).to_have_count(MULTISELECT_COUNT)
+    expect(themed_app.get_by_test_id("stMultiSelect")).to_have_count(MULTISELECT_COUNT)
 
-    assert_snapshot(multiselect_elements.nth(0), name="st_multiselect-placeholder_help")
-    assert_snapshot(multiselect_elements.nth(1), name="st_multiselect-format_func")
-    assert_snapshot(multiselect_elements.nth(2), name="st_multiselect-empty_list")
-    assert_snapshot(multiselect_elements.nth(3), name="st_multiselect-initial_value")
-    assert_snapshot(multiselect_elements.nth(4), name="st_multiselect-long_values")
-    assert_snapshot(multiselect_elements.nth(5), name="st_multiselect-disabled")
-    assert_snapshot(multiselect_elements.nth(6), name="st_multiselect-hidden_label")
-    assert_snapshot(multiselect_elements.nth(7), name="st_multiselect-collapsed_label")
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 1"),
+        name="st_multiselect-placeholder_help",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 2"), name="st_multiselect-format_func"
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 3"), name="st_multiselect-empty_list"
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 4"),
+        name="st_multiselect-initial_value",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 5"), name="st_multiselect-long_values"
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 6"), name="st_multiselect-disabled"
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "Hidden label"), name="st_multiselect-hidden_label"
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "Collapsed label"),
+        name="st_multiselect-collapsed_label",
+    )
     # The other multiselect widgets do not need to be screenshot tested since they
     # don't have any visually interesting differences.
-    assert_snapshot(multiselect_elements.nth(11), name="st_multiselect-narrow_column")
-    assert_snapshot(multiselect_elements.nth(12), name="st_multiselect-markdown_label")
-    assert_snapshot(multiselect_elements.nth(16), name="st_multiselect-maxHeight")
-    assert_snapshot(multiselect_elements.nth(17), name="st_multiselect-width_300px")
-    assert_snapshot(multiselect_elements.nth(18), name="st_multiselect-width_stretch")
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 12"),
+        name="st_multiselect-narrow_column",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, re.compile(r"^multiselect 13")),
+        name="st_multiselect-markdown_label",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 17 - show maxHeight"),
+        name="st_multiselect-maxHeight",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 18 (width=300px)"),
+        name="st_multiselect-width_300px",
+    )
+    assert_snapshot(
+        get_multiselect(themed_app, "multiselect 19 (width='stretch')"),
+        name="st_multiselect-width_stretch",
+    )
 
 
 def test_help_tooltip_works(app: Page):
-    element_with_help = app.get_by_test_id("stMultiSelect").nth(0)
+    element_with_help = get_multiselect(app, "multiselect 1")
     expect_help_tooltip(app, element_with_help, "Help text")
 
 
 def test_multiselect_initial_value(app: Page):
     """Should show the correct initial values."""
-    text_elements = app.get_by_test_id("stText")
-    # -3 because the last three multiselects do not have accompanying text elements
-    expect(text_elements).to_have_count(MULTISELECT_COUNT - 3)
-
-    expected = [
-        "value 1: []",
-        "value 2: []",
-        "value 3: []",
-        "value 4: ['tea', 'water']",
-        "value 5: []",
-        "value 6: []",
-        "value 7: []",
-        "value 8: []",
-        "value 9: []",
-        "value 10: []",
-        "value 11: []",
-        "multiselect changed: False",
-        "value 12: ['A long option']",
-        "value 14: []",
-        "value 15: ['apple', 'orange']",
-        "value 16: []",
-    ]
-
-    for text_element, expected_text in zip(text_elements.all(), expected):
-        expect(text_element).to_have_text(expected_text, use_inner_text=True)
+    expect_text(app, "value 1: []")
+    expect_text(app, "value 2: []")
+    expect_text(app, "value 3: []")
+    expect_text(app, "value 4: ['tea', 'water']")
+    expect_text(app, "value 5: []")
+    expect_text(app, "value 6: []")
+    expect_text(app, "value 7: []")
+    expect_text(app, "value 8: []")
+    expect_text(app, "value 9: []")
+    expect_text(app, "value 10: []")
+    expect_text(app, "value 11: []")
+    expect_text(app, "multiselect changed: False")
+    expect_text(app, "value 12: ['A long option']")
+    expect_text(app, "value 14: []")
+    expect_text(app, "value 15: ['apple', 'orange']")
+    expect_text(app, "value 16: []")
 
 
 def test_multiselect_clear_all(app: Page):
     """Should clear all options when clicking clear all."""
-    select_for_kth_multiselect(app, "Female", 1, True)
-    app.locator('.stMultiSelect [role="button"][aria-label="Clear all"]').first.click()
-    expect(app.get_by_test_id("stText").nth(1)).to_have_text("value 2: []")
+    select_for_multiselect(app, "multiselect 2", "Female", True)
+    get_multiselect(app, "multiselect 2").locator(
+        '[role="button"][aria-label="Clear all"]'
+    ).first.click()
+    expect_text(app, "value 2: []")
 
 
 def test_multiselect_show_values_in_dropdown(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Screenshot test to check that values are shown in dropdown."""
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(0)
+    multiselect_elem = get_multiselect(app, "multiselect 1")
     multiselect_elem.locator("input").click()
     wait_for_app_run(app)
     dropdown_elements = app.locator("li")
     expect(dropdown_elements).to_have_count(2)
-    assert_snapshot(dropdown_elements.nth(0), name="st_multiselect-dropdown_0")
-    assert_snapshot(dropdown_elements.nth(1), name="st_multiselect-dropdown_1")
+    assert_snapshot(
+        dropdown_elements.filter(has_text="male").first,
+        name="st_multiselect-dropdown_0",
+    )
+    assert_snapshot(
+        dropdown_elements.filter(has_text="female").first,
+        name="st_multiselect-dropdown_1",
+    )
 
 
 def test_multiselect_long_values_in_dropdown(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
     """Should show long values correctly (with ellipses) in the dropdown menu."""
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(4)
+    multiselect_elem = get_multiselect(app, "multiselect 5")
     multiselect_elem.locator("input").click()
     wait_for_app_run(app)
     dropdown_elems = app.locator("li").all()
@@ -163,7 +180,7 @@ def test_multiselect_long_values_in_narrow_column(
     """Should show long values correctly (with ellipses) when in narrow column
     widths.
     """
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(11)
+    multiselect_elem = get_multiselect(app, "multiselect 12")
     wait_for_app_run(app)
     # Wait for list items to be loaded in
     app.locator("li").all()
@@ -172,17 +189,15 @@ def test_multiselect_long_values_in_narrow_column(
 
 def test_multiselect_register_callback(app: Page):
     """Should call the callback when an option is selected."""
-    app.get_by_test_id("stMultiSelect").nth(10).locator("input").click()
+    _get_multiselect_input(app, "multiselect 11").click()
     app.locator("li").first.click()
-    expect(app.get_by_test_id("stText").nth(10)).to_have_text("value 11: ['male']")
-    expect(app.get_by_test_id("stText").nth(11)).to_have_text(
-        "multiselect changed: True"
-    )
+    expect_text(app, "value 11: ['male']")
+    expect_text(app, "multiselect changed: True")
 
 
 def test_multiselect_max_selections_form(app: Page):
     """Should apply max selections when used in form."""
-    select_for_kth_multiselect(app, "male", 8, False)
+    select_for_multiselect(app, "multiselect 10", "male", False)
     expect(app.locator("li")).to_have_text(
         "You can only select up to 1 option. Remove an option first.",
         use_inner_text=True,
@@ -193,8 +208,8 @@ def test_multiselect_max_selections_1(app: Page):
     """Should show the correct text when maxSelections is reached and closing after
     selecting.
     """
-    select_for_kth_multiselect(app, "male", 9, True)
-    app.get_by_test_id("stMultiSelect").nth(9).click()
+    select_for_multiselect(app, "multiselect 9", "male", True)
+    get_multiselect(app, "multiselect 9").click()
     expect(app.locator("li")).to_have_text(
         "You can only select up to 1 option. Remove an option first.",
         use_inner_text=True,
@@ -205,7 +220,7 @@ def test_multiselect_max_selections_2(app: Page):
     """Should show the correct text when maxSelections is reached and not closing after
     selecting.
     """
-    select_for_kth_multiselect(app, "male", 9, False)
+    select_for_multiselect(app, "multiselect 9", "male", False)
     expect(app.locator("li")).to_have_text(
         "You can only select up to 1 option. Remove an option first.",
         use_inner_text=True,
@@ -214,38 +229,36 @@ def test_multiselect_max_selections_2(app: Page):
 
 def test_multiselect_valid_options(app: Page):
     """Should allow selections when there are valid options."""
-    expect(app.get_by_test_id("stMultiSelect").first).to_have_text(
+    expect(get_multiselect(app, "multiselect 1")).to_have_text(
         "multiselect 1\n\nPlease select", use_inner_text=True
     )
 
 
 def test_multiselect_no_valid_options(app: Page):
     """Should show that their are no options."""
-    expect(app.get_by_test_id("stMultiSelect").nth(2)).to_have_text(
+    expect(get_multiselect(app, "multiselect 3")).to_have_text(
         "multiselect 3\n\nNo options to select", use_inner_text=True
     )
 
 
 def test_multiselect_single_selection(app: Page, assert_snapshot: ImageCompareFunction):
     """Should allow selections."""
-    select_for_kth_multiselect(app, "Female", 1, True)
-    expect(app.get_by_test_id("stMultiSelect").locator("span").nth(1)).to_have_text(
+    select_for_multiselect(app, "multiselect 2", "Female", True)
+    expect(get_multiselect(app, "multiselect 2").locator("span").nth(1)).to_have_text(
         "Female", use_inner_text=True
     )
     assert_snapshot(
-        app.get_by_test_id("stMultiSelect").nth(1), name="st_multiselect-selection"
+        get_multiselect(app, "multiselect 2"), name="st_multiselect-selection"
     )
-    expect(app.get_by_test_id("stText").nth(1)).to_have_text(
-        "value 2: ['female']", use_inner_text=True
-    )
+    expect_text(app, "value 2: ['female']")
 
 
 def test_multiselect_deselect_option(app: Page):
     """Should deselect an option when deselecting it."""
-    select_for_kth_multiselect(app, "Female", 1, True)
-    select_for_kth_multiselect(app, "Male", 1, True)
-    del_from_kth_multiselect(app, "Female", 1)
-    expect(app.get_by_test_id("stText").nth(1)).to_have_text("value 2: ['male']")
+    select_for_multiselect(app, "multiselect 2", "Female", True)
+    select_for_multiselect(app, "multiselect 2", "Male", True)
+    del_from_multiselect(app, "multiselect 2", "Female")
+    expect_text(app, "value 2: ['male']")
 
 
 def test_multiselect_option_over_max_selections(app: Page):
@@ -258,11 +271,9 @@ def test_multiselect_option_over_max_selections(app: Page):
 
 def test_multiselect_double_selection(app: Page):
     """Should allow multiple selections."""
-    select_for_kth_multiselect(app, "Female", 1, True)
-    select_for_kth_multiselect(app, "Male", 1, True)
-    expect(app.get_by_test_id("stText").nth(1)).to_have_text(
-        "value 2: ['female', 'male']"
-    )
+    select_for_multiselect(app, "multiselect 2", "Female", True)
+    select_for_multiselect(app, "multiselect 2", "Male", True)
+    expect_text(app, "value 2: ['female', 'male']")
 
 
 def test_check_top_level_class(app: Page):
@@ -280,7 +291,7 @@ def test_multiselect_accept_new_options(app: Page):
     max_selections.
     """
     # Get the last multiselect (index 13)
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(13)
+    multiselect_elem = get_multiselect(app, "multiselect 14 - accept new options")
 
     # Click to open dropdown
     multiselect_elem.locator("input").click()
@@ -304,9 +315,7 @@ def test_multiselect_accept_new_options(app: Page):
     wait_for_app_run(app)
 
     # Verify three options were added successfully
-    expect(app.get_by_test_id("stText").nth(13)).to_have_text(
-        "value 14: ['mango', 'grape', 'apple']"
-    )
+    expect_text(app, "value 14: ['mango', 'grape', 'apple']")
     # Verify that format_func was applied to original option but not to the dynamically
     # added option
     expect(
@@ -327,12 +336,10 @@ def test_multiselect_accept_new_options(app: Page):
     input_elem.press("Enter")
     wait_for_app_run(app)
     # Verify that this option was not added as it would have exceeded max_selections
-    expect(app.get_by_test_id("stText").nth(13)).to_have_text(
-        "value 14: ['mango', 'grape', 'apple']"
-    )
+    expect_text(app, "value 14: ['mango', 'grape', 'apple']")
 
     # Remove one option
-    del_from_kth_multiselect(app, "mango", 13)
+    del_from_multiselect(app, "multiselect 14 - accept new options", "mango")
     wait_for_app_run(app)
 
     # Verify we can add another option after removing one
@@ -342,18 +349,14 @@ def test_multiselect_accept_new_options(app: Page):
     wait_for_app_run(app)
 
     # Verify final selections are correct
-    expect(app.get_by_test_id("stText").nth(13)).to_have_text(
-        "value 14: ['grape', 'apple', 'kiwi']"
-    )
+    expect_text(app, "value 14: ['grape', 'apple', 'kiwi']")
 
 
 def test_multiselect_preset_session_state(app: Page):
     """Should display values from session_state."""
     # Check the initial values from session_state
-    expect(app.get_by_test_id("stText").nth(14)).to_have_text(
-        "value 15: ['apple', 'orange']"
-    )
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(14)
+    expect_text(app, "value 15: ['apple', 'orange']")
+    multiselect_elem = get_multiselect(app, "multiselect 15 - session_state values")
     selections_button = multiselect_elem.locator('[data-baseweb="tag"]')
     expect(selections_button).to_have_count(2)
     expect(selections_button.get_by_text("apple")).to_be_visible()
@@ -363,7 +366,9 @@ def test_multiselect_preset_session_state(app: Page):
 def test_multiselect_empty_options_with_accept_new_options(app: Page):
     """Should allow adding new options when options list is empty but accept_new_options is True."""
     # Get the multiselect with empty options but accept_new_options=True (index 15)
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(15)
+    multiselect_elem = get_multiselect(
+        app, "multiselect 16 - empty options with accept_new_options"
+    )
 
     # Verify the initial placeholder shows "Add options" (frontend now handles default placeholders)
     expect(multiselect_elem).to_contain_text("Add options")
@@ -383,9 +388,7 @@ def test_multiselect_empty_options_with_accept_new_options(app: Page):
     wait_for_app_run(app)
 
     # Verify options were added successfully
-    expect(app.get_by_test_id("stText").nth(15)).to_have_text(
-        "value 16: ['strawberry', 'blueberry']"
-    )
+    expect_text(app, "value 16: ['strawberry', 'blueberry']")
 
     # Verify the selections are visible in the UI
     selections_button = multiselect_elem.locator('[data-baseweb="tag"]')
@@ -394,17 +397,19 @@ def test_multiselect_empty_options_with_accept_new_options(app: Page):
     expect(selections_button.get_by_text("blueberry")).to_be_visible()
 
     # Remove one option
-    del_from_kth_multiselect(app, "strawberry", 15)
+    del_from_multiselect(
+        app, "multiselect 16 - empty options with accept_new_options", "strawberry"
+    )
     wait_for_app_run(app)
 
     # Verify one option was removed
-    expect(app.get_by_test_id("stText").nth(15)).to_have_text("value 16: ['blueberry']")
+    expect_text(app, "value 16: ['blueberry']")
 
 
 def test_multiselect_empty_options_disabled_when_no_accept_new(app: Page):
     """Should show 'No options to select' placeholder and be disabled when empty and accept_new_options=False."""
     # Get multiselect 3 (index 2) which has empty options and accept_new_options=False (default)
-    multiselect_elem = app.get_by_test_id("stMultiSelect").nth(2)
+    multiselect_elem = get_multiselect(app, "multiselect 3")
 
     # Verify the placeholder shows "No options to select"
     expect(multiselect_elem).to_contain_text("No options to select")
@@ -422,4 +427,4 @@ def test_multiselect_empty_options_disabled_when_no_accept_new(app: Page):
     expect(dropdown_options).to_have_count(0)
 
     # Verify the widget value remains empty
-    expect(app.get_by_test_id("stText").nth(2)).to_have_text("value 3: []")
+    expect_text(app, "value 3: []")

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-import re
-
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -92,7 +92,7 @@ def test_multiselect_on_load(themed_app: Page, assert_snapshot: ImageCompareFunc
         name="st_multiselect-narrow_column",
     )
     assert_snapshot(
-        get_multiselect(themed_app, re.compile(r"^multiselect 13")),
+        get_multiselect(themed_app, "multiselect 13"),
         name="st_multiselect-markdown_label",
     )
     assert_snapshot(

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import re
+
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
@@ -91,7 +93,7 @@ def test_multiselect_on_load(themed_app: Page, assert_snapshot: ImageCompareFunc
         name="st_multiselect-narrow_column",
     )
     assert_snapshot(
-        get_multiselect(themed_app, "multiselect 13"),
+        get_multiselect(themed_app, re.compile("^multiselect 13")),
         name="st_multiselect-markdown_label",
     )
     assert_snapshot(


### PR DESCRIPTION
## Describe your changes

Refactors the multiselect e2e tests to use label and key-based access instead of index-based access. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
