### PR TITLE
Increase e2e CI workflow timeout

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   playwright-e2e-tests:
     runs-on: ubuntu-latest-32-cores
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

I have seen the e2e workflow run into the 30 min timeout a couple of times, with runs that contained flaky tests but still seemed somewhat fine. Increasing this to 35 minutes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
