### PR TITLE
Refactor the `st.slider` e2e test

### DIFF
--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -190,6 +190,35 @@ def get_date_input(locator: Locator | Page, label: str | Pattern[str]) -> Locato
     return element
 
 
+def get_slider(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
+    """Get a slider with the given label.
+
+    Parameters
+    ----------
+    locator : Locator | Page
+        The locator to search for the element.
+
+    label : str or Pattern[str]
+        The label of the element to get.
+
+    Returns
+    -------
+    Locator
+        The element.
+    """
+    # Prefer matching the widget label exactly to avoid substring collisions
+    if isinstance(label, Pattern):
+        label_locator = locator.get_by_test_id("stWidgetLabel").filter(has_text=label)
+    else:
+        label_locator = locator.get_by_test_id("stWidgetLabel").get_by_text(
+            label, exact=True
+        )
+
+    element = locator.get_by_test_id("stSlider").filter(has=label_locator)
+    expect(element).to_be_visible()
+    return element
+
+
 def get_checkbox(locator: Locator | Page, label: str | Pattern[str]) -> Locator:
     """Get a checkbox widget with the given label.
 

--- a/e2e_playwright/st_slider.py
+++ b/e2e_playwright/st_slider.py
@@ -66,11 +66,11 @@ w4 = st.slider("Label 4", 10000, 25000, 10000, disabled=True)
 st.write("Value 4:", w4)
 
 # Slider 8
-w5 = st.slider("Label 5", 0, 100, 25, 1, label_visibility="hidden")
+w5 = st.slider("Label 5", 0, 100, 25, 1, label_visibility="hidden", key="slider_5")
 st.write("Value 5:", w5)
 
 # Slider 9
-w6 = st.slider("Label 6", 0, 100, 36, label_visibility="collapsed")
+w6 = st.slider("Label 6", 0, 100, 36, label_visibility="collapsed", key="slider_6")
 st.write("Value 6:", w6)
 
 # Slider 10

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -23,7 +25,9 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
     expect_help_tooltip,
+    expect_markdown,
     get_element_by_key,
+    get_slider,
 )
 
 
@@ -31,32 +35,66 @@ def test_slider_rendering(themed_app: Page, assert_snapshot: ImageCompareFunctio
     st_sliders = themed_app.get_by_test_id("stSlider")
     expect(st_sliders).to_have_count(24)
 
-    assert_snapshot(st_sliders.nth(4), name="st_slider-regular_with_format")
-    assert_snapshot(st_sliders.nth(7), name="st_slider-disabled")
-    assert_snapshot(st_sliders.nth(8), name="st_slider-hidden_label")
-    assert_snapshot(st_sliders.nth(9), name="st_slider-label_collapsed")
-    assert_snapshot(st_sliders.nth(10), name="st_slider-labels_overlap_slider")
-    assert_snapshot(st_sliders.nth(15), name="st_slider-time_value")
-    assert_snapshot(st_sliders.nth(16), name="st_slider-overlap_left")
-    assert_snapshot(st_sliders.nth(17), name="st_slider-overlap_near_left")
-    assert_snapshot(st_sliders.nth(18), name="st_slider-overlap_right")
-    assert_snapshot(st_sliders.nth(19), name="st_slider-overlap_near_right")
-    assert_snapshot(st_sliders.nth(20), name="st_slider-overlap_near_center")
-    assert_snapshot(st_sliders.nth(21), name="st_slider-markdown_label")
-    assert_snapshot(st_sliders.nth(22), name="st_slider-width_300px")
-    assert_snapshot(st_sliders.nth(23), name="st_slider-width_stretch")
+    assert_snapshot(
+        get_slider(themed_app, "Label 1"), name="st_slider-regular_with_format"
+    )
+    assert_snapshot(get_slider(themed_app, "Label 4"), name="st_slider-disabled")
+    assert_snapshot(
+        get_element_by_key(themed_app, "slider_5"), name="st_slider-hidden_label"
+    )
+    assert_snapshot(
+        get_element_by_key(themed_app, "slider_6"), name="st_slider-label_collapsed"
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 7"), name="st_slider-labels_overlap_slider"
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Slider 12 (time-value)"), name="st_slider-time_value"
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 13 - Overlapping on the left"),
+        name="st_slider-overlap_left",
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 14 - Overlapping near the left"),
+        name="st_slider-overlap_near_left",
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 15 - Overlapping on the right"),
+        name="st_slider-overlap_right",
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 16 - Overlapping near the right"),
+        name="st_slider-overlap_near_right",
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 17 - Overlapping near the center"),
+        name="st_slider-overlap_near_center",
+    )
+    assert_snapshot(
+        get_slider(themed_app, re.compile(r"^Label 18")),
+        name="st_slider-markdown_label",
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 19 - Width 300px"), name="st_slider-width_300px"
+    )
+    assert_snapshot(
+        get_slider(themed_app, "Label 20 - Width Stretch"),
+        name="st_slider-width_stretch",
+    )
 
 
 def test_help_tooltip_works(app: Page):
-    st_sliders = app.get_by_test_id("stSlider")
-    expect_help_tooltip(app, st_sliders.nth(4), "This is some help tooltip!")
+    element_with_help = get_slider(app, "Label 1")
+    expect_help_tooltip(app, element_with_help, "This is some help tooltip!")
 
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
-    expect(app.get_by_text("Value B: 10000")).to_have_count(1)
-    expect(app.get_by_text("Range Value B: (10000, 25000)")).to_have_count(1)
-    first_slider_in_expander = app.get_by_test_id("stSlider").nth(2)
-    second_slider_in_expander = app.get_by_test_id("stSlider").nth(3)
+    expect_markdown(app, "Value B: 10000")
+    expect_markdown(app, "Range Value B: (10000, 25000)")
+    # Target by label at page scope to avoid container scoping issues
+    first_slider_in_expander = get_slider(app, "Label B")
+    second_slider_in_expander = get_slider(app, "Range B")
 
     first_slider_in_expander.hover()
     # click in middle
@@ -80,12 +118,11 @@ def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
 def test_slider_contains_correct_format_func_value_and_in_session_state(
     app: Page,
 ):
-    expect(
-        app.get_by_text(
-            "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))"
-        )
-    ).to_have_count(1)
-    slider = app.get_by_test_id("stSlider").nth(4)
+    expect_markdown(
+        app,
+        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
+    )
+    slider = get_slider(app, "Label 1")
     slider.hover()
     # click in middle
     app.mouse.down()
@@ -95,20 +132,18 @@ def test_slider_contains_correct_format_func_value_and_in_session_state(
     app.mouse.up()
     wait_for_app_run(app)
 
-    expect(
-        app.get_by_text(
-            "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 8, 1))"
-        )
-    ).to_have_count(1)
+    expect_markdown(
+        app,
+        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 8, 1))",
+    )
 
 
 def test_using_arrow_keys_on_slider_produces_correct_values(app: Page):
-    expect(
-        app.get_by_text(
-            "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))"
-        )
-    ).to_have_count(1)
-    slider = app.get_by_test_id("stSlider").nth(4)
+    expect_markdown(
+        app,
+        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
+    )
+    slider = get_slider(app, "Label 1")
     slider.hover()
     # click in middle
     app.mouse.down()
@@ -116,27 +151,25 @@ def test_using_arrow_keys_on_slider_produces_correct_values(app: Page):
     # Move slider once to right
     app.keyboard.press("ArrowRight")
     wait_for_app_run(app)
-    expect(
-        app.get_by_text(
-            "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 3))"
-        )
-    ).to_have_count(1)
+    expect_markdown(
+        app,
+        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 3))",
+    )
 
     # Move slider once to left
     app.keyboard.press("ArrowLeft")
     wait_for_app_run(app)
 
-    expect(
-        app.get_by_text(
-            "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 2))"
-        )
-    ).to_have_count(1)
+    expect_markdown(
+        app,
+        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 2))",
+    )
 
 
 def test_slider_calls_callback(app: Page):
     expect(app.get_by_text("Value 8: 25")).to_be_visible()
     expect(app.get_by_text("Slider changed: False")).to_be_visible()
-    slider = app.get_by_test_id("stSlider").nth(11)
+    slider = get_slider(app, "Label 8")
     # click in middle
     slider.click()
 
@@ -147,15 +180,13 @@ def test_slider_calls_callback(app: Page):
 
 def test_slider_works_in_forms(app: Page):
     expect(app.get_by_text("slider-in-form selection: 25")).to_be_visible()
-    slider = app.get_by_test_id("stSlider").nth(12)
+    slider = get_slider(app, "Label 9")
     # click in middle
     slider.click()
 
     # The value is not submitted so the value should not have changed yet
     expect(app.get_by_text("slider-in-form selection: 25")).to_be_visible()
 
-    # need to wait for the actual component value to update and then submit
-    app.wait_for_timeout(200)
     click_form_button(app, "Submit")
 
     expect(app.get_by_text("slider-in-form selection: 50")).to_be_visible()
@@ -164,7 +195,7 @@ def test_slider_works_in_forms(app: Page):
 def test_slider_works_with_fragments(app: Page):
     expect(app.get_by_text("Runs: 1")).to_be_visible()
     expect(app.get_by_text("slider-in-fragment selection: 25")).to_be_visible()
-    slider = app.get_by_test_id("stSlider").nth(13)
+    slider = get_slider(app, "Label 10")
     # click in middle
     slider.click()
 
@@ -174,7 +205,7 @@ def test_slider_works_with_fragments(app: Page):
 
 
 def test_slider_with_float_formatting(app: Page, assert_snapshot: ImageCompareFunction):
-    slider = app.get_by_test_id("stSlider").nth(14)
+    slider = get_slider(app, "Slider 11 (formatted float)")
     slider.hover()
     # click in middle
     app.mouse.down()
@@ -196,7 +227,7 @@ def test_no_rerun_on_drag(app: Page):
     runs_text = app.get_by_text("Runs: 1")
     expect(runs_text).to_be_visible()
 
-    slider = app.get_by_test_id("stSlider").nth(11)
+    slider = get_slider(app, "Label 8")
     slider.hover()
     # click in middle and drag
     app.mouse.down()
@@ -219,7 +250,7 @@ def test_slider_interaction_performance(app: Page):
     As of writing, a simple slider interaction effectively causes a full page
     re-render.
     """
-    slider = app.get_by_test_id("stSlider").nth(8)
+    slider = get_element_by_key(app, "slider_5")
     slider.hover()
     # click in middle
     app.mouse.down()

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -26,6 +26,7 @@ from e2e_playwright.shared.app_utils import (
     click_form_button,
     expect_help_tooltip,
     expect_markdown,
+    expect_prefixed_markdown,
     get_element_by_key,
     get_slider,
 )
@@ -90,8 +91,8 @@ def test_help_tooltip_works(app: Page):
 
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
-    expect_markdown(app, "Value B: 10000")
-    expect_markdown(app, "Range Value B: (10000, 25000)")
+    expect_prefixed_markdown(app, "Value B:", "10000")
+    expect_markdown(app, "Range Value B:", "(10000, 25000)")
     # Target by label at page scope to avoid container scoping issues
     first_slider_in_expander = get_slider(app, "Label B")
     second_slider_in_expander = get_slider(app, "Range B")
@@ -118,9 +119,10 @@ def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
 def test_slider_contains_correct_format_func_value_and_in_session_state(
     app: Page,
 ):
-    expect_markdown(
+    expect_prefixed_markdown(
         app,
-        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
+        "Value 1:",
+        "(datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
     )
     slider = get_slider(app, "Label 1")
     slider.hover()
@@ -132,16 +134,18 @@ def test_slider_contains_correct_format_func_value_and_in_session_state(
     app.mouse.up()
     wait_for_app_run(app)
 
-    expect_markdown(
+    expect_prefixed_markdown(
         app,
-        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 8, 1))",
+        "Value 1:",
+        "(datetime.date(2019, 8, 1), datetime.date(2019, 8, 1))",
     )
 
 
 def test_using_arrow_keys_on_slider_produces_correct_values(app: Page):
-    expect_markdown(
+    expect_prefixed_markdown(
         app,
-        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
+        "Value 1:",
+        "(datetime.date(2019, 8, 1), datetime.date(2019, 9, 1))",
     )
     slider = get_slider(app, "Label 1")
     slider.hover()
@@ -151,18 +155,20 @@ def test_using_arrow_keys_on_slider_produces_correct_values(app: Page):
     # Move slider once to right
     app.keyboard.press("ArrowRight")
     wait_for_app_run(app)
-    expect_markdown(
+    expect_prefixed_markdown(
         app,
-        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 3))",
+        "Value 1:",
+        "(datetime.date(2019, 8, 1), datetime.date(2020, 7, 3))",
     )
 
     # Move slider once to left
     app.keyboard.press("ArrowLeft")
     wait_for_app_run(app)
 
-    expect_markdown(
+    expect_prefixed_markdown(
         app,
-        "Value 1: (datetime.date(2019, 8, 1), datetime.date(2020, 7, 2))",
+        "Value 1:",
+        "(datetime.date(2019, 8, 1), datetime.date(2020, 7, 2))",
     )
 
 

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -25,7 +25,6 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
     expect_help_tooltip,
-    expect_markdown,
     expect_prefixed_markdown,
     get_element_by_key,
     get_slider,
@@ -92,7 +91,7 @@ def test_help_tooltip_works(app: Page):
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
     expect_prefixed_markdown(app, "Value B:", "10000")
-    expect_markdown(app, "Range Value B:", "(10000, 25000)")
+    expect_prefixed_markdown(app, "Range Value B:", "(10000, 25000)")
     # Target by label at page scope to avoid container scoping issues
     first_slider_in_expander = get_slider(app, "Label B")
     second_slider_in_expander = get_slider(app, "Range B")

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -25,6 +25,7 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
     expect_help_tooltip,
+    expect_markdown,
     expect_prefixed_markdown,
     get_element_by_key,
     get_slider,
@@ -90,7 +91,7 @@ def test_help_tooltip_works(app: Page):
 
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
-    expect_prefixed_markdown(app, "Value B:", "10000")
+    c(app, "Value B: 10000")
     expect_prefixed_markdown(app, "Range Value B:", "(10000, 25000)")
     # Target by label at page scope to avoid container scoping issues
     first_slider_in_expander = get_slider(app, "Label B")
@@ -108,8 +109,8 @@ def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
     app.mouse.up()
     wait_for_app_run(app)
 
-    expect(app.get_by_text("Value B: 17500")).to_have_count(1)
-    expect(app.get_by_text("Range Value B: (17500, 25000)")).to_have_count(1)
+    expect_markdown(app, "Value B: 17500")
+    expect_prefixed_markdown(app, "Range Value B:", "(17500, 25000)")
 
     assert_snapshot(first_slider_in_expander, name="st_slider-in_expander_regular")
     assert_snapshot(second_slider_in_expander, name="st_slider-in_expander_range")

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -192,6 +192,8 @@ def test_slider_works_in_forms(app: Page):
     # The value is not submitted so the value should not have changed yet
     expect(app.get_by_text("slider-in-form selection: 25")).to_be_visible()
 
+    # need to wait for the actual component value to update and then submit
+    app.wait_for_timeout(200)
     click_form_button(app, "Submit")
 
     expect(app.get_by_text("slider-in-form selection: 50")).to_be_visible()

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -91,7 +91,7 @@ def test_help_tooltip_works(app: Page):
 
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):
-    c(app, "Value B: 10000")
+    expect_markdown(app, "Value B: 10000")
     expect_prefixed_markdown(app, "Range Value B:", "(10000, 25000)")
     # Target by label at page scope to avoid container scoping issues
     first_slider_in_expander = get_slider(app, "Label B")


### PR DESCRIPTION
## Describe your changes

Refactor the `st.slide`r e2e test to use label-based access instead of index-based access.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
