### PR TITLE
[test] Remove problematic 5000ms wait in the e2e's st_audio_input stop_recording

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -194,8 +194,10 @@ def _test_download_audio_file(app: Page, locator: FrameLocator | Locator):
     is_iframe = isinstance(locator, FrameLocator)
     stop_recording(audio_input, app, wait_for_run=not is_iframe)
     if is_iframe:
-        # Give iframe time to process the recording
-        app.wait_for_timeout(2000)
+        # Wait for the recording to be processed in iframe
+        expect(
+            audio_input.get_by_role("button", name="Download as WAV")
+        ).to_be_visible()
 
     with app.expect_download() as download_info:
         download_button = audio_input.get_by_role("button", name="Download as WAV")


### PR DESCRIPTION
## Describe your changes

This pull request updates the end-to-end Playwright tests for audio input to better handle recording and downloading audio files, especially in iframe contexts. The main improvements include making the recording stop logic more robust and ensuring microphone permissions are granted in iframe tests.

**Test robustness and iframe handling:**

- Modified the `stop_recording` function in `st_audio_input_test.py` to accept a `wait_for_run` parameter
- Updated `_test_download_audio_file` to detect when running in an iframe and adjust waiting logic accordingly, ensuring reliable test execution in both normal and iframe contexts.
- Ensured microphone permissions are granted before running audio input tests within iframes, improving test reliability.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.