### PR TITLE
[fix] Improve Release Automation Scripts

### DIFF
--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   cherry-pick:
     name: Cherry-pick ${{ inputs.cherry_pick_sha }} to release/${{ inputs.release_version }}
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'streamlit/streamlit' && github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/patch-release-branch-creation.yml
+++ b/.github/workflows/patch-release-branch-creation.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   create-patch-branch:
     name: Create Patch Branch ${{ inputs.patch_version }}
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'streamlit/streamlit' && github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-branch-creation.yml
+++ b/.github/workflows/release-branch-creation.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   create-branch:
     name: Create Release Branch ${{ inputs.release_version }}
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'streamlit/streamlit' && github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-tag-and-pr-creation.yml
+++ b/.github/workflows/release-tag-and-pr-creation.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   prepare-release:
     name: Prepare Release ${{ inputs.release_version }}
+    if: ${{ github.repository == 'streamlit/streamlit' && github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-tag-and-pr-creation.yml
+++ b/.github/workflows/release-tag-and-pr-creation.yml
@@ -62,14 +62,14 @@ jobs:
             exit 1
           fi
 
-          # Ensure the release branch exists remotely
-          if ! git ls-remote --heads origin | grep -q "refs/heads/release/${{ inputs.release_version }}$"; then
+          # Ensure the release branch exists on origin by attempting a shallow fetch of that branch
+          if ! git fetch --no-tags --depth=1 origin "release/${{ inputs.release_version }}"; then
             echo "::error::Branch release/${{ inputs.release_version }} not found on origin. Run Release Branch Creation first." >&2
             exit 1
           fi
 
           # Ensure the tag doesn't already exist remotely
-          if git ls-remote --tags origin | grep -q "refs/tags/${{ inputs.release_version }}$"; then
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.release_version }}" >/dev/null 2>&1; then
             echo "::error::Tag ${{ inputs.release_version }} already exists on origin" >&2
             exit 1
           fi


### PR DESCRIPTION
## Describe your changes

- Fixes an issue with getting the upstream tag/release branches.
- Adds a guard that ensures these are only running on the `streamlit/streamlit` repo for clarity.

## GitHub Issue Link (if applicable)

## Testing Plan

- ✅ Manually ran in GH ([latest run here](https://github.com/streamlit/streamlit/actions/runs/17955061244))

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
