### PR TITLE
Make our Python Altair code thread-safe

### DIFF
--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, Union, cast, overload
@@ -105,6 +106,8 @@ AltairChart: TypeAlias = Union[
     "alt.RepeatChart",
     "alt.VConcatChart",
 ]
+
+altair_globals_lock = threading.Lock()
 
 
 class VegaLiteState(TypedDict, total=False):
@@ -323,7 +326,7 @@ def _marshall_chart_data(
             dataset = proto.datasets.add()
             dataset.name = str(dataset_name)
             dataset.has_name = True
-            # The ID transformer (id_transform function registered before conversion to dict)
+            # The ID transformer (_to_arrow_dataset function registered before conversion to dict)
             # already serializes the data into Arrow IPC format (bytes) when the Altair object
             # gets converted into the vega-lite spec dict.
             # If its already in bytes, we don't need to serialize it here again.
@@ -364,41 +367,46 @@ def _convert_altair_to_vega_lite_spec(
     """Convert an Altair chart object to a Vega-Lite chart spec."""
     import altair as alt
 
+    # alt.themes was deprecated in Altair 5.5.0 in favor of alt.theme
+    if type_util.is_altair_version_less_than("5.5.0"):
+        alt_theme = alt.themes  # ty: ignore[unresolved-attribute]
+    else:
+        alt_theme = alt.theme
+
+    # This is where we'll store Arrow-serialized versions of the chart data.
+    # This happens in _to_arrow_dataset().
+    datasets: dict[str, Any] = {}
+
     # Normally altair_chart.to_dict() would transform the dataframe used by the
     # chart into an array of dictionaries. To avoid that, we install a
     # transformer that replaces datasets with a reference by the object id of
     # the dataframe. We then fill in the dataset manually later on.
+    #
+    # Note: it's OK to re-register this every time we run this function since
+    # transformers are stored in a dict. So there's no duplication.
+    #
+    # type: ignore[arg-type,attr-defined,unused-ignore]
+    alt.data_transformers.register("to_arrow_dataset", _to_arrow_dataset)
 
-    datasets = {}
+    # Settings like alt.theme.enable and alt.data_fransformers.enable are global to all
+    # threads. So this lock makes sure that whatever we set those to only apply to the
+    # current thread.
+    with altair_globals_lock:
+        # The default altair theme has some width/height defaults defined
+        # which are not useful for Streamlit. Therefore, we change the theme to
+        # "none" to avoid those defaults.
+        theme_context = (
+            alt_theme.enable("none") if alt_theme.active == "default" else nullcontext()
+        )
 
-    def id_transform(data: Any) -> dict[str, str]:
-        """Altair data transformer that serializes the data,
-        creates a stable name based on the hash of the data,
-        stores the bytes into the datasets mapping and
-        returns this name to have it be used in Altair.
-        """
-        # Already serialize the data to be able to create a stable
-        # dataset name:
-        data_bytes = dataframe_util.convert_anything_to_arrow_bytes(data)
-        # Use the md5 hash of the data as the name:
-        name = calc_md5(str(data_bytes))
+        data_transformer = alt.data_transformers.enable(
+            "to_arrow_dataset", datasets=datasets
+        )
 
-        datasets[name] = data_bytes
-        return {"name": name}
-
-    alt.data_transformers.register("id", id_transform)  # type: ignore[arg-type,attr-defined,unused-ignore]
-
-    # alt.themes was deprecated in Altair 5.5.0 in favor of alt.theme
-    alt_theme = (
-        alt.themes if type_util.is_altair_version_less_than("5.5.0") else alt.theme  # ty: ignore[unresolved-attribute]
-    )
-
-    # The default altair theme has some width/height defaults defined
-    # which are not useful for Streamlit. Therefore, we change the theme to
-    # "none" to avoid those defaults.
-    with alt_theme.enable("none") if alt_theme.active == "default" else nullcontext():  # ty: ignore
-        with alt.data_transformers.enable("id"):  # type: ignore[attr-defined,unused-ignore]
-            chart_dict = altair_chart.to_dict()
+        with theme_context:  # ty: ignore[invalid-context-manager]
+            # type: ignore[attr-defined,unused-ignore]
+            with data_transformer:  # ty: ignore[invalid-context-manager]
+                chart_dict = altair_chart.to_dict()
 
     # Put datasets back into the chart dict:
     chart_dict["datasets"] = datasets
@@ -1844,7 +1852,8 @@ class VegaChartsMixin:
         >>> chart = (
         ...     alt.Chart(df)
         ...     .mark_circle()
-        ...     .encode(x="a", y="b", size="c", color="c", tooltip=["a", "b", "c"])
+        ...     .encode(x="a", y="b", size="c", color="c",
+                        tooltip=["a", "b", "c"])
         ... )
         >>>
         >>> st.altair_chart(chart)
@@ -2246,11 +2255,13 @@ class VegaChartsMixin:
             if use_container_width is not None
             else width == "stretch"
         )
+
         spec = _prepare_vega_lite_spec(spec, use_container_width_for_spec, **kwargs)
         _marshall_chart_data(vega_lite_proto, spec, data)
 
         # Prevent the spec from changing across reruns:
         vega_lite_proto.spec = _stabilize_vega_json_spec(json.dumps(spec))
+
         if use_container_width is not None:
             vega_lite_proto.use_container_width = use_container_width
         vega_lite_proto.theme = theme or ""
@@ -2339,3 +2350,19 @@ class VegaChartsMixin:
     def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)
