### PR TITLE
Fix issue with typing formatted values into `st.number_input`

### DIFF
--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -167,6 +167,17 @@ def test_number_input_has_correct_value_on_blur(app: Page):
     )
 
 
+def test_number_input_typing_decimal_via_keyboard(app: Page):
+    """Typing a decimal value using the keyboard should work and commit correctly."""
+    first_number_input_field = app.get_by_label("number input 1 (default)")
+    first_number_input_field.click()
+    first_number_input_field.type("12.34")
+    first_number_input_field.press("Enter")
+    wait_for_app_run(app)
+
+    expect_markdown(app, "number input 1 (default) - value: 12.34")
+
+
 def test_empty_number_input_behaves_correctly(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -1184,5 +1184,34 @@ describe("NumberInput widget", () => {
         expect(input).toHaveDisplayValue("1")
       })
     })
+
+    describe("Typing behavior (FLOAT)", () => {
+      it("does not reformat while focused when typing digits", async () => {
+        const user = userEvent.setup()
+        const props = getFloatProps({ default: 0.0, step: 0.01 })
+        render(<NumberInput {...props} />)
+
+        const input = screen.getByTestId("stNumberInputField")
+        await user.clear(input)
+        await user.type(input, "123")
+
+        // Should show raw typed value without forcing decimal formatting yet
+        expect(input).toHaveDisplayValue("123")
+      })
+
+      it("supports backspace correctly when typing a decimal value", async () => {
+        const user = userEvent.setup()
+        const props = getFloatProps({ default: 0.0 })
+        render(<NumberInput {...props} />)
+
+        const input = screen.getByTestId("stNumberInputField")
+        await user.clear(input)
+        await user.type(input, "12.3")
+        expect(input).toHaveDisplayValue("12.3")
+
+        await user.keyboard("{backspace}")
+        expect(input).toHaveDisplayValue("12")
+      })
+    })
   })
 })

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -109,6 +109,16 @@ const NumberInput: React.FC<Props> = ({
     })
   }, [value, elementDataType, elementFormat, step])
 
+  // While the input is focused, avoid applying formatting that enforces
+  // fixed decimal places. This prevents keystrokes (including backspace)
+  // from being immediately overridden by formatted output.
+  const displayValue = useMemo(() => {
+    if (isFocused) {
+      return isNullOrUndefined(value) ? "" : value.toString()
+    }
+    return formattedValue ?? ""
+  }, [isFocused, value, formattedValue])
+
   const canDec = canDecrement(value, step, min)
   const canInc = canIncrement(value, step, max)
 
@@ -359,7 +369,7 @@ const NumberInput: React.FC<Props> = ({
         <UIInput
           type="number"
           inputRef={inputRef}
-          value={formattedValue ?? ""}
+          value={displayValue}
           placeholder={element.placeholder}
           onBlur={onBlur}
           onFocus={onFocus}


### PR DESCRIPTION
## Describe your changes

Fix a regression that makes it very hard to type in decimal numbers into `st.number_input`.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/12349

## Testing Plan

- Added e2e test that uses type and a decimal number. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
