### PR TITLE
[nit] noqa: TRY301 should not be necessary in this position

### DIFF
--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -151,7 +151,7 @@ class Credentials:
             with open(self._conf_file) as f:
                 data = toml.load(f).get("general")
             if data is None:
-                raise RuntimeError  # noqa: TRY301
+                raise RuntimeError
             self.activation = _verify_email(data.get("email"))
         except FileNotFoundError:
             if auto_resolve:


### PR DESCRIPTION
TRY301 triggering when you raise a different exception type was a bug in TRY301 that has now been fixed https://github.com/astral-sh/ruff/issues/5246

## Describe your changes

removes a noqa comment

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed:

presumably the current CI lints with the appropriate tools.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
