### PR TITLE
break prism dep on initial load

### DIFF
--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { lazy, ReactElement, ReactNode } from "react"
+import React, { ReactElement, ReactNode } from "react"
 
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import React, { lazy, ReactElement, ReactNode } from "react"
 
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {
@@ -26,7 +26,6 @@ import {
   ModalHeader,
   SessionInfo,
   StreamlitMarkdown,
-  StreamlitSyntaxHighlighter,
 } from "@streamlit/lib"
 import { IException } from "@streamlit/protobuf"
 
@@ -172,9 +171,9 @@ function ScriptCompileErrorDialog(
     <Modal isOpen onClose={props.onClose} size="auto" autoFocus={false}>
       <ModalHeader>Script execution error</ModalHeader>
       <ModalBody>
-        <StreamlitSyntaxHighlighter showLineNumbers={false} wrapLines={false}>
+        <pre>
           {props.exception?.message ? props.exception.message : "No message"}
-        </StreamlitSyntaxHighlighter>
+        </pre>
       </ModalBody>
       <ModalFooter>
         <ModalButton kind={BaseButtonKind.SECONDARY} onClick={props.onClose}>

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -18,6 +18,7 @@ import React, {
   CSSProperties,
   type FC,
   type HTMLProps,
+  lazy,
   memo,
   type ReactElement,
   type ReactNode,
@@ -50,7 +51,6 @@ import xxhash from "xxhashjs"
 import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg"
 import IsDialogContext from "~lib/components/core/IsDialogContext"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import StreamlitSyntaxHighlighter from "~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter"
 import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
 import ErrorBoundary from "~lib/components/shared/ErrorBoundary"
 import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon"
@@ -72,6 +72,10 @@ import {
 } from "./styled-components"
 
 import "katex/dist/katex.min.css"
+
+const StreamlitSyntaxHighlighter = lazy(
+  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+)
 
 export enum Tags {
   H1 = "h1",

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -34,7 +34,6 @@ export type { LibConfig, LibContextProps } from "./components/core/LibContext"
 export { PortalProvider } from "./components/core/Portal/PortalProvider"
 export { default as ThemeProvider } from "./components/core/ThemeProvider"
 export { default as AlertElement } from "./components/elements/AlertElement"
-export { default as StreamlitSyntaxHighlighter } from "./components/elements/CodeBlock/StreamlitSyntaxHighlighter"
 export { handleFavicon } from "./components/elements/Favicon"
 export { default as TextElement } from "./components/elements/TextElement"
 export {


### PR DESCRIPTION
## Describe your changes

The `StreamlitSyntaxHighlighter` component loads the prism styler under the hood which takes some time. It can be broken out into its own bundle. The only dependency that is difficult to break is when displaying a connection error message, it is expected to be used when rendering the `StreamlitDialog`. Unfortunately if there is no server to communicate with, the bundle can't load! This PR does not fix this and instead a POC that this truly does have an impact. Further lazy loading of this component would be beneficial to all apps.

Before (186ms)
<img width="1785" height="519" alt="image" src="https://github.com/user-attachments/assets/1682a5c9-8454-4118-9ece-6189f376bf14" />

After (47ms)
<img width="1105" height="425" alt="image" src="https://github.com/user-attachments/assets/c6deaaec-c41d-41f8-aabb-97d5eb2770a2" />


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
