### PR TITLE
[AdvancedLayouts] Add height to st.altair_chart

### DIFF
--- a/e2e_playwright/st_vega_charts_height.py
+++ b/e2e_playwright/st_vega_charts_height.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import altair as alt
 import pandas as pd
 
 import streamlit as st
@@ -81,3 +82,27 @@ vconcat_spec = {
     ]
 }
 st.vega_lite_chart(simple_df, vconcat_spec)
+
+# Test st.altair_chart with fixed height
+st.write("Altair chart with height=250:")
+chart = (
+    alt.Chart(simple_df)
+    .mark_bar()
+    .encode(
+        x=alt.X("a:O"),
+        y=alt.Y("b:Q"),
+    )
+)
+st.altair_chart(chart, height=250)
+
+st.write("Altair chart with height in spec (180) and height='content' parameter:")
+content_chart = (
+    alt.Chart(simple_df)
+    .mark_circle(size=100)
+    .encode(
+        x=alt.X("a:O"),
+        y=alt.Y("b:Q"),
+    )
+    .properties(height=180)
+)
+st.altair_chart(content_chart, height="content")

--- a/e2e_playwright/st_vega_charts_height.py
+++ b/e2e_playwright/st_vega_charts_height.py
@@ -106,3 +106,15 @@ content_chart = (
     .properties(height=180)
 )
 st.altair_chart(content_chart, height="content")
+
+st.write("Altair chart with height='stretch':")
+with st.container(border=True, key="test_altair_height_stretch", height=500):
+    stretch_chart = (
+        alt.Chart(simple_df)
+        .mark_area()
+        .encode(
+            x=alt.X("a:O"),
+            y=alt.Y("b:Q"),
+        )
+    )
+    st.altair_chart(stretch_chart, height="stretch")

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -18,7 +18,7 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 from e2e_playwright.shared.vega_utils import assert_vega_chart_height
 
-VEGA_CHART_COUNT = 9
+VEGA_CHART_COUNT = 10
 
 
 def test_vega_chart_height_behavior(app: Page):
@@ -36,6 +36,7 @@ def test_vega_chart_height_behavior(app: Page):
         852,  # 6: Vertical concatenation chart with default height (content)
         250,  # 7: Altair chart with height=250
         180,  # 8: Altair chart with height in spec (180) and height='content' parameter
+        468,  # 9: Altair chart with height='stretch' (in 500px container, minus padding)
     ]
 
     descriptions = [
@@ -48,6 +49,7 @@ def test_vega_chart_height_behavior(app: Page):
         "Vertical concatenation chart with default height (content)",
         "Altair chart with height=250",
         "Altair chart with height in spec (180) and height='content' parameter",
+        "Altair chart with height='stretch' (in 300px container)",
     ]
 
     for i, expected_height in enumerate(expected_heights):

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -49,7 +49,7 @@ def test_vega_chart_height_behavior(app: Page):
         "Vertical concatenation chart with default height (content)",
         "Altair chart with height=250",
         "Altair chart with height in spec (180) and height='content' parameter",
-        "Altair chart with height='stretch' (in 300px container)",
+        "Altair chart with height='stretch' (in 500px container)",
     ]
 
     for i, expected_height in enumerate(expected_heights):

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -18,7 +18,7 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 from e2e_playwright.shared.vega_utils import assert_vega_chart_height
 
-VEGA_CHART_COUNT = 7
+VEGA_CHART_COUNT = 9
 
 
 def test_vega_chart_height_behavior(app: Page):
@@ -34,6 +34,8 @@ def test_vega_chart_height_behavior(app: Page):
         368,  # 4: Chart with height in spec (200) and height='stretch' parameter (in 400px container)
         100,  # 5: Chart with height in spec (200) and height=100 parameter
         852,  # 6: Vertical concatenation chart with default height (content)
