### PR TITLE
[fix] Share more code between Selectbox and Multiselect to align behavior

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { fireEvent, screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
@@ -25,7 +23,7 @@ import * as Utils from "~lib/theme/utils"
 import * as MobileUtil from "~lib/util/isMobile"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
-import Selectbox, { fuzzyFilterSelectOptions, Props } from "./Selectbox"
+import Selectbox, { Props } from "./Selectbox"
 
 vi.mock("~lib/WidgetStateManager")
 
@@ -170,40 +168,6 @@ describe("Selectbox widget", () => {
     options = screen.getAllByRole("option")
     expect(options).toHaveLength(1)
     expect(options[0]).toHaveTextContent("b")
-  })
-
-  it("fuzzy filters options correctly", () => {
-    // This test just makes sure the filter algorithm works correctly. The e2e
-    // test actually types something in the selectbox and makes sure that it
-    // shows the right options.
-
-    const options = [
-      { label: "e2e/scripts/components_iframe.py", value: "" },
-      { label: "e2e/scripts/st_warning.py", value: "" },
-      { label: "e2e/scripts/st_container.py", value: "" },
-      { label: "e2e/scripts/st_dataframe_sort_column.py", value: "" },
-      { label: "e2e/scripts/app_hotkeys.py", value: "" },
-      { label: "e2e/scripts/st_info.py", value: "" },
-      { label: "e2e/scripts/st_echo.py", value: "" },
-      { label: "e2e/scripts/st_json.py", value: "" },
-      { label: "e2e/scripts/st_experimental_get_query_params.py", value: "" },
-      { label: "e2e/scripts/st_markdown.py", value: "" },
-      { label: "e2e/scripts/st_color_picker.py", value: "" },
-      { label: "e2e/scripts/st_expander.py", value: "" },
-    ]
-
-    const results1 = fuzzyFilterSelectOptions(options, "esstm")
-    expect(results1.map(it => it.label)).toEqual([
-      "e2e/scripts/st_markdown.py",
-      "e2e/scripts/st_dataframe_sort_column.py",
-      "e2e/scripts/st_experimental_get_query_params.py",
-      "e2e/scripts/components_iframe.py",
-    ])
-
-    const results2 = fuzzyFilterSelectOptions(options, "eseg")
-    expect(results2.map(it => it.label)).toEqual([
-      "e2e/scripts/st_experimental_get_query_params.py",
-    ])
   })
 
   it("predictably produces case sensitive matches", async () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -29,7 +29,6 @@ import {
   type Option,
   Select as UISelect,
 } from "baseui/select"
-import sortBy from "lodash/sortBy"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import VirtualDropdown from "~lib/components/shared/Dropdown/VirtualDropdown"
@@ -40,13 +39,8 @@ import {
   WidgetLabel,
 } from "~lib/components/widgets/BaseWidget"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { isMobile } from "~lib/util/isMobile"
-import {
-  getSelectPlaceholder,
-  isNullOrUndefined,
-  LabelVisibilityOptions,
-} from "~lib/util/utils"
-import { hasMatch, score } from "~lib/vendor/fzy.js/fuzzySearch"
+import { useSelectCommon } from "~lib/hooks/useSelectCommon"
+import { LabelVisibilityOptions } from "~lib/util/utils"
 
 export interface Props {
   value: string | null
@@ -60,34 +54,6 @@ export interface Props {
   placeholder: string
   clearable?: boolean
   acceptNewOptions: boolean
-}
-
-interface SelectOption {
-  label: string
-  value: string
-}
-
-// Add a custom filterOptions method to filter options only based on labels.
-// The baseweb default method filters based on labels or indices
-// More details: https://github.com/streamlit/streamlit/issues/1010
-// Also filters using fuzzy search.
-export function fuzzyFilterSelectOptions(
-  options: SelectOption[],
-  pattern: string
-): readonly SelectOption[] {
-  if (!pattern) {
-    return options
-  }
-
-  const filteredOptions = options.filter((opt: SelectOption) =>
-    hasMatch(pattern, opt.label)
-  )
-  return sortBy(
-    filteredOptions,
-    // Use the negative score to sort the list in a stable manner
-    // This ensures highest score is first
-    (opt: SelectOption) => -score(pattern, opt.label, true)
-  )
 }
 
 const Selectbox: React.FC<Props> = ({
@@ -147,43 +113,30 @@ const Selectbox: React.FC<Props> = ({
     }
   }, [])
 
-  const filterOptions = useCallback(
-    (options: readonly Option[], filterValue: string): readonly Option[] =>
-      fuzzyFilterSelectOptions(options as SelectOption[], filterValue),
-    []
-  )
-
   const opts = propOptions
 
-  let selectValue: Option[] = []
-  if (!isNullOrUndefined(value)) {
-    selectValue = [{ label: value, value }]
-  }
-
-  // Get placeholder and disabled state using utility function
-  const { placeholder: selectboxPlaceholder, shouldDisable } =
-    getSelectPlaceholder(
-      placeholder,
-      opts,
-      acceptNewOptions,
-      false // isMultiSelect = false for single select
-    )
+  const {
+    placeholder: selectboxPlaceholder,
+    disabled: shouldDisable,
+    selectOptions,
+    inputReadOnly,
+    valueToUiSingle,
+    createFilterOptions,
+  } = useSelectCommon({
+    options: opts as string[],
+    isMulti: false,
+    acceptNewOptions,
+    placeholderInput: placeholder,
+  })
 
   const selectDisabled = disabled || shouldDisable
 
-  const selectOptions: SelectOption[] = opts.map(
-    (option: string, index: number) => ({
-      label: option,
-      value: option,
-      // We are using an id because if multiple options are equal,
-      // we have observed weird UI glitches
-      id: `${option}_${index}`,
-    })
+  const filterOptions = React.useMemo(
+    () => createFilterOptions(),
+    [createFilterOptions]
   )
 
-  // Check if we have more than 10 options in the selectbox.
-  // If that's true, we show the keyboard on mobile. If not, we hide it.
-  const showKeyboardOnMobile = opts.length > 10
+  const selectValue: Option[] = valueToUiSingle(value)
 
   return (
     <div className="stSelectbox" data-testid="stSelectbox">
@@ -275,10 +228,7 @@ const Selectbox: React.FC<Props> = ({
               // When on mobile, if there are less than 10 options and new
               // options are not accepted, set the input to read-only to hide
               // the mobile keyboard.
-              readOnly:
-                isMobile() && !showKeyboardOnMobile && !acceptNewOptions
-                  ? "readonly"
-                  : null,
+              readOnly: inputReadOnly,
             },
             style: () => ({
               lineHeight: theme.lineHeights.inputWidget,

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-import React, {
+import {
+  FC,
   memo,
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
 
 import { ChevronDown } from "baseui/icon"
-import {
-  type OnChangeParams,
-  type Option,
-  Select as UISelect,
-} from "baseui/select"
+import { type OnChangeParams, Select as UISelect } from "baseui/select"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import VirtualDropdown from "~lib/components/shared/Dropdown/VirtualDropdown"
@@ -56,7 +54,7 @@ export interface Props {
   acceptNewOptions: boolean
 }
 
-const Selectbox: React.FC<Props> = ({
+const Selectbox: FC<Props> = ({
   disabled,
   value: propValue,
   onChange,
@@ -131,12 +129,12 @@ const Selectbox: React.FC<Props> = ({
 
   const selectDisabled = disabled || shouldDisable
 
-  const filterOptions = React.useMemo(
+  const filterOptions = useMemo(
     () => createFilterOptions(),
     [createFilterOptions]
   )
 
-  const selectValue: Option[] = valueToUiSingle(value)
+  const selectValue = valueToUiSingle(value)
 
   return (
     <div className="stSelectbox" data-testid="stSelectbox">

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -223,9 +223,6 @@ const Selectbox: FC<Props> = ({
           },
           Input: {
             props: {
-              // When on mobile, if there are less than 10 options and new
-              // options are not accepted, set the input to read-only to hide
-              // the mobile keyboard.
               readOnly: inputReadOnly,
             },
             style: () => ({

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -29,7 +29,6 @@ import { MultiSelect as MultiSelectProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { VirtualDropdown } from "~lib/components/shared/Dropdown"
-import { fuzzyFilterSelectOptions } from "~lib/components/shared/Dropdown/Selectbox"
 import { Placement } from "~lib/components/shared/Tooltip"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
@@ -42,11 +41,8 @@ import {
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { isMobile } from "~lib/util/isMobile"
-import {
-  getSelectPlaceholder,
-  labelVisibilityProtoValueToEnum,
-} from "~lib/util/utils"
+import { useSelectCommon } from "~lib/hooks/useSelectCommon"
+import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 export interface Props {
@@ -57,11 +53,6 @@ export interface Props {
 }
 
 type MultiselectValue = string[]
-
-interface MultiselectOption {
-  label: string
-  value: string
-}
 
 const getStateFromWidgetMgr = (
   widgetMgr: WidgetStateManager,
@@ -127,11 +118,7 @@ const Multiselect: FC<Props> = props => {
     return "No results"
   }, [element.maxSelections, value.length])
 
-  const valueFromState = useMemo(() => {
-    return value.map(option => {
-      return { value: option, label: option }
-    })
-  }, [value])
+  // replaced by useSelectCommon valuesToUiMulti
 
   const generateNewState = useCallback(
     (data: OnChangeParams): MultiselectValue => {
@@ -184,62 +171,38 @@ const Multiselect: FC<Props> = props => {
     [element.maxSelections, generateNewState, setValueWithSource, value.length]
   )
 
+  const { options } = element
+
+  const {
+    placeholder,
+    disabled: shouldDisable,
+    selectOptions,
+    inputReadOnly,
+    valuesToUiMulti,
+    createFilterOptions,
+    maxHeight,
+  } = useSelectCommon({
+    options,
+    isMulti: true,
+    acceptNewOptions: element.acceptNewOptions ?? false,
+    placeholderInput: element.placeholder,
+  })
+
   const filterOptions = useCallback(
-    (options: readonly Option[], filterValue: string): readonly Option[] => {
+    (opts: readonly Option[], fv: string): readonly Option[] => {
       if (overMaxSelections) {
         return []
       }
-      // We need to manually filter for previously selected options here
-      const unselectedOptions = options.filter(
-        option => !value.includes(option.value)
-      )
-
-      return fuzzyFilterSelectOptions(
-        unselectedOptions as MultiselectOption[],
-        filterValue
-      )
+      return createFilterOptions(value)(opts, fv)
     },
-    [overMaxSelections, value]
-  )
-
-  const { options } = element
-
-  // Get placeholder and disabled state using utility function
-  const { placeholder, shouldDisable } = getSelectPlaceholder(
-    element.placeholder,
-    options,
-    element.acceptNewOptions ?? false,
-    true // isMultiSelect = true for multi-select
+    [createFilterOptions, overMaxSelections, value]
   )
 
   const disabled = props.disabled || shouldDisable
-  const selectOptions: MultiselectOption[] = options.map(
-    (option: string, index: number) => {
-      return {
-        label: option,
-        value: option,
-        // We are using an id because if multiple options are equal,
-        // we have observed weird UI glitches
-        id: `${option}_${index}`,
-      }
-    }
+  const valueFromState = useMemo(
+    () => valuesToUiMulti(value),
+    [valuesToUiMulti, value]
   )
-
-  // Check if we have more than 10 options in the selectbox.
-  // If that's true, we show the keyboard on mobile. If not, we hide it.
-  const showKeyboardOnMobile = options.length > 10
-
-  // Calculate the max height of the selectbox based on the baseFontSize
-  // to better support advanced theming
-  const maxHeight = useMemo(() => {
-    // Option height = lineHeight (1.6 * baseFontSize) + margin/padding (14px total)
-    const optionHeight = theme.fontSizes.baseFontSize * 1.6 + 14
-    // Allow up to 4 options tall before scrolling + show small portion
-    // of the next row so its clear the user can scroll
-    const pxMaxHeight = Math.round(optionHeight * 4.25)
-    // Return value in px
-    return `${pxMaxHeight}px`
-  }, [theme.fontSizes.baseFontSize])
 
   return (
     <div className="stMultiSelect" data-testid="stMultiSelect">
@@ -422,15 +385,7 @@ const Multiselect: FC<Props> = props => {
                 },
               },
             },
-            Input: {
-              props: {
-                // Change the 'readonly' prop to hide the mobile keyboard if options < 10
-                readOnly:
-                  isMobile() && showKeyboardOnMobile === false
-                    ? "readonly"
-                    : null,
-              },
-            },
+            Input: { props: { readOnly: inputReadOnly } },
             Dropdown: { component: VirtualDropdown },
           }}
         />

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -178,7 +178,6 @@ const Multiselect: FC<Props> = props => {
     inputReadOnly,
     valuesToUiMulti,
     createFilterOptions,
-    maxHeight,
   } = useSelectCommon({
     options,
     isMulti: true,
@@ -201,6 +200,18 @@ const Multiselect: FC<Props> = props => {
     () => valuesToUiMulti(value),
     [valuesToUiMulti, value]
   )
+
+  // Calculate the max height of the selectbox based on the baseFontSize
+  // to better support advanced theming
+  const maxHeight = useMemo(() => {
+    // Option height = lineHeight (1.6 * baseFontSize) + margin/padding (14px total)
+    const optionHeight = theme.fontSizes.baseFontSize * 1.6 + 14
+    // Allow up to 4 options tall before scrolling + show small portion
+    // of the next row so its clear the user can scroll
+    const pxMaxHeight = Math.round(optionHeight * 4.25)
+    // Return value in px
+    return `${pxMaxHeight}px`
+  }, [theme.fontSizes.baseFontSize])
 
   return (
     <div className="stMultiSelect" data-testid="stMultiSelect">

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -118,8 +118,6 @@ const Multiselect: FC<Props> = props => {
     return "No results"
   }, [element.maxSelections, value.length])
 
-  // replaced by useSelectCommon valuesToUiMulti
-
   const generateNewState = useCallback(
     (data: OnChangeParams): MultiselectValue => {
       switch (data.type) {

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback, useContext, useMemo } from "react"
+import { FC, memo, useCallback, useContext, useMemo } from "react"
 
 import { ChevronDown } from "baseui/icon"
 import {
@@ -189,11 +189,11 @@ const Multiselect: FC<Props> = props => {
   })
 
   const filterOptions = useCallback(
-    (opts: readonly Option[], fv: string): readonly Option[] => {
+    (options: readonly Option[], filterValue: string): readonly Option[] => {
       if (overMaxSelections) {
         return []
       }
-      return createFilterOptions(value)(opts, fv)
+      return createFilterOptions(value)(options, filterValue)
     },
     [createFilterOptions, overMaxSelections, value]
   )

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -18,7 +18,6 @@ import { useMemo } from "react"
 
 import { type Option } from "baseui/select"
 
-import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { fuzzyFilterSelectOptions } from "~lib/util/fuzzyFilterSelectOptions"
 import { isMobile } from "~lib/util/isMobile"
 import { getSelectPlaceholder, isNullOrUndefined } from "~lib/util/utils"
@@ -47,7 +46,6 @@ export interface UseSelectCommonResult {
   createFilterOptions: (
     selectedValues?: string[]
   ) => (options: readonly Option[], filterValue: string) => readonly Option[]
-  maxHeight?: string
 }
 
 export function useSelectCommon(
@@ -55,13 +53,13 @@ export function useSelectCommon(
 ): UseSelectCommonResult {
   const { options, isMulti, acceptNewOptions, placeholderInput } = args
 
-  const theme = useEmotionTheme()
-
   const selectOptions: SelectOption[] = useMemo(
     () =>
       options.map((option: string, index: number) => ({
         label: option,
         value: option,
+        // We are using an id because if multiple options are equal,
+        // we have observed weird UI glitches
         id: `${option}_${index}`,
       })),
     [options]
@@ -122,16 +120,6 @@ export function useSelectCommon(
     []
   )
 
-  const maxHeight = useMemo(() => {
-    if (!isMulti) {
-      return undefined
-    }
-
-    const optionHeight = theme.fontSizes.baseFontSize * 1.6 + 14
-    const pxMaxHeight = Math.round(optionHeight * 4.25)
-    return `${pxMaxHeight}px`
-  }, [isMulti, theme.fontSizes.baseFontSize])
-
   return {
     selectOptions,
     placeholder,
@@ -140,6 +128,5 @@ export function useSelectCommon(
     valueToUiSingle,
     valuesToUiMulti,
     createFilterOptions,
-    maxHeight,
   }
 }

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -67,6 +67,7 @@ export function useSelectCommon(
     [options]
   )
 
+  // Get placeholder and disabled state using utility function
   const { placeholder, shouldDisable } = useMemo(
     () =>
       getSelectPlaceholder(
@@ -109,8 +110,10 @@ export function useSelectCommon(
         filterValue: string
       ): readonly Option[] => {
         const base = Array.isArray(selectedValues)
-          ? optionsList.filter(opt => !selectedValues.includes(opt.value))
+          ? // We need to manually filter for previously selected options here
+            optionsList.filter(opt => !selectedValues.includes(opt.value))
           : optionsList
+
         return fuzzyFilterSelectOptions(
           base as { label: string; value: string }[],
           filterValue
@@ -120,7 +123,10 @@ export function useSelectCommon(
   )
 
   const maxHeight = useMemo(() => {
-    if (!isMulti) return undefined
+    if (!isMulti) {
+      return undefined
+    }
+
     const optionHeight = theme.fontSizes.baseFontSize * 1.6 + 14
     const pxMaxHeight = Math.round(optionHeight * 4.25)
     return `${pxMaxHeight}px`

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -48,6 +48,23 @@ export interface UseSelectCommonResult {
   ) => (options: readonly Option[], filterValue: string) => readonly Option[]
 }
 
+/**
+ * React hook that centralizes common logic for select-like widgets (e.g.,
+ * Selectbox and Multiselect).
+ *
+ * It memoizes UI-ready options, determines placeholder and disabled state,
+ * controls input read-only behavior on mobile, and provides helpers to map
+ * between backend values and BaseWeb Select `Option`s, including a fuzzy filter
+ * that excludes already selected options.
+ *
+ * @param {UseSelectCommonArgs} args - Configuration for the select behavior.
+ * @param {string[]} args.options - All available option labels/values.
+ * @param {boolean} args.isMulti - Whether multiple selections are allowed.
+ * @param {boolean} args.acceptNewOptions - Whether free-form user input is allowed.
+ * @param {string} args.placeholderInput - Placeholder text source from backend.
+ * @param {number} [args.maxSelections] - Optional cap on the number of selections.
+ * @returns {UseSelectCommonResult} Derived values and mapping/filter helpers for the UI.
+ */
 export function useSelectCommon(
   args: UseSelectCommonArgs
 ): UseSelectCommonResult {

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react"
+
+import { type Option } from "baseui/select"
+
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { fuzzyFilterSelectOptions } from "~lib/util/fuzzyFilterSelectOptions"
+import { isMobile } from "~lib/util/isMobile"
+import { getSelectPlaceholder, isNullOrUndefined } from "~lib/util/utils"
+
+export interface SelectOption {
+  label: string
+  value: string
+  id: string
+}
+
+export interface UseSelectCommonArgs {
+  options: string[]
+  isMulti: boolean
+  acceptNewOptions: boolean
+  placeholderInput: string
+  maxSelections?: number
+}
+
+export interface UseSelectCommonResult {
+  selectOptions: SelectOption[]
+  placeholder: string
+  disabled: boolean
+  inputReadOnly: "readonly" | null
+  valueToUiSingle: (value: string | null) => Option[]
+  valuesToUiMulti: (values: string[]) => Option[]
+  createFilterOptions: (
+    selectedValues?: string[]
+  ) => (options: readonly Option[], filterValue: string) => readonly Option[]
+  maxHeight?: string
+}
+
+export function useSelectCommon(
+  args: UseSelectCommonArgs
+): UseSelectCommonResult {
+  const { options, isMulti, acceptNewOptions, placeholderInput } = args
+
+  const theme = useEmotionTheme()
+
+  const selectOptions: SelectOption[] = useMemo(
+    () =>
+      options.map((option: string, index: number) => ({
+        label: option,
+        value: option,
+        id: `${option}_${index}`,
+      })),
+    [options]
+  )
+
+  const { placeholder, shouldDisable } = useMemo(
+    () =>
+      getSelectPlaceholder(
+        placeholderInput,
+        options,
+        acceptNewOptions,
+        isMulti
+      ),
+    [acceptNewOptions, isMulti, options, placeholderInput]
+  )
+
+  const showKeyboardOnMobile = options.length > 10
+
+  const inputReadOnly =
+    isMobile() && !showKeyboardOnMobile && !acceptNewOptions
+      ? "readonly"
+      : null
+
+  const valueToUiSingle = useMemo(
+    () =>
+      (value: string | null): Option[] => {
+        if (isNullOrUndefined(value)) return []
+        return [{ label: value, value }]
+      },
+    []
+  )
+
+  const valuesToUiMulti = useMemo(
+    () =>
+      (values: string[]): Option[] =>
+        values.map(v => ({ label: v, value: v })),
+    []
+  )
+
+  const createFilterOptions = useMemo(
+    () =>
+      (selectedValues?: string[]) =>
+      (
+        optionsList: readonly Option[],
+        filterValue: string
+      ): readonly Option[] => {
+        const base = Array.isArray(selectedValues)
+          ? optionsList.filter(opt => !selectedValues.includes(opt.value))
+          : optionsList
+        return fuzzyFilterSelectOptions(
+          base as { label: string; value: string }[],
+          filterValue
+        )
+      },
+    []
+  )
+
+  const maxHeight = useMemo(() => {
+    if (!isMulti) return undefined
+    const optionHeight = theme.fontSizes.baseFontSize * 1.6 + 14
+    const pxMaxHeight = Math.round(optionHeight * 4.25)
+    return `${pxMaxHeight}px`
+  }, [isMulti, theme.fontSizes.baseFontSize])
+
+  return {
+    selectOptions,
+    placeholder,
+    disabled: shouldDisable,
+    inputReadOnly,
+    valueToUiSingle,
+    valuesToUiMulti,
+    createFilterOptions,
+    maxHeight,
+  }
+}

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -33,7 +33,6 @@ export interface UseSelectCommonArgs {
   isMulti: boolean
   acceptNewOptions: boolean
   placeholderInput: string
-  maxSelections?: number
 }
 
 export interface UseSelectCommonResult {
@@ -62,7 +61,6 @@ export interface UseSelectCommonResult {
  * @param {boolean} args.isMulti - Whether multiple selections are allowed.
  * @param {boolean} args.acceptNewOptions - Whether free-form user input is allowed.
  * @param {string} args.placeholderInput - Placeholder text source from backend.
- * @param {number} [args.maxSelections] - Optional cap on the number of selections.
  * @returns {UseSelectCommonResult} Derived values and mapping/filter helpers for the UI.
  */
 export function useSelectCommon(

--- a/frontend/lib/src/hooks/useSelectCommon.ts
+++ b/frontend/lib/src/hooks/useSelectCommon.ts
@@ -79,6 +79,10 @@ export function useSelectCommon(
 
   const showKeyboardOnMobile = options.length > 10
 
+  /**
+   * When on mobile, if there are less than 10 options and new options are not
+   * accepted, set the input to read-only to hide the mobile keyboard.
+   */
   const inputReadOnly =
     isMobile() && !showKeyboardOnMobile && !acceptNewOptions
       ? "readonly"

--- a/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
+++ b/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fuzzyFilterSelectOptions } from "~lib/util/fuzzyFilterSelectOptions"
+
+describe("fuzzyFilterSelectOptions", () => {
+  it("fuzzy filters options correctly", () => {
+    // This test just makes sure the filter algorithm works correctly. The e2e
+    // test actually types something in the selectbox and makes sure that it
+    // shows the right options.
+
+    const options = [
+      { label: "e2e/scripts/components_iframe.py", value: "" },
+      { label: "e2e/scripts/st_warning.py", value: "" },
+      { label: "e2e/scripts/st_container.py", value: "" },
+      { label: "e2e/scripts/st_dataframe_sort_column.py", value: "" },
+      { label: "e2e/scripts/app_hotkeys.py", value: "" },
+      { label: "e2e/scripts/st_info.py", value: "" },
+      { label: "e2e/scripts/st_echo.py", value: "" },
+      { label: "e2e/scripts/st_json.py", value: "" },
+      { label: "e2e/scripts/st_experimental_get_query_params.py", value: "" },
+      { label: "e2e/scripts/st_markdown.py", value: "" },
+      { label: "e2e/scripts/st_color_picker.py", value: "" },
+      { label: "e2e/scripts/st_expander.py", value: "" },
+    ]
+
+    const results1 = fuzzyFilterSelectOptions(options, "esstm")
+    expect(results1.map(it => it.label)).toEqual([
+      "e2e/scripts/st_markdown.py",
+      "e2e/scripts/st_dataframe_sort_column.py",
+      "e2e/scripts/st_experimental_get_query_params.py",
+      "e2e/scripts/components_iframe.py",
+    ])
+
+    const results2 = fuzzyFilterSelectOptions(options, "eseg")
+    expect(results2.map(it => it.label)).toEqual([
+      "e2e/scripts/st_experimental_get_query_params.py",
+    ])
+  })
+})

--- a/frontend/lib/src/util/fuzzyFilterSelectOptions.ts
+++ b/frontend/lib/src/util/fuzzyFilterSelectOptions.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sortBy from "lodash/sortBy"
+
+import { hasMatch, score } from "~lib/vendor/fzy.js/fuzzySearch"
+
+export interface LabeledOption {
+  label: string
+  value: string
+}
+
+// Add a custom filterOptions method to filter options only based on labels.
+// The baseweb default method filters based on labels or indices
+// More details: https://github.com/streamlit/streamlit/issues/1010
+// Also filters using fuzzy search.
+export function fuzzyFilterSelectOptions<T extends LabeledOption>(
+  options: readonly T[],
+  pattern: string
+): readonly T[] {
+  if (!pattern) {
+    return options
+  }
+
+  const filteredOptions = options.filter((opt: T) =>
+    hasMatch(pattern, opt.label)
+  )
+  return sortBy(
+    filteredOptions,
+    // Use the negative score to sort the list in a stable manner
+    // This ensures highest score is first
+    (opt: T) => -score(pattern, opt.label, true)
+  )
+}


### PR DESCRIPTION
## Describe your changes

- We previously fixed a bug in `st.selectbox` (https://github.com/streamlit/streamlit/pull/12219), but not in `st.multiselect`. Ultimately, this is because the code is effectively duplicated between the 2, despite much of the behavior needing to be the same.
- This PR moves the shared logic into a shared place, thus reducing duplication and fixing the bug in both places as expected.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Updated unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
