### PR TITLE
Remove frontend typecheck exclusion line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,6 @@ frontend-lint:
 .PHONY: frontend-types
 # Run the frontend type checker.
 frontend-types:
-	cd frontend/ ; yarn workspaces foreach --all --exclude @streamlit/lib --exclude @streamlit/app run typecheck
 	cd frontend/ ; yarn workspaces foreach --all run typecheck
 
 .PHONY: frontend-format


### PR DESCRIPTION
## Describe your changes

For some reason, we frontend type check excluding app and lib, but then we run typecheck on all the packages, which duplicates efforts. This change just removes the check.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
