### PR TITLE
[chore] improve protobuf compilation guidance in Cursor rules

### DIFF
--- a/.cursor/rules/protobuf.mdc
+++ b/.cursor/rules/protobuf.mdc
@@ -24,8 +24,16 @@ Typical incompatible changes are:
 
 ## Compile Protobuf
 
-If you ever modify the protobufs, you'll need to run the command below (from the repo root) to compile the
-protos into libraries that can be used in Python and JS:
+Some changes require compiling the protobufs into libraries that can be used in python and JS.
+
+Examples of changes that require the compilation step:
+- Adding a field.
+
+Examples of changes that do not require the compilation step:
+- Adding or modifying comments.
+- Adding the `[deprecated=true]` notation.
+
+Run this command to recompile the protobufs:
 
 ```bash
 make protobuf

--- a/.cursor/rules/protobuf.mdc
+++ b/.cursor/rules/protobuf.mdc
@@ -24,7 +24,7 @@ Typical incompatible changes are:
 
 ## Compile Protobuf
 
-Some changes require compiling the protobufs into libraries that can be used in python and JS.
+Some changes require compiling the protobufs into libraries that can be used in Python and JS.
 
 Examples of changes that require the compilation step:
 - Adding a field.

--- a/.cursor/rules/protobuf.mdc
+++ b/.cursor/rules/protobuf.mdc
@@ -8,30 +8,37 @@ alwaysApply: false
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
+**Note**: Messages are "released" once shipped in any Streamlit version.
+
 ## Protobuf Compatibility
 
-Always keep Streamlit's protobuf messages backwards compatible. New versions of the protobuf messages must work with
-old versions of Streamlit. Thereby, we can assume that the backend and frontend version are the same. All changes
-that would not work with an older Streamlit version are incompatible and should be avoided as much as possible.
+Always keep protobuf messages backwards compatible. New versions must work with older Streamlit versions.
 
-Typical incompatible changes are:
+**Incompatible changes to avoid:**
 
-- Removing a field → instead add a `// DEPRECATED` comment and mark it as `[deprecated=true]`
-- Renaming a field → instead deprecate it and introduce a new field with a *new* number
-- Changing the number of a field -> all field numbers must be kept as is.
-- Adding or removing the `optional` keyword -> deprecate field and add a new one.
-- Changing the type of a field in an incompatible way → see the @Protobuf docs for message types for more details.
+- Removing a field → Add `// DEPRECATED` comment and mark `[deprecated=true]`
+- Renaming a field → Deprecate old field, add new field with next available number
+- Changing field numbers → Keep all existing numbers unchanged
+- Adding/removing `optional` → Deprecate and create new field
+- Changing field types incompatibly → Use new field with compatible type
+
+**Compatible changes (safe to make):**
+
+- Adding new optional fields
+- Adding comments
+- Marking fields as deprecated
+- Modifying/removing unreleased fields
 
 ## Compile Protobuf
 
-Some changes require compiling the protobufs into libraries that can be used in Python and JS.
+Changes requiring compilation:
 
-Examples of changes that require the compilation step:
-- Adding a field.
+- Adding a field
+- **Unreleased messages only:** Modifying/removing fields
 
-Examples of changes that do not require the compilation step:
-- Adding or modifying comments.
-- Adding the `[deprecated=true]` notation.
+Changes not requiring compilation:
+
+- Comments and `[deprecated=true]` notation
 
 Run this command to recompile the protobufs:
 

--- a/.github/instructions/protobuf.instructions.md
+++ b/.github/instructions/protobuf.instructions.md
@@ -6,30 +6,37 @@ applyTo: "**/*.proto"
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
+**Note**: Messages are "released" once shipped in any Streamlit version.
+
 ## Protobuf Compatibility
 
-Always keep Streamlit's protobuf messages backwards compatible. New versions of the protobuf messages must work with
-old versions of Streamlit. Thereby, we can assume that the backend and frontend version are the same. All changes
-that would not work with an older Streamlit version are incompatible and should be avoided as much as possible.
+Always keep protobuf messages backwards compatible. New versions must work with older Streamlit versions.
 
-Typical incompatible changes are:
+**Incompatible changes to avoid:**
 
-- Removing a field → instead add a `// DEPRECATED` comment and mark it as `[deprecated=true]`
-- Renaming a field → instead deprecate it and introduce a new field with a *new* number
-- Changing the number of a field -> all field numbers must be kept as is.
-- Adding or removing the `optional` keyword -> deprecate field and add a new one.
-- Changing the type of a field in an incompatible way → see the @Protobuf docs for message types for more details.
+- Removing a field → Add `// DEPRECATED` comment and mark `[deprecated=true]`
+- Renaming a field → Deprecate old field, add new field with next available number
+- Changing field numbers → Keep all existing numbers unchanged
+- Adding/removing `optional` → Deprecate and create new field
+- Changing field types incompatibly → Use new field with compatible type
+
+**Compatible changes (safe to make):**
+
+- Adding new optional fields
+- Adding comments
+- Marking fields as deprecated
+- Modifying/removing unreleased fields
 
 ## Compile Protobuf
 
