### PR TITLE
Update credentials.py: try to fix showEmailPrompt in case where there is no email

### DIFF
--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -248,6 +248,8 @@ class Credentials:
                 )
         else:
             if not config.get_option("server.showEmailPrompt"):
+                self.activation = _verify_email(email)
+                self.save()
                 return
             activated = False
 

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -248,7 +248,9 @@ class Credentials:
                 )
         else:
             if not config.get_option("server.showEmailPrompt"):
-                self.activation = _verify_email(email)
+                # Since self.activation is None, there is no real email to fall back
+                # to, so we just use "". (Which, of course, is considered "valid".)
+                self.activation = _verify_email("")
                 self.save()
                 return
             activated = False

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -343,7 +343,6 @@ def check_credentials() -> None:
     check, since credential would be automatically set to an empty string.
 
     """
-    from streamlit import config
 
     if not _check_credential_file_exists() and (
         config.get_option("server.headless")

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -346,7 +346,7 @@ def check_credentials() -> None:
 
     if not _check_credential_file_exists() and (
         config.get_option("server.headless")
-        or config.get_option("server.showEmailPrompt")
+        or not config.get_option("server.showEmailPrompt")
     ):
         if not config.is_manually_set("browser.gatherUsageStats"):
             # If not manually defined, show short message about usage stats gathering.

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -247,12 +247,6 @@ class Credentials:
                     "`streamlit activate reset` then `streamlit activate`"
                 )
         else:
-            if not config.get_option("server.showEmailPrompt"):
-                # Since self.activation is None, there is no real email to fall back
-                # to, so we just use "". (Which, of course, is considered "valid".)
-                self.activation = _verify_email("")
-                self.save()
-                return
             activated = False
 
             while not activated:
@@ -351,7 +345,7 @@ def check_credentials() -> None:
     """
     from streamlit import config
 
-    if not _check_credential_file_exists() and config.get_option("server.headless"):
+    if not _check_credential_file_exists() and (config.get_option("server.headless") or config.get_option("server.showEmailPrompt")):
         if not config.is_manually_set("browser.gatherUsageStats"):
             # If not manually defined, show short message about usage stats gathering.
             cli_util.print_to_cli(_TELEMETRY_HEADLESS_TEXT)

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -345,7 +345,10 @@ def check_credentials() -> None:
     """
     from streamlit import config
 
-    if not _check_credential_file_exists() and (config.get_option("server.headless") or config.get_option("server.showEmailPrompt")):
+    if not _check_credential_file_exists() and (
+        config.get_option("server.headless")
+        or config.get_option("server.showEmailPrompt")
+    ):
         if not config.is_manually_set("browser.gatherUsageStats"):
             # If not manually defined, show short message about usage stats gathering.
             cli_util.print_to_cli(_TELEMETRY_HEADLESS_TEXT)

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -410,7 +410,7 @@ class CliTest(unittest.TestCase):
 
             # Assert that makedirs was never called to create ~/.streamlit directory
             mock_makedirs.assert_not_called()
-            assert result.exit_code != 0
+            assert result.exit_code == 0
 
     def test_streamlit_folder_created_when_show_email_prompt_true(self):
         """Test that ~/.streamlit directory is created when server.showEmailPrompt=True."""


### PR DESCRIPTION
## Describe your changes

Fixes #12166 “If showEmailPrompt is false, but there is no email configured, "Activation email not valid" error results”

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/12166

## Testing Plan

This should be testable, and in fact the tests that were written for the original PR just have a small blindspot that needs to be fixed, for this case. Perhaps this addresses it:

This PR changes `test_streamlit_folder_not_created_when_show_email_prompt_false` to expect a succeeding error code instead of a error code — it's surprising to me that it ever expected a failing error code, and maybe that was a typo that caused this undesired behavior to slip through (or maybe I don't understand what it was doing).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
