### PR TITLE
[WIP] Persist `health`/`host-config` retry counter across sessions, increase backoff

### DIFF
--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -59,10 +59,11 @@ export function doInitPings(
     message: string,
     source: string
   ) => void,
-  onHostConfigResp: (resp: IHostConfigResponse) => void
+  onHostConfigResp: (resp: IHostConfigResponse) => void,
+  initialTotalTries = 0
 ): AsyncPingRequest {
   const { promise, resolve, reject } = Promise.withResolvers<number>()
-  let totalTries = 0
+  let totalTries = initialTotalTries
   let uriNumber = 0
   let timeout: NodeJS.Timeout | number | undefined
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -24,8 +24,8 @@ import { ConnectionState } from "./ConnectionState"
 import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   MAX_RETRIES_BEFORE_CLIENT_ERROR,
-  PING_MINIMUM_RETRY_PERIOD_MS,
   PING_MAXIMUM_RETRY_PERIOD_MS,
+  PING_MINIMUM_RETRY_PERIOD_MS,
 } from "./constants"
 import {
   AsyncPingRequest,
@@ -959,7 +959,7 @@ If you are trying to access a Streamlit app running on another server, this coul
         pingRequest.cancel()
         try {
           await pingRequest.promise
-        } catch (e) {
+        } catch {
           // Expected cancellation error - ignore it
         }
         pingRequest = undefined
@@ -1004,7 +1004,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 
       const retryTimeouts: number[] = []
       const onRetry = vi.fn(
-        (totalTries: number, errorMsg: string, retryTimeout: number) => {
+        (_totalTries: number, _errorMsg: string, retryTimeout: number) => {
           retryTimeouts.push(retryTimeout)
         }
       )
@@ -1068,7 +1068,7 @@ describe("WebsocketConnection", () => {
       await vi.runAllTimersAsync()
       vi.clearAllTimers()
       vi.useRealTimers()
-    } catch (e) {
+    } catch {
       // Ignore timer errors if timers weren't mocked in this test
     }
   })
@@ -1182,7 +1182,7 @@ describe("WebsocketConnection", () => {
     it("grows exponentially up to 60-second maximum", async () => {
       const retryTimeouts: number[] = []
       const onRetry = vi.fn(
-        (totalTries: number, errorMsg: string, retryTimeout: number) => {
+        (_totalTries: number, _errorMsg: string, retryTimeout: number) => {
           retryTimeouts.push(retryTimeout)
         }
       )
@@ -1217,7 +1217,7 @@ describe("WebsocketConnection", () => {
     })
 
     it("calculates specific retry intervals correctly", () => {
-      const calculateRetryDelay = (totalTries: number) => {
+      const calculateRetryDelay = (totalTries: number): number => {
         const timeoutMs =
           totalTries === 1
             ? PING_MINIMUM_RETRY_PERIOD_MS
@@ -1244,7 +1244,7 @@ describe("WebsocketConnection", () => {
     it("solves VPN disconnect spam with longer intervals", async () => {
       const retryTimeouts: number[] = []
       const onRetry = vi.fn(
-        (totalTries: number, errorMsg: string, retryTimeout: number) => {
+        (_totalTries: number, _errorMsg: string, retryTimeout: number) => {
           retryTimeouts.push(retryTimeout)
         }
       )
@@ -1256,7 +1256,7 @@ describe("WebsocketConnection", () => {
         onConnectionStateChange: vi.fn(),
         onRetry,
         onMessage: vi.fn(),
-        claimHostAuthToken: async () => undefined,
+        claimHostAuthToken: () => Promise.resolve(undefined),
         resetHostAuthToken: vi.fn(),
         sendClientError: vi.fn(),
         onHostConfigResp: vi.fn(),
@@ -1284,7 +1284,7 @@ describe("WebsocketConnection", () => {
     it("handles very large retry counts gracefully", async () => {
       const retryTimeouts: number[] = []
       const onRetry = vi.fn(
-        (totalTries: number, errorMsg: string, retryTimeout: number) => {
+        (_totalTries: number, _errorMsg: string, retryTimeout: number) => {
           retryTimeouts.push(retryTimeout)
         }
       )

--- a/frontend/connection/src/constants.ts
+++ b/frontend/connection/src/constants.ts
@@ -38,9 +38,11 @@ export const HOST_CONFIG_PATH = "_stcore/host-config"
 
 /**
  * Min and max wait time between pings in millis.
+ * Maximum increased to 60 seconds to allow proper exponential backoff
+ * during extended network outages (e.g., VPN disconnections).
  */
 export const PING_MINIMUM_RETRY_PERIOD_MS = 100
-export const PING_MAXIMUM_RETRY_PERIOD_MS = 2000
+export const PING_MAXIMUM_RETRY_PERIOD_MS = 60000
 
 /**
  * Max number of times we retry pinging the server before we show an error.


### PR DESCRIPTION
## Describe your changes
We attempt an exponential backoff in attempts to ping the `health` & `host-config` endpoints, but the counter is only being preserved within each ping session (retry counter gets reset every time the WebSocket connection state machine transitions back to `PINGING_SERVER`, ex: VPN disconnect). Additionally, we cap the max retry period at 2 seconds.

This PR both extends the max retry period to 60 sec from 2 sec to avoid spamming for extended connection disruption and preserves the retry counter to handle VPN disconnect scenario. The connection error dialog is still displayed at the same timing after 6 failed attempts.

## GitHub Issue Link (if applicable)
Closes #12513 

## Testing Plan
- JS Unit Tests: ✅ Added
- Manual Testing: ✅ 