### PR TITLE
[feat] Add Presenter to Session State

### DIFF
--- a/lib/streamlit/runtime/state/presentation.py
+++ b/lib/streamlit/runtime/state/presentation.py
@@ -1,0 +1,85 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from streamlit.logger import get_logger
+
+_LOGGER: Final = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from streamlit.runtime.state.session_state import SessionState
+
+
+def apply_presenter(
+    session_state: SessionState, widget_id: str, base_value: Any
+) -> Any:
+    """Return the user-visible value for a widget if it has a ``presenter``.
+
+    If the widget's metadata defines a ``presenter`` callable, it is used to
+    transform the stored value into its presentation form. Any exception raised
+    while resolving metadata or invoking the presenter is swallowed and
+    ``base_value`` is returned, so presentation never interferes with core
+    behavior.
+
+    Notes
+    -----
+    Presentation is applied exclusively for user-facing access paths such as:
+    - `st.session_state[... ]` via `SessionState.__getitem__`
+    - `SessionState.filtered_state`
+
+    Internal serialization paths (for example `WStates.as_widget_states()` and
+    `SessionState.get_widget_states()`) must operate on base (unpresented)
+    values to ensure stable and lossless serialization. Do not use
+    `apply_presenter` in serialization code paths.
+
+    Parameters
+    ----------
+    session_state : SessionState
+        The current session state object that holds widget state and metadata.
+    widget_id : str
+        The identifier of the widget whose value is being presented.
+    base_value : Any
+        The raw value stored for the widget.
+
+    Returns
+    -------
+    Any
+        The value that should be shown to the user.
+    """
+
+    try:
+        meta = session_state._get_widget_metadata(widget_id)
+        presenter = getattr(meta, "presenter", None) if meta is not None else None
+        if presenter is None:
+            return base_value
+
+        # Ensure the presenter is callable to avoid silently failing on a
+        # TypeError when attempting to invoke a non-callable value.
+        if not callable(presenter):
+            _LOGGER.warning(
+                "Widget '%s' has a non-callable presenter (%r); returning base value.",
+                widget_id,
+                presenter,
+            )
+            return base_value
+        try:
+            return presenter(base_value, session_state)
+        except Exception:
+            return base_value
+    except Exception:
+        # If metadata is unavailable or any other error occurs, degrade gracefully.
+        return base_value

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -42,6 +42,7 @@ from streamlit.runtime.state.common import (
     is_element_id,
     is_keyed_element_id,
 )
+from streamlit.runtime.state.presentation import apply_presenter
 from streamlit.runtime.state.query_params import QueryParams
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 
@@ -399,7 +400,7 @@ class SessionState:
 
     @property
     def filtered_state(self) -> dict[str, Any]:
-        """The combined session and widget state, excluding keyless widgets."""
+        """The combined session and widget state, excluding keyless widgets and internal widgets."""
 
         wid_key_map = self._key_id_mapper.id_key_mapping
 
@@ -412,9 +413,10 @@ class SessionState:
         for k in self._keys():
             if not is_element_id(k) and not _is_internal_key(k):
                 state[k] = self[k]
-            elif is_keyed_element_id(k):
+            elif is_keyed_element_id(k) and not _is_internal_key(k):
                 try:
                     key = wid_key_map[k]
+                    # Value returned by __getitem__ is already presented.
                     state[key] = self[k]
                 except KeyError:
                     # Widget id no longer maps to a key, it is a not yet
@@ -464,7 +466,12 @@ class SessionState:
             # the "key" is a raw widget id, so get its associated user key for lookup
             key = wid_key_map[widget_id]
         try:
-            return self._getitem(widget_id, key)
+            base_value = self._getitem(widget_id, key)
+            return (
+                apply_presenter(self, widget_id, base_value)
+                if widget_id is not None
+                else base_value
+            )
         except KeyError:
             raise KeyError(_missing_key_error_message(key))
 
@@ -660,6 +667,10 @@ class SessionState:
                 )
             )
         }
+
+    def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
+        """Return the metadata for a widget id from the current widget state."""
+        return self._new_widget_state.widget_metadata.get(widget_id)
 
     def _set_widget_metadata(self, widget_metadata: WidgetMetadata[Any]) -> None:
         """Set a widget's metadata."""

