### PR TITLE
[feat] Add ComponentManager and wire it into the Runtime

### DIFF
--- a/lib/streamlit/components/v2/component_definition_resolver.py
+++ b/lib/streamlit/components/v2/component_definition_resolver.py
@@ -1,0 +1,143 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared resolver for building component definitions with path validation.
+
+This module centralizes the logic for interpreting js/css inputs as inline
+content vs path/glob strings, validating them against a component's asset
+directory, and producing a BidiComponentDefinition with correct asset-relative
+URLs used by the server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from streamlit.components.v2.component_path_utils import ComponentPathUtils
+from streamlit.components.v2.component_registry import BidiComponentDefinition
+from streamlit.errors import StreamlitAPIException
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+
+def build_definition_with_validation(
+    *,
+    manager: BidiComponentManager,
+    component_key: str,
+    html: str | None,
+    css: str | None,
+    js: str | None,
+) -> BidiComponentDefinition:
+    """Construct a definition and validate ``js``/``css`` inputs against ``asset_dir``.
+
+    Parameters
+    ----------
+    manager : BidiComponentManager
+        Component manager used to resolve the component's ``asset_dir`` and
+        related metadata.
+    component_key : str
+        Fully-qualified name of the component to build a definition for.
+    html : str | None
+        Inline HTML content to include in the definition. If ``None``, the
+        component will not include HTML content.
+    css : str | None
+        Either inline CSS content or a path/glob to a CSS file inside the
+        component's ``asset_dir``. Inline strings are kept as-is; file-backed
+        inputs are validated and converted to an ``asset_dir``-relative URL.
+    js : str | None
+        Either inline JavaScript content or a path/glob to a JS file inside the
+        component's ``asset_dir``. Inline strings are kept as-is; file-backed
+        inputs are validated and converted to an ``asset_dir``-relative URL.
+
+    Returns
+    -------
+    BidiComponentDefinition
+        A component definition with inline content preserved and file-backed
+        entries resolved to absolute filesystem paths plus their
+        ``asset_dir``-relative URLs.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If a path/glob is provided but the component has no declared
+        ``asset_dir``, if a glob resolves to zero or multiple files, or if any
+        resolved path escapes the declared ``asset_dir``.
+
+    Notes
+    -----
+    - Inline strings are treated as content (no manifest required).
+    - Path-like strings require the component to be declared in the package
+      manifest with an ``asset_dir``.
+    - Globs are supported only within ``asset_dir`` and must resolve to exactly
+      one file.
+    - Relative paths are resolved strictly against the component's ``asset_dir``
+      and must remain within it after resolution. Absolute paths are not
+      allowed.
+    - For file-backed entries, the URL sent to the frontend is the
+      ``asset_dir``-relative path, served under
+      ``/_stcore/bidi-components/<component>/<relative_path>``.
+    """
+
+    asset_root = manager.get_component_asset_root(component_key)
+
+    def _resolve_entry(
+        value: str | None, *, kind: str
+    ) -> tuple[str | None, str | None]:
+        # Inline content: None rel URL
+        if value is None:
+            return None, None
+        if ComponentPathUtils.looks_like_inline_content(value):
+            return value, None
+
+        # For path-like strings, asset_root must exist
+        if asset_root is None:
+            raise StreamlitAPIException(
+                f"Component '{component_key}' must be declared in pyproject.toml with asset_dir "
+                f"to use file-backed {kind}."
+            )
+
+        value_str = value
+
+        # If looks like a glob, resolve strictly inside asset_root
+        if ComponentPathUtils.has_glob_characters(value_str):
+            resolved = ComponentPathUtils.resolve_glob_pattern(value_str, asset_root)
+            ComponentPathUtils.ensure_within_root(resolved, asset_root, kind=kind)
+            # Use resolved absolute paths to avoid macOS /private prefix mismatch
+            rel_url = str(
+                resolved.resolve().relative_to(asset_root.resolve()).as_posix()
+            )
+            return str(resolved), rel_url
+
+        # Concrete path: must be asset-dir-relative (reject absolute & traversal)
+        ComponentPathUtils.validate_path_security(value_str)
+        candidate = asset_root / Path(value_str)
+        ComponentPathUtils.ensure_within_root(candidate, asset_root, kind=kind)
+        resolved_candidate = candidate.resolve()
+        rel_url = str(resolved_candidate.relative_to(asset_root.resolve()).as_posix())
+        return str(resolved_candidate), rel_url
+
+    css_value, css_rel = _resolve_entry(css, kind="css")
+    js_value, js_rel = _resolve_entry(js, kind="js")
+
+    # Build definition with possible asset_dir-relative paths
+    return BidiComponentDefinition(
+        name=component_key,
+        html=html,
+        css=css_value,
+        js=js_value,
+        css_asset_relative_path=css_rel,
+        js_asset_relative_path=js_rel,
+    )

