### PR TITLE
In `streamlit hello`, preload Python modules that are slow to compile in a fresh venv

### DIFF
--- a/lib/streamlit/hello/hello.py
+++ b/lib/streamlit/hello/hello.py
@@ -36,3 +36,11 @@ st.write(
     - Explore a [New York City rideshare dataset](https://github.com/streamlit/demo-uber-nyc-pickups)
     """
 )
+
+# Preload Python modules that take a while to compile in a new venv.
+# Otherwise, when users switch to another page, it seems that Streamlit
+# is slow, when in reality this is just an artifact of loading/compiling
+# large modules from zero.
+with st.spinner("Preloading Python modules for other pages..."):
+    import numpy  # noqa: ICN001 F401
+    import pandas  # noqa: ICN001 F401


### PR DESCRIPTION
## Describe your changes

Today, when running `streamlit hello` in a fresh venv the first loads quickly (yay!) but then subpages like the "Dataframe demo" are super slow. Here's what it looks like:

https://github.com/user-attachments/assets/5cf3fb8f-d02e-492f-9f07-214551120658

This slowness is due to the `import pandas`, which in a fresh venv requires a slow compilation step.

This PR makes up for this by adding `import pandas` to the _bottom_ of the first page of `streamlit hello`, after all important content has loaded. My feeling is that this makes everything feel faster. See for yourself:

https://github.com/user-attachments/assets/cef7ce29-f1c5-4f6a-9a6e-f38608e2856f


## GitHub Issue Link (if applicable)

n/a

## Testing Plan

- Explanation of why no additional tests are needed: this just adds some no-op imports to a file. I'm not even sure how we'd test this if we wanted to...
- ~~Unit Tests (JS and/or Python)~~
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