+        250,  # 7: Altair chart with height=250
+        180,  # 8: Altair chart with height in spec (180) and height='content' parameter
     ]
 
     descriptions = [
@@ -44,6 +46,8 @@ def test_vega_chart_height_behavior(app: Page):
         "Chart with height in spec (200) and height='stretch' parameter (in 400px container)",
         "Chart with height in spec (200) and height=100 parameter",
         "Vertical concatenation chart with default height (content)",
+        "Altair chart with height=250",
+        "Altair chart with height in spec (180) and height='content' parameter",
     ]
 
     for i, expected_height in enumerate(expected_heights):

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1645,6 +1645,7 @@ class VegaChartsMixin:
         altair_chart: AltairChart,
         *,
         width: Width | None = None,
+        height: Height = "content",
         use_container_width: bool | None = None,
         theme: Literal["streamlit"] | None = "streamlit",
         key: Key | None = None,
@@ -1659,6 +1660,7 @@ class VegaChartsMixin:
         altair_chart: AltairChart,
         *,
         width: Width | None = None,
+        height: Height = "content",
         use_container_width: bool | None = None,
         theme: Literal["streamlit"] | None = "streamlit",
         key: Key | None = None,
@@ -1672,6 +1674,7 @@ class VegaChartsMixin:
         altair_chart: AltairChart,
         *,
         width: Width | None = None,
+        height: Height = "content",
         use_container_width: bool | None = None,
         theme: Literal["streamlit"] | None = "streamlit",
         key: Key | None = None,
@@ -1705,6 +1708,13 @@ class VegaChartsMixin:
             ``"facet"`` in the spec or ``"row"``, ``"column"``, or ``"facet"``
             in the encoding), horizontal concatenation charts (``"hconcat"``),
             and repeat charts (``"repeat"``).
+
+        height : "stretch", "content", or int
+            How to size the chart's height. Can be one of:
+
+            - ``"content"`` (default): Size the chart to fit its contents.
+            - ``"stretch"``: Expand to the height of the parent container.
+            - An integer: Set the chart height to this many pixels.
 
         use_container_width : bool or None
             Whether to override the chart's native width with the width of
