### PR TITLE
[fix] Blob URL memory leak in AudioInput

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -90,6 +90,8 @@ const AudioInput: React.FC<Props> = ({
   const previousTheme = usePrevious(theme)
   const [wavesurfer, setWavesurfer] = useState<WaveSurfer | null>(null)
   const waveSurferRef = useRef<HTMLDivElement | null>(null)
+  // Track current blob URL for cleanup
+  const currentBlobUrlRef = useRef<string | null>(null)
   const [deleteFileUrl, setDeleteFileUrl] = useWidgetManagerElementState<
     string | null
   >({
@@ -170,6 +172,14 @@ const AudioInput: React.FC<Props> = ({
         let blobUrl: string
         try {
           blobUrl = URL.createObjectURL(wavBlob)
+          // Track the new blob URL and revoke the old one if it exists
+          if (
+            currentBlobUrlRef.current &&
+            currentBlobUrlRef.current !== blobUrl
+          ) {
+            URL.revokeObjectURL(currentBlobUrlRef.current)
+          }
+          currentBlobUrlRef.current = blobUrl
         } catch {
           setIsError(true)
           setIsUploading(false)
@@ -262,6 +272,12 @@ const AudioInput: React.FC<Props> = ({
       }
 
       const urlToRevoke = recordingUrl
+
+      // Clean up the blob URL when clearing
+      if (urlToRevoke && currentBlobUrlRef.current === urlToRevoke) {
+        URL.revokeObjectURL(urlToRevoke)
+        currentBlobUrlRef.current = null
+      }
 
       setRecordingUrl(null)
       setDeleteFileUrl(null)
@@ -414,9 +430,11 @@ const AudioInput: React.FC<Props> = ({
     return cleanup
   }, [initializeWaveSurfer])
 
-  // Note: We don't revoke blob URLs here because they need to persist
-  // across component remounts. They'll be cleaned up when the page unloads
-  // or when the user explicitly clears the recording.
+  // Note: We don't revoke blob URLs on unmount because they need to persist
+  // across component remounts. They'll be cleaned up when:
+  // 1. User records a new audio (old one is revoked)
+  // 2. User explicitly clears the recording
+  // 3. Page unloads (browser handles this)
 
   useEffect(() => {
     if (!isEqual(previousTheme, theme)) {


### PR DESCRIPTION
## Describe your changes

This pull request improves the memory management of audio recordings in the `AudioInput` component by ensuring that blob URLs are properly revoked when they are no longer needed. This helps prevent memory leaks when users record new audio or clear existing recordings.

Resource management improvements:

* Added a `currentBlobUrlRef` ref to track the current blob URL for audio recordings, enabling more precise cleanup.
* Updated the logic to revoke the old blob URL whenever a new audio recording is created, ensuring that only the latest blob URL is retained.
* Ensured that the blob URL is revoked when the user clears the recording, preventing unused blob URLs from lingering in memory.

Documentation and comments:

* Clarified the blob URL cleanup strategy in comments, specifying when blob URLs are revoked and why they are not revoked on component unmount.
<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

No reported issue.

## Testing Plan

I don't think this requires (is worth the effort of) any additional testing, but don't hold this view strongly.




---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
