### PR TITLE
[fix] Suppress type checker warning in data_editor._parse_value

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -241,7 +241,7 @@ def _parse_value(
             ColumnDataKind.DATE,
             ColumnDataKind.TIME,
         ]:
-            datetime_value = pd.Timestamp(value)
+            datetime_value = pd.Timestamp(value)  # ty: ignore
 
             if datetime_value is pd.NaT:
                 return None


### PR DESCRIPTION
## Describe your changes

In creating #12544 I ran into this `ty` issue. I chatted with @lukasmasuch and we both don't know why this didn't get picked up in CI, but going to add this ignore check here to unblock.

## GitHub Issue Link (if applicable)
None

## Testing Plan

None

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