--- a/lib/streamlit/components/v2/component_manager.py
+++ b/lib/streamlit/components/v2/component_manager.py
@@ -1,0 +1,431 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom Components v2 manager and supporting orchestration.
+
+This module composes the registry, manifest handling, and file watching
+capabilities for Streamlit's Custom Components v2. It provides a unified
+interface to register components from manifests or individual definitions, query
+component metadata and asset paths, and react to on-disk changes by re-resolving
+component definitions.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from streamlit.components.v2.component_definition_resolver import (
+    build_definition_with_validation,
+)
+from streamlit.components.v2.component_file_watcher import ComponentFileWatcher
+from streamlit.components.v2.component_manifest_handler import ComponentManifestHandler
+from streamlit.components.v2.component_registry import (
+    BidiComponentDefinition,
+    BidiComponentRegistry,
+)
+from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from streamlit.components.v2.manifest_scanner import ComponentManifest
+
+_LOGGER: Final = get_logger(__name__)
+
+
+@dataclass
+class _ApiInputs:
+    """Inputs provided via the Python API to resolve a component definition.
+
+    Attributes
+    ----------
+    css : str | None
+        Inline CSS content or a path/glob to a CSS asset within ``asset_dir``.
+    js : str | None
+        Inline JS content or a path/glob to a JS asset within ``asset_dir``.
+    """
+
+    css: str | None
+    js: str | None
+
+
+class BidiComponentManager:
+    """Manager class that composes component registry, manifest handler, and
+    file watcher.
+
+    This class provides a unified interface for working with bidirectional
+    components while maintaining clean separation of concerns through
+    composition. It handles the coordination and lifecycle management of all
+    component-related functionality.
+
+    Component Lifecycle
+    -------------------
+    The lifecycle of a component managed by this class involves four key stages:
+
+    1.  **Discovery**: On startup, ``discover_and_register_components`` scans
+        for installed packages with component manifests (``pyproject.toml``).
+        For each component found, a placeholder definition containing only its
+        name and ``asset_dir`` is registered. This makes the system aware of all
+        available installed components from the outset.
+
+    2.  **Definition & Validation**: When a user's script calls the public API
+        (e.g., ``st.components.v2.component(...)``), the manager invokes
+        ``build_definition_with_validation``. This function is the single,
+        centralized point for all validation. It resolves file paths, performs
+        security checks against the component's ``asset_dir``, and produces a
+        complete, validated ``BidiComponentDefinition``.
+
+    3.  **Registration**: The validated definition is then passed to the
+        registry's ``register`` method. This adds the complete definition,
+        overwriting the placeholder if one existed from the discovery phase.
+
+    4.  **Updating**: The ``ComponentFileWatcher`` monitors the ``asset_dir``
+        for changes. On a change, it triggers a re-computation of the definition
+        using the original API inputs, runs it through the same validation
+        logic, and updates the registry with the new definition via the stricter
+        ``update_component`` method.
+
+    Notes
+    -----
+    This manager intentionally favors composition over inheritance and delegates
+    specialized responsibilities to ``BidiComponentRegistry``,
+    ``ComponentManifestHandler``, and ``ComponentFileWatcher``.
+    """
+
+    def __init__(
+        self,
+        registry: BidiComponentRegistry | None = None,
+        manifest_handler: ComponentManifestHandler | None = None,
+        file_watcher: ComponentFileWatcher | None = None,
+    ) -> None:
+        """Initialize the component manager.
+
+        Parameters
+        ----------
+        registry : BidiComponentRegistry, optional
+            Component registry instance. If not provided, a new one will be created.
+        manifest_handler : ComponentManifestHandler, optional
+            Manifest handler instance. If not provided, a new one will be created.
+        file_watcher : ComponentFileWatcher, optional
+            File watcher instance. If not provided, a new one will be created.
+        """
+        # Create dependencies
+        self._registry = registry or BidiComponentRegistry()
+        self._manifest_handler = manifest_handler or ComponentManifestHandler()
+        # Store API inputs for re-resolution on change events
+        self._api_inputs: dict[str, _ApiInputs] = {}
+        self._api_inputs_lock = threading.Lock()
+        self._file_watcher = file_watcher or ComponentFileWatcher(
+            self._on_components_changed
+        )
+
+    def record_api_inputs(
+        self, component_key: str, css: str | None, js: str | None
+    ) -> None:
+        """Record original API inputs for later re-resolution on file changes.
+
+        Parameters
+        ----------
+        component_key : str
+            Fully-qualified component name.
+        css : str | None
+            Inline CSS or a path/glob to a CSS file within the component's
+            ``asset_dir``.
+        js : str | None
+            Inline JavaScript or a path/glob to a JS file within the component's
+            ``asset_dir``.
+        """
+        with self._api_inputs_lock:
+            self._api_inputs[component_key] = _ApiInputs(css=css, js=js)
+
+    def register_from_manifest(
+        self, manifest: ComponentManifest, package_root: Path
+    ) -> None:
+        """Register components from a manifest file.
+
+        This is a high-level method that processes the manifest and registers
+        all components found within it.
+
+        Parameters
+        ----------
+        manifest : ComponentManifest
+            The component manifest to process.
+        package_root : Path
+            Root path of the package containing the components.
+        """
+        # First process the manifest
+        component_definitions = self._manifest_handler.process_manifest(
+            manifest, package_root
+        )
+
+        # Register all component definitions
+        self._registry.register_components_from_definitions(component_definitions)
+
+        _LOGGER.debug(
+            "Registered %d components from manifest", len(component_definitions)
+        )
+
+    def register(self, definition: BidiComponentDefinition) -> None:
+        """Register a single component definition.
+
+        Parameters
+        ----------
+        definition : BidiComponentDefinition
+            The component definition to register.
+        """
+        self._registry.register(definition)
+
+    def get(self, name: str) -> BidiComponentDefinition | None:
+        """Get a component definition by name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the component to retrieve.
+
+        Returns
+        -------
+        BidiComponentDefinition or None
+            The component definition if found; otherwise ``None``.
+        """
+        return self._registry.get(name)
+
+    def build_definition_with_validation(
+        self,
+        *,
+        component_key: str,
+        html: str | None,
+        css: str | None,
+        js: str | None,
+    ) -> BidiComponentDefinition:
+        """Build a validated component definition for the given inputs.
+
+        Parameters
+        ----------
+        component_key : str
+            Fully-qualified component name the definition is for.
+        html : str | None
+            Inline HTML content to include in the definition.
+        css : str | None
+            Inline CSS content or a path/glob under the component's asset_dir.
+        js : str | None
+            Inline JS content or a path/glob under the component's asset_dir.
+
+        Returns
+        -------
+        BidiComponentDefinition
+            The fully validated component definition.
+        """
+        return build_definition_with_validation(
+            manager=self,
+            component_key=component_key,
+            html=html,
+            css=css,
+            js=js,
+        )
+
+    def get_component_asset_root(self, name: str) -> Path | None:
+        """Get the asset root for a manifest-backed component.
+
+        Parameters
+        ----------
+        name : str
+            The name of the component to get the asset root for.
+
+        Returns
+        -------
+        Path or None
+            The component's ``asset_root`` directory if found; otherwise
+            ``None``.
+        """
+        return self._manifest_handler.get_asset_root(name)
+
+    def unregister(self, name: str) -> None:
+        """Unregister a component by name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the component to unregister.
+        """
+        self._registry.unregister(name)
+
+    def clear(self) -> None:
+        """Clear all registered components."""
+        self._registry.clear()
+
+    def get_component_path(self, name: str) -> str | None:
+        """Get the filesystem path for a manifest-backed component.
+
+        Parameters
+        ----------
+        name : str
+            The name of the component.
+
+        Returns
+        -------
+        str or None
+            The component's ``asset_dir`` directory if found; otherwise
+            ``None``.
+        """
+        asset_root = self._manifest_handler.get_asset_root(name)
+        if asset_root is not None:
+            return str(asset_root)
+
+        return None
+
+    def start_file_watching(self) -> None:
+        """Start file watching for component changes."""
+        if self._file_watcher.is_watching_active:
+            _LOGGER.warning("File watching is already started")
+            return
+
+        # Get asset watch roots from manifest handler
+        asset_roots = self._manifest_handler.get_asset_watch_roots()
+
+        # Start file watching
+        self._file_watcher.start_file_watching(asset_roots)
+
+        if self._file_watcher.is_watching_active:
+            _LOGGER.debug("Started file watching for component changes")  # type: ignore[unreachable]
+        else:
+            _LOGGER.debug("File watching not started")
+
+    def discover_and_register_components(self) -> None:
+        """Discover installed v2 components and register them.
+
+        This scans installed distributions for manifests, registers all discovered
+        components, and starts file watching for development workflows.
+        """
+        try:
+            from streamlit.components.v2.manifest_scanner import (
+                scan_component_manifests,
+            )
+
+            manifests = scan_component_manifests()
+            for manifest, package_root in manifests:
+                self.register_from_manifest(manifest, package_root)
+                _LOGGER.info(
+                    "Registered components from pyproject.toml: %s v%s",
+                    manifest.name,
+                    manifest.version,
+                )
+
+            # Start file watching for development mode after all components are registered
+            self.start_file_watching()
+
+        except Exception as e:
+            _LOGGER.warning("Failed to scan component manifests: %s", e)
+
+    def stop_file_watching(self) -> None:
+        """Stop file watching."""
+        if not self._file_watcher.is_watching_active:
+            _LOGGER.warning("File watching is not started")
+            return
+
+        self._file_watcher.stop_file_watching()
+
+        _LOGGER.debug("Stopped file watching")
+
+    def get_metadata(self, component_name: str) -> ComponentManifest | None:
+        """Get metadata for a component.
+
+        Parameters
+        ----------
+        component_name : str
+            The name of the component to get metadata for.
+
+        Returns
+        -------
+        ComponentManifest or None
+            The component metadata if found; otherwise ``None``.
+        """
+        return self._manifest_handler.get_metadata(component_name)
+
+    def _on_components_changed(self, component_names: list[str]) -> None:
+        """Handle change events for components' asset roots.
+
+        For each component, re-resolve from stored API inputs and update the
+        registry with the new definition if resolution succeeds.
+
+        Parameters
+        ----------
+        component_names : list[str]
+            Fully-qualified component names whose watched files changed.
+        """
+        for name in component_names:
+            try:
+                updated_def = self._recompute_definition_from_api(name)
+                if updated_def is not None:
+                    self._registry.update_component(updated_def)
+            except Exception:  # noqa: PERF203
+                _LOGGER.exception("Failed to update component after change: %s", name)
+
+    def _recompute_definition_from_api(
+        self, component_name: str
+    ) -> BidiComponentDefinition | None:
+        """Recompute a component's definition using previously recorded API inputs.
+
+        Parameters
+        ----------
+        component_name : str
+            Fully-qualified component name to recompute.
+
+        Returns
+        -------
+        BidiComponentDefinition | None
+            A fully validated component definition suitable for replacing the
+            stored entry in the registry, or ``None`` if recomputation failed
+            or no API inputs were previously recorded.
+        """
+        with self._api_inputs_lock:
+            inputs = self._api_inputs.get(component_name)
+            if inputs is None:
+                return None
+
+            # Get existing def to preserve html unless new content is provided later
+            existing_def = self._registry.get(component_name)
+            html_value = existing_def.html if existing_def else None
+
+            try:
+                # Resolve a fully validated definition from stored API inputs and
+                # the preserved html value from the existing definition.
+                new_def = self.build_definition_with_validation(
+                    component_key=component_name,
+                    html=html_value,
+                    css=inputs.css,
+                    js=inputs.js,
+                )
+            except Exception as e:
+                _LOGGER.debug(
+                    "Skipping update for %s due to re-resolution error: %s",
+                    component_name,
+                    e,
+                )
+                return None
+
+        return new_def
+
+    @property
+    def is_file_watching_started(self) -> bool:
+        """Check if file watching is currently active.
+
+        Returns
+        -------
+        bool
+            True if file watching is started, False otherwise
+        """
+        return self._file_watcher.is_watching_active

