### PR TITLE
[feat] Add BidiComponentMixin and Widget Presenter

### DIFF
--- a/lib/streamlit/components/v2/bidi_component/__init__.py
+++ b/lib/streamlit/components/v2/bidi_component/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from streamlit.components.v2.bidi_component.main import BidiComponentMixin
+from streamlit.components.v2.bidi_component.state import BidiComponentResult
+
+__all__ = ["BidiComponentMixin", "BidiComponentResult"]

--- a/lib/streamlit/components/v2/bidi_component/constants.py
+++ b/lib/streamlit/components/v2/bidi_component/constants.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Final
+
+INTERNAL_COMPONENT_NAME: Final[str] = "bidi_component"
+
+# Shared constant that delimits the base widget id from the event suffix.
+# This value **must** stay in sync with its TypeScript counterpart defined in
+# `frontend/lib/src/components/widgets/BidiComponent/constants.ts`.
+EVENT_DELIM: Final[str] = "__"
+
+# Shared constant that is used to identify ArrowReference objects in the data structure.
+# This value **must** stay in sync with its TypeScript counterpart defined in
+# `frontend/lib/src/components/widgets/BidiComponent/constants.ts`.
+ARROW_REF_KEY: Final[str] = "__streamlit_arrow_ref__"

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -1,0 +1,375 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+from streamlit.components.v2.bidi_component.constants import (
+    EVENT_DELIM,
+    INTERNAL_COMPONENT_NAME,
+)
+from streamlit.components.v2.bidi_component.serialization import (
+    BidiComponentSerde,
+    deserialize_trigger_list,
+    serialize_mixed_data,
+)
+from streamlit.components.v2.bidi_component.state import (
+    BidiComponentResult,
+    BidiComponentState,
+    unwrap_component_state,
+)
+from streamlit.components.v2.presentation import make_bidi_component_presenter
+from streamlit.dataframe_util import (
+    DataFormat,
+    convert_anything_to_arrow_bytes,
+    determine_data_format,
+)
+from streamlit.elements.lib.form_utils import current_form_id
+from streamlit.elements.lib.layout_utils import (
+    Height,
+    LayoutConfig,
+    Width,
+    validate_width,
+)
+from streamlit.elements.lib.policies import check_cache_replay_rules
+from streamlit.elements.lib.utils import compute_and_register_element_id, to_key
+from streamlit.errors import (
+    BidiComponentInvalidDefaultKeyError,
+    BidiComponentInvalidIdError,
+    BidiComponentMissingContentError,
+    BidiComponentUnserializableDataError,
+)
+from streamlit.logger import get_logger
+from streamlit.proto.ArrowData_pb2 import ArrowData as ArrowDataProto
+from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state import register_widget
+
+if TYPE_CHECKING:
+    # Define DeltaGenerator for type checking the dg property
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.runtime.state.common import WidgetCallback
+
+
+_LOGGER = get_logger(__name__)
+
+
+def _make_trigger_id(base: str, event: str) -> str:
+    """Construct the per-event *trigger widget* identifier.
+
+    The widget ID for a trigger is derived from the *base* component ID plus
+    an *event* name. We join those two parts with :py:const:`EVENT_DELIM` and
+    perform a couple of validations so that downstream logic can always split
+    the identifier unambiguously.
+
+    Trigger widgets are marked as internal by prefixing with an internal key prefix,
+    so they won't be exposed in `st.session_state` to end users.
+
+    Parameters
+    ----------
+    base
+        The unique, framework-assigned ID of the component instance.
+    event
+        The event name as provided by either the frontend or the developer
+        (e.g., "click", "change").
+
+    Returns
+    -------
+    str
+        The composite widget ID in the form ``"$$STREAMLIT_INTERNAL_KEY_{base}__{event}"``
+        where ``__`` is the delimiter.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If either `base` or `event` already contains the delimiter sequence.
+
+    """
+    from streamlit.runtime.state.session_state import STREAMLIT_INTERNAL_KEY_PREFIX
+
+    if EVENT_DELIM in base:
+        raise BidiComponentInvalidIdError("base", EVENT_DELIM)
+    if EVENT_DELIM in event:
+        raise BidiComponentInvalidIdError("event", EVENT_DELIM)
+
+    return f"{STREAMLIT_INTERNAL_KEY_PREFIX}_{base}{EVENT_DELIM}{event}"
+
+
+class BidiComponentMixin:
+    """Mixin class for the bidi_component DeltaGenerator method."""
+
+    @gather_metrics("_bidi_component")
+    def _bidi_component(
+        self,
+        component_name: str,
+        key: str | None = None,
+        isolate_styles: bool = True,
+        data: Any | None = None,
+        default: dict[str, Any] | None = None,
+        width: Width = "stretch",
+        height: Height = "content",
+        **kwargs: WidgetCallback | None,
+    ) -> BidiComponentResult:
+        """Add a bidirectional component instance to the app.
+
+        This method uses a component that has already been registered with the
+        application.
+
+        Parameters
+        ----------
+        component_name
+            The name of the registered component to use. The component's HTML,
+            CSS, and JavaScript will be loaded from the registry.
+        key
+            An optional string to use as the unique key for the component.
+            If this is omitted, a key will be generated based on the
+            component's execution sequence.
+        isolate_styles
+            Whether to sandbox the component's styles in a shadow root.
+            Defaults to True.
+        data
+            Data to pass to the component. This can be any JSON-serializable
+            data, or a pandas DataFrame, NumPy array, or other dataframe-like
+            object that can be serialized to Arrow.
+        default
+            A dictionary of default values for the component's state properties.
+            These defaults are applied only when the state key doesn't exist
+            in session state. Keys must correspond to valid state names (those
+            with `on_*_change` callbacks). Trigger values do not support
+            defaults.
+        width
+            The desired width of the component. This can be one of "stretch",
+            "content", or a number of pixels.
+        height
+            The desired height of the component. This can be one of "stretch",
+            "content", or a number of pixels.
+        **kwargs
+            Keyword arguments to pass to the component. Callbacks can be passed
+            here, with the naming convention `on_{event_name}_change`.
+
+        Returns
+        -------
+        BidiComponentResult
+            A dictionary-like object that holds the component's state and
+            trigger values.
+
+        Raises
+        ------
+        ValueError
+            If the component name is not found in the registry.
+        StreamlitAPIException
+            If the component does not have the required JavaScript or HTML
+            content, or if the provided data cannot be serialized.
+
+        """
+        check_cache_replay_rules()
+
+        key = to_key(key)
+        ctx = get_script_run_ctx()
+
+        if ctx is None:
+            # Create an empty state with the default value and return it
+            state: BidiComponentState = {"value": {}}
+            return BidiComponentResult(state.get("value", {}), {})
+
+        # Get the component definition from the registry
+        from streamlit.runtime import Runtime
+
+        registry = Runtime.instance().bidi_component_registry
+        component_def = registry.get(component_name)
+
+        if component_def is None:
+            raise ValueError(f"Component '{component_name}' is not registered")
+
+        # Validate that the component has the required content
+        has_js = bool(component_def.js_content or component_def.js_url)
+        has_html = bool(component_def.html_content)
+
+        if not has_js and not has_html:
+            raise BidiComponentMissingContentError(component_name)
+
+        # Compute a unique ID for this component instance
+        computed_id = compute_and_register_element_id(
+            "bidi_component",
+            user_key=key,
+            component_name=component_name,
+            isolate_styles=isolate_styles,
+            width=width,
+            height=height,
+            dg=self.dg,
+            key_as_main_identity=True,
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Parse user-supplied callbacks
+        # ------------------------------------------------------------------
+        # Event-specific callbacks follow the pattern ``on_<event>_change``.
+        # We deliberately *do not* support the legacy generic ``on_change``
+        # or ``on_<event>`` forms.
+        callbacks_by_event: dict[str, WidgetCallback] = {}
+        for kwarg_key, kwarg_value in list(kwargs.items()):
+            if not callable(kwarg_value):
+                continue
+
+            if kwarg_key.startswith("on_") and kwarg_key.endswith("_change"):
+                # Preferred pattern: on_<event>_change
+                event_name = kwarg_key[3:-7]  # strip prefix + suffix
+            else:
+                # Not an event callback we recognize - skip.
+                continue
+
+            if not event_name:
+                # Malformed name like "on__change" - ignore for now.
+                continue
+
+            callbacks_by_event[event_name] = kwarg_value
+
+        # ------------------------------------------------------------------
+        # 2. Validate default keys against registered callbacks
+        # ------------------------------------------------------------------
+        if default is not None:
+            for state_key in default:
+                if state_key not in callbacks_by_event:
+                    raise BidiComponentInvalidDefaultKeyError(
+                        state_key, list(callbacks_by_event.keys())
+                    )
+
+        # Set up the component proto
+        bidi_component_proto = BidiComponentProto()
+        bidi_component_proto.id = computed_id
+        bidi_component_proto.component_name = component_name
+        bidi_component_proto.isolate_styles = isolate_styles
+        bidi_component_proto.js_content = component_def.js_content or ""
+        bidi_component_proto.js_source_path = component_def.js_url or ""
+        bidi_component_proto.html_content = component_def.html_content or ""
+        bidi_component_proto.css_content = component_def.css_content or ""
+        bidi_component_proto.css_source_path = component_def.css_url or ""
+
+        validate_width(width, allow_content=True)
+        layout_config = LayoutConfig(width=width, height=height)
+
+        if data is not None:
+            try:
+                # 1. Raw byte payloads - forward as-is.
+                if isinstance(data, (bytes, bytearray)):
+                    bidi_component_proto.bytes = bytes(data)
+
+                # 2. Mapping-like structures (e.g. plain dict) - check for mixed data.
+                elif isinstance(data, (Mapping, list, tuple)):
+                    serialize_mixed_data(data, bidi_component_proto)
+
+                # 3. Dataframe-like structures - attempt Arrow serialization.
+                else:
+                    data_format = determine_data_format(data)
+
+                    if data_format != DataFormat.UNKNOWN:
+                        arrow_bytes = convert_anything_to_arrow_bytes(data)
+
+                        arrow_data_proto = ArrowDataProto()
+                        arrow_data_proto.data = arrow_bytes
+
+                        bidi_component_proto.arrow_data.CopyFrom(arrow_data_proto)
+                    else:
+                        # Fallback to JSON.
+                        bidi_component_proto.json = json.dumps(data)
+            except Exception:
+                # As a last resort attempt JSON serialization so that we don't
+                # silently drop developer data.
+                try:
+                    bidi_component_proto.json = json.dumps(data)
+                except Exception:
+                    raise BidiComponentUnserializableDataError()
+        bidi_component_proto.form_id = current_form_id(self.dg)
+
+        # Instantiate the Serde for this component instance
+        serde = BidiComponentSerde(default=default)
+
+        # ------------------------------------------------------------------
+        # 3. Prepare IDs and register widgets
+        # ------------------------------------------------------------------
+
+        # Compute trigger aggregator id from the base id
+        def _make_trigger_aggregator_id(base: str) -> str:
+            return _make_trigger_id(base, "events")
+
+        aggregator_id = _make_trigger_aggregator_id(computed_id)
+
+        # With generalized runtime dispatch, we can attach per-key callbacks
+        # directly to the state widget by passing the callbacks mapping.
+        # We also register a presenter to shape the user-visible session_state.
+        presenter = make_bidi_component_presenter(aggregator_id)
+        component_state = register_widget(
+            bidi_component_proto.id,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
+            ctx=ctx,
+            callbacks=callbacks_by_event if callbacks_by_event else None,
+            value_type="json_value",
+            presenter=presenter,
+        )
+
+        # ------------------------------------------------------------------
+        # 4. Register a single *trigger aggregator* widget
+        # ------------------------------------------------------------------
+        trigger_vals: dict[str, Any] = {}
+
+        trig_state = register_widget(
+            aggregator_id,
+            deserializer=deserialize_trigger_list,  # always returns list or None
+            serializer=lambda v: json.dumps(v),  # send dict as JSON
+            ctx=ctx,
+            callbacks=callbacks_by_event if callbacks_by_event else None,
+            value_type="json_trigger_value",
+        )
+
+        # Surface per-event trigger values derived from the aggregator payload list.
+        payloads: list[object] = trig_state.value or []
+
+        event_to_value: dict[str, Any] = {}
+        for payload in payloads:
+            if isinstance(payload, dict):
+                ev = payload.get("event")
+                if isinstance(ev, str):
+                    event_to_value[ev] = payload.get("value")
+
+        for evt_name in callbacks_by_event:
+            trigger_vals[evt_name] = event_to_value.get(evt_name)
+
+        # Note: We intentionally do not inspect SessionState for additional
+        # trigger widget IDs here because doing so can raise KeyErrors when
+        # widgets are freshly registered but their values haven't been
+        # populated yet. Only the triggers explicitly registered above are
+        # included in the result object.
+
+        # ------------------------------------------------------------------
+        # 5. Enqueue proto and assemble the result object
+        # ------------------------------------------------------------------
+        self.dg._enqueue(
+            INTERNAL_COMPONENT_NAME,
+            bidi_component_proto,
+            layout_config=layout_config,
+        )
+
+        state_vals = unwrap_component_state(component_state.value)
+
+        return BidiComponentResult(state_vals, trigger_vals)
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -29,7 +29,6 @@ from streamlit.components.v2.bidi_component.serialization import (
 )
 from streamlit.components.v2.bidi_component.state import (
     BidiComponentResult,
-    BidiComponentState,
     unwrap_component_state,
 )
 from streamlit.components.v2.presentation import make_bidi_component_presenter
@@ -48,12 +47,12 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.elements.lib.policies import check_cache_replay_rules
 from streamlit.elements.lib.utils import compute_and_register_element_id, to_key
 from streamlit.errors import (
+    BidiComponentInvalidCallbackNameError,
     BidiComponentInvalidDefaultKeyError,
     BidiComponentInvalidIdError,
     BidiComponentMissingContentError,
     BidiComponentUnserializableDataError,
 )
-from streamlit.logger import get_logger
 from streamlit.proto.ArrowData_pb2 import ArrowData as ArrowDataProto
 from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -64,9 +63,6 @@ if TYPE_CHECKING:
     # Define DeltaGenerator for type checking the dg property
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.runtime.state.common import WidgetCallback
-
-
-_LOGGER = get_logger(__name__)
 
 
 def _make_trigger_id(base: str, event: str) -> str:
@@ -184,8 +180,7 @@ class BidiComponentMixin:
 
         if ctx is None:
             # Create an empty state with the default value and return it
-            state: BidiComponentState = {"value": {}}
-            return BidiComponentResult(state.get("value", {}), {})
+            return BidiComponentResult({}, {})
 
         # Get the component definition from the registry
         from streamlit.runtime import Runtime
@@ -233,9 +228,8 @@ class BidiComponentMixin:
                 # Not an event callback we recognize - skip.
                 continue
 
-            if not event_name:
-                # Malformed name like "on__change" - ignore for now.
-                continue
+            if not event_name or event_name == "_":
+                raise BidiComponentInvalidCallbackNameError(kwarg_key)
 
             callbacks_by_event[event_name] = kwarg_value
 
@@ -312,7 +306,16 @@ class BidiComponentMixin:
         # With generalized runtime dispatch, we can attach per-key callbacks
         # directly to the state widget by passing the callbacks mapping.
         # We also register a presenter to shape the user-visible session_state.
-        presenter = make_bidi_component_presenter(aggregator_id)
+        # Allowed state keys are the ones that have callbacks registered.
+        allowed_state_keys = (
+            set(callbacks_by_event.keys()) if callbacks_by_event else None
+        )
+        presenter = make_bidi_component_presenter(
+            aggregator_id,
+            computed_id,
+            allowed_state_keys,
+        )
+
         component_state = register_widget(
             bidi_component_proto.id,
             deserializer=serde.deserialize,

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -1,0 +1,263 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from streamlit.components.v2.bidi_component.constants import ARROW_REF_KEY
+from streamlit.dataframe_util import convert_anything_to_arrow_bytes, is_dataframe_like
+from streamlit.logger import get_logger
+from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
+from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
+from streamlit.util import AttributeDictionary
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.bidi_component.state import BidiComponentState
+
+_LOGGER = get_logger(__name__)
+
+
+def _extract_dataframes_from_dict(
+    data: dict[str, Any], arrow_blobs: dict[str, bytes] | None = None
+) -> dict[str, Any]:
+    """Extract dataframe-like objects from a dictionary and replace them with
+    placeholders.
+
+    This function traverses the first level of a dictionary, detects any
+    dataframe-like objects, stores their Arrow bytes representation in the
+    `arrow_blobs` dictionary, and replaces them with JSON-serializable
+    placeholder objects.
+
+    Parameters
+    ----------
+    data
+        The dictionary to process. Only the first level is checked for
+        dataframe-like objects.
+    arrow_blobs
+        The dictionary to store the extracted Arrow bytes in, keyed by a unique
+        reference ID.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new dictionary with dataframe-like objects replaced by placeholders.
+    """
+    import uuid
+
+    if arrow_blobs is None:
+        arrow_blobs = {}
+
+    processed_data = {}
+
+    for key, value in data.items():
+        if is_dataframe_like(value):
+            # This is a dataframe-like object, serialize it to Arrow
+            try:
+                arrow_bytes = convert_anything_to_arrow_bytes(value)
+                ref_id = str(uuid.uuid4())
+                arrow_blobs[ref_id] = arrow_bytes
+                processed_data[key] = {ARROW_REF_KEY: ref_id}
+            except Exception:
+                # If Arrow serialization fails, keep the original value for JSON serialization
+                processed_data[key] = value
+        else:
+            # Not dataframe-like, keep as-is
+            processed_data[key] = value
+
+    return processed_data
+
+
+def serialize_mixed_data(data: Any, bidi_component_proto: BidiComponentProto) -> None:
+    """Serialize mixed data with automatic dataframe detection into a protobuf message.
+
+    This function detects dataframe-like objects in the first level of a dictionary,
+    extracts them into separate Arrow blobs, and populates a `MixedDataProto`
+    protobuf message for efficient serialization.
+
+    Parameters
+    ----------
+    data
+        The data structure to serialize. If it is a dictionary, its first
+        level will be scanned for dataframe-like objects.
+    bidi_component_proto
+        The protobuf message to populate with the serialized data.
+
+    """
+    arrow_blobs: dict[str, bytes] = {}
+
+    # Only process dictionaries for automatic dataframe detection
+    if isinstance(data, dict):
+        processed_data = _extract_dataframes_from_dict(data, arrow_blobs)
+    else:
+        # For non-dict data (lists, tuples, etc.), pass through as-is
+        # We don't automatically detect dataframes in these structures
+        processed_data = data
+
+    if arrow_blobs:
+        # We have dataframes, use mixed data serialization
+        mixed_proto = MixedDataProto()
+        try:
+            mixed_proto.json = json.dumps(processed_data)
+        except TypeError:
+            # If JSON serialization fails (e.g., due to undetected dataframes),
+            # fall back to string representation
+            mixed_proto.json = json.dumps(str(processed_data))
+
+        # Add Arrow blobs to the protobuf
+        for ref_id, arrow_bytes in arrow_blobs.items():
+            mixed_proto.arrow_blobs[ref_id].data = arrow_bytes
+
+        bidi_component_proto.mixed.CopyFrom(mixed_proto)
+    else:
+        # No dataframes found, use regular JSON serialization
+        try:
+            bidi_component_proto.json = json.dumps(processed_data)
+        except TypeError:
+            # If JSON serialization fails (e.g., due to dataframes in lists/tuples),
+            # fall back to string representation
+            bidi_component_proto.json = json.dumps(str(processed_data))
+
+
+def handle_deserialize(s: str | None) -> Any:
+    """Deserialize a JSON string, returning the string itself if it's not valid JSON.
+
+    Parameters
+    ----------
+    s
+        The string to deserialize.
+
+    Returns
+    -------
+    Any
+        The deserialized JSON object, or the original string if parsing fails.
+        Returns `None` if the input is `None`.
+
+    """
+    if s is None:
+        return None
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        return s
+
+
+def deserialize_trigger_list(s: str | None) -> list[Any] | None:
+    """Deserialize trigger aggregator payloads as a list.
+
+    For bidirectional components, the frontend always sends a JSON array of payload
+    objects. This deserializer normalizes older or singular payloads into a list
+    while preserving ``None`` for cleared values.
+
+    Parameters
+    ----------
+    s
+        The JSON string to deserialize, hopefully representing a list of payloads.
+
+    Returns
+    -------
+    list[Any] or None
+        A list of payloads, or `None` if the input was `None`.
+
+    """
+    value = handle_deserialize(s)
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+@dataclass
+class BidiComponentSerde:
+    """Serialization and deserialization logic for a bidirectional component.
+
+    This class handles the conversion of component state between the frontend
+    (JSON strings) and the backend (Python objects).
+
+    Parameters
+    ----------
+    default
+        A dictionary of default values to be applied to the state when
+        deserializing, if the corresponding keys are not already present.
+
+    """
+
+    default: dict[str, Any] | None = None
+
+    def deserialize(self, ui_value: str | dict[str, Any] | None) -> BidiComponentState:
+        """Deserialize the component's state from a frontend value.
+
+        Parameters
+        ----------
+        ui_value
+            The value received from the frontend, which can be a JSON string,
+            a dictionary, or `None`.
+
+        Returns
+        -------
+        BidiComponentState
+            The deserialized state, wrapped in an `AttributeDictionary` for
+            convenient access.
+
+        """
+        # We always normalize the incoming JSON payload into a *dict*.
+        # Any failure to decode (or an unexpected non-mapping structure)
+        # results in an empty mapping so that the returned type adheres to
+        # :class:`BidiComponentState`.
+
+        deserialized_value: dict[str, Any]
+
+        if isinstance(ui_value, dict):
+            deserialized_value = ui_value
+        elif isinstance(ui_value, str):
+            try:
+                parsed = json.loads(ui_value)
+                deserialized_value = parsed if isinstance(parsed, dict) else {}
+            except (json.JSONDecodeError, TypeError) as e:
+                _LOGGER.warning(
+                    "Failed to deserialize component state from frontend: %s",
+                    e,
+                    exc_info=e,
+                )
+                deserialized_value = {}
+        else:
+            deserialized_value = {}
+
+        # Apply default values for keys that don't exist in the current state
+        if self.default is not None:
+            for default_key, default_value in self.default.items():
+                if default_key not in deserialized_value:
+                    deserialized_value[default_key] = default_value
+
+        state: BidiComponentState = {"value": deserialized_value}
+        return cast("BidiComponentState", AttributeDictionary(state))
+
+    def serialize(self, value: Any) -> str:
+        """Serialize the component's state into a JSON string for the frontend.
+
+        Parameters
+        ----------
+        value
+            The component state to serialize.
+
+        Returns
+        -------
+        str
+            A JSON string representation of the value.
+
+        """
+        return json.dumps(value)

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -188,6 +188,8 @@ class BidiComponentSerde:
     This class handles the conversion of component state between the frontend
     (JSON strings) and the backend (Python objects).
 
+    The canonical shape is a flat mapping of state keys to values.
+
     Parameters
     ----------
     default
@@ -210,14 +212,12 @@ class BidiComponentSerde:
         Returns
         -------
         BidiComponentState
-            The deserialized state, wrapped in an `AttributeDictionary` for
-            convenient access.
+            The deserialized state as a flat mapping.
 
         """
-        # We always normalize the incoming JSON payload into a *dict*.
-        # Any failure to decode (or an unexpected non-mapping structure)
-        # results in an empty mapping so that the returned type adheres to
-        # :class:`BidiComponentState`.
+        # Normalize the incoming JSON payload into a dict. Any failure to decode
+        # (or an unexpected non-mapping structure) results in an empty mapping
+        # so that the returned type adheres to :class:`BidiComponentState`.
 
         deserialized_value: dict[str, Any]
 
@@ -243,8 +243,10 @@ class BidiComponentSerde:
                 if default_key not in deserialized_value:
                     deserialized_value[default_key] = default_value
 
-        state: BidiComponentState = {"value": deserialized_value}
-        return cast("BidiComponentState", AttributeDictionary(state))
+        state: BidiComponentState = cast(
+            "BidiComponentState", AttributeDictionary(deserialized_value)
+        )
+        return state
 
     def serialize(self, value: Any) -> str:
         """Serialize the component's state into a JSON string for the frontend.

--- a/lib/streamlit/components/v2/bidi_component/state.py
+++ b/lib/streamlit/components/v2/bidi_component/state.py
@@ -23,19 +23,12 @@ class BidiComponentState(TypedDict, total=False):
     """
     The schema for the state of a bidirectional component.
 
-    The state is stored in a dictionary-like object that supports both key and
-    attribute notation. States cannot be programmatically changed or set through
-    Session State.
-
-    Attributes
-    ----------
-    value
-        The current value of the component instance returned from the frontend,
-        or the default value if not yet set. This is a dictionary containing
-        the actual state key-value pairs.
+    The state is a flat dictionary-like object (key -> value) that supports
+    both key and attribute notation via :class:`AttributeDictionary`.
     """
 
-    value: dict[str, Any]
+    # Flat mapping of state key -> value
+    # (kept empty to reflect open set of keys)
 
 
 class BidiComponentResult(AttributeDictionary):
@@ -61,7 +54,9 @@ class BidiComponentResult(AttributeDictionary):
         super().__init__(
             {
                 # The order here matters, because all stateful values will
-                # always be returned, but trigger values may be transient.
+                # always be returned, but trigger values may be transient. This
+                # mirrors presentation behavior in
+                # `make_bidi_component_presenter`.
                 **trigger_vals,
                 **state_vals,
             }
@@ -69,36 +64,10 @@ class BidiComponentResult(AttributeDictionary):
 
 
 def unwrap_component_state(raw_state: Any) -> dict[str, Any]:
-    """Return the inner mapping of a valid :class:`BidiComponentState`.
+    """Return flat mapping when given a dict; otherwise, empty dict.
 
-    A valid component state **must** be a mapping that contains exactly one key:
-    ``"value"``, whose associated value is itself a mapping holding the actual
-    per-key state entries produced by the frontend.
-
-    Any other shape is considered invalid and will be treated as an empty
-    mapping. This strictness ensures we never silently accept malformed data
-    that could mask bugs elsewhere in the stack.
-
-    Parameters
-    ----------
-    raw_state
-        The value retrieved from Session State.
-
-    Returns
-    -------
-    dict[str, Any]
-        The *inner* state mapping if the input adheres to the expected
-        structure; otherwise, an empty ``dict``.
-
+    The new canonical state is flat, so this is effectively an identity for
+    dict inputs and a guard for other types.
     """
 
-    if (
-        isinstance(raw_state, dict)
-        and set(raw_state.keys()) == {"value"}
-        and isinstance(raw_state["value"], dict)
-    ):
-        # Shallow-copy to decouple from the original reference.
-        return dict(raw_state["value"])
-
-    # Any deviation from the expected schema is regarded as invalid.
-    return {}
+    return dict(raw_state) if isinstance(raw_state, dict) else {}

--- a/lib/streamlit/components/v2/bidi_component/state.py
+++ b/lib/streamlit/components/v2/bidi_component/state.py
@@ -1,0 +1,104 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from streamlit.util import AttributeDictionary
+
+
+class BidiComponentState(TypedDict, total=False):
+    """
+    The schema for the state of a bidirectional component.
+
+    The state is stored in a dictionary-like object that supports both key and
+    attribute notation. States cannot be programmatically changed or set through
+    Session State.
+
+    Attributes
+    ----------
+    value
+        The current value of the component instance returned from the frontend,
+        or the default value if not yet set. This is a dictionary containing
+        the actual state key-value pairs.
+    """
+
+    value: dict[str, Any]
+
+
+class BidiComponentResult(AttributeDictionary):
+    """Rich return object for ``st.bidi_component``.
+
+    It behaves like a regular :class:`dict` *and* allows attribute-style
+    access to its keys, mirroring the behaviour of
+    :class:`streamlit.util.AttributeDictionary`. It surfaces both trigger and
+    state values as top-level entries so they can be accessed via either key or
+    attribute access.
+    """
+
+    def __init__(
+        self,
+        state_vals: dict[str, Any] | None = None,
+        trigger_vals: dict[str, Any] | None = None,
+    ) -> None:
+        if state_vals is None:
+            state_vals = {}
+        if trigger_vals is None:
+            trigger_vals = {}
+
+        super().__init__(
+            {
+                # The order here matters, because all stateful values will
+                # always be returned, but trigger values may be transient.
+                **trigger_vals,
+                **state_vals,
+            }
+        )
+
+
+def unwrap_component_state(raw_state: Any) -> dict[str, Any]:
+    """Return the inner mapping of a valid :class:`BidiComponentState`.
+
+    A valid component state **must** be a mapping that contains exactly one key:
+    ``"value"``, whose associated value is itself a mapping holding the actual
+    per-key state entries produced by the frontend.
+
+    Any other shape is considered invalid and will be treated as an empty
+    mapping. This strictness ensures we never silently accept malformed data
+    that could mask bugs elsewhere in the stack.
+
+    Parameters
+    ----------
+    raw_state
+        The value retrieved from Session State.
+
+    Returns
+    -------
+    dict[str, Any]
+        The *inner* state mapping if the input adheres to the expected
+        structure; otherwise, an empty ``dict``.
+
+    """
+
+    if (
+        isinstance(raw_state, dict)
+        and set(raw_state.keys()) == {"value"}
+        and isinstance(raw_state["value"], dict)
+    ):
+        # Shallow-copy to decouple from the original reference.
+        return dict(raw_state["value"])
+
+    # Any deviation from the expected schema is regarded as invalid.
+    return {}

--- a/lib/streamlit/components/v2/presentation.py
+++ b/lib/streamlit/components/v2/presentation.py
@@ -1,0 +1,128 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict, TypeGuard, cast
+
+from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from streamlit.runtime.state import SessionState
+    from streamlit.runtime.state.common import WidgetValuePresenter
+
+
+_LOGGER = get_logger(__name__)
+
+
+class _WrappedValue(TypedDict):
+    value: Mapping[str, object]
+
+
+class _TriggerPayload(TypedDict, total=False):
+    event: str
+    value: object
+
+
+def make_bidi_component_presenter(aggregator_id: str) -> WidgetValuePresenter:
+    """Return a presenter that merges trigger events into CCv2 state.
+
+    This function returns a callable that takes a component's persistent state
+    value and the current `SessionState` instance, and returns the user-visible
+    value that should appear in `st.session_state`.
+
+    The presenter is side-effect-free and does not mutate stored state or
+    callback behavior. It is intended to be attached to the persistent state
+    widget via the generic `presenter` hook.
+
+    Parameters
+    ----------
+    aggregator_id
+        The ID of the trigger aggregator widget that holds the event payloads.
+
+    Returns
+    -------
+    WidgetValuePresenter
+        A callable that merges the trigger event values into the component's
+        base state for presentation in `st.session_state`.
+
+    """
+
+    def _present(base_value: object, session_state: SessionState) -> object:
+        def _is_wrapped_value(obj: object) -> TypeGuard[_WrappedValue]:
+            if not isinstance(obj, dict):
+                return False
+
+            # The cast is necessary to convince the type checker that key access is safe.
+            obj = cast("dict[str, object]", obj)
+
+            if "value" not in obj or len(obj) != 1:
+                return False
+
+            return isinstance(obj["value"], dict)
+
+        if _is_wrapped_value(base_value):
+            # Read the trigger aggregator payloads if present
+            try:
+                agg_meta = session_state._new_widget_state.widget_metadata.get(
+                    aggregator_id
+                )
+                if agg_meta is None or agg_meta.value_type != "json_trigger_value":
+                    return base_value
+
+                try:
+                    agg_payloads_obj = session_state._new_widget_state[aggregator_id]
+                except KeyError:
+                    agg_payloads_obj = None
+
+                payloads_list: list[_TriggerPayload] | None
+                if agg_payloads_obj is None:
+                    payloads_list = None
+                elif isinstance(agg_payloads_obj, list):
+                    # Filter and cast to the expected payload type shape
+                    payloads_list = [
+                        cast("_TriggerPayload", p)
+                        for p in agg_payloads_obj
+                        if isinstance(p, dict)
+                    ]
+                elif isinstance(agg_payloads_obj, dict):
+                    payloads_list = [cast("_TriggerPayload", agg_payloads_obj)]
+                else:
+                    payloads_list = None
+
+                event_to_val: dict[str, object] = {}
+                if payloads_list is not None:
+                    for payload in payloads_list:
+                        ev = payload.get("event")
+                        if isinstance(ev, str):
+                            event_to_val[ev] = payload.get("value")
+
+                wrapped = cast("_WrappedValue", base_value)  # type: ignore[redundant-cast]
+                inner: dict[str, object] = dict(wrapped["value"])  # shallow copy
+                inner.update(event_to_val)
+                return {"value": inner}
+            except Exception as e:
+                # On any error, fall back to the base value
+                _LOGGER.debug(
+                    "Failed to merge trigger events into component state: %s",
+                    e,
+                    exc_info=e,
+                )
+                return base_value
+
+        return base_value
+
+    return _present

--- a/lib/streamlit/components/v2/presentation.py
+++ b/lib/streamlit/components/v2/presentation.py
@@ -14,13 +14,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict, TypeGuard, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+from typing_extensions import Self
+
+from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from streamlit.runtime.state import SessionState
     from streamlit.runtime.state.common import WidgetValuePresenter
 
@@ -28,16 +30,16 @@ if TYPE_CHECKING:
 _LOGGER = get_logger(__name__)
 
 
-class _WrappedValue(TypedDict):
-    value: Mapping[str, object]
-
-
 class _TriggerPayload(TypedDict, total=False):
     event: str
     value: object
 
 
-def make_bidi_component_presenter(aggregator_id: str) -> WidgetValuePresenter:
+def make_bidi_component_presenter(
+    aggregator_id: str,
+    component_id: str | None = None,
+    allowed_state_keys: set[str] | None = None,
+) -> WidgetValuePresenter:
     """Return a presenter that merges trigger events into CCv2 state.
 
     This function returns a callable that takes a component's persistent state
@@ -62,19 +64,25 @@ def make_bidi_component_presenter(aggregator_id: str) -> WidgetValuePresenter:
     """
 
     def _present(base_value: object, session_state: SessionState) -> object:
-        def _is_wrapped_value(obj: object) -> TypeGuard[_WrappedValue]:
-            if not isinstance(obj, dict):
-                return False
+        def _check_modification(k: str) -> None:
+            ctx = get_script_run_ctx()
+            if ctx is not None and component_id is not None:
+                user_key = session_state._key_id_mapper.get_key_from_id(component_id)
+                if (
+                    component_id in ctx.widget_ids_this_run
+                    or user_key in ctx.form_ids_this_run
+                ):
+                    raise StreamlitAPIException(
+                        f"`st.session_state.{user_key}.{k}` cannot be modified after the component"
+                        f" with key `{user_key}` is instantiated."
+                    )
 
-            # The cast is necessary to convince the type checker that key access is safe.
-            obj = cast("dict[str, object]", obj)
+        # Base state must be a flat mapping; otherwise, present as-is.
+        base_map: dict[str, object] | None = None
+        if isinstance(base_value, dict):
+            base_map = cast("dict[str, object]", base_value)
 
-            if "value" not in obj or len(obj) != 1:
-                return False
-
-            return isinstance(obj["value"], dict)
-
-        if _is_wrapped_value(base_value):
+        if base_map is not None:
             # Read the trigger aggregator payloads if present
             try:
                 agg_meta = session_state._new_widget_state.widget_metadata.get(
@@ -110,10 +118,72 @@ def make_bidi_component_presenter(aggregator_id: str) -> WidgetValuePresenter:
                         if isinstance(ev, str):
                             event_to_val[ev] = payload.get("value")
 
-                wrapped = cast("_WrappedValue", base_value)  # type: ignore[redundant-cast]
-                inner: dict[str, object] = dict(wrapped["value"])  # shallow copy
-                inner.update(event_to_val)
-                return {"value": inner}
+                # Merge triggers into a flat view: triggers first, then base
+                flat: dict[str, object] = dict(event_to_val)
+                flat.update(base_map)
+
+                # Return a write-through dict that updates the underlying
+                # component state when users assign nested keys via
+                # st.session_state[component_user_key][name] = value. Using a
+                # dict subclass ensures pretty-printing and JSON serialization
+                # behave as expected for st.write and logs.
+                class _WriteThrough(dict[str, object]):
+                    def __init__(self, data: dict[str, object]) -> None:
+                        super().__init__(data)
+
+                    def __getattr__(self, name: str) -> object:
+                        return self.get(name)
+
+                    def __setattr__(self, name: str, value: object) -> None:
+                        if name.startswith(("__", "_")):
+                            return super().__setattr__(name, value)
+                        self[name] = value
+                        return None
+
+                    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
+                        # This object is a proxy to the real state. Don't copy it.
+                        memo[id(self)] = self
+                        return self
+
+                    def __setitem__(self, k: str, v: object) -> None:
+                        _check_modification(k)
+
+                        if (
+                            allowed_state_keys is not None
+                            and k not in allowed_state_keys
+                        ):
+                            # Silently ignore invalid keys to match permissive session_state semantics
+                            return
+
+                        # Update the underlying stored base state and this dict
+                        super().__setitem__(k, v)
+                        try:
+                            # Store back to session state's widget store as a flat mapping
+                            ss = session_state
+                            # Directly set the value in the new widget state store
+                            if component_id is not None:
+                                ss._new_widget_state.set_from_value(
+                                    component_id, dict(self)
+                                )
+                        except Exception as e:
+                            _LOGGER.debug("Failed to persist CCv2 state update: %s", e)
+
+                    def __delitem__(self, k: str) -> None:
+                        _check_modification(k)
+
+                        super().__delitem__(k)
+                        try:
+                            ss = session_state
+                            if component_id is not None:
+                                ss._new_widget_state.set_from_value(
+                                    component_id, dict(self)
+                                )
+                        except Exception as e:
+                            _LOGGER.debug(
+                                "Failed to persist CCv2 state deletion: %s", e
+                            )
+
+                return _WriteThrough(flat)
             except Exception as e:
                 # On any error, fall back to the base value
                 _LOGGER.debug(

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -39,6 +39,7 @@ from streamlit import (
     runtime,
     util,
 )
+from streamlit.components.v2.bidi_component import BidiComponentMixin
 from streamlit.delta_generator_singletons import (
     context_dg_stack,
     get_last_dg_added_to_context_stack,
@@ -216,6 +217,7 @@ class DeltaGenerator(
     ArrowMixin,
     VegaChartsMixin,
     DataEditorMixin,
+    BidiComponentMixin,
 ):
     """Creator of Delta protobuf messages.
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -439,6 +439,55 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
         )
 
 
+# Bidirectional Components
+class BidiComponentInvalidIdError(LocalizableStreamlitException):
+    """Exception raised when an invalid ID component is provided."""
+
+    def __init__(self, part: str, delimiter: str) -> None:
+        super().__init__(
+            "The `{part}` of a bidirectional component's ID must not contain "
+            "the delimiter sequence `{delimiter}`.",
+            part=part,
+            delimiter=delimiter,
+        )
+
+
+class BidiComponentMissingContentError(LocalizableStreamlitException):
+    """Exception raised when a component is missing required content."""
+
+    def __init__(self, component_name: str) -> None:
+        super().__init__(
+            "Component `{component_name}` must have either JavaScript content "
+            "(`js_content` or `js_url`) or HTML content (`html_content`), or both. "
+            "Please ensure the component definition includes at least one of these.",
+            component_name=component_name,
+        )
+
+
+class BidiComponentInvalidDefaultKeyError(LocalizableStreamlitException):
+    """Exception raised when an invalid key is provided in the default dict."""
+
+    def __init__(self, state_key: str, available_keys: list[str]) -> None:
+        super().__init__(
+            "Key `'{state_key}'` in `default` is not a valid state name. "
+            "Valid state names are those with corresponding `on_{{state_name}}_change` "
+            "callbacks. Available state names: `{available_keys}`",
+            state_key=state_key,
+            available_keys=available_keys or "none",
+        )
+
+
+class BidiComponentUnserializableDataError(LocalizableStreamlitException):
+    """Exception raised when data provided to a bidirectional component cannot be serialized."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "The `data` provided to the bidirectional component could not be serialized. "
+            "Please ensure the data is JSON-serializable, or is a supported data structure "
+            "like a pandas DataFrame."
+        )
+
+
 # policies
 class StreamlitFragmentWidgetsNotAllowedOutsideError(LocalizableStreamlitException):
     """Exception raised when the fragment attempts to write to an element outside of its container."""

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -464,6 +464,18 @@ class BidiComponentMissingContentError(LocalizableStreamlitException):
         )
 
 
+class BidiComponentInvalidCallbackNameError(LocalizableStreamlitException):
+    """Exception raised when a callback with an invalid name is provided."""
+
+    def __init__(self, callback_name: str) -> None:
+        super().__init__(
+            "The callback name `'{callback_name}'` is not allowed. "
+            "Callback names must follow the pattern `on_{{event_name}}_change` "
+            "where `event_name` is not empty.",
+            callback_name=callback_name,
+        )
+
+
 class BidiComponentInvalidDefaultKeyError(LocalizableStreamlitException):
     """Exception raised when an invalid key is provided in the default dict."""
 

--- a/lib/tests/streamlit/components/v2/bidi_component/__init__.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
@@ -46,28 +46,28 @@ def test_serde_deserialize_with_dict():
     """Test deserialize with a dictionary."""
     serde = BidiComponentSerde()
     state = serde.deserialize({"foo": "bar"})
-    assert state == {"value": {"foo": "bar"}}
+    assert state == {"foo": "bar"}
 
 
 def test_serde_deserialize_with_json_string():
     """Test deserialize with a JSON string."""
     serde = BidiComponentSerde()
     state = serde.deserialize('{"foo": "bar"}')
-    assert state == {"value": {"foo": "bar"}}
+    assert state == {"foo": "bar"}
 
 
 def test_serde_deserialize_with_defaults():
     """Test deserialize with default values."""
     serde = BidiComponentSerde(default={"bar": "baz"})
     state = serde.deserialize({"foo": "qux"})
-    assert state == {"value": {"foo": "qux", "bar": "baz"}}
+    assert state == {"foo": "qux", "bar": "baz"}
 
 
 def test_serde_deserialize_with_none():
     """Test deserialize with None."""
     serde = BidiComponentSerde()
     state = serde.deserialize(None)
-    assert state == {"value": {}}
+    assert state == {}
 
 
 def test_serde_serialize():
@@ -86,9 +86,9 @@ def test_serde_deserialize_with_defaults_empty_state():
     result = serde.deserialize(None)
 
     # Should have defaults applied
-    assert result["value"]["count"] == 0
-    assert result["value"]["message"] == "hello"
-    assert result["value"]["enabled"] is True
+    assert result["count"] == 0
+    assert result["message"] == "hello"
+    assert result["enabled"] is True
 
 
 def test_serde_deserialize_with_defaults_partial_state():
@@ -101,9 +101,9 @@ def test_serde_deserialize_with_defaults_partial_state():
     result = serde.deserialize(json.dumps(partial_state))
 
     # Should preserve existing values and add missing defaults
-    assert result["value"]["count"] == 5  # Existing value preserved
-    assert result["value"]["message"] == "custom"  # Existing value preserved
-    assert result["value"]["enabled"] is True  # Default applied
+    assert result["count"] == 5  # Existing value preserved
+    assert result["message"] == "custom"  # Existing value preserved
+    assert result["enabled"] is True  # Default applied
 
 
 def test_serde_deserialize_with_defaults_complete_state():
@@ -116,9 +116,9 @@ def test_serde_deserialize_with_defaults_complete_state():
     result = serde.deserialize(json.dumps(complete_state))
 
     # Should preserve all existing values
-    assert result["value"]["count"] == 10
-    assert result["value"]["message"] == "world"
-    assert result["value"]["extra"] == "data"
+    assert result["count"] == 10
+    assert result["message"] == "world"
+    assert result["extra"] == "data"
 
 
 def test_serde_deserialize_without_defaults():
@@ -130,7 +130,7 @@ def test_serde_deserialize_without_defaults():
     result = serde.deserialize(json.dumps(state))
 
     # Should just return the state as-is
-    assert result["value"]["count"] == 5
+    assert result["count"] == 5
 
 
 def test_serde_deserialize_with_invalid_json():
@@ -142,7 +142,7 @@ def test_serde_deserialize_with_invalid_json():
     result = serde.deserialize("invalid json {")
 
     # Should fall back to empty state with defaults applied
-    assert result["value"]["fallback"] == "value"
+    assert result["fallback"] == "value"
 
 
 def test_serde_deserialize_with_dict_input_and_defaults():
@@ -155,8 +155,8 @@ def test_serde_deserialize_with_dict_input_and_defaults():
     result = serde.deserialize(input_dict)
 
     # Should merge defaults with existing
-    assert result["value"]["existing_key"] == "existing_value"
-    assert result["value"]["default_key"] == "default_value"
+    assert result["existing_key"] == "existing_value"
+    assert result["default_key"] == "default_value"
 
 
 def test_serde_deserialize_with_none_defaults():
@@ -168,8 +168,8 @@ def test_serde_deserialize_with_none_defaults():
     result = serde.deserialize(None)
 
     # Should apply None as a valid default
-    assert result["value"]["nullable"] is None
-    assert result["value"]["string"] == "value"
+    assert result["nullable"] is None
+    assert result["string"] == "value"
 
 
 def test_extract_dataframes_from_dict():

--- a/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
@@ -1,0 +1,240 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from streamlit.components.v2.bidi_component.serialization import (
+    BidiComponentSerde,
+    _extract_dataframes_from_dict,
+    deserialize_trigger_list,
+    handle_deserialize,
+    serialize_mixed_data,
+)
+from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
+
+
+def test_handle_deserialize():
+    """Test handle_deserialize with valid JSON, invalid JSON, and None."""
+    assert handle_deserialize('{"key": "value"}') == {"key": "value"}
+    assert handle_deserialize("not a json string") == "not a json string"
+    assert handle_deserialize(None) is None
+
+
+def test_deserialize_trigger_list():
+    """Test deserialize_trigger_list with different payload formats."""
+    assert deserialize_trigger_list('[{"event": "click"}]') == [{"event": "click"}]
+    assert deserialize_trigger_list('{"event": "click"}') == [{"event": "click"}]
+    assert deserialize_trigger_list(None) is None
+
+
+def test_serde_deserialize_with_dict():
+    """Test deserialize with a dictionary."""
+    serde = BidiComponentSerde()
+    state = serde.deserialize({"foo": "bar"})
+    assert state == {"value": {"foo": "bar"}}
+
+
+def test_serde_deserialize_with_json_string():
+    """Test deserialize with a JSON string."""
+    serde = BidiComponentSerde()
+    state = serde.deserialize('{"foo": "bar"}')
+    assert state == {"value": {"foo": "bar"}}
+
+
+def test_serde_deserialize_with_defaults():
+    """Test deserialize with default values."""
+    serde = BidiComponentSerde(default={"bar": "baz"})
+    state = serde.deserialize({"foo": "qux"})
+    assert state == {"value": {"foo": "qux", "bar": "baz"}}
+
+
+def test_serde_deserialize_with_none():
+    """Test deserialize with None."""
+    serde = BidiComponentSerde()
+    state = serde.deserialize(None)
+    assert state == {"value": {}}
+
+
+def test_serde_serialize():
+    """Test serialize."""
+    serde = BidiComponentSerde()
+    serialized = serde.serialize({"foo": "bar"})
+    assert serialized == '{"foo": "bar"}'
+
+
+def test_serde_deserialize_with_defaults_empty_state():
+    """Test that defaults are applied when state is empty."""
+    defaults = {"count": 0, "message": "hello", "enabled": True}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize empty state
+    result = serde.deserialize(None)
+
+    # Should have defaults applied
+    assert result["value"]["count"] == 0
+    assert result["value"]["message"] == "hello"
+    assert result["value"]["enabled"] is True
+
+
+def test_serde_deserialize_with_defaults_partial_state():
+    """Test that defaults are applied only for missing keys."""
+    defaults = {"count": 0, "message": "hello", "enabled": True}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize partial state
+    partial_state = {"count": 5, "message": "custom"}
+    result = serde.deserialize(json.dumps(partial_state))
+
+    # Should preserve existing values and add missing defaults
+    assert result["value"]["count"] == 5  # Existing value preserved
+    assert result["value"]["message"] == "custom"  # Existing value preserved
+    assert result["value"]["enabled"] is True  # Default applied
+
+
+def test_serde_deserialize_with_defaults_complete_state():
+    """Test that defaults don't override existing values."""
+    defaults = {"count": 0, "message": "hello"}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize complete state
+    complete_state = {"count": 10, "message": "world", "extra": "data"}
+    result = serde.deserialize(json.dumps(complete_state))
+
+    # Should preserve all existing values
+    assert result["value"]["count"] == 10
+    assert result["value"]["message"] == "world"
+    assert result["value"]["extra"] == "data"
+
+
+def test_serde_deserialize_without_defaults():
+    """Test that serde works correctly without defaults."""
+    serde = BidiComponentSerde()  # No defaults
+
+    # Deserialize state
+    state = {"count": 5}
+    result = serde.deserialize(json.dumps(state))
+
+    # Should just return the state as-is
+    assert result["value"]["count"] == 5
+
+
+def test_serde_deserialize_with_invalid_json():
+    """Test that defaults are applied even with invalid JSON input."""
+    defaults = {"fallback": "value"}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize invalid JSON
+    result = serde.deserialize("invalid json {")
+
+    # Should fall back to empty state with defaults applied
+    assert result["value"]["fallback"] == "value"
+
+
+def test_serde_deserialize_with_dict_input_and_defaults():
+    """Test that defaults work with direct dict input."""
+    defaults = {"default_key": "default_value"}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize dict input
+    input_dict = {"existing_key": "existing_value"}
+    result = serde.deserialize(input_dict)
+
+    # Should merge defaults with existing
+    assert result["value"]["existing_key"] == "existing_value"
+    assert result["value"]["default_key"] == "default_value"
+
+
+def test_serde_deserialize_with_none_defaults():
+    """Test that None values in defaults are properly handled."""
+    defaults = {"nullable": None, "string": "value"}
+    serde = BidiComponentSerde(default=defaults)
+
+    # Deserialize empty state
+    result = serde.deserialize(None)
+
+    # Should apply None as a valid default
+    assert result["value"]["nullable"] is None
+    assert result["value"]["string"] == "value"
+
+
+def test_extract_dataframes_from_dict():
+    """Test _extract_dataframes_from_dict."""
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    data = {"key1": "value1", "dataframe": df, "key2": 123}
+
+    arrow_blobs = {}
+    processed_data = _extract_dataframes_from_dict(data, arrow_blobs)
+
+    assert "key1" in processed_data
+    assert "key2" in processed_data
+    assert "dataframe" in processed_data
+    assert "__streamlit_arrow_ref__" in processed_data["dataframe"]
+    assert len(arrow_blobs) == 1
+
+
+def test_serialize_mixed_data_with_dataframe():
+    """Test serialize_mixed_data with a dataframe."""
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    data = {"my_df": df, "other_key": "value"}
+    proto = BidiComponentProto()
+
+    serialize_mixed_data(data, proto)
+
+    assert proto.HasField("mixed")
+    assert not proto.HasField("json")
+    mixed_data = json.loads(proto.mixed.json)
+    assert "my_df" in mixed_data
+    assert "__streamlit_arrow_ref__" in mixed_data["my_df"]
+    assert len(proto.mixed.arrow_blobs) == 1
+
+
+def test_serialize_mixed_data_without_dataframe():
+    """Test serialize_mixed_data without a dataframe."""
+    data = {"key": "value"}
+    proto = BidiComponentProto()
+
+    serialize_mixed_data(data, proto)
+
+    assert not proto.HasField("mixed")
+    assert proto.HasField("json")
+    assert json.loads(proto.json) == data
+
+
+def test_serialize_mixed_data_with_non_dict():
+    """Test serialize_mixed_data with non-dictionary data."""
+    data = [1, 2, 3]
+    proto = BidiComponentProto()
+
+    serialize_mixed_data(data, proto)
+
+    assert not proto.HasField("mixed")
+    assert proto.HasField("json")
+    assert json.loads(proto.json) == data
+
+
+def test_serialization_fallback_to_string():
+    """Test that serialization falls back to string representation on failure."""
+    # Sets are not directly JSON-serializable
+    data = {"key": {1, 2, 3}}
+    proto = BidiComponentProto()
+
+    serialize_mixed_data(data, proto)
+
+    assert not proto.HasField("mixed")
+    assert proto.HasField("json")
+    assert json.loads(proto.json) == str(data)

--- a/lib/tests/streamlit/components/v2/bidi_component/test_state.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_state.py
@@ -1,0 +1,59 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from streamlit.components.v2.bidi_component.state import (
+    BidiComponentResult,
+    unwrap_component_state,
+)
+
+
+def test_unwrap_component_state() -> None:
+    """Test unwrap_component_state with valid and invalid state structures."""
+    valid_state = {"value": {"foo": "bar"}}
+    assert unwrap_component_state(valid_state) == {"foo": "bar"}
+
+    invalid_state_1 = {"foo": "bar"}  # Missing 'value' key
+    assert unwrap_component_state(invalid_state_1) == {}
+
+    invalid_state_2 = {"value": "not a dict"}
+    assert unwrap_component_state(invalid_state_2) == {}
+
+
+def test_bidi_component_result_merges_state_and_trigger_values() -> None:
+    """Test that BidiComponentResult surfaces trigger and state values."""
+
+    state_vals = {"foo": "bar"}
+    trigger_vals = {"on_click": 42}
+
+    result = BidiComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
+
+    assert result["foo"] == "bar"
+    assert result.foo == "bar"
+    assert result["on_click"] == 42
+    assert result.on_click == 42
+    assert "delta_generator" not in result
+
+
+def test_bidi_component_result_merge_order() -> None:
+    """Test that trigger keys precede state keys and state overrides duplicates."""
+
+    state_vals = {"shared": "state", "state_only": "value"}
+    trigger_vals = {"shared": "trigger", "trigger_only": "value"}
+
+    result = BidiComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
+
+    assert list(result.keys()) == ["shared", "trigger_only", "state_only"]
+    assert result.shared == "state"

--- a/lib/tests/streamlit/components/v2/bidi_component/test_state.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_state.py
@@ -14,22 +14,13 @@
 
 from __future__ import annotations
 
-from streamlit.components.v2.bidi_component.state import (
-    BidiComponentResult,
-    unwrap_component_state,
-)
+from streamlit.components.v2.bidi_component.state import BidiComponentResult
 
 
-def test_unwrap_component_state() -> None:
-    """Test unwrap_component_state with valid and invalid state structures."""
-    valid_state = {"value": {"foo": "bar"}}
-    assert unwrap_component_state(valid_state) == {"foo": "bar"}
-
-    invalid_state_1 = {"foo": "bar"}  # Missing 'value' key
-    assert unwrap_component_state(invalid_state_1) == {}
-
-    invalid_state_2 = {"value": "not a dict"}
-    assert unwrap_component_state(invalid_state_2) == {}
+def test_bidi_component_result_empty() -> None:
+    """Test empty result handling."""
+    result = BidiComponentResult()
+    assert dict(result) == {}
 
 
 def test_bidi_component_result_merges_state_and_trigger_values() -> None:

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1,0 +1,39 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from streamlit.components.v2.bidi_component.constants import EVENT_DELIM
+from streamlit.components.v2.bidi_component.main import _make_trigger_id
+from streamlit.errors import StreamlitAPIException
+
+
+def test_make_trigger_id():
+    """Test that _make_trigger_id constructs a valid trigger ID."""
+    base = "component_id"
+    event = "click"
+    trigger_id = _make_trigger_id(base, event)
+    assert base in trigger_id
+    assert event in trigger_id
+    assert EVENT_DELIM in trigger_id
+
+
+def test_make_trigger_id_with_invalid_chars():
+    """Test that _make_trigger_id raises an exception if invalid characters are used."""
+    with pytest.raises(StreamlitAPIException):
+        _make_trigger_id(f"base{EVENT_DELIM}id", "click")
+    with pytest.raises(StreamlitAPIException):
+        _make_trigger_id("base_id", f"click{EVENT_DELIM}event")

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -16,9 +16,16 @@ from __future__ import annotations
 
 import pytest
 
+from streamlit import _main as st_main
 from streamlit.components.v2.bidi_component.constants import EVENT_DELIM
 from streamlit.components.v2.bidi_component.main import _make_trigger_id
-from streamlit.errors import StreamlitAPIException
+from streamlit.components.v2.component_registry import BidiComponentDefinition
+from streamlit.errors import (
+    BidiComponentInvalidCallbackNameError,
+    StreamlitAPIException,
+)
+from streamlit.runtime import Runtime
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
 def test_make_trigger_id():
@@ -37,3 +44,31 @@ def test_make_trigger_id_with_invalid_chars():
         _make_trigger_id(f"base{EVENT_DELIM}id", "click")
     with pytest.raises(StreamlitAPIException):
         _make_trigger_id("base_id", f"click{EVENT_DELIM}event")
+
+
+class BidiComponentTest(DeltaGeneratorTestCase):
+    def setUp(self):
+        super().setUp()
+        registry = Runtime.instance().bidi_component_registry
+        component_def = BidiComponentDefinition(
+            name="my_component",
+            js="console.log('hello');",
+        )
+        registry._components["my_component"] = component_def
+        self.dg = st_main
+
+    def test_bidi_component_disallowed_on_change_callbacks(self):
+        """Test that `on_change` and `on__change` are disallowed as callbacks."""
+        with pytest.raises(BidiComponentInvalidCallbackNameError):
+            self.dg._bidi_component(
+                "my_component",
+                key="key1",
+                on_change=lambda: None,
+            )
+
+        with pytest.raises(BidiComponentInvalidCallbackNameError):
+            self.dg._bidi_component(
+                "my_component",
+                key="key2",
+                on__change=lambda: None,
+            )

--- a/lib/tests/streamlit/components/v2/test_bidi_presentation.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_presentation.py
@@ -14,10 +14,16 @@
 
 from __future__ import annotations
 
+import copy
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from streamlit.components.v2.presentation import make_bidi_component_presenter
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.state import SessionState
 
 
 class _FakeWStates:
@@ -50,9 +56,9 @@ def test_bidi_presenter_merges_events_when_present() -> None:
         {"event": "bar", "value": 123},
     ]
 
-    base = {"value": {"alpha": 1}}
+    base = {"alpha": 1}
     out = presenter(base, ss)
-    assert out == {"value": {"alpha": 1, "foo": True, "bar": 123}}
+    assert dict(out) == {"alpha": 1, "foo": True, "bar": 123}
 
 
 def test_bidi_presenter_handles_non_list_payload() -> None:
@@ -65,9 +71,9 @@ def test_bidi_presenter_handles_non_list_payload() -> None:
     )
     ss._new_widget_state._payloads[agg_id] = {"event": "foo", "value": "x"}
 
