### PR TITLE
[AdvancedLayouts] Modernize width and height for st.area_chart and st.bar_chart

### DIFF
--- a/e2e_playwright/st_area_chart.py
+++ b/e2e_playwright/st_area_chart.py
@@ -64,7 +64,7 @@ st.area_chart(df)
 st.area_chart(df, x="a")
 st.area_chart(df, y="a")
 st.area_chart(df, y=["a", "b"])
-st.area_chart(df, x="a", y="b", height=500, width=300, use_container_width=False)
+st.area_chart(df, x="a", y="b", height=500, width=300)
 st.area_chart(df, x="b", y="a")
 st.area_chart(df, x="a", y=["b", "c"])
 st.area_chart(utc_df)
@@ -81,7 +81,7 @@ st.area_chart(source, x="date", y="count", color="series", stack="normalize")
 st.area_chart(source, x="date", y="count", color="series", stack="center")
 
 # Test that add_rows maintains original styling params:
-# color, width, height, use_container_width, horizontal, stack
+# color, width, height, horizontal, stack
 area_data = pd.DataFrame({"Area 1": [], "Area 2": []})
 
 empty_area = st.area_chart(
@@ -91,7 +91,6 @@ empty_area = st.area_chart(
     width=600,
     height=300,
     stack="center",
-    use_container_width=False,
 )
 
 if st.button("Add data to Area Chart"):

--- a/e2e_playwright/st_bar_chart.py
+++ b/e2e_playwright/st_bar_chart.py
@@ -64,7 +64,7 @@ st.bar_chart(df)
 st.bar_chart(df, x="a")
 st.bar_chart(df, y="a")
 st.bar_chart(df, y=["a", "b"])
-st.bar_chart(df, x="a", y="b", height=500, width=300, use_container_width=False)
+st.bar_chart(df, x="a", y="b", height=500, width=300)
 st.bar_chart(df, x="b", y="a")
 st.bar_chart(df, x="a", y=["b", "c"])
 st.bar_chart(utc_df)
@@ -95,7 +95,7 @@ st.bar_chart(
 st.bar_chart(df, x="b", y="a", sort="a", horizontal=True)  # horizontal, sort by values
 
 # Test that add_rows maintains original styling params:
-# color, width, height, use_container_width, horizontal, stack
+# color, width, height, horizontal, stack
 bar_data = pd.DataFrame({"Bar 1": [], "Bar 2": []})
 
 empty_bar = st.bar_chart(
@@ -106,7 +106,6 @@ empty_bar = st.bar_chart(
     height=300,
     stack=False,
     horizontal=True,
-    use_container_width=False,
 )
 
 if st.button("Add data to Bar Chart"):

--- a/e2e_playwright/st_vega_charts_height.py
+++ b/e2e_playwright/st_vega_charts_height.py
@@ -136,3 +136,17 @@ st.scatter_chart(scatter_df, x="x", y="y", size="size", height="content")
 st.write("Scatter chart with height='stretch':")
 with st.container(border=True, key="test_scatter_height_stretch", height=400):
     st.scatter_chart(scatter_df, x="x", y="y", size="size", height="stretch")
+
+st.write("Bar chart with height='content':")
+st.bar_chart(scatter_df, x="x", y="y", height="content")
+
+st.write("Bar chart with height='stretch':")
+with st.container(border=True, key="test_bar_height_stretch", height=400):
+    st.bar_chart(scatter_df, x="x", y="y", height="stretch")
+
+st.write("Area chart with height='content':")
+st.area_chart(scatter_df, x="x", y="y", height="content")
+
+st.write("Area chart with height='stretch':")
+with st.container(border=True, key="test_area_height_stretch", height=400):
+    st.area_chart(scatter_df, x="x", y="y", height="stretch")

--- a/e2e_playwright/st_vega_charts_height_test.py
+++ b/e2e_playwright/st_vega_charts_height_test.py
@@ -18,7 +18,7 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
 from e2e_playwright.shared.vega_utils import assert_vega_chart_height
 
-VEGA_CHART_COUNT = 12
+VEGA_CHART_COUNT = 16
 
 
 def test_vega_chart_height_behavior(app: Page):
@@ -39,6 +39,10 @@ def test_vega_chart_height_behavior(app: Page):
         468,  # 9: Altair chart with height='stretch' (in 500px container, minus padding)
         350,  # 10: Scatter chart with height='content'
         368,  # 11: Scatter chart with height='stretch' (in 400px container, minus padding)
+        350,  # 12: Bar chart with height='content'
+        368,  # 13: Bar chart with height='stretch' (in 400px container, minus padding)
+        350,  # 12: Area chart with height='content'
+        368,  # 13: Area chart with height='stretch' (in 400px container, minus padding)
     ]
 
     descriptions = [
@@ -54,6 +58,10 @@ def test_vega_chart_height_behavior(app: Page):
         "Altair chart with height='stretch' (in 500px container)",
         "Scatter chart with height='content'",
         "Scatter chart with height='stretch' (in 400px container)",
+        "Bar chart with height='content'",
+        "Bar chart with height='stretch' (in 400px container)",
+        "Area chart with height='content'",
+        "Area chart with height='stretch' (in 400px container)",
     ]
 
     for i, expected_height in enumerate(expected_heights):

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -791,25 +791,6 @@ class VegaChartsMixin:
            height: 440px
 
         """
-        if use_container_width is not None:
-            show_deprecation_warning(
-                make_deprecated_name_warning(
-                    "use_container_width",
-                    "width",
-                    "2025-12-31",
-                    "For `use_container_width=True`, use `width='stretch'`. "
-                    "For `use_container_width=False`, use `width='content'`.",
-                    include_st_prefix=False,
-                ),
-                show_in_browser=False,
-            )
-            if use_container_width:
-                width = "stretch"
-            elif not isinstance(width, int):
-                # This preserves the existing behavior of setting use_container_width
-                # to False combined with an integer width.
-                width = "content"
-
         chart, add_rows_metadata = generate_chart(
             chart_type=ChartType.LINE,
             data=data,
@@ -828,6 +809,7 @@ class VegaChartsMixin:
             "DeltaGenerator",
             self._altair_chart(
                 chart,
+                use_container_width=use_container_width,
                 theme="streamlit",
                 add_rows_metadata=add_rows_metadata,
                 width=width,
@@ -846,9 +828,9 @@ class VegaChartsMixin:
         y_label: str | None = None,
         color: str | Color | list[Color] | None = None,
         stack: bool | ChartStackType | None = None,
-        width: int | None = None,
-        height: int | None = None,
-        use_container_width: bool = True,
+        width: Width = "stretch",
+        height: Height = "content",
+        use_container_width: bool | None = None,
     ) -> DeltaGenerator:
         """Display an area chart.
 
@@ -939,27 +921,37 @@ class VegaChartsMixin:
             - ``"center"``: The areas are stacked and shifted to center their
               baseline, which creates a steamgraph.
 
-        width : int or None
-            Desired width of the chart expressed in pixels. If ``width`` is
-            ``None`` (default), Streamlit sets the width of the chart to fit
-            its contents according to the plotting library, up to the width of
-            the parent container. If ``width`` is greater than the width of the
-            parent container, Streamlit sets the chart width to match the width
-            of the parent container.
+        width : "stretch", "content", or int
+            How to size the chart's width. Can be one of:
 
-            To use ``width``, you must set ``use_container_width=False``.
+            - ``"stretch"`` (default): Expand to the width of the parent container.
+            - ``"content"``: Size the chart to fit its contents, up to the width
+              of the parent container.
+            - An integer: Set the chart width to this many pixels.
 
-        height : int or None
-            Desired height of the chart expressed in pixels. If ``height`` is
-            ``None`` (default), Streamlit sets the height of the chart to fit
-            its contents according to the plotting library.
+        height : "stretch", "content", or int
+            How to size the chart's height. Can be one of:
 
-        use_container_width : bool
-            Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``True`` (default),
-            Streamlit sets the width of the chart to match the width of the
-            parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the chart's width according to ``width``.
+            - ``"content"`` (default): Size the chart to fit its contents.
+            - ``"stretch"``: Expand to the height of the parent container.
+            - An integer: Set the chart height to this many pixels.
+
+        use_container_width : bool or None
+            Whether to override the chart's native width with the width of
+            the parent container. This can be one of the following:
+
+            - ``None`` (default): Streamlit will use the chart's default behavior.
+            - ``True``: Streamlit sets the width of the chart to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the chart to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
+
+            .. deprecated::
+                The ``use_container_width`` parameter is deprecated and will
+                be removed in a future version. Use the ``width`` parameter
+                with ``width="stretch"`` instead of ``use_container_width=True``,
+                and ``width="content"`` instead of ``use_container_width=False``.
 
         Examples
         --------
@@ -1060,7 +1052,6 @@ class VegaChartsMixin:
            height: 440px
 
         """
-
         # Check that the stack parameter is valid, raise more informative error message if not
         maybe_raise_stack_warning(
             stack,
@@ -1090,7 +1081,7 @@ class VegaChartsMixin:
             width=width,
             height=height,
             stack=stack,
-            use_container_width=use_container_width,
+            use_container_width=(width == "stretch"),
         )
         return cast(
             "DeltaGenerator",
@@ -1099,6 +1090,8 @@ class VegaChartsMixin:
                 use_container_width=use_container_width,
                 theme="streamlit",
                 add_rows_metadata=add_rows_metadata,
+                width=width,
+                height=height,
             ),
         )
 
@@ -1115,9 +1108,9 @@ class VegaChartsMixin:
         horizontal: bool = False,
         sort: bool | str = True,
         stack: bool | ChartStackType | None = None,
-        width: int | None = None,
-        height: int | None = None,
-        use_container_width: bool = True,
+        width: Width = "stretch",
+        height: Height = "content",
+        use_container_width: bool | None = None,
     ) -> DeltaGenerator:
         """Display a bar chart.
 
@@ -1228,27 +1221,37 @@ class VegaChartsMixin:
             - ``"center"``: The bars are stacked and shifted to center the
               total height around an axis.
 
-        width : int or None
-            Desired width of the chart expressed in pixels. If ``width`` is
-            ``None`` (default), Streamlit sets the width of the chart to fit
-            its contents according to the plotting library, up to the width of
-            the parent container. If ``width`` is greater than the width of the
-            parent container, Streamlit sets the chart width to match the width
-            of the parent container.
+        width : "stretch", "content", or int
+            How to size the chart's width. Can be one of:
 
-            To use ``width``, you must set ``use_container_width=False``.
+            - ``"stretch"`` (default): Expand to the width of the parent container.
+            - ``"content"``: Size the chart to fit its contents, up to the width
+              of the parent container.
+            - An integer: Set the chart width to this many pixels.
 
-        height : int or None
-            Desired height of the chart expressed in pixels. If ``height`` is
-            ``None`` (default), Streamlit sets the height of the chart to fit
-            its contents according to the plotting library.
+        height : "stretch", "content", or int
+            How to size the chart's height. Can be one of:
 
-        use_container_width : bool
-            Whether to override ``width`` with the width of the parent
-            container. If ``use_container_width`` is ``True`` (default),
-            Streamlit sets the width of the chart to match the width of the
-            parent container. If ``use_container_width`` is ``False``,
-            Streamlit sets the chart's width according to ``width``.
+            - ``"content"`` (default): Size the chart to fit its contents.
+            - ``"stretch"``: Expand to the height of the parent container.
+            - An integer: Set the chart height to this many pixels.
+
+        use_container_width : bool or None
+            Whether to override the chart's native width with the width of
+            the parent container. This can be one of the following:
+
+            - ``None`` (default): Streamlit will use the chart's default behavior.
+            - ``True``: Streamlit sets the width of the chart to match the
+              width of the parent container.
+            - ``False``: Streamlit sets the width of the chart to fit its
+              contents according to the plotting library, up to the width of
+              the parent container.
+
+            .. deprecated::
+                The ``use_container_width`` parameter is deprecated and will
+                be removed in a future version. Use the ``width`` parameter
+                with ``width="stretch"`` instead of ``use_container_width=True``,
+                and ``width="content"`` instead of ``use_container_width=False``.
 
         Examples
         --------
@@ -1366,7 +1369,6 @@ class VegaChartsMixin:
            height: 440px
 
         """
-
         # Check that the stack parameter is valid, raise more informative error message if not
         maybe_raise_stack_warning(
             stack,
@@ -1408,6 +1410,8 @@ class VegaChartsMixin:
                 use_container_width=use_container_width,
                 theme="streamlit",
                 add_rows_metadata=add_rows_metadata,
+                width=width,
+                height=height,
             ),
         )
 
@@ -1624,24 +1628,6 @@ class VegaChartsMixin:
            height: 440px
 
         """
-        if use_container_width is not None:
-            show_deprecation_warning(
-                make_deprecated_name_warning(
-                    "use_container_width",
-                    "width",
-                    "2025-12-31",
-                    "For `use_container_width=True`, use `width='stretch'`. "
-                    "For `use_container_width=False`, use `width='content'` or specify an integer width.",
-                    include_st_prefix=False,
-                ),
-                show_in_browser=False,
-            )
-            if use_container_width:
-                width = "stretch"
-            elif not isinstance(width, int):
-                width = "content"
-                # Otherwise keep the integer width - user explicitly set both use_container_width=False and width=int
-
         chart, add_rows_metadata = generate_chart(
             chart_type=ChartType.SCATTER,
             data=data,
@@ -1659,6 +1645,7 @@ class VegaChartsMixin:
             "DeltaGenerator",
             self._altair_chart(
                 chart,
+                use_container_width=use_container_width,
                 theme="streamlit",
                 add_rows_metadata=add_rows_metadata,
                 width=width,
@@ -1854,25 +1841,6 @@ class VegaChartsMixin:
            height: 450px
 
         """
-        if use_container_width is not None:
-            show_deprecation_warning(
-                make_deprecated_name_warning(
-                    "use_container_width",
-                    "width",
-                    "2025-12-31",
-                    "For `use_container_width=True`, use `width='stretch'`. "
-                    "For `use_container_width=False`, use `width='content'`.",
-                    include_st_prefix=False,
-                ),
-                show_in_browser=False,
-            )
-            if use_container_width:
-                width = "stretch"
-            elif not isinstance(width, int):
-                # This preserves the existing behavior of setting use_container_width
-                # to False combined with an integer width.
-                width = "content"
-
         return self._altair_chart(
             altair_chart=altair_chart,
             width=width,
@@ -2094,25 +2062,6 @@ class VegaChartsMixin:
         translated to the syntax shown above.
 
         """
-        if use_container_width is not None:
-            show_deprecation_warning(
-                make_deprecated_name_warning(
-                    "use_container_width",
-                    "width",
-                    "2025-12-31",
-                    "For `use_container_width=True`, use `width='stretch'`. "
-                    "For `use_container_width=False`, use `width='content'`.",
-                    include_st_prefix=False,
-                ),
-                show_in_browser=False,
-            )
-            if use_container_width:
-                width = "stretch"
-            elif not isinstance(width, int):
-                # This preserves the existing behavior of setting use_container_width
-                # to False combined with an integer width (consistent with line_chart etc).
-                width = "content"
-
         return self._vega_lite_chart(
             data=data,
             spec=spec,
@@ -2136,7 +2085,7 @@ class VegaChartsMixin:
         selection_mode: str | Iterable[str] | None = None,
         add_rows_metadata: AddRowsMetadata | None = None,
         width: Width | None = None,
-        height: Height | None = None,
+        height: Height = "content",
     ) -> DeltaGenerator | VegaLiteState:
         """Internal method to enqueue a vega-lite chart element based on an Altair chart.
 
@@ -2176,7 +2125,7 @@ class VegaChartsMixin:
         selection_mode: str | Iterable[str] | None = None,
         add_rows_metadata: AddRowsMetadata | None = None,
         width: Width | None = None,
-        height: Height | None = None,
+        height: Height = "content",
         **kwargs: Any,
     ) -> DeltaGenerator | VegaLiteState:
         """Internal method to enqueue a vega-lite chart element based on a vega-lite spec.
@@ -2221,7 +2170,8 @@ class VegaChartsMixin:
         if spec is None:
             spec = {}
 
-        # Set the default value for width.
+        # Set the default value for width. Altair and Vega charts have different defaults depending on the chart type,
+        # so they don't default the value in the function signature and width could be None here.
         if use_container_width is None and width is None:
             # Some multi-view charts (facet, horizontal concatenation, and repeat;
             # see https://altair-viz.github.io/user_guide/compound_charts.html)
@@ -2239,6 +2189,29 @@ class VegaChartsMixin:
                 else "content"
             )
 
+        if use_container_width is not None:
+            show_deprecation_warning(
+                make_deprecated_name_warning(
+                    "use_container_width",
+                    "width",
+                    "2025-12-31",
+                    "For `use_container_width=True`, use `width='stretch'`. "
+                    "For `use_container_width=False`, use `width='content'` or specify an integer width.",
+                    include_st_prefix=False,
+                ),
+                show_in_browser=False,
+            )
+            if use_container_width:
+                width = "stretch"
+            elif not isinstance(width, int):
+                # No specific width provided, use content width
+                width = "content"
+                # Otherwise keep the integer width - user explicitly set both use_container_width=False and width=int
+
+        if width is not None:
+            validate_width(width, allow_content=True)
+        validate_height(height, allow_content=True)
+
         vega_lite_proto = ArrowVegaLiteChartProto()
 
         use_container_width_for_spec = (
@@ -2254,11 +2227,6 @@ class VegaChartsMixin:
         if use_container_width is not None:
             vega_lite_proto.use_container_width = use_container_width
         vega_lite_proto.theme = theme or ""
-
-        if width is not None:
-            validate_width(width, allow_content=True)
-        if height is not None:
-            validate_height(height, allow_content=True)
 
         if is_selection_activated:
             # Load the stabilized spec again as a dict:
@@ -2301,38 +2269,23 @@ class VegaChartsMixin:
                 value_type="string_value",
             )
 
-            if width is not None or height is not None:
-                layout_config = LayoutConfig(width=width, height=height)
-                self.dg._enqueue(
-                    "arrow_vega_lite_chart",
-                    vega_lite_proto,
-                    add_rows_metadata=add_rows_metadata,
-                    layout_config=layout_config,
-                )
-            else:
-                self.dg._enqueue(
-                    "arrow_vega_lite_chart",
-                    vega_lite_proto,
-                    add_rows_metadata=add_rows_metadata,
-                )
-            return widget_state.value
-
-        # Handle layout config for width/height parameters
-        if width is not None or height is not None:
             layout_config = LayoutConfig(width=width, height=height)
-            return self.dg._enqueue(
+            self.dg._enqueue(
                 "arrow_vega_lite_chart",
                 vega_lite_proto,
                 add_rows_metadata=add_rows_metadata,
                 layout_config=layout_config,
             )
+            return widget_state.value
 
         # If its not used with selections activated, just return
         # the delta generator related to this element.
+        layout_config = LayoutConfig(width=width, height=height)
         return self.dg._enqueue(
             "arrow_vega_lite_chart",
             vega_lite_proto,
             add_rows_metadata=add_rows_metadata,
+            layout_config=layout_config,
         )
 
     @property

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -2087,6 +2087,8 @@ class ChartWidthHeightTest(DeltaGeneratorTestCase):
     CHART_COMMANDS: ClassVar[list[tuple[Callable, str]]] = [
         (st.line_chart, "line_chart"),
         (st.scatter_chart, "scatter_chart"),
+        (st.bar_chart, "bar_chart"),
+        (st.area_chart, "area_chart"),
     ]
 
     @parameterized.expand(


### PR DESCRIPTION
## Describe your changes

Modernizes `st.area_chart` and `st.bar_chart` to use the new `Height` and `Width` type systems (`"stretch"`, `"content"`, or pixel values) for consistency with other chart elements.

Also begins deprecation of `use_container_width`, which will be removed after 12-31-2025. When explicitly set, `use_container_width=True` maps to `width="stretch"` and `use_container_width=False` maps to `width="content"`.

**Changes Made:**

- **Updated parameter signatures**: 
  - `width`: `int | None = None` → `Width = "stretch"`
  - `height`: `int | None = None` → `Height = "content"`
  - `use_container_width`: `bool = True` → `bool | None = None` (deprecated)
- **Preserved backward compatibility**: Existing integer values and `use_container_width` behavior still work with deprecation warnings
- **Updated layout system**: Uses `LayoutConfig(width=width, height=height)` for consistent layout handling
- **Enhanced validation**: Added proper parameter validation with clear error messages

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python) - Width/height parameter functionality and backward compatibility
- [x] Unit Tests (Python) - `use_container_width` deprecation warnings
- [x] E2E Tests - Visual behavior across `width`/`height` values ("content", "stretch", pixel values)
- [x] Manual testing completed

**Additional Notes:**

Part of the broader AdvancedLayouts initiative to provide consistent width and height APIs across all chart elements.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