@@ -1838,6 +1848,7 @@ class VegaChartsMixin:
         return self._altair_chart(
             altair_chart=altair_chart,
             width=width,
+            height=height,
             use_container_width=use_container_width,
             theme=theme,
             key=key,

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -791,6 +791,117 @@ class AltairChartWidthTest(DeltaGeneratorTestCase):
         assert el.width_config.use_content is True
 
 
+class AltairChartHeightTest(DeltaGeneratorTestCase):
+    """Test altair_chart height parameter functionality."""
+
+    @parameterized.expand(
+        [
+            # height, expected_height_spec, expected_height_value
+            ("content", "use_content", True),
+            ("stretch", "use_stretch", True),
+            (400, "pixel_height", 400),
+        ]
+    )
+    def test_altair_chart_height_combinations(
+        self,
+        height: str | int,
+        expected_height_spec: str,
+        expected_height_value: bool | int,
+    ):
+        """Test altair_chart with various height combinations."""
+        df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
+        chart = (
+            alt.Chart(df)
+            .mark_bar()
+            .encode(
+                x=alt.X("a:O"),
+                y=alt.Y("b:Q"),
+            )
+        )
+
+        st.altair_chart(chart, height=height)
+
+        el = self.get_delta_from_queue().new_element
+
+        # Check height configuration
+        assert el.height_config.WhichOneof("height_spec") == expected_height_spec
+        assert getattr(el.height_config, expected_height_spec) == expected_height_value
+
+    @parameterized.expand(
+        [
+            ("height", "invalid_height"),
+            ("height", 0),  # height must be positive
+            ("height", -100),  # negative height
+        ]
+    )
+    def test_altair_chart_height_validation_errors(
+        self, param_name: str, invalid_value: str | int
+    ):
+        """Test that invalid height values raise validation errors."""
+        df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
+        chart = (
+            alt.Chart(df)
+            .mark_bar()
+            .encode(
+                x=alt.X("a:O"),
+                y=alt.Y("b:Q"),
+            )
+        )
+
+        kwargs = {param_name: invalid_value}
+        with pytest.raises(StreamlitAPIException):
+            st.altair_chart(chart, **kwargs)
+
+    def test_altair_chart_default_height_content(self):
+        """Test that default height is 'content'."""
+        df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
+        chart = (
+            alt.Chart(df)
+            .mark_bar()
+            .encode(
+                x=alt.X("a:O"),
+                y=alt.Y("b:Q"),
+            )
+        )
+
+        st.altair_chart(chart)
+
+        el = self.get_delta_from_queue().new_element
+
+        assert el.height_config.WhichOneof("height_spec") == "use_content"
+        assert el.height_config.use_content is True
+
+    @pytest.mark.skipif(
+        is_altair_version_less_than("5.0.0"),
+        reason="This test only runs if altair is >= 5.0.0",
+    )
+    def test_altair_chart_height_with_selections(self):
+        """Test that height works correctly with selections enabled."""
+        df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
+        chart = (
+            alt.Chart(df)
+            .mark_bar()
+            .encode(
+                x=alt.X("a:O"),
+                y=alt.Y("b:Q"),
+            )
+            .add_params(alt.selection_point("my_param"))
+        )
+
+        result = st.altair_chart(
+            chart, height=300, on_select="rerun", key="test_altair_chart_height"
+        )
+
+        # Check that the chart element has the correct height configuration
+        el = self.get_delta_from_queue().new_element
+        assert el.height_config.WhichOneof("height_spec") == "pixel_height"
+        assert el.height_config.pixel_height == 300
+
+        # Check that selections are still working
+        assert hasattr(result, "selection")
+        assert result.selection.my_param == {}
+
+
 class VegaLiteChartTest(DeltaGeneratorTestCase):
     """Test the `st.vega_lite_chart` command."""
 


### PR DESCRIPTION
## Describe your changes

Adds a new `height` parameter to `st.altair_chart` using the `Height` type system (`"stretch"`, `"content"`, or pixel values) for consistency with other chart elements.

**Changes Made:**

- **Added new parameter**: Added `height: Height = "content"` parameter to `st.altair_chart`
- **Added comprehensive height support**: 
  - `height="content"` (default): Respects Altair chart's native height if specified in chart properties
  - `height="stretch"`: Expands to fill the parent container's height
  - `height=<integer>`: Sets fixed pixel height
- **Enhanced parameter validation**: Validates height parameter with appropriate error messages for invalid values
- **Comprehensive test coverage**: Added E2E tests and unit tests covering all height scenarios

**Key Implementation Details:**

_Height Parameter Addition:_

- **New functionality**: Adds `height` parameter with default `height="content"`
- **Native height support**: `height="content"` extracts height from native Altair chart object if available
- **Container-based sizing**: `height="stretch"` properly fills parent containers (tested in 500px container)
- **Flexible sizing**: Supports integer values for fixed pixel heights

## GitHub Issue Link (if applicable)

Part of the AdvancedLayouts initiative

## Testing Plan

- [x] Unit Tests (Python) - New height parameter functionality with parameterized tests
- [x] Unit Tests (Python) - Parameter validation and error handling  
- [x] Unit Tests (Python) - Default behavior verification (`height="content"`)
- [x] Unit Tests (Python) - Compatibility with chart selections
- [x] E2E Tests - Visual height behavior validation across all scenarios:
  - Fixed height values (`height=250`)
  - Content-based sizing (`height="content"` with chart spec height=180)
  - Container-based sizing (`height="stretch"` in 500px container)
- [x] Manual testing completed for all height scenarios

**Screenshots/Demos:**
_(E2E test snapshots show visual differences for all height behaviors: fixed pixels, content-based, and container stretching)_

<img width="844" height="1037" alt="Screenshot 2025-09-25 at 1 21 31 PM" src="https://github.com/user-attachments/assets/8d37ddc5-5c00-4137-912a-e6e9b5305ea7" />

**Additional Notes:**

This extends the AdvancedLayouts initiative by adding height support to `st.altair_chart`, bringing it in line with other chart elements that support the `Height` type system. The default of `height="content"` ensures backward compatibility while enabling users to override with `"stretch"` for responsive designs or specific pixel values for fixed layouts.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
