### PR TITLE
[fix] attempt to stabilize st_pyplot_test width snapshots

### DIFF
--- a/e2e_playwright/st_pyplot_test.py
+++ b/e2e_playwright/st_pyplot_test.py
@@ -61,12 +61,15 @@ def test_width_parameter(app: Page, assert_snapshot: ImageCompareFunction):
     wait_for_all_images_to_be_loaded(app)
 
     content_pyplot = pyplot_elements.nth(8)
+    expect(content_pyplot).to_be_visible()
     assert_snapshot(content_pyplot, name="st_pyplot-width_content")
 
     stretch_pyplot = pyplot_elements.nth(9)
+    expect(stretch_pyplot).to_be_visible()
     assert_snapshot(stretch_pyplot, name="st_pyplot-width_stretch")
 
     pixel_pyplot = pyplot_elements.nth(10)
+    expect(pixel_pyplot).to_be_visible()
     assert_snapshot(pixel_pyplot, name="st_pyplot-width_pixel")
 
 

--- a/e2e_playwright/st_pyplot_test.py
+++ b/e2e_playwright/st_pyplot_test.py
@@ -56,10 +56,9 @@ def test_shows_deprecation_warning(app: Page):
 
 def test_width_parameter(app: Page, assert_snapshot: ImageCompareFunction):
     """Test the new width parameter options: content, stretch, and pixel values."""
-    # Wait for all images to be fully loaded before taking snapshots
-    wait_for_all_images_to_be_loaded(app)
-
     pyplot_elements = app.get_by_test_id("stImage").locator("img")
+    expect(pyplot_elements).to_have_count(11)
+    wait_for_all_images_to_be_loaded(app)
 
     content_pyplot = pyplot_elements.nth(8)
     assert_snapshot(content_pyplot, name="st_pyplot-width_content")

--- a/e2e_playwright/st_pyplot_test.py
+++ b/e2e_playwright/st_pyplot_test.py
@@ -22,6 +22,7 @@ from e2e_playwright.shared.app_utils import (
     expect_warning,
     wait_for_all_images_to_be_loaded,
 )
+from e2e_playwright.shared.react18_utils import take_stable_snapshot
 
 
 def test_displays_a_pyplot_figures(
@@ -62,15 +63,21 @@ def test_width_parameter(app: Page, assert_snapshot: ImageCompareFunction):
 
     content_pyplot = pyplot_elements.nth(8)
     expect(content_pyplot).to_be_visible()
-    assert_snapshot(content_pyplot, name="st_pyplot-width_content")
+    take_stable_snapshot(
+        app, content_pyplot, assert_snapshot, name="st_pyplot-width_content"
+    )
 
     stretch_pyplot = pyplot_elements.nth(9)
     expect(stretch_pyplot).to_be_visible()
-    assert_snapshot(stretch_pyplot, name="st_pyplot-width_stretch")
+    take_stable_snapshot(
+        app, stretch_pyplot, assert_snapshot, name="st_pyplot-width_stretch"
+    )
 
     pixel_pyplot = pyplot_elements.nth(10)
     expect(pixel_pyplot).to_be_visible()
-    assert_snapshot(pixel_pyplot, name="st_pyplot-width_pixel")
+    take_stable_snapshot(
+        app, pixel_pyplot, assert_snapshot, name="st_pyplot-width_pixel"
+    )
 
 
 def test_check_top_level_class(app: Page):


### PR DESCRIPTION
## Describe your changes

The new snapshot tests for width have been flaky, this is an attempt to stabilize them. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Test only.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
