### PR TITLE
Fix pytest warning filter error

### DIFF
--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -9,5 +9,5 @@ filterwarnings =
     ignore::DeprecationWarning:flatbuffers.*:
     # Deprecation warning about our early fixture marker trick:
     # Likely needs to be refactored to support pytest 9.
-    ignore:Marks applied to fixtures have no effect.*:_pytest.warning_types.PytestRemovedIn9Warning::
+    ignore:Marks applied to fixtures have no effect.*:pytest.PytestWarning
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -9,5 +9,5 @@ filterwarnings =
     ignore::DeprecationWarning:flatbuffers.*:
     # Deprecation warning about our early fixture marker trick:
     # Likely needs to be refactored to support pytest 9.
-    ignore:Marks applied to fixtures have no effect.*:pytest.PytestWarning
+    ignore:Marks applied to fixtures have no effect.*:pytest.PytestWarning::
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short


### PR DESCRIPTION
## Describe your changes

I'm getting the following error with pytest locally indicating that the internal class we use in the ignore doesn't exist in the pytest version I'm using:

```
ERROR: while parsing the following warning configuration: ignore:Marks applied to fixtures have no effect.*:_pytest.warning_types.PytestRemovedIn9Warning:: This error occurred: Traceback (most recent call last): File "/opt/homebrew/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1761, in parse_warning_filter category: Type[Warning] = _resolve_warning_category(category_) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/homebrew/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1800, in _resolve_warning_category cat = getattr(m, klass) ^^^^^^^^^^^^^^^^^ AttributeError: module '_pytest.warning_types' has no attribute 'PytestRemovedIn9Warning'
```

Fixing this by using a more generic non-internal base class instead.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
