### PR TITLE
Remove unused global variable

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -56,7 +56,7 @@ HELP_TYPES: Final[tuple[type[Any], ...]] = (
     types.ModuleType,
 )
 
-_LOGGER: Final = get_logger(__name__)
+
 
 _TEXT_CURSOR: Final = " ▏"
 

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -37,7 +37,6 @@ from typing import (
 
 from streamlit import dataframe_util, type_util
 from streamlit.errors import StreamlitAPIException
-from streamlit.logger import get_logger
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import (
     is_mem_address_str,
@@ -55,7 +54,6 @@ HELP_TYPES: Final[tuple[type[Any], ...]] = (
     types.MethodType,
     types.ModuleType,
 )
-
 
 
 _TEXT_CURSOR: Final = " ▏"


### PR DESCRIPTION
Potential fix for [https://github.com/streamlit/streamlit/security/code-scanning/10720](https://github.com/streamlit/streamlit/security/code-scanning/10720)

The best way to fix this issue is to remove the definition of `_LOGGER` from line 59, since the variable is not used anywhere in the visible code snippet and its right-hand side assignment `get_logger(__name__)` does not have crucial side effects that require retention. No changes elsewhere are necessary because there's no functional dependency on `_LOGGER`. This edit only affects the definition on line 59 in the file `lib/streamlit/elements/write.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
