### PR TITLE
[fix] Ensure python env vars are set in automation jobs

### DIFF
--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -36,6 +36,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/patch-release-branch-creation.yml
+++ b/.github/workflows/patch-release-branch-creation.yml
@@ -36,6 +36,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-branch-creation.yml
+++ b/.github/workflows/release-branch-creation.yml
@@ -36,6 +36,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-tag-and-pr-creation.yml
+++ b/.github/workflows/release-tag-and-pr-creation.yml
@@ -32,6 +32,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Describe your changes

- The new automation scripts are using `${{ env.PYTHON_MAX_VERSION }}`, but were missing the `./.github/actions/build_info` step.

## GitHub Issue Link (if applicable)

## Testing Plan

- Failed run: https://github.com/streamlit/streamlit/actions/runs/17833870838
- Successful run with this fix: https://github.com/streamlit/streamlit/actions/runs/17834773452

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
