### PR TITLE
[feat] Add BidiComponentRegistry classes

### DIFF
--- a/lib/streamlit/components/v2/component_path_utils.py
+++ b/lib/streamlit/components/v2/component_path_utils.py
@@ -203,3 +203,43 @@ class ComponentPathUtils:
             raise StreamlitComponentRegistryError(
                 f"{kind} path '{abs_path}' is outside the declared asset_dir '{root}'."
             )
+
+    @staticmethod
+    def looks_like_inline_content(value: str) -> bool:
+        r"""Heuristic to detect inline JS/CSS content strings.
+
+        Treat a string as a file path ONLY if it looks path-like:
+        - Does not contain newlines
+        - Contains glob characters (*, ?, [, ])
+        - Starts with ./, /, or \
+        - Contains a path separator ("/" or "\\")
+        - Or ends with a common asset extension like .js, .mjs, .cjs, or .css
+
+        Otherwise, treat it as inline content.
+
+        Parameters
+        ----------
+        value : str
+            The string to classify as inline content or a file path.
+
+        Returns
+        -------
+        bool
+            True if ``value`` looks like inline content; False if it looks like a
+            file path.
+        """
+        s = value.strip()
+        # If the value contains newlines, it's definitely inline content
+        if "\n" in s or "\r" in s:
+            return True
+        # Glob patterns indicate path-like
+        if ComponentPathUtils.has_glob_characters(s):
+            return False
+        # Obvious path prefixes
+        if s.startswith(("./", "/", "\\")):
+            return False
+        # Any path separator
+        if "/" in s or "\\" in s:
+            return False
+
+        return not (s.lower().endswith((".js", ".css", ".mjs", ".cjs")))