--- a/lib/streamlit/components/v2/get_bidi_component_manager.py
+++ b/lib/streamlit/components/v2/get_bidi_component_manager.py
@@ -1,0 +1,51 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accessors for the BidiComponentManager used by Custom Components v2.
+
+This module exposes `get_bidi_component_manager`, which returns the singleton
+`BidiComponentManager` registered on the active Streamlit runtime. When no
+runtime is active, a local manager instance is created and returned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+
+def get_bidi_component_manager() -> BidiComponentManager:
+    """Return the singleton ``BidiComponentManager`` instance.
+
+    Returns
+    -------
+    BidiComponentManager
+        The singleton BidiComponentManager instance.
+
+
+    Notes
+    -----
+    If the Streamlit runtime is not running, a local ``BidiComponentManager``
+    is created and returned.
+    """
+    from streamlit.components.v2.component_manager import BidiComponentManager
+    from streamlit.runtime import Runtime
+
+    if Runtime.exists():
+        return Runtime.instance().bidi_component_registry
+
+    # Return a local manager when running without the streamlit runtime
+    return BidiComponentManager()

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -23,6 +23,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Final, NamedTuple
 
 from streamlit.components.lib.local_component_registry import LocalComponentRegistry
+from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.app_session import AppSession
@@ -99,6 +100,11 @@ class RuntimeConfig:
     # The ComponentRegistry instance to use.
     component_registry: BaseComponentRegistry = field(
         default_factory=LocalComponentRegistry
+    )
+
+    # The BidiComponentManager instance to use for v2 components.
+    bidi_component_registry: BidiComponentManager = field(
+        default_factory=BidiComponentManager
     )
 
     # The SessionManager class to be used.
