### PR TITLE
[AdvancedLayouts] Update width and height on st.map

### DIFF
--- a/e2e_playwright/st_map.py
+++ b/e2e_playwright/st_map.py
@@ -71,7 +71,6 @@ st.map(
     longitude="xlon",
     color="color",
     size="size",
-    use_container_width=False,
 )
 
 
@@ -79,4 +78,4 @@ st.map(
 ### Simple map with defined width and height
 """
 
-st.map(simple_map_df, width=200, height=250, use_container_width=False)
+st.map(simple_map_df, width=200, height=250)

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -492,7 +492,7 @@ class PydeckMixin:
             )
             if use_container_width:
                 width = "stretch"
-            # Otherwise keep the provided width which should be an integer (validated below).
+            # Otherwise keep the provided width.
 
         validate_width(width, allow_content=False)
         validate_height(height, allow_content=False)

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -21,12 +21,23 @@ import json
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from streamlit import config, dataframe_util
+from streamlit.deprecation_util import (
+    make_deprecated_name_warning,
+    show_deprecation_warning,
+)
 from streamlit.elements import deck_gl_json_chart
 from streamlit.elements.lib.color_util import (
     Color,
     IntColorTuple,
     is_color_like,
     to_int_color_tuple,
+)
+from streamlit.elements.lib.layout_utils import (
+    HeightWithoutContent,
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_height,
+    validate_width,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
@@ -85,9 +96,9 @@ class MapMixin:
         color: None | str | Color = None,
         size: None | str | float = None,
         zoom: int | None = None,
-        use_container_width: bool = True,
-        width: int | None = None,
-        height: int | None = None,
+        width: WidthWithoutContent = "stretch",
+        height: HeightWithoutContent = 500,
+        use_container_width: bool | None = None,
     ) -> DeltaGenerator:
         """Display a map with a scatterplot overlaid onto it.
 
@@ -163,28 +174,35 @@ class MapMixin:
             Zoom level as specified in
             https://wiki.openstreetmap.org/wiki/Zoom_levels.
 
-        use_container_width : bool
+        width : "stretch" or int
+            How to size the map's width. Can be one of:
+
+            - ``"stretch"`` (default): Expand to the width of the parent container.
+            - An integer: Set the map width to this many pixels.
+
+        height : "stretch" or int
+            How to size the map's height. Can be one of:
+
+            - ``"stretch"``: Expand to the height of the parent container.
+            When outside of a container, the default height is 6.25rem.
+            - An integer: Set the map height to this many pixels. Defaults to 500.
+
+        use_container_width : bool or None
             Whether to override the map's native width with the width of
-            the parent container. If ``use_container_width`` is ``True``
-            (default), Streamlit sets the width of the map to match the width
-            of the parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the width of the chart to fit its contents according
-            to the plotting library, up to the width of the parent container.
+            the parent container. This can be one of the following:
 
-        width : int or None
-            Desired width of the chart expressed in pixels. If ``width`` is
-            ``None`` (default), Streamlit sets the width of the chart to fit
-            its contents according to the plotting library, up to the width of
-            the parent container. If ``width`` is greater than the width of the
-            parent container, Streamlit sets the chart width to match the width
-            of the parent container.
+            - ``None`` (default): Streamlit will use the map's default behavior.
+            - ``True``: Streamlit sets the width of the map to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the map to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
 
-            To use ``width``, you must set ``use_container_width=False``.
-
-        height : int or None
-            Desired height of the chart expressed in pixels. If ``height`` is
-            ``None`` (default), Streamlit sets the height of the chart to fit
-            its contents according to the plotting library.
+            .. deprecated::
+                The ``use_container_width`` parameter is deprecated and will
+                be removed in a future version. Use the ``width`` parameter
+                with ``width="stretch"`` instead of ``use_container_width=True``,
+                and specify an integer width instead of ``use_container_width=False``.
 
         Examples
         --------
@@ -231,15 +249,35 @@ class MapMixin:
            height: 600px
 
         """
-        # TODO(lawilby): Remove this once we have modernized height for map.
-        if height is None:
-            height = 500
+        # Handle use_container_width deprecation (for elements that already had width parameter)
+        if use_container_width is not None:
+            show_deprecation_warning(
+                make_deprecated_name_warning(
+                    "use_container_width",
+                    "width",
+                    "2025-12-31",
+                    "For `use_container_width=True`, use `width='stretch'`. "
+                    "For `use_container_width=False`, specify an integer width.",
+                    include_st_prefix=False,
+                ),
+                show_in_browser=False,
+            )
+            if use_container_width:
+                width = "stretch"
+            # For use_container_width=False, preserve any integer width that was set.
+
+        validate_width(width, allow_content=False)
+        validate_height(height, allow_content=False)
+
         map_proto = DeckGlJsonChartProto()
         deck_gl_json = to_deckgl_json(data, latitude, longitude, size, color, zoom)
-        marshall(
-            map_proto, deck_gl_json, use_container_width, width=width, height=height
+
+        marshall(map_proto, deck_gl_json)
+
+        layout_config = LayoutConfig(width=width, height=height)
+        return self.dg._enqueue(
+            "deck_gl_json_chart", map_proto, layout_config=layout_config
         )
-        return self.dg._enqueue("deck_gl_json_chart", map_proto)
 
     @property
     def dg(self) -> DeltaGenerator:
@@ -467,18 +505,13 @@ def _get_zoom_level(distance: float) -> int:
 def marshall(
     pydeck_proto: DeckGlJsonChartProto,
     pydeck_json: str,
-    use_container_width: bool,
-    height: int | None = None,
-    width: int | None = None,
 ) -> None:
+    """Marshall a map proto with the given pydeck JSON specification.
+
+    Layout configuration (width, height, etc.) is handled by the LayoutConfig
+    system and not through proto fields.
+    """
     pydeck_proto.json = pydeck_json
-    pydeck_proto.use_container_width = use_container_width
-
-    if width:
-        pydeck_proto.width = width
-    if height:
-        pydeck_proto.height = height
-
     pydeck_proto.id = ""
 
     mapbox_token = config.get_option("mapbox.token")

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -14,6 +14,8 @@
 
 """Unit tests for st.map()."""
 
+from __future__ import annotations
+
 import itertools
 import json
 import re
@@ -331,18 +333,6 @@ class StMapTest(DeltaGeneratorTestCase):
         ):
             st.map(df)
 
-    def test_map_with_height(self):
-        """Test st.map with height."""
-        st.map(mock_df, height=500)
-        c = self.get_delta_from_queue().new_element.deck_gl_json_chart
-        assert c.height == 500
-
-    def test_map_with_width(self):
-        """Test st.map with width."""
-        st.map(mock_df, width=240)
-        c = self.get_delta_from_queue().new_element.deck_gl_json_chart
-        assert c.width == 240
-
     def test_mapbox_token_is_set_in_proto(self):
         """Test that mapbox token is set in proto if configured."""
 
@@ -350,3 +340,151 @@ class StMapTest(DeltaGeneratorTestCase):
             st.map(mock_df)
             c = self.get_delta_from_queue().new_element.deck_gl_json_chart
             assert c.mapbox_token == "test_mapbox_token"
+
+
+class StMapWidthHeightTest(DeltaGeneratorTestCase):
+    """Test st.map width and height parameter functionality."""
+
+    @parameterized.expand(
+        [
+            # width, expected_width_spec, expected_width_value
+            ("stretch", "use_stretch", True),
+            (500, "pixel_width", 500),
+        ]
+    )
+    def test_width_parameter(
+        self,
+        width: str | int,
+        expected_width_spec: str,
+        expected_width_value: bool | int,
+    ):
+        """Test st.map with various width combinations."""
+        st.map(mock_df, width=width)
+
+        delta = self.get_delta_from_queue()
+        el = delta.new_element
+
+        assert el.width_config.WhichOneof("width_spec") == expected_width_spec
+        assert getattr(el.width_config, expected_width_spec) == expected_width_value
+
+    @parameterized.expand(
+        [
+            # height, expected_height_spec, expected_height_value
+            ("stretch", "use_stretch", True),
+            (400, "pixel_height", 400),
+        ]
+    )
+    def test_height_parameter(
+        self,
+        height: str | int,
+        expected_height_spec: str,
+        expected_height_value: bool | int,
+    ):
+        """Test st.map with various height combinations."""
+        st.map(mock_df, height=height)
+
+        delta = self.get_delta_from_queue()
+        el = delta.new_element
+
+        assert el.height_config.WhichOneof("height_spec") == expected_height_spec
+        assert getattr(el.height_config, expected_height_spec) == expected_height_value
+
+    def test_default_width_stretch(self):
+        """Test that default width is 'stretch'."""
+        st.map(mock_df)
+
+        delta = self.get_delta_from_queue()
+        el = delta.new_element
+
+        assert el.width_config.WhichOneof("width_spec") == "use_stretch"
+        assert el.width_config.use_stretch
+
+    def test_default_height_500(self):
+        """Test that default height is 500."""
+        st.map(mock_df)
+
+        delta = self.get_delta_from_queue()
+        el = delta.new_element
+
+        assert el.height_config.WhichOneof("height_spec") == "pixel_height"
+        assert el.height_config.pixel_height == 500
+
+    @parameterized.expand(
+        [
+            # use_container_width, width, expected_width_spec, expected_width_value
+            (True, None, "use_stretch", True),  # use_container_width=True -> stretch
+            (
+                False,
+                None,
+                "use_stretch",
+                True,
+            ),  # use_container_width=False, no width provided -> uses default "stretch"
+            (
+                True,
+                500,
+                "use_stretch",
+                True,
+            ),  # use_container_width=True overrides width -> stretch
+            (
+                True,
+                "stretch",
+                "use_stretch",
+                True,
+            ),  # use_container_width=True overrides width -> stretch
+            (
+                False,
+                "stretch",
+                "use_stretch",
+                True,
+            ),  # use_container_width=False, width="stretch" -> stretch
+            (
+                False,
+                400,
+                "pixel_width",
+                400,
+            ),  # use_container_width=False, integer width -> preserve integer
+        ]
+    )
+    @mock.patch("streamlit.elements.map.show_deprecation_warning")
+    def test_use_container_width_deprecation(
+        self,
+        use_container_width: bool,
+        width: str | int | None,
+        expected_width_spec: str,
+        expected_width_value: bool | int,
+        mock_show_warning,
+    ):
+        """Test deprecation warning and translation logic."""
+        kwargs = {"use_container_width": use_container_width}
+        if width is not None:
+            kwargs["width"] = width
+
+        st.map(mock_df, **kwargs)
+
+        # Check that deprecation warning was called
+        mock_show_warning.assert_called_once()
+
+        delta = self.get_delta_from_queue()
+        el = delta.new_element
+
+        # Check width_config reflects the expected width (NOT deprecated proto fields) - NO conditionals!
+        assert el.width_config.WhichOneof("width_spec") == expected_width_spec
+        assert getattr(el.width_config, expected_width_spec) == expected_width_value
+
+    @parameterized.expand(
+        [
+            ("width", "invalid_width"),
+            ("width", "content"),  # content not supported for maps
+            ("width", 0),  # width must be positive
+            ("width", -100),  # negative width
+            ("height", "invalid_height"),
+            ("height", "content"),  # content not supported for maps
+            ("height", 0),  # height must be positive
+            ("height", -100),  # negative height
+        ]
+    )
+    def test_validation_errors(self, param_name: str, invalid_value: str | int):
+        """Test that invalid width/height values raise validation errors."""
+        kwargs = {param_name: invalid_value}
+        with pytest.raises(StreamlitAPIException):
+            st.map(mock_df, **kwargs)


### PR DESCRIPTION
## Describe your changes

Modernizes `st.map` to use the new `Width` and `Height` type system (`"stretch"` or pixel values) for consistency with other chart elements.

**Changes Made:**

- **Updated parameters**: `width: WidthWithoutContent = "stretch"` and `height: HeightWithoutContent = 500`
- **Deprecated `use_container_width`**: Now defaults to `None` with deprecation warnings, will be removed after 12-31-2025
- **Backward compatibility**: Existing integer values and `use_container_width` behavior preserved
- **Parameter precedence**: `use_container_width=True` → `width="stretch"`, `use_container_width=False` → uses integer width or falls back to `"stretch"`

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (Python) - Width/height parameter functionality and backward compatibility
- [x] Unit Tests (Python) - `use_container_width` deprecation warnings  
- [x] Manual testing completed for stretch height. E2E tests for st.pydeck_chart cover this in combination with unit tests for st.map. 

**Additional Notes:**

Part of the broader AdvancedLayouts initiative to provide consistent width/height APIs across all chart elements. Note: `st.map` supports `"stretch"` and pixel values, but not `"content"` (uses `WidthWithoutContent` and `HeightWithoutContent` types).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
