### PR TITLE
[chore] Set up Cursor Commands gitignore like we have for Rules

### DIFF
--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -1,3 +1,8 @@
+# Ignore all commands
+commands/*
+# Only track certain commands so that we don't track a user's local commands
+# You can add more commands to this list as needed!
+
 # Ignore all rules
 rules/*
 # Only track certain rules so that we don't track a user's local rules


### PR DESCRIPTION
## Describe your changes

- Sets up the `.gitignore` for Cursor Commands like we have for Cursor Rules.
- This PR doesn't actually add any Cursor Commands, but allows us to have some locally without accidentally committing them.

## GitHub Issue Link (if applicable)

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
