### PR TITLE
[AdvancedLayouts] Modernize width/height parameters for st.scatter_chart

### DIFF
--- a/e2e_playwright/st_scatter_chart.py
+++ b/e2e_playwright/st_scatter_chart.py
@@ -63,7 +63,7 @@ st.scatter_chart(df)
 st.scatter_chart(df, x="a")
 st.scatter_chart(df, y="a")
 st.scatter_chart(df, y=["a", "b"])
-st.scatter_chart(df, x="a", y="b", height=500, width=300, use_container_width=False)
+st.scatter_chart(df, x="a", y="b", height=500, width=300)
 st.scatter_chart(df, x="b", y="a")
 st.scatter_chart(df, x="a", y=["b", "c"])
 st.scatter_chart(utc_df)
@@ -88,7 +88,6 @@ empty_scatter = st.scatter_chart(
     color=["#800080", "#0000FF"],  # Purple and Blue
     width=600,
     height=300,
-    use_container_width=False,
 )
 
 if st.button("Add data to Scatter Chart"):

--- a/e2e_playwright/st_vega_charts_height.py
+++ b/e2e_playwright/st_vega_charts_height.py
@@ -118,3 +118,21 @@ with st.container(border=True, key="test_altair_height_stretch", height=500):
         )
     )
     st.altair_chart(stretch_chart, height="stretch")
+
+# Test scatter chart height parameters
+st.subheader("Scatter Chart Height Tests")
+
+scatter_df = pd.DataFrame(
+    {
+        "x": [1, 2, 3, 4, 5],
+        "y": [2, 5, 3, 8, 7],
+        "size": [20, 40, 30, 60, 50],
+    }
+)
+
+st.write("Scatter chart with height='content':")
+st.scatter_chart(scatter_df, x="x", y="y", size="size", height="content")
+
+st.write("Scatter chart with height='stretch':")
+with st.container(border=True, key="test_scatter_height_stretch", height=400):
+    st.scatter_chart(scatter_df, x="x", y="y", size="size", height="stretch")

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -18,7 +18,7 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 from e2e_playwright.shared.vega_utils import assert_vega_chart_height
 
-VEGA_CHART_COUNT = 10
+VEGA_CHART_COUNT = 12
 
 
 def test_vega_chart_height_behavior(app: Page):
@@ -37,6 +37,8 @@ def test_vega_chart_height_behavior(app: Page):
         250,  # 7: Altair chart with height=250
         180,  # 8: Altair chart with height in spec (180) and height='content' parameter
         468,  # 9: Altair chart with height='stretch' (in 500px container, minus padding)
+        350,  # 10: Scatter chart with height='content'
+        368,  # 11: Scatter chart with height='stretch' (in 400px container, minus padding)
     ]
 
     descriptions = [
@@ -50,6 +52,8 @@ def test_vega_chart_height_behavior(app: Page):
         "Altair chart with height=250",
         "Altair chart with height in spec (180) and height='content' parameter",
         "Altair chart with height='stretch' (in 500px container)",
+        "Scatter chart with height='content'",
+        "Scatter chart with height='stretch' (in 400px container)",
     ]
 
     for i, expected_height in enumerate(expected_heights):
