### PR TITLE
refactor: deprecate kwargs in st.plotly_chart and add config dict instead

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -316,6 +316,7 @@ class PlotlyMixin:
             "box",
             "lasso",
         ),
+        config: dict | None = None,
         **kwargs: Any,
     ) -> DeltaGenerator | PlotlyState:
         """Display an interactive Plotly chart.
@@ -415,6 +416,12 @@ class PlotlyMixin:
 
             All selections modes are activated by default.
 
+        config : dict or None
+            A dictionary of Plotly configuration options. This is passed to
+            Plotly's ``plot()`` function. For more information about Plotly
+            configuration options, see Plotly's documentation on `Configuration
+            in Python <https://plotly.com/python/configuration-options/>`_.
+
         **kwargs
             Additional arguments accepted by Plotly's ``plot()`` function.
 
@@ -422,6 +429,9 @@ class PlotlyMixin:
             options. For more information about Plotly configuration options,
             see Plotly's documentation on `Configuration in Python
             <https://plotly.com/python/configuration-options/>`_.
+
+            .. deprecated:: 1.48.2
+               The keyword arguments are deprecated. use ``config`` instead.
 
         Returns
         -------
@@ -542,8 +552,10 @@ class PlotlyMixin:
         plotly_chart_proto.theme = theme or ""
         plotly_chart_proto.form_id = current_form_id(self.dg)
 
-        config = dict(kwargs.get("config", {}))
+        if not config:
+            config = dict(kwargs.get("config", {}))
         # Copy over some kwargs to config dict. Plotly does the same in plot().
+        # TODO: Remove this once we remove the kwargs support.
         config.setdefault("showLink", kwargs.get("show_link", False))
         config.setdefault("linkText", kwargs.get("link_text", False))
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -505,7 +505,7 @@ class PlotlyMixin:
 
         if kwargs:
             show_deprecation_warning(
-                "The keyword arguments has been deprecated and will be removed "
+                "The keyword arguments have been deprecated and will be removed "
                 "in a future release. Use `config` instead to specify Plotly "
                 "configuration options."
             )

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -316,7 +316,7 @@ class PlotlyMixin:
             "box",
             "lasso",
         ),
-        config: dict | None = None,
+        config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> DeltaGenerator | PlotlyState:
         """Display an interactive Plotly chart.
@@ -418,7 +418,7 @@ class PlotlyMixin:
 
         config : dict or None
             A dictionary of Plotly configuration options. This is passed to
-            Plotly's ``plot()`` function. For more information about Plotly
+            Plotly's ``show()`` function. For more information about Plotly
             configuration options, see Plotly's documentation on `Configuration
             in Python <https://plotly.com/python/configuration-options/>`_.
 
@@ -503,11 +503,11 @@ class PlotlyMixin:
         # for their main parameter. I don't like the name, but it's best to
         # keep it in sync with what Plotly calls it.
 
-        if "sharing" in kwargs:
+        if kwargs:
             show_deprecation_warning(
-                "The `sharing` parameter has been deprecated and will be removed "
-                "in a future release. Plotly charts will always be rendered using "
-                "Streamlit's offline mode."
+                "The keyword arguments has been deprecated and will be removed "
+                "in a future release. Use `config` instead to specify Plotly "
+                "configuration options."
             )
 
         if theme not in ["streamlit", None]:
@@ -552,13 +552,7 @@ class PlotlyMixin:
         plotly_chart_proto.theme = theme or ""
         plotly_chart_proto.form_id = current_form_id(self.dg)
 
-        if config is None:
-            config = dict(kwargs.get("config", {}))
-            # Copy over some kwargs to config dict. Plotly does the same in plot().
-            # TODO: Remove this once we remove the kwargs support.
-            config.setdefault("showLink", kwargs.get("show_link", False))
-            config.setdefault("linkText", kwargs.get("link_text", False))
-
+        config = config or {}
         plotly_chart_proto.spec = plotly.io.to_json(figure, validate=False)
         plotly_chart_proto.config = json.dumps(config)
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -552,12 +552,14 @@ class PlotlyMixin:
         plotly_chart_proto.theme = theme or ""
         plotly_chart_proto.form_id = current_form_id(self.dg)
 
