### PR TITLE
Add numeric formatting to Metric value and delta

### DIFF
--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -35,6 +35,7 @@ import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { StyledWidgetLabelHelpInline } from "~lib/components/widgets/BaseWidget"
+import { formatNumber } from "~lib/components/widgets/DataFrame/columns"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 
@@ -312,6 +313,29 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
     }
   }, [chartData, color, theme, chartWidth, chartType, chartRef])
 
+  const numericBody = Number(body.replace(/,/g, "")) // remove commas if any
+  const formattedBody =
+    !Number.isNaN(numericBody) && Number.isFinite(numericBody)
+      ? formatNumber(
+          numericBody,
+          element.shortenNumbers ? "compact" : undefined,
+          4
+        ) // adjust precision as needed
+      : body
+
+  let formattedDelta: string | undefined
+  if (deltaExists) {
+    const numericDelta = Number(delta)
+    formattedDelta =
+      !Number.isNaN(numericDelta) && Number.isFinite(numericDelta)
+        ? formatNumber(
+            numericDelta,
+            element.shortenNumbers ? "compact" : undefined,
+            4
+          ) // adjust precision as needed
+        : delta
+  }
+
   return (
     <StyledMetricContainer
       className="stMetric"
@@ -333,8 +357,9 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
           )}
         </StyledMetricLabelText>
         <StyledMetricValueText data-testid="stMetricValue">
-          <StyledTruncateText> {body} </StyledTruncateText>
+          <StyledTruncateText>{formattedBody}</StyledTruncateText>
         </StyledMetricValueText>
+
         {deltaExists && (
           <StyledMetricDeltaText
             data-testid="stMetricDelta"
@@ -352,7 +377,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
                 margin={arrowMargin}
               />
             )}
-            <StyledTruncateText> {delta} </StyledTruncateText>
+            <StyledTruncateText>{formattedDelta}</StyledTruncateText>
           </StyledMetricDeltaText>
         )}
       </StyledMetricContent>

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -71,6 +71,7 @@ class MetricMixin:
         height: Height = "content",
         chart_data: OptionSequence[Any] | None = None,
         chart_type: Literal["line", "bar", "area"] = "line",
+        shorten_numbers: bool | int = False,
     ) -> DeltaGenerator:
         r"""Display a metric in big bold font, with an optional indicator of how the metric changed.
 
@@ -171,6 +172,10 @@ class MetricMixin:
         chart_type : "line", "bar", or "area"
             The type of sparkline chart to display. Defaults to line chart.
 
+        shorten_numbers : bool
+            Whether to shorten long numbers in the value and delta. If True,
+            it will shorten long numbers without showing decimals (e.g. 1234 to 1k)
+
         Examples
         --------
         **Example 1: Show a metric**
@@ -240,6 +245,10 @@ class MetricMixin:
         metric_proto.body = _parse_value(value)
         metric_proto.label = _parse_label(label)
         metric_proto.delta = _parse_delta(delta)
+
+        if shorten_numbers is True:
+            metric_proto.shorten_numbers = True
+
         metric_proto.show_border = border
         if help is not None:
             metric_proto.help = dedent(help)

--- a/proto/streamlit/proto/Metric.proto
+++ b/proto/streamlit/proto/Metric.proto
@@ -50,4 +50,5 @@ message Metric {
     AREA = 2;
   }
   ChartType chart_type = 10;
+  bool shorten_numbers = 11;
 }


### PR DESCRIPTION
## Describe your changes
Shorten numbers in st.metric #12229 

Added numeric formatting (shortening numers) to Metric values and delta indicators using the formatNumber utility in TypeScript.
Integrated `shorten_numbers` flag for compact display (e.g., 1200000 to 1.2M)
Updated Python backend (Metric element) and TS frontend (Metric component) for consistent formatting across the app.
`value` and `delta` fields use the same formatting logic for consistency.
`shorten_numbers` flag is sent from Python backend via the protobuf message to TS frontend.

<!-- If it's a visual change, please include a screenshot or video! -->
#### Sample code and output example
Sample Code where `shorten_numbers` is `True`
` 
import streamlit as st
st.metric(label="Revenue", value=1234567.89123, delta=45.6789, shorten_numbers= True)
`

#### Output:
Revenue

1.2M
46

Sample Code when `shorten_numbers` is `False`
`
import streamlit as st
st.metric(label="Revenue", value=1234567.89123, delta=45.6789, shorten_numbers= False) 
`

#### Output:
Revenue

1234567.8912
45.6789

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/12229

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

Pre-existing unit tests on formatNumber and Metric components ensure numeric formatting correctness. No additional manual tests required.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
