### PR TITLE
[feat] Add ComponentManifest infra

### DIFF
--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/components/v2/component_manifest_handler.py
+++ b/lib/streamlit/components/v2/component_manifest_handler.py
@@ -1,0 +1,122 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+    from pathlib import Path
+
+    from streamlit.components.v2.manifest_scanner import ComponentManifest
+
+
+class ComponentManifestHandler:
+    """Handles component registration from parsed ComponentManifest objects."""
+
+    def __init__(self) -> None:
+        # Component metadata from pyproject.toml
+        self._metadata: MutableMapping[str, ComponentManifest] = {}
+        # Resolved asset roots keyed by fully-qualified component name
+        self._asset_roots: MutableMapping[str, Path] = {}
+
+    def process_manifest(
+        self, manifest: ComponentManifest, package_root: Path
+    ) -> dict[str, dict[str, Any]]:
+        """Process a manifest and return component definitions to register.
+
+        Parameters
+        ----------
+        manifest : ComponentManifest
+            The manifest to process
+        package_root : Path
+            The package root directory
+
+        Returns
+        -------
+        dict[str, dict[str, Any]]
+            Dictionary mapping component names to their definitions
+
+        Raises
+        ------
+        StreamlitComponentRegistryError
+            If a declared ``asset_dir`` does not exist, is not a directory, or
+            resolves (after following symlinks) outside of ``package_root``.
+        """
+        base_name = manifest.name
+        component_definitions = {}
+
+        # Process each component in the manifest
+        for comp_config in manifest.components:
+            comp_name = comp_config.name
+
+            component_name = f"{base_name}.{comp_name}"
+
+            # Parse and persist asset_dir if provided. This is the component's
+            # root directory for all future file references.
+            asset_root = comp_config.resolve_asset_root(package_root)
+            if asset_root is not None:
+                self._asset_roots[component_name] = asset_root
+
+            # Create component definition data
+            component_definitions[component_name] = {
+                "name": component_name,
+            }
+
+            # Store metadata
+            self._metadata[component_name] = manifest
+
+        return component_definitions
+
+    def get_metadata(self, component_name: str) -> ComponentManifest | None:
+        """Get metadata for a specific component.
+
+        Parameters
+        ----------
+        component_name : str
+            Fully-qualified component name (e.g., ``"package.component"``).
+
+        Returns
+        -------
+        ComponentManifest | None
+            The manifest that declared this component, or ``None`` if unknown.
+        """
+        return self._metadata.get(component_name)
+
+    def get_asset_root(self, component_name: str) -> Path | None:
+        """Get the absolute asset root directory for a component if declared.
+
+        Parameters
+        ----------
+        component_name : str
+            Fully-qualified component name (e.g. "package.component").
+
+        Returns
+        -------
+        Path | None
+            Absolute path to the component's asset root if present, otherwise None.
+        """
+        return self._asset_roots.get(component_name)
+
+    def get_asset_watch_roots(self) -> dict[str, Path]:
+        """Get a mapping of component names to their asset root directories.
+
+        Returns
+        -------
+        dict[str, Path]
+            A shallow copy mapping fully-qualified component names to absolute
+            asset root directories.
+        """
+        return dict(self._asset_roots)

--- a/lib/streamlit/components/v2/component_path_utils.py
+++ b/lib/streamlit/components/v2/component_path_utils.py
@@ -1,0 +1,205 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Security-hardened path utilities for Component v2.
+
+This module centralizes path validation and resolution logic used by the
+Component v2 registration and file access code paths. All helpers here are
+designed to prevent path traversal, insecure prefix checks, and symlink escapes
+outside of a declared package root.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+from streamlit.errors import StreamlitComponentRegistryError
+from streamlit.logger import get_logger
+
+_LOGGER: Final = get_logger(__name__)
+
+
+class ComponentPathUtils:
+    """Utility class for component path operations and security validation."""
+
+    @staticmethod
+    def has_glob_characters(path: str) -> bool:
+        """Check if a path contains glob pattern characters.
+
+        Parameters
+        ----------
+        path : str
+            The path to check
+
+        Returns
+        -------
+        bool
+            True if the path contains glob characters
+        """
+        return any(char in path for char in ["*", "?", "[", "]"])
+
+    @staticmethod
+    def validate_path_security(path: str) -> None:
+        """Validate that a path doesn't contain security vulnerabilities.
+
+        Parameters
+        ----------
+        path : str
+            The path to validate
+
+        Raises
+        ------
+        StreamlitComponentRegistryError
+            If the path contains security vulnerabilities like path traversal attempts
+        """
+        ComponentPathUtils._assert_relative_no_traversal(path, label="component paths")
+
+    @staticmethod
+    def resolve_glob_pattern(pattern: str, package_root: Path) -> Path:
+        """Resolve a glob pattern to a single file path with security checks.
+
+        Parameters
+        ----------
+        pattern : str
+            The glob pattern to resolve
+        package_root : Path
+            The package root directory for security validation
+
+        Returns
+        -------
+        Path
+            The resolved file path
+
+        Raises
+        ------
+        StreamlitComponentRegistryError
+            If zero or more than one file matches the pattern, or if security
+            checks fail (path traversal attempts)
+        """
+        # Ensure pattern is relative and doesn't contain path traversal attempts
+        ComponentPathUtils._assert_relative_no_traversal(pattern, label="glob patterns")
+
+        # Use glob from the package root so subdirectory patterns are handled correctly
+        matching_files = list(package_root.glob(pattern))
+
+        # Ensure all matched files are within package_root (security check)
+        validated_files = []
+        for file_path in matching_files:
+            try:
+                # Resolve to absolute path and check if it's within package_root
+                resolved_path = file_path.resolve()
+                package_root_resolved = package_root.resolve()
+
+                # Check if the resolved path is within the package root using
+                # pathlib's relative path check to avoid prefix-matching issues
+                if not resolved_path.is_relative_to(package_root_resolved):
+                    _LOGGER.warning(
+                        "Skipping file outside package root: %s", resolved_path
+                    )
+                    continue
+
+                validated_files.append(resolved_path)
+            except (OSError, ValueError) as e:
+                _LOGGER.warning("Failed to resolve path %s: %s", file_path, e)
+                continue
+
+        # Ensure exactly one file matches
+        if len(validated_files) == 0:
+            raise StreamlitComponentRegistryError(
+                f"No files found matching pattern '{pattern}' in package root {package_root}"
+            )
+        if len(validated_files) > 1:
+            file_list = ", ".join(str(f) for f in validated_files)
+            raise StreamlitComponentRegistryError(
+                f"Multiple files found matching pattern '{pattern}': {file_list}. "
+                "Exactly one file must match the pattern."
+            )
+
+        return Path(validated_files[0])
+
+    @staticmethod
+    def _assert_relative_no_traversal(path: str, *, label: str) -> None:
+        """Raise if ``path`` is absolute or contains ``..`` segments.
+
+        Parameters
+        ----------
+        path : str
+            Path string to validate.
+        label : str
+            Human-readable label used in error messages (e.g., "component paths").
+        """
+        # Absolute path checks (POSIX, Windows drive-letter, UNC)
+        is_windows_drive_abs = (
+            len(path) >= 3
+            and path[0].isalpha()
+            and path[1] == ":"
+            and path[2] in ("/", "\\")
+        )
+        is_unc_abs = path.startswith("\\\\")
+
+        # Consider rooted backslash paths "\\dir" as absolute on Windows-like inputs
+        is_rooted_backslash = path.startswith("\\") and not is_unc_abs
+
+        if (
+            os.path.isabs(path)
+            or is_windows_drive_abs
+            or is_unc_abs
+            or is_rooted_backslash
+        ):
+            raise StreamlitComponentRegistryError(
+                f"Absolute paths are not allowed in {label}: {path}"
+            )
+
+        # Segment-based traversal detection to avoid false positives (e.g. "file..js")
+        normalized = path.replace("\\", "/")
+        segments = [seg for seg in normalized.split("/") if seg != ""]
+        if any(seg == ".." for seg in segments):
+            raise StreamlitComponentRegistryError(
+                f"Path traversal attempts are not allowed in {label}: {path}"
+            )
+
+    @staticmethod
+    def ensure_within_root(abs_path: Path, root: Path, *, kind: str) -> None:
+        """Ensure that abs_path is within root; raise if not.
+
+        Parameters
+        ----------
+        abs_path : Path
+            Absolute file path
+        root : Path
+            Root directory path
+        kind : str
+            Human-readable descriptor for error messages (e.g., "js" or "css")
+
+        Raises
+        ------
+        StreamlitComponentRegistryError
+            If the path cannot be resolved or if the resolved path does not
+            reside within ``root`` after following symlinks.
+        """
+        try:
+            resolved = abs_path.resolve()
+            root_resolved = root.resolve()
+        except Exception as e:
+            raise StreamlitComponentRegistryError(
+                f"Failed to resolve {kind} path '{abs_path}': {e}"
+            ) from e
+
+        # Use Path.is_relative_to to avoid insecure prefix-based checks
+        if not resolved.is_relative_to(root_resolved):
+            raise StreamlitComponentRegistryError(
+                f"{kind} path '{abs_path}' is outside the declared asset_dir '{root}'."
+            )

