### PR TITLE
[fix] Makefile help command delimiter to preserve :: in comments

### DIFF
--- a/.cursor/rules/make_commands.mdc
+++ b/.cursor/rules/make_commands.mdc
@@ -8,41 +8,41 @@ alwaysApply: false
 
 List of all `make` commands that are available for execution from the repository root folder:
 
-help                       Show all available make commands.
-all                        Install all dependencies, build frontend, and install editable Streamlit.
-all-dev                    Install all dependencies and editable Streamlit, but do not build the frontend.
-init                       Install all dependencies and build protobufs.
-clean                      Remove all generated files.
-protobuf                   Recompile Protobufs for Python and the frontend.
-python-init                Install Python dependencies and Streamlit in editable mode.
-python-lint                Lint and check formatting of Python files.
-python-format              Format Python files.
-python-tests               Run Python unit tests.
-python-performance-tests   Run Python performance tests.
-python-integration-tests   Run Python integration tests. Requires `integration-requirements.txt` to be installed.
-python-types               Run the Python type checker.
-frontend-init              Install all frontend dependencies.
-frontend                   Build the frontend.
-frontend-with-profiler     Build the frontend with the profiler enabled.
-frontend-fast              Build the frontend (as fast as possible).
-frontend-dev               Start the frontend development server.
-frontend-lint              Lint and check formatting of frontend files.
-frontend-types             Run the frontend type checker.
-frontend-format            Format frontend files.
-frontend-tests             Run frontend unit tests and generate coverage report.
-frontend-typesync          Check for unsynced frontend types.
-update-frontend-typesync   Installs missing typescript typings for dependencies.
-update-snapshots           Update e2e playwright snapshots based on the latest completed CI run.
-update-snapshots-changed   Update e2e playwright snapshots of changed e2e files based on the latest completed CI run.
-update-material-icons      Update material icons based on latest Google material symbol version.
-update-notices             Update the notices file (licenses of frontend assets and dependencies).
-update-headers             Update all license headers.
-update-min-deps            Update minimum dependency constraints file.
-debug-e2e-test             Run a playwright e2e test in debug mode. Use it via `make debug-e2e-test st_command_test.py`.
-run-e2e-test               Run a playwright e2e test. Use it via `make run-e2e-test st_command_test.py`.
-lighthouse-tests           Run Lighthouse performance tests.
-bare-execution-tests       Run all e2e tests in bare mode.
-cli-smoke-tests            Run CLI smoke tests.
-autofix                    Autofix linting and formatting errors.
-package                    Create Python wheel files in `dist/`.
-conda-package              Create conda distribution files.
+help                      Show all available make commands.
+all                       Install all dependencies, build frontend, and install editable Streamlit.
+all-dev                   Install all dependencies and editable Streamlit, but do not build the frontend.
+init                      Install all dependencies and build protobufs.
+clean                     Remove all generated files.
+protobuf                  Recompile Protobufs for Python and the frontend.
+python-init               Install Python dependencies and Streamlit in editable mode.
+python-lint               Lint and check formatting of Python files.
+python-format             Format Python files.
+python-tests              Run Python unit tests.
+python-performance-tests  Run Python performance tests.
+python-integration-tests  Run Python integration tests. Requires `integration-requirements.txt` to be installed.
+python-types              Run the Python type checker.
+frontend-init             Install all frontend dependencies.
+frontend                  Build the frontend.
+frontend-with-profiler    Build the frontend with the profiler enabled.
+frontend-fast             Build the frontend (as fast as possible).
+frontend-dev              Start the frontend development server.
+frontend-lint             Lint and check formatting of frontend files.
+frontend-types            Run the frontend type checker.
+frontend-format           Format frontend files.
+frontend-tests            Run frontend unit tests and generate coverage report.
+frontend-typesync         Check for unsynced frontend types.
+update-frontend-typesync  Installs missing typescript typings for dependencies.
+update-snapshots          Update e2e playwright snapshots based on the latest completed CI run.
+update-snapshots-changed  Update e2e playwright snapshots of changed e2e files based on the latest completed CI run.
+update-material-icons     Update material icons based on latest Google material symbol version.
+update-notices            Update the notices file (licenses of frontend assets and dependencies).
+update-headers            Update all license headers.
+update-min-deps           Update minimum dependency constraints file.
+debug-e2e-test            Run a playwright e2e test in debug mode. Use it via `make debug-e2e-test st_command_test.py`.
+run-e2e-test              Run a playwright e2e test. Use it via `make run-e2e-test st_command_test.py`.
+lighthouse-tests          Run Lighthouse performance tests.
+bare-execution-tests      Run all e2e tests in bare mode.
+cli-smoke-tests           Run CLI smoke tests.
+autofix                   Autofix linting and formatting errors.
+package                   Create Python wheel files in `dist/`.
+conda-package             Create conda distribution files.

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help:
 	@# Magic line used to create self-documenting makefiles.
 	@# Note that this means the documenting comment just before the command (but after the .PHONY) must be all one line, and should begin with a capital letter and end with a period.
 	@# See https://stackoverflow.com/a/35730928
-	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' Makefile | column -s: -t
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")-1) ";" c}1{c=0}' Makefile | column -s';' -t
 
 .PHONY: all
 # Install all dependencies, build frontend, and install editable Streamlit.


### PR DESCRIPTION
## Describe your changes

In pursuit of #12561 I ran into this bizarre issue where my :: kept turning into a bunch of tabs. After some investigation I found the culprit in this bit of bash here. I made the assumption that `:` is more useful in make command helps than `;` is. While I was at it, claude noticed that we have an extra space on the end of our command name so I let it remove that with the `-1`

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

None

## Testing Plan

I ran the script.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
