### PR TITLE
[refactor] Simplification of `st.graphviz_chart` rendering logic

### DIFF
--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -26,8 +26,6 @@ def click_fullscreen(app: Page):
     fullscreen_button = app.get_by_role("button", name="Fullscreen").nth(0)
     expect(fullscreen_button).to_be_visible()
     fullscreen_button.click()
-    # Wait for the animation to finish
-    app.wait_for_timeout(1000)
 
 
 def test_initial_setup(app: Page):
@@ -62,12 +60,14 @@ def test_first_graph_fullscreen(app: Page, assert_snapshot: ImageCompareFunction
     expect(first_graph_svg).to_have_attribute("width", "79pt")
     first_graph_svg.hover()
 
+    # Get the fullscreen wrapper element
+    fullscreen_frame = app.get_by_test_id("stFullScreenFrame").nth(0)
+
     # Enter fullscreen
     click_fullscreen(app)
 
-    # The width and height unset on the element on fullscreen
-    expect(first_graph_svg).not_to_have_attribute("width", "79pt")
-    expect(first_graph_svg).not_to_have_attribute("height", "116pt")
+    # Wait for fullscreen mode to be active by checking the position style
+    expect(fullscreen_frame).to_have_css("position", "fixed")
 
     def check_dimensions() -> bool:
         svg_dimensions = first_graph_svg.bounding_box()
@@ -88,12 +88,18 @@ def test_first_graph_after_exit_fullscreen(
     expect(first_graph_svg).to_have_attribute("width", "79pt")
     first_graph_svg.hover()
 
-    # Enter and exit fullscreen
+    # Get the fullscreen wrapper element
+    fullscreen_frame = app.get_by_test_id("stFullScreenFrame").nth(0)
+
+    # Enter fullscreen
     click_fullscreen(app)
-    # in fullscreen mode, the width attribute is removed. Wait for this to
-    # avoid flakiness.
-    expect(first_graph_svg).not_to_have_attribute("width", "79pt")
+    # Wait for fullscreen mode to be active by checking the position style
+    expect(fullscreen_frame).to_have_css("position", "fixed")
+
+    # Exit fullscreen
     click_fullscreen(app)
+    # Wait for fullscreen mode to be exited by checking position is back to static
+    expect(fullscreen_frame).to_have_css("position", "static")
 
     expect(first_graph_svg).to_have_attribute("width", "79pt")
     expect(first_graph_svg).to_have_attribute("height", "116pt")

--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -26,6 +26,8 @@ def click_fullscreen(app: Page):
     fullscreen_button = app.get_by_role("button", name="Fullscreen").nth(0)
     expect(fullscreen_button).to_be_visible()
     fullscreen_button.click()
+    # Wait for the animation to finish
+    app.wait_for_timeout(1000)
 
 
 def test_initial_setup(app: Page):

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -16,7 +16,6 @@
 
 import React, { memo, ReactElement, useEffect } from "react"
 
-import { select } from "d3"
 import { Engine, graphviz } from "d3-graphviz"
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -69,14 +69,6 @@ function GraphVizChart({
         .scale(1)
         .engine(element.engine as Engine)
         .renderDot(element.spec)
-
-      if (isFullScreen || shouldUseContainerWidth) {
-        const node = select(`#${chartId} > svg`).node() as SVGGraphicsElement
-        // We explicitly remove width and height to let CSS and the SVG viewBox
-        // define its dimensions
-        node.removeAttribute("width")
-        node.removeAttribute("height")
-      }
     } catch (error) {
       LOG.error(error)
     }


### PR DESCRIPTION
## Describe your changes

This logic was originally added [here to fix a bug ](https://github.com/streamlit/streamlit/pull/7398)with fullscreen rendering. While working on height for `st.graphviz_chart`, I have found it does not seem to be necessary any longer, I have not noticed the described issues after removing the code. This may be because of the changes that have been made to `StyledElementContainer` including the min-width styling which was added to fix issues with returning from full screen for other elements. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Existing tests. There is a snapshot test that covers the original bug. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