@@ -101,6 +105,34 @@ def test_vega_chart_height_150px_snapshot(
     assert_snapshot(
         vega_lite_charts.nth(2),
         name="st_vega_charts_height-height_150px",
+    )
+
+
+def test_scatter_chart_height_content_snapshot(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Tests scatter chart height='content' parameter visual appearance."""
+    vega_lite_charts = app.get_by_test_id("stVegaLiteChart")
+    expect(vega_lite_charts).to_have_count(VEGA_CHART_COUNT)
+
+    expect(vega_lite_charts.nth(10)).to_be_visible()
+    assert_snapshot(
+        vega_lite_charts.nth(10),
+        name="st_scatter_chart-height_content",
+    )
+
+
+def test_scatter_chart_height_stretch_snapshot(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Tests scatter chart height='stretch' parameter visual appearance."""
+    vega_lite_charts = app.get_by_test_id("stVegaLiteChart")
+    expect(vega_lite_charts).to_have_count(VEGA_CHART_COUNT)
+
+    expect(get_element_by_key(app, "test_scatter_height_stretch")).to_be_visible()
+    assert_snapshot(
+        vega_lite_charts.nth(11),
+        name="st_scatter_chart-height_stretch",
     )
 
 

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -108,34 +108,6 @@ def test_vega_chart_height_150px_snapshot(
     )
 
 
-def test_scatter_chart_height_content_snapshot(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Tests scatter chart height='content' parameter visual appearance."""
-    vega_lite_charts = app.get_by_test_id("stVegaLiteChart")
-    expect(vega_lite_charts).to_have_count(VEGA_CHART_COUNT)
-
-    expect(vega_lite_charts.nth(10)).to_be_visible()
-    assert_snapshot(
-        vega_lite_charts.nth(10),
-        name="st_scatter_chart-height_content",
-    )
-
-
-def test_scatter_chart_height_stretch_snapshot(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Tests scatter chart height='stretch' parameter visual appearance."""
-    vega_lite_charts = app.get_by_test_id("stVegaLiteChart")
-    expect(vega_lite_charts).to_have_count(VEGA_CHART_COUNT)
-
-    expect(get_element_by_key(app, "test_scatter_height_stretch")).to_be_visible()
-    assert_snapshot(
-        vega_lite_charts.nth(11),
-        name="st_scatter_chart-height_stretch",
-    )
-
-
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stVegaLiteChart")

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1422,9 +1422,9 @@ class VegaChartsMixin:
         y_label: str | None = None,
         color: str | Color | list[Color] | None = None,
         size: str | float | int | None = None,
-        width: int | None = None,
-        height: int | None = None,
-        use_container_width: bool = True,
+        width: Width = "stretch",
+        height: Height = "content",
+        use_container_width: bool | None = None,
     ) -> DeltaGenerator:
         """Display a scatterplot chart.
 
@@ -1509,27 +1509,37 @@ class VegaChartsMixin:
             - The name of the column to use for the size. This allows each
               datapoint to be represented by a circle of a different size.
 
-        width : int or None
-            Desired width of the chart expressed in pixels. If ``width`` is
-            ``None`` (default), Streamlit sets the width of the chart to fit
-            its contents according to the plotting library, up to the width of
-            the parent container. If ``width`` is greater than the width of the
-            parent container, Streamlit sets the chart width to match the width
-            of the parent container.
+        width : "stretch", "content", or int
+            How to size the chart's width. Can be one of:
 
-            To use ``width``, you must set ``use_container_width=False``.
+            - ``"stretch"`` (default): Expand to the width of the parent container.
+            - ``"content"``: Size the chart to fit its contents, up to the width
+              of the parent container.
+            - An integer: Set the chart width to this many pixels.
 
-        height : int or None
-            Desired height of the chart expressed in pixels. If ``height`` is
-            ``None`` (default), Streamlit sets the height of the chart to fit
-            its contents according to the plotting library.
+        height : "stretch", "content", or int
+            How to size the chart's height. Can be one of:
 
-        use_container_width : bool
-            Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``True`` (default),
-            Streamlit sets the width of the chart to match the width of the
-            parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the chart's width according to ``width``.
+            - ``"content"`` (default): Size the chart to fit its contents.
+            - ``"stretch"``: Expand to the height of the parent container.
+            - An integer: Set the chart height to this many pixels.
+
+        use_container_width : bool or None
+            Whether to override the chart's native width with the width of
+            the parent container. This can be one of the following:
+
+            - ``None`` (default): Streamlit will use the chart's default behavior.
+            - ``True``: Streamlit sets the width of the chart to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the chart to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
+
+            .. deprecated::
+                The ``use_container_width`` parameter is deprecated and will
+                be removed in a future version. Use the ``width`` parameter
+                with ``width="stretch"`` instead of ``use_container_width=True``,
+                and ``width="content"`` instead of ``use_container_width=False``.
 
         Examples
         --------
@@ -1614,6 +1624,23 @@ class VegaChartsMixin:
            height: 440px
 
         """
+        if use_container_width is not None:
+            show_deprecation_warning(
+                make_deprecated_name_warning(
+                    "use_container_width",
+                    "width",
+                    "2025-12-31",
+                    "For `use_container_width=True`, use `width='stretch'`. "
+                    "For `use_container_width=False`, use `width='content'` or specify an integer width.",
+                    include_st_prefix=False,
+                ),
+                show_in_browser=False,
+            )
+            if use_container_width:
+                width = "stretch"
+            elif not isinstance(width, int):
+                width = "content"
+                # Otherwise keep the integer width - user explicitly set both use_container_width=False and width=int
 
         chart, add_rows_metadata = generate_chart(
             chart_type=ChartType.SCATTER,
@@ -1626,15 +1653,16 @@ class VegaChartsMixin:
             size_from_user=size,
             width=width,
             height=height,
-            use_container_width=use_container_width,
+            use_container_width=(width == "stretch"),
         )
         return cast(
             "DeltaGenerator",
             self._altair_chart(
                 chart,
-                use_container_width=use_container_width,
                 theme="streamlit",
                 add_rows_metadata=add_rows_metadata,
+                width=width,
+                height=height,
             ),
         )
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import unittest
-from typing import Any, Callable
+from typing import Any, Callable, ClassVar
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
@@ -2081,8 +2081,13 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
             st.bar_chart(df, x="A", y="B", sort="-nonexistent_column")
 
 
-class LineChartWidthHeightTest(DeltaGeneratorTestCase):
-    """Test line_chart width and height parameter functionality."""
+class ChartWidthHeightTest(DeltaGeneratorTestCase):
+    """Test width and height parameter functionality for modernized chart commands."""
+
+    CHART_COMMANDS: ClassVar[list[tuple[Callable, str]]] = [
+        (st.line_chart, "line_chart"),
+        (st.scatter_chart, "scatter_chart"),
+    ]
 
     @parameterized.expand(
         [
@@ -2102,7 +2107,7 @@ class LineChartWidthHeightTest(DeltaGeneratorTestCase):
             (600, 400, "pixel_width", 600, "pixel_height", 400),
         ]
     )
-    def test_line_chart_width_height_combinations(
+    def test_chart_width_height_combinations(
         self,
         width: str | int,
         height: str | int,
@@ -2111,24 +2116,32 @@ class LineChartWidthHeightTest(DeltaGeneratorTestCase):
         expected_height_spec: str,
         expected_height_value: bool | int,
     ):
-        """Test line_chart with various width and height combinations."""
+        """Test chart commands with various width and height combinations."""
         df = pd.DataFrame([[20, 30, 50]], columns=["a", "b", "c"])
 
-        st.line_chart(df, x="a", y="b", width=width, height=height)
+        for chart_command, chart_name in self.CHART_COMMANDS:
+            with self.subTest(chart=chart_name):
+                chart_command(df, x="a", y="b", width=width, height=height)
 
-        el = self.get_delta_from_queue().new_element
+                el = self.get_delta_from_queue().new_element
 
-        # Check width configuration
-        assert el.width_config.WhichOneof("width_spec") == expected_width_spec
-        assert getattr(el.width_config, expected_width_spec) == expected_width_value
+                assert el.width_config.WhichOneof("width_spec") == expected_width_spec
+                assert (
+                    getattr(el.width_config, expected_width_spec)
+                    == expected_width_value
+                )
 
-        # Check height configuration
-        assert el.height_config.WhichOneof("height_spec") == expected_height_spec
-        assert getattr(el.height_config, expected_height_spec) == expected_height_value
+                assert (
+                    el.height_config.WhichOneof("height_spec") == expected_height_spec
+                )
+                assert (
+                    getattr(el.height_config, expected_height_spec)
+                    == expected_height_value
+                )
 
     @parameterized.expand(
         [
-            # Test parameters: use_container_width, width, expected_width_spec, expected_width_value
+            # use_container_width, width, expected_width_spec, expected_width_value
             (
                 True,
                 None,
@@ -2174,7 +2187,7 @@ class LineChartWidthHeightTest(DeltaGeneratorTestCase):
         ]
     )
     @patch("streamlit.elements.vega_charts.show_deprecation_warning")
-    def test_line_chart_use_container_width_deprecation(
+    def test_chart_use_container_width_deprecation(
         self,
         use_container_width: bool,
         width: int | str | None,
@@ -2190,18 +2203,26 @@ class LineChartWidthHeightTest(DeltaGeneratorTestCase):
         if width is not None:
             kwargs["width"] = width
 
-        st.line_chart(df, x="a", y="b", **kwargs)
+        for chart_command, chart_name in self.CHART_COMMANDS:
+            with self.subTest(chart=chart_name):
+                chart_command(df, x="a", y="b", **kwargs)
 
-        mock_warning.assert_called_once()
+                mock_warning.assert_called()
 
-        el = self.get_delta_from_queue().new_element
+                el = self.get_delta_from_queue().new_element
 
-        # Should be translated to the correct width configuration
-        assert el.width_config.WhichOneof("width_spec") == expected_width_spec
-        assert getattr(el.width_config, expected_width_spec) == expected_width_value
+                assert el.width_config.WhichOneof("width_spec") == expected_width_spec
+                assert (
+                    getattr(el.width_config, expected_width_spec)
+                    == expected_width_value
+                )
+
+        # Verify the warning was called for each chart command
+        assert mock_warning.call_count == len(self.CHART_COMMANDS)
 
     @parameterized.expand(
         [
+            # param_name, invalid_value
             ("width", "invalid_width"),
             ("height", "invalid_height"),
             ("width", 0),  # width must be positive
@@ -2210,15 +2231,32 @@ class LineChartWidthHeightTest(DeltaGeneratorTestCase):
             ("height", -100),  # negative height
         ]
     )
-    def test_line_chart_validation_errors(
-        self, param_name: str, invalid_value: str | int
-    ):
+    def test_chart_validation_errors(self, param_name: str, invalid_value: str | int):
         """Test that invalid width/height values raise validation errors."""
         df = pd.DataFrame([[20, 30, 50]], columns=["a", "b", "c"])
 
         kwargs = {param_name: invalid_value}
-        with pytest.raises(StreamlitAPIException):
-            st.line_chart(df, x="a", y="b", **kwargs)
+
+        for chart_command, chart_name in self.CHART_COMMANDS:
+            with self.subTest(chart=chart_name):
+                with pytest.raises(StreamlitAPIException):
+                    chart_command(df, x="a", y="b", **kwargs)
+
+    def test_chart_default_width_height(self):
+        """Test that default width is 'stretch' and default height is 'content'."""
+        df = pd.DataFrame([[20, 30, 50]], columns=["a", "b", "c"])
+
+        for chart_command, chart_name in self.CHART_COMMANDS:
+            with self.subTest(chart=chart_name):
+                chart_command(df, x="a", y="b")  # No width/height specified
+
+                el = self.get_delta_from_queue().new_element
+
+                # Should default to stretch width and content height
+                assert el.width_config.WhichOneof("width_spec") == "use_stretch"
+                assert el.width_config.use_stretch is True
+                assert el.height_config.WhichOneof("height_spec") == "use_content"
+                assert el.height_config.use_content is True
 
 
 class VegaLiteChartWidthTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

Modernizes `st.scatter_chart` width/height parameters to use the new `Width`/`Height` type system (`"stretch"`, `"content"`, or pixel values) for consistency with other chart elements.

**Changes Made:**

- **Updated parameter signature**: `width: Width = "stretch"` and `height: Height = "content"` (previously `int | None = None`)
- **Deprecated `use_container_width`**: Changed from `bool = True` to `bool | None = None` with deprecation warnings
- **Preserved backward compatibility**: Existing integer values and `use_container_width` behavior still work
- **Updated documentation**: New parameter descriptions explaining the Width/Height type system

**Deprecation Details:**

- `use_container_width` will be removed after 2025-12-31
- When explicitly set, `use_container_width` takes precedence over `width`
- Users receive deprecation warnings with migration guidance

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (Python) - Width/height parameter functionality and backward compatibility
- [x] Unit Tests (Python) - `use_container_width` deprecation warnings and behavior
- [x] E2E Tests - Testing for width/height behavior across different values (covered by existing tests, new tests for height="content" and height="stretch")
- [x] Manual testing completed

**Additional Notes:**

Part of the AdvancedLayouts initiative to provide consistent width/height APIs across all chart elements.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
