### PR TITLE
Make checkboxes for row selections have white background

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -1175,8 +1175,8 @@ function DataFrame({
               kind: "checkbox-visible",
               checkboxStyle: "square",
               theme: {
-                bgCell: gridTheme.glideTheme.bgHeader,
-                bgCellMedium: gridTheme.glideTheme.bgHeader,
+                bgCell: gridTheme.glideTheme.bgCell,
+                bgCellMedium: gridTheme.glideTheme.bgCell,
                 // Use a lighter color for the checkboxes in the row markers column,
                 // otherwise its a bit too prominent:
                 textMedium: gridTheme.glideTheme.textLight,
@@ -1242,8 +1242,8 @@ function DataFrame({
                 kind: "checkbox",
                 checkboxStyle: "square",
                 theme: {
-                  bgCell: gridTheme.glideTheme.bgHeader,
-                  bgCellMedium: gridTheme.glideTheme.bgHeader,
+                  bgCell: gridTheme.glideTheme.bgCell,
+                  bgCellMedium: gridTheme.glideTheme.bgCell,
                 },
               },
               rowSelectionMode: "multi",

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -1175,8 +1175,6 @@ function DataFrame({
               kind: "checkbox-visible",
               checkboxStyle: "square",
               theme: {
-                bgCell: gridTheme.glideTheme.bgCell,
-                bgCellMedium: gridTheme.glideTheme.bgCell,
                 // Use a lighter color for the checkboxes in the row markers column,
                 // otherwise its a bit too prominent:
                 textMedium: gridTheme.glideTheme.textLight,
@@ -1239,11 +1237,12 @@ function DataFrame({
                 tint: true,
               },
               rowMarkers: {
-                kind: "checkbox",
+                kind: "checkbox-visible",
                 checkboxStyle: "square",
                 theme: {
-                  bgCell: gridTheme.glideTheme.bgCell,
-                  bgCellMedium: gridTheme.glideTheme.bgCell,
+                  // Use a lighter color for the checkboxes in the row markers column,
+                  // otherwise its a bit too prominent:
+                  textMedium: gridTheme.glideTheme.textLight,
                 },
               },
               rowSelectionMode: "multi",


### PR DESCRIPTION
## Describe your changes

This make the checkbox column for row selection in `st.dataframe` have the normal white background. It also changes `st.data_editor` to use the same style for that column (white background, checkboxes always showing). 

**Before:**

<img width="729" height="430" alt="Screenshot 2025-08-16 at 00 19 12" src="https://github.com/user-attachments/assets/19834fa3-0a79-4b20-8193-2f81dbb0d92b" />


**After:**
<img width="737" height="434" alt="Screenshot 2025-08-16 at 00 18 45" src="https://github.com/user-attachments/assets/f46613d5-061b-4963-9cd2-5b1b9f2552f0" />


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
