### PR TITLE
Make threading better: auto-add context, join() before script done

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -40,6 +40,7 @@ from streamlit.runtime.scriptrunner.exec_code import (
     modified_sys_path,
 )
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+from streamlit.runtime.scriptrunner.thread import ScriptThread
 from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
     StopException,
@@ -263,7 +264,7 @@ class ScriptRunner:
         self._execing = False
 
         # This is initialized in the start() method
-        self._script_thread: threading.Thread | None = None
+        self._script_thread: ScriptThread | None = None
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -300,7 +301,7 @@ class ScriptRunner:
         if self._script_thread is not None:
             raise RuntimeError("ScriptRunner was already started")
 
-        self._script_thread = threading.Thread(
+        self._script_thread = ScriptThread(
             target=self._run_script_thread,
             name="ScriptRunner.scriptThread",
         )
@@ -367,6 +368,7 @@ class ScriptRunner:
             pages_manager=self._pages_manager,
             context_info=None,
         )
+
         add_script_run_ctx(threading.current_thread(), ctx)
 
         request = self._requests.on_scriptrunner_ready()
@@ -380,7 +382,9 @@ class ScriptRunner:
 
         if request.type != ScriptRequestType.STOP:
             raise RuntimeError(
-                f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
+                f"Unrecognized ScriptRequestType: {
+                    request.type
+                }. This should never happen."
             )
 
         # Send a SHUTDOWN event before exiting, so some state can be saved
@@ -447,7 +451,9 @@ class ScriptRunner:
 
         if request.type != ScriptRequestType.STOP:
             raise RuntimeError(
-                f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
+                f"Unrecognized ScriptRequestType: {
+                    request.type
+                }. This should never happen."
             )
         raise StopException()
 
@@ -485,7 +491,8 @@ class ScriptRunner:
         while True:
             _LOGGER.debug("Running script %s", rerun_data)
             start_time: float = timer()
-            prep_time: float = 0  # This will be overwritten once preparations are done.
+            # This will be overwritten once preparations are done.
+            prep_time: float = 0
 
             if not rerun_data.fragment_id_queue:
                 # Don't clear session refs for media files if we're running a fragment.
@@ -671,6 +678,9 @@ class ScriptRunner:
                             new_fragment_ids=ctx.new_fragment_ids
                         )
 
+                    cast(
+                        "ScriptThread", threading.current_thread()
+                    ).wait_for_subthreads()
                     self._session_state.maybe_check_serializable()
                     # check for control requests, e.g. rerun requests have arrived
                     self._maybe_handle_execution_control_request()

