### PR TITLE
[fix] MediaStream track cleanup on error

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -472,15 +472,19 @@ const AudioInput: React.FC<Props> = ({
     if (!hasRequestedMicPermissions) {
       setHasRequestedMicPermissions(true)
 
+      let stream: MediaStream | null = null
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
+        stream = await navigator.mediaDevices.getUserMedia({
           audio: true,
         })
-
-        stream.getTracks().forEach(track => track.stop())
       } catch {
         setHasNoMicPermissions(true)
         return
+      } finally {
+        // Always stop tracks if we got a stream, even if an error occurred
+        if (stream) {
+          stream.getTracks().forEach(track => track.stop())
+        }
       }
     }
 


### PR DESCRIPTION
## Describe your changes

This is a nit/p4 sort of thing, but figured I'd fix it when in the codepath.

This pull request improves the microphone permission handling logic in the `AudioInput` component to ensure that audio tracks are always stopped, even if an error occurs during permission request.

Microphone permission handling:

* Updated the logic in `AudioInput.tsx` so that any acquired audio tracks are stopped in a `finally` block, ensuring resources are released regardless of whether permission was granted or an error occurred.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

No filed issue.

## Testing Plan

I don't think this requires (is worth the effort of) any additional testing, but don't hold this view strongly.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