+
         if config is None:
             config = dict(kwargs.get("config", {}))
-        # Copy over some kwargs to config dict. Plotly does the same in plot().
-        # TODO: Remove this once we remove the kwargs support.
-        config.setdefault("showLink", kwargs.get("show_link", False))
-        config.setdefault("linkText", kwargs.get("link_text", False))
+            # Copy over some kwargs to config dict. Plotly does the same in plot().
+            # TODO: Remove this once we remove the kwargs support.
+            config.setdefault("showLink", kwargs.get("show_link", False))
+            config.setdefault("linkText", kwargs.get("link_text", False))
+
 
         plotly_chart_proto.spec = plotly.io.to_json(figure, validate=False)
         plotly_chart_proto.config = json.dumps(config)

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -552,7 +552,7 @@ class PlotlyMixin:
         plotly_chart_proto.theme = theme or ""
         plotly_chart_proto.form_id = current_form_id(self.dg)
 
-        if not config:
+        if config is None:
             config = dict(kwargs.get("config", {}))
         # Copy over some kwargs to config dict. Plotly does the same in plot().
         # TODO: Remove this once we remove the kwargs support.

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -552,14 +552,12 @@ class PlotlyMixin:
         plotly_chart_proto.theme = theme or ""
         plotly_chart_proto.form_id = current_form_id(self.dg)
 
-
         if config is None:
             config = dict(kwargs.get("config", {}))
             # Copy over some kwargs to config dict. Plotly does the same in plot().
             # TODO: Remove this once we remove the kwargs support.
             config.setdefault("showLink", kwargs.get("show_link", False))
             config.setdefault("linkText", kwargs.get("link_text", False))
-
 
         plotly_chart_proto.spec = plotly.io.to_json(figure, validate=False)
         plotly_chart_proto.config = json.dumps(config)

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -289,6 +289,6 @@ class PyDeckTest(DeltaGeneratorTestCase):
         # Get the second to last element, which should be deprecation warning
         el = self.get_delta_from_queue(-2).new_element
         assert (
-            "has been deprecated and will be removed in a future release"
+            "have been deprecated and will be removed in a future release"
             in el.alert.body
         )

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -264,7 +264,22 @@ class PyDeckTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.plotly_chart(data, on_select="rerun", selection_mode=["invalid", "box"])
 
-    def test_show_deprecation_warning_for_sharing(self):
+    def test_plotly_config(self):
+        """Test st.plotly_chart config dict parameter."""
+        import plotly.graph_objs as go
+
+        trace0 = go.Scatter(x=[1, 2, 3, 4], y=[10, 15, 13, 17])
+        data = [trace0]
+
+        config = {"displayModeBar": False, "responsive": True}
+        st.plotly_chart(data, config=config)
+
+        el = self.get_delta_from_queue().new_element
+        assert el.plotly_chart.config != ""
+        assert '"displayModeBar": false' in el.plotly_chart.config
+        assert '"responsive": true' in el.plotly_chart.config
+
+    def test_show_deprecation_warning_for_kwargs(self):
         import plotly.graph_objs as go
 
         trace0 = go.Scatter(x=[1, 2, 3, 4], y=[10, 15, 13, 17])


### PR DESCRIPTION
## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->

mark the `**kwargs` of `st.plotly_chart` as deprecated, and add a new `config` argument to directly pass to `plot()`

## GitHub Issue Link (if applicable)

- Closes #12280 

## Testing Plan

This is a refactor and doesn't break the existing e2e tests for `st.plotly_chart`, so no new tests are needed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