--- a/lib/tests/streamlit/runtime/state/test_presentation.py
+++ b/lib/tests/streamlit/runtime/state/test_presentation.py
@@ -1,0 +1,237 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from streamlit.runtime.state.common import WidgetMetadata
+from streamlit.runtime.state.presentation import apply_presenter
+from streamlit.runtime.state.session_state import SessionState
+
+
+class _FakeWStates:
+    def __init__(self) -> None:
+        self.widget_metadata: dict[str, Any] = {}
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self._new_widget_state = _FakeWStates()
+
+    def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
+        return self._new_widget_state.widget_metadata.get(widget_id)
+
+
+def test_apply_presenter_returns_base_when_no_meta() -> None:
+    """Return base value unchanged when widget metadata is missing."""
+    ss = _FakeSession()
+    base = {"value": 1}
+    out = apply_presenter(ss, "wid", base)
+    assert out is base
+
+
+def test_apply_presenter_returns_base_when_no_presenter() -> None:
+    """Return base value unchanged when metadata has no presenter."""
+    ss = _FakeSession()
+    ss._new_widget_state.widget_metadata["wid"] = SimpleNamespace()
+    base = [1, 2, 3]
+    out = apply_presenter(ss, "wid", base)
+    assert out is base
+
+
+def test_apply_presenter_applies_presenter() -> None:
+    """Apply the registered presenter to the base value."""
+
+    def _presenter(base: Any, _ss: Any) -> Any:
+        return {"presented": base}
+
+    ss = _FakeSession()
+    ss._new_widget_state.widget_metadata["wid"] = SimpleNamespace(presenter=_presenter)
+    base = {"value": 123}
+    out = apply_presenter(ss, "wid", base)
+    assert out == {"presented": {"value": 123}}
+
+
+def test_apply_presenter_swallows_presenter_errors() -> None:
+    """Return base value unchanged if presenter raises an exception."""
+
+    def _boom(_base: Any, _ss: Any) -> Any:
+        raise RuntimeError("boom")
+
+    ss = _FakeSession()
+    ss._new_widget_state.widget_metadata["wid"] = SimpleNamespace(presenter=_boom)
+    base = "hello"
+    out = apply_presenter(ss, "wid", base)
+    assert out is base
+
+
+def test_presenter_applied_once_via_getitem_and_filtered_state() -> None:
+    """Presenter must be applied exactly once for both __getitem__ and filtered_state.
+
+    We simulate a widget with a user key mapping and attach a presenter that wraps
+    the base value in a dict. Double application would produce nested wrapping.
+    """
+
+    ss = SessionState()
+
+    # Simulate a widget with element id and user key mapping
+    widget_id = "$$ID-abc-ukey"
+    user_key = "ukey"
+
+    # Register metadata with a no-op deserializer/serializer for a simple string
+    meta = WidgetMetadata[str](
+        id=widget_id,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="string_value",
+    )
+    ss._set_widget_metadata(meta)
+    ss._set_key_widget_mapping(widget_id, user_key)
+
+    # Set the underlying widget value in new widget state
+    ss._new_widget_state.set_from_value(widget_id, "base")
+
+    # Install a presenter that wraps once
+    def _wrap_once(base: Any, _ss: Any) -> Any:
+        return {"presented": base}
+
+    # Attach presenter to metadata store
+    ss._new_widget_state.widget_metadata[widget_id] = SimpleNamespace(
+        id=widget_id,
+        deserializer=meta.deserializer,
+        serializer=meta.serializer,
+        value_type=meta.value_type,
+        presenter=_wrap_once,
+    )
+
+    # Access via __getitem__ using the widget id; should apply once
+    got = ss[widget_id]
+    assert got == {"presented": "base"}
+
+    # Access via filtered_state using the user key; should apply once
+    filtered = ss.filtered_state
+    assert filtered[user_key] == {"presented": "base"}
+
+
+def test_get_widget_states_uses_base_value_not_presented() -> None:
+    """Serialized widget states must contain base (unpresented) values.
+
+    This ensures presentation is only applied for user-facing access via
+    `st.session_state[...]` and `filtered_state`, while serialization stays
+    lossless and stable.
+    """
+
+    ss = SessionState()
+
+    # Create widget metadata for a simple string and register mapping.
+    widget_id = "$$ID-abc-ukey"
+    user_key = "ukey"
+    meta = WidgetMetadata[str](
+        id=widget_id,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="string_value",
+    )
+    ss._set_widget_metadata(meta)
+    ss._set_key_widget_mapping(widget_id, user_key)
+
+    # Underlying base value stored in widget state.
+    base_value = "raw"
+    ss._new_widget_state.set_from_value(widget_id, base_value)
+
+    # Presenter that would wrap the base value if applied.
+    def _wrap(base: Any, _ss: Any) -> Any:
+        return {"presented": base}
+
+    # Attach presenter on metadata store (simulating element registration that
+    # enriches the metadata entry).
+    ss._new_widget_state.widget_metadata[widget_id] = SimpleNamespace(
+        id=widget_id,
+        deserializer=meta.deserializer,
+        serializer=meta.serializer,
+        value_type=meta.value_type,
+        presenter=_wrap,
+    )
+
+    # Verify that user-facing access applies presentation.
+    assert ss[widget_id] == {"presented": base_value}
+
+    # Now get serialized widget states; these should contain the base value
+    # via the `string_value` field and not the presented wrapper.
+    states = ss.get_widget_states()
+    assert len(states) == 1
+    st = states[0]
+    # Ensure we serialized as string_value and not JSON or other wrappers
+    assert st.WhichOneof("value") == "string_value"
+    assert st.string_value == base_value
+
+
+def test_filtered_state_includes_keyed_element_when_not_internal() -> None:
+    """filtered_state includes user key for keyed element ids when not internal."""
+
+    ss = SessionState()
+
+    widget_id = "$$ID-abc-ukey"
+    user_key = "ukey"
+
+    # Minimal metadata and value
+    meta = WidgetMetadata[str](
+        id=widget_id,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="string_value",
+    )
+    ss._set_widget_metadata(meta)
+    ss._new_widget_state.set_from_value(widget_id, "base")
+    ss._set_key_widget_mapping(widget_id, user_key)
+
+    filtered = ss.filtered_state
+    assert user_key in filtered
+    assert filtered[user_key] == "base"
+
+
+def test_filtered_state_excludes_keyed_element_when_internal(monkeypatch) -> None:
+    """filtered_state excludes entries when _is_internal_key(k) is True for the id."""
+
+    import streamlit.runtime.state.session_state as ss_mod
+
+    ss = SessionState()
+
+    widget_id = "$$ID-internal-ukey"
+    user_key = "ukey"
+
+    meta = WidgetMetadata[str](
+        id=widget_id,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="string_value",
+    )
+    ss._set_widget_metadata(meta)
+    ss._new_widget_state.set_from_value(widget_id, "base")
+    ss._set_key_widget_mapping(widget_id, user_key)
+
+    # Patch _is_internal_key to treat this widget_id as internal
+    original = ss_mod._is_internal_key
+    monkeypatch.setattr(
+        ss_mod,
+        "_is_internal_key",
+        lambda k: True if k == widget_id else original(k),
+        raising=True,
+    )
+
+    filtered = ss.filtered_state
+    assert user_key not in filtered


### PR DESCRIPTION
## Describe your changes

Added a presentation layer for widget values in session state. This allows widgets to define a `presenter` callable that transforms the stored value into a user-visible form when accessed through `st.session_state`. The presentation logic is applied when values are retrieved via `__getitem__` or through `filtered_state`.

Key features:
- Created a new `apply_presenter` function that handles the transformation
- Integrated presentation into the session state access paths
- Ensured presentation is applied exactly once for both direct access and filtered state
- Added robust error handling to ensure presentation never interferes with core behavior

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): Added comprehensive tests in `test_presentation.py` that verify:
  - Base values are returned unchanged when metadata or presenter is missing
  - Presenters are correctly applied to transform values
  - Exceptions in presenters are properly handled
  - Presentation is applied exactly once when accessing values through different paths

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.