### PR TITLE
Update cache headers to include `max-age` and `immutable`

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -62,16 +62,20 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         super().initialize(path, default_filename)
 
     def set_extra_headers(self, path: str) -> None:
-        """Disable cache for HTML files.
+        """Disable cache for HTML files and manifest.json.
 
         Other assets like JS and CSS are suffixed with their hash, so they can
         be cached indefinitely.
         """
+
         is_index_url = len(path) == 0
-        if is_index_url or path.endswith(".html"):
+        if is_index_url or path.endswith((".html", "manifest.json")):
             self.set_header("Cache-Control", "no-cache")
         else:
-            self.set_header("Cache-Control", "public")
+            # For all other static files, we set a long cache time.
+            # This is because these files are versioned with a hash in their name,
+            # so they can be cached indefinitely.
+            self.set_header("Cache-Control", "public, immutable, max-age=31536000")
 
     def validate_absolute_path(self, root: str, absolute_path: str) -> str | None:
         try:

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
 import tornado.web
 
@@ -28,6 +28,11 @@ from streamlit.web.server.server_util import (
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Sequence
+
+
+NO_CACHE_SUFFIXES: Final = (".html", "manifest.json")
+
+STATIC_ASSET_CACHE_MAX_AGE: Final = 31536000
 
 
 def allow_all_cross_origin_requests() -> bool:
@@ -69,13 +74,16 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         """
 
         is_index_url = len(path) == 0
-        if is_index_url or path.endswith((".html", "manifest.json")):
+        if is_index_url or path.endswith(NO_CACHE_SUFFIXES):
             self.set_header("Cache-Control", "no-cache")
         else:
             # For all other static files, we set a long cache time.
             # This is because these files are versioned with a hash in their name,
             # so they can be cached indefinitely.
-            self.set_header("Cache-Control", "public, immutable, max-age=31536000")
+            self.set_header(
+                "Cache-Control",
+                f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE}",
+            )
 
     def validate_absolute_path(self, root: str, absolute_path: str) -> str | None:
         try:

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
 import tornado.web
@@ -30,9 +31,11 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Sequence
 
 
-NO_CACHE_SUFFIXES: Final = (".html", "manifest.json")
+# Files that match this pattern do not get cached.
+NO_CACHE_PATTERN = re.compile(r"(?:\.html$|^manifest\.json$)")
 
-STATIC_ASSET_CACHE_MAX_AGE: Final = 31536000
+# The max-age value to send with cached assets. Set to one year.
+STATIC_ASSET_CACHE_MAX_AGE_SECONDS: Final = 365 * 24 * 60 * 60
 
 
 def allow_all_cross_origin_requests() -> bool:
@@ -74,15 +77,13 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         """
 
         is_index_url = len(path) == 0
-        if is_index_url or path.endswith(NO_CACHE_SUFFIXES):
+        if is_index_url or NO_CACHE_PATTERN.search(path):
             self.set_header("Cache-Control", "no-cache")
         else:
-            # For all other static files, we set a long cache time.
-            # This is because these files are versioned with a hash in their name,
-            # so they can be cached indefinitely.
+            # For all other static files suffixed with their hash, we set a long cache time.
             self.set_header(
                 "Cache-Control",
-                f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE}",
+                f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}",
             )
 
     def validate_absolute_path(self, root: str, absolute_path: str) -> str | None:

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -130,11 +130,15 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmp_css_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="stylesheet.css", delete=False
         )
+        self._tmp_manifest_file = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, suffix="manifest.json", delete=False
+        )
         self._filename = os.path.basename(self._tmpfile.name)
         self._js_filename = os.path.basename(self._tmp_js_file.name)
         self._mjs_filename = os.path.basename(self._tmp_mjs_file.name)
         self._html_filename = os.path.basename(self._tmp_html_file.name)
         self._css_filename = os.path.basename(self._tmp_css_file.name)
+        self._manifest_filename = os.path.basename(self._tmp_manifest_file.name)
 
         super().setUp()
 
@@ -193,6 +197,19 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         for r in responses:
             assert r.code == 404
+
+    def test_cache_control_header(self):
+        r = self.fetch(f"/{self._html_filename}")
+        assert r.headers["Cache-Control"] == "no-cache"
+
+        r = self.fetch(f"/{self._manifest_filename}")
+        assert r.headers["Cache-Control"] == "no-cache"
+
+        r = self.fetch(f"/{self._js_filename}")
+        assert r.headers["Cache-Control"] == "public, immutable, max-age=31536000"
+
+        r = self.fetch(f"/{self._css_filename}")
+        assert r.headers["Cache-Control"] == "public, immutable, max-age=31536000"
 
     def test_mimetype_is_overridden_by_server(self):
         """Test get_content_type function."""

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -18,6 +18,7 @@ import json
 import mimetypes
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import tornado.httpserver
@@ -130,15 +131,16 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._tmp_css_file = tempfile.NamedTemporaryFile(
             dir=self._tmpdir.name, suffix="stylesheet.css", delete=False
         )
-        self._tmp_manifest_file = tempfile.NamedTemporaryFile(
-            dir=self._tmpdir.name, suffix="manifest.json", delete=False
-        )
+        # The manifest file must not have a prefix - create it manually in the tmpdir
+        self._tmp_manifest_filename = os.path.join(self._tmpdir.name, "manifest.json")
+        Path(self._tmp_manifest_filename).touch()
+
         self._filename = os.path.basename(self._tmpfile.name)
         self._js_filename = os.path.basename(self._tmp_js_file.name)
         self._mjs_filename = os.path.basename(self._tmp_mjs_file.name)
         self._html_filename = os.path.basename(self._tmp_html_file.name)
         self._css_filename = os.path.basename(self._tmp_css_file.name)
-        self._manifest_filename = os.path.basename(self._tmp_manifest_file.name)
+        self._manifest_filename = os.path.basename(self._tmp_manifest_filename)
 
         super().setUp()
 
@@ -204,6 +206,9 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         r = self.fetch(f"/{self._manifest_filename}")
         assert r.headers["Cache-Control"] == "no-cache"
+
+        r = self.fetch(f"/nested/{self._manifest_filename}")
+        assert r.headers["Cache-Control"] == "public, immutable, max-age=31536000"
 
         r = self.fetch(f"/{self._js_filename}")
         assert r.headers["Cache-Control"] == "public, immutable, max-age=31536000"


### PR DESCRIPTION
## Describe your changes
Without `max-age` defined in the cache header, browsers fallback to use a heuristic caching strategy which is typically (Chrome)10% of the time since the "Last Modified" header (see https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.2). Firefox caps this at a week. Since the files being served all contain a hash, the actual cache duration can be much much longer.

For environments where the static files get written at deployment or startup time, the heuristic cache can be on the order of minutes/hours.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
