### PR TITLE
Add MIME type for `.mjs`

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -318,6 +318,7 @@ class Server:
         """Ensures that common mime-types are robust against system misconfiguration."""
         mimetypes.add_type("text/html", ".html")
         mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("application/javascript", ".mjs")
         mimetypes.add_type("text/css", ".css")
         mimetypes.add_type("image/webp", ".webp")
 

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -224,10 +224,12 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         """Test get_content_type function."""
         mimetypes.add_type("custom/html", ".html")
         mimetypes.add_type("custom/js", ".js")
+        mimetypes.add_type("custom/mjs", ".mjs")
         mimetypes.add_type("custom/css", ".css")
 
         assert ComponentRequestHandler.get_content_type("test.html") == "custom/html"
         assert ComponentRequestHandler.get_content_type("test.js") == "custom/js"
+        assert ComponentRequestHandler.get_content_type("test.mjs") == "custom/mjs"
         assert ComponentRequestHandler.get_content_type("test.css") == "custom/css"
 
         # Have the server reinitialize the mimetypes
@@ -236,6 +238,10 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert ComponentRequestHandler.get_content_type("test.html") == "text/html"
         assert (
             ComponentRequestHandler.get_content_type("test.js")
+            == "application/javascript"
+        )
+        assert (
+            ComponentRequestHandler.get_content_type("test.mjs")
             == "application/javascript"
         )
         assert ComponentRequestHandler.get_content_type("test.css") == "text/css"

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -121,6 +121,9 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmp_js_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="script.js", delete=False
         )
+        self._tmp_mjs_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="module.mjs", delete=False
+        )
         self._tmp_html_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="file.html", delete=False
         )
@@ -129,6 +132,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
         self._filename = os.path.basename(self._tmpfile.name)
         self._js_filename = os.path.basename(self._tmp_js_file.name)
+        self._mjs_filename = os.path.basename(self._tmp_mjs_file.name)
         self._html_filename = os.path.basename(self._tmp_html_file.name)
         self._css_filename = os.path.basename(self._tmp_css_file.name)
 
@@ -194,6 +198,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         """Test get_content_type function."""
         mimetypes.add_type("custom/html", ".html")
         mimetypes.add_type("custom/js", ".js")
+        mimetypes.add_type("custom/mjs", ".mjs")
         mimetypes.add_type("custom/css", ".css")
 
         r = self.fetch(f"/{self._html_filename}")
@@ -201,6 +206,9 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         r = self.fetch(f"/{self._js_filename}")
         assert r.headers["Content-Type"] == "custom/js"
+
+        r = self.fetch(f"/{self._mjs_filename}")
+        assert r.headers["Content-Type"] == "custom/mjs"
 
         r = self.fetch(f"/{self._css_filename}")
         assert r.headers["Content-Type"] == "custom/css"
@@ -211,6 +219,9 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert r.headers["Content-Type"] == "text/html"
 
         r = self.fetch(f"/{self._js_filename}")
+        assert r.headers["Content-Type"] == "application/javascript"
+
+        r = self.fetch(f"/{self._mjs_filename}")
         assert r.headers["Content-Type"] == "application/javascript"
 
         r = self.fetch(f"/{self._css_filename}")


### PR DESCRIPTION
## Describe your changes

Added MIME type for `.mjs` file extension as it is needed for the worker script of `st.pdf` on some Windows platforms

## GitHub Issue Link (if applicable)
Fixes #12387 

## Testing Plan

MIME types tests got extended.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
