### PR TITLE
Make crossorigin property configurable for st.logo

### DIFF
--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -18,7 +18,7 @@ import React from "react"
 
 import { screen } from "@testing-library/react"
 
-import { render } from "@streamlit/lib"
+import { render, renderWithContexts } from "@streamlit/lib"
 import { Logo as LogoProto } from "@streamlit/protobuf"
 
 import LogoComponent from "./LogoComponent"
@@ -200,5 +200,190 @@ describe("LogoComponent", () => {
 
     logo = screen.getByTestId("stHeaderLogo")
     expect(logo).toHaveStyle("height: 2rem")
+  })
+
+  describe("crossOrigin attribute", () => {
+    const scenarios = [
+      {
+        backendBaseUrl: undefined,
+        description: "without BACKEND_BASE_URL",
+      },
+      {
+        backendBaseUrl: "http://localhost:8501",
+        description: "with BACKEND_BASE_URL",
+      },
+    ]
+
+    afterEach(() => {
+      // Clean up window.__streamlit after each test
+      if (window.__streamlit) {
+        delete window.__streamlit.BACKEND_BASE_URL
+      }
+    })
+
+    it.each(scenarios)(
+      "sets crossOrigin attribute for relative URLs when resourceCrossOriginMode is configured ($description)",
+      ({ backendBaseUrl }) => {
+        // Setup window.__streamlit.BACKEND_BASE_URL if specified
+        if (backendBaseUrl) {
+          window.__streamlit = window.__streamlit || {}
+          window.__streamlit.BACKEND_BASE_URL = backendBaseUrl
+        }
+
+        const logoWithRelativeUrl = LogoProto.create({
+          image: "/media/logo.png",
+          size: "medium",
+        })
+
+        renderWithContexts(
+          <LogoComponent
+            {...getProps({
+              appLogo: logoWithRelativeUrl,
+              dataTestId: "stHeaderLogo",
+            })}
+          />,
+          {
+            libConfig: { resourceCrossOriginMode: "anonymous" },
+          }
+        )
+
+        const logo = screen.getByTestId("stHeaderLogo")
+        if (backendBaseUrl) {
+          // When BACKEND_BASE_URL is set, crossOrigin should be set for relative URLs
+          expect(logo).toHaveAttribute("crossOrigin", "anonymous")
+        } else {
+          // When BACKEND_BASE_URL is not set, crossOrigin should not be set for relative URLs (same-origin)
+          expect(logo).not.toHaveAttribute("crossOrigin")
+        }
+      }
+    )
+
+    it("sets crossOrigin attribute for backend URLs when configured", () => {
+      window.__streamlit = window.__streamlit || {}
+      window.__streamlit.BACKEND_BASE_URL = "http://localhost:8501"
+
+      const logoWithBackendUrl = LogoProto.create({
+        image: "http://localhost:8501/media/logo.png",
+        iconImage: "http://localhost:8501/media/icon.png",
+        size: "medium",
+      })
+
+      const { rerender } = renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithBackendUrl,
+            dataTestId: "stHeaderLogo",
+            collapsed: false,
+          })}
+        />,
+        {
+          libConfig: { resourceCrossOriginMode: "anonymous" },
+        }
+      )
+
+      // Test main image
+      let logo = screen.getByTestId("stHeaderLogo")
+      expect(logo).toHaveAttribute("crossOrigin", "anonymous")
+      expect(logo).toHaveAttribute(
+        "src",
+        "http://localhost:8501/media/logo.png"
+      )
+
+      // Test icon image when collapsed
+      rerender(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithBackendUrl,
+            dataTestId: "stHeaderLogo",
+            collapsed: true,
+          })}
+        />
+      )
+
+      logo = screen.getByTestId("stHeaderLogo")
+      expect(logo).toHaveAttribute("crossOrigin", "anonymous")
+      expect(logo).toHaveAttribute(
+        "src",
+        "http://localhost:8501/media/icon.png"
+      )
+    })
+
+    it("does not set crossOrigin attribute for external URLs", () => {
+      window.__streamlit = window.__streamlit || {}
+      window.__streamlit.BACKEND_BASE_URL = "http://localhost:8501"
+
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: sampleLogo, // Uses https://example.com URLs
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          libConfig: { resourceCrossOriginMode: "anonymous" },
+        }
+      )
+
+      const logo = screen.getByTestId("stHeaderLogo")
+      // External URLs should not have crossOrigin attribute set
+      expect(logo).not.toHaveAttribute("crossOrigin")
+      expect(logo).toHaveAttribute("src", "https://example.com/logo.png")
+    })
+
+    it.each(scenarios)(
+      "does not set crossOrigin attribute when resourceCrossOriginMode is undefined ($description)",
+      ({ backendBaseUrl }) => {
+        // Setup window.__streamlit.BACKEND_BASE_URL if specified
+        if (backendBaseUrl) {
+          window.__streamlit = window.__streamlit || {}
+          window.__streamlit.BACKEND_BASE_URL = backendBaseUrl
+        }
+
+        const logoWithRelativeUrl = LogoProto.create({
+          image: "/media/logo.png",
+          size: "medium",
+        })
+
+        renderWithContexts(
+          <LogoComponent
+            {...getProps({
+              appLogo: logoWithRelativeUrl,
+              dataTestId: "stHeaderLogo",
+            })}
+          />,
+          {
+            libConfig: { resourceCrossOriginMode: undefined },
+          }
+        )
+
+        const logo = screen.getByTestId("stHeaderLogo")
+        expect(logo).not.toHaveAttribute("crossOrigin")
+      }
+    )
+
+    it("works with use-credentials mode", () => {
+      window.__streamlit = window.__streamlit || {}
+      window.__streamlit.BACKEND_BASE_URL = "http://localhost:8501"
+
+      const logoWithRelativeUrl = LogoProto.create({
+        image: "/media/logo.png",
+        size: "medium",
+      })
+
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithRelativeUrl,
+            dataTestId: "stSidebarLogo",
+          })}
+        />,
+        {
+          libConfig: { resourceCrossOriginMode: "use-credentials" },
+        }
+      )
+
+      const logo = screen.getByTestId("stSidebarLogo")
+      expect(logo).toHaveAttribute("crossOrigin", "use-credentials")
+    })
   })
 })

