### PR TITLE
Fix PlotlyChart flickering by adding overflow hidden

### DIFF
--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -466,6 +466,9 @@ export function PlotlyChart({
           // to prevent flickering issues.
           visibility:
             plotlyFigure.layout?.width === undefined ? "hidden" : undefined,
+          // If the scrollbars are activated, it leads to flickering issues.
+          // We don't need overflow here since the parent container and plot dimensions are in sync.
+          overflow: "hidden",
         }}
         onSelected={isSelectionActivated ? handleSelectionCallback : () => {}}
         // Double click is needed to make it easier to the user to


### PR DESCRIPTION
## Describe your changes

Fixes a flickering issue in `st.plotly_chart` by adding `overflow: "hidden"` to the chart container style. Previously, when scrollbars were activated on the chart container, it caused visual flickering issues that degraded the user experience.

**Changes Made:**

- **Fixed chart flickering**: Added `overflow: "hidden"` to PlotlyChart container style
- **Improved visual stability**: Eliminates flickering caused by scrollbar activation
- **Maintains functionality**: Parent container and plot dimensions remain synchronized

**Root Cause:**
The flickering occurred when scrollbars would activate on the chart container, causing the display to flicker as the scrollbars appeared/disappeared. Since the parent container and plot dimensions are kept in sync, the overflow scrolling is not needed and can be safely hidden.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Manual testing completed - verified flickering issue is resolved
- I haven't added automated tests due to the difficulty of reproducing a flicker in a test. 

**Screenshots/Demos:**
The fix eliminates the visual flickering that users would experience when interacting with Plotly charts, providing a smoother user experience.

**Additional Notes:**
This is a targeted fix that addresses a specific visual issue without changing the chart functionality or API. The change is minimal and low-risk, only affecting the visual rendering behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
