### PR TITLE
[Prototype] Support configuring background and shadow for `st.container`

### DIFF
--- a/e2e_playwright/dashboard_grid.py
+++ b/e2e_playwright/dashboard_grid.py
@@ -1,0 +1,222 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import pandas as pd
+
+import streamlit as st
+
+
+@st.cache_data(show_spinner=False)
+def generate_mock_data(
+    days: int = 90, seed: int = 7
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Generate mock time-series and categorical data for the dashboard.
+
+    Parameters
+    ----------
+    days:
+        Number of days of data to generate.
+    seed:
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, pd.DataFrame]
+        time_series_df: Columns [date, users, sales, revenue, conversion_rate]
+        category_df: Columns [category, revenue]
+    """
+
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range(end=dt.date.today(), periods=days, freq="D")
+
+    base_users = rng.normal(loc=1200, scale=120, size=days).clip(min=300)
+    trend_users = np.linspace(0, 150, days)
+    users = (base_users + trend_users).round().astype(int)
+
+    # Sales roughly proportional to users with noise
+    sales_rate = rng.normal(loc=0.08, scale=0.01, size=days).clip(0.03, 0.15)
+    sales = (
+        np.floor(users * sales_rate + rng.normal(0, 10, size=days))
+        .clip(min=0)
+        .astype(int)
+    )
+
+    # Revenue per sale varies slightly day-to-day
+    revenue_per_sale = rng.normal(loc=42.0, scale=4.5, size=days).clip(20, 80)
+    revenue = (sales * revenue_per_sale).round(2)
+
+    conversion_rate = (sales / np.maximum(users, 1) * 100).round(2)
+
+    time_series_df = pd.DataFrame(
+        {
+            "date": dates,
+            "users": users,
+            "sales": sales,
+            "revenue": revenue,
+            "conversion_rate": conversion_rate,
+        }
+    )
+
+    categories = ["Alpha", "Beta", "Gamma", "Delta", "Omega"]
+    cat_weights = rng.uniform(0.8, 1.2, size=len(categories))
+    cat_revenue = (cat_weights / cat_weights.sum()) * revenue[-7:].sum()
+    category_df = pd.DataFrame(
+        {"category": categories, "revenue": cat_revenue.round(2)}
+    )
+
+    return time_series_df, category_df
+
+
+def percentage_delta(current: float, previous: float) -> float:
+    if previous == 0:
+        return 0.0
+    return (current - previous) / previous * 100.0
+
+
+st.set_page_config(page_title="Dashboard Grid (Mock)", layout="wide")
+
+use_container_shadow = st.sidebar.toggle("Use container shadow", value=True)
+use_container_background = st.sidebar.toggle("Use container background", value=True)
+use_container_border = st.sidebar.toggle("Use container border", value=False)
+
+# Header / meta
+with st.container():
+    st.title(":material/bar_chart: Demo Dashboard Grid")
+    st.caption(
+        "Mock data showcasing containers, columns, metrics, a dataframe, and charts."
+    )
+    st.write(f"Last updated: {dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+ts_df, cat_df = generate_mock_data(days=120)
+
+# KPI row
+kpi_cols = st.columns(4)
+latest = ts_df.iloc[-1]
+prev = ts_df.iloc[-2]
+
+with kpi_cols[0]:
+    st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ).metric(
+        label="Active Users",
+        value=f"{latest.users:,}",
+        delta=f"{abs(percentage_delta(latest.users, prev.users)):+.1f}%",
+    )
+with kpi_cols[1]:
+    st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ).metric(
+        label="Sales",
+        value=f"{latest.sales:,}",
+        delta=f"{abs(percentage_delta(latest.sales, prev.sales)):+.1f}%",
+    )
+with kpi_cols[2]:
+    st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ).metric(
+        label="Revenue",
+        value=f"${latest.revenue:,.0f}",
+        delta=f"{abs(percentage_delta(latest.revenue, prev.revenue)):+.1f}%",
+    )
+with kpi_cols[3]:
+    st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ).metric(
+        label="Conversion Rate",
+        value=f"{latest.conversion_rate:.2f}%",
+        delta=f"{abs(latest.conversion_rate - prev.conversion_rate):+.2f} pp",
+    )
+
+
+# Main grid
+left_col, right_col = st.columns([3, 2], gap="small")
+
+with left_col:
+    with st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+        height=350,
+    ):
+        st.subheader("Recent Activity")
+        st.dataframe(
+            ts_df.tail(25).sort_values("date", ascending=False).reset_index(drop=True),
+            use_container_width=True,
+            hide_index=True,
+            height=240,
+        )
+
+with right_col:
+    with st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+        height=350,
+    ):
+        st.subheader("Trends (Last 60 Days)")
+        recent = ts_df.set_index("date").tail(60)[["users", "sales"]]
+        st.line_chart(recent, height=220)
+        st.caption("Users and Sales over time")
+
+
+# Secondary grid
+c1, c2, c3 = st.columns([2, 2, 2])
+
+with c1:
+    with st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ):
+        st.subheader("Category Revenue (7d)")
+        st.dataframe(
+            cat_df.sort_values("revenue", ascending=False),
+            use_container_width=True,
+            height=240,
+        )
+
+with c2:
+    with st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ):
+        st.subheader("Sales (14d)")
+        sales_14 = ts_df.set_index("date").tail(14)[["sales"]]
+        st.bar_chart(sales_14, height=240)
+
+with c3:
+    with st.container(
+        shadow=use_container_shadow,
+        background=use_container_background,
+        border=use_container_border,
+    ):
+        st.subheader("Revenue vs. Conversion (30d)")
+        rev_conv = ts_df.set_index("date").tail(30)[["revenue", "conversion_rate"]]
+        st.area_chart(rev_conv, height=240)

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -32,6 +32,7 @@ import {
   shouldWidthStretch,
 } from "~lib/components/core/Layout/utils"
 import { LibContext } from "~lib/components/core/LibContext"
+import ThemeProvider from "~lib/components/core/ThemeProvider"
 import ChatMessage from "~lib/components/elements/ChatMessage"
 import Dialog from "~lib/components/elements/Dialog"
 import Expander from "~lib/components/elements/Expander"
@@ -42,6 +43,7 @@ import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
 import { useScrollToBottom } from "~lib/hooks/useScrollToBottom"
 import { ScriptRunState } from "~lib/ScriptRunState"
+import { createTheme } from "~lib/theme"
 import { getElementId, notNullOrUndefined } from "~lib/util/utils"
 
 import ElementNodeRenderer from "./ElementNodeRenderer"
@@ -211,6 +213,8 @@ interface FlexBoxContainerProps extends BaseBlockProps {
 export const FlexBoxContainer = (
   props: FlexBoxContainerProps
 ): ReactElement => {
+  const { activeTheme } = useContext(LibContext)
+
   const direction = getDirectionOfBlock(props.node.deltaBlock)
 
   const activateScrollToBottom = getActivateScrollToBottomBackwardsCompatible(
@@ -241,11 +245,13 @@ export const FlexBoxContainer = (
     flex: "1",
     align: props.node.deltaBlock.flexContainer?.align,
     justify: props.node.deltaBlock.flexContainer?.justify,
+    background: props.node.deltaBlock.flexContainer?.background ?? false,
+    shadow: props.node.deltaBlock.flexContainer?.shadow ?? false,
   }
 
   const userKey = getKeyFromId(props.node.deltaBlock.id)
 
-  return (
+  const flexContainerBlock = (
     <FlexContextProvider direction={direction}>
       <StyledFlexContainerBlock
         {...styles}
@@ -263,6 +269,29 @@ export const FlexBoxContainer = (
       </StyledFlexContainerBlock>
     </FlexContextProvider>
   )
+
+  if (props.node.deltaBlock.flexContainer?.background) {
+    const updatedTheme = createTheme(
+      "Container",
+      {
+        // Change the colors:
+        secondaryBackgroundColor: activeTheme.emotion.colors.bgColor,
+        backgroundColor: activeTheme.emotion.colors.secondaryBg,
+      },
+      activeTheme,
+      false
+    )
+    console.log("updatedTheme", updatedTheme)
+    return (
+      <ThemeProvider
+        theme={updatedTheme.emotion}
+        baseuiTheme={updatedTheme.basewebTheme}
+      >
+        {flexContainerBlock}
+      </ThemeProvider>
+    )
+  }
+  return flexContainerBlock
 }
 
 export interface BlockPropsWithoutWidth extends BaseBlockProps {

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -257,7 +257,7 @@ export const StyledFlexContainerBlock =
         ...(shadow && {
           boxShadow: lightTheme
             ? `0 ${theme.spacing.px} ${theme.spacing.twoXS} rgba(0,0,0,0.15)`
-            : `0 ${theme.spacing.threeXS} ${theme.spacing.xs} rgba(0,0,0,0.5)`,
+            : `0 ${theme.spacing.threeXS} ${theme.spacing.xs} rgba(0,0,0,0.4)`,
           borderRadius: theme.radii.default,
           padding: `calc(${theme.spacing.lg} - ${theme.sizes.borderWidth})`,
         }),

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -208,6 +208,8 @@ export interface StyledFlexContainerBlockProps {
   align?: BlockProto.FlexContainer.Align | null
   justify?: BlockProto.FlexContainer.Justify | null
   overflow?: React.CSSProperties["overflow"]
+  background?: boolean
+  shadow?: boolean
 }
 
 export const StyledFlexContainerBlock =
@@ -223,6 +225,8 @@ export const StyledFlexContainerBlock =
       align,
       justify,
       overflow,
+      background,
+      shadow,
     }) => {
       let gapWidth
       if (gap !== undefined) {
@@ -241,6 +245,14 @@ export const StyledFlexContainerBlock =
         alignItems: getAlignItems(align),
         justifyContent: getJustifyContent(justify),
         flexWrap: $wrap ? "wrap" : "nowrap",
+        ...(background && {
+          backgroundColor: theme.colors.bgColor,
+          borderRadius: theme.radii.default,
+          padding: `calc(${theme.spacing.lg} - ${theme.sizes.borderWidth})`,
+        }),
+        ...(shadow && {
+          boxShadow: `0 ${theme.spacing.threeXS} ${theme.spacing.xs} rgba(0,0,0,0.15)`,
+        }),
         ...(border && {
           border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
           borderRadius: theme.radii.default,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -21,7 +21,11 @@ import styled from "@emotion/styled"
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
 import { StyledCheckbox } from "~lib/components/widgets/Checkbox/styled-components"
-import { EmotionTheme, STALE_STYLES } from "~lib/theme"
+import {
+  EmotionTheme,
+  hasLightBackgroundColor,
+  STALE_STYLES,
+} from "~lib/theme"
 import { assertNever } from "~lib/util/assertNever"
 
 function translateGapWidth(
@@ -232,7 +236,7 @@ export const StyledFlexContainerBlock =
       if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
       }
-
+      const lightTheme = hasLightBackgroundColor(theme)
       return {
         display: "flex",
         gap: gapWidth,
@@ -251,7 +255,11 @@ export const StyledFlexContainerBlock =
           padding: `calc(${theme.spacing.lg} - ${theme.sizes.borderWidth})`,
         }),
         ...(shadow && {
-          boxShadow: `0 ${theme.spacing.threeXS} ${theme.spacing.xs} rgba(0,0,0,0.15)`,
+          boxShadow: lightTheme
+            ? `0 ${theme.spacing.px} ${theme.spacing.twoXS} rgba(0,0,0,0.15)`
+            : `0 ${theme.spacing.threeXS} ${theme.spacing.xs} rgba(0,0,0,0.5)`,
+          borderRadius: theme.radii.default,
+          padding: `calc(${theme.spacing.lg} - ${theme.sizes.borderWidth})`,
         }),
         ...(border && {
           border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -70,6 +70,8 @@ class LayoutsMixin:
         horizontal_alignment: HorizontalAlignment = "left",
         vertical_alignment: VerticalAlignment = "top",
         gap: Gap | None = "small",
+        background: bool = False,
+        shadow: bool = False,
     ) -> DeltaGenerator:
         """Insert a multi-element container.
 
