### PR TITLE
[feat] Add env_compatibility_check Cursor Command

### DIFF
--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -12,3 +12,4 @@ rules/*
 !rules/overview.mdc
 !rules/make_commands.mdc
 !rules/new_feature.mdc
+!rules/env_compatibility_check.mdc

--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -12,4 +12,9 @@ rules/*
 !rules/overview.mdc
 !rules/make_commands.mdc
 !rules/new_feature.mdc
-!rules/env_compatibility_check.mdc
+
+# Ignore all commands
+commands/*
+# Only track certain commands so that we don't track a user's local commands
+# You can add more commands to this list as needed!
+!commands/env_compatibility_check.md

--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -1,3 +1,9 @@
+# Ignore all commands
+commands/*
+# Only track certain commands so that we don't track a user's local commands
+# You can add more commands to this list as needed!
+!commands/env_compatibility_check.md
+
 # Ignore all rules
 rules/*
 # Only track certain rules so that we don't track a user's local rules
@@ -12,9 +18,3 @@ rules/*
 !rules/overview.mdc
 !rules/make_commands.mdc
 !rules/new_feature.mdc
-
-# Ignore all commands
-commands/*
-# Only track certain commands so that we don't track a user's local commands
-# You can add more commands to this list as needed!
-!commands/env_compatibility_check.md

--- a/.cursor/commands/env_compatibility_check.md
+++ b/.cursor/commands/env_compatibility_check.md
@@ -1,0 +1,60 @@
+# Environment Compatibility Check
+
+## Overview
+
+Assess whether the current branch's changes could break users in common deployment environments. Analyze only what changed and decide if manual compatibility testing is required in vNext and Community Cloud.
+
+## Steps:
+
+1. Collect the exact changes on this branch.
+   - Prefer NDJSON hunk output from the provided script and analyze only those line ranges. If unavailable, fall back to the absolute list of changed file paths and limit review to modified regions.
+   - If no changes are detected, respond "No files changed" and stop.
+2. Evaluate the changes against the Decision Checks below, considering only the changed lines/regions.
+3. Decide the outcome:
+   - If any Decision Check is triggered, the answer is Yes.
+   - Otherwise, the answer is No.
+4. Respond:
+   - First, state Yes or No.
+   - Then provide brief reasoning for each Decision Check (why it did or did not trigger).
+   - If Yes, instruct the user to manually test in vNext and Community Cloud. If No, no further action is required.
+
+---
+
+## Decision Checks:
+
+1. Does the change introduce or modify Tornado routes, `server.baseUrlPath`, catch-alls, request methods, URL resolution, redirects, or status codes?
+2. Does it touch auth (OAuth/login/logout), cookies (`streamlit_user`, `streamlit_xsrf`), CSRF/XSRF handling, `server.trustedUserHeaders`, or session-to-identity binding?
+3. Does it affect the WebSocket handshake/subprotocols, session affinity/identity, reconnect behavior, ping/timeout, message size, or fragmentation?
+4. Does it alter embedding or the iframe boundary (host<->guest postMessage, sizing/resize behavior, sandbox/allow attributes, or permissions policy)?
+5. Does it change static asset handling or component asset serving (handlers, cache headers, size limits, base paths like `server.customComponentBaseUrlPath`, or proxying rules)?
+6. Does it modify the service worker, uploads, or downloads (registration/scope/cache strategy, upload/download endpoints, JWT/CSRF wrapping, or download attribute behavior)?
+7. Does it modify CORS allowlists, crossOrigin usage, external-origin fetches/External Networks, or backend URL discovery via `window.streamlit.*`?
+8. Does it introduce cross-origin theming assets or resource discovery changes (fonts/images/theme globals, CSS isolation with host, manifest/asset discovery when HTML isn't served by Tornado)?
+9. Does it rely on SiS/Snowflake runtime behavior (`running_in_sis()`, `get_active_session()`), Snowflake connection/session semantics, or SiS-specific environment variables/flags?
+10. Does it introduce or change client storage usage (cookies/localStorage/sessionStorage) that may differ in embedded/third-party contexts?
+11. Does it change security headers or policies (CSP, Referrer-Policy, Permissions-Policy) that impact embedding or resource loading?
+
+Treat these checks as examples; if in doubt about a feature, please test! Exemplary features in the past that would fall into this category were: custom theming in general (loading assets via a path), audio input (permissions on the iframe; file uploading), and st.pdf (resource embedding).
+
+---
+
+How to run against the whole PR changeset (committed + uncommitted)
+
+- Always scope analysis to the exact set of files changed on this branch compared to its base, plus any staged, unstaged, and untracked files in the working tree. Use absolute paths.
+- In CI, prefer `origin/${GITHUB_BASE_REF}` as base; locally, default to `origin/develop`.
+
+Preferred: change-aware ranges
+
+To avoid false positives, restrict analysis to only the added/modified line ranges of changed files. From the repository root:
+
+```bash
+bash ./scripts/collect_changed_ranges.sh
+```
+
+This emits one NDJSON object per file with the absolute path and the list of added line ranges. Agents should only analyze those ranges in each file.
+
+Fallback: absolute changed paths (one per line)
+
+```bash
+bash ./scripts/collect_changed_ranges.sh --paths-only
+```

--- a/scripts/collect_changed_ranges.sh
+++ b/scripts/collect_changed_ranges.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+base_remote="${GITHUB_BASE_REF:-develop}"
+
+# Best-effort fetch of the base ref
+git fetch origin "$base_remote" --depth=1 >/dev/null 2>&1 || true
+
+# Optional mode: print absolute changed paths only (one per line)
+if [ "${1-}" = "--paths-only" ]; then
+  {
+    git diff --name-only "origin/${base_remote}"...HEAD || true
+    git diff --name-only --cached || true
+    git diff --name-only || true
+    git ls-files --others --exclude-standard || true
+  } | sort -u | awk -v root="$repo_root" 'NF{ printf "%s/%s\n", root, $0 }'
+  exit 0
+fi
+
+emit_hunks_from_diff() {
+  awk -v repo_root="$repo_root" '
+    function print_obj() {
+      if (count > 0 && path != "") {
+        printf "{\"path\":\"%s/%s\",\"ranges\":[", repo_root, path
+        for (i=0; i<count; i++) {
+          if (i>0) printf ","
+          printf "{\"start\":%d,\"end\":%d}", starts[i], ends[i]
+        }
+        printf "]}\n"
+      }
+    }
+    BEGIN { path=""; count=0 }
+    /^\+\+\+ / {
+      newfile=$2
+      if (newfile == "/dev/null") { next }
+      sub(/^a\//, "", newfile); sub(/^b\//, "", newfile)
+      if (path != "" && newfile != path) { print_obj(); count=0 }
+      path=newfile; next
+    }
+    /^@@ / {
+      newhunk=$3; sub(/^\+/, "", newhunk)
+      n = split(newhunk, parts, ",")
+      start = parts[1] + 0
+      len = (n >= 2 ? parts[2] + 0 : 1)
+      if (len > 0 && path != "") { end = start + len - 1; starts[count]=start; ends[count]=end; count++ }
+      next
+    }
+    END { print_obj() }
+  '
+}
+
+emit_untracked() {
+  local f="$1"
+  local abs="$repo_root/$f"
+  if [ -f "$abs" ]; then
+    lines=$(wc -l < "$abs" | awk '{print $1}')
+    if [ "$lines" -gt 0 ]; then
+      printf '{"path":"%s","ranges":[{"start":1,"end":%d}]}' "$abs" "$lines"
+      printf '\n'
+    fi
+  fi
+}
+
+# 1) Committed changes vs merge-base with origin/${base_remote}
+git diff --no-color -U0 "origin/${base_remote}"...HEAD | emit_hunks_from_diff || true
+
+# 2) Staged but uncommitted changes vs HEAD
+git diff --no-color -U0 --cached | emit_hunks_from_diff || true
+
+# 3) Unstaged working tree changes vs index
+git diff --no-color -U0 | emit_hunks_from_diff || true
+
+# 4) Untracked new files (entire file range)
+git ls-files --others --exclude-standard | while IFS= read -r f; do
+  emit_untracked "$f"
+done


### PR DESCRIPTION
## Describe your changes

- Adds a Cursor Command that can be run to help automate determining if a changeset might require extra testing in other Streamlit Environments

## GitHub Issue Link (if applicable)

## Testing Plan

I triggered it on this PR with `/env_compatibility_check`. This is the output:

```md
I'll collect the exact changed line ranges on this branch to scope the compatibility analysis, using the provided script.

[1 tool called]

I gathered the changed file ranges. Now I'll open the specific changed files/sections to evaluate them against the compatibility checks.

[3 tools called]

Analyzed the changed line ranges from 3 files; all are dev scripts/docs, not runtime paths.

No.

- 1. Tornado routes/baseUrlPath/status codes: No — only `scripts/collect_changed_ranges.sh`, `.cursor/.gitignore`, and `.cursor/commands/env_compatibility_check.md` changed.
- 2. Auth/cookies/CSRF/trusted headers/session identity: No — none of these areas touched.
- 3. WebSocket handshake/affinity/reconnect/limits: No — no related code changed.
- 4. Embedding/iframe boundary/postMessage/sandbox/permissions: No — no frontend/backend embedding logic changed.
- 5. Static/component asset handling/cache/base paths/proxying: No — no asset-serving code changed.
- 6. Service worker/uploads/downloads/JWT/CSRF wrapping: No — no related logic changed.
- 7. CORS/crossOrigin/external fetches/backend URL discovery: No — unchanged.
- 8. Cross-origin theming/assets/manifest/resource discovery: No — unchanged.
- 9. SiS/Snowflake runtime/session/env flags: No — unchanged.
- 10. Client storage (cookies/localStorage/sessionStorage): No — unchanged.
- 11. Security headers/policies (CSP/Referrer/Permissions): No — unchanged.

No further action required.
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
