### PR TITLE
[fix] Log deprecation warning for use_container_width in `st.dataframe`

### DIFF
--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -29,6 +29,10 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from streamlit import dataframe_util
+from streamlit.deprecation_util import (
+    make_deprecated_name_warning,
+    show_deprecation_warning,
+)
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ColumnConfigMappingInput,
@@ -625,6 +629,17 @@ class ArrowMixin:
             )
 
         if use_container_width is not None:
+            show_deprecation_warning(
+                make_deprecated_name_warning(
+                    "use_container_width",
+                    "width",
+                    "2025-12-31",
+                    "For `use_container_width=True`, use `width='stretch'`. "
+                    "For `use_container_width=False`, use `width='content'`.",
+                    include_st_prefix=False,
+                ),
+                show_in_browser=False,
+            )
             if use_container_width:
                 width = "stretch"
             elif not isinstance(width, int):


### PR DESCRIPTION
## Describe your changes

I noticed this was missed in [this PR](https://github.com/streamlit/streamlit/pull/11930). 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python) ✅ 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
