### PR TITLE
st.pills / st.segmented_control: disable individual options

### DIFF
--- a/frontend/demo_disabled.py
+++ b/frontend/demo_disabled.py
@@ -18,7 +18,7 @@ st.title("Per-option disabled demo")
 
 st.pills(
     "Pick one",
-options=["A","B","C","D"],
+options=["A", "B", "C", "D"],
     disabled=("B","D"),
     key="p1",
 )

--- a/frontend/demo_disabled.py
+++ b/frontend/demo_disabled.py
@@ -18,7 +18,7 @@ st.title("Per-option disabled demo")
 
 st.pills(
     "Pick one",
-    options=["A","B","C","D"],
+options=["A","B","C","D"],
     disabled=("B","D"),
     key="p1",
 )

--- a/frontend/demo_disabled.py
+++ b/frontend/demo_disabled.py
@@ -1,0 +1,31 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.title("Per-option disabled demo")
+
+st.pills(
+    "Pick one",
+    options=["A","B","C","D"],
+    disabled=("B","D"),
+    key="p1",
+)
+
+st.segmented_control(
+    "Pick a number",
+    options=[1,2,3,4],
+    disabled=(2,4),
+    key="s1",
+)

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
@@ -38,16 +38,20 @@ import {
   StyledTertiaryButton,
   StyledTertiaryFormSubmitButton,
 } from "./styled-components"
-
-function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
+type HTMLBtnAttrs = React.ButtonHTMLAttributes<HTMLButtonElement>
+type MergedBaseButtonProps = BaseButtonPropsT & HTMLBtnAttrs
+function BaseButton(props: Readonly<MergedBaseButtonProps>): ReactElement {
   const {
     kind,
     size,
     disabled,
     onClick,
+    onKeyDown,
+    tabIndex,
     containerWidth,
     children,
     autoFocus,
+    ...rest
   } = props
 
   let ComponentType = StyledPrimaryButton
@@ -85,14 +89,43 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
   } else if (kind === BaseButtonKind.ELEMENT_TOOLBAR) {
     ComponentType = StyledElementToolbarButton
   }
+  const isActivationKey = (e: React.KeyboardEvent<HTMLButtonElement>) =>
+    e.key === "Enter" || e.key === " " || e.key === "Space" || e.key === "Spacebar"
+
+  const handleDisabledEvent = (
+    e: React.SyntheticEvent,
+    checkKey?: (e: React.KeyboardEvent<HTMLButtonElement>) => boolean
+  ): boolean => {
+    if (!disabled) return false
+    if (!checkKey || checkKey(e as React.KeyboardEvent<HTMLButtonElement>)) {
+      e.preventDefault()
+      e.stopPropagation()
+      return true
+    }
+    return false
+  }
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (handleDisabledEvent(e)) return
+    onClick?.(e)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (handleDisabledEvent(e, isActivationKey)) return
+    onKeyDown?.(e)
+  }
 
   return (
     <ComponentType
+      {...rest}
       kind={kind}
       size={size ?? BaseButtonSize.MEDIUM}
       containerWidth={containerWidth || false}
       disabled={disabled || false}
-      onClick={onClick || (() => {})}
+      aria-disabled={disabled || false}
+      tabIndex={disabled ? -1 : (tabIndex ?? 0)}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
       autoFocus={autoFocus || false}
       data-testid={props["data-testid"] ?? `stBaseButton-${kind}`}
       aria-label={props["aria-label"] ?? ""}
@@ -101,6 +134,6 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
     </ComponentType>
   )
 }
-export type BaseButtonProps = BaseButtonPropsT
+export type BaseButtonProps = MergedBaseButtonProps
 export { BaseButtonKind, BaseButtonSize }
 export default BaseButton

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -245,7 +245,8 @@ function createOptionChild(
   clickMode: ButtonGroupProto.ClickMode,
   selected: number[],
   style: ButtonGroupProto.Style,
-  containerWidth: boolean
+  containerWidth: boolean,
+  isDisabled: boolean
 ): React.FunctionComponent {
   const isVisuallySelected = showAsSelected(
     selectionVisualization,
@@ -281,12 +282,50 @@ function createOptionChild(
       ),
       kind
     )
+
+    const onClickSafe = (e: React.MouseEvent<HTMLElement>) => {
+      if (isDisabled) {
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+      props?.onClick?.(e)
+    }
+
     return (
       <BaseButton
         {...props}
         size={size}
         kind={buttonKind}
         containerWidth={containerWidth}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        tabIndex={isDisabled ? -1 : (props?.tabIndex ?? 0)}
+        onClick={onClickSafe}
+        onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
+          if (isDisabled && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault()
+            e.stopPropagation()
+          }
+          props?.onKeyDown?.(e)
+        }}
+        onFocus={(e: React.FocusEvent<HTMLElement>) => {
+          if (isDisabled) {
+            ;(e.currentTarget as HTMLElement).blur()
+            e.preventDefault()
+            e.stopPropagation()
+          }
+          props?.onFocus?.(e)
+        }}
+        onFocusCapture={(e: React.FocusEvent<HTMLElement>) => {
+          if (isDisabled) {
+            ;(e.currentTarget as HTMLElement).blur()
+            e.preventDefault()
+            e.stopPropagation()
+          }
+          props?.onFocusCapture?.(e)
+        }}
+        style={isDisabled ? { pointerEvents: "none" } : undefined}
       >
         {element}
       </BaseButton>
@@ -356,24 +395,49 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
     mode = MODE.checkbox
   }
 
