### PR TITLE
[feat] Add ComponentFileWatcher

### DIFF
--- a/lib/streamlit/components/v2/component_file_watcher.py
+++ b/lib/streamlit/components/v2/component_file_watcher.py
@@ -1,0 +1,403 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Component file watching utilities.
+
+This module provides the `ComponentFileWatcher`, a utility that watches
+component asset directories for changes and notifies a caller-provided callback
+with the affected component names. It abstracts the underlying path-watcher
+implementation and ensures exception-safe startup and cleanup.
+
+Why this exists
+---------------
+Streamlit supports advanced Custom Components that ship a package of static
+assets (for example, a Vite/Webpack build output). While a user develops their
+app, those frontend files may change. The component registry for Custom
+Components v2 must stay synchronized with the on-disk assets so that the server
+can resolve the up-to-date files.
+
+This watcher exists to keep the registry in sync by listening for changes in
+component asset roots and notifying a higher-level manager that can re-resolve
+the affected component definitions.
+
+Notes
+-----
+- Watching is directory-based with a recursive glob ("**/*").
+- Common noisy directories (e.g., ``node_modules``) are ignored in callbacks.
+- Startup is exception-safe and does not leak partially created watchers.
+
+See Also
+--------
+- :class:`streamlit.watcher.local_sources_watcher.LocalSourcesWatcher` - watches
+  app source files per session to trigger reruns.
+- :class:`streamlit.components.v2.component_registry.BidiComponentRegistry` -
+  the server-side store of Custom Component v2 definitions that reacts to
+  watcher notifications.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Final, Protocol, cast
+
+from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+_LOGGER: Final = get_logger(__name__)
+
+
+class _HasClose(Protocol):
+    def close(self) -> None: ...
+
+
+class ComponentFileWatcher:
+    """Handle file watching for component asset directories.
+
+    Parameters
+    ----------
+    component_update_callback : Callable[[list[str]], None]
+        Callback invoked when files change under any watched directory. It
+        receives a list of component names affected by the change.
+    """
+
+    def __init__(self, component_update_callback: Callable[[list[str]], None]) -> None:
+        """Initialize the file watcher.
+
+        Parameters
+        ----------
+        component_update_callback : Callable[[list[str]], None]
+            Callback function to call when components under watched roots change.
+            Signature: (affected_component_names)
+        """
+        self._component_update_callback = component_update_callback
+        self._lock = threading.Lock()
+
+        # File watching state
+        self._watched_directories: dict[
+            str, list[str]
+        ] = {}  # directory -> component_names
+        self._path_watchers: list[_HasClose] = []  # Store actual watcher instances
+        self._watching_active = False
+
+        # Store asset roots to watch: component_name -> asset_root
+        self._asset_watch_roots: dict[str, Path] = {}
+
+        # Default noisy directories to ignore in callbacks
+        self._ignored_dirs: tuple[str, ...] = (
+            "__pycache__",
+            ".cache",
+            ".git",
+            ".hg",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".svn",
+            ".swc",
+            ".yarn",
+            "coverage",
+            "node_modules",
+            "venv",
+        )
+
+    @property
+    def is_watching_active(self) -> bool:
+        """Check if file watching is currently active.
+
+        Returns
+        -------
+        bool
+            True if file watching is active, False otherwise
+        """
+        return self._watching_active
+
+    def start_file_watching(self, asset_watch_roots: dict[str, Path]) -> None:
+        """Start file watching for asset roots.
+
+        Parameters
+        ----------
+        asset_watch_roots : dict[str, Path]
+            Mapping of component names to asset root directories to watch.
+
+        Notes
+        -----
+        The method is idempotent: it stops any active watchers first, then
+        re-initializes watchers for the provided ``asset_watch_roots``.
+        """
+        # Always stop first to ensure a clean state, then start with the new roots.
+        # This sequencing avoids races between concurrent stop/start calls.
+        self.stop_file_watching()
+        self._start_file_watching(asset_watch_roots)
+
+    def stop_file_watching(self) -> None:
+        """Stop file watching and clean up watchers.
+
+        Notes
+        -----
+        This method is safe to call multiple times and will no-op if
+        watching is not active.
+        """
+        with self._lock:
+            if not self._watching_active:
+                return
+
+            # Close all path watchers
+            for watcher in self._path_watchers:
+                try:
+                    watcher.close()
+                except Exception:  # noqa: PERF203
+                    _LOGGER.exception("Failed to close path watcher")
+
+            self._path_watchers.clear()
+            self._watched_directories.clear()
+            # Also clear asset root references to avoid stale state retention
+            self._asset_watch_roots.clear()
+            self._watching_active = False
+            _LOGGER.debug("Stopped file watching for component registry")
+
+    def _start_file_watching(self, asset_watch_roots: dict[str, Path]) -> None:
+        """Internal method to start file watching with the given roots.
+
+        This method is exception-safe: in case of failures while creating
+        watchers, any previously created watcher instances are closed and no
+        internal state is committed.
+        """
+        with self._lock:
+            if self._watching_active:
+                return
+
+            if not asset_watch_roots:
+                _LOGGER.debug("No asset roots to watch")
+                return
+
+            try:
+                path_watcher_class = self._get_default_path_watcher_class()
+                if path_watcher_class is None:
+                    # NoOp watcher; skip activation
+                    return
+
+                directories_to_watch = self._prepare_directories_to_watch(
+                    asset_watch_roots
+                )
+
+                new_watchers, new_watched_dirs = self._build_watchers_for_directories(
+                    path_watcher_class, directories_to_watch
+                )
+
+                # Commit new watchers and state only after successful creation
+                if new_watchers:
+                    self._commit_watch_state(
+                        new_watchers, new_watched_dirs, asset_watch_roots
+                    )
+                else:
+                    _LOGGER.debug("No directories were watched; staying inactive")
+            except Exception:
+                _LOGGER.exception("Failed to start file watching")
+
+    def _get_default_path_watcher_class(self) -> type | None:
+        """Return the default path watcher class.
+
+        Returns
+        -------
+        type | None
+            The concrete path watcher class to instantiate, or ``None`` if
+            the NoOp watcher is configured and file watching should be
+            skipped.
+        """
+        from streamlit.watcher.path_watcher import (
+            NoOpPathWatcher,
+            get_default_path_watcher_class,
+        )
+
+        path_watcher_class = get_default_path_watcher_class()
+        if path_watcher_class is NoOpPathWatcher:
+            _LOGGER.debug("NoOpPathWatcher in use; skipping component file watching")
+            return None
+        return path_watcher_class
+
+    def _prepare_directories_to_watch(
+        self, asset_watch_roots: dict[str, Path]
+    ) -> dict[str, list[str]]:
+        """Build a mapping of directory to component names.
+
+        Parameters
+        ----------
+        asset_watch_roots : dict[str, Path]
+            Mapping of component names to their asset root directories.
+
+        Returns
+        -------
+        dict[str, list[str]]
+            A map from absolute directory path to a deduplicated list of
+            component names contained in that directory.
+        """
+        directories_to_watch: dict[str, list[str]] = {}
+        for comp_name, root in asset_watch_roots.items():
+            directory = str(root.resolve())
+            if directory not in directories_to_watch:
+                directories_to_watch[directory] = []
+            if comp_name not in directories_to_watch[directory]:
+                directories_to_watch[directory].append(comp_name)
+        return directories_to_watch
+
+    def _build_watchers_for_directories(
+        self, path_watcher_class: type, directories_to_watch: dict[str, list[str]]
+    ) -> tuple[list[_HasClose], dict[str, list[str]]]:
+        """Create watchers for directories with rollback on failure.
+
+        Parameters
+        ----------
+        path_watcher_class : type
+            The path watcher class to instantiate for each directory.
+        directories_to_watch : dict[str, list[str]]
+            A map of directory to the associated component name list.
+
+        Returns
+        -------
+        tuple[list[_HasClose], dict[str, list[str]]]
+            The list of created watcher instances and the watched directory
+            mapping.
+
+        Raises
+        ------
+        Exception
+            Propagates any exception during watcher creation after closing
+            already-created watchers.
+        """
+        new_watchers: list[_HasClose] = []
+        new_watched_dirs: dict[str, list[str]] = {}
+
+        for directory, component_names in directories_to_watch.items():
+            try:
+                cb = self._make_directory_callback(tuple(component_names))
+                # Use a glob pattern that matches all files to let Streamlit's
+                # watcher handle MD5 calculation and change detection
+                watcher = path_watcher_class(
+                    directory,
+                    cb,
+                    glob_pattern="**/*",
+                    allow_nonexistent=False,
+                )
+                new_watchers.append(cast("_HasClose", watcher))
+                new_watched_dirs[directory] = component_names
+                _LOGGER.debug(
+                    "Prepared watcher for directory %s (components: %s)",
+                    directory,
+                    component_names,
+                )
+            except Exception:  # noqa: PERF203
+                # Roll back watchers created so far
+                self._rollback_watchers(new_watchers)
+                raise
+
+        return new_watchers, new_watched_dirs
+
+    def _commit_watch_state(
+        self,
+        new_watchers: list[_HasClose],
+        new_watched_dirs: dict[str, list[str]],
+        asset_watch_roots: dict[str, Path],
+    ) -> None:
+        """Commit created watchers and mark watching active.
+
+        Parameters
+        ----------
+        new_watchers : list[_HasClose]
+            Fully initialized watcher instances.
+        new_watched_dirs : dict[str, list[str]]
+            Mapping from directory to component names.
+        asset_watch_roots : dict[str, Path]
+            The asset roots used to initialize watchers; stored for reference.
+        """
+        self._path_watchers = new_watchers
+        self._watched_directories = new_watched_dirs
+        self._asset_watch_roots = dict(asset_watch_roots)
+        self._watching_active = True
+        _LOGGER.debug(
+            "Started file watching for %d directories", len(self._watched_directories)
+        )
+
+    def _rollback_watchers(self, watchers: list[_HasClose]) -> None:
+        """Close any created watchers when setup fails.
+
+        Parameters
+        ----------
+        watchers : list[_HasClose]
+            Watcher instances that were successfully created before a failure.
+        """
+        for w in watchers:
+            try:
+                w.close()
+            except Exception:  # noqa: PERF203
+                _LOGGER.exception("Failed to close path watcher during rollback")
+
+    def _make_directory_callback(self, comps: tuple[str, ...]) -> Callable[[str], None]:
+        """Create a callback for a directory watcher that captures component names."""
+
+        def callback(changed_path: str) -> None:
+            if self._is_in_ignored_directory(changed_path):
+                _LOGGER.debug("Ignoring change in noisy directory: %s", changed_path)
+                return
+            _LOGGER.debug(
+                "Directory change detected: %s, checking components: %s",
+                changed_path,
+                comps,
+            )
+            self._handle_component_change(list(comps))
+
+        return callback
+
+    def _handle_component_change(self, affected_components: list[str]) -> None:
+        """Handle component changes for both directory and file events.
+
+        Parameters
+        ----------
+        affected_components : list[str]
+            List of component names affected by the change
+        """
+        if not self._watching_active:
+            return
+
+        # Notify manager to handle re-resolution based on recorded API inputs
+        try:
+            self._component_update_callback(affected_components)
+        except Exception:
+            # Never allow exceptions from user callbacks to break watcher loops
+            _LOGGER.exception("Component update callback raised")
+
+    def _is_in_ignored_directory(self, changed_path: str) -> bool:
+        """Return True if the changed path is inside an ignored directory.
+
+        Parameters
+        ----------
+        changed_path : str
+            The filesystem path that triggered the change event.
+
+        Returns
+        -------
+        bool
+            True if the path is located inside one of the ignored directories,
+            False otherwise.
+        """
+        try:
+            from pathlib import Path as _Path
+
+            parts = set(_Path(changed_path).resolve().parts)
+            return any(ignored in parts for ignored in self._ignored_dirs)
+        except Exception:
+            return False