@@ -201,10 +207,14 @@ class Runtime:
 
         # Initialize managers
         self._component_registry = config.component_registry
+        self._bidi_component_registry = config.bidi_component_registry
         self._uploaded_file_mgr = config.uploaded_file_manager
         self._media_file_mgr = MediaFileManager(storage=config.media_file_storage)
         self._cache_storage_manager = config.cache_storage_manager
         self._script_cache = ScriptCache()
+
+        # Discover and register components for CCv2 from installed packages
+        self._bidi_component_registry.discover_and_register_components()
 
         self._session_mgr = config.session_manager_class(
             session_storage=config.session_storage,
@@ -226,6 +236,10 @@ class Runtime:
     @property
     def component_registry(self) -> BaseComponentRegistry:
         return self._component_registry
+
+    @property
+    def bidi_component_registry(self) -> BidiComponentManager:
+        return self._bidi_component_registry
 
     @property
     def uploaded_file_mgr(self) -> UploadedFileManager:

--- a/lib/tests/streamlit/components/v2/test_component_manager.py
+++ b/lib/tests/streamlit/components/v2/test_component_manager.py
@@ -1,0 +1,226 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from streamlit.components.v2.component_manager import BidiComponentManager
+from streamlit.components.v2.component_registry import BidiComponentDefinition
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+
+
+def _setup_manager_with_manifest(tmp_path: Path) -> tuple[BidiComponentManager, str]:
+    """Set up a BidiComponentManager with a manifest-backed component.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        A temporary path to create the component package and assets.
+
+    Returns
+    -------
+    tuple[BidiComponentManager, str]
+        A tuple containing the component manager and the component name.
+    """
+    manager = BidiComponentManager()
+
+    package_root = tmp_path / "pkg"
+    assets = package_root / "assets"
+    (assets / "js").mkdir(parents=True)
+    (assets / "js" / "main.js").write_text("console.log('ok');")
+    (assets / "style.css").write_text(".x{color:red}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="comp", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    comp_name = "pkg.comp"
+    manager.register(BidiComponentDefinition(name=comp_name, html="<div>ok</div>"))
+    return manager, comp_name
+
+
+def test_manager_uses_lock_for_api_inputs(tmp_path: Path) -> None:
+    """Verify manager exposes a lock and handles inputs safely during updates."""
+    manager, comp_name = _setup_manager_with_manifest(tmp_path)
+
+    # The manager is expected to expose an _api_inputs_lock used to guard access.
+    assert hasattr(manager, "_api_inputs_lock"), (
+        "BidiComponentManager must define _api_inputs_lock to guard _api_inputs"
+    )
+
+    # Exercise calls to ensure no exceptions and that state updates correctly
+    manager.record_api_inputs(comp_name, css="*.css", js="js/*.js")
+    manager._on_components_changed([comp_name])
+
+    d = manager.get(comp_name)
+    assert d is not None
+    assert d.html_content == "<div>ok</div>"
+
+
+def test_concurrent_record_and_change_no_exceptions(tmp_path: Path) -> None:
+    """Stress concurrent access to record_api_inputs and change handling.
+
+    This validates that under concurrent use there are no exceptions and the
+    registry remains consistent. This will still pass without a lock in CPython
+    in many cases due to the GIL, but combined with the lock assertion test
+    above, we get stronger guarantees.
+    """
+    manager, comp_name = _setup_manager_with_manifest(tmp_path)
+
+    stop_event = threading.Event()
+    errors: list[BaseException] = []
+
+    def writer() -> None:
+        try:
+            while not stop_event.is_set():
+                manager.record_api_inputs(comp_name, css="*.css", js="js/*.js")
+        except BaseException as e:  # pragma: no cover - diagnostic capture
+            errors.append(e)
+
+    def reader() -> None:
+        try:
+            while not stop_event.is_set():
+                manager._on_components_changed([comp_name])
+        except BaseException as e:  # pragma: no cover - diagnostic capture
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+    for t in threads:
+        t.start()
+
+    time.sleep(0.2)
+    stop_event.set()
+    for t in threads:
+        t.join(timeout=2)
+
+    assert not errors, f"Unexpected errors under concurrency: {errors}"
+
+    # Registry remains valid
+    d = manager.get(comp_name)
+    assert d is not None
+    assert d.html_content == "<div>ok</div>"
+
+
+def test_get_component_path_prefers_asset_dir_when_present() -> None:
+    """Verify manager returns manifest asset_dir over registry paths."""
+    manager = BidiComponentManager()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        # Create a registry-backed JS file in dir A
+        dir_a = tmp_path / "dir_a"
+        dir_a.mkdir(parents=True)
+        js_a = dir_a / "index.js"
+        js_a.write_text("console.log('A');")
+
+        # Register component with file-backed JS path (registry fallback)
+        comp_name = "pkg.slider"
+        manager.register(
+            BidiComponentDefinition(
+                name=comp_name,
+                js=str(js_a),
+            )
+        )
+
+        # Prepare manifest-declared asset_dir (dir B)
+        package_root = tmp_path / "package"
+        assets_b = package_root / "assets"
+        assets_b.mkdir(parents=True)
+        (assets_b / "index.js").write_text("console.log('B');")
+
+        manifest = ComponentManifest(
+            name="pkg",
+            version="0.0.1",
+            components=[ComponentConfig(name="slider", asset_dir="assets")],
+        )
+
+        # Register manifest; manager should now prefer asset_dir
+        manager.register_from_manifest(manifest, package_root)
+
+        got = manager.get_component_path(comp_name)
+        assert got is not None
+        assert os.path.realpath(got) == os.path.realpath(str(assets_b))
+
+
+def test_register_from_manifest_does_not_require_asset_dir() -> None:
+    """Verify registering a component without asset_dir works."""
+    manager = BidiComponentManager()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        package_root = tmp_path / "package"
+        package_root.mkdir(parents=True)
+
+        manifest = ComponentManifest(
+            name="pkg",
+            version="0.0.1",
+            components=[ComponentConfig(name="no_assets")],
+        )
+        manager.register_from_manifest(manifest, package_root)
+
+        asset_root = manager.get_component_path("pkg.no_assets")
+        assert asset_root is None
+
+
+def test_on_components_changed_preserves_html_and_resolves_assets(
+    tmp_path: Path,
+) -> None:
+    """Verify recompute preserves html and resolves assets under asset_dir."""
+    manager = BidiComponentManager()
+
+    # Prepare manifest with asset_dir
+    package_root = tmp_path / "package"
+    assets = package_root / "assets"
+    (assets / "js").mkdir(parents=True)
+    (assets / "style.css").write_text(".x { color: red; }")
+    (assets / "js" / "main.js").write_text("console.log('ok');")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    comp_name = "pkg.slider"
+
+    # Existing definition with html to be preserved during recompute
+    manager.register(BidiComponentDefinition(name=comp_name, html="<p>orig</p>"))
+
+    # Record API inputs as globs resolved relative to asset_dir
+    manager.record_api_inputs(comp_name, css="*.css", js="js/*.js")
+
+    # Trigger change handler for this component
+    manager._on_components_changed([comp_name])
+
+    # Validate outcome in the registry
+    d = manager.get(comp_name)
+    assert d is not None
+    assert d.html_content == "<p>orig</p>"
+    # File-backed entries expose asset-dir-relative URLs
+    assert d.css_url == "style.css"
+    assert d.js_url == "js/main.js"
+    # Content properties must be None for file-backed entries
+    assert d.css_content is None
+    assert d.js_content is None

--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -16,15 +16,20 @@ from __future__ import annotations
 
 import os
 import tempfile
+import threading
+import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_path_utils import ComponentPathUtils
 from streamlit.components.v2.component_registry import (
     BidiComponentDefinition,
     BidiComponentRegistry,
 )
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
 from streamlit.errors import StreamlitComponentRegistryError
 
 
@@ -334,6 +339,26 @@ def temp_test_files() -> dict:
     temp_dir.cleanup()
 
 
+@pytest.fixture
+def temp_manager_setup() -> dict:
+    """Create a temporary directory and manager for BidiComponentManager tests."""
+    temp_dir = tempfile.TemporaryDirectory()
+    component_manager = BidiComponentManager()
+
+    # Create test files
+    js_path = os.path.join(temp_dir.name, "index.js")
+    with open(js_path, "w") as f:
+        f.write("console.log('test');")
+
+    yield {
+        "temp_dir": temp_dir,
+        "component_manager": component_manager,
+        "js_path": js_path,
+    }
+
+    temp_dir.cleanup()
+
+
 def test_string_content() -> None:
     """Test component instantiation with direct string content."""
     comp = BidiComponentDefinition(
@@ -417,6 +442,250 @@ def test_mixed_content(temp_test_files) -> None:
     assert comp.source_paths["js"] == os.path.dirname(temp_test_files["js_path"])
 
 
+def test_register_from_manifest_basic(temp_manager_setup) -> None:
+    """Test basic manifest registration with a single component.
+
+    Note
+    ----
+    JS/CSS entries in the manifest are ignored.
+    """
+    setup = temp_manager_setup
+    # Create component files in package root
+    package_root = Path(setup["temp_dir"].name)
+    # Files may exist but are not read from manifest anymore
+    (package_root / "component.js").write_text(
+        "export default function() { console.log('basic test'); }"
+    )
+    (package_root / "styles.css").write_text(".test { color: blue; }")
+
+    manifest = ComponentManifest(
+        name="test_package",
+        version="1.0.0",
+        components=[
+            ComponentConfig(
+                name="basic_component",
+            )
+        ],
+    )
+
+    setup["component_manager"].register_from_manifest(manifest, package_root)
+
+    # Check component was registered
+    component = setup["component_manager"].get("test_package.basic_component")
+    assert component is not None
+    assert component.name == "test_package.basic_component"
+    # Assert that html/js/css are None because they must be provided via the
+    # st.components.v2.component() API
+    assert component.html_content is None
+    assert component.js_content is None
+    assert component.css_content is None
+
+    # Check metadata was stored
+    assert (
+        setup["component_manager"].get_metadata("test_package.basic_component")
+        == manifest
+    )
+
+
+def test_register_from_manifest_multiple_components(temp_manager_setup) -> None:
+    """Test manifest registration with multiple components."""
+    setup = temp_manager_setup
+    package_root = Path(setup["temp_dir"].name)
+
+    # Create files (not used by manifest anymore)
+    (package_root / "comp1.js").write_text("console.log('component 1');")
+    (package_root / "comp1.css").write_text(".comp1 { background: red; }")
+    (package_root / "comp2.js").write_text("console.log('component 2');")
+
+    manifest = ComponentManifest(
+        name="multi_package",
+        version="2.0.0",
+        components=[
+            ComponentConfig(
+                name="component_one",
+            ),
+            ComponentConfig(
+                name="component_two",
+            ),
+        ],
+    )
+
+    setup["component_manager"].register_from_manifest(manifest, package_root)
+
+    # Check first component was registered
+    comp1 = setup["component_manager"].get("multi_package.component_one")
+    assert comp1 is not None
+    assert comp1.name == "multi_package.component_one"
+    assert comp1.html_content is None
+    assert comp1.js_content is None
+    assert comp1.css_content is None
+
+    # Check second component was registered
+    comp2 = setup["component_manager"].get("multi_package.component_two")
+    assert comp2 is not None
+    assert comp2.name == "multi_package.component_two"
+    assert comp2.html_content is None
+    assert comp2.js_content is None
+    assert comp2.css_content is None
+
+    # Check both components have same manifest metadata
+    assert (
+        setup["component_manager"].get_metadata("multi_package.component_one")
+        == manifest
+    )
+    assert (
+        setup["component_manager"].get_metadata("multi_package.component_two")
+        == manifest
+    )
+
+
+def test_register_from_manifest_minimal_component(temp_manager_setup) -> None:
+    """Test manifest registration with a minimal component (only HTML)."""
+    setup = temp_manager_setup
+    package_root = Path(setup["temp_dir"].name)
+
+    manifest = ComponentManifest(
+        name="minimal_package",
+        version="0.1.0",
+        components=[ComponentConfig(name="html_only")],
+    )
+
+    setup["component_manager"].register_from_manifest(manifest, package_root)
+
+    # Check component was registered
+    component = setup["component_manager"].get("minimal_package.html_only")
+    assert component is not None
+    assert component.name == "minimal_package.html_only"
+    assert component.html_content is None
+    assert component.js_content is None
+    assert component.css_content is None
+
+    # Check metadata
+    assert (
+        setup["component_manager"].get_metadata("minimal_package.html_only") == manifest
+    )
+
+
+def test_register_from_manifest_empty_components(temp_manager_setup) -> None:
+    """Test that manifest registration handles an empty components list."""
+    setup = temp_manager_setup
+    package_root = Path(setup["temp_dir"].name)
+
+    manifest = ComponentManifest(
+        name="empty_package",
+        version="1.0.0",
+        components=[],
+    )
+
+    setup["component_manager"].register_from_manifest(manifest, package_root)
+
+
+def test_register_from_manifest_overwrites_existing(temp_manager_setup) -> None:
+    """Verify that manifest registration overwrites existing components."""
+    setup = temp_manager_setup
+    package_root = Path(setup["temp_dir"].name)
+    js_file = package_root / "component.js"
+    js_file.write_text("console.log('original');")
+
+    # Register first version
+    manifest1 = ComponentManifest(
+        name="test_package",
+        version="1.0.0",
+        components=[
+            ComponentConfig(
+                name="component",
+            )
+        ],
+    )
+
+    setup["component_manager"].register_from_manifest(manifest1, package_root)
+
+    # Check first registration
+    component = setup["component_manager"].get("test_package.component")
+    assert component.html_content is None
+
+    # Register updated version
+    js_file.write_text("console.log('updated');")
+    manifest2 = ComponentManifest(
+        name="test_package",
+        version="2.0.0",
+        components=[
+            ComponentConfig(
+                name="component",
+            )
+        ],
+    )
+
+    with patch("streamlit.logger.get_logger") as mock_logger:
+        setup["component_manager"].register_from_manifest(manifest2, package_root)
+
+        # Should not log warning for manifest registration (different from manual registration)
+        mock_logger.return_value.warning.assert_not_called()
+
+    # Check component was updated
+    updated_component = setup["component_manager"].get("test_package.component")
+    assert updated_component.html_content is None
+    assert (
+        setup["component_manager"].get_metadata("test_package.component") == manifest2
+    )
+
+
+def test_register_from_manifest_thread_safety(temp_manager_setup) -> None:
+    """Verify that manifest registration is thread-safe."""
+    setup = temp_manager_setup
+    package_root = Path(setup["temp_dir"].name)
+    js_file = package_root / "thread_test.js"
+    js_file.write_text("console.log('thread test');")
+
+    results = []
+    errors = []
+
+    def register_manifest(thread_id: int) -> None:
+        try:
+            manifest = ComponentManifest(
+                name=f"thread_package_{thread_id}",
+                version="1.0.0",
+                components=[
+                    ComponentConfig(
+                        name="thread_component",
+                    )
+                ],
+            )
+
+            # Add small delay to increase chance of race conditions
+            time.sleep(0.01)
+
+            setup["component_manager"].register_from_manifest(manifest, package_root)
+            results.append(thread_id)
+
+        except Exception as e:
+            errors.append(e)
+
+    # Create multiple threads
+    threads = []
+    for i in range(5):
+        thread = threading.Thread(target=register_manifest, args=(i,))
+        threads.append(thread)
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+
+    # Check all threads completed successfully
+    assert len(errors) == 0
+    assert len(results) == 5
+    assert set(results) == {0, 1, 2, 3, 4}
+
+    # Check all components were registered
+    for i in range(5):
+        component = setup["component_manager"].get(
+            f"thread_package_{i}.thread_component"
+        )
+        assert component is not None
+        assert component.html_content is None
+
+
 def test_resolve_glob_pattern_direct() -> None:
     """Test the `ComponentPathUtils.resolve_glob_pattern` function directly."""
 
@@ -457,6 +726,38 @@ def test_resolve_glob_pattern_direct() -> None:
         assert "Absolute paths are not allowed" in str(exc_info.value)
 
 
+@pytest.fixture
+def component_manager():
+    """Create a fresh BidiComponentManager for testing."""
+    return BidiComponentManager()
+
+
+def test_basic_registration(component_manager) -> None:
+    """Test basic component registration via `BidiComponentManager`."""
+    definition = BidiComponentDefinition(
+        name="test_component",
+        html="<div>Test</div>",
+        js="console.log('test');",
+    )
+
+    component_manager.register(definition)
+
+    retrieved = component_manager.get("test_component")
+    assert retrieved == definition
+
+
+def test_file_watching_state_tracking(component_manager) -> None:
+    """Verify that file watching state is correctly tracked."""
+    # Initially, file watching should not be started
+    assert not component_manager.is_file_watching_started
+
+    # The state should remain consistent with the file watcher
+    assert (
+        component_manager.is_file_watching_started
+        == component_manager._file_watcher.is_watching_active
+    )
+
+
 def test_glob_pattern_resolution() -> None:
     """Test glob pattern resolution via `ComponentPathUtils`."""
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -495,6 +796,38 @@ def test_glob_pattern_no_matches_error() -> None:
 
         with pytest.raises(StreamlitComponentRegistryError):
             ComponentPathUtils.resolve_glob_pattern("*.js", temp_path)
+
+
+@patch("streamlit.watcher.path_watcher.get_default_path_watcher_class")
+def test_file_watching_starts(mock_path_watcher_class) -> None:
+    """Verify that file watching starts correctly in."""
+    mock_watcher_instance = MagicMock()
+    mock_path_watcher_class.return_value.return_value = mock_watcher_instance
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test file
+        js_file = temp_path / "component.js"
+        js_file.write_text("console.log('test');")
+
+        # Create mock manifest with glob pattern
+        manifest = ComponentManifest(
+            name="test_package",
+            version="1.0.0",
+            components=[ComponentConfig(name="test_component")],
+        )
+
+        # Create manager and register from manifest
+        manager = BidiComponentManager()
+        manager.register_from_manifest(manifest, temp_path)
+
+        # Start file watching
+        manager.start_file_watching()
+
+        # No watchers should be created from manifest-only data
+        assert not manager.is_file_watching_started
+        mock_path_watcher_class.return_value.assert_not_called()
 
 
 def test_security_validation() -> None:

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -25,6 +25,10 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytest
 
 from streamlit.components.lib.local_component_registry import LocalComponentRegistry
+from streamlit.components.v2.component_manager import BidiComponentManager
+from streamlit.components.v2.component_registry import (
+    BidiComponentDefinition,
+)
 from streamlit.runtime import (
     Runtime,
     RuntimeConfig,
@@ -593,3 +597,55 @@ time.sleep(5)
         event_based_path_watcher._MultiPathWatcher._singleton = None
         assert expected_loads == ok
         assert expected_msg == msg
+
+
+class BidiComponentManagerTest(unittest.TestCase):
+    """Test that the BidiComponentManager is properly initialized in the runtime."""
+
+    def tearDown(self) -> None:
+        # Clear the singleton instance after each test
+        Runtime._instance = None
+
+    def test_bidi_component_registry_initialization(self):
+        """Test that the BidiComponentManager is properly initialized."""
+        # Create a mock config with minimum required parameters
+        config = RuntimeConfig(
+            script_path="test_path",
+            command_line=None,
+            media_file_storage=MagicMock(),
+            uploaded_file_manager=MagicMock(),
+        )
+
+        # Initialize the runtime
+        runtime = Runtime(config)
+
+        # Verify that the BidiComponentManager is initialized
+        assert runtime.bidi_component_registry is not None
+        assert isinstance(runtime.bidi_component_registry, BidiComponentManager)
+
+    def test_custom_bidi_component_registry(self):
+        """Test that a custom BidiComponentManager can be provided to the runtime."""
+        # Create a custom component manager
+        custom_component_manager = BidiComponentManager()
+        custom_component_manager.register(
+            BidiComponentDefinition(
+                name="test_component",
+                html="<div>Test</div>",
+            )
+        )
+
+        # Create a mock config with our custom registry
+        config = RuntimeConfig(
+            script_path="test_path",
+            command_line=None,
+            media_file_storage=MagicMock(),
+            uploaded_file_manager=MagicMock(),
+            bidi_component_registry=custom_component_manager,
+        )
+
+        # Initialize the runtime
+        runtime = Runtime(config)
+
+        # Verify that our custom component manager is used
+        assert runtime.bidi_component_registry is custom_component_manager
+        assert runtime.bidi_component_registry.get("test_component") is not None


### PR DESCRIPTION
## Describe your changes

- Adds a new `BidiComponentManager` class that centralizes component management for bidirectional components. This manager composes three key responsibilities:
  1. Registry management via `BidiComponentRegistry`
  2. Manifest handling via `ComponentManifestHandler`
  3. File watching via `ComponentFileWatcher`
- The point of the `BidiComponentManager` is that all actions go through the Manager, which is responsible for delegating to its composed classes as needed.
  - This Manager is instantiated in the `Runtime` for access throughout the typical Streamlit runtime.
- Adds a component definition resolver that centralizes the logic for interpreting js/css inputs as inline content vs path/glob strings, validating them against a component's asset directory, and producing a `BidiComponentDefinition` with correct asset-relative URLs for security.

## Testing Plan

- Unit Tests: Added comprehensive tests in `test_component_manager_asset_dir.py` and `test_bidi_component_registry.py` that verify:
  - Asset directory resolution and preference
  - Component registration from manifests
  - File change handling and definition recomputation
  - Registry update behavior

- Updated existing tests in `test_component_registry.py` to reflect the new update mechanism

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.