### PR TITLE
Refactor `st.toggle` e2e test

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -190,6 +190,27 @@ def get_checkbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
     return element
 
 
+def get_toggle(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
+    """Get a toggle widget with the given label.
+
+    Parameters
+    ----------
+    locator : Locator
+        The locator to search for the element.
+
+    label : str or Pattern[str]
+        The label of the element to get.
+
+    Returns
+    -------
+    Locator
+        The element.
+    """
+    element = locator.get_by_test_id("stCheckbox").filter(has_text=label)
+    expect(element).to_be_visible()
+    return element
+
+
 def get_radio_option(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
     """Get a radio button widget with the given label.
 

--- a/e2e_playwright/st_toggle.py
+++ b/e2e_playwright/st_toggle.py
@@ -42,10 +42,12 @@ st.write("toggle 5 - value:", i5)
 i6 = st.toggle("toggle 6 (True, disabled)", value=True, disabled=True)
 st.write("toggle 6 - value:", i6)
 
-i7 = st.toggle("toggle 7 (label hidden)", label_visibility="hidden")
+i7 = st.toggle("toggle 7 (label hidden)", label_visibility="hidden", key="toggle_7")
 st.write("toggle 7 - value:", i7)
 
-i8 = st.toggle("toggle 8 (label collapsed)", label_visibility="collapsed")
+i8 = st.toggle(
+    "toggle 8 (label collapsed)", label_visibility="collapsed", key="toggle_8"
+)
 st.write("toggle 8 - value:", i8)
 
 with st.expander("Grouped toggles", expanded=True):
@@ -55,7 +57,8 @@ with st.expander("Grouped toggles", expanded=True):
     st.text("A non-toggle element")
 
 st.toggle(
-    "toggle 9 -> :material/check: :rainbow[Fancy] _**markdown** `label` _support_"
+    "toggle 9 -> :material/check: :rainbow[Fancy] _**markdown** `label` _support_",
+    key="toggle_9",
 )
 
 st.toggle("toggle with content width", width="content")

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -21,9 +21,9 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
     expect_markdown,
-    get_checkbox,
     get_element_by_key,
     get_expander,
+    get_toggle,
 )
 
 TOGGLE_ELEMENTS = 15
@@ -34,24 +34,22 @@ def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFu
     toggle_elements = themed_app.get_by_test_id("stCheckbox")
     expect(toggle_elements).to_have_count(TOGGLE_ELEMENTS)
 
-    assert_snapshot(get_checkbox(themed_app, "toggle 1 (True)"), name="st_toggle-true")
+    assert_snapshot(get_toggle(themed_app, "toggle 1 (True)"), name="st_toggle-true")
+    assert_snapshot(get_toggle(themed_app, "toggle 2 (False)"), name="st_toggle-false")
     assert_snapshot(
-        get_checkbox(themed_app, "toggle 2 (False)"), name="st_toggle-false"
-    )
-    assert_snapshot(
-        get_checkbox(themed_app, re.compile(r"^toggle 3")),
+        get_toggle(themed_app, re.compile(r"^toggle 3")),
         name="st_toggle-long_label",
     )
     assert_snapshot(
-        get_checkbox(themed_app, "toggle 4 (with callback)"),
+        get_toggle(themed_app, "toggle 4 (with callback)"),
         name="st_toggle-callback",
     )
     assert_snapshot(
-        get_checkbox(themed_app, "toggle 5 (False, disabled)"),
+        get_toggle(themed_app, "toggle 5 (False, disabled)"),
         name="st_toggle-false_disabled",
     )
     assert_snapshot(
-        get_checkbox(themed_app, "toggle 6 (True, disabled)"),
+        get_toggle(themed_app, "toggle 6 (True, disabled)"),
         name="st_toggle-true_disabled",
     )
     assert_snapshot(
@@ -66,15 +64,15 @@ def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFu
 
     # Width examples
     assert_snapshot(
-        get_checkbox(themed_app, "toggle with content width"),
+        get_toggle(themed_app, "toggle with content width"),
         name="st_toggle-width_content",
     )
     assert_snapshot(
-        get_checkbox(themed_app, "toggle with stretch width"),
+        get_toggle(themed_app, "toggle with stretch width"),
         name="st_toggle-width_stretch",
     )
     assert_snapshot(
-        get_checkbox(themed_app, "toggle with 150px width"),
+        get_toggle(themed_app, "toggle with 150px width"),
         name="st_toggle-width_150px",
     )
 
@@ -124,7 +122,7 @@ def test_grouped_toggles_height(app: Page, assert_snapshot: ImageCompareFunction
     )
     expect(expander_details.get_by_test_id("stCheckbox")).to_have_count(3)
     assert_snapshot(expander_details, name="st_toggle-grouped_styling")
-    expect(get_checkbox(expander_details, "toggle group - 1")).to_have_css(
+    expect(get_toggle(expander_details, "toggle group - 1")).to_have_css(
         "height", "24px"
     )
 

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
+    click_toggle,
+    expect_markdown,
+    get_checkbox,
     get_element_by_key,
     get_expander,
 )
@@ -30,74 +34,86 @@ def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFu
     toggle_elements = themed_app.get_by_test_id("stCheckbox")
     expect(toggle_elements).to_have_count(TOGGLE_ELEMENTS)
 
-    assert_snapshot(toggle_elements.nth(0), name="st_toggle-true")
-    assert_snapshot(toggle_elements.nth(1), name="st_toggle-false")
-    assert_snapshot(toggle_elements.nth(2), name="st_toggle-long_label")
-    assert_snapshot(toggle_elements.nth(3), name="st_toggle-callback")
-    assert_snapshot(toggle_elements.nth(4), name="st_toggle-false_disabled")
-    assert_snapshot(toggle_elements.nth(5), name="st_toggle-true_disabled")
-    assert_snapshot(toggle_elements.nth(6), name="st_toggle-hidden_label")
-    assert_snapshot(toggle_elements.nth(7), name="st_toggle-collapsed_label")
-    assert_snapshot(toggle_elements.nth(11), name="st_toggle-markdown_label")
+    assert_snapshot(get_checkbox(themed_app, "toggle 1 (True)"), name="st_toggle-true")
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle 2 (False)"), name="st_toggle-false"
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, re.compile(r"^toggle 3")),
+        name="st_toggle-long_label",
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle 4 (with callback)"),
+        name="st_toggle-callback",
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle 5 (False, disabled)"),
+        name="st_toggle-false_disabled",
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle 6 (True, disabled)"),
+        name="st_toggle-true_disabled",
+    )
+    assert_snapshot(
+        get_element_by_key(themed_app, "toggle_7"), name="st_toggle-hidden_label"
+    )
+    assert_snapshot(
+        get_element_by_key(themed_app, "toggle_8"), name="st_toggle-collapsed_label"
+    )
+    assert_snapshot(
+        get_element_by_key(themed_app, "toggle_9"), name="st_toggle-markdown_label"
+    )
 
     # Width examples
-    assert_snapshot(toggle_elements.nth(12), name="st_toggle-width_content")
-    assert_snapshot(toggle_elements.nth(13), name="st_toggle-width_stretch")
-    assert_snapshot(toggle_elements.nth(14), name="st_toggle-width_150px")
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle with content width"),
+        name="st_toggle-width_content",
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle with stretch width"),
+        name="st_toggle-width_stretch",
+    )
+    assert_snapshot(
+        get_checkbox(themed_app, "toggle with 150px width"),
+        name="st_toggle-width_150px",
+    )
 
 
 def test_toggle_initial_values(app: Page):
     """Test that st.toggle has the correct initial values."""
-    markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(9)
-
-    expected = [
-        "toggle 1 - value: True",
-        "toggle 2 - value: False",
-        "toggle 3 - value: False",
-        "toggle 4 - value: False",
-        "toggle 4 - clicked: False",
-        "toggle 5 - value: False",
-        "toggle 6 - value: True",
-        "toggle 7 - value: False",
-        "toggle 8 - value: False",
-    ]
-
-    for markdown_element, expected_text in zip(markdown_elements.all(), expected):
-        expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
+    expect_markdown(app, "toggle 1 - value: True")
+    expect_markdown(app, "toggle 2 - value: False")
+    expect_markdown(app, "toggle 3 - value: False")
+    expect_markdown(app, "toggle 4 - value: False")
+    expect_markdown(app, "toggle 4 - clicked: False")
+    expect_markdown(app, "toggle 5 - value: False")
+    expect_markdown(app, "toggle 6 - value: True")
+    expect_markdown(app, "toggle 7 - value: False")
+    expect_markdown(app, "toggle 8 - value: False")
 
 
 def test_toggle_values_on_click(app: Page):
     """Test that st.toggle updates values correctly when user clicks."""
-    toggle_elements = app.get_by_test_id("stCheckbox")
-    expect(toggle_elements).to_have_count(TOGGLE_ELEMENTS)
+    # Click only the toggles that affect the displayed markdown values
+    click_toggle(app, "toggle 1 (True)")
+    click_toggle(app, "toggle 2 (False)")
+    click_toggle(app, re.compile(r"^toggle 3"))
+    click_toggle(app, "toggle 4 (with callback)")
+    # Hidden/collapsed labels: click via key wrapper
+    get_element_by_key(app, "toggle_7").locator("label").click()
+    wait_for_app_run(app)
+    get_element_by_key(app, "toggle_8").locator("label").click()
+    wait_for_app_run(app)
 
-    for toggle_element in toggle_elements.all():
-        # Not sure if this is needed, but somehow it is slightly
-        # flaky with the last toggle without it.
-        # It seems that it sometimes fails to click,
-        # and in these cases the toggle was not scrolled into view.
-        # So, maybe thats the reason why it fails to click it.
-        # But this is just a guess.
-        toggle_element.scroll_into_view_if_needed()
-        toggle_element.locator("label").click(delay=50, force=True)
-        wait_for_app_run(app)
-
-    markdown_elements = app.get_by_test_id("stMarkdown")
-    expected = [
-        "toggle 1 - value: False",
-        "toggle 2 - value: True",
-        "toggle 3 - value: True",
-        "toggle 4 - value: True",
-        "toggle 4 - clicked: True",
-        "toggle 5 - value: False",
-        "toggle 6 - value: True",
-        "toggle 7 - value: True",
-        "toggle 8 - value: True",
-    ]
-
-    for markdown_element, expected_text in zip(markdown_elements.all(), expected):
-        expect(markdown_element).to_have_text(expected_text, use_inner_text=True)
+    expect_markdown(app, "toggle 1 - value: False")
+    expect_markdown(app, "toggle 2 - value: True")
+    expect_markdown(app, "toggle 3 - value: True")
+    expect_markdown(app, "toggle 4 - value: True")
+    expect_markdown(app, "toggle 4 - clicked: True")
+    expect_markdown(app, "toggle 5 - value: False")
+    expect_markdown(app, "toggle 6 - value: True")
+    expect_markdown(app, "toggle 7 - value: True")
+    expect_markdown(app, "toggle 8 - value: True")
 
 
 def test_grouped_toggles_height(app: Page, assert_snapshot: ImageCompareFunction):
@@ -108,7 +124,7 @@ def test_grouped_toggles_height(app: Page, assert_snapshot: ImageCompareFunction
     )
     expect(expander_details.get_by_test_id("stCheckbox")).to_have_count(3)
     assert_snapshot(expander_details, name="st_toggle-grouped_styling")
-    expect(expander_details.get_by_test_id("stCheckbox").nth(0)).to_have_css(
+    expect(get_checkbox(expander_details, "toggle group - 1")).to_have_css(
         "height", "24px"
     )
 


### PR DESCRIPTION
## Describe your changes

Refactor the `st.toggle` e2e test to use label based access instead of index based access.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