@@ -183,6 +185,15 @@ class LayoutsMixin:
             between the elements. Elements may have larger gaps in one
             direction if you use a distributed horizontal alignment or fixed
             height.
+
+        background : bool or None
+            Whether to show a background color behind the container. If this is
+            ``False`` (default), no background color is shown. If this is ``True``,
+            the configured secondary background color us used.
+
+        shadow : bool
+            Whether to show a shadow around the container. If this is ``False`` (default), no shadow is shown.
+             If this is ``True``, a box shadow is shown around the container.
 
         Examples
         --------
@@ -312,6 +323,9 @@ class LayoutsMixin:
             block_proto.flex_container.border = True
         else:
             block_proto.flex_container.border = False
+
+        block_proto.flex_container.background = background
+        block_proto.flex_container.shadow = shadow
 
         validate_height(height, allow_content=True)
         block_proto.height_config.CopyFrom(get_height_config(height))

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -84,6 +84,8 @@ message Block {
       STRETCH = 4;
     }
     Align align = 8;
+    bool background = 9;
+    bool shadow = 10;
   }
 
   message Column {


### PR DESCRIPTION
## Describe your changes

Adds a `background: bool` and `shadow: bool` parameter to `st.container` to make it easy to build beautiful dashboards. 

- Demo: https://container-background-prototype.streamlit.app/

<img width="1289" height="876" alt="image" src="https://github.com/user-attachments/assets/3619ac71-5102-45b7-b5ef-2882fd435c2b" />

Setting `background = True` creates a new theme for the container that uses the `secondaryBackground` as the main background. 

## GitHub Issue Link (if applicable)

- https://github.com/streamlit/streamlit/issues/10531
- https://github.com/streamlit/streamlit/issues/12418

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
