### PR TITLE
[feat] Add BidiComponentRequestHandler and wire it up to the Server

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -386,6 +386,7 @@ img-src 'self' https: data: blob:;
 media-src 'self' https: data: blob:;
 connect-src ws://localhost:{app_port}/_stcore/stream
     {app_url}/_stcore/component/
+    {app_url}/_stcore/bidi-components/
     {app_url}/component/
     {app_url}/_stcore/upload_file/
     {app_url}/_stcore/host-config

--- a/lib/streamlit/web/server/bidi_component_request_handler.py
+++ b/lib/streamlit/web/server/bidi_component_request_handler.py
@@ -1,0 +1,193 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serve static assets for Custom Components v2.
+
+This module defines a Tornado ``RequestHandler`` that serves static files for
+Custom Components v2 from their registered component directories. Requests are
+resolved safely within the component's root to avoid directory traversal and are
+served with appropriate content type and cache headers. CORS headers are applied
+based on the server configuration.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Final, cast
+
+import tornado.web
+
+import streamlit.web.server.routes
+from streamlit.logger import get_logger
+from streamlit.web.server.component_file_utils import (
+    build_safe_abspath,
+    guess_content_type,
+)
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+_LOGGER: Final = get_logger(__name__)
+
+
+class BidiComponentRequestHandler(tornado.web.RequestHandler):
+    """Request handler for serving Custom Components v2 static assets.
+
+    The handler resolves a requested path to a registered component's asset
+    within its component root, writes the file contents to the response, and
+    sets appropriate ``Content-Type`` and cache headers. If the component or
+    asset cannot be found, a suitable HTTP status is returned.
+    """
+
+    def initialize(self, component_manager: BidiComponentManager) -> None:
+        """Initialize the handler with the given component manager.
+
+        Parameters
+        ----------
+        component_manager : BidiComponentManager
+            Manager used to look up registered components and their root paths.
+        """
+        self._component_manager = component_manager
+
+    def get(self, path: str) -> None:
+        """Serve a component asset for the given URL path.
+
+        The first path segment is interpreted as the component name. The rest
+        of the path is resolved to a file within that component's root
+        directory. If the file exists and is readable, its bytes are written to
+        the response and the ``Content-Type`` header is set based on the file
+        type.
+
+        Parameters
+        ----------
+        path : str
+            Request path in the form ``"<component_name>/<relative_file>"``.
+
+        Notes
+        -----
+        This method writes directly to the response and sets appropriate HTTP
+        status codes on error (``404`` for missing components/files, ``403`` for
+        forbidden paths).
+        """
+        parts = path.split("/")
+        component_name = parts[0]
+        component_def = self._component_manager.get(component_name)
+        if component_def is None:
+            self.write("not found")
+            self.set_status(404)
+            return
+
+        # Get the component path from the component manager
+        component_path = self._component_manager.get_component_path(component_name)
+        if component_path is None:
+            self.write("not found")
+            self.set_status(404)
+            return
+
+        # Build a safe absolute path within the component root
+        filename = "/".join(parts[1:])
+        # If no file segment is provided (e.g. only component name or trailing slash),
+        # treat as not found rather than attempting to open a directory.
+        if not filename or filename.endswith("/"):
+            self.write("not found")
+            self.set_status(404)
+            return
+        abspath = build_safe_abspath(component_path, filename)
+        if abspath is None:
+            self.write("forbidden")
+            self.set_status(403)
+            return
+
+        # If the resolved path is a directory, return 404 not found.
+        if os.path.isdir(abspath):
+            self.write("not found")
+            self.set_status(404)
+            return
+
+        try:
+            with open(abspath, "rb") as file:
+                contents = file.read()
+        except OSError:
+            sanitized_abspath = abspath.replace("\n", "").replace("\r", "")
+            _LOGGER.exception(
+                "BidiComponentRequestHandler: GET %s read error", sanitized_abspath
+            )
+            self.write("read error")
+            self.set_status(404)
+            return
+
+        self.write(contents)
+        self.set_header("Content-Type", guess_content_type(abspath))
+
+        self.set_extra_headers(path)
+
+    def set_extra_headers(self, path: str) -> None:
+        """Disable cache for HTML files.
+
+        We assume other assets like JS and CSS are suffixed with their hash, so
+        they can be cached indefinitely.
+        """
+        if path.endswith(".html"):
+            self.set_header("Cache-Control", "no-cache")
+        else:
+            self.set_header("Cache-Control", "public")
+
+    def set_default_headers(self) -> None:
+        """Set default CORS headers based on server configuration.
+
+        If cross-origin requests are fully allowed, ``Access-Control-Allow-
+        Origin`` is set to ``"*"``. Otherwise, if the request ``Origin`` header
+        is an allowed origin, the header is echoed back.
+        """
+        if streamlit.web.server.routes.allow_all_cross_origin_requests():
+            self.set_header("Access-Control-Allow-Origin", "*")
+        elif streamlit.web.server.routes.is_allowed_origin(
+            origin := self.request.headers.get("Origin")
+        ):
+            self.set_header("Access-Control-Allow-Origin", cast("str", origin))
+
+    def options(self) -> None:
+        """Handle preflight CORS requests.
+
+        Returns
+        -------
+        None
+            Responds with HTTP ``204 No Content`` to indicate that the actual
+            request can proceed.
+        """
+        self.set_status(204)
+        self.finish()
+
+    @staticmethod
+    def get_url(file_id: str) -> str:
+        """Return the URL for a component asset identified by ``file_id``.
+
+        Parameters
+        ----------
+        file_id : str
+            Component file identifier (typically a relative path or hashed
+            filename).
+
+        Returns
+        -------
+        str
+            Relative URL path for the resource, to be joined with the server
+            base URL.
+
+        Examples
+        --------
+        >>> BidiComponentRequestHandler.get_url("my_component/main.js")
+        '_stcore/bidi-components/my_component/main.js'
+        """
+        return f"_stcore/bidi-components/{file_id}"