-Some changes require compiling the protobufs into libraries that can be used in python and JS.
+Changes requiring compilation:
 
-Examples of changes that require the compilation step:
-- Adding a field.
+- Adding a field
+- **Unreleased messages only:** Modifying/removing fields
 
-Examples of changes that do not require the compilation step:
-- Adding or modifying comments.
-- Adding the `[deprecated=true]` notation.
+Changes not requiring compilation:
+
+- Comments and `[deprecated=true]` notation
 
 Run this command to recompile the protobufs:
 

--- a/.github/instructions/protobuf.instructions.md
+++ b/.github/instructions/protobuf.instructions.md
@@ -22,8 +22,16 @@ Typical incompatible changes are:
 
 ## Compile Protobuf
 
-If you ever modify the protobufs, you'll need to run the command below (from the repo root) to compile the
-protos into libraries that can be used in Python and JS:
+Some changes require compiling the protobufs into libraries that can be used in python and JS.
+
+Examples of changes that require the compilation step:
+- Adding a field.
+
+Examples of changes that do not require the compilation step:
+- Adding or modifying comments.
+- Adding the `[deprecated=true]` notation.
+
+Run this command to recompile the protobufs:
 
 ```bash
 make protobuf

--- a/proto/streamlit/proto/AGENTS.md
+++ b/proto/streamlit/proto/AGENTS.md
@@ -18,8 +18,16 @@ Typical incompatible changes are:
 
 ## Compile Protobuf
 
-If you ever modify the protobufs, you'll need to run the command below (from the repo root) to compile the
-protos into libraries that can be used in Python and JS:
+Some changes require compiling the protobufs into libraries that can be used in python and JS.
+
+Examples of changes that require the compilation step:
+- Adding a field.
+
+Examples of changes that do not require the compilation step:
+- Adding or modifying comments.
+- Adding the `[deprecated=true]` notation.
+
+Run this command to recompile the protobufs:
 
 ```bash
 make protobuf

--- a/proto/streamlit/proto/AGENTS.md
+++ b/proto/streamlit/proto/AGENTS.md
@@ -2,30 +2,37 @@
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
+**Note**: Messages are "released" once shipped in any Streamlit version.
+
 ## Protobuf Compatibility
 
-Always keep Streamlit's protobuf messages backwards compatible. New versions of the protobuf messages must work with
-old versions of Streamlit. Thereby, we can assume that the backend and frontend version are the same. All changes
-that would not work with an older Streamlit version are incompatible and should be avoided as much as possible.
+Always keep protobuf messages backwards compatible. New versions must work with older Streamlit versions.
 
-Typical incompatible changes are:
+**Incompatible changes to avoid:**
 
-- Removing a field → instead add a `// DEPRECATED` comment and mark it as `[deprecated=true]`
-- Renaming a field → instead deprecate it and introduce a new field with a *new* number
-- Changing the number of a field -> all field numbers must be kept as is.
-- Adding or removing the `optional` keyword -> deprecate field and add a new one.
-- Changing the type of a field in an incompatible way → see the @Protobuf docs for message types for more details.
+- Removing a field → Add `// DEPRECATED` comment and mark `[deprecated=true]`
+- Renaming a field → Deprecate old field, add new field with next available number
+- Changing field numbers → Keep all existing numbers unchanged
+- Adding/removing `optional` → Deprecate and create new field
+- Changing field types incompatibly → Use new field with compatible type
+
+**Compatible changes (safe to make):**
+
+- Adding new optional fields
+- Adding comments
+- Marking fields as deprecated
+- Modifying/removing unreleased fields
 
 ## Compile Protobuf
 
-Some changes require compiling the protobufs into libraries that can be used in python and JS.
+Changes requiring compilation:
 
-Examples of changes that require the compilation step:
-- Adding a field.
+- Adding a field
+- **Unreleased messages only:** Modifying/removing fields
 
-Examples of changes that do not require the compilation step:
-- Adding or modifying comments.
-- Adding the `[deprecated=true]` notation.
+Changes not requiring compilation:
+
+- Comments and `[deprecated=true]` notation
 
 Run this command to recompile the protobufs:
 


### PR DESCRIPTION
## Describe your changes

Improves the protobuf compilation guidance in Cursor rules to provide clearer information about when compilation is required.

**Changes Made:**

- Added clarification about when protobuf compilation is needed vs when it's not required
- Provided specific examples of changes that require compilation (e.g., adding fields)
- Provided examples of changes that don't require compilation (e.g., adding comments, deprecation notation)
- Enhanced the documentation structure for better AI assistant understanding

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Manual testing completed - verified the rule documentation is clear and accurate
- [x] Explanation of why no additional tests are needed: This is documentation/rules improvement that doesn't affect code functionality

**Additional Notes:**

This improves the AI development workflow by providing clearer guidance about protobuf compilation requirements in the Cursor rules system.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
