### PR TITLE
[fix] Prevent the snapshot hygiene workflow from spamming comments

### DIFF
--- a/.github/workflows/snapshot-hygiene.yml
+++ b/.github/workflows/snapshot-hygiene.yml
@@ -92,20 +92,47 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.issues.createComment({
+            const body = `❌ **Orphaned Snapshots Detected**
+
+            This PR contains orphaned e2e snapshots that are no longer used by tests.
+
+            **To fix this:**
+            1. Run \`python scripts/snapshot_cleanup.py\` locally to clean them up
+            2. Or review the snapshots manually to ensure they're actually orphaned
+            3. Commit and push the changes
+
+            This helps keep our snapshot directory clean and our tests maintainable.
+
+            If you believe the script incorrectly flagged valid snapshots, add them to the \`DISALLOWED_SNAPSHOTS\` set in the cleanup script.`;
+
+            // Find existing orphaned snapshots comment
+            const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `❌ **Orphaned Snapshots Detected**
+            });
 
-              This PR contains orphaned e2e snapshots that are no longer used by tests.
+            const existingComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('❌ **Orphaned Snapshots Detected**')
+            );
 
-              **To fix this:**
-              1. Run \`python scripts/snapshot_cleanup.py\` locally to clean them up
-              2. Or review the snapshots manually to ensure they're actually orphaned
-              3. Commit and push the changes
-
-              This helps keep our snapshot directory clean and our tests maintainable.
-
-              If you believe the script incorrectly flagged valid snapshots, add them to the \`DISALLOWED_SNAPSHOTS\` set in the cleanup script.`
-            })
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+              console.log(`Updated existing comment ${existingComment.id}`);
+            } else {
+              // Create new comment if none exists
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+              console.log('Created new orphaned snapshots comment');
+            }


### PR DESCRIPTION
## Describe your changes

When I was working on the audio input tests suite pr, I noticed that every commit I made while leaving the orphaned snapshots in place would create a new PR comment becoming quite spammy. This attempts to resolve the spamminess by opting to update comment before creating a new one.

## GitHub Issue Link (if applicable)

None



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