--- a/lib/streamlit/web/server/component_file_utils.py
+++ b/lib/streamlit/web/server/component_file_utils.py
@@ -1,0 +1,97 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Utilities for safely resolving component asset paths and content types.
+
+These helpers are used by server handlers to construct safe absolute paths for
+component files and to determine the appropriate ``Content-Type`` header for
+responses. Path resolution prevents directory traversal by normalizing and
+checking real paths against a component's root directory.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+from typing import Final
+
+_OCTET_STREAM: Final[str] = "application/octet-stream"
+
+
+def build_safe_abspath(component_root: str, relative_url_path: str) -> str | None:
+    """Build an absolute path inside ``component_root`` if safe.
+
+    The function joins ``relative_url_path`` with ``component_root`` and
+    normalizes and resolves symlinks. If the resulting path escapes the
+    component root, ``None`` is returned to indicate a forbidden traversal.
+
+    Parameters
+    ----------
+    component_root : str
+        Absolute path to the component's root directory.
+    relative_url_path : str
+        Relative URL path from the component root to the requested file.
+
+    Returns
+    -------
+    str or None
+        The resolved absolute path if it stays within ``component_root``;
+        otherwise ``None`` when the path would traverse outside the root.
+    """
+    root_real = os.path.realpath(component_root)
+    candidate = os.path.normpath(os.path.join(root_real, relative_url_path))
+    candidate_real = os.path.realpath(candidate)
+
+    try:
+        # Ensure the candidate stays within the real component root
+        if os.path.commonpath([root_real, candidate_real]) != root_real:
+            return None
+    except ValueError:
+        # On some platforms, commonpath can raise if drives differ; treat as forbidden.
+        return None
+
+    return candidate_real
+
+
+def guess_content_type(abspath: str) -> str:
+    """Guess the HTTP ``Content-Type`` for a file path.
+
+    This logic mirrors Tornado's ``StaticFileHandler`` by respecting encoding
+    metadata from ``mimetypes.guess_type`` and falling back to
+    ``application/octet-stream`` when no specific type can be determined.
+
+    Parameters
+    ----------
+    abspath : str
+        Absolute file path used for type detection (only the suffix matters).
+
+    Returns
+    -------
+    str
+        Guessed content type string suitable for the ``Content-Type`` header.
+    """
+    mime_type, encoding = mimetypes.guess_type(abspath)
+    # per RFC 6713, use the appropriate type for a gzip compressed file
+    if encoding == "gzip":
+        return "application/gzip"
+    # As of 2015-07-21 there is no bzip2 encoding defined at
+    # http://www.iana.org/assignments/media-types/media-types.xhtml
+    # So for that (and any other encoding), use octet-stream.
+    if encoding is not None:
+        return _OCTET_STREAM
+    if mime_type is not None:
+        return mime_type
+    # if mime_type not detected, use application/octet-stream
+    return _OCTET_STREAM

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -14,14 +14,16 @@
 
 from __future__ import annotations
 