--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { ReactElement, useContext } from "react"
 
 import { getLogger } from "loglevel"
 
@@ -23,6 +23,7 @@ import {
   StyledLogoLink,
 } from "@streamlit/app/src/components/Sidebar/styled-components"
 import { StreamlitEndpoints } from "@streamlit/connection"
+import { getCrossOriginAttribute, LibContext } from "@streamlit/lib"
 import { Logo } from "@streamlit/protobuf"
 
 const LOG = getLogger("LogoComponent")
@@ -45,6 +46,8 @@ const LogoComponent = ({
   componentName = "Logo",
   dataTestId = "stLogo",
 }: LogoComponentProps): ReactElement | null => {
+  const { libConfig } = useContext(LibContext)
+
   if (!appLogo) {
     return null
   }
@@ -66,6 +69,11 @@ const LogoComponent = ({
 
   const source = endpoints.buildMediaURL(displayImage)
 
+  const crossOrigin = getCrossOriginAttribute(
+    libConfig.resourceCrossOriginMode,
+    displayImage
+  )
+
   const logo = (
     <StyledLogo
       src={source}
@@ -75,6 +83,7 @@ const LogoComponent = ({
       data-testid={dataTestId}
       // Save to logo's src to send on load error
       onError={_ => handleLogoError(source)}
+      crossOrigin={crossOrigin}
     />
   )
 

--- a/frontend/lib/src/hooks/useCrossOriginAttribute.ts
+++ b/frontend/lib/src/hooks/useCrossOriginAttribute.ts
@@ -39,5 +39,10 @@ export const useCrossOriginAttribute = (
   url?: string
 ): undefined | "anonymous" | "use-credentials" => {
   const { libConfig } = useContext(LibContext)
+
+  if (!url) {
+    return undefined
+  }
+
   return getCrossOriginAttribute(libConfig.resourceCrossOriginMode, url)
 }

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -67,6 +67,7 @@ export { ComponentRegistry } from "./components/widgets/CustomComponent"
 export { Quiver } from "./dataframes/Quiver"
 export { FileUploadClient } from "./FileUploadClient"
 export { useCopyToClipboard } from "./hooks/useCopyToClipboard"
+export { useCrossOriginAttribute } from "./hooks/useCrossOriginAttribute"
 export { useEmotionTheme } from "./hooks/useEmotionTheme"
 export { useExecuteWhenChanged } from "./hooks/useExecuteWhenChanged"
 export { useRequiredContext } from "./hooks/useRequiredContext"
@@ -129,6 +130,7 @@ export {
 } from "./util/performance"
 export { LocalStore } from "./util/storageUtils"
 export { Timer } from "./util/Timer"
+export { getCrossOriginAttribute } from "./util/UriUtil"
 export {
   extractPageNameFromPathName,
   generateUID,


### PR DESCRIPTION
## Describe your changes

Follow-up of https://github.com/streamlit/streamlit/pull/11948 and https://github.com/streamlit/streamlit/pull/12087
Allows configuring the `crossorigin` attribute also for the img element used by the `st.logo` command.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - Added JavaScript unit tests
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
