### PR TITLE
Allow OAuth redirect_uri to reference current port

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -19,6 +19,7 @@ import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
+from urllib.parse import urlparse
 
 from streamlit import config
 from streamlit.errors import StreamlitAuthError
@@ -92,8 +93,8 @@ def get_signing_secret() -> str:
 
 
 def get_secrets_auth_section() -> AttrDict:
-    auth_section = AttrDict({})
     """Get the 'auth' section of the secrets.toml."""
+    auth_section = AttrDict({})
     if secrets_singleton.load_if_toml_exists():
         auth_section = cast("AttrDict", secrets_singleton.get("auth", AttrDict({})))
 
@@ -123,6 +124,28 @@ def get_expose_tokens_config() -> list[str]:
         )
 
     return res
+
+
+def get_redirect_uri(auth_section: AttrDict) -> str | None:
+    """Get the redirect_uri from auth_section - filling in port number if needed."""
+
+    if "redirect_uri" not in auth_section:
+        return None
+
+    redirect_uri = auth_section["redirect_uri"]
+    if "{port}" in redirect_uri:
+        redirect_uri = redirect_uri.replace(
+            "{port}", str(config.get_option("server.port"))
+        )
+
+    try:
+        redirect_uri_parsed = urlparse(redirect_uri)
+    except ValueError:
+        raise StreamlitAuthError(
+            f"Invalid redirect_uri: {redirect_uri}. Please check your configuration."
+        )
+
+    return redirect_uri_parsed.geturl()
 
 
 def encode_provider_token(provider: str) -> str:

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -132,7 +132,7 @@ def get_redirect_uri(auth_section: AttrDict) -> str | None:
     if "redirect_uri" not in auth_section:
         return None
 
-    redirect_uri = auth_section["redirect_uri"]
+    redirect_uri: str = auth_section["redirect_uri"]
     if "{port}" in redirect_uri:
         redirect_uri = redirect_uri.replace(
             "{port}", str(config.get_option("server.port"))

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -42,7 +42,7 @@ def create_oauth_client(provider: str) -> tuple[TornadoOAuth2App, str]:
     """Create an OAuth client for the given provider based on secrets.toml configuration."""
     auth_section = get_secrets_auth_section()
     if auth_section:
-        redirect_uri = get_redirect_uri(auth_section)
+        redirect_uri = get_redirect_uri(auth_section) or "/"
         config = auth_section.to_dict()
     else:
         config = {}

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -23,6 +23,7 @@ from streamlit.auth_util import (
     clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
+    get_redirect_uri,
     get_secrets_auth_section,
     set_cookie_with_chunks,
 )
@@ -41,7 +42,7 @@ def create_oauth_client(provider: str) -> tuple[TornadoOAuth2App, str]:
     """Create an OAuth client for the given provider based on secrets.toml configuration."""
     auth_section = get_secrets_auth_section()
     if auth_section:
-        redirect_uri = auth_section.get("redirect_uri", None)
+        redirect_uri = get_redirect_uri(auth_section)
         config = auth_section.to_dict()
     else:
         config = {}
@@ -253,7 +254,7 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         redirect_uri = None
         auth_section = get_secrets_auth_section()
         if auth_section:
-            redirect_uri = auth_section.get("redirect_uri", None)
+            redirect_uri = get_redirect_uri(auth_section)
 
         if not redirect_uri:
             return None

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -28,10 +28,12 @@ from streamlit.auth_util import (
     clear_cookie_and_chunks,
     get_cookie_with_chunks,
     get_expose_tokens_config,
+    get_redirect_uri,
     get_signing_secret,
     set_cookie_with_chunks,
 )
 from streamlit.errors import StreamlitAuthError
+from streamlit.runtime.secrets import AttrDict
 
 # Simulates realistic Tornado cookie signing overhead (~100 bytes for signature, timestamp, etc.)
 MOCK_SIGNING_OVERHEAD = 100
@@ -46,7 +48,6 @@ def create_realistic_signed_value(name: str, value: str) -> bytes:
     # Simulate: "2|1:0|10:timestamp|{name_len}:{name}|{val_len}:{base64_value}||{signature}" noqa: ERA001
     overhead = "x" * MOCK_SIGNING_OVERHEAD
     return f"{overhead}{base64_value}".encode()
-
 
 CONFIG_MOCK: dict[str, Any] = {}
 
@@ -99,6 +100,26 @@ class AuthUtilTest(unittest.TestCase):
         """Get the cookie signing secret from the configuration or secrets.toml."""
         x = get_signing_secret()
         assert x == "your_cookie_secret_here"
+
+    def test_get_redirect_uri_verbatim(self):
+        """Test get_redirect_uri returns the existing redirect_uri when present."""
+        auth_section = AttrDict({"redirect_uri": "https://example.com/callback"})
+        result = get_redirect_uri(auth_section)
+        assert result == "https://example.com/callback"
+
+    @patch(
+        "streamlit.auth_util.config",
+        MagicMock(
+            get_option=MagicMock(return_value=8502),
+        ),
+    )
+    def test_get_redirect_uri_with_port_placeholder(self):
+        """Test get_redirect_uri substitutes {port} in redirect_uri when present."""
+        auth_section = AttrDict(
+            {"redirect_uri": "http://localhost:{port}/oauth2callback"}
+        )
+        result = get_redirect_uri(auth_section)
+        assert result == "http://localhost:8502/oauth2callback"
 
 
 class ExposeTokensConfigTest(unittest.TestCase):

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -49,6 +49,7 @@ def create_realistic_signed_value(name: str, value: str) -> bytes:
     overhead = "x" * MOCK_SIGNING_OVERHEAD
     return f"{overhead}{base64_value}".encode()
 
+
 CONFIG_MOCK: dict[str, Any] = {}
 
 SECRETS_MOCK = {
@@ -120,6 +121,12 @@ class AuthUtilTest(unittest.TestCase):
         )
         result = get_redirect_uri(auth_section)
         assert result == "http://localhost:8502/oauth2callback"
+
+    def test_get_redirect_uri_not_present(self):
+        """Test get_redirect_uri returns None when redirect_uri is not in auth_section."""
+        auth_section = AttrDict({"client_id": "some_client_id"})
+        result = get_redirect_uri(auth_section)
+        assert result is None
 
 
 class ExposeTokensConfigTest(unittest.TestCase):


### PR DESCRIPTION
## Describe your changes

Changed functionality so that if redirect_uri hostname part ends with a colon, it adds the current running port after it. 
This allows multiple streamlit dashboards to run on the same host and share a secrets.toml file - which is especially useful in the local development environment, but might also have uses in some deployment situations

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/12249

## Testing Plan
- Added unit tests
- Hopefully no additional tests needed as behavior did not change unless redirect_uri has hostname ending in a colon. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