-import mimetypes
-import os
 from typing import TYPE_CHECKING, Final, cast
 
 import tornado.web
 
 import streamlit.web.server.routes
 from streamlit.logger import get_logger
+from streamlit.web.server.component_file_utils import (
+    build_safe_abspath,
+    guess_content_type,
+)
 
 if TYPE_CHECKING:
     from streamlit.components.types.base_component_registry import BaseComponentRegistry
@@ -42,13 +44,10 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             self.set_status(404)
             return
 
-        # follow symlinks to get an accurate normalized path
-        component_root = os.path.realpath(component_root)
+        # Build a safe absolute path within the component root
         filename = "/".join(parts[1:])
-        abspath = os.path.normpath(os.path.join(component_root, filename))
-
-        # Do NOT expose anything outside of the component root.
-        if os.path.commonpath([component_root, abspath]) != component_root:
+        abspath = build_safe_abspath(component_root, filename)
+        if abspath is None:
             self.write("forbidden")
             self.set_status(403)
             return
@@ -100,19 +99,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         """Returns the ``Content-Type`` header to be used for this request.
         From tornado.web.StaticFileHandler.
         """
-        mime_type, encoding = mimetypes.guess_type(abspath)
-        # per RFC 6713, use the appropriate type for a gzip compressed file
-        if encoding == "gzip":
-            return "application/gzip"
-        # As of 2015-07-21 there is no bzip2 encoding defined at
-        # http://www.iana.org/assignments/media-types/media-types.xhtml
-        # So for that (and any other encoding), use octet-stream.
-        if encoding is not None:
-            return "application/octet-stream"
-        if mime_type is not None:
-            return mime_type
-        # if mime_type not detected, use application/octet-stream
-        return "application/octet-stream"
+        return guess_content_type(abspath)
 
     @staticmethod
     def get_url(file_id: str) -> str:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -38,6 +38,9 @@ from streamlit.web.cache_storage_manager_config import (
     create_default_cache_storage_manager,
 )
 from streamlit.web.server.app_static_file_handler import AppStaticFileHandler
+from streamlit.web.server.bidi_component_request_handler import (
+    BidiComponentRequestHandler,
+)
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
@@ -133,6 +136,7 @@ UNIX_SOCKET_PREFIX: Final = "unix://"
 # as the endpoints in frontend/connection/src/DefaultStreamlitEndpoints
 MEDIA_ENDPOINT: Final = "/media"
 COMPONENT_ENDPOINT: Final = "/component"
+BIDI_COMPONENT_ENDPOINT: Final = "/_stcore/bidi-components"
 STATIC_SERVING_ENDPOINT: Final = "/app/static"
 UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
@@ -394,6 +398,11 @@ class Server:
                 make_url_path_regex(base, f"{COMPONENT_ENDPOINT}/(.*)"),
                 ComponentRequestHandler,
                 {"registry": self._runtime.component_registry},
+            ),
+            (
+                make_url_path_regex(base, f"{BIDI_COMPONENT_ENDPOINT}/(.*)"),
+                BidiComponentRequestHandler,
+                {"component_manager": self._runtime.bidi_component_registry},
             ),
         ]
 

