### PR TITLE
Add client_id to OIDC logout request

### DIFF
--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -179,9 +179,12 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
                 _LOGGER.info("Redirect url could not be determined")
                 return None
 
-            logout_params = {"post_logout_redirect_uri": redirect_root}
+            logout_params = {
+                "client_id": client.client_id,
+                "post_logout_redirect_uri": redirect_root,
+                # Not using id_token_hint as we don't store the id token
+            }
 
-            # Not using id_token_hint as we don't store the id token
             return f"{end_session_endpoint}?{urlencode(logout_params)}"
 
         except Exception as e:

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -178,12 +178,13 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
         return_value=(
             MagicMock(
+                client_id="test_client_id",
                 load_server_metadata=MagicMock(
                     return_value={
                         # Use a fake ese-provider as google does not use end_session_endpoint
                         "end_session_endpoint": "https://ese-provider.example.com/logout"
                     }
-                )
+                ),
             ),
             "",
         ),
@@ -214,10 +215,11 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.code == 302
         assert '_streamlit_user="";' in response.headers["Set-Cookie"]
 
-        # Should redirect to provider's logout URL with post_logout_redirect_uri
+        # Should redirect to provider's logout URL with post_logout_redirect_uri and client_id
         location = response.headers["Location"]
         assert location.startswith("https://ese-provider.example.com/logout")
         assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+        assert "client_id=test_client_id" in location
 
         # Verify create_oauth_client was called with the correct provider
         mock_create_oauth_client.assert_called_once_with("ese-provider")


### PR DESCRIPTION
## Describe your changes
Hotfix to the [OIDC logout PR](https://github.com/streamlit/streamlit/pull/11901) merged in 1.47 that neglected to include client_id that is usually optional but seems to be required by some OIDC providers.

## GitHub Issue Link (if applicable)
[#12144](https://github.com/streamlit/streamlit/issues/12144)
[#12169](https://github.com/streamlit/streamlit/issues/12169)

## Testing Plan
- unit tests updated to check for the addition
- would be good if the reporters of the two issues could check if it fixes the issue for their providers

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
