### PR TITLE
Fix Issue #12068 - given buttonGroup a minWidth preset

### DIFF
--- a/e2e_playwright/st_feedback.py
+++ b/e2e_playwright/st_feedback.py
@@ -80,6 +80,9 @@ st.feedback("thumbs", width="content", key="thumbs_content_width")
 st.feedback("thumbs", width="stretch", key="thumbs_stretch_width")
 st.feedback("thumbs", width=300, key="thumbs_300px_width")
 
+st.subheader("Stars with width=10")
+st.feedback("stars", width=10, key="stars_no_wrap_width")
+
 if "runs" not in st.session_state:
     st.session_state.runs = 0
 st.session_state.runs += 1

--- a/e2e_playwright/st_feedback_test.py
+++ b/e2e_playwright/st_feedback_test.py
@@ -224,3 +224,30 @@ def test_feedback_width_examples(app: Page, assert_snapshot: ImageCompareFunctio
 
     thumbs_300px = get_element_by_key(app, "thumbs_300px_width")
     assert_snapshot(thumbs_300px, name="st_feedback-thumbs_width_300px")
+
+
+def test_stars_width_10_no_wrap(app: Page):
+    """Test that st.feedback('stars', width=10) doesn't wrap to multiple lines."""
+
+    stars_container = get_element_by_key(app, "stars_no_wrap_width")
+    expect(stars_container).to_be_visible()
+
+    button_group = get_button_group(stars_container)
+    expect(button_group).to_be_visible()
+    star_buttons = get_feedback_icon_buttons(button_group, "star")
+
+    # Check that all buttons are on the same horizontal line by comparing their y-coordinates
+    button_positions = []
+    for i in range(5):
+        button = star_buttons.nth(i)
+        expect(button).to_be_visible()
+        bbox = button.bounding_box()
+        assert bbox is not None
+        button_positions.append(bbox["y"])
+
+    # All buttons should be on the same horizontal line (within a few pixels tolerance)
+    first_button_y = button_positions[0]
+    for y in button_positions[1:]:
+        assert abs(y - first_button_y) < 5, (
+            f"Button y-coordinates differ too much: {button_positions}. This indicates line wrapping."
+        )

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -162,6 +162,9 @@ export const StyledElementContainerLayoutWrapper: FC<
       // and here set the width to auto.
       // This also covers st.pyplot() which is a special case of st.image.
       styles.width = "auto"
+    } else if (node.element.type === "buttonGroup") {
+      styles.minWidth =
+        (node.element[node.element.type]?.options?.length || 0) * 26 + "px"
     }
 
     return styles

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -46,18 +46,28 @@ export interface StyledElementContainerProps {
   elementType: string
   overflow: React.CSSProperties["overflow"]
   flex?: React.CSSProperties["flex"]
+  minWidth?: React.CSSProperties["minWidth"]
 }
 
 const GLOBAL_ELEMENTS = ["balloons", "snow"]
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
-  ({ theme, isStale, width, height, elementType, overflow, flex }) => ({
+  ({
+    theme,
+    isStale,
     width,
+    height,
+    elementType,
+    overflow,
+    flex,
+    minWidth,
+  }) => ({
+    width: width,
     height,
     maxWidth: "100%",
     // Important so that individual elements don't take up too much space
     // in horizontal layouts. Particularly when an element uses the full screen wrapper.
     // Some components support zero width (e.g. iframe).
-    minWidth: width === "0px" ? 0 : "1rem",
+    minWidth: minWidth ? minWidth : width === "0px" ? 0 : "1rem",
     // Allows to have absolutely-positioned nodes inside app elements, like
     // floating buttons.
     position: "relative",


### PR DESCRIPTION
## Describe your changes

Calculate the minimum width for the button group in StyledElementContainerLayoutWrapper, and add minWith preset to StyledElementContainerProps

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/12068

## Testing Plan
- [X] E2E Tests

Screenshots/Demos:

<img width="531" height="510" alt="image" src="https://github.com/user-attachments/assets/89f0c7a6-30de-4ead-ad68-4c626c5cdf1e" />

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