--- a/lib/tests/streamlit/web/server/bidi_component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/bidi_component_request_handler_test.py
@@ -1,0 +1,241 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import tornado.testing
+import tornado.web
+
+from streamlit.components.v2.component_manager import BidiComponentManager
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+from streamlit.web.server.bidi_component_request_handler import (
+    BidiComponentRequestHandler,
+)
+from tests.testutil import patch_config_options
+
+
+class BidiComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def setUp(self) -> None:
+        self.component_manager = BidiComponentManager()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        super().setUp()
+
+        # Create a fake package root with a component asset_dir
+        self.package_root = Path(self.temp_dir.name) / "pkgroot"
+        self.package_root.mkdir(parents=True, exist_ok=True)
+
+        self.component_assets_dir = self.package_root / "test_component"
+        self.component_assets_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create assets
+        (self.component_assets_dir / "index.js").write_text(
+            "console.log('test component');"
+        )
+        (self.component_assets_dir / "index.html").write_text(
+            "<div>Test Component</div>"
+        )
+        (self.component_assets_dir / "styles.css").write_text("div { color: red; }")
+        # Create a subdirectory to validate directory path handling
+        (self.component_assets_dir / "subdir").mkdir(parents=True, exist_ok=True)
+
+        # Register from a manifest that declares the asset_dir
+        manifest = ComponentManifest(
+            name="pkg",
+            version="0.0.1",
+            components=[
+                ComponentConfig(name="test_component", asset_dir="test_component")
+            ],
+        )
+        self.component_manager.register_from_manifest(manifest, self.package_root)
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    def get_app(self) -> tornado.web.Application:
+        return tornado.web.Application(
+            [
+                (
+                    r"/_stcore/bidi-components/(.*)",
+                    BidiComponentRequestHandler,
+                    {"component_manager": self.component_manager},
+                )
+            ]
+        )
+
+    def test_get_component_file(self) -> None:
+        # JS should be accessible
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component/index.js")
+        assert response.code == 200
+        assert response.body.decode() == "console.log('test component');"
+
+        # HTML files should be accessible
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component/index.html")
+        assert response.code == 200
+        assert response.body.decode() == "<div>Test Component</div>"
+
+        # CSS should be accessible
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component/styles.css")
+        assert response.code == 200
+        assert response.body.decode() == "div { color: red; }"
+
+    def test_component_not_found(self) -> None:
+        response = self.fetch("/_stcore/bidi-components/nonexistent_component/index.js")
+        assert response.code == 404
+
+        response = self.fetch(
+            "/_stcore/bidi-components/pkg.nonexistent_component/index.js"
+        )
+        assert response.code == 404
+
+    def test_disallow_path_traversal(self) -> None:
+        # Attempt path traversal attack
+        response = self.fetch(
+            "/_stcore/bidi-components/pkg.test_component/../../../etc/passwd"
+        )
+        assert response.code == 403
+
+    def test_file_not_found_in_component_dir(self) -> None:
+        response = self.fetch(
+            "/_stcore/bidi-components/pkg.test_component/nonexistent.js"
+        )
+        assert response.code == 404
+
+    def test_get_url(self) -> None:
+        url = BidiComponentRequestHandler.get_url("pkg.test_component/index.js")
+        assert url == "_stcore/bidi-components/pkg.test_component/index.js"
+
+    def test_missing_file_segment_returns_404_not_found(self) -> None:
+        """Requesting component without a file should return 404 not found."""
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component")
+        assert response.code == 404
+        assert response.body == b"not found"
+
+    def test_trailing_slash_returns_404_not_found(self) -> None:
+        """Requesting component with trailing slash should return 404 not found."""
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component/")
+        assert response.code == 404
+        assert response.body == b"not found"
+
+    def test_directory_path_returns_404_not_found(self) -> None:
+        """Requesting a directory within component should return 404 not found."""
+        response = self.fetch("/_stcore/bidi-components/pkg.test_component/subdir/")
+        assert response.code == 404
+        assert response.body == b"not found"
+
+    def test_cors_all_origins_star(self) -> None:
+        """When CORS allows all, Access-Control-Allow-Origin should be '*'."""
+        with mock.patch(
+            "streamlit.web.server.routes.allow_all_cross_origin_requests",
+            mock.MagicMock(return_value=True),
+        ):
+            response = self.fetch(
+                "/_stcore/bidi-components/pkg.test_component/index.js"
+            )
+        assert response.code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    @mock.patch(
+        "streamlit.web.server.routes.allow_all_cross_origin_requests",
+        mock.MagicMock(return_value=False),
+    )
+    @patch_config_options({"server.corsAllowedOrigins": ["http://example.com"]})
+    def test_cors_allowlisted_origin_echo(self) -> None:
+        """When origin is allowlisted, it should be echoed in the header."""
+        response = self.fetch(
+            "/_stcore/bidi-components/pkg.test_component/index.js",
+            headers={"Origin": "http://example.com"},
+        )
+        assert response.code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
+
+
+class BidiComponentRequestHandlerAssetDirTest(tornado.testing.AsyncHTTPTestCase):
+    def setUp(self) -> None:  # type: ignore[override]
+        self.manager = BidiComponentManager()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        super().setUp()
+
+        # Prepare a package with asset_dir and a file to be served
+        self.package_root = Path(self.temp_dir.name) / "pkg"
+        self.package_root.mkdir(parents=True, exist_ok=True)
+        self.assets_dir = self.package_root / "assets"
+        self.assets_dir.mkdir(parents=True, exist_ok=True)
+
+        self.js_file_path = self.assets_dir / "bundle.js"
+        with open(self.js_file_path, "w") as f:
+            f.write("console.log('served from asset_dir');")
+
+        manifest = ComponentManifest(
+            name="pkg",
+            version="0.0.1",
+            components=[ComponentConfig(name="slider", asset_dir="assets")],
+        )
+        self.manager.register_from_manifest(manifest, self.package_root)
+
+    def tearDown(self) -> None:  # type: ignore[override]
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    def get_app(self) -> tornado.web.Application:  # type: ignore[override]
+        return tornado.web.Application(
+            [
+                (
+                    r"/_stcore/bidi-components/(.*)",
+                    BidiComponentRequestHandler,
+                    {"component_manager": self.manager},
+                )
+            ]
+        )
+
+    def test_serves_within_asset_dir(self) -> None:
+        """Handler should serve files under manifest-declared asset_dir."""
+        resp = self.fetch("/_stcore/bidi-components/pkg.slider/bundle.js")
+        assert resp.code == 200
+        assert resp.body.decode() == "console.log('served from asset_dir');"
+
+    def test_forbids_traversal_outside_asset_dir(self) -> None:
+        """Traversal outside asset_dir is forbidden and returns 403."""
+        resp = self.fetch("/_stcore/bidi-components/pkg.slider/../../etc/passwd")
+        assert resp.code == 403
+
+    def test_absolute_path_injection_forbidden(self) -> None:
+        """Absolute path injection via double-slash should be forbidden (403)."""
+        # When the requested filename begins with a slash due to a double-slash in the URL,
+        # joining with the component root would otherwise discard the root. We must reject it.
+        resp = self.fetch("/_stcore/bidi-components/pkg.slider//etc/passwd")
+        assert resp.code == 403
+
+    def test_symlink_escape_outside_asset_dir_forbidden(self) -> None:
+        """Symlink in asset_dir pointing outside should be forbidden (403)."""
+        # Create a real file outside of the component asset_dir
+        outside_file = Path(self.temp_dir.name) / "outside.js"
+        outside_file.write_text("console.log('outside');")
+
+        # Create a symlink inside the asset_dir pointing to the outside file
+        link_path = self.assets_dir / "link_out.js"
+        try:
+            # On Windows, creating symlinks may require elevated permissions; skip if unsupported
+            os.symlink(outside_file, link_path)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlinks not supported in this environment")
+
+        # Attempt to fetch the symlinked file via the handler
+        resp = self.fetch("/_stcore/bidi-components/pkg.slider/link_out.js")
+        assert resp.code == 403

