### PR TITLE
Remove `**kwargs` support from `st.write`

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -254,7 +254,7 @@ class WriteMixin:
         return written_content
 
     @gather_metrics("write")
-    def write(self, *args: Any, unsafe_allow_html: bool = False, **kwargs: Any) -> None:
+    def write(self, *args: Any, unsafe_allow_html: bool = False) -> None:
         """Displays arguments in the app.
 
         This is the Swiss Army knife of Streamlit commands: it does different
@@ -323,13 +323,6 @@ class WriteMixin:
                 If you only want to insert HTML or CSS without Markdown text,
                 we recommend using ``st.html`` instead.
 
-        **kwargs : any
-            Keyword arguments. Not used.
-
-        .. deprecated::
-            ``**kwargs`` is deprecated and will be removed in a later version.
-            Use other, more specific Streamlit commands to pass additional
-            keyword arguments.
 
         Returns
         -------
@@ -400,13 +393,6 @@ class WriteMixin:
             height: 300px
 
         """
-        if kwargs:
-            _LOGGER.warning(
-                'Invalid arguments were passed to "st.write" function. Support for '
-                "passing such unknown keywords arguments will be dropped in future. "
-                "Invalid arguments were: %s",
-                kwargs,
-            )
 
         if len(args) == 1 and isinstance(args[0], str):
             # Optimization: If there is only one arg, and it's a string,

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -31,7 +31,6 @@ from PIL import Image
 
 import streamlit as st
 from streamlit import type_util
-from streamlit.elements import write
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import QueryParamsProxy, SessionStateProxy
@@ -409,16 +408,6 @@ class StreamlitWriteTest(unittest.TestCase):
 
             with pytest.raises(Exception, match="some exception"):
                 st.write("some text")
-
-    def test_unknown_arguments(self):
-        """Test st.write that raises an exception."""
-        with self.assertLogs(write._LOGGER) as logs:
-            st.write("some text", unknown_keyword_arg=123)
-
-        assert (
-            'Invalid arguments were passed to "st.write" function.'
-            in logs.records[0].msg
-        )
 
     def test_spinner(self):
         """Test st.spinner."""


### PR DESCRIPTION
## Describe your changes

This removes support for passing in arbitrary keyword arguments to `st.write`, which has been deprecated for a long time and hasn't been doing anything anyway. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/12374

## Testing Plan

- Just removing something, no new tests needed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
