### PR TITLE
Fix CI failure caused by rerunfailures update by ignoring version

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -27,7 +27,9 @@ playwright==1.54.*
 pytest-playwright>=0.3.3
 pixelmatch>=0.3.0
 pytest-xdist>=3.6.1
-pytest-rerunfailures>=15.0
+# pytest-rerunfailures 16.0 is breaking our CI:
+# https://github.com/pytest-dev/pytest-rerunfailures/issues/302
+pytest-rerunfailures>=15.0,<16.0
 pytest-github-actions-annotate-failures
 pytest-benchmark>=5.1.0
 pytest-repeat>=0.9.3

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -29,7 +29,7 @@ pixelmatch>=0.3.0
 pytest-xdist>=3.6.1
 # pytest-rerunfailures 16.0 is breaking our CI:
 # https://github.com/pytest-dev/pytest-rerunfailures/issues/302
-pytest-rerunfailures>=15.0,<16.0
+pytest-rerunfailures>=15.0,!=16.0
 pytest-github-actions-annotate-failures
 pytest-benchmark>=5.1.0
 pytest-repeat>=0.9.3


### PR DESCRIPTION
## Describe your changes

The pytest-rerunfailures 16.0 update is breaking our CI, see related issue reports:

https://github.com/pytest-dev/pytest-rerunfailures/issues/302
https://github.com/pytest-dev/pytest-rerunfailures/issues/303

Ignoring 16.0 version to get our CI running again.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