--- a/lib/streamlit/components/v2/manifest_scanner.py
+++ b/lib/streamlit/components/v2/manifest_scanner.py
@@ -1,0 +1,615 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discovery utilities for Component v2 manifests in installed packages.
+
+The scanner searches installed distributions for a ``pyproject.toml`` with
+``[tool.streamlit.component]`` configuration and extracts the component
+manifests along with their package roots.
+
+The implementation prioritizes efficiency and safety by filtering likely
+candidates and avoiding excessive filesystem operations.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import toml
+from packaging import utils as packaging_utils
+
+from streamlit.components.v2.component_path_utils import ComponentPathUtils
+from streamlit.errors import StreamlitComponentRegistryError
+from streamlit.logger import get_logger
+
+_LOGGER: Final = get_logger(__name__)
+
+
+def _normalize_package_name(dist_name: str) -> str:
+    """Normalize a distribution name to an importable package name.
+
+    This helper converts hyphens to underscores to derive a best-effort
+    importable module/package name from a distribution name.
+
+    Parameters
+    ----------
+    dist_name : str
+        The distribution/project name (e.g., "my-awesome-component").
+
+    Returns
+    -------
+    str
+        The normalized package name suitable for import lookups
+        (e.g., "my_awesome_component").
+    """
+    return dist_name.replace("-", "_")
+
+
+@dataclass
+class ComponentManifest:
+    """Parsed component manifest data."""
+
+    name: str
+    version: str
+    components: list[ComponentConfig]
+
+
+@dataclass
+class ComponentConfig:
+    """Structured configuration for a single component entry.
+
+    Parameters
+    ----------
+    name
+        Component name as declared in ``pyproject.toml``.
+    asset_dir
+        Optional relative directory containing component assets.
+    """
+
+    name: str
+    asset_dir: str | None = None
+
+    @staticmethod
+    def from_dict(config: dict[str, Any]) -> ComponentConfig:
+        """Create a ComponentConfig from a raw dict.
+
+        Parameters
+        ----------
+        config
+            Raw component dictionary parsed from TOML.
+
+        Returns
+        -------
+        ComponentConfig
+            Parsed and validated component configuration.
+        """
+        name_value = config.get("name")
+        if not isinstance(name_value, str) or not name_value:
+            # Fail closed: invalid component entry
+            raise ValueError("Component entry missing required 'name' field")
+
+        asset_dir_value = config.get("asset_dir")
+        if asset_dir_value is not None and not isinstance(asset_dir_value, str):
+            # Fail closed: invalid asset_dir value
+            raise ValueError("'asset_dir' must be a string")
+
+        return ComponentConfig(
+            name=name_value,
+            asset_dir=asset_dir_value,
+        )
+
+    @staticmethod
+    def parse_or_none(config: dict[str, Any]) -> ComponentConfig | None:
+        """Best-effort parse without raising; returns None on malformed input."""
+        try:
+            return ComponentConfig.from_dict(config)
+        except Exception as e:
+            _LOGGER.debug("Skipping malformed component entry: %s", e)
+            return None
+
+    def resolve_asset_root(self, package_root: Path) -> Path | None:
+        """Resolve and security-check the component's asset root directory.
+
+        Parameters
+        ----------
+        package_root : Path
+            The root directory of the installed component package.
+
+        Returns
+        -------
+        Path | None
+            Absolute, resolved path to the asset directory, or ``None`` if
+            ``asset_dir`` is not declared.
+
+        Raises
+        ------
+        StreamlitComponentRegistryError
+            If the declared directory does not exist, is not a directory, or
+            resolves outside of ``package_root``.
+        """
+        if self.asset_dir is None:
+            return None
+
+        # Validate the configured path string first
+        ComponentPathUtils.validate_path_security(self.asset_dir)
+
+        asset_root = (package_root / self.asset_dir).resolve()
+
+        if not asset_root.exists() or not asset_root.is_dir():
+            raise StreamlitComponentRegistryError(
+                f"Declared asset_dir '{self.asset_dir}' for component '{self.name}' "
+                f"does not exist or is not a directory under package root '{package_root}'."
+            )
+
+        # Ensure the resolved directory is within the package root after following symlinks
+        ComponentPathUtils.ensure_within_root(
+            abs_path=asset_root,
+            root=package_root.resolve(),
+            kind="asset_dir",
+        )
+
+        return asset_root
+
+
+def _is_likely_streamlit_component_package(
+    dist: importlib.metadata.Distribution,
+) -> bool:
+    """Check if a package is likely to contain streamlit components before
+    expensive operations.
+
+    This early filter reduces the number of packages that need file I/O
+    operations from potentially hundreds down to just a few candidates.
+
+    Parameters
+    ----------
+    dist : importlib.metadata.Distribution
+        The package distribution to check.
+
+    Returns
+    -------
+    bool
+        True if the package might contain streamlit components, False otherwise.
+    """
+    # Get package metadata
+    name = dist.name.lower()
+    summary = dist.metadata["Summary"].lower() if "Summary" in dist.metadata else ""
+
+    # Filter 1: Package name suggests streamlit component
+    if "streamlit" in name:
+        return True
+
+    # Filter 2: Package description mentions streamlit
+    if "streamlit" in summary:
+        return True
+
+    # Filter 3: Check if package depends on streamlit
+    try:
+        # Check requires_dist for streamlit dependency
+        requires_dist = dist.metadata.get_all("Requires-Dist") or []
+        for requirement in requires_dist:
+            if requirement and "streamlit" in requirement.lower():
+                return True
+    except Exception as e:
+        # Don't fail on metadata parsing issues, but log for debugging purposes
+        _LOGGER.debug(
+            "Failed to parse package metadata for streamlit component detection: %s", e
+        )
+
+    # Filter 4: Check if this is a known streamlit ecosystem package
+    # Common patterns in streamlit component package names. Use anchored checks to
+    # avoid matching unrelated packages like "test-utils".
+    return name.startswith(("streamlit-", "streamlit_", "st-", "st_"))
+
+
+def _find_package_pyproject_toml(dist: importlib.metadata.Distribution) -> Path | None:
+    """Find ``pyproject.toml`` for a package.
+
+    Handles both regular and editable installs. The function uses increasingly
+    permissive strategies to locate the file while validating that the file
+    belongs to the given distribution.
+
+    Parameters
+    ----------
+    dist : importlib.metadata.Distribution
+        The package distribution to find pyproject.toml for.
+
+    Returns
+    -------
+    Path | None
+        Path to the ``pyproject.toml`` file if found, otherwise ``None``.
+    """
+    package_name = _normalize_package_name(dist.name)
+
+    # Try increasingly permissive strategies
+    for finder in (
+        _pyproject_via_read_text,
+        _pyproject_via_dist_files,
+        lambda d: _pyproject_via_import_spec(d, package_name),
+    ):
+        result = finder(dist)
+        if result is not None:
+            return result
+
+    return None
+
+
+def _pyproject_via_read_text(dist: importlib.metadata.Distribution) -> Path | None:
+    """Locate pyproject.toml using the distribution's read_text + nearby files.
+
+    This works for many types of installations including some editable ones.
+    """
+    package_name = _normalize_package_name(dist.name)
+    try:
+        if hasattr(dist, "read_text"):
+            pyproject_content = dist.read_text("pyproject.toml")
+            if pyproject_content and dist.files:
+                # Found content, now find the actual file path
+                # Look for a reasonable file to get the directory
+                for file in dist.files:
+                    if "__init__.py" in str(file) or ".py" in str(file):
+                        try:
+                            file_path = Path(str(dist.locate_file(file)))
+                            # Check nearby directories for pyproject.toml
+                            current_dir = file_path.parent
+                            # Check current directory and parent
+                            for search_dir in [current_dir, current_dir.parent]:
+                                pyproject_path = search_dir / "pyproject.toml"
+                                if (
+                                    pyproject_path.exists()
+                                    and _validate_pyproject_for_package(
+                                        pyproject_path,
+                                        dist.name,
+                                        package_name,
+                                    )
+                                ):
+                                    return pyproject_path
+                            # Stop after first reasonable file
+                            break
+                        except Exception:  # noqa: S112
+                            continue
+    except Exception:
+        return None
+    return None
+
+
+def _pyproject_via_dist_files(dist: importlib.metadata.Distribution) -> Path | None:
+    """Locate pyproject.toml by scanning the distribution's file list."""
+    package_name = _normalize_package_name(dist.name)
+    files = getattr(dist, "files", None)
+    if not files:
+        return None
+    for file in files:
+        if getattr(file, "name", None) == "pyproject.toml" or str(file).endswith(
+            "pyproject.toml"
+        ):
+            try:
+                pyproject_path = Path(str(dist.locate_file(file)))
+                if _validate_pyproject_for_package(
+                    pyproject_path,
+                    dist.name,
+                    package_name,
+                ):
+                    return pyproject_path
+            except Exception:  # noqa: S112
+                continue
+    return None
+
+
+def _pyproject_via_import_spec(
+    dist: importlib.metadata.Distribution, package_name: str
+) -> Path | None:
+    """Locate pyproject.toml by resolving the import spec and checking nearby.
+
+    For editable installs, try the package directory and its parent only.
+    """
+    try:
+        spec = importlib.util.find_spec(package_name)
+        if spec and spec.origin:
+            package_dir = Path(spec.origin).parent
+            for search_dir in [package_dir, package_dir.parent]:
+                pyproject_path = search_dir / "pyproject.toml"
+                if pyproject_path.exists() and _validate_pyproject_for_package(
+                    pyproject_path,
+                    dist.name,
+                    package_name,
+                ):
+                    return pyproject_path
+    except Exception:
+        return None
+    return None
+
+
+def _validate_pyproject_for_package(
+    pyproject_path: Path, dist_name: str, package_name: str
+) -> bool:
+    """Validate that a ``pyproject.toml`` file belongs to the specified package.
+
+    Parameters
+    ----------
+    pyproject_path : Path
+        Path to the pyproject.toml file to validate.
+    dist_name : str
+        The distribution name (e.g., "streamlit-bokeh").
+    package_name : str
+        The package name (e.g., "streamlit_bokeh").
+
+    Returns
+    -------
+    bool
+        True if the file belongs to this package, False otherwise.
+    """
+    try:
+        with open(pyproject_path, encoding="utf-8") as f:
+            pyproject_data = toml.load(f)
+
+        # Check if this pyproject.toml is for the package we're looking for
+        project_name = None
+
+        # Try to get the project name from [project] table
+        if "project" in pyproject_data and "name" in pyproject_data["project"]:
+            project_name = pyproject_data["project"]["name"]
+
+        # Also try to get it from [tool.setuptools] or other build system configs
+        if (
+            not project_name
+            and "tool" in pyproject_data
+            and (
+                "setuptools" in pyproject_data["tool"]
+                and "package-name" in pyproject_data["tool"]["setuptools"]
+            )
+        ):
+            project_name = pyproject_data["tool"]["setuptools"]["package-name"]
+
+        # If we found a project name, check if it matches either the dist name or package name
+        if project_name:
+            # Normalize names for comparison using PEP 503 canonicalization
+            # This handles hyphens, underscores, and dots consistently.
+            canonical_project = packaging_utils.canonicalize_name(project_name)
+            canonical_dist = packaging_utils.canonicalize_name(dist_name)
+            canonical_package = packaging_utils.canonicalize_name(package_name)
+
+            # Check if project name matches either the distribution name or the package name
+            return canonical_project in (canonical_dist, canonical_package)
+
+        # If we can't determine ownership, be conservative and reject it
+        return False
+
+    except Exception as e:
+        _LOGGER.debug(
+            "Error validating pyproject.toml at %s for %s: %s",
+            pyproject_path,
+            dist_name,
+            e,
+        )
+        return False
+
+
+def _load_pyproject(pyproject_path: Path) -> dict[str, Any] | None:
+    """Load and parse a pyproject.toml, returning parsed data or None on failure."""
+    try:
+        with open(pyproject_path, encoding="utf-8") as f:
+            return toml.load(f)
+    except Exception as e:
+        _LOGGER.debug("Failed to parse pyproject.toml at %s: %s", pyproject_path, e)
+        return None
+
+
+def _extract_components(pyproject_data: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Extract raw component dicts from pyproject data; return None if absent."""
+    streamlit_component = (
+        pyproject_data.get("tool", {}).get("streamlit", {}).get("component")
+    )
+    if not streamlit_component:
+        return None
+    raw_components = streamlit_component.get("components")
+    if not isinstance(raw_components, list):
+        return None
+    # Ensure a list of dicts for type safety
+    result: list[dict[str, Any]] = [
+        item for item in raw_components if isinstance(item, dict)
+    ]
+    if not result:
+        return None
+    return result
+
+
+def _resolve_package_root(
+    dist: importlib.metadata.Distribution, package_name: str, pyproject_path: Path
+) -> Path:
+    """Resolve the package root directory with fallbacks."""
+    package_root: Path | None = None
+    try:
+        spec = importlib.util.find_spec(package_name)
+        if spec and spec.origin:
+            package_root = Path(spec.origin).parent
+    except Exception as e:
+        _LOGGER.debug(
+            "Failed to resolve package root via import spec for %s: %s",
+            package_name,
+            e,
+        )
+
+    files = getattr(dist, "files", None)
+    if not package_root and files:
+        for file in files:
+            if package_name in str(file) and "__init__.py" in str(file):
+                try:
+                    init_path = Path(str(dist.locate_file(file)))
+                    package_root = init_path.parent
+                    break
+                except Exception as e:
+                    _LOGGER.debug(
+                        "Failed to resolve package root via dist files for %s: %s",
+                        package_name,
+                        e,
+                    )
+
+    if not package_root:
+        package_root = pyproject_path.parent
+
+    return package_root
+
+
+def _derive_project_metadata(
+    pyproject_data: dict[str, Any], dist: importlib.metadata.Distribution
+) -> tuple[str, str]:
+    """Derive project name and version with safe fallbacks."""
+    project_table = pyproject_data.get("project", {})
+    derived_name = project_table.get("name") or dist.name
+    derived_version = project_table.get("version") or dist.version or "0.0.0"
+    return derived_name, derived_version
+
+
+def _process_single_package(
+    dist: importlib.metadata.Distribution,
+) -> tuple[ComponentManifest, Path] | None:
+    """Process a single package to extract component manifest.
+
+    This function is designed to be called from a thread pool for parallel processing.
+
+    Parameters
+    ----------
+    dist : importlib.metadata.Distribution
+        The package distribution to process.
+
+    Returns
+    -------
+    tuple[ComponentManifest, Path] | None
+        The manifest and package root if found, otherwise ``None``.
+    """
+    try:
+        pyproject_path = _find_package_pyproject_toml(dist)
+        if not pyproject_path:
+            return None
+
+        pyproject_data = _load_pyproject(pyproject_path)
+        if pyproject_data is None:
+            return None
+
+        raw_components = _extract_components(pyproject_data)
+        if not raw_components:
+            return None
+
+        package_name = _normalize_package_name(dist.name)
+        package_root = _resolve_package_root(dist, package_name, pyproject_path)
+
+        derived_name, derived_version = _derive_project_metadata(pyproject_data, dist)
+
+        parsed_components: list[ComponentConfig] = [
+            parsed
+            for comp in raw_components
+            if (parsed := ComponentConfig.parse_or_none(comp)) is not None
+        ]
+
+        if not parsed_components:
+            return None
+
+        manifest = ComponentManifest(
+            name=derived_name,
+            version=derived_version,
+            components=parsed_components,
+        )
+
+        return (manifest, package_root)
+
+    except Exception as e:
+        _LOGGER.debug(
+            "Unexpected error processing distribution %s: %s",
+            getattr(dist, "name", "<unknown>"),
+            e,
+        )
+        return None
+
+
+def scan_component_manifests(
+    max_workers: int | None = None,
+) -> list[tuple[ComponentManifest, Path]]:
+    """Scan installed packages for Streamlit component metadata.
+
+    Uses parallel processing to improve performance in environments with many
+    installed packages. Applies early filtering to only check packages likely to
+    contain streamlit components.
+
+    Parameters
+    ----------
+    max_workers : int or None
+        Maximum number of worker threads. If None, uses min(32, (os.cpu_count()
+        or 1) + 4).
+
+    Returns
+    -------
+    list[tuple[ComponentManifest, Path]]
+        List of tuples of manifests and their package root paths.
+    """
+    manifests: list[tuple[ComponentManifest, Path]] = []
+
+    # Get all distributions first (this is fast)
+    all_distributions = list(importlib.metadata.distributions())
+
+    if not all_distributions:
+        return manifests
+
+    # Apply early filtering to reduce expensive file operations
+    candidate_distributions = [
+        dist
+        for dist in all_distributions
+        if _is_likely_streamlit_component_package(dist)
+    ]
+
+    _LOGGER.debug(
+        "Filtered %d packages down to %d candidates for component scanning",
+        len(all_distributions),
+        len(candidate_distributions),
+    )
+
+    if not candidate_distributions:
+        return manifests
+
+    # Default max_workers follows ThreadPoolExecutor's default logic
+    if max_workers is None:
+        max_workers = min(32, (os.cpu_count() or 1) + 4)
+
+    # Clamp max_workers to reasonable bounds for this task
+    max_workers = min(
+        max_workers, len(candidate_distributions), 16
+    )  # Don't use more threads than packages or 16
+
+    _LOGGER.debug(
+        "Scanning %d candidate packages for component manifests using %d worker threads",
+        len(candidate_distributions),
+        max_workers,
+    )
+
+    # Process packages in parallel
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all tasks
+        future_to_dist = {
+            executor.submit(_process_single_package, dist): dist.name
+            for dist in candidate_distributions
+        }
+
+        # Collect results as they complete
+        for future in as_completed(future_to_dist):
+            result = future.result()
+            if result:
+                manifests.append(result)
+
+    _LOGGER.debug("Found %d component manifests total", len(manifests))
+    return manifests

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -41,6 +41,17 @@ class CustomComponentError(Error):
     pass
 
 
+class StreamlitComponentRegistryError(Error):
+    """Exceptions raised while discovering or registering Streamlit components.
+
+    These errors occur during Streamlit startup when scanning installed
+    distributions for component metadata and registering them with the component
+    registry.
+    """
+
+    pass
+
+
 class DeprecationError(Error):
     pass
 

--- a/lib/tests/streamlit/components/v2/test_component_manifest_handler.py
+++ b/lib/tests/streamlit/components/v2/test_component_manifest_handler.py
@@ -1,0 +1,130 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from streamlit.components.v2.component_manifest_handler import (
+    ComponentManifestHandler,
+)
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+from streamlit.errors import StreamlitComponentRegistryError
+
+
+def test_component_manifest_handler_stores_asset_dir() -> None:
+    """Test that ComponentManifestHandler parses and persists asset_dir per component."""
+    # Create a manifest with an asset_dir entry
+    manifest = ComponentManifest(
+        name="test-package",
+        version="1.0.0",
+        components=[ComponentConfig(name="slider", asset_dir="slider/assets")],
+    )
+
+    handler = ComponentManifestHandler()
+
+    # Create a real temp package root and asset_dir to satisfy existence check
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_root = Path(temp_dir)
+        os.makedirs(package_root / "slider" / "assets")
+
+        handler.process_manifest(manifest, package_root)
+
+    # Fully qualified name
+    comp_full_name = "test-package.slider"
+    asset_root = handler.get_asset_root(comp_full_name)
+
+    assert asset_root is not None
+    assert asset_root == (package_root / "slider/assets").resolve()
+
+
+def test_component_manifest_handler_get_asset_root_none_when_missing() -> None:
+    """Test that get_asset_root returns None when asset_dir is not provided."""
+    manifest = ComponentManifest(
+        name="test-package",
+        version="1.0.0",
+        components=[ComponentConfig(name="slider")],
+    )
+
+    handler = ComponentManifestHandler()
+    package_root = Path("/pkg/root")
+
+    handler.process_manifest(manifest, package_root)
+
+    comp_full_name = "test-package.slider"
+    assert handler.get_asset_root(comp_full_name) is None
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="OS does not support symlinks")
+def test_component_manifest_handler_rejects_asset_dir_symlink_outside_root() -> None:
+    """asset_dir that resolves outside package_root via symlink must be rejected."""
+    manifest = ComponentManifest(
+        name="test-package",
+        version="1.0.0",
+        components=[ComponentConfig(name="widget", asset_dir="linked_outside")],
+    )
+
+    handler = ComponentManifestHandler()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_root = Path(temp_dir) / "pkg"
+        outside_root = Path(temp_dir) / "outside"
+        real_outside_assets = outside_root / "assets"
+        real_outside_assets.mkdir(parents=True, exist_ok=True)
+
+        link_inside = package_root / "linked_outside"
+        link_inside.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            os.symlink(
+                str(real_outside_assets), str(link_inside), target_is_directory=True
+            )
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlink creation not permitted in this environment")
+
+        with pytest.raises(StreamlitComponentRegistryError):
+            handler.process_manifest(manifest, package_root)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="OS does not support symlinks")
+def test_component_manifest_handler_allows_symlink_within_root() -> None:
+    """asset_dir symlinked within package_root should be accepted and resolved."""
+    manifest = ComponentManifest(
+        name="test-package",
+        version="1.0.0",
+        components=[ComponentConfig(name="widget", asset_dir="linked_inside")],
+    )
+
+    handler = ComponentManifestHandler()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_root = Path(temp_dir) / "pkg"
+        real_assets = package_root / "real_assets"
+        real_assets.mkdir(parents=True, exist_ok=True)
+
+        link_inside = package_root / "linked_inside"
+        try:
+            os.symlink(str(real_assets), str(link_inside), target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlink creation not permitted in this environment")
+
+        handler.process_manifest(manifest, package_root)
+
+        comp_full_name = "test-package.widget"
+        asset_root = handler.get_asset_root(comp_full_name)
+        assert asset_root == real_assets.resolve()

--- a/lib/tests/streamlit/components/v2/test_component_path_utils.py
+++ b/lib/tests/streamlit/components/v2/test_component_path_utils.py
@@ -1,0 +1,194 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from streamlit.components.v2.component_path_utils import ComponentPathUtils
+from streamlit.errors import StreamlitComponentRegistryError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("console.log('ok');", encoding="utf-8")
+
+
+def test_resolve_glob_pattern_accepts_file_within_root(tmp_path: Path) -> None:
+    """Resolves a simple relative path within the package root."""
+    package_root = tmp_path / "pkg"
+    asset = package_root / "assets" / "main.js"
+    _touch(asset)
+
+    resolved = ComponentPathUtils.resolve_glob_pattern(
+        pattern="assets/main.js", package_root=package_root
+    )
+
+    assert resolved == asset.resolve()
+
+
+def test_resolve_glob_pattern_handles_subdirectory_wildcards_single_match(
+    tmp_path: Path,
+) -> None:
+    """Resolves a wildcard pattern when only one match exists."""
+    package_root = tmp_path / "pkg"
+    a1 = package_root / "assets" / "v1" / "main.js"
+    a2 = package_root / "assets" / "v2" / "other.js"
+    _touch(a1)
+    _touch(a2)
+
+    # Only one file should match this pattern
+    resolved = ComponentPathUtils.resolve_glob_pattern(
+        pattern="assets/*/main.js", package_root=package_root
+    )
+    assert resolved == a1.resolve()
+
+
+def test_resolve_glob_pattern_raises_on_multiple_matches(tmp_path: Path) -> None:
+    """Raises when wildcard pattern matches multiple files."""
+    package_root = tmp_path / "pkg"
+    a1 = package_root / "assets" / "v1" / "main.js"
+    a2 = package_root / "assets" / "v2" / "main.js"
+    _touch(a1)
+    _touch(a2)
+
+    with pytest.raises(StreamlitComponentRegistryError):
+        ComponentPathUtils.resolve_glob_pattern(
+            pattern="assets/*/main.js", package_root=package_root
+        )
+
+
+def test_ensure_within_root_blocks_outside_with_prefix_collision(
+    tmp_path: Path,
+) -> None:
+    """Blocks files outside root even if paths share a prefix."""
+    root = tmp_path / "package"
+    inside_file = root / "dir" / "file.js"
+    outside_file = tmp_path / "package_malicious" / "file.js"
+    _touch(inside_file)
+    _touch(outside_file)
+
+    # Sanity: inside should not raise
+    ComponentPathUtils.ensure_within_root(
+        abs_path=inside_file.resolve(), root=root.resolve(), kind="js"
+    )
+
+    # Prevent a prefix-collision path escape: an attacker could place files in a
+    # sibling directory named "package_malicious" that shares the "package"
+    # prefix to bypass naive prefix-based checks and access files outside the
+    # package root. Such access must raise.
+    with pytest.raises(StreamlitComponentRegistryError):
+        ComponentPathUtils.ensure_within_root(
+            abs_path=outside_file.resolve(), root=root.resolve(), kind="js"
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="OS does not support symlinks")
+def test_resolve_glob_pattern_rejects_symlink_pointing_outside_root(
+    tmp_path: Path,
+) -> None:
+    """Rejects symlinked files that resolve outside the package root."""
+    package_root = tmp_path / "pkg"
+    outside_dir = tmp_path / "outside"
+    outside_file = outside_dir / "evil.js"
+    _touch(outside_file)
+
+    link_dir = package_root / "link"
+    link_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        os.symlink(str(outside_dir), str(link_dir), target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlink creation not permitted in this environment")
+
+    # The pattern targets a file reachable via a symlink inside package_root,
+    # but the resolved path points outside. It must be ignored, causing a
+    # 'no files found' error.
+    with pytest.raises(StreamlitComponentRegistryError):
+        ComponentPathUtils.resolve_glob_pattern(
+            pattern="link/evil.js", package_root=package_root
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_path",
+    [
+        "/etc/passwd",  # POSIX absolute
+        "C:\\Windows\\system32",  # Windows drive
+        "\\\\server\\share\\file",  # UNC
+        "../secret",  # traversal
+        "dir/../secret",  # traversal in middle
+        "\\rooted\\path",  # rooted backslash
+        "C:\\mix/sep\\file.js",  # mixed separators but absolute
+    ],
+)
+def test_validate_path_security_rejects_invalid_paths(invalid_path: str) -> None:
+    """Absolute, rooted-backslash, and traversal paths must be rejected."""
+    with pytest.raises(StreamlitComponentRegistryError):
+        ComponentPathUtils.validate_path_security(invalid_path)
+
+
+def test_validate_path_security_allows_non_traversal_double_dots() -> None:
+    """Double dots in filenames are allowed when not a traversal segment."""
+    # Should not raise
+    ComponentPathUtils.validate_path_security("dir/file..js")
+
+
+@pytest.mark.parametrize(
+    "invalid_pattern",
+    [
+        "/etc/*.js",  # POSIX absolute
+        "C:/Windows/*.dll",  # Windows drive
+        "\\\\server\\share\\*.js",  # UNC
+        "../assets/*.js",  # traversal
+        "assets/../*.js",  # traversal in middle
+        "\\assets\\*.js",  # rooted backslash
+        "assets/**/../evil.js",  # traversal with glob
+    ],
+)
+def test_resolve_glob_pattern_rejects_invalid_patterns(
+    tmp_path: Path, invalid_pattern: str
+) -> None:
+    """resolve_glob_pattern must reject absolute, rooted-backslash, and traversal patterns."""
+    package_root = tmp_path / "pkg"
+    (package_root / "assets").mkdir(parents=True, exist_ok=True)
+    with pytest.raises(StreamlitComponentRegistryError):
+        ComponentPathUtils.resolve_glob_pattern(
+            pattern=invalid_pattern, package_root=package_root
+        )
+
+
+def test_validate_path_security_allows_current_dir_segment() -> None:
+    """'.' segments are benign and should not raise."""
+    ComponentPathUtils.validate_path_security("./assets/file.js")
+    ComponentPathUtils.validate_path_security("assets/./file.js")
+
+
+def test_resolve_glob_pattern_accepts_dot_prefixed_relative(tmp_path: Path) -> None:
+    """'./' prefixed relative patterns should resolve normally within root."""
+    package_root = tmp_path / "pkg"
+    asset = package_root / "assets" / "a.js"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_text("console.log('ok');", encoding="utf-8")
+
+    resolved = ComponentPathUtils.resolve_glob_pattern(
+        pattern="./assets/a.js", package_root=package_root
+    )
+    assert resolved == asset.resolve()

--- a/lib/tests/streamlit/components/v2/test_manifest_scanner.py
+++ b/lib/tests/streamlit/components/v2/test_manifest_scanner.py
@@ -1,0 +1,949 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, mock_open, patch
+
+from parameterized import parameterized
+
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+
+
+@parameterized.expand(
+    [
+        ("hyphen_to_underscore", "my-awesome-component", "my_awesome_component"),
+        ("no_change_simple", "simple", "simple"),
+        (
+            "already_normalized",
+            "already_normalized_name",
+            "already_normalized_name",
+        ),
+        (
+            "preserve_dots_and_case",
+            "Streamlit.Bokeh",
+            "Streamlit.Bokeh",
+        ),
+        ("hyphen_replaced_before_dot", "foo-bar.baz", "foo_bar.baz"),
+    ]
+)
+def test_normalize_package_name_param(_case: str, raw: str, expected: str) -> None:
+    """Validate name normalization across representative cases."""
+    from streamlit.components.v2.manifest_scanner import _normalize_package_name
+
+    assert _normalize_package_name(raw) == expected
+
+
+def test_process_single_package_no_files() -> None:
+    """Test _process_single_package with distribution that has no files."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    # Create mock distribution with no files
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "test-package"
+
+    result = _process_single_package(mock_dist)
+    assert result is None
+
+
+def test_process_single_package_no_pyproject() -> None:
+    """Test _process_single_package with distribution that has no pyproject.toml."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    # Create mock distribution with files but no pyproject.toml
+    mock_file = Mock()
+    mock_file.name = "some_file.py"
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file]
+    mock_dist.name = "test-package"
+
+    result = _process_single_package(mock_dist)
+    assert result is None
+
+
+def test_process_single_package_no_streamlit_config() -> None:
+    """Test _process_single_package with pyproject.toml but no Streamlit config."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    # Create mock file and distribution
+    mock_file = Mock()
+    mock_file.name = "pyproject.toml"
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file]
+    mock_dist.name = "test-package"
+    mock_dist.locate_file.return_value = "/path/to/pyproject.toml"
+
+    # Mock toml content without Streamlit config
+    toml_content = """
+    [build-system]
+    requires = ["setuptools"]
+
+    [project]
+    name = "test-package"
+    """
+
+    with (
+        patch("builtins.open", mock_open(read_data=toml_content)),
+        patch("streamlit.components.v2.manifest_scanner.toml.load") as mock_toml_load,
+        patch("streamlit.components.v2.manifest_scanner.Path"),
+    ):
+        mock_toml_load.return_value = {
+            "build-system": {"requires": ["setuptools"]},
+            "project": {"name": "test-package"},
+        }
+
+        result = _process_single_package(mock_dist)
+        assert result is None
+
+
+def test_process_single_package_valid_manifest() -> None:
+    """Test _process_single_package with valid Streamlit component manifest."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    # Create mock file and distribution
+    mock_file = Mock()
+    mock_file.name = "pyproject.toml"
+
+    mock_init_file = Mock()
+    mock_init_file.__str__ = Mock(return_value="test_package/__init__.py")
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file, mock_init_file]
+    mock_dist.name = "test-package"
+    mock_dist.locate_file.side_effect = (
+        lambda f: "/path/to/pyproject.toml"
+        if f == mock_file
+        else "/path/to/test_package/__init__.py"
+    )
+
+    with (
+        patch("builtins.open", mock_open()),
+        patch("streamlit.components.v2.manifest_scanner.toml.load") as mock_toml_load,
+        patch("streamlit.components.v2.manifest_scanner.Path") as mock_path,
+    ):
+        mock_toml_load.return_value = {
+            "project": {"name": "test-package", "version": "1.0.0"},
+            "tool": {
+                "streamlit": {
+                    "component": {
+                        "components": [
+                            {
+                                "name": "slider",
+                                "js": "slider.js",
+                                "css": "slider.css",
+                            }
+                        ],
+                    }
+                }
+            },
+        }
+
+        # Mock Path behavior
+        mock_path_instance = Mock()
+        mock_path_instance.parent = "/path/to/test_package"
+        mock_path.return_value = mock_path_instance
+
+        result = _process_single_package(mock_dist)
+
+        assert result is not None
+        manifest, _package_root = result
+        assert manifest.name == "test-package"
+        assert manifest.version == "1.0.0"
+        assert len(manifest.components) == 1
+        assert manifest.components[0].name == "slider"
+
+
+def test_scan_multiple_component_manifests() -> None:
+    """Test that scanning handles multiple packages correctly."""
+    from streamlit.components.v2.manifest_scanner import (
+        scan_component_manifests,
+    )
+
+    # Create mock distributions with proper name and metadata attributes
+    mock_dists = []
+    for i in range(10):
+        mock_dist = Mock()
+        # Make some packages look like streamlit components
+        if i < 5:
+            mock_dist.name = f"streamlit-package-{i}"
+            package_name = f"streamlit-package-{i}"
+        else:
+            mock_dist.name = f"package-{i}"
+            package_name = f"package-{i}"
+
+        # Mock metadata that returns proper strings
+        mock_metadata = MagicMock()
+        metadata_dict = {
+            "Name": package_name,
+            "Summary": f"Description for {package_name}",
+        }
+        mock_metadata.__getitem__.side_effect = metadata_dict.__getitem__
+        mock_metadata.__contains__.side_effect = metadata_dict.__contains__
+        mock_metadata.get_all.return_value = []
+        mock_dist.metadata = mock_metadata
+        mock_dists.append(mock_dist)
+
+    results = []
+    for i in range(3):  # Only 3 packages have valid manifests
+        results.append(
+            (
+                ComponentManifest(
+                    name=f"component_{i}",
+                    version="1.0.0",
+                    components=[ComponentConfig(name="test")],
+                ),
+                Path(f"/path/to/component_{i}"),
+            )
+        )
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.metadata.distributions"
+        ) as mock_distributions,
+        patch(
+            "streamlit.components.v2.manifest_scanner._process_single_package"
+        ) as mock_process,
+    ):
+        mock_distributions.return_value = mock_dists
+        mock_process.side_effect = (
+            lambda dist: results[int(dist.name.split("-")[-1])]
+            if "streamlit" in dist.name and int(dist.name.split("-")[-1]) < 3
+            else None
+        )
+
+        manifests = scan_component_manifests(max_workers=2)
+
+        # Should return 3 valid manifests
+        assert len(manifests) == 3
+        assert all(manifest.name.startswith("component_") for manifest, _ in manifests)
+
+
+def test_scan_component_manifests_max_workers() -> None:
+    """Test that max_workers parameter is respected."""
+    from streamlit.components.v2.manifest_scanner import (
+        scan_component_manifests,
+    )
+
+    # Create a small number of mock distributions with proper name and metadata attributes
+    mock_dists = []
+    for i in range(3):
+        mock_dist = Mock()
+        # Make all packages look like streamlit components for this test
+        mock_dist.name = f"streamlit-package-{i}"
+        package_name = f"streamlit-package-{i}"
+
+        # Mock metadata that returns proper strings
+        mock_metadata = MagicMock()
+        metadata_dict = {
+            "Name": package_name,
+            "Summary": f"Description for {package_name}",
+        }
+        mock_metadata.__getitem__.side_effect = metadata_dict.__getitem__
+        mock_metadata.__contains__.side_effect = metadata_dict.__contains__
+        mock_metadata.get_all.return_value = []
+        mock_dist.metadata = mock_metadata
+        mock_dists.append(mock_dist)
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.metadata.distributions"
+        ) as mock_distributions,
+        patch(
+            "streamlit.components.v2.manifest_scanner._process_single_package"
+        ) as mock_process,
+        patch(
+            "streamlit.components.v2.manifest_scanner.ThreadPoolExecutor"
+        ) as mock_executor,
+    ):
+        mock_distributions.return_value = mock_dists
+        mock_process.return_value = None
+
+        # Mock the executor to work with as_completed
+        mock_executor_instance = Mock()
+        mock_executor.return_value.__enter__.return_value = mock_executor_instance
+        mock_future = Mock()
+        mock_future.result.return_value = None
+        mock_executor_instance.submit.return_value = mock_future
+
+        # Mock as_completed to return the futures immediately
+        with patch(
+            "streamlit.components.v2.manifest_scanner.as_completed"
+        ) as mock_as_completed:
+            mock_as_completed.return_value = [mock_future] * len(mock_dists)
+
+            # Test with explicit max_workers
+            scan_component_manifests(max_workers=2)
+            mock_executor.assert_called_with(max_workers=2)
+
+            # Test with default max_workers (should be limited by number of packages)
+            scan_component_manifests()
+            # Should use min(default, len(distributions), 16) = min(?, 3, 16) = 3
+            assert mock_executor.call_args[1]["max_workers"] <= 3
+
+
+def test_scan_component_manifests_empty_distributions() -> None:
+    """Test scanning with no installed packages."""
+    from streamlit.components.v2.manifest_scanner import (
+        scan_component_manifests,
+    )
+
+    with patch(
+        "streamlit.components.v2.manifest_scanner.importlib.metadata.distributions"
+    ) as mock_distributions:
+        mock_distributions.return_value = []
+
+        manifests = scan_component_manifests()
+        assert manifests == []
+
+
+def test_scan_component_manifests_error_handling() -> None:
+    """Test that scanning handles errors gracefully."""
+    from streamlit.components.v2.manifest_scanner import (
+        scan_component_manifests,
+    )
+
+    # Create mock distributions, some will cause errors
+    mock_dists = []
+    for i in range(5):
+        mock_dist = Mock()
+        # Make all packages look like streamlit components for this test
+        mock_dist.name = f"streamlit-package-{i}"
+        package_name = f"streamlit-package-{i}"
+
+        # Mock metadata that returns proper strings
+        mock_metadata = MagicMock()
+        metadata_dict = {
+            "Name": package_name,
+            "Summary": f"Description for {package_name}",
+        }
+        mock_metadata.__getitem__.side_effect = metadata_dict.__getitem__
+        mock_metadata.__contains__.side_effect = metadata_dict.__contains__
+        mock_metadata.get_all.return_value = []
+        mock_dist.metadata = mock_metadata
+        mock_dists.append(mock_dist)
+
+    def mock_process_with_errors(dist):
+        if "package-2" in dist.name:
+            # Simulate an error by returning None (what the real function does on error)
+            return
+        return  # For this test, all packages return None (no manifests found)
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.metadata.distributions"
+        ) as mock_distributions,
+        patch(
+            "streamlit.components.v2.manifest_scanner._process_single_package"
+        ) as mock_process,
+    ):
+        mock_distributions.return_value = mock_dists
+        mock_process.side_effect = mock_process_with_errors
+
+        # Should not raise exception even with errors
+        manifests = scan_component_manifests()
+        assert manifests == []
+
+
+# Tests for editable installs and _find_package_pyproject_toml function
+
+
+@parameterized.expand(
+    [
+        (
+            "project_name_match",
+            '[project]\nname = "test-package"\n',
+            (
+                ("test-package", "test_package", True),
+                ("test_package", "test_package", True),
+                ("different-package", "different_package", False),
+            ),
+        ),
+        (
+            "requires_explicit_project_name",
+            "[tool.streamlit.component]\ncomponents = []\n",
+            (("test-package", "test_package", False),),
+        ),
+        (
+            "no_match_other_tool",
+            '[project]\nname = "different-package"\n\n[tool.other]\nconfig = "value"\n',
+            (("test-package", "test_package", False),),
+        ),
+        (
+            "invalid_file",
+            "invalid toml content [[[",
+            (("test-package", "test_package", False),),
+        ),
+        (
+            "uses_package_name",
+            '[project]\nname = "my_component"\n',
+            (
+                ("my-awesome-component", "my_component", True),
+                ("different-component", "different_component", False),
+            ),
+        ),
+        (
+            "canonicalization_cases_streamlit_bokeh",
+            '[project]\nname = "Streamlit.Bokeh"\n',
+            (("streamlit-bokeh", "streamlit_bokeh", True),),
+        ),
+        (
+            "canonicalization_cases_mixed_separators",
+            '[project]\nname = "foo_-bar"\n',
+            (("foo-bar", "foo_bar", True),),
+        ),
+        (
+            "canonicalization_cases_upper_and_multiple",
+            '[project]\nname = "FOO...BAR__BAZ"\n',
+            (("foo-bar-baz", "foo_bar_baz", True),),
+        ),
+        (
+            "canonicalization_negative",
+            '[project]\nname = "streamlit.bokeh"\n',
+            (("streamlit-other", "streamlit_other", False),),
+        ),
+    ]
+)
+def test_validate_pyproject_for_package_param(
+    _case: str, pyproject_text: str, checks: tuple[tuple[str, str, bool], ...]
+) -> None:
+    """Validate pyproject parsing and name matching across many scenarios."""
+    from streamlit.components.v2.manifest_scanner import _validate_pyproject_for_package
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text(pyproject_text.strip())
+
+        for dist_name, package_name, expected in checks:
+            assert (
+                _validate_pyproject_for_package(pyproject_path, dist_name, package_name)
+                is expected
+            )
+
+
+def test_find_package_pyproject_toml_traditional_approach() -> None:
+    """Test _find_package_pyproject_toml with traditional dist.files approach."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    # Create mock file and distribution
+    mock_file = Mock()
+    mock_file.name = "pyproject.toml"
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file]
+    mock_dist.name = "test-package"
+    mock_dist.locate_file.return_value = "/path/to/pyproject.toml"
+
+    # Make sure read_text fails so it goes to the traditional approach
+    mock_dist.read_text.side_effect = Exception("read_text not available")
+
+    with (
+        patch("streamlit.components.v2.manifest_scanner.Path") as mock_path_class,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+    ):
+        # Create a real Path object that the function can use
+        expected_path = Path("/path/to/pyproject.toml")
+        mock_path_class.return_value = expected_path
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == expected_path
+        mock_dist.locate_file.assert_called_once_with(mock_file)
+        mock_validate.assert_called_once_with(
+            expected_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_traditional_approach_fails() -> None:
+    """Test _find_package_pyproject_toml when traditional approach fails but file exists."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    # Create mock file and distribution
+    mock_file = Mock()
+    mock_file.name = "pyproject.toml"
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file]
+    mock_dist.name = "test-package"
+    mock_dist.locate_file.side_effect = Exception("Failed to locate file")
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create package directory
+        package_dir = Path(temp_dir) / "test_package"
+        package_dir.mkdir()
+
+        # Mock importlib to find the package
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        # Create pyproject.toml file in the package directory
+        pyproject_path = package_dir / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == pyproject_path
+        mock_find_spec.assert_called_once_with("test_package")
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_editable_install() -> None:
+    """Test _find_package_pyproject_toml with editable install (no dist.files)."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.files = None  # Simulates editable install
+    mock_dist.name = "test-package"
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create a real directory structure for testing
+        package_dir = Path(temp_dir) / "test_package"
+        package_dir.mkdir()
+        pyproject_path = package_dir / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Mock importlib to find the package
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == pyproject_path
+        mock_find_spec.assert_called_once_with("test_package")
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_no_parent_traversal() -> None:
+    """Test _find_package_pyproject_toml does not traverse parent directories for security."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "test-package"
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create a nested directory structure
+        src_dir = Path(temp_dir) / "src"
+        src_dir.mkdir()
+        package_dir = src_dir / "test_package"
+        package_dir.mkdir()
+
+        # Create pyproject.toml in the root directory (parent of src/)
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Mock importlib to find the package
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        # For security, should NOT find pyproject.toml in parent directory
+        assert result is None
+        mock_find_spec.assert_called_once_with("test_package")
+        # Should check package directory but not find pyproject.toml there
+        mock_validate.assert_not_called()
+
+
+def test_find_package_pyproject_toml_read_text_approach() -> None:
+    """Test _find_package_pyproject_toml using dist.read_text() method for editable installs."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    # Create a mock file that looks like a Python file
+    mock_file = Mock()
+    mock_file.name = (
+        "__init__.py"  # This will match the condition in the implementation
+    )
+    mock_file.__str__ = Mock(return_value="__init__.py")  # Make sure str(file) works
+
+    mock_dist = Mock()
+    mock_dist.files = [mock_file]
+    mock_dist.name = "test-package"
+    mock_dist.read_text.return_value = "[project]\nname = 'test-package'"
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create a real pyproject.toml file that validation can find
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Mock locate_file to return a file in the same directory as pyproject.toml
+        mock_dist.locate_file.return_value = Path(temp_dir) / "__init__.py"
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == pyproject_path
+        mock_dist.read_text.assert_called_once_with("pyproject.toml")
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_path_distribution() -> None:
+    """Test _find_package_pyproject_toml using Method 3 (find_spec) for editable installs."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.files = None  # No files to trigger Methods 1 and 2 failure
+    mock_dist.name = "test-package"
+
+    # Make sure read_text fails so it doesn't use Method 1
+    mock_dist.read_text.side_effect = Exception("read_text not available")
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create pyproject.toml in temp directory
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Mock find_spec to return a spec that points to our temp directory
+        mock_spec = Mock()
+        mock_spec.origin = str(Path(temp_dir) / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == pyproject_path
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_validation_rejects_wrong_package() -> None:
+    """Test _find_package_pyproject_toml when validation rejects wrong package."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "test-package"
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create directory structure
+        package_dir = Path(temp_dir) / "test_package"
+        package_dir.mkdir()
+        pyproject_path = package_dir / "pyproject.toml"
+        pyproject_path.write_text(
+            "[project]\nname = 'different-package'"
+        )  # Wrong package
+
+        # Mock importlib to find the package
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        # Mock validation to return False (wrong package)
+        mock_validate.return_value = False
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result is None  # Should not find anything
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_read_text_fallback() -> None:
+    """Test _find_package_pyproject_toml using read_text fallback method."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.name = "test-package"
+    mock_dist.read_text.return_value = "[project]\nname = 'test-package'"
+
+    # Mock importlib to fail
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch(
+            "streamlit.components.v2.manifest_scanner._validate_pyproject_for_package"
+        ) as mock_validate,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        mock_find_spec.side_effect = Exception("Package not found")
+
+        # Create some files to work with
+        package_dir = Path(temp_dir) / "test_package"
+        package_dir.mkdir()
+        pyproject_path = package_dir / "pyproject.toml"
+        pyproject_path.write_text("[project]\nname = 'test-package'")
+
+        # Create a mock file that looks like a Python file
+        mock_file = Mock()
+        mock_file.name = "some_file.py"
+        mock_file.__str__ = Mock(return_value="some_file.py")
+        mock_dist.files = [mock_file]
+        mock_dist.locate_file.return_value = str(package_dir / "some_file.py")
+
+        # Mock validation to return True
+        mock_validate.return_value = True
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result == pyproject_path
+        mock_dist.read_text.assert_called_once_with("pyproject.toml")
+        mock_validate.assert_called_once_with(
+            pyproject_path, "test-package", "test_package"
+        )
+
+
+def test_find_package_pyproject_toml_not_found() -> None:
+    """Test _find_package_pyproject_toml when pyproject.toml cannot be found."""
+    from streamlit.components.v2.manifest_scanner import _find_package_pyproject_toml
+
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "test-package"
+
+    # Mock importlib to fail
+    with patch(
+        "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+    ) as mock_find_spec:
+        mock_find_spec.side_effect = Exception("Package not found")
+
+        result = _find_package_pyproject_toml(mock_dist)
+
+        assert result is None
+
+
+def test_process_single_package_editable_install_success() -> None:
+    """Test _process_single_package with successful editable install detection."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    mock_dist = Mock()
+    mock_dist.files = None  # Editable install
+    mock_dist.name = "my-awesome-component"
+
+    pyproject_content = {
+        "project": {"name": "my-awesome-component", "version": "2.0.0"},
+        "tool": {
+            "streamlit": {
+                "component": {
+                    "components": [
+                        {
+                            "name": "slider",
+                            "js": "slider.js",
+                            "css": "slider.css",
+                        }
+                    ],
+                }
+            }
+        },
+    }
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner._find_package_pyproject_toml"
+        ) as mock_find_pyproject,
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch("builtins.open", mock_open()),
+        patch("streamlit.components.v2.manifest_scanner.toml.load") as mock_toml_load,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create real directories for testing
+        package_dir = Path(temp_dir) / "my_awesome_component"
+        package_dir.mkdir()
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("dummy content")
+
+        # Mock the functions
+        mock_find_pyproject.return_value = pyproject_path
+        mock_toml_load.return_value = pyproject_content
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        result = _process_single_package(mock_dist)
+
+        assert result is not None
+        manifest, package_root = result
+        assert manifest.name == "my-awesome-component"
+        assert manifest.version == "2.0.0"
+        assert len(manifest.components) == 1
+        assert manifest.components[0].name == "slider"
+        assert package_root == package_dir
+
+
+def test_process_single_package_editable_install_fallback_to_pyproject_parent() -> None:
+    """Test _process_single_package falls back to pyproject.toml parent for package root."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "test-component"
+
+    pyproject_content = {
+        "project": {"name": "test-component", "version": "1.0.0"},
+        "tool": {
+            "streamlit": {
+                "component": {
+                    "components": [{"name": "widget"}],
+                }
+            }
+        },
+    }
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner._find_package_pyproject_toml"
+        ) as mock_find_pyproject,
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch("builtins.open", mock_open()),
+        patch("streamlit.components.v2.manifest_scanner.toml.load") as mock_toml_load,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create pyproject.toml in temp directory
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("dummy content")
+
+        # Mock functions
+        mock_find_pyproject.return_value = pyproject_path
+        mock_toml_load.return_value = pyproject_content
+        # Mock importlib to fail finding the package (for both calls)
+        mock_find_spec.side_effect = Exception("Package not found")
+
+        result = _process_single_package(mock_dist)
+
+        assert result is not None
+        manifest, package_root = result
+        assert manifest.name == "test-component"
+        assert package_root == Path(temp_dir)  # Should be pyproject.toml parent
+
+
+def test_process_single_package_mixed_install_scenarios() -> None:
+    """Test _process_single_package handles mixed scenarios correctly."""
+    from streamlit.components.v2.manifest_scanner import _process_single_package
+
+    mock_dist = Mock()
+    mock_dist.files = None
+    mock_dist.name = "mixed-component"
+
+    pyproject_content = {
+        "project": {"name": "mixed-component", "version": "1.5.0"},
+        "tool": {
+            "streamlit": {
+                "component": {
+                    "components": [{"name": "chart"}],
+                }
+            }
+        },
+    }
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner._find_package_pyproject_toml"
+        ) as mock_find_pyproject,
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.util.find_spec"
+        ) as mock_find_spec,
+        patch("builtins.open", mock_open()),
+        patch("streamlit.components.v2.manifest_scanner.toml.load") as mock_toml_load,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        # Create real directories for testing
+        package_dir = Path(temp_dir) / "mixed_component"
+        package_dir.mkdir()
+        pyproject_path = Path(temp_dir) / "pyproject.toml"
+        pyproject_path.write_text("dummy content")
+
+        # Mock functions
+        mock_find_pyproject.return_value = pyproject_path
+        mock_toml_load.return_value = pyproject_content
+        mock_spec = Mock()
+        mock_spec.origin = str(package_dir / "__init__.py")
+        mock_find_spec.return_value = mock_spec
+
+        result = _process_single_package(mock_dist)
+
+        assert result is not None
+        manifest, package_root = result
+        assert manifest.name == "mixed-component"
+        assert manifest.version == "1.5.0"
+        assert package_root == package_dir


### PR DESCRIPTION
## Describe your changes

- This PR introduces the Python side of CCv2 support with three focused modules and comprehensive unit tests:
  - `manifest_scanner`: Discovers installed packages that declare CCv2 metadata in pyproject.toml and parses a `ComponentManifest`.
  - `component_path_utils`: Centralizes secure path handling and file/glob resolution with parent directory traversal and symlink-escape protection.
  - `component_manifest_handler`: Processes a parsed manifest, validates `asset_dir` locations, and stores per-component asset roots and metadata.
- No user-facing API is exposed yet. These are internal building blocks to wire into registration/execution in follow-up work.

**Motivation:**
We need a secure and reliable way to discover and validate third-party Streamlit CCv2s declared via package metadata, and to resolve their asset roots safely. This lays the foundation for automatic component registration and asset serving in a future PR.

## GitHub Issue Link (if applicable)

## Testing Plan

- Adds Python unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