--- a/lib/streamlit/components/v2/component_registry.py
+++ b/lib/streamlit/components/v2/component_registry.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+"""Component registry for Custom Components v2.
+
+This module defines the data model and in-memory registry for Custom Components
+v2. During development, component assets (JS/CSS/HTML) may change on disk as
+build tools produce new outputs.
+
+See Also
+--------
+- :class:`streamlit.components.v2.component_file_watcher.ComponentFileWatcher`
+  for directory watching and change notifications.
+"""
+
 from __future__ import annotations
 
 import os

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -47,6 +47,15 @@ PathWatcher: PathWatcherType | None = None
 
 
 class LocalSourcesWatcher:
+    """Watch local Python sources and pages to trigger app reruns.
+
+    Purpose
+    -------
+    This watcher powers Streamlit's core developer workflow: save a Python file
+    and the app reruns. It tracks Python modules, the main script directory, and
+    configured watch folders to notify the runtime when a relevant file changes.
+    """
+
     def __init__(self, pages_manager: PagesManager) -> None:
         self._pages_manager = pages_manager
         self._main_script_path = os.path.realpath(self._pages_manager.main_script_path)

--- a/lib/tests/streamlit/components/v2/test_component_file_watcher.py
+++ b/lib/tests/streamlit/components/v2/test_component_file_watcher.py
@@ -1,0 +1,393 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from streamlit.components.v2.component_file_watcher import ComponentFileWatcher
+
+
+@pytest.fixture
+def temp_component_files():
+    """Create temporary directory structure with component files for testing."""
+    temp_dir = tempfile.TemporaryDirectory()
+    temp_path = Path(temp_dir.name)
+
+    # Create directory structure
+    js_dir = temp_path / "js"
+    css_dir = temp_path / "css"
+    js_dir.mkdir()
+    css_dir.mkdir()
+
+    # Create test files
+    js_file = js_dir / "component.js"
+    js_file.write_text("console.log('original');")
+
+    css_file = css_dir / "styles.css"
+    css_file.write_text(".test { color: red; }")
+
+    # Create glob pattern files
+    glob_js_file = js_dir / "component-v1.0.js"
+    glob_js_file.write_text("console.log('glob v1');")
+
+    glob_css_file = css_dir / "styles-v1.0.css"
+    glob_css_file.write_text(".glob { color: blue; }")
+
+    yield {
+        "temp_dir": temp_path,
+        "js_file": js_file,
+        "css_file": css_file,
+        "glob_js_file": glob_js_file,
+        "glob_css_file": glob_css_file,
+    }
+
+    temp_dir.cleanup()
+
+
+@pytest.fixture
+def mock_callback():
+    """Create a mock callback function."""
+    return Mock()
+
+
+@pytest.fixture
+def file_watcher(mock_callback):
+    """Create a ComponentFileWatcher instance with mock callback."""
+    return ComponentFileWatcher(mock_callback)
+
+
+def test_init(mock_callback):
+    """Test initialization of ComponentFileWatcher."""
+    watcher = ComponentFileWatcher(mock_callback)
+
+    assert watcher._component_update_callback is mock_callback
+    assert not watcher.is_watching_active
+    assert watcher._watched_directories == {}
+    assert watcher._path_watchers == []
+    assert watcher._asset_watch_roots == {}
+
+
+def test_start_file_watching_no_watchers(file_watcher):
+    """Test starting file watching with no asset roots."""
+    file_watcher.start_file_watching({})
+
+    assert not file_watcher.is_watching_active
+
+
+@pytest.mark.parametrize(
+    ("roots_kind", "expected_watchers", "expected_dirs"),
+    [
+        ("single", 1, 1),
+        ("multiple", 2, 2),
+        ("shared", 1, 1),
+    ],
+)
+def test_start_file_watching_various_roots(
+    file_watcher,
+    temp_component_files,
+    roots_kind: str,
+    expected_watchers: int,
+    expected_dirs: int,
+):
+    """Start watching with different root configurations and verify watcher counts.
+
+    Parameters
+    ----------
+    roots_kind
+        One of ``single``, ``multiple``, or ``shared`` to setup asset roots.
+    expected_watchers
+        Expected number of watcher instances created.
+    expected_dirs
+        Expected number of watched directories recorded.
+    """
+    mock_watcher_instance = Mock()
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=Mock(return_value=mock_watcher_instance),
+    ):
+        if roots_kind == "single":
+            asset_roots = {"test.component": temp_component_files["temp_dir"]}
+        elif roots_kind == "multiple":
+            js_root = temp_component_files["temp_dir"] / "js"
+            css_root = temp_component_files["temp_dir"] / "css"
+            asset_roots = {
+                "test.js_component": js_root,
+                "test.css_component": css_root,
+            }
+        else:  # shared
+            root = temp_component_files["temp_dir"]
+            asset_roots = {"test.direct": root, "test.glob": root}
+
+        file_watcher.start_file_watching(asset_roots)
+
+        assert file_watcher.is_watching_active
+        assert len(file_watcher._path_watchers) == expected_watchers
+        assert len(file_watcher._watched_directories) == expected_dirs
+
+
+def test_stop_file_watching(file_watcher):
+    """Test stopping file watching."""
+    # Mock some active watchers
+    mock_watcher1 = Mock()
+    mock_watcher2 = Mock()
+    file_watcher._path_watchers = [mock_watcher1, mock_watcher2]
+    file_watcher._watched_directories = {"dir1": ["comp1"]}
+    # No file watchers in directory-only approach
+    file_watcher._watching_active = True
+    # Seed asset roots to verify cleanup
+    file_watcher._asset_watch_roots = {"comp1": Path("/tmp")}
+
+    file_watcher.stop_file_watching()
+
+    # Should have closed all watchers
+    mock_watcher1.close.assert_called_once()
+    mock_watcher2.close.assert_called_once()
+
+    # Should have cleared all state
+    assert not file_watcher.is_watching_active
+    assert file_watcher._path_watchers == []
+    assert file_watcher._watched_directories == {}
+    assert file_watcher._asset_watch_roots == {}
+
+
+def test_handle_component_change_catches_callback_exceptions(file_watcher):
+    """Ensure exceptions in the update callback are caught and logged."""
+    file_watcher._watching_active = True
+
+    # Replace the callback with a raising one
+    def raising_callback(_components):
+        raise RuntimeError("boom")
+
+    file_watcher._component_update_callback = raising_callback
+
+    # Patch logger.exception to ensure we log instead of propagating
+    with patch("streamlit.components.v2.component_file_watcher._LOGGER") as logger_mock:
+        # Should not raise
+        file_watcher._handle_component_change(["test.component"])
+        logger_mock.exception.assert_called_once()
+
+    # Subsequent normal callbacks should still be invoked
+    ok_mock = Mock()
+    file_watcher._component_update_callback = ok_mock
+    file_watcher._handle_component_change(["test.component"])
+    ok_mock.assert_called_once_with(["test.component"])
+
+
+def test_stop_file_watching_with_close_errors(file_watcher):
+    """Test stopping file watching when watcher.close() raises an exception."""
+    # Mock a watcher that raises an exception on close
+    mock_watcher = Mock()
+    mock_watcher.close.side_effect = Exception("Close failed")
+    file_watcher._path_watchers = [mock_watcher]
+    file_watcher._watching_active = True
+
+    # Should not raise exception, just log it
+    file_watcher.stop_file_watching()
+
+    # Should still clean up state
+    assert not file_watcher.is_watching_active
+    assert file_watcher._path_watchers == []
+
+
+def test_change_event_triggers_callback(file_watcher, temp_component_files):
+    """Simulate a change event and ensure the update callback is invoked once."""
+    file_watcher._watching_active = True
+    file_watcher._handle_component_change(["test.component"])  # simulate both kinds
+    file_watcher._component_update_callback.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "attr_name",
+    [
+        "_re_resolve_component_patterns",
+        "_resolve_single_pattern",
+        "_extract_html_content",
+    ],
+)
+def test_no_legacy_helpers_present(file_watcher, attr_name: str):
+    """Assert that removed legacy helpers are not present on the watcher."""
+    assert not hasattr(file_watcher, attr_name)
+
+
+@pytest.mark.parametrize("name_key", ["test.glob_recursive", "test.direct_parent"])
+def test_directory_watchers_use_recursive_globs(
+    file_watcher, temp_component_files, name_key: str
+):
+    """Ensure directory watchers are configured with recursive "**/*" globs."""
+    mock_watcher_instance = Mock()
+    watcher_class_mock = Mock(return_value=mock_watcher_instance)
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=watcher_class_mock,
+    ):
+        file_watcher.start_file_watching({name_key: temp_component_files["temp_dir"]})
+
+        assert watcher_class_mock.call_count == 1
+        assert watcher_class_mock.call_args.kwargs.get("glob_pattern") == "**/*"
+
+
+@pytest.mark.parametrize(
+    "ignored_dir",
+    ["node_modules", ".git", "__pycache__", ".cache", "coverage", "venv"],
+)
+def test_ignores_noisy_directories_in_callbacks(
+    file_watcher, temp_component_files, ignored_dir: str
+):
+    """Change events under common noisy directories must be ignored in callbacks."""
+    mock_watcher_instance = Mock()
+    watcher_class_mock = Mock(return_value=mock_watcher_instance)
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=watcher_class_mock,
+    ):
+        file_watcher.start_file_watching(
+            {"test.glob_ignore": temp_component_files["temp_dir"]}
+        )
+
+        assert watcher_class_mock.call_count == 1
+        cb = watcher_class_mock.call_args.args[1]
+        noisy_path = str(
+            (temp_component_files["temp_dir"] / "js" / ignored_dir / "dep.js").resolve()
+        )
+
+        cb(noisy_path)
+
+        file_watcher._component_update_callback.assert_not_called()
+
+
+def test_restart_replaces_previous_watchers(file_watcher, tmp_path: Path):
+    """Calling start_file_watching twice should restart and replace watchers and directories."""
+    mock_watcher_first = Mock()
+    mock_watcher_second = Mock()
+
+    # The watcher class will return different instances on subsequent calls
+    watcher_class_mock = Mock(side_effect=[mock_watcher_first, mock_watcher_second])
+
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=watcher_class_mock,
+    ):
+        # First start with one root
+        first_root = tmp_path / "first"
+        first_root.mkdir()
+        file_watcher.start_file_watching({"comp.first": first_root})
+
+        assert file_watcher.is_watching_active
+        assert len(file_watcher._path_watchers) == 1
+        assert list(file_watcher._watched_directories.keys()) == [
+            str(first_root.resolve())
+        ]
+
+        # Now restart with a different root; previous watcher should be closed and replaced
+        second_root = tmp_path / "second"
+        second_root.mkdir()
+
+        file_watcher.start_file_watching({"comp.second": second_root})
+
+        # The first watcher should have been closed by the restart
+        mock_watcher_first.close.assert_called_once()
+
+        # We should have exactly one current watcher, and directories should reflect the new root
+        assert file_watcher.is_watching_active
+        assert len(file_watcher._path_watchers) == 1
+        assert list(file_watcher._watched_directories.keys()) == [
+            str(second_root.resolve())
+        ]
+
+
+def test_noop_path_watcher_short_circuits_and_stays_inactive(
+    file_watcher, tmp_path: Path
+):
+    """When NoOpPathWatcher is returned, we should not create watchers or mark active."""
+    # Import NoOpPathWatcher to use identity comparison in code under test
+    from streamlit.watcher.path_watcher import NoOpPathWatcher
+
+    # Patch to return NoOpPathWatcher
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=NoOpPathWatcher,
+    ):
+        root = tmp_path / "comp"
+        root.mkdir()
+        file_watcher.start_file_watching({"comp": root})
+
+        # Should remain inactive and not register any watchers or directories
+        assert not file_watcher.is_watching_active
+        assert file_watcher._path_watchers == []
+        assert file_watcher._watched_directories == {}
+
+
+def test_start_failure_rolls_back_and_leaves_no_watchers(file_watcher, tmp_path: Path):
+    """If creating a watcher fails mid-setup, previously created watchers are closed and no state is committed."""
+    # Prepare two directories to trigger two watcher creations
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    first_watcher = Mock()
+
+    def ctor(*args, **kwargs):
+        if ctor.calls == 0:
+            ctor.calls += 1
+            return first_watcher
+        raise RuntimeError("boom")
+
+    ctor.calls = 0
+
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=ctor,
+    ):
+        # Should not raise; internal code logs and rolls back
+        file_watcher.start_file_watching(
+            {
+                "c1": dir_a,
+                "c2": dir_b,
+            }
+        )
+
+    # Rollback: no watchers kept, not active, no directories remembered, roots not set
+    assert not file_watcher.is_watching_active
+    assert file_watcher._path_watchers == []
+    assert file_watcher._watched_directories == {}
+    assert file_watcher._asset_watch_roots == {}
+    # The partially created watcher must be closed during rollback
+    first_watcher.close.assert_called_once()
+
+
+def test_asset_roots_only_committed_after_success(file_watcher, tmp_path: Path):
+    """Roots should be committed only on successful watcher setup; on failure, they remain empty."""
+    root = tmp_path / "comp"
+    root.mkdir()
+
+    def ctor(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    with patch(
+        "streamlit.watcher.path_watcher.get_default_path_watcher_class",
+        return_value=ctor,
+    ):
+        file_watcher.start_file_watching({"comp": root})
+
+    assert not file_watcher.is_watching_active
+    assert file_watcher._path_watchers == []
+    assert file_watcher._watched_directories == {}
+    # Roots should not be committed on failure
+    assert file_watcher._asset_watch_roots == {}


### PR DESCRIPTION
## Describe your changes

- Added a new `ComponentFileWatcher` class to handle file watching for asset directories, files, and globs. This class provides functionality to:
  - Watch directories containing component assets
  - Detect changes in component files and trigger updates
  - Ignore changes in noisy directories like node_modules, .git, etc.
  - Handle file watching lifecycle (start/stop)
- The implementation uses Streamlit's path watcher system with recursive glob patterns to efficiently monitor component directories.
- No user-facing API is exposed yet. These are internal building blocks to wire into registration/execution in follow-up work.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): Added comprehensive test suite in `test_component_file_watcher.py` that covers:
  - Initialization and state management
  - Starting/stopping file watching with various root configurations
  - Change event handling and callback invocation
  - Error handling for callback exceptions
  - Verification of recursive glob pattern usage
  - Proper filtering of noisy directories

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.