### PR TITLE
Use `key` as main identity for custom components

### DIFF
--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -170,46 +170,22 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
             if tab_index is not None:
                 element.component_instance.tab_index = tab_index
 
-            # Normally, a widget's element_hash (which determines
-            # its identity across multiple runs of an app) is computed
-            # by hashing its arguments. This means that, if any of the arguments
-            # to the widget are changed, Streamlit considers it a new widget
-            # instance and it loses its previous state.
-            #
-            # However! If a *component* has a `key` argument, then the
-            # component's hash identity is determined by entirely by
-            # `component_name + url + key`. This means that, when `key`
-            # exists, the component will maintain its identity even when its
-            # other arguments change, and the component's iframe won't be
-            # remounted on the frontend.
+            element.component_instance.json_args = serialized_json_args
+            element.component_instance.special_args.extend(special_args)
 
-            def marshall_element_args() -> None:
-                element.component_instance.json_args = serialized_json_args
-                element.component_instance.special_args.extend(special_args)
-
-            ctx = get_script_run_ctx()
-
-            if key is None:
-                marshall_element_args()
-                computed_id = compute_and_register_element_id(
-                    "component_instance",
-                    user_key=key,
-                    key_as_main_identity=False,
-                    dg=dg,
-                    name=self.name,
-                    url=self.url,
-                    json_args=serialized_json_args,
-                    special_args=special_args,
-                )
-            else:
-                computed_id = compute_and_register_element_id(
-                    "component_instance",
-                    user_key=key,
-                    key_as_main_identity=False,
-                    dg=dg,
-                    name=self.name,
-                    url=self.url,
-                )
+            computed_id = compute_and_register_element_id(
+                "component_instance",
+                user_key=key,
+                # Ensure that the component identity is kept stable when key is provided,
+                # Only the name and url are whitelisted to result in a new identity
+                # if they are changed.
+                key_as_main_identity={"name", "url"},
+                dg=dg,
+                name=self.name,
+                url=self.url,
+                json_args=serialized_json_args,
+                special_args=special_args,
+            )
             element.component_instance.id = computed_id
 
             def deserialize_component(ui_value: Any) -> Any:
@@ -220,14 +196,11 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                 element.component_instance.id,
                 deserializer=deserialize_component,
                 serializer=lambda x: x,
-                ctx=ctx,
+                ctx=get_script_run_ctx(),
                 on_change_handler=on_change,
                 value_type="json_value",
             )
             widget_value = component_state.value
-
-            if key is not None:
-                marshall_element_args()
 
             if widget_value is None:
                 widget_value = default

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -452,7 +452,7 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         self.assertJSONEqual({"key": None, "default": None}, proto.json_args)
 
     def test_widget_id_with_key(self):
-        """UNLIKE OTHER WIDGET TYPES, a component with a user-supplied `key` will have a stable widget ID
+        """A component with a user-supplied `key` will have a stable widget ID
         even when the component's other parameters change.
 
         This is important because a component's iframe gets unmounted and remounted - wiping all its


### PR DESCRIPTION
## Describe your changes

Refactors custom components to use the new `key_as_main_identity` parameter instead of the previous approach. This doesn't change the behaviour. 

## GitHub Issue Link (if applicable)

- Related to https://github.com/streamlit/streamlit/issues/11277

## Testing Plan

- This has already been the behaviour, the change here is just a refactoring to adapt it to how we do it in other widgets. The existing tests should cover this fine.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