--- a/lib/streamlit/runtime/scriptrunner/thread.py
+++ b/lib/streamlit/runtime/scriptrunner/thread.py
@@ -1,0 +1,160 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, cast
+
+_OrigThread = threading.Thread  # pyright: ignore
+_OrigTimer = threading.Timer  # pyright: ignore
+
+
+def replace_thread_classes() -> None:
+    """Replace Python's threading.Thread an threading.Timer with our versions.
+
+    The originals are stored in _OrigThread and _OrigTimer.
+    """
+    threading.Thread = StreamlitThread  # type: ignore[assignment,misc] # ty: ignore[invalid-assignment]
+    threading.Timer = StreamlitTimer  # type: ignore[assignment,misc] # ty: ignore[invalid-assignment]
+
+
+class ScriptThread(threading.Thread):
+    """Thread class used for Streamlit script runs.
+
+    This class only exists so we can keep track of threads created by the Streamlit
+    developer, in order for us to join() them all before the script thread concludes.
+
+    For this to work, all threads created by the developer must be of type StreamlitThread,
+    which is a special type that registers itself in this class's self._subthreads when
+    started.
+    """
+
+    def __init__(
+        self,
+        group: None = None,
+        target: Callable[..., Any] | None = None,
+        name: str | None = None,
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+    ) -> None:
+        super().__init__(
+            group=group,
+            target=target,
+            name=name,
+            args=args,
+            kwargs=kwargs,
+            daemon=daemon,
+        )
+        self._root_thread: ScriptThread = self
+        self._subthreads: set[StreamlitThread] = set()
+
+    def register_subthread(self, subthread: StreamlitThread) -> None:
+        self._subthreads.add(subthread)
+
+    def unregister_subthread(self, subthread: StreamlitThread) -> None:
+        self._subthreads.remove(subthread)
+
+    def wait_for_subthreads(self) -> None:
+        while subthreads := self._get_subthreads_to_wait_for():
+            for child in subthreads:
+                child.join()
+
+                # Give the loop a little breathing time so it doesn't block other threads.
+                time.sleep(0.05)
+
+    def _get_subthreads_to_wait_for(self) -> list[StreamlitThread]:
+        return [t for t in self._subthreads if t.is_alive() and not t.daemon]
+
+
+class StreamlitThread(threading.Thread):
+    """Thread class that replaces threading.Thread, so it will be used by developers
+    inside Streamlit apps.
+    """
+
+    def __init__(
+        self,
+        group: None = None,
+        target: Callable[..., Any] | None = None,
+        name: str | None = None,
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+    ) -> None:
+        super().__init__(
+            group=group,
+            target=target,
+            name=name,
+            args=args,
+            kwargs=kwargs,
+            daemon=daemon,
+        )
+        self._init_subthread_properties()
+
+    def start(self) -> None:
+        self._before_start()
+        return super().start()
+
+    def run(self) -> None:
+        super().run()
+        self._after_run()
+
+    def _init_subthread_properties(self) -> None:
+        curr_thread = cast("StreamlitThread", threading.current_thread())
+        self._is_script_subthread = hasattr(curr_thread, "_root_thread")
+        self._root_thread: ScriptThread | None = getattr(
+            curr_thread, "_root_thread", None
+        )
+        self._ctx = None
+
+    def _before_start(self) -> None:
+        if self._is_script_subthread:
+            from streamlit.runtime.scriptrunner import add_script_run_ctx
+
+            add_script_run_ctx(thread=self)
+
+        if self._root_thread:
+            self._root_thread.register_subthread(self)
+
+    def _after_run(self) -> None:
+        if self._root_thread:
+            self._root_thread.unregister_subthread(self)
+
+
+class StreamlitTimer(threading.Timer, StreamlitThread):
+    """Timer class that replaces threading.Timer, so it will be used by developers
+    inside Streamlit apps.
+    """
+
+    def __init__(
+        self,
+        interval: float,
+        function: Callable[..., Any],
+        args: tuple[Any, ...] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(interval, function, args, kwargs)
+        self._init_subthread_properties()
+
+    def start(self) -> None:
+        self._before_start()
+        return super().start()
+
+    def run(self) -> None:
+        super().run()
+        self._after_run()

--- a/lib/streamlit/runtime/scriptrunner/thread.py
+++ b/lib/streamlit/runtime/scriptrunner/thread.py
@@ -23,7 +23,7 @@ _OrigTimer = threading.Timer  # pyright: ignore
 
 
 def replace_thread_classes() -> None:
-    """Replace Python's threading.Thread an threading.Timer with our versions.
+    """Replace Python's threading.Thread and threading.Timer with our versions.
 
     The originals are stored in _OrigThread and _OrigTimer.
     """

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -22,6 +22,7 @@ from typing import Any, Final
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
 from streamlit.logger import get_logger
+from streamlit.runtime.scriptrunner.thread import replace_thread_classes
 from streamlit.watcher import report_watchdog_availability, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket, server_util
 
@@ -282,6 +283,7 @@ def run(
     _fix_sys_argv(main_script_path, args)
     _fix_pydeck_mapbox_api_warning()
     _install_config_watchers(flag_options)
+    replace_thread_classes()
 
     # Create the server. It won't start running yet.
     server = Server(main_script_path, is_hello)


### PR DESCRIPTION
## Describe your changes

Two improvements to threading in Streamlit:
1. When the developer creates a new thread, auto-add Streamlit's context to that thread
   - For this, the PR replaces `threading.Thread` with a subclass of it (called `StreamlitThread`) which adds the script run context to the thread work for you automatically. 
1. When the script thread is done, wait for all non-daemon threads in that session to end before ending the script thread. This emulates Python's own behavior with stand-alone scripts.
   - For this, the PR makes the script thread run with a special `ScriptThread` class that keeps track of all `StreamlitThreads` created in that script run, and then `join()`s them at the end.
   - TODO: Need to decide if this is desirable or not. On the one hand, this makes Streamlit act like regular Python, but on the other it might break existing scripts that use threading and rely on the current un-Python-like behavior (need to check). 

## GitHub Issue Link (if applicable)

?

## Testing Plan

No tests yet! I'll add before merging.

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
