### PR TITLE
[refactor] Light refactoring to clarify usage of height in full screen context.

### DIFF
--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -80,7 +80,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
 
   const {
     expanded: isFullScreen,
-    height,
+    height: fullScreenHeight,
     width: fullScreenWidth,
     expand,
     collapse,
@@ -112,7 +112,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
     isFullScreen,
     // Facet charts enter a loop when using the width from the StyledVegaLiteChartContainer.
     isFacet ? (fullScreenWidth ?? 0) : width,
-    height ?? 0
+    fullScreenHeight ?? 0
   )
 
   // This hook provides lifecycle functions for creating and removing the view.
@@ -144,7 +144,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
     finalizeView,
     spec,
     fullScreenWidth,
-    height,
+    fullScreenHeight,
     showData,
     containerRef,
   ])
@@ -172,7 +172,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
     return (
       <ReadOnlyGrid
         data={data ?? datasets[0]?.data}
-        height={height ?? chartHeight ?? undefined}
+        height={chartHeight ?? undefined}
         customToolbarActions={[
           <ToolbarAction
             key="show-chart"
@@ -192,7 +192,7 @@ const ArrowVegaLiteChart: FC<Props> = ({
   // the tooltip element is drawn outside of this component.
   return (
     <StyledToolbarElementContainer
-      height={height}
+      height={fullScreenHeight}
       useContainerWidth={element.useContainerWidth}
     >
       <Toolbar

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -166,7 +166,7 @@ function updateWidgetMgrState(
 
 export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
   const {
-    height: propsHeight,
+    height: fullScreenHeight,
     width: propsWidth,
     expanded: propsIsFullScreen,
   } = useRequiredContext(ElementFullscreenContext)
@@ -199,7 +199,7 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
     element,
     isFullScreen,
     shouldUseContainerWidth,
-    container: { height: propsHeight, width: propsWidth },
+    container: { height: fullScreenHeight, width: propsWidth },
     heightFallback:
       (viewState?.initialViewState as { height: number } | undefined)
         ?.height || theme.sizes.defaultMapHeight,

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -46,7 +46,7 @@ function GraphVizChart({
   const {
     expanded: isFullScreen,
     width,
-    height,
+    height: fullScreenHeight,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
@@ -81,7 +81,7 @@ function GraphVizChart({
   return (
     <StyledToolbarElementContainer
       width={width ?? 0}
-      height={height}
+      height={fullScreenHeight}
       useContainerWidth={isFullScreen || element.useContainerWidth}
     >
       <Toolbar

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -170,7 +170,7 @@ function ImageList({
   const {
     expanded: isFullScreen,
     width,
-    height,
+    height: fullScreenHeight,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
@@ -181,8 +181,8 @@ function ImageList({
 
   const imgStyle: CSSProperties = {}
 
-  if (height && isFullScreen) {
-    imgStyle.maxHeight = height
+  if (fullScreenHeight && isFullScreen) {
+    imgStyle.maxHeight = fullScreenHeight
     imgStyle.objectFit = "contain"
     // @see issue https://github.com/streamlit/streamlit/issues/10904
     // Ensure the image tries to fill the width to prevent sizeless SVGs from
@@ -213,7 +213,7 @@ function ImageList({
   return (
     <StyledToolbarElementContainer
       width={containerWidth}
-      height={height}
+      height={fullScreenHeight}
       useContainerWidth={isFullScreen}
       topCentered
     >

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -84,7 +84,7 @@ export function PlotlyChart({
   const {
     expanded: isFullScreen,
     width: elWidth,
-    height,
+    height: fullScreenHeight,
     expand,
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
@@ -310,7 +310,7 @@ export function PlotlyChart({
 
   if (isFullScreen) {
     calculatedWidth = width
-    calculatedHeight = height
+    calculatedHeight = fullScreenHeight
   } else if (calculatedHeight === undefined) {
     calculatedHeight = DEFAULT_PLOTLY_HEIGHT
   }

--- a/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
@@ -23,14 +23,10 @@ import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
 import { useFullscreen } from "./useFullscreen"
 
-type ElementFullscreenWrapperProps = PropsWithChildren<{
-  height?: number
-  width?: number
-}>
+type ElementFullscreenWrapperProps = PropsWithChildren
 
 const ElementFullscreenWrapper: FC<ElementFullscreenWrapperProps> = ({
   children,
-  height,
 }) => {
   const theme = useEmotionTheme()
   const { expanded, fullHeight, fullWidth, zoomIn, zoomOut } = useFullscreen()
@@ -39,12 +35,12 @@ const ElementFullscreenWrapper: FC<ElementFullscreenWrapperProps> = ({
   const fullscreenContextValue = useMemo(() => {
     return {
       width: expanded ? fullWidth : width,
-      height: expanded ? fullHeight : height,
+      height: expanded ? fullHeight : undefined,
       expanded,
       expand: zoomIn,
       collapse: zoomOut,
     }
-  }, [expanded, fullHeight, fullWidth, height, width, zoomIn, zoomOut])
+  }, [expanded, fullHeight, fullWidth, width, zoomIn, zoomOut])
 
   return (
     <ElementFullscreenContext.Provider value={fullscreenContextValue}>

--- a/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
@@ -34,10 +34,7 @@ import { TestAppWrapper, render as testUtilRender } from "~lib/test_util"
 const FullscreenHarness: FC<PropsWithChildren> = ({ children }) => {
   return (
     <TestAppWrapper>
-      {/* 500 is an arbitrary value for the width, as it's not actually used in the tests */}
-      <ElementFullscreenWrapper width={500}>
-        {children}
-      </ElementFullscreenWrapper>
+      <ElementFullscreenWrapper>{children}</ElementFullscreenWrapper>
     </TestAppWrapper>
   )
 }

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -158,7 +158,7 @@ function DataFrame({
     expand,
     collapse,
     width: containerWidth,
-    height: containerHeight,
+    height: fullScreenHeight,
   } = useRequiredContext(ElementFullscreenContext)
 
   const { isInHorizontalLayout } = useRequiredContext(FlexContext)
@@ -702,7 +702,7 @@ function DataFrame({
     numRows,
     usesGroupRow,
     containerWidth || 0,
-    containerHeight,
+    fullScreenHeight,
     isFullScreen,
     widthConfig,
     heightConfig


### PR DESCRIPTION
## Describe your changes

This is some preparatory refactoring for adding height to the chart elements that use the full screen wrapper. I noticed that height is only defined when in full screen mode since it doesn't seem to be drilled down anywhere so this just clarifies that in the codebase.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Adds some test coverage, but mainly relies on existing tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