-  const optionElements = useMemo(
-    () =>
-      options.map((option, index) => {
-        const Element = createOptionChild(
-          option,
-          index,
-          selectionVisualization,
-          clickMode,
-          value,
-          style,
-          containerWidth
-        )
-        // TODO: Update to match React best practices
-        // eslint-disable-next-line @eslint-react/no-array-index-key
-        return <Element key={`${option.content}-${index}`} />
-      }),
-    [clickMode, options, selectionVisualization, style, value, containerWidth]
-  )
+interface ButtonGroupElement {
+  disabled?: boolean;
+  disabledIndices?: number[];
+  options?: Array<{ disabled?: boolean }>;
+}
+
+const bg = (props.element as ButtonGroupElement | undefined) ?? undefined
+const overallDisabled = !!(props.disabled || bg?.disabled)
+const disabledIndices = Array.isArray(bg?.disabledIndices) ? bg!.disabledIndices! : []
+const disabledIndexSet = useMemo(() => new Set(disabledIndices), [disabledIndices])
+
+const optionElements = useMemo(
+  () =>
+    options.map((option, index) => {
+      const perOptionDisabled = !!bg?.options?.[index]?.disabled
+      const isDisabled =
+        overallDisabled || perOptionDisabled || disabledIndexSet.has(index)
+
+      const Element = createOptionChild(
+        option,
+        index,
+        selectionVisualization,
+        clickMode,
+        value,
+        style,
+        containerWidth,
+        isDisabled
+      )
+      return <Element key={`${option.content}-${index}`} />
+    }),
+  [
+    options,
+    selectionVisualization,
+    clickMode,
+    value,
+    style,
+    containerWidth,
+    overallDisabled,
+    bg?.options,
+    disabledIndexSet,
+  ]
+)
+
 
   return (
     <StyledButtonGroup

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -311,7 +311,7 @@ function createOptionChild(
         }}
         onFocus={(e: React.FocusEvent<HTMLElement>) => {
           if (isDisabled) {
-            ;(e.currentTarget as HTMLElement).blur()
+;(e.currentTarget as HTMLElement).blur()
             e.preventDefault()
             e.stopPropagation()
           }

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -14,21 +14,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Final,
-    Generic,
-    Literal,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import Any, Callable, Generic, Literal, cast
 
 from typing_extensions import TypeAlias
+from typing import (
+    TYPE_CHECKING,
+    Final,
+    TypeVar,
+    overload,
+)
 
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.layout_utils import (
@@ -92,6 +88,55 @@ _STAR_ICON: Final = ":material/star:"
 _SELECTED_STAR_ICON: Final = ":material/star_filled:"
 
 SelectionMode: TypeAlias = Literal["single", "multi"]
+
+
+def _normalize_disabled_mask(options: Sequence[Any], disabled: Any) -> list[bool]:
+    """
+    Normalize `disabled` into a per-option boolean mask.
+
+    Supported forms:
+      - True / False: all disabled / all enabled
+      - Iterable of bools with same length as options: positional mask
+      - Iterable of option values: disable by value (e.g., ("B","D"))
+      - Callable: lambda o -> bool
+      - None: all enabled
+    """
+
+    n = len(options)
+
+    if disabled is None or disabled is False:
+        return [False] * n
+
+    if disabled is True:
+        return [True] * n
+
+    if callable(disabled):
+        try:
+            return [bool(disabled(o)) for o in options]
+        except Exception as e:
+            raise StreamlitAPIException(
+                f"`disabled` callable raised an error: {e}"
+            ) from e
+
+    if isinstance(disabled, Iterable) and not isinstance(disabled, (str, bytes)):
+        seq = list(disabled)
+
+        # Case A: iterable of bools (positional mask)
+        if all(isinstance(x, bool) for x in seq):
+            if len(seq) != n:
+                raise StreamlitAPIException(
+                    f"`disabled` mask length {len(seq)} must match options length {n}."
+                )
+            return seq
+
+        # Case B: iterable of option values (disable-by-value)
+        disabled_set = set(seq)
+        return [o in disabled_set for o in options]
+
+    raise StreamlitAPIException(
+        "`disabled` should be a bool, an iterable of bools, "
+        "an iterable of option values, a callable, or None."
+    )
 
 
 @dataclass
@@ -214,12 +259,39 @@ def get_mapped_options(
 
     return options, options_indices
 
+# --- helpers for disabled state handling ---
+
+def _set_option_disabled_states(proto, mask):
+    """Set per-option disabled states if supported by proto.options[]."""
+    if len(proto.options) and hasattr(proto.options[0], "disabled"):
+        for opt, d in zip(proto.options, mask):
+            opt.disabled = bool(d)
+        return True
+    return False
+
+
+def _set_proto_disabled_indices(proto, disabled_indices):
+    """Set disabled_indices if supported by proto."""
+    if hasattr(proto, "disabled_indices"):
+        del proto.disabled_indices[:]      # keep existing list object
+        proto.disabled_indices.extend(disabled_indices)
+        return True
+    return False
+
+
+def _set_proto_disabled(proto, mask):
+    """Fallback: set proto.disabled if supported and mask is uniform."""
+    if all(mask) or not any(mask):
+        if hasattr(proto, "disabled"):
+            proto.disabled = all(mask)
+            return True
+    return False
 
 def _build_proto(
     widget_id: str,
     formatted_options: Sequence[ButtonGroupProto.Option],
     default_values: list[int],
-    disabled: bool,
+    disabled_mask: Sequence[bool] | bool,
     current_form_id: str,
     click_mode: ButtonGroupProto.ClickMode.ValueType,
     selection_visualization: ButtonGroupProto.SelectionVisualization.ValueType = (
@@ -235,11 +307,34 @@ def _build_proto(
     proto.id = widget_id
     proto.default[:] = default_values
     proto.form_id = current_form_id
-    proto.disabled = disabled
     proto.click_mode = click_mode
     proto.style = ButtonGroupProto.Style.Value(style.upper())
 
-    # not passing the label looks the same as a collapsed label
+    n = len(formatted_options)
+    mask = (
+        [disabled_mask] * n if isinstance(disabled_mask, bool) else list(disabled_mask)
+    )
+    if len(mask) != n:
+        raise StreamlitAPIException(
+            f"`disabled` mask length {len(mask)} must match options length {n}."
+        )
+
+    for opt in formatted_options:
+        proto.options.append(opt)
+
+    disabled_indices = [i for i, d in enumerate(mask) if d]
+
+    if not (
+        _set_option_disabled_states(proto, mask)
+        or _set_proto_disabled_indices(proto, disabled_indices)
+        or _set_proto_disabled(proto, mask)
+    ):
+        raise StreamlitAPIException(
+            "Per-option disabled unsupported by ButtonGroupProto. "
+            "Add `Option.disabled` or `disabled_indices` to the proto."
+        )
+
+
     if label is not None:
         proto.label = label
         proto.label_visibility.value = get_label_visibility_proto_value(
@@ -248,8 +343,6 @@ def _build_proto(
         if help is not None:
             proto.help = help
 
-    for formatted_option in formatted_options:
-        proto.options.append(formatted_option)
     proto.selection_visualization = selection_visualization
     return proto
 
@@ -1056,13 +1149,16 @@ class ButtonGroupMixin:
             label=label,
             help=help,
         )
+        disabled_mask = _normalize_disabled_mask(indexable_options, disabled)
+
+        default_indices = check_and_convert_to_indices(indexable_options, default) or []
 
         proto = _build_proto(
-            element_id,
-            formatted_options,
-            default or [],
-            disabled,
-            form_id,
+            widget_id=element_id,
+            formatted_options=formatted_options,
+            default_values=default_indices,
+            disabled_mask=disabled_mask,
+            current_form_id=form_id,
             click_mode=parsed_selection_mode,
             selection_visualization=selection_visualization,
             style=style,


### PR DESCRIPTION
Closes #12254
… for dev testing

## Summary
- Enable per-option disabling for `st.pills` and `st.segmented_control`.
- Frontend: propagate disabled state down to BaseButton; support HTML attrs (tabIndex, onKeyDown) for accessibility.
- Backend: update `button_group.py` to accept `disabled` per-option and serialize to proto.
- Added `frontend/demo_disabled.py` for local dev verification.

## Motivation
The previous implementation did not support disabling individual options in `st.pills` or `st.segmented_control`.  
This PR introduces parity with patterns already used in other widgets (e.g., `st.data_editor`) and improves accessibility.

## API
```python
st.pills(
    "Command categories",
    options=["Charts","Cache","Custom components","Widgets","Media"],
    disabled=("Widgets",),   # disable subset of options
)
```

## Test Plan
### 1) Run frontend dev server
```bash
cd frontend/app
yarn install
yarn start --port 3000
```
### 2) Run backend dev server
```bash
source .venv/bin/activate
export STREAMLIT_GLOBAL_DEVELOPMENT_MODE=true
python -m streamlit run frontend/demo_disabled.py --server.port 8501
```