--- a/lib/streamlit/components/v2/component_registry.py
+++ b/lib/streamlit/components/v2/component_registry.py
@@ -1,0 +1,396 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Final
+
+from streamlit.components.v2.component_path_utils import ComponentPathUtils
+from streamlit.errors import StreamlitComponentRegistryError
+from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+_LOGGER: Final = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class BidiComponentDefinition:
+    """Definition of a bidirectional component V2.
+
+    The definition holds inline content or file references for HTML, CSS, and
+    JavaScript, plus metadata used by the runtime to serve assets. When CSS/JS
+    are provided as file paths, their asset-dir-relative URLs are exposed via
+    ``css_url`` and ``js_url`` (or can be overridden with
+    ``css_asset_relative_path``/``js_asset_relative_path``).
+
+    Parameters
+    ----------
+    name : str
+        A short, descriptive name for the component.
+    html : str or None, optional
+        HTML content as a string.
+    css : str or None, optional
+        Inline CSS content or an absolute/relative path to a ``.css`` file.
+        Relative paths are interpreted as asset-dir-relative and validated to
+        reside within the component's ``asset_dir``. Absolute paths are rejected
+        by the API.
+    js : str or None, optional
+        Inline JavaScript content or an absolute/relative path to a ``.js``
+        file. Relative paths are interpreted as asset-dir-relative and validated
+        to reside within the component's ``asset_dir``. Absolute paths are
+        rejected by the API.
+    css_asset_relative_path : str or None, optional
+        Asset-dir-relative URL path to use when serving the CSS file. If not
+        provided, the filename from ``css`` is used when ``css`` is file-backed.
+    js_asset_relative_path : str or None, optional
+        Asset-dir-relative URL path to use when serving the JS file. If not
+        provided, the filename from ``js`` is used when ``js`` is file-backed.
+    """
+
+    name: str
+    html: str | None = None
+    css: str | None = None
+    js: str | None = None
+    # Store processed content and metadata
+    _has_css_path: bool = field(default=False, init=False, repr=False)
+    _has_js_path: bool = field(default=False, init=False, repr=False)
+    _source_paths: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+    # Asset-dir-relative paths used for frontend loading. These represent the
+    # URL path segment under the component's declared asset_dir (e.g. "build/index.js")
+    # and are independent of the on-disk absolute file path stored in css/js.
+    css_asset_relative_path: str | None = None
+    js_asset_relative_path: str | None = None
+
+    def __post_init__(self) -> None:
+        # Keep track of source paths for content loaded from files
+        source_paths = {}
+
+        # Store CSS and JS paths if provided
+        is_css_path, css_path = self._is_file_path(self.css)
+        is_js_path, js_path = self._is_file_path(self.js)
+
+        if css_path:
+            source_paths["css"] = os.path.dirname(css_path)
+        if js_path:
+            source_paths["js"] = os.path.dirname(js_path)
+
+        object.__setattr__(self, "_has_css_path", is_css_path)
+        object.__setattr__(self, "_has_js_path", is_js_path)
+        object.__setattr__(self, "_source_paths", source_paths)
+
+        # Allow empty definitions to support manifest-registered components that
+        # declare only an asset sandbox (asset_dir) without inline or file-backed
+        # entry content. Runtime API calls can later provide js/css/html.
+
+    def _is_file_path(self, content: str | None) -> tuple[bool, str | None]:
+        """Determine whether ``content`` is a filesystem path and resolve it.
+
+        For string inputs that look like paths (contain separators, prefixes, or
+        have common asset extensions), values are normally provided by the v2
+        public API, which resolves and validates asset-dir-relative inputs and
+        passes absolute paths here. When this dataclass is constructed
+        internally, callers must supply already-resolved absolute paths that
+        have passed the same validation rules upstream. Relative paths are not
+        accepted here.
+
+        Parameters
+        ----------
+        content : str or None
+            The potential inline content or path.
+
+        Returns
+        -------
+        tuple[bool, str | None]
+            ``(is_path, abs_path)`` where ``is_path`` indicates whether the
+            input was treated as a path and ``abs_path`` is the resolved
+            absolute path if a path, otherwise ``None``.
+
+        Raises
+        ------
+        ValueError
+            If ``content`` is treated as a path but the file does not exist, or
+            if a non-absolute, path-like string is provided.
+        """
+        if content is None:
+            return False, None
+
+        # Determine if it's a file path or inline content for strings
+        if isinstance(content, str):
+            stripped = content.strip()
+            is_likely_path = not ComponentPathUtils.looks_like_inline_content(stripped)
+
+            if is_likely_path:
+                if os.path.isabs(content):
+                    abs_path = content
+                    if not os.path.exists(abs_path):
+                        raise ValueError(f"File does not exist: {abs_path}")
+                    return True, abs_path
+                # Relative, path-like strings are not accepted at this layer.
+                raise ValueError(
+                    "Relative file paths are not accepted in BidiComponentDefinition; "
+                    "pass absolute, pre-validated paths from the v2 API."
+                )
+
+        # If we get here, it's content, not a path
+        return False, None
+
+    @property
+    def css_url(self) -> str | None:
+        """Return the asset-dir-relative URL path for CSS when file-backed.
+
+        When present, servers construct
+        ``/_stcore/bidi-components/<component>/<css_url>`` using this value. If
+        ``css_asset_relative_path`` is specified, it takes precedence over the
+        filename derived from ``css``.
+        """
+        return self._derive_asset_url(
+            has_path=self._has_css_path,
+            value=self.css,
+            override=self.css_asset_relative_path,
+        )
+
+    @property
+    def js_url(self) -> str | None:
+        """Return the asset-dir-relative URL path for JS when file-backed.
+
+        When present, servers construct
+        ``/_stcore/bidi-components/<component>/<js_url>`` using this value. If
+        ``js_asset_relative_path`` is specified, it takes precedence over the
+        filename derived from ``js``.
+        """
+        return self._derive_asset_url(
+            has_path=self._has_js_path,
+            value=self.js,
+            override=self.js_asset_relative_path,
+        )
+
+    def _derive_asset_url(
+        self, *, has_path: bool, value: str | None, override: str | None
+    ) -> str | None:
+        """Compute asset-dir-relative URL for a file-backed asset.
+
+        Parameters
+        ----------
+        has_path
+            Whether the value refers to a file path.
+        value
+            The css/js field value (inline string or path).
+        override
+            Optional explicit asset-dir-relative override.
+
+        Returns
+        -------
+        str or None
+            The derived URL path or ``None`` if not file-backed.
+        """
+        if not has_path:
+            return None
+        # Prefer explicit URL override if provided (relative to asset_dir)
+        if override:
+            return override
+        # Fallback: preserve relative subpath if the provided path is relative;
+        # otherwise default to the basename for absolute paths. Normalize
+        # leading "./" to avoid awkward prefixes in URLs.
+        path_str = str(value)
+        if os.path.isabs(path_str):
+            return os.path.basename(path_str)
+        norm = path_str.replace("\\", "/").removeprefix("./")
+        # If there's a subpath remaining, preserve it; otherwise use basename
+        return norm if "/" in norm else os.path.basename(norm)
+
+    @property
+    def css_content(self) -> str | None:
+        """Return inline CSS content or ``None`` if file-backed or missing."""
+        if self._has_css_path or self.css is None:
+            return None
+        # Return as string if it's not a path
+        return str(self.css)
+
+    @property
+    def js_content(self) -> str | None:
+        """Return inline JavaScript content or ``None`` if file-backed or missing."""
+        if self._has_js_path or self.js is None:
+            return None
+        # Return as string if it's not a path
+        return str(self.js)
+
+    @property
+    def html_content(self) -> str | None:
+        """Return inline HTML content or ``None`` if not provided."""
+        return self.html
+
+    @property
+    def source_paths(self) -> dict[str, str]:
+        """Return source directories for file-backed CSS/JS content.
+
+        The returned mapping contains keys like ``"js"`` and ``"css"`` with the
+        directory path from which each was loaded.
+        """
+        return self._source_paths
+
+
+class BidiComponentRegistry:
+    """Registry for bidirectional components V2.
+
+    The registry stores and updates :class:`BidiComponentDefinition` instances in
+    a thread-safe mapping guarded by a lock.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the component registry with an empty, thread-safe store."""
+        self._components: MutableMapping[str, BidiComponentDefinition] = {}
+        self._lock = threading.Lock()
+
+    def register_components_from_definitions(
+        self, component_definitions: dict[str, dict[str, Any]]
+    ) -> None:
+        """Register components from processed definition data.
+
+        Parameters
+        ----------
+        component_definitions : dict[str, dict[str, Any]]
+            Mapping from component identifier to definition data.
+        """
+        with self._lock:
+            # Register all component definitions
+            for comp_name, comp_def_data in component_definitions.items():
+                # Validate required keys and gracefully handle optional ones.
+                name = comp_def_data.get("name")
+                if not name:
+                    raise ValueError(
+                        f"Component definition for key '{comp_name}' is missing required 'name' field"
+                    )
+
+                definition = BidiComponentDefinition(
+                    name=name,
+                    js=comp_def_data.get("js"),
+                    css=comp_def_data.get("css"),
+                    html=comp_def_data.get("html"),
+                    css_asset_relative_path=comp_def_data.get(
+                        "css_asset_relative_path"
+                    ),
+                    js_asset_relative_path=comp_def_data.get("js_asset_relative_path"),
+                )
+                self._components[comp_name] = definition
+                _LOGGER.debug(
+                    "Registered component %s from processed definitions", comp_name
+                )
+
+    def register(self, definition: BidiComponentDefinition) -> None:
+        """Register or overwrite a component definition by name.
+
+        This method is the primary entry point for adding a component to the
+        registry. It is used when a component is first declared via the public
+        API (e.g., ``st.components.v2.component``).
+
+        If a component with the same name already exists (e.g., a placeholder
+        from a manifest scan), it is overwritten. A warning is logged if the
+        new definition differs from the old one to alert developers of
+        potential conflicts.
+
+        Parameters
+        ----------
+        definition : BidiComponentDefinition
+            The component definition to store.
+        """
+
+        # Register the definition
+        with self._lock:
+            name = definition.name
+            if name in self._components:
+                existing_definition = self._components[name]
+                if existing_definition != definition:
+                    _LOGGER.warning(
+                        "Component %s is already registered. Overwriting "
+                        "previous definition. This may lead to unexpected behavior "
+                        "if different modules register the same component name with "
+                        "different definitions.",
+                        name,
+                    )
+            self._components[name] = definition
+            _LOGGER.debug("Registered component %s", name)
+
+    def get(self, name: str) -> BidiComponentDefinition | None:
+        """Return a component definition by name, or ``None`` if not found.
+
+        Parameters
+        ----------
+        name : str
+            Component name to retrieve.
+
+        Returns
+        -------
+        BidiComponentDefinition or None
+            The component definition if present, otherwise ``None``.
+        """
+        with self._lock:
+            return self._components.get(name)
+
+    def unregister(self, name: str) -> None:
+        """Remove a component definition from the registry.
+
+        Primarily useful for tests and dynamic scenarios.
+
+        Parameters
+        ----------
+        name : str
+            Component name to unregister.
+        """
+        with self._lock:
+            if name in self._components:
+                del self._components[name]
+                _LOGGER.debug("Unregistered component %s", name)
+
+    def clear(self) -> None:
+        """Clear all component definitions from the registry."""
+        with self._lock:
+            self._components.clear()
+            _LOGGER.debug("Cleared all components from registry")
+
+    def update_component(self, definition: BidiComponentDefinition) -> None:
+        """Update (replace) a stored component definition by name.
+
+        This method provides a stricter way to update a component definition
+        and is used for internal processes like file-watcher updates. Unlike
+        ``register``, it will raise an error if the component is not already
+        present in the registry.
+
+        This ensures that background processes can only modify components that
+        have been explicitly defined in the current session, preventing race
+        conditions or unexpected behavior where a file-watcher event might try
+        to update a component that has since been unregistered.
+
+        Callers must supply a fully validated :class:`BidiComponentDefinition`.
+        The registry replaces the stored definition under ``definition.name`` in
+        a thread-safe manner.
+
+        Parameters
+        ----------
+        definition : BidiComponentDefinition
+            The fully-resolved component definition to store.
+        """
+        with self._lock:
+            name = definition.name
+            if name not in self._components:
+                raise StreamlitComponentRegistryError(
+                    f"Cannot update unregistered component: {name}"
+                )
+            self._components[name] = definition
+            _LOGGER.debug("Updated component definition for %s", name)

