### PR TITLE
[poc] Add `width="auto"` for `st.markdown` and make it the default.

### DIFF
--- a/e2e_playwright/st_markdown.py
+++ b/e2e_playwright/st_markdown.py
@@ -349,6 +349,38 @@ with st.container(border=True, horizontal_alignment="center"):
         ```
     """)
 
+    st.markdown("""
+        You can print something in python like this `print("Hello, world!")`
+    """)
+
+    st.markdown(
+        """
+        Here's how to define a function in Python:
+
+            def greet_user(name):
+                return f"Hello, {name}!"
+
+            result = greet_user("Streamlit")
+            print(result)
+
+        The function above demonstrates basic Python syntax.
+        """
+    )
+    st.markdown(
+        """
+        Here's some code in an HTML pre block:
+
+        <pre><code class="language-python">
+        def hello_world():
+            print("Hello from HTML!")
+            return "success"
+        </code></pre>
+
+        This will render with full width and syntax highlighting.
+        """,
+        unsafe_allow_html=True,
+    )
+
 with st.container(border=True, horizontal=True):
     st.markdown("""
         Here is some code:

--- a/e2e_playwright/st_markdown.py
+++ b/e2e_playwright/st_markdown.py
@@ -329,3 +329,39 @@ with st.expander("Badge Width Examples", expanded=True):
         st.badge("Fixed 100px badge", width=100)
 
         st.badge("Stretch badge", width="stretch")
+
+with st.container(border=True):
+    st.markdown("---")
+    st.write("---")
+
+with st.container(border=True, horizontal_alignment="center"):
+    st.markdown("""
+        Here is some code:
+
+        ```python
+        abc = 123
+        ```
+
+        And here is some more:
+
+        ```python
+        abc = 123
+        ```
+    """)
+
+with st.container(border=True, horizontal=True):
+    st.markdown("""
+        Here is some code:
+
+        ```python
+        abc = 123
+        ```
+
+        And here is some more:
+
+        ```python
+        abc = 123
+        ```
+    """)
+    st.title("Test")
+    st.write("The markdown has a code block.")


### PR DESCRIPTION
## Describe your changes

We kept width on `st.markdown` (and therefore also `st.write`) as `"stretch"` by default due to some visual issues with `width="content"`. However, we would like the width to be content by default. 

This PR introduces an `"auto"` width option as the default. When this is selected, the behavior is mostly the same as "content" but in a few cases, like rendering dividers and code blocks, it acts as "stretch" width.  

<img width="757" height="283" alt="Screenshot 2025-08-13 at 5 12 35 PM" src="https://github.com/user-attachments/assets/069688c5-7251-4c9c-b515-d565ce10aad9" />

<img width="742" height="1093" alt="Screenshot 2025-08-13 at 5 17 08 PM" src="https://github.com/user-attachments/assets/8f6b662f-34d0-4a14-9f7f-6e2971c3cc1c" />

<img width="793" height="796" alt="Screenshot 2025-08-13 at 5 17 24 PM" src="https://github.com/user-attachments/assets/6493fff5-01cd-45c2-87ea-1bc59b1aa01e" />

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