+
+
+def _to_arrow_dataset(data: Any, datasets: dict[str, Any]) -> dict[str, str]:
+    """Altair data transformer that serializes the data,
+    creates a stable name based on the hash of the data,
+    stores the bytes into the datasets mapping and
+    returns this name to have it be used in Altair.
+    """
+    # Already serialize the data to be able to create a stable
+    # dataset name:
+    data_bytes = dataframe_util.convert_anything_to_arrow_bytes(data)
+    # Use the md5 hash of the data as the name:
+    name = calc_md5(str(data_bytes))
+
+    datasets[name] = data_bytes
+    return {"name": name}

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1852,8 +1852,7 @@ class VegaChartsMixin:
         >>> chart = (
         ...     alt.Chart(df)
         ...     .mark_circle()
-        ...     .encode(x="a", y="b", size="c", color="c",
-                        tooltip=["a", "b", "c"])
+        ...     .encode(x="a", y="b", size="c", color="c", tooltip=["a", "b", "c"])
         ... )
         >>>
         >>> st.altair_chart(chart)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -388,7 +388,7 @@ def _convert_altair_to_vega_lite_spec(
     # type: ignore[arg-type,attr-defined,unused-ignore]
     alt.data_transformers.register("to_arrow_dataset", _to_arrow_dataset)
 
-    # Settings like alt.theme.enable and alt.data_fransformers.enable are global to all
+    # Settings like alt.theme.enable and alt.data_transformers.enable are global to all
     # threads. So this lock makes sure that whatever we set those to only apply to the
     # current thread.
     with _altair_globals_lock:

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -107,7 +107,7 @@ AltairChart: TypeAlias = Union[
     "alt.VConcatChart",
 ]
 
-altair_globals_lock = threading.Lock()
+_altair_globals_lock = threading.Lock()
 
 
 class VegaLiteState(TypedDict, total=False):
@@ -391,7 +391,7 @@ def _convert_altair_to_vega_lite_spec(
     # Settings like alt.theme.enable and alt.data_fransformers.enable are global to all
     # threads. So this lock makes sure that whatever we set those to only apply to the
     # current thread.
-    with altair_globals_lock:
+    with _altair_globals_lock:
         # The default altair theme has some width/height defaults defined
         # which are not useful for Streamlit. Therefore, we change the theme to
         # "none" to avoid those defaults.


### PR DESCRIPTION
## Describe your changes

Today, our Altair-handling code in Python does some things that modify global variables in the `altair` module differently for each chart, which makes the code thead-unsafe. This leads to empty charts whenever two charts are drawn at the same time in different threads.

This PR addresses that by wrapping the thread-unsafe code into a `threading.Lock`, plus a couple of small refactors.

## GitHub Issue Link (if applicable)

none

## Testing Plan

- **Explanation of why no additional tests are needed:** I'm having a hard time coming up with tests for this. Any ideas? I found that this can be reproduced 100% of the time by drawing two charts in two different threads, but I'm not sure that's actually guaranteed to be true. I worry about creating a flaky e2e test this way.
- ~~Unit Tests (JS and/or Python)~~
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
