### PR TITLE
[feat] Add multi-callback support to Widgets

### DIFF
--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import (
+    TYPE_CHECKING,
     Any,
     Final,
     Generic,
@@ -34,6 +35,9 @@ from streamlit import util
 from streamlit.errors import (
     StreamlitAPIException,
 )
+
+if TYPE_CHECKING:
+    from streamlit.runtime.state.session_state import SessionState
 
 GENERATED_ELEMENT_ID_PREFIX: Final = "$$ID"
 TESTING_KEY = "$$STREAMLIT_INTERNAL_KEY_TESTING"
@@ -92,6 +96,7 @@ ValueFieldName: TypeAlias = Literal[
     "file_uploader_state_value",
     "int_value",
     "json_value",
+    "json_trigger_value",
     "string_value",
     "trigger_value",
     "string_trigger_value",
@@ -101,6 +106,13 @@ ValueFieldName: TypeAlias = Literal[
 
 def is_array_value_field_name(obj: object) -> TypeGuard[ArrayValueFieldName]:
     return obj in _ARRAY_VALUE_FIELD_NAMES
+
+
+# Optional hook that allows a widget to customize how its value should be
+# presented in `st.session_state` without altering the underlying stored value
+# or callback semantics. The presenter receives the widget's base value and the
+# SessionState instance in case it needs to access additional widget state.
+WidgetValuePresenter: TypeAlias = Callable[[Any, "SessionState"], Any]
 
 
 @dataclass(frozen=True)
@@ -116,10 +128,24 @@ class WidgetMetadata(Generic[T]):
     # Widget callbacks are called at the start of a script run, before the
     # body of the script is executed.
     callback: WidgetCallback | None = None
+
+    # An optional dictionary of event names to user-code callbacks. These are
+    # invoked when the corresponding widget event occurs. Callbacks are called
+    # at the start of a script run, before the body of the script is executed.
+    # Right now, multiple callbacks are only supported for widgets with a
+    # `value_type` of `json_value` or `json_trigger_value`. The keys in this
+    # dictionary should correspond to keys in the widget's JSON state.
+    callbacks: dict[str, WidgetCallback] | None = None
     callback_args: WidgetArgs | None = None
     callback_kwargs: WidgetKwargs | None = None
 
     fragment_id: str | None = None
+
+    # Optional presenter hook used for customizing the user-visible value in
+    # st.session_state. This is intended for advanced widgets (e.g. Custom
+    # Components v2) that need to synthesize a presentation-only value from
+    # multiple internal widget states.
+    presenter: WidgetValuePresenter | None = None
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -27,8 +27,8 @@ from typing import (
     cast,
 )
 
-import streamlit as st
 from streamlit import config, util
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.errors import StreamlitAPIException, UnserializableSessionStateError
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
@@ -37,6 +37,8 @@ from streamlit.runtime.state.common import (
     RegisterWidgetResult,
     T,
     ValueFieldName,
+    WidgetArgs,
+    WidgetCallback,
     WidgetMetadata,
     is_array_value_field_name,
     is_element_id,
@@ -227,7 +229,7 @@ class WStates(MutableMapping[str, Any]):
         if is_array_value_field_name(field):
             arr = getattr(widget, field)
             arr.data.extend(serialized)
-        elif field == "json_value":
+        elif field in {"json_value", "json_trigger_value"}:
             setattr(widget, field, json.dumps(serialized))
         elif field == "file_uploader_state_value":
             widget.file_uploader_state_value.CopyFrom(serialized)
@@ -581,19 +583,210 @@ class SessionState:
         self._call_callbacks()
 
     def _call_callbacks(self) -> None:
-        """Call any callback associated with each widget whose value
-        changed between the previous and current script runs.
-        """
+        """Call callbacks for widgets whose value changed or whose trigger fired."""
         from streamlit.runtime.scriptrunner import RerunException
 
-        changed_widget_ids = [
-            wid for wid in self._new_widget_state if self._widget_changed(wid)
+        # Path 1: single callback.
+        changed_widget_ids_for_single_callback = [
+            wid
+            for wid in self._new_widget_state
+            if self._widget_changed(wid)
+            and (metadata := self._new_widget_state.widget_metadata.get(wid))
+            is not None
+            and metadata.callback is not None
         ]
-        for wid in changed_widget_ids:
+
+        for wid in changed_widget_ids_for_single_callback:
             try:
                 self._new_widget_state.call_callback(wid)
             except RerunException:  # noqa: PERF203
-                st.warning("Calling st.rerun() within a callback is a no-op.")
+                get_dg_singleton_instance().main_dg.warning(
+                    "Calling st.rerun() within a callback is a no-op."
+                )
+
+        # Path 2: multiple callbacks.
+        widget_ids_to_process = list(self._new_widget_state.states.keys())
+
+        for wid in widget_ids_to_process:
+            metadata = self._new_widget_state.widget_metadata.get(wid)
+            if not metadata or metadata.callbacks is None:
+                continue
+
+            args = metadata.callback_args or ()
+            kwargs = metadata.callback_kwargs or {}
+
+            # 1) Trigger dispatch: bool + JSON trigger aggregator
+            self._dispatch_trigger_callbacks(wid, metadata, args, kwargs)
+
+            # 2) JSON value change dispatch
+            if metadata.value_type == "json_value":
+                self._dispatch_json_change_callbacks(wid, metadata, args, kwargs)
+
+    def _execute_widget_callback(
+        self,
+        callback_fn: WidgetCallback,
+        cb_metadata: WidgetMetadata[Any],
+        cb_args: WidgetArgs,
+        cb_kwargs: dict[str, Any],
+    ) -> None:
+        """Execute a widget callback with fragment-aware context.
+
+        If the widget belongs to a fragment, temporarily marks the current
+        script context as being inside a fragment callback to adapt rerun
+        semantics. Attempts to call ``st.rerun()`` inside a widget callback are
+        converted to a user-visible warning and treated as a no-op.
+
+        Parameters
+        ----------
+        callback_fn : WidgetCallback
+            The user-provided callback to execute.
+        cb_metadata : WidgetMetadata[Any]
+            Metadata of the widget associated with the callback.
+        cb_args : WidgetArgs
+            Positional arguments passed to the callback.
+        cb_kwargs : dict[str, Any]
+            Keyword arguments passed to the callback.
+        """
+        from streamlit.runtime.scriptrunner import RerunException
+
+        ctx = get_script_run_ctx()
+        if ctx and cb_metadata.fragment_id is not None:
+            ctx.in_fragment_callback = True
+            try:
+                callback_fn(*cb_args, **cb_kwargs)
+            except RerunException:
+                get_dg_singleton_instance().main_dg.warning(
+                    "Calling st.rerun() within a callback is a no-op."
+                )
+            finally:
+                ctx.in_fragment_callback = False
+        else:
+            try:
+                callback_fn(*cb_args, **cb_kwargs)
+            except RerunException:
+                get_dg_singleton_instance().main_dg.warning(
+                    "Calling st.rerun() within a callback is a no-op."
+                )
+
+    def _dispatch_trigger_callbacks(
+        self,
+        wid: str,
+        metadata: WidgetMetadata[Any],
+        args: WidgetArgs,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Dispatch trigger-style callbacks for a widget.
+
+        Handles the JSON trigger aggregator. The JSON payload may be a single
+        event dict or a list of event dicts; each event must contain an
+        ``"event"`` field that maps to the corresponding callback name in
+        ``metadata.callbacks``.
+
+        Examples
+        --------
+        A component with a "submit" callback:
+
+        >>> metadata.callbacks = {"submit": on_submit}
+
+        The frontend can send a single event payload:
+
+        >>> {"event": "submit", "value": "payload"}
+
+        Or a list of event payloads to be processed in order:
+
+        >>> [{"event": "edit", ...}, {"event": "submit", ...}]
+
+        Parameters
+        ----------
+        wid : str
+            The widget ID.
+        metadata : WidgetMetadata[Any]
+            Metadata for the widget, including registered callbacks.
+        args : WidgetArgs
+            Positional arguments forwarded to the callback.
+        kwargs : dict[str, Any]
+            Keyword arguments forwarded to the callback.
+        """
+        widget_proto_state = self._new_widget_state.get_serialized(wid)
+        if not widget_proto_state:
+            return
+
+        # JSON trigger aggregator: value is deserialized by metadata.deserializer
+        if widget_proto_state.json_trigger_value:
+            try:
+                deserialized = self._new_widget_state[wid]
+            except KeyError:
+                deserialized = None
+
+            payloads: list[object]
+            if isinstance(deserialized, list):
+                payloads = deserialized
+            else:
+                payloads = [deserialized]
+
+            for payload in payloads:
+                if isinstance(payload, dict):
+                    event_name = payload.get("event")
+                    if isinstance(event_name, str) and metadata.callbacks:
+                        cb = metadata.callbacks.get(event_name)
+                        if cb is not None:
+                            self._execute_widget_callback(cb, metadata, args, kwargs)
+
+    def _dispatch_json_change_callbacks(
+        self,
+        wid: str,
+        metadata: WidgetMetadata[Any],
+        args: WidgetArgs,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Dispatch change callbacks for JSON-valued widgets.
+
+        Computes a shallow diff between the new and old JSON maps and invokes
+        callbacks for keys that changed or were added/removed.
+
+        Parameters
+        ----------
+        wid : str
+            The widget ID.
+        metadata : WidgetMetadata[Any]
+            Metadata for the widget, including registered callbacks.
+        args : WidgetArgs
+            Positional arguments forwarded to the callback.
+        kwargs : dict[str, Any]
+            Keyword arguments forwarded to the callback.
+        """
+        if not metadata.callbacks:
+            return
+
+        try:
+            new_val = self._new_widget_state.get(wid)
+        except KeyError:
+            new_val = None
+        old_val = self._old_state.get(wid)
+
+        def unwrap(obj: object) -> dict[str, object]:
+            if not isinstance(obj, dict):
+                return {}
+
+            obj = cast("dict[str, Any]", obj)
+            if set(obj.keys()) == {"value"}:
+                value = obj.get("value")
+                if isinstance(value, dict):
+                    return dict(value)  # shallow copy
+
+            return dict(obj)
+
+        new_map = unwrap(new_val)
+        old_map = unwrap(old_val)
+
+        if new_map or old_map:
+            all_keys = new_map.keys() | old_map.keys()
+            changed_keys = {k for k in all_keys if old_map.get(k) != new_map.get(k)}
+
+            for key in changed_keys:
+                cb = metadata.callbacks.get(key)
+                if cb is not None:
+                    self._execute_widget_callback(cb, metadata, args, kwargs)
 
     def _widget_changed(self, widget_id: str) -> bool:
         """True if the given widget's value changed between the previous
@@ -628,6 +821,7 @@ class SessionState:
                 elif metadata.value_type in {
                     "string_trigger_value",
                     "chat_input_value",
+                    "json_trigger_value",
                 }:
                     self._new_widget_state[state_id] = Value(None)
 
@@ -639,6 +833,7 @@ class SessionState:
                 elif metadata.value_type in {
                     "string_trigger_value",
                     "chat_input_value",
+                    "json_trigger_value",
                 }:
                     self._old_state[state_id] = None
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state.common import (
     RegisterWidgetResult,
     T,
@@ -26,6 +27,7 @@ from streamlit.runtime.state.common import (
     WidgetKwargs,
     WidgetMetadata,
     WidgetSerializer,
+    WidgetValuePresenter,
     user_key_from_element_id,
 )
 
@@ -39,10 +41,12 @@ def register_widget(
     deserializer: WidgetDeserializer[T],
     serializer: WidgetSerializer[T],
     ctx: ScriptRunContext | None,
+    callbacks: dict[str, WidgetCallback] | None = None,
     on_change_handler: WidgetCallback | None = None,
     args: WidgetArgs | None = None,
     kwargs: WidgetKwargs | None = None,
     value_type: ValueFieldName,
+    presenter: WidgetValuePresenter | None = None,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -58,13 +62,15 @@ def register_widget(
         Called to convert a widget's value to its protobuf representation.
     ctx : ScriptRunContext or None
         Used to ensure uniqueness of widget IDs, and to look up widget values.
+    callbacks : dict[str, WidgetCallback] or None
+        A dictionary of callbacks for multi-callback support.
     on_change_handler : WidgetCallback or None
         An optional callback invoked when the widget's value changes.
     args : WidgetArgs or None
-        args to pass to on_change_handler when invoked
+        Positional arguments to pass to the `on_change_handler` or `callbacks`.
     kwargs : WidgetKwargs or None
-        kwargs to pass to on_change_handler when invoked
-    value_type: ValueType
+        Keyword arguments to pass to the `on_change_handler` or `callbacks`.
+    value_type: ValueFieldName
         The value_type the widget is going to use.
         We use this information to start with a best-effort guess for the value_type
         of each widget. Once we actually receive a proto for a widget from the
@@ -72,6 +78,9 @@ def register_widget(
         not able to always rely on the proto as the type may be needed earlier.
         Thankfully, in these cases (when value_type == "trigger_value"), the static
         table here being slightly inaccurate should never pose a problem.
+    presenter : WidgetValuePresenter or None
+        An optional hook that allows a widget to customize how its value should be
+        presented.
 
 
     Returns
@@ -98,6 +107,11 @@ def register_widget(
         For both paths a widget return value is provided, allowing the widgets
         to be used in a non-streamlit setting.
     """
+    if on_change_handler is not None and callbacks is not None:
+        raise StreamlitAPIException(
+            "Cannot provide both `on_change` and `callbacks` to a widget."
+        )
+
     # Create the widget's updated metadata, and register it with session_state.
     metadata = WidgetMetadata(
         element_id,
@@ -105,9 +119,11 @@ def register_widget(
         serializer,
         value_type=value_type,
         callback=on_change_handler,
+        callbacks=callbacks,
         callback_args=args,
         callback_kwargs=kwargs,
         fragment_id=ctx.current_fragment_id if ctx else None,
+        presenter=presenter,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from copy import deepcopy
 from datetime import date, datetime, timedelta
@@ -410,6 +411,47 @@ def test_callbacks_with_rerun():
     assert at.session_state["message"] == "ran callback"
     warning = at.warning[0]
     assert "no-op" in warning.value
+
+
+def test_fragment_callback_flag_resets_on_rerun_exception() -> None:
+    """Ensure fragment callback context flag is cleared on RerunException.
+
+    This guards against leaving `ctx.in_fragment_callback` stuck to True if
+    a callback raises, which could contaminate subsequent runs.
+    """
+    from streamlit.runtime.scriptrunner import RerunException
+
+    ss = SessionState()
+    wid = "w-frag"
+
+    # A callback that raises RerunException
+    def cb() -> None:
+        raise RerunException(None)
+
+    meta = WidgetMetadata(
+        id=wid,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="int_value",
+        callbacks={"change": cb},
+        fragment_id="frag-1",
+    )
+
+    ss._set_widget_metadata(meta)
+    ss._old_state[wid] = 1
+    ss._new_widget_state.set_from_value(wid, 2)  # ensure _widget_changed is True
+
+    mock_ctx = MagicMock()
+    mock_ctx.in_fragment_callback = False
+
+    with patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        # Callbacks internally catch RerunException and log a warning.
+        ss._call_callbacks()
+
+    assert mock_ctx.in_fragment_callback is False
 
 
 def test_updates():
@@ -1102,3 +1144,120 @@ class KeyIdMapperTest(unittest.TestCase):
         assert key_id_mapper.get_key_from_id("wid2") == "key2"
         assert key_id_mapper.get_id_from_key("key") == "wid3"
         assert key_id_mapper.get_key_from_id("wid") == "key"
+
+
+# region Multiple callbacks
+
+
+def test_per_key_callbacks_only_fire_for_changed_keys() -> None:
+    """Test that per-key callbacks only fire for changed keys."""
+    calls: list[str] = []
+
+    def cb_a() -> None:
+        calls.append("a")
+
+    def cb_b() -> None:
+        calls.append("b")
+
+    ss = SessionState()
+    wid = "w-json"
+    meta = WidgetMetadata(
+        id=wid,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="json_value",
+        callbacks={"a": cb_a, "b": cb_b},
+    )
+
+    # Register metadata
+    ss._set_widget_metadata(meta)
+
+    # Old state: {value: {a:1, b:2}}
+    ss._old_state[wid] = {"value": {"a": 1, "b": 2}}
+    # New state: {value: {a:1, b:3}}
+    ss._new_widget_state.set_from_value(wid, {"value": {"a": 1, "b": 3}})
+
+    ss._call_callbacks()
+    assert calls == ["b"]
+
+
+def test_json_trigger_aggregator_routes_to_named_callback() -> None:
+    """Test that JSON trigger values are routed to the correct named callback.
+
+    This test verifies that for widgets using `json_trigger_value`, the
+    `event` field in the JSON payload is used to look up and execute the
+    corresponding callback from the `callbacks` dictionary.
+    """
+    called: list[str] = []
+
+    def cb_click() -> None:
+        called.append("click")
+
+    def cb_submit() -> None:
+        called.append("submit")
+
+    ss = SessionState()
+    wid = "w-trig"
+    meta = WidgetMetadata(
+        id=wid,
+        # Convert JSON string from proto into a dict
+        deserializer=lambda s: json.loads(s) if s else None,
+        serializer=lambda v: v,
+        value_type="json_trigger_value",
+        callbacks={"click": cb_click, "submit": cb_submit},
+    )
+
+    ss._set_widget_metadata(meta)
+
+    # Emulate serialized proto received from frontend
+    ws = WidgetStateProto(id=wid)
+    ws.json_trigger_value = json.dumps({"event": "submit"})
+    ss._new_widget_state.set_widget_from_proto(ws)
+
+    ss._call_callbacks()
+    assert called == ["submit"]
+
+
+def _dummy_serializer(x):
+    return x
+
+
+def _dummy_deserializer(x):
+    return x
+
+
+def test_json_trigger_value_gets_reset():
+    """Ensure json_trigger_value fields are cleared to None after _reset_triggers."""
+    ss = SessionState()
+
+    widget_id = "comp__event"
+
+    meta = WidgetMetadata(
+        id=widget_id,
+        deserializer=_dummy_deserializer,
+        serializer=_dummy_serializer,
+        value_type="json_trigger_value",
+        callbacks=None,
+        callback_args=None,
+        callback_kwargs=None,
+        fragment_id=None,
+    )
+
+    # Register metadata and set initial trigger payload
+    ss._set_widget_metadata(meta)
+    payload = {"clicked": True}
+    ss._new_widget_state[widget_id] = Value(json.dumps(payload))
+    ss._old_state[widget_id] = payload
+
+    # Act
+    ss._reset_triggers()
+
+    # Assert: value should now be None in both new and old state mappings
+    # `_reset_triggers()` sets the new state to `Value(None)`
+    new_value = ss._new_widget_state.states[widget_id]
+    assert isinstance(new_value, Value)
+    assert new_value.value is None
+    assert ss._old_state[widget_id] is None
+
+
+# endregion Multiple callbacks

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -38,6 +38,7 @@ from streamlit.runtime.state.common import (
 )
 from streamlit.runtime.state.session_state import SessionState, WidgetMetadata
 from streamlit.runtime.state.widgets import (
+    register_widget,
     register_widget_from_metadata,
     user_key_from_element_id,
 )
@@ -628,6 +629,21 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
         assert widget_metadata_arg.value_type in get_args(ValueFieldName)
         # test that the value_type also maps to a protobuf field
         assert widget_metadata_arg.value_type in WidgetState.DESCRIPTOR.fields_by_name
+
+    def test_raises_exception_with_on_change_and_callbacks(self):
+        """Test that `register_widget` raises an exception when both `on_change`
+        and `callbacks` are provided.
+        """
+        with pytest.raises(errors.StreamlitAPIException):
+            register_widget(
+                "el_id",
+                deserializer=lambda x: x,
+                serializer=lambda x: x,
+                ctx=None,
+                on_change_handler=lambda: None,
+                callbacks={"change": lambda: None},
+                value_type="bool_value",
+            )
 
 
 @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))


### PR DESCRIPTION
## Describe your changes

Added support for multiple callbacks in widgets:

1. Added a `callbacks` dictionary to `WidgetMetadata` to support multiple named callbacks per widget
2. Implemented a JSON trigger aggregator using `json_trigger_value` field type
3. Added support for per-key callbacks in JSON-valued widgets

These changes enable widgets to respond to multiple different events (like "click", "submit", etc.) with different callbacks, and allow JSON-based widgets to trigger callbacks when specific keys change.

## Testing Plan

- Unit Tests: Added comprehensive tests for the new callback functionality, including:
  - Tests for per-key callbacks only firing when specific keys change
  - Tests for JSON trigger aggregator routing to named callbacks
  - Tests for proper resetting of `json_trigger_value` fields
  - Tests for fragment callback context flag resetting on exceptions

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.