-    base = {"value": {}}
+    base = {}
     out = presenter(base, ss)
-    assert out == {"value": {"foo": "x"}}
+    assert dict(out) == {"foo": "x"}
 
 
 def test_bidi_presenter_returns_base_on_missing_meta_or_wrong_type() -> None:
@@ -95,3 +101,148 @@ def test_bidi_presenter_returns_base_on_non_canonical_state_shape() -> None:
     )
     base = {"not_value": {}}
     assert presenter(base, ss) == base
+
+
+def test_setitem_disallows_setting_created_widget():
+    """Test that __setitem__ disallows setting a created widget."""
+    mock_session_state = MagicMock(spec=SessionState)
+    mock_session_state._key_id_mapper = MagicMock()
+    mock_session_state._key_id_mapper.get_key_from_id.return_value = "test_key"
+    mock_session_state._new_widget_state = MagicMock()
+    mock_session_state._new_widget_state.widget_metadata.get.return_value = MagicMock(
+        value_type="json_trigger_value"
+    )
+
+    mock_ctx = MagicMock()
+    mock_ctx.widget_ids_this_run = {"test_component_id"}
+    mock_ctx.form_ids_this_run = set()
+
+    presenter = make_bidi_component_presenter(
+        aggregator_id="test_aggregator_id",
+        component_id="test_component_id",
+    )
+    write_through_dict = presenter({}, mock_session_state)
+
+    with patch(
+        "streamlit.components.v2.presentation.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(StreamlitAPIException) as e:
+            write_through_dict["value"] = "new_value"
+        assert (
+            "`st.session_state.test_key.value` cannot be modified after the component"
+            in str(e.value)
+        )
+
+
+def test_delitem_disallows_deleting_from_created_widget():
+    """Test that __delitem__ disallows deleting from a created widget."""
+    mock_session_state = MagicMock(spec=SessionState)
+    mock_session_state._key_id_mapper = MagicMock()
+    mock_session_state._key_id_mapper.get_key_from_id.return_value = "test_key"
+    mock_session_state._new_widget_state = MagicMock()
+    mock_session_state._new_widget_state.widget_metadata.get.return_value = MagicMock(
+        value_type="json_trigger_value"
+    )
+
+    mock_ctx = MagicMock()
+    mock_ctx.widget_ids_this_run = {"test_component_id"}
+    mock_ctx.form_ids_this_run = set()
+
+    presenter = make_bidi_component_presenter(
+        aggregator_id="test_aggregator_id",
+        component_id="test_component_id",
+    )
+    write_through_dict = presenter({"value": "old_value"}, mock_session_state)
+
+    with patch(
+        "streamlit.components.v2.presentation.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(StreamlitAPIException) as e:
+            del write_through_dict["value"]
+        assert (
+            "`st.session_state.test_key.value` cannot be modified after the component"
+            in str(e.value)
+        )
+
+
+def test_setitem_disallows_setting_widget_in_form():
+    """Test that __setitem__ disallows setting a widget in a form."""
+    mock_session_state = MagicMock(spec=SessionState)
+    mock_session_state._key_id_mapper = MagicMock()
+    mock_session_state._key_id_mapper.get_key_from_id.return_value = "test_key"
+    mock_session_state._new_widget_state = MagicMock()
+    mock_session_state._new_widget_state.widget_metadata.get.return_value = MagicMock(
+        value_type="json_trigger_value"
+    )
+
+    mock_ctx = MagicMock()
+    mock_ctx.widget_ids_this_run = set()
+    mock_ctx.form_ids_this_run = {"test_key"}
+
+    presenter = make_bidi_component_presenter(
+        aggregator_id="test_aggregator_id",
+        component_id="test_component_id",
+    )
+    write_through_dict = presenter({}, mock_session_state)
+
+    with patch(
+        "streamlit.components.v2.presentation.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(StreamlitAPIException) as e:
+            write_through_dict["value"] = "new_value"
+        assert (
+            "`st.session_state.test_key.value` cannot be modified after the component"
+            in str(e.value)
+        )
+
+
+def test_setitem_allows_setting_before_widget_creation():
+    """Test that __setitem__ allows setting state before widget creation."""
+    mock_session_state = MagicMock(spec=SessionState)
+    mock_session_state._key_id_mapper = MagicMock()
+    mock_session_state._key_id_mapper.get_key_from_id.return_value = "test_key"
+    mock_session_state._new_widget_state = MagicMock()
+    mock_session_state._new_widget_state.widget_metadata.get.return_value = MagicMock(
+        value_type="json_trigger_value"
+    )
+
+    mock_ctx = MagicMock()
+    mock_ctx.widget_ids_this_run = set()
+    mock_ctx.form_ids_this_run = set()
+
+    presenter = make_bidi_component_presenter(
+        aggregator_id="test_aggregator_id",
+        component_id="test_component_id",
+    )
+    write_through_dict = presenter({}, mock_session_state)
+
+    with patch(
+        "streamlit.components.v2.presentation.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        try:
+            write_through_dict["value"] = "new_value"
+        except StreamlitAPIException as e:
+            pytest.fail(f"Setting state before creation raised an exception: {e}")
+
+
+def test_deepcopy_returns_self():
+    """Test that deepcopy returns the same object."""
+    mock_session_state = MagicMock(spec=SessionState)
+    mock_session_state._key_id_mapper = MagicMock()
+    mock_session_state._new_widget_state = MagicMock()
+    mock_session_state._new_widget_state.widget_metadata.get.return_value = MagicMock(
+        value_type="json_trigger_value"
+    )
+
+    presenter = make_bidi_component_presenter(
+        aggregator_id="test_aggregator_id",
+        component_id="test_component_id",
+    )
+    write_through_dict = presenter({}, mock_session_state)
+
+    copied_dict = copy.deepcopy(write_through_dict)
+    assert write_through_dict is copied_dict

--- a/lib/tests/streamlit/components/v2/test_bidi_presentation.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_presentation.py
@@ -1,0 +1,97 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from streamlit.components.v2.presentation import make_bidi_component_presenter
+
+
+class _FakeWStates:
+    def __init__(self) -> None:
+        self.widget_metadata: dict[str, Any] = {}
+        self._payloads: dict[str, Any] = {}
+
+    def __getitem__(self, k: str) -> Any:  # emulate WStates __getitem__
+        if k not in self._payloads:
+            raise KeyError(k)
+        return self._payloads[k]
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self._new_widget_state = _FakeWStates()
+
+
+def test_bidi_presenter_merges_events_when_present() -> None:
+    """Test that the presenter correctly merges event payloads into the base state."""
+    ss = _FakeSession()
+    agg_id = "$$_internal__wid__events"
+    presenter = make_bidi_component_presenter(agg_id)
+
+    ss._new_widget_state.widget_metadata[agg_id] = SimpleNamespace(
+        value_type="json_trigger_value"
+    )
+    ss._new_widget_state._payloads[agg_id] = [
+        {"event": "foo", "value": True},
+        {"event": "bar", "value": 123},
+    ]
+
+    base = {"value": {"alpha": 1}}
+    out = presenter(base, ss)
+    assert out == {"value": {"alpha": 1, "foo": True, "bar": 123}}
+
+
+def test_bidi_presenter_handles_non_list_payload() -> None:
+    """Test that the presenter can handle a single, non-list event payload."""
+    ss = _FakeSession()
+    agg_id = "$$_internal__wid__events"
+    presenter = make_bidi_component_presenter(agg_id)
+    ss._new_widget_state.widget_metadata[agg_id] = SimpleNamespace(
+        value_type="json_trigger_value"
+    )
+    ss._new_widget_state._payloads[agg_id] = {"event": "foo", "value": "x"}
+
+    base = {"value": {}}
+    out = presenter(base, ss)
+    assert out == {"value": {"foo": "x"}}
+
+
+def test_bidi_presenter_returns_base_on_missing_meta_or_wrong_type() -> None:
+    """Test that the presenter returns the base value if metadata is missing or incorrect."""
+    ss = _FakeSession()
+    agg_id = "$$_internal__wid__events"
+    presenter = make_bidi_component_presenter(agg_id)
+
+    base = {"value": {"beta": 2}}
+    # No metadata
+    assert presenter(base, ss) == base
+
+    # Wrong value type
+    ss._new_widget_state.widget_metadata[agg_id] = SimpleNamespace(value_type="json")
+    assert presenter(base, ss) == base
+
+
+def test_bidi_presenter_returns_base_on_non_canonical_state_shape() -> None:
+    """Test that the presenter returns the base value if the state shape is not canonical."""
+    ss = _FakeSession()
+    agg_id = "$$_internal__wid__events"
+    presenter = make_bidi_component_presenter(agg_id)
+    ss._new_widget_state.widget_metadata[agg_id] = SimpleNamespace(
+        value_type="json_trigger_value"
+    )
+    base = {"not_value": {}}
+    assert presenter(base, ss) == base

--- a/lib/tests/streamlit/runtime/state/test_presentation.py
+++ b/lib/tests/streamlit/runtime/state/test_presentation.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from streamlit.components.v2.bidi_component.main import _make_trigger_id
+from streamlit.components.v2.presentation import make_bidi_component_presenter
 from streamlit.runtime.state.common import WidgetMetadata
 from streamlit.runtime.state.presentation import apply_presenter
-from streamlit.runtime.state.session_state import SessionState
+from streamlit.runtime.state.session_state import SessionState, Value
 
 
 class _FakeWStates:
@@ -235,3 +237,132 @@ def test_filtered_state_excludes_keyed_element_when_internal(monkeypatch) -> Non
 
     filtered = ss.filtered_state
     assert user_key not in filtered
+
+
+def test_session_state_merges_ccv2_trigger_values_via_presenter() -> None:
+    """Integration: SessionState uses presenter to merge CCv2 trigger values.
+
+    We simulate a CCv2 component with a persistent state widget and an internal
+    trigger aggregator. The component registers a presenter via the shared
+    facade. We then assert that SessionState.filtered_state (user-facing view)
+    returns the persistent state merged with the latest trigger values, while
+    the underlying stored state remains unmodified.
+    """
+
+    session_state = SessionState()
+
+    # Simulate a component persistent state widget with user key mapping
+    component_id = "$$ID-bidi_component-my_component"
+    user_key = "my_component"
+    session_state._key_id_mapper[user_key] = component_id
+
+    # Store base persistent state as flat mapping
+    base_persistent = {"alpha": 1}
+    session_state._new_widget_state.states[component_id] = Value(base_persistent)
+    session_state._new_widget_state.widget_metadata[component_id] = WidgetMetadata(
+        id=component_id,
+        deserializer=lambda x: x,
+        serializer=lambda x: x,
+        value_type="json_value",
+    )
+
+    # Create trigger aggregator and payloads
+    aggregator_id = _make_trigger_id(component_id, "events")
+    session_state._new_widget_state.widget_metadata[aggregator_id] = WidgetMetadata(
+        id=aggregator_id,
+        deserializer=lambda x: x,
+        serializer=lambda x: x,
+        value_type="json_trigger_value",
+    )
+    session_state._new_widget_state.states[aggregator_id] = Value(
+        [
+            {"event": "foo", "value": True},
+            {"event": "bar", "value": 123},
+        ]
+    )
+
+    # Attach presenter (what bidi_component.py does during registration)
+    presenter = make_bidi_component_presenter(aggregator_id)
+    meta = session_state._new_widget_state.widget_metadata[component_id]
+    object.__setattr__(meta, "presenter", presenter)
+
+    # User-visible filtered state should show merged view
+    merged = session_state.filtered_state[user_key]
+    assert dict(merged) == {"alpha": 1, "foo": True, "bar": 123}
+
+    # Underlying stored state remains unmodified
+    assert session_state._new_widget_state.states[component_id].value is base_persistent
+
+
+def test_session_state_presenter_errors_degrade_gracefully() -> None:
+    """Integration: presenter exceptions should not break SessionState access.
+
+    If a presenter raises, SessionState should fall back to the base value
+    without propagating exceptions to the caller.
+    """
+
+    session_state = SessionState()
+
+    component_id = "$$ID-bidi_component-err_component"
+    user_key = "err_component"
+    session_state._key_id_mapper[user_key] = component_id
+
+    base_persistent: dict[str, Any] = {"value": {"x": 1}}
+    session_state._new_widget_state.states[component_id] = Value(base_persistent)
+    meta = WidgetMetadata(
+        id=component_id,
+        deserializer=lambda x: x,
+        serializer=lambda x: x,
+        value_type="json_value",
+    )
+    object.__setattr__(
+        meta, "presenter", lambda _b, _s: exec('raise RuntimeError("boom")')
+    )
+    session_state._new_widget_state.widget_metadata[component_id] = meta
+
+    # Access should not raise; should return base value instead
+    assert session_state.filtered_state[user_key] == base_persistent
+
+
+def test_bidi_presenter_state_overrides_duplicate_keys() -> None:
+    """State must override trigger values on duplicate keys.
+
+    This verifies the merge precedence documented in the presenter and in
+    BidiComponentResult: triggers are surfaced first, but persistent state
+    wins for duplicate keys.
+    """
+
+    class _FakeWStates2:
+        def __init__(self) -> None:
+            self.widget_metadata: dict[str, Any] = {}
+            self._payloads: dict[str, Any] = {}
+
+        def __getitem__(self, k: str) -> Any:  # emulate __getitem__ for payloads
+            if k not in self._payloads:
+                raise KeyError(k)
+            return self._payloads[k]
+
+    class _FakeSession2:
+        def __init__(self) -> None:
+            self._new_widget_state = _FakeWStates2()
+
+    ss = _FakeSession2()
+    agg_id = "$$__internal__events"
+    presenter = make_bidi_component_presenter(agg_id)
+
+    ss._new_widget_state.widget_metadata[agg_id] = SimpleNamespace(
+        value_type="json_trigger_value"
+    )
+    ss._new_widget_state._payloads[agg_id] = [
+        {"event": "shared", "value": "trigger"},
+        {"event": "only_trigger", "value": 1},
+    ]
+
+    base = {"shared": "state", "only_state": 2}
+    out = presenter(base, ss)
+
+    assert dict(out) == {
+        "shared": "state",
+        "only_trigger": 1,
+        "only_state": 2,
+    }


### PR DESCRIPTION
## Describe your changes

Adds the BidiComponentMixin to support CCv2.

- A `BidiComponentMixin` class that adds the `_bidi_component` method to the `DeltaGenerator`
- Support for mixed data serialization, including automatic detection and handling of dataframes
- Event-based callback system with the `on_{event}_change` pattern
- State management with default values
- Efficient serialization of complex data structures using Arrow

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): Added comprehensive test coverage for the new bidirectional component system, including tests for serialization/deserialization, event handling, state management, and dataframe handling
- The implementation includes tests for edge cases such as invalid JSON, missing data, and fallback behaviors
- No E2E tests are included in this PR as they would require frontend implementation which will be added in a later PR

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.