### PR TITLE
[test] Add e2e test for `st.audio_input` timer display

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -541,3 +541,41 @@ def test_audio_input_cleans_up_blob_urls_on_abort(app: Page):
     for i in range(min(2, len(tracking["created"]) - 1)):
         url = tracking["created"][i]
         assert url in tracking["revoked"], f"Blob URL {url} should have been revoked"
+
+
+@pytest.mark.skip_browser("webkit")  # Webkit CI audio permission issue
+def test_audio_input_timer_display(app: Page):
+    """Test that the timer display shows correct values during recording and playback."""
+    grant_microphone_permissions(app)
+    audio_input = get_audio_input_by_label(app, "Audio Input 1")
+    timer = audio_input.get_by_test_id("stAudioInputWaveformTimeCode")
+
+    # Record for 3 seconds (add buffer for recording startup)
+    audio_input.get_by_role("button", name="Record", exact=True).click()
+    app.wait_for_timeout(3200)
+    audio_input.get_by_role("button", name="Stop recording", exact=True).click()
+    wait_for_app_run(app)
+
+    # Verify timer shows 00:03 (duration of recording)
+    expect(timer).to_have_text("00:03")
+
+    # Click play for 100ms and verify it shows 00:00 (playback starts at beginning)
+    audio_input.get_by_role("button", name="Play").click()
+    expect(timer).to_have_text("00:00")
+    app.wait_for_timeout(100)
+    audio_input.get_by_role("button", name="Pause").click()
+
+    # Click play again for 1 second and verify it shows 00:01
+    audio_input.get_by_role("button", name="Play").click()
+    app.wait_for_timeout(1000)
+    expect(timer).to_have_text("00:01")
+    audio_input.get_by_role("button", name="Pause").click()
+
+    # Re-record for 4 seconds (add buffer for recording startup)
+    audio_input.get_by_role("button", name="Record", exact=True).click()
+    app.wait_for_timeout(4200)
+    audio_input.get_by_role("button", name="Stop recording", exact=True).click()
+    wait_for_app_run(app)
+
+    # Verify timer shows 00:04
+    expect(timer).to_have_text("00:04")

--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -543,16 +543,39 @@ def test_audio_input_cleans_up_blob_urls_on_abort(app: Page):
         assert url in tracking["revoked"], f"Blob URL {url} should have been revoked"
 
 
-@pytest.mark.skip_browser("webkit")  # Webkit CI audio permission issue
+# Marking this as only Chromium because Playwright Firefox
+# is having a strange issue that does not reproduce locally with Firefox,
+# where clicking play seeks to the end and sets the time to 00:03.
+@pytest.mark.only_browser("chromium")
 def test_audio_input_timer_display(app: Page):
     """Test that the timer display shows correct values during recording and playback."""
     grant_microphone_permissions(app)
     audio_input = get_audio_input_by_label(app, "Audio Input 1")
     timer = audio_input.get_by_test_id("stAudioInputWaveformTimeCode")
 
+    def timer_seconds() -> int:
+        """Return the timer value in seconds or -1 if not yet initialized."""
+        value = timer.inner_text().strip()
+        if value == "--:--":
+            return -1
+
+        try:
+            minutes, seconds = value.split(":", maxsplit=1)
+        except ValueError:
+            return -1
+
+        return int(minutes) * 60 + int(seconds)
+
+    def wait_for_timer_seconds(target_seconds: int, *, timeout: int = 6000) -> None:
+        def _reached_target() -> bool:
+            current = timer_seconds()
+            return current >= target_seconds if current >= 0 else False
+
+        wait_until(app, _reached_target, timeout=timeout)
+
     # Record for 3 seconds (add 200ms buffer for recording startup)
     audio_input.get_by_role("button", name="Record", exact=True).click()
-    app.wait_for_timeout(3200)
+    wait_for_timer_seconds(3)
     audio_input.get_by_role("button", name="Stop recording", exact=True).click()
     wait_for_app_run(app)
 
@@ -568,7 +591,7 @@ def test_audio_input_timer_display(app: Page):
     expect(timer).to_have_text("00:00")
 
     # Wait 1 second + 200ms buffer and verify timer shows 00:01
-    app.wait_for_timeout(1200)
+    wait_for_timer_seconds(1, timeout=3000)
     expect(timer).to_have_text("00:01")
 
     # Pause playback
@@ -578,7 +601,7 @@ def test_audio_input_timer_display(app: Page):
 
     # Re-record for 4 seconds (add 200ms buffer for recording startup)
     audio_input.get_by_role("button", name="Record", exact=True).click()
-    app.wait_for_timeout(4200)
+    wait_for_timer_seconds(4, timeout=7000)
     audio_input.get_by_role("button", name="Stop recording", exact=True).click()
     wait_for_app_run(app)
 

--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -550,7 +550,7 @@ def test_audio_input_timer_display(app: Page):
     audio_input = get_audio_input_by_label(app, "Audio Input 1")
     timer = audio_input.get_by_test_id("stAudioInputWaveformTimeCode")
 
-    # Record for 3 seconds (add buffer for recording startup)
+    # Record for 3 seconds (add 200ms buffer for recording startup)
     audio_input.get_by_role("button", name="Record", exact=True).click()
     app.wait_for_timeout(3200)
     audio_input.get_by_role("button", name="Stop recording", exact=True).click()
@@ -559,19 +559,24 @@ def test_audio_input_timer_display(app: Page):
     # Verify timer shows 00:03 (duration of recording)
     expect(timer).to_have_text("00:03")
 
-    # Click play for 100ms and verify it shows 00:00 (playback starts at beginning)
-    audio_input.get_by_role("button", name="Play").click()
+    # Click play and wait for playback to start
+    audio_input.get_by_role("button", name="Play", exact=True).click()
+    # Wait for pause button to appear, confirming playback started
+    expect(audio_input.get_by_role("button", name="Pause", exact=True)).to_be_visible()
+
+    # Verify timer shows 00:00 at start of playback
     expect(timer).to_have_text("00:00")
-    app.wait_for_timeout(100)
-    audio_input.get_by_role("button", name="Pause").click()
 
-    # Click play again for 1 second and verify it shows 00:01
-    audio_input.get_by_role("button", name="Play").click()
-    app.wait_for_timeout(1000)
+    # Wait 1 second + 200ms buffer and verify timer shows 00:01
+    app.wait_for_timeout(1200)
     expect(timer).to_have_text("00:01")
-    audio_input.get_by_role("button", name="Pause").click()
 
-    # Re-record for 4 seconds (add buffer for recording startup)
+    # Pause playback
+    audio_input.get_by_role("button", name="Pause", exact=True).click()
+    # Wait for play button to reappear
+    expect(audio_input.get_by_role("button", name="Play", exact=True)).to_be_visible()
+
+    # Re-record for 4 seconds (add 200ms buffer for recording startup)
     audio_input.get_by_role("button", name="Record", exact=True).click()
     app.wait_for_timeout(4200)
     audio_input.get_by_role("button", name="Stop recording", exact=True).click()


### PR DESCRIPTION


# Describe your changes

I noticed a regression in development of the chat input x audio input that wasn't covered by tests.


This pull request adds a new end-to-end test to verify the timer display functionality for audio input recording and playback in the application. The test ensures that the timer updates correctly during different stages of audio interaction.

**New test for audio input timer display:**

* Adds `test_audio_input_timer_display` to `e2e_playwright/st_audio_input_test.py` to check that the timer shows the correct values during recording and playback, including after re-recording. The test is skipped for the Webkit browser due to known audio permission issues.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
