### PR TITLE
[fix] WaveSurfer event listener memory leak

### DIFF
--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -352,13 +352,17 @@ const AudioInput: React.FC<Props> = ({
       interact: true,
     })
 
-    ws.on("timeupdate", time => {
+    // Store event handlers for cleanup
+    const handleTimeUpdate = (time: number): void => {
       setProgressTime(formatTime(time * 1000)) // get from seconds to milliseconds
-    })
+    }
 
-    ws.on("pause", () => {
+    const handlePause = (): void => {
       forceRerender()
-    })
+    }
+
+    ws.on("timeupdate", handleTimeUpdate)
+    ws.on("pause", handlePause)
 
     setWavesurfer(ws)
 
@@ -414,7 +418,12 @@ const AudioInput: React.FC<Props> = ({
         recordPluginRef.current = null
         recordPluginHandlersRef.current = {}
       }
-      if (ws) ws.destroy()
+      if (ws) {
+        // Remove WaveSurfer event listeners before destroying
+        ws.un("timeupdate", handleTimeUpdate)
+        ws.un("pause", handlePause)
+        ws.destroy()
+      }
     }
   }, [
     theme,


### PR DESCRIPTION
## Describe your changes

<!-- If it's a visual change, please include a screenshot or video! -->

This pull request improves the event handling and cleanup logic for the `AudioInput` component. The main focus is to ensure that event listeners attached to the `WaveSurfer` instance are properly managed and removed, preventing potential memory leaks or unintended side effects.

**Event handler management and cleanup:**

* Refactored the `timeupdate` and `pause` event handlers into named functions (`handleTimeUpdate` and `handlePause`) to allow for their removal during cleanup.
* Updated the cleanup logic to explicitly remove (`un`) the `timeupdate` and `pause` event listeners from the `WaveSurfer` instance before destroying it.


## GitHub Issue Link (if applicable)
Not a reported issue.

## Testing Plan

I don't think this requires (is worth the effort of) any additional testing, but don't hold this view strongly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