--- a/lib/tests/streamlit/components/v2/test_component_path_utils.py
+++ b/lib/tests/streamlit/components/v2/test_component_path_utils.py
@@ -192,3 +192,21 @@ def test_resolve_glob_pattern_accepts_dot_prefixed_relative(tmp_path: Path) -> N
         pattern="./assets/a.js", package_root=package_root
     )
     assert resolved == asset.resolve()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_inline"),
+    [
+        ("console.log('x')", True),  # Base JS case -> inline
+        ("console.log('x')\nalert('y')", True),  # newlines -> inline
+        ("var x = 1;/*no path*/", False),  # has '/' -> path-like
+        ("var x = 1;\n/*no path*/", True),  # multiline -> inline
+        ("assets/main.js", False),
+        ("./main.css", False),
+        ("dir\\file.mjs", False),
+        ("file.cjs", False),
+    ],
+)
+def test_looks_like_inline_content_heuristic(value: str, expected_inline: bool) -> None:
+    """Inline content heuristic should classify strings correctly across cases."""
+    assert ComponentPathUtils.looks_like_inline_content(value) == expected_inline

--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -1,0 +1,510 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from streamlit.components.v2.component_path_utils import ComponentPathUtils
+from streamlit.components.v2.component_registry import (
+    BidiComponentDefinition,
+    BidiComponentRegistry,
+)
+from streamlit.errors import StreamlitComponentRegistryError
+
+
+def _mk_file(path: os.PathLike[str] | str, content: bytes | str = b"x") -> str:
+    """Create a file and return its absolute path.
+
+    Parameters
+    ----------
+    path
+        Path to write. Parent directories are created if they don't exist.
+    content
+        Bytes or text to write to the file. Defaults to a single ``x`` byte.
+
+    Returns
+    -------
+    str
+        Absolute path to the created file.
+    """
+    p = os.fspath(path)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    mode = "wb" if isinstance(content, (bytes, bytearray)) else "w"
+    with open(p, mode) as f:
+        f.write(content)
+    return os.path.abspath(p)
+
+
+def test_path_classification_and_resolution(tmp_path) -> None:
+    """Verify classification at dataclass layer: absolute paths vs inline.
+
+    - Accepts absolute file paths (post-validation upstream).
+    - Rejects relative, path-like strings.
+    - Treats inline-like content as inline.
+    """
+    base_dir = tmp_path / "base"
+    caller_dir = base_dir / "pkg" / "subpkg"
+    caller_file = caller_dir / "fakecaller.py"
+
+    # Files to be resolved relative to caller_dir
+    style_css = caller_dir / "style.css"
+    assets_js = caller_dir / "assets" / "app.js"
+    bare_js = caller_dir / "script.js"
+    upper_js = base_dir / "pkg" / "upper.js"  # resolves via ../upper.js from subpkg
+
+    _mk_file(caller_file)
+    _mk_file(style_css)
+    _mk_file(assets_js)
+    _mk_file(bare_js)
+    _mk_file(upper_js)
+
+    d1 = BidiComponentDefinition(name="c1", css=os.fspath(style_css))
+    assert d1._has_css_path is True
+    assert d1.source_paths["css"] == os.path.dirname(os.fspath(style_css))
+    assert d1.css_url == "style.css"
+
+    with pytest.raises(ValueError, match=r"Relative file paths are not accepted"):
+        BidiComponentDefinition(name="c_bad", js="../upper.js")
+
+    # Accept: path with separator
+    d2 = BidiComponentDefinition(name="c2", js=os.fspath(assets_js))
+    assert d2._has_js_path is True
+    assert d2.source_paths["js"] == os.path.dirname(os.fspath(assets_js))
+
+    # Reject: bare filename with known extension (relative path-like)
+    with pytest.raises(ValueError, match=r"Relative file paths are not accepted"):
+        BidiComponentDefinition(name="c3", js="script.js")
+
+    # Inline-like content is not treated as a path
+    d4 = BidiComponentDefinition(
+        name="c4",
+        html="<div>Hi</div>",
+        css=".class { color: red; }",
+        js="function f() { return 1; }",
+    )
+    assert d4._has_css_path is False
+    assert d4._has_js_path is False
+    assert d4.css_content == ".class { color: red; }"
+    assert d4.js_content == "function f() { return 1; }"
+    assert d4.html_content == "<div>Hi</div>"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_css_url", "expected_js_url"),
+    [
+        (
+            {
+                "css_asset_relative_path": "assets/bundle.css",
+                "js_asset_relative_path": "build/main.mjs",
+            },
+            "assets/bundle.css",
+            "build/main.mjs",
+        ),
+        ({}, "style.css", "main.js"),
+    ],
+)
+def test_asset_url_overrides_and_defaults(
+    tmp_path,
+    monkeypatch,
+    overrides: dict[str, str],
+    expected_css_url: str,
+    expected_js_url: str,
+) -> None:
+    """Verify that asset URL overrides take precedence over default filenames."""
+    caller_dir = tmp_path / "caller"
+    caller_file = caller_dir / "fakecaller.py"
+    css_file = caller_dir / "style.css"
+    js_file = caller_dir / "main.js"
+    _mk_file(caller_file)
+    _mk_file(css_file)
+    _mk_file(js_file)
+
+    d = BidiComponentDefinition(
+        name="c",
+        css=os.fspath(css_file),
+        js=os.fspath(js_file),
+        **overrides,
+    )
+    assert d.css_url == expected_css_url
+    assert d.js_url == expected_js_url
+
+
+@pytest.mark.parametrize(
+    ("css_input", "js_input", "expected_css_url", "expected_js_url"),
+    [
+        (
+            "build/static/css/main.css",
+            "build/static/js/main.js",
+            "build/static/css/main.css",
+            "build/static/js/main.js",
+        ),
+        (
+            "styles/bundle.css",
+            "main.js",
+            "styles/bundle.css",
+            "main.js",
+        ),
+    ],
+)
+def test_default_asset_url_preserves_subpath(
+    tmp_path,
+    monkeypatch,
+    css_input: str,
+    js_input: str,
+    expected_css_url: str,
+    expected_js_url: str,
+) -> None:
+    """Verify that default asset URLs preserve subpaths and simple filenames."""
+    caller_dir = tmp_path / "caller"
+    caller_file = caller_dir / "fakecaller.py"
+    css_file = caller_dir / css_input
+    js_file = caller_dir / js_input
+    _mk_file(caller_file)
+    _mk_file(css_file)
+    _mk_file(js_file)
+
+    d = BidiComponentDefinition(
+        name="c",
+        css=os.fspath(css_file),
+        js=os.fspath(js_file),
+        css_asset_relative_path=css_input,
+        js_asset_relative_path=js_input,
+    )
+    assert d.css_url == expected_css_url
+    assert d.js_url == expected_js_url
+
+
+def test_register_components_respects_asset_overrides(tmp_path: Path) -> None:
+    """Verify that the registry preserves asset URL overrides on registration."""
+    css_path = _mk_file(tmp_path / "c" / "style.css")
+    js_path = _mk_file(tmp_path / "c" / "main.js")
+
+    reg = BidiComponentRegistry()
+    reg.register_components_from_definitions(
+        {
+            "comp": {
+                "name": "comp",
+                "html": None,
+                "css": css_path,
+                "js": js_path,
+                "css_asset_relative_path": "assets/styles.css",
+                "js_asset_relative_path": "build/app.js",
+            }
+        }
+    )
+
+    d = reg.get("comp")
+    assert d is not None
+    assert d.css_url == "assets/styles.css"
+    assert d.js_url == "build/app.js"
+
+
+def test_update_component_merge_enforcement() -> None:
+    """Verify that updates preserve missing fields and enforce name matching."""
+    reg = BidiComponentRegistry()
+
+    # Initial inline definition
+    d0 = BidiComponentDefinition(name="comp", html=None, css="orig-css", js="orig-js")
+    reg.register(d0)
+
+    # Attempt to update only js and css override
+    d1 = BidiComponentDefinition(
+        name="comp",
+        html=None,
+        css="new-css",
+        js="new-js",
+    )
+
+    reg.update_component(d1)
+
+    d = reg.get("comp")
+    assert d is not None
+    assert d.name == "comp"
+    assert d.html_content is None
+    # css and js are updated
+    assert d.css_content == "new-css"
+    assert d.js_content == "new-js"
+
+
+def test_update_component_replaces_definition() -> None:
+    """Verify that `update_component` replaces the stored definition by name."""
+    reg = BidiComponentRegistry()
+
+    # Initial inline definition
+    d0 = BidiComponentDefinition(name="comp", html=None, css="orig-css", js="orig-js")
+    reg.register(d0)
+
+    # New fully-validated definition (simulating resolver output)
+    d1 = BidiComponentDefinition(
+        name="comp",
+        html="<div></div>",
+        css="new-css",
+        js="new-js",
+        css_asset_relative_path="x.css",
+    )
+
+    reg.update_component(d1)
+
+    d = reg.get("comp")
+    assert d is not None
+    assert d.name == "comp"
+    assert d.html_content == "<div></div>"
+    assert d.css_content == "new-css"
+    assert d.js_content == "new-js"
+    assert d.css_asset_relative_path == "x.css"
+
+
+def test_update_component_can_clear_fields_via_none() -> None:
+    """Verify that passing None to `update_component` clears fields."""
+    reg = BidiComponentRegistry()
+
+    d0 = BidiComponentDefinition(
+        name="comp",
+        html="<div>keep?</div>",
+        css="inline-css",
+        js="inline-js",
+    )
+    reg.register(d0)
+
+    # Provide a definition that clears css/js and html explicitly via None
+    d1 = BidiComponentDefinition(name="comp", html=None, css=None, js=None)
+    reg.update_component(d1)
+
+    d = reg.get("comp")
+    assert d is not None
+    assert d.html_content is None
+    assert d.css_content is None
+    assert d.js_content is None
+
+
+def test_update_component_raises_for_unregistered_definition() -> None:
+    """Verify `update_component` raises for an unregistered definition."""
+    reg = BidiComponentRegistry()
+
+    d = BidiComponentDefinition(name="unknown", html=None, css=None, js=None)
+
+    with pytest.raises(
+        StreamlitComponentRegistryError,
+        match=r"^Cannot update unregistered component: unknown$",
+    ):
+        reg.update_component(d)
+
+
+@pytest.fixture
+def temp_test_files() -> dict:
+    """Create a temporary directory with test files for definition tests."""
+    temp_dir = tempfile.TemporaryDirectory()
+
+    # Create test files
+    js_path = os.path.join(temp_dir.name, "index.js")
+    with open(js_path, "w") as f:
+        f.write("console.log('test');")
+
+    html_path = os.path.join(temp_dir.name, "index.html")
+    with open(html_path, "w") as f:
+        f.write("<div>Test</div>")
+
+    css_path = os.path.join(temp_dir.name, "styles.css")
+    with open(css_path, "w") as f:
+        f.write("div { color: blue; }")
+
+    yield {
+        "temp_dir": temp_dir,
+        "js_path": js_path,
+        "html_path": html_path,
+        "css_path": css_path,
+    }
+
+    temp_dir.cleanup()
+
+
+def test_string_content() -> None:
+    """Test component instantiation with direct string content."""
+    comp = BidiComponentDefinition(
+        name="test",
+        html="<div>Hello</div>",
+        css=".div { color: red; }",
+        js="console.log('hello');",
+    )
+
+    assert comp.html_content == "<div>Hello</div>"
+    assert comp.css_content == ".div { color: red; }"
+    assert comp.js_content == "console.log('hello');"
+    assert comp.css_url is None
+    assert comp.js_url is None
+    assert comp.source_paths == {}
+
+
+def test_newline_strings_treated_as_inline() -> None:
+    """Verify that strings with newlines are treated as inline content."""
+    multi_line_js = "export default function() {\n  console.log('hi');\n}"
+    multi_line_css = ".root {\n  color: red;\n}"
+    multi_line_html = "<div>\n  <span>hi</span>\n</div>"
+
+    comp = BidiComponentDefinition(
+        name="newline_test",
+        html=multi_line_html,
+        css=multi_line_css,
+        js=multi_line_js,
+    )
+
+    # Inline content should be exposed via *_content and have no URLs
+    assert comp.html_content == multi_line_html
+    assert comp.css_content == multi_line_css
+    assert comp.js_content == multi_line_js
+    assert comp.css_url is None
+    assert comp.js_url is None
+    assert comp.source_paths == {}
+
+
+def test_file_path_content(temp_test_files) -> None:
+    """Test component instantiation with absolute file path content."""
+    comp = BidiComponentDefinition(
+        name="test",
+        js=temp_test_files["js_path"],
+        html="<div>Inline HTML</div>",  # HTML should be a string, not a path
+        css=temp_test_files["css_path"],
+    )
+
+    assert comp.html_content == "<div>Inline HTML</div>"
+    assert comp.css_content is None  # CSS content is None because it's a path
+    assert comp.js_content is None  # JS content is None because it's a path
+
+    # Check URLs are generated for path resources
+    assert comp.css_url == f"{os.path.basename(temp_test_files['css_path'])}"
+    assert comp.js_url == f"{os.path.basename(temp_test_files['js_path'])}"
+
+    # Check source paths
+    assert len(comp.source_paths) == 2
+    assert comp.source_paths["css"] == os.path.dirname(temp_test_files["css_path"])
+    assert comp.source_paths["js"] == os.path.dirname(temp_test_files["js_path"])
+    assert "html" not in comp.source_paths
+
+
+def test_mixed_content(temp_test_files) -> None:
+    """Test component instantiation with mixed string and file content."""
+    comp = BidiComponentDefinition(
+        name="test",
+        js=temp_test_files["js_path"],
+        html="<div>Inline HTML</div>",
+        css="div { color: green; }",
+    )
+
+    assert comp.html_content == "<div>Inline HTML</div>"
+    assert comp.css_content == "div { color: green; }"
+    assert comp.js_content is None  # JS content is None because it's a path
+
+    assert comp.css_url is None  # No URL for inline CSS
+    assert comp.js_url == f"{os.path.basename(temp_test_files['js_path'])}"
+
+    assert len(comp.source_paths) == 1
+    assert comp.source_paths["js"] == os.path.dirname(temp_test_files["js_path"])
+
+
+def test_resolve_glob_pattern_direct() -> None:
+    """Test the `ComponentPathUtils.resolve_glob_pattern` function directly."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_root = Path(temp_dir)
+
+        # Create test file
+        test_file = os.path.join(temp_dir, "test-pattern.js")
+        with open(test_file, "w") as f:
+            f.write("console.log('test');")
+
+        # Test successful resolution
+        resolved = ComponentPathUtils.resolve_glob_pattern("test-*.js", package_root)
+        assert str(resolved.resolve()) == Path(test_file).resolve().as_posix()
+
+        # Test no matches
+        with pytest.raises(StreamlitComponentRegistryError) as exc_info:
+            ComponentPathUtils.resolve_glob_pattern("nomatch-*.js", package_root)
+        assert "No files found matching pattern" in str(exc_info.value)
+
+        # Test multiple matches
+        duplicate_file = os.path.join(temp_dir, "test-duplicate.js")
+        with open(duplicate_file, "w") as f:
+            f.write("console.log('duplicate');")
+
+        with pytest.raises(StreamlitComponentRegistryError) as exc_info:
+            ComponentPathUtils.resolve_glob_pattern("test-*.js", package_root)
+        assert "Multiple files found matching pattern" in str(exc_info.value)
+
+        # Test path traversal protection
+        with pytest.raises(StreamlitComponentRegistryError) as exc_info:
+            ComponentPathUtils.resolve_glob_pattern("../outside.js", package_root)
+        assert "Path traversal attempts are not allowed" in str(exc_info.value)
+
+        # Test absolute path protection
+        with pytest.raises(StreamlitComponentRegistryError) as exc_info:
+            ComponentPathUtils.resolve_glob_pattern("/absolute/path.js", package_root)
+        assert "Absolute paths are not allowed" in str(exc_info.value)
+
+
+def test_glob_pattern_resolution() -> None:
+    """Test glob pattern resolution via `ComponentPathUtils`."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test files
+        (temp_path / "component.js").write_text("console.log('component');")
+        (temp_path / "styles.css").write_text("body { color: red; }")
+
+        # Test JS glob resolution
+        js_path = ComponentPathUtils.resolve_glob_pattern("*.js", temp_path)
+        assert js_path.name == "component.js"
+
+        # Test CSS glob resolution
+        css_path = ComponentPathUtils.resolve_glob_pattern("*.css", temp_path)
+        assert css_path.name == "styles.css"
+
+
+def test_glob_pattern_multiple_matches_error() -> None:
+    """Verify that multiple matches for a glob pattern raise an error."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create multiple matching files
+        (temp_path / "component1.js").write_text("console.log('1');")
+        (temp_path / "component2.js").write_text("console.log('2');")
+
+        with pytest.raises(StreamlitComponentRegistryError):
+            ComponentPathUtils.resolve_glob_pattern("*.js", temp_path)
+
+
+def test_glob_pattern_no_matches_error() -> None:
+    """Verify that no matches for a glob pattern raise an error."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        with pytest.raises(StreamlitComponentRegistryError):
+            ComponentPathUtils.resolve_glob_pattern("*.js", temp_path)
+
+
+def test_security_validation() -> None:
+    """Test security validation for file paths."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Test path traversal protection
+        with pytest.raises(StreamlitComponentRegistryError):
+            ComponentPathUtils.resolve_glob_pattern("../malicious.js", temp_path)
+
+        with pytest.raises(StreamlitComponentRegistryError):
+            ComponentPathUtils.resolve_glob_pattern("/etc/passwd", temp_path)


### PR DESCRIPTION
## Describe your changes

- Added a new component registry system for CCv2. This implementation includes:
  - `BidiComponentDefinition` class to store component metadata, content, and file paths
  - `BidiComponentRegistry` class for thread-safe registration and retrieval of components
- The registry provides a centralized store for component definitions with proper path resolution against caller files and thread-safe operations.
- No user-facing API is exposed yet. These are internal building blocks to wire into registration/execution in follow-up work.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): Added comprehensive test suite in `test_component_registry.py` covering:
  - Path classification and resolution
  - Asset URL overrides and defaults
  - Subpath preservation in URLs
  - Component registration with asset overrides
  - Component update and name enforcement

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.