### PR TITLE
[feat] Hover, active, focus-visible states for CopyButton

### DIFF
--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -38,10 +38,14 @@ const CopyButton: React.FC<Props> = ({ text }) => {
     copyToClipboard(text)
   }, [copyToClipboard, text])
 
+  const label = isCopied ? "Copied" : "Copy to clipboard"
+
   return (
     <StyledCopyButton
       data-testid="stCodeCopyButton"
-      title="Copy to clipboard"
+      title={label}
+      aria-label={label}
+      type="button"
       ref={buttonRef}
       onClick={handleCopy}
     >

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -32,13 +32,11 @@ const CopyButton: React.FC<Props> = ({ text }) => {
   const theme = useEmotionTheme()
   const buttonRef = useRef<HTMLButtonElement>(null)
 
-  const { isCopied, copyToClipboard } = useCopyToClipboard()
+  const { isCopied, copyToClipboard, label } = useCopyToClipboard()
 
   const handleCopy = useCallback(() => {
     copyToClipboard(text)
   }, [copyToClipboard, text])
-
-  const label = isCopied ? "Copied" : "Copy to clipboard"
 
   return (
     <StyledCopyButton

--- a/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
@@ -245,11 +245,35 @@ export const StyledCopyButton = styled.button(({ theme }) => ({
   top: 0,
   right: 0,
 
-  [`${StyledCodeBlock}:hover &, &:active, &:focus, &:hover`]: {
+  // Show button on container hover
+  [`${StyledCodeBlock}:hover &`]: {
     opacity: 1,
     transform: "scale(1)",
     outline: "none",
     transition: "none",
+  },
+
+  // Show button on its own hover/focus states
+  "&:hover, &:focus, &:active, &:focus-visible": {
+    opacity: 1,
+    transform: "scale(1)",
+    outline: "none",
+    transition: "none",
+    borderRadius: theme.radii.md,
+  },
+
+  "&:hover": {
     color: theme.colors.bodyText,
+    backgroundColor: theme.colors.darkenedBgMix15,
+  },
+
+  "&:active": {
+    color: theme.colors.bodyText,
+    backgroundColor: theme.colors.darkenedBgMix25,
+  },
+
+  // Accessible focus ring when keyboard focusing the button
+  "&:focus-visible": {
+    boxShadow: `0 0 0 0.2rem ${theme.colors.darkenedBgMix25}`,
   },
 }))

--- a/frontend/lib/src/hooks/useCopyToClipboard.ts
+++ b/frontend/lib/src/hooks/useCopyToClipboard.ts
@@ -22,11 +22,39 @@ import useTimeout from "./useTimeout"
 
 const LOG = getLogger("useCopyToClipboard")
 
+/**
+ * Result returned by `useCopyToClipboard`.
+ */
 export type UseCopyToClipboardResult = {
+  /**
+   * Whether the last copy action has recently succeeded. This
+   * flag automatically resets to false after the timeout elapses.
+   */
   isCopied: boolean
+  /**
+   * Copies the provided text to the user's clipboard.
+   *
+   * @param text The text content to write to the clipboard.
+   */
   copyToClipboard: (text: string) => void
+  /**
+   * Convenience label suitable for UI controls. Becomes "Copied" while
+   * `isCopied` is true; otherwise "Copy to clipboard".
+   */
+  label: string
 }
 
+/**
+ * React hook that exposes a copy-to-clipboard action and a transient "copied"
+ * state that resets after a configurable timeout.
+ *
+ * It writes the provided text to `navigator.clipboard` and toggles `isCopied`
+ * to true upon success, reverting to false after `timeout`.
+ *
+ * @param options Optional configuration.
+ * @param options.timeout Timeout in milliseconds before `isCopied` resets. Defaults to 2000ms.
+ * @returns An object containing `isCopied`, `copyToClipboard`, and `label`.
+ */
 export const useCopyToClipboard = ({
   timeout = 2_000,
 }: {
@@ -67,5 +95,7 @@ export const useCopyToClipboard = ({
     [restart]
   )
 
-  return { isCopied, copyToClipboard }
+  const label = isCopied ? "Copied" : "Copy to clipboard"
+
+  return { isCopied, copyToClipboard, label }
 }


### PR DESCRIPTION
## Describe your changes

- Adds an explicit hover, active, and focus-active CSS states for CopyButton
- Adds a11y label

Dark mode:

https://github.com/user-attachments/assets/f3607a7b-71cb-4ca2-8251-ebb2684b52cd

Light mode:

https://github.com/user-attachments/assets/92884ac9-75ed-4278-aa26-ac99d9d34551

Focus ring when keyboard focus:

<img width="118" height="71" alt="Screenshot 2025-08-27 at 8 51 51 AM" src="https://github.com/user-attachments/assets/db250c3e-49bf-44d6-adfc-ac310879924f" />



## GitHub Issue Link (if applicable)

## Testing Plan

- Manually tested. This is a small enough visual change that doesn't warrant a snapshot test. The behavioral aspects are already tested.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
