### PR TITLE
Fix: prevents underlying column menu from opening when column visibility menu is open for `st.dataframe`

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -1060,10 +1060,12 @@ function DataFrame({
           validateCell={validateCell}
           // Open column context menu:
           onHeaderMenuClick={(columnIdx, screenPosition) => {
-            setShowMenu({
-              columnIdx,
-              headerBounds: screenPosition,
-            })
+            if (!showColumnVisibilityMenu) {
+              setShowMenu({
+                columnIdx,
+                headerBounds: screenPosition,
+              })
+            }
           }}
           // The default setup is read only, and therefore we deactivate paste here:
           onPaste={false}

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -1060,6 +1060,11 @@ function DataFrame({
           validateCell={validateCell}
           // Open column context menu:
           onHeaderMenuClick={(columnIdx, screenPosition) => {
+            // There is an issue that clicking on the column visibility menu
+            // can trigger a menu click event on the column header.
+            // To prevent another menu from opening, we check if column
+            // visibility menu open state.
+            // https://github.com/streamlit/streamlit/pull/12233
             if (!showColumnVisibilityMenu) {
               setShowMenu({
                 columnIdx,


### PR DESCRIPTION
## Describe your changes
Fixes #12230 by preventing underlying column menu from opening.

Doesn't affect opening other column menus that are not underneath- the visibility menu closes when clicking outside, which enables the below segment to run without issues.

## GitHub Issue Link (if applicable)
- #12230

## Testing Plan
- Not sure how to directly test the interaction through the code because it relies on a specific mouse location, open to suggestions and comments

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.