### PR TITLE
[Prototype] Make widget font size smaller

### DIFF
--- a/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
@@ -19,7 +19,7 @@ import styled, { CSSObject } from "@emotion/styled"
 import { EmotionTheme } from "~lib/theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
-  fontSize: theme.fontSizes.md,
+  fontSize: theme.fontSizes.sm,
   fontFamily: theme.genericFonts.bodyFont,
   lineHeight: theme.lineHeights.small,
   captionSide: "bottom",

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
@@ -25,6 +25,7 @@ import { StyledCode } from "~lib/components/elements/CodeBlock/styled-components
 import AlertContainer, { Kind } from "~lib/components/shared/AlertContainer"
 import { StyledStackTrace } from "~lib/components/shared/ErrorElement/styled-components"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
+import styled from "@emotion/styled"
 import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { notNullOrUndefined } from "~lib/util/utils"
 
@@ -62,6 +63,10 @@ function isNonEmptyString(value: string | null | undefined): boolean {
   return notNullOrUndefined(value) && value !== ""
 }
 
+const StyledExceptionMarkdown = styled.div(({ theme }) => ({
+  fontSize: theme.fontSizes.md,
+}))
+
 function ExceptionMessage({
   type,
   message,
@@ -77,14 +82,18 @@ function ExceptionMessage({
     if (type.length !== 0) {
       markdown = `**${type}**: ${markdown}`
     }
-    return <StreamlitMarkdown source={markdown} allowHTML={false} />
+    return (
+      <StyledExceptionMarkdown>
+        <StreamlitMarkdown source={markdown} allowHTML={false} />
+      </StyledExceptionMarkdown>
+    )
   }
   return (
-    <>
+    <StyledExceptionMarkdown>
       <StyledMessageType>{type}</StyledMessageType>
       {type.length !== 0 && ": "}
       {isNonEmptyString(message) ? message : null}
-    </>
+    </StyledExceptionMarkdown>
   )
 }
 

--- a/frontend/lib/src/components/elements/ExceptionElement/styled-components.ts
+++ b/frontend/lib/src/components/elements/ExceptionElement/styled-components.ts
@@ -29,6 +29,7 @@ export const StyledMessageType = styled.span(({ theme }) => ({
 
 export const StyledStackTraceTitle = styled.div(({ theme }) => ({
   marginBottom: theme.spacing.sm,
+  fontSize: theme.fontSizes.md,
 }))
 
 // This extra div makes sure that we also have a padding on the right side of the stack

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -265,12 +265,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
             {showUserIcon && <ExpanderIcon icon={element.icon} />}
 
             <StyledSummaryLabelWrapper>
-              <StreamlitMarkdown
-                source={label}
-                allowHTML={false}
-                isLabel
-                largerLabel
-              />
+              <StreamlitMarkdown source={label} allowHTML={false} isLabel />
             </StyledSummaryLabelWrapper>
           </StyledSummaryHeading>
         </StyledSummary>

--- a/frontend/lib/src/components/elements/Expander/styled-components.ts
+++ b/frontend/lib/src/components/elements/Expander/styled-components.ts
@@ -87,7 +87,7 @@ export const StyledSummary = styled.summary<StyledSummaryProps>(
     "&:focus-visible": {
       boxShadow: `0 0 0 0.2rem ${transparentize(theme.colors.primary, 0.5)}`,
     },
-    fontSize: "inherit",
+    fontSize: theme.fontSizes.sm,
     paddingLeft: theme.spacing.md,
     paddingRight: theme.spacing.md,
     paddingTop: theme.spacing.twoXS,

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -68,7 +68,11 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           rel="noreferrer"
           aria-disabled={element.disabled}
         >
-          <DynamicButtonLabel icon={element.icon} label={element.label} />
+          <DynamicButtonLabel
+            icon={element.icon}
+            label={element.label}
+            useSmallerFont
+          />
         </BaseLinkButton>
       </BaseButtonTooltip>
     </Box>

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -81,6 +81,7 @@ export const StyledBaseLinkButton = styled.a<RequiredBaseLinkButtonProps>(
       minHeight: theme.sizes.minElementHeight,
       margin: 0,
       lineHeight: theme.lineHeights.base,
+      fontSize: theme.fontSizes.sm,
       color: theme.colors.primary,
       textDecoration: "none",
       width: containerWidth ? "100%" : "auto",

--- a/frontend/lib/src/components/elements/PageLink/PageLink.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.tsx
@@ -90,7 +90,6 @@ function PageLink(props: Readonly<Props>): ReactElement {
                 allowHTML={false}
                 isLabel
                 boldLabel={isCurrentPage}
-                largerLabel
                 disableLinks
               />
             </StyledNavLinkText>

--- a/frontend/lib/src/components/elements/PageLink/styled-components.ts
+++ b/frontend/lib/src/components/elements/PageLink/styled-components.ts
@@ -90,6 +90,7 @@ export interface StyledNavLinkTextProps {
 
 export const StyledNavLinkText = styled.span<StyledNavLinkTextProps>(
   ({ disabled, theme }) => ({
+    fontSize: theme.fontSizes.sm,
     color: theme.colors.bodyText,
     overflow: "hidden",
     whiteSpace: "nowrap",

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -144,7 +144,11 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               containerWidth={true}
               onClick={() => setOpen(!open)}
             >
-              <DynamicButtonLabel icon={element.icon} label={element.label} />
+              <DynamicButtonLabel
+                icon={element.icon}
+                label={element.label}
+                useSmallerFont
+              />
               <StyledPopoverButtonIcon>
                 <StyledIcon
                   as={open ? ExpandLess : ExpandMore}

--- a/frontend/lib/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.tsx
@@ -72,7 +72,11 @@ function Spinner({ element }: Readonly<SpinnerProps>): ReactElement {
       <StyledSpinnerContainer>
         <StyledSpinnerIcon size="base" margin="0 md 0 0" padding="0" />
         <StyledSpinnerText>
-          <StreamlitMarkdown source={element.text} allowHTML={false} />
+          <StreamlitMarkdown
+            source={element.text}
+            allowHTML={false}
+            inheritFont
+          />
           {showTime && (
             <StyledSpinnerTimeText>
               {formatTime(elapsedTime)}

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -41,6 +41,7 @@ export const StyledSpinnerText = styled.div(({ theme }) => ({
   display: "flex",
   gap: theme.spacing.sm,
   alignItems: "baseline",
+  fontSize: theme.fontSizes.sm,
 }))
 
 // TODO: Maybe move this to `theme/consts.ts`, see

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -99,7 +99,7 @@ export const StyledBaseButton = styled.button<RequiredBaseButtonProps>(
       margin: theme.spacing.none,
       lineHeight: theme.lineHeights.base,
       textTransform: "none",
-      fontSize: "inherit",
+      fontSize: theme.fontSizes.sm,
       fontFamily: "inherit",
       color: "inherit",
       width: containerWidth ? "100%" : "auto",
@@ -248,8 +248,8 @@ const StyledButtonGroupBaseButton = styled(
     fontSize: theme.fontSizes.sm,
     lineHeight: theme.lineHeights.base,
     fontWeight: theme.fontWeights.normal,
-    height: theme.sizes.largeLogoHeight,
-    minHeight: theme.sizes.largeLogoHeight,
+    height: theme.sizes.minElementHeight,
+    minHeight: theme.sizes.minElementHeight,
     maxWidth: theme.sizes.contentMaxWidth,
 
     // show pills with long text in single line and use ellipsis for overflow

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -218,6 +218,7 @@ const Selectbox: React.FC<Props> = ({
             style: () => ({
               lineHeight: theme.lineHeights.inputWidget,
               fontWeight: theme.fontWeights.normal,
+              fontSize: theme.fontSizes.sm,
             }),
           },
           Dropdown: { component: VirtualDropdown },
@@ -268,6 +269,7 @@ const Selectbox: React.FC<Props> = ({
               paddingLeft: theme.spacing.md,
               paddingBottom: theme.spacing.sm,
               paddingTop: theme.spacing.sm,
+              fontSize: theme.fontSizes.sm,
             }),
           },
           Input: {
@@ -282,6 +284,7 @@ const Selectbox: React.FC<Props> = ({
             },
             style: () => ({
               lineHeight: theme.lineHeights.inputWidget,
+              fontSize: theme.fontSizes.sm,
             }),
           },
           // Nudge the dropdown menu by 1px so the focus state doesn't get cut off
@@ -301,6 +304,7 @@ const Selectbox: React.FC<Props> = ({
             style: () => ({
               // remove margin from select value so that there is no jumpb, e.g. when pressing backspace on a selected option and removing a character.
               marginLeft: theme.spacing.none,
+              fontSize: theme.fontSizes.sm,
             }),
           },
           SelectArrow: {

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -218,12 +218,7 @@ function Radio({
               },
             }}
           >
-            <StreamlitMarkdown
-              source={option}
-              allowHTML={false}
-              isLabel
-              largerLabel
-            />
+            <StreamlitMarkdown source={option} allowHTML={false} isLabel />
             {hasCaptions && (
               <StreamlitMarkdown
                 source={spacerNeeded(captions[index])}

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -61,7 +61,11 @@ function Button(props: Props): ReactElement {
             widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
           }
         >
-          <DynamicButtonLabel icon={element.icon} label={element.label} />
+          <DynamicButtonLabel
+            icon={element.icon}
+            label={element.label}
+            useSmallerFont
+          />
         </BaseButton>
       </BaseButtonTooltip>
     </Box>

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -438,6 +438,7 @@ function ChatInput({
                   },
                   style: {
                     fontWeight: theme.fontWeights.normal,
+                    fontSize: theme.fontSizes.sm,
                     lineHeight: theme.lineHeights.inputWidget,
                     "::placeholder": {
                       color: theme.colors.fadedText60,

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -216,7 +216,6 @@ function Checkbox({
             source={element.label}
             allowHTML={false}
             isLabel
-            largerLabel
           />
           {element.help && (
             <StyledWidgetLabelHelpInline color={color}>

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -96,7 +96,7 @@ function DownloadButton(props: Props): ReactElement {
           onClick={handleDownloadClick}
           containerWidth={true}
         >
-          <DynamicButtonLabel icon={icon} label={label} />
+          <DynamicButtonLabel icon={icon} label={label} useSmallerFont />
         </BaseButton>
       </BaseButtonTooltip>
     </div>

--- a/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
@@ -63,6 +63,7 @@ export const StyledFileDropzoneInstructionsFileUploaderIcon = styled.span(
 export const StyledFileDropzoneInstructionsText = styled.span<{
   disabled?: boolean
 }>(({ theme, disabled }) => ({
+  fontSize: theme.fontSizes.sm,
   color: disabled ? theme.colors.fadedText40 : theme.colors.bodyText,
 }))
 
@@ -123,6 +124,7 @@ export const StyledUploadedFileName = styled.div<{ disabled?: boolean }>(
   ({ theme, disabled }) => ({
     marginRight: theme.spacing.sm,
     marginBottom: theme.spacing.twoXS,
+    fontSize: theme.fontSizes.sm,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -374,7 +374,7 @@ const Multiselect: FC<Props> = props => {
                       borderTopRightRadius: theme.radii.md,
                       borderBottomRightRadius: theme.radii.md,
                       borderBottomLeftRadius: theme.radii.md,
-                      fontSize: theme.fontSizes.md,
+                      fontSize: theme.fontSizes.sm,
                       paddingLeft: theme.spacing.sm,
                       marginLeft: theme.spacing.none,
                       marginRight: theme.spacing.sm,

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -418,6 +418,7 @@ const NumberInput: React.FC<Props> = ({
               },
               style: {
                 fontWeight: theme.fontWeights.normal,
+                fontSize: theme.fontSizes.sm,
                 lineHeight: theme.lineHeights.inputWidget,
                 // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
                 paddingRight: theme.spacing.sm,

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -246,6 +246,7 @@ const TextArea: FC<Props> = ({
           Input: {
             style: {
               fontWeight: theme.fontWeights.normal,
+              fontSize: theme.fontSizes.sm,
               lineHeight: theme.lineHeights.inputWidget,
               // The default height of the text area is calculated to perfectly fit 3 lines of text.
               height: isAutoHeight ? autoExpandHeight : inputHeight,

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -195,6 +195,7 @@ function TextInput({
           Input: {
             style: {
               fontWeight: theme.fontWeights.normal,
+              fontSize: theme.fontSizes.sm,
               // Issue: https://github.com/streamlit/streamlit/issues/2495
               // The input won't shrink in Firefox,
               // unless the line below is provided.

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -106,12 +106,14 @@ function TimeInput({
               paddingLeft: theme.spacing.md,
               paddingBottom: theme.spacing.sm,
               paddingTop: theme.spacing.sm,
+              fontSize: theme.fontSizes.sm,
             }),
           },
 
           SingleValue: {
             style: {
               fontWeight: theme.fontWeights.normal,
+              fontSize: theme.fontSizes.sm,
             },
             props: {
               "data-testid": "stTimeInputTimeDisplay",

--- a/frontend/lib/src/theme/createBaseUiTheme.ts
+++ b/frontend/lib/src/theme/createBaseUiTheme.ts
@@ -91,7 +91,7 @@ const createBaseUiThemeOverrides = (
 
   const fontStyles = {
     fontFamily: genericFonts.bodyFont,
-    fontSize: fontSizes.md,
+    fontSize: fontSizes.sm,
     fontSizeSm: fontSizes.sm,
     fontWeight: "normal",
     lineHeight: lineHeights.base,

--- a/frontend/lib/src/theme/primitives/sizes.ts
+++ b/frontend/lib/src/theme/primitives/sizes.ts
@@ -31,7 +31,7 @@ export const sizes = {
   // Used for checkboxes/toggle
   smallElementHeight: "1.5rem",
   // min height used for most input widgets
-  minElementHeight: "2.5rem",
+  minElementHeight: "2.25rem",
   // min height for larger input widgets like text area and audio input
   largestElementHeight: "4.25rem",
   smallLogoHeight: "1.25rem",
@@ -44,7 +44,7 @@ export const sizes = {
   appStatusMaxWidth: "20rem",
   spinnerSize: "1.375rem",
   spinnerThickness: "0.125rem",
-  tabHeight: "2.5rem",
+  tabHeight: "2.25rem",
   // Min width used for popover and dialog:
   minPopupWidth: "20rem",
   maxTooltipHeight: "18.75rem",
@@ -53,7 +53,7 @@ export const sizes = {
   clearIconSize: "1.5em",
   numberInputControlsWidth: "2rem",
   emptyDropdownHeight: "5.625rem",
-  dropdownItemHeight: "2.5rem",
+  dropdownItemHeight: "2.25rem",
   maxDropdownHeight: "18.75rem",
   appDefaultBottomPadding: "3.5rem",
   defaultMapHeight: "31.25rem",


### PR DESCRIPTION
## Describe your changes

Just a little prototype to see what it would look like if we made all widgets have 14px font size. This is just vibe-coded and not planning to finish this anytime soon. 

## GitHub Issue Link (if applicable)

Closes #12311

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