--- a/lib/tests/streamlit/web/server/component_file_utils_test.py
+++ b/lib/tests/streamlit/web/server/component_file_utils_test.py
@@ -1,0 +1,206 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from streamlit.web.server.component_file_utils import (
+    build_safe_abspath,
+    guess_content_type,
+)
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    """Create an isolated component root with a single file inside."""
+    root_dir = tmp_path / "root"
+    root_dir.mkdir(parents=True, exist_ok=True)
+    (root_dir / "inside.txt").write_text("ok")
+    return root_dir
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expect_allowed"),
+    [
+        pytest.param("inside.txt", True, id="inside_ok"),
+        pytest.param("../etc/passwd", False, id="relative_traversal_forbidden"),
+        pytest.param(
+            os.sep + "etc" + os.sep + "passwd", False, id="absolute_injection_forbidden"
+        ),
+    ],
+)
+def test_path_security_cases(root: Path, candidate: str, expect_allowed: bool) -> None:
+    """Validate safe path resolution and forbidden cases (relative and absolute traversal).
+
+    Parameters
+    ----------
+    root
+        Temporary component root directory fixture.
+    candidate
+        Relative URL path candidate to resolve under the component root.
+    expect_allowed
+        Whether the candidate is expected to resolve inside the root.
+    """
+    abspath = build_safe_abspath(str(root), candidate)
+    if expect_allowed:
+        assert abspath is not None
+        assert Path(abspath).read_text() == "ok"
+    else:
+        assert abspath is None
+
+
+def test_rejects_symlink_escape(root: Path, tmp_path: Path) -> None:
+    """Rejects a symlink inside root that points outside root."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope")
+    link_inside = root / "link.txt"
+    try:
+        os.symlink(outside, link_inside)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported in this environment")
+
+    abspath = build_safe_abspath(str(root), "link.txt")
+    assert abspath is None
+
+
+def test_commonpath_valueerror_treated_as_forbidden(root: Path) -> None:
+    """When os.path.commonpath raises ValueError (e.g., cross-drive), treat as forbidden."""
+    with mock.patch(
+        "streamlit.web.server.component_file_utils.os.path.commonpath"
+    ) as m:
+        m.side_effect = ValueError("different drives")
+        abspath = build_safe_abspath(str(root), "inside.txt")
+        assert abspath is None
+
+
+def test_symlink_within_root_allowed(root: Path) -> None:
+    """Allows a symlink that targets a file within the same root directory.
+
+    This ensures we don't over-block legitimate symlinked resources that resolve
+    inside the component root after ``realpath`` resolution.
+    """
+    target = root / "inside.txt"
+    link_inside = root / "alias.txt"
+    try:
+        os.symlink(target, link_inside)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported in this environment")
+
+    abspath = build_safe_abspath(str(root), "alias.txt")
+    assert abspath is not None
+    assert Path(abspath).read_text() == "ok"
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expect"),
+    [
+        pytest.param(
+            "", lambda root: os.path.realpath(str(root)), id="empty_means_root"
+        ),
+        pytest.param(
+            ".", lambda root: os.path.realpath(str(root)), id="dot_means_root"
+        ),
+        pytest.param(
+            os.path.join("sub", "..", "inside.txt"),
+            lambda root: os.path.realpath(str(root / "inside.txt")),
+            id="normalized_parent_segments",
+        ),
+        pytest.param(
+            os.path.join("does", "not", "exist.txt"),
+            lambda root: os.path.realpath(str(root / "does" / "not" / "exist.txt")),
+            id="nonexistent_inside_root",
+        ),
+    ],
+)
+def test_normalization_and_nonexistent_paths(
+    root: Path, candidate: str, expect
+) -> None:  # type: ignore[no-untyped-def]
+    """Normalizes candidates and allows non-existent paths that remain inside root.
+
+    The helper under test does not enforce existence; it only enforces that the
+    resolved path stays within the component root.
+    """
+    abspath = build_safe_abspath(str(root), candidate)
+    assert abspath is not None
+    assert abspath == expect(root)
+
+
+def test_component_root_is_symlink(tmp_path: Path) -> None:
+    """Supports a component root that itself is a symlink to a real directory."""
+    real_root = tmp_path / "real_root"
+    real_root.mkdir(parents=True, exist_ok=True)
+    (real_root / "inside.txt").write_text("ok")
+    link_root = tmp_path / "root_link"
+    try:
+        os.symlink(real_root, link_root)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported in this environment")
+
+    abspath = build_safe_abspath(str(link_root), "inside.txt")
+    assert abspath == os.path.realpath(str(real_root / "inside.txt"))
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        pytest.param("file.js.gz", "application/gzip", id="gzip_encoding_overrides"),
+        pytest.param("file.svgz", "application/gzip", id="svgz_is_gzip"),
+    ],
+)
+def test_guess_content_type_gzip(path: str, expected: str) -> None:
+    """Returns application/gzip when encoding is gzip, regardless of base type."""
+    assert guess_content_type(path) == expected
+
+
+def test_guess_content_type_other_encoding_bzip2() -> None:
+    """Falls back to octet-stream when an encoding other than gzip is detected."""
+    # .bz2 is commonly recognized with encoding "bzip2" across platforms
+    assert guess_content_type("archive.tar.bz2") == "application/octet-stream"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_prefix"),
+    [
+        pytest.param("note.txt", "text/plain", id="plain_text"),
+        pytest.param("image.png", "image/png", id="png_image"),
+        pytest.param("script.js", "application/javascript", id="javascript"),
+    ],
+)
+def test_guess_content_type_basic_types(path: str, expected_prefix: str) -> None:
+    """Returns the detected mime type when there is no content encoding.
+
+    We accept that the exact string can vary slightly across Python versions or
+    platforms (e.g., application/javascript vs text/javascript), so for types
+    known to be stable we check equality, and for JavaScript we assert a prefix.
+    """
+    mime = guess_content_type(path)
+    if path.endswith(".js"):
+        assert (
+            mime.endswith("javascript") and mime.startswith("application")
+        ) or mime.startswith("text")
+    else:
+        assert mime == expected_prefix
+
+
+def test_guess_content_type_unknown_extension() -> None:
+    """Returns octet-stream for unknown or unregistered file extensions."""
+    assert (
+        guess_content_type("file.somethingreallyrandomext")
+        == "application/octet-stream"
+    )

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -15,7 +15,10 @@
 from __future__ import annotations
 
 import mimetypes
+import os
+import tempfile
 import threading
+from pathlib import Path
 from unittest import mock
 
 import tornado.testing
@@ -185,6 +188,61 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 404
         assert response.body == b"read error"
+
+    def test_directory_request_results_in_read_error(self) -> None:
+        """Requesting a directory (trailing slash) should result in 404 read error."""
+
+        with mock.patch(MOCK_IS_DIR_PATH):
+            declare_component("test", path=PATH)
+
+        response = self._request_component(
+            "tests.streamlit.web.server.component_request_handler_test.test/"
+        )
+
+        assert response.code == 404
+        assert response.body == b"read error"
+
+    def test_missing_file_segment_results_in_read_error(self) -> None:
+        """Requesting component without a file should result in 404 read error."""
+
+        with mock.patch(MOCK_IS_DIR_PATH):
+            declare_component("test", path=PATH)
+
+        response = self._request_component(
+            "tests.streamlit.web.server.component_request_handler_test.test"
+        )
+
+        assert response.code == 404
+        assert response.body == b"read error"
+
+    def test_symlink_escape_outside_component_root_forbidden(self) -> None:
+        """Symlink inside component directory pointing outside should be forbidden (403)."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            comp_root = Path(tmpdir)
+            comp_root.mkdir(parents=True, exist_ok=True)
+
+            outside_dir = Path(tempfile.mkdtemp())
+            outside_file = outside_dir / "outside.js"
+            outside_file.write_text("console.log('outside');")
+
+            link_path = comp_root / "link_out.js"
+            try:
+                os.symlink(outside_file, link_path)
+            except (OSError, NotImplementedError):
+                self.skipTest("Symlinks not supported in this environment")
+
+            # Register the component with the real directory
+            declare_component("symlink", path=str(comp_root))
+
+            # Use the fully-qualified component name pattern used in other tests
+            fq_comp = (
+                "tests.streamlit.web.server.component_request_handler_test.symlink"
+            )
+            response = self._request_component(f"{fq_comp}/link_out.js")
+
+            assert response.code == 403
+            assert response.body == b"forbidden"
 
     def test_support_binary_files_request(self):
         """Test support for binary files reads."""


### PR DESCRIPTION
## Describe your changes

Added support for bidirectional component file serving with a new `BidiComponentRequestHandler`. This handler serves static files from component asset directories, similar to the existing `ComponentRequestHandler`, but works with the CCv2 registry.

Key additions:
- Created `BidiComponentRequestHandler` to serve files from bidirectional component asset directories
- Added `component_file_utils.py` with shared utility functions for safe path handling and content type detection
- Refactored `ComponentRequestHandler` to use the new shared utilities
- Added the `/bidi-components/` endpoint to the server routes
- Implemented comprehensive tests for the new handler

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive test suite in `bidi_component_request_handler_test.py` that verifies:
  - Proper file serving from component asset directories
  - 404 responses for non-existent components
  - Prevention of path traversal attacks
  - Correct URL generation
  - Proper handling of asset directories specified in component manifests

- The implementation reuses proven patterns from the existing component handler, with shared utilities extracted to ensure consistent behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.