### PR TITLE
[feat] Add st.components.v2.components namespace and classes

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -165,6 +165,7 @@ audio_input = _main.audio_input
 badge = _main.badge
 balloons = _main.balloons
 bar_chart = _main.bar_chart
+_bidi_component = _main._bidi_component
 bokeh_chart = _main.bokeh_chart
 button = _main.button
 caption = _main.caption
@@ -305,4 +306,5 @@ experimental_set_query_params = _deprecate_func_name(
 # make it possible to call streamlit.components.v1.html etc. by importing it here
 # import in the very end to avoid partially-initialized module import errors, because
 # streamlit.components.v1 also uses some streamlit imports
-import streamlit.components.v1  # noqa: F401
+import streamlit.components.v1
+import streamlit.components.v2  # noqa: F401

--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -11,3 +11,223 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Register the st.components.v2 API namespace."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from streamlit.components.v2.component_definition_resolver import (
+    build_definition_with_validation,
+)
+from streamlit.components.v2.get_bidi_component_manager import (
+    get_bidi_component_manager,
+)
+from streamlit.errors import StreamlitAPIException
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.types import BidiComponentCallable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from streamlit.components.v2.bidi_component import BidiComponentResult
+    from streamlit.elements.lib.layout_utils import Height, Width
+    from streamlit.runtime.state.common import WidgetCallback
+
+
+def _register_component(
+    name: str,
+    html: str | None = None,
+    css: str | None = None,
+    js: str | None = None,
+) -> str:
+    """Register a component and return its fully qualified key.
+
+    This shared function handles the component registration and constructing a
+    validated definition against any pre-registered components from
+    ``pyproject.toml``.
+
+    Parameters
+    ----------
+    name : str
+        A short, descriptive identifier for the component.
+    html : str or None
+        Inline HTML markup for the component root.
+    css : str | None
+        Either inline CSS (string) or an asset-dir-relative path/glob to a
+        ``.css`` file declared in the component's ``asset_dir``. Globs are
+        allowed and must resolve to exactly one file within ``asset_dir``.
+    js : str | None
+        Either inline JavaScript (string) or an asset-dir-relative path/glob to
+        a ``.js`` file declared in the component's ``asset_dir``. Globs are
+        allowed and must resolve to exactly one file within ``asset_dir``.
+
+    Returns
+    -------
+    str
+        The fully qualified component key in the form ``<module_name>.<n>``.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If ``css`` or ``js`` parameters are not strings or None.
+    """
+    # Parameter type guards: only strings or None are supported for js/css
+    for _param_name, _param_value in (("css", css), ("js", js)):
+        if _param_value is not None and not isinstance(_param_value, str):
+            raise StreamlitAPIException(
+                f"{_param_name} parameter must be a string or None. Pass a string path or glob."
+            )
+
+    component_key = name
+
+    manager = get_bidi_component_manager()
+    manager.register(
+        build_definition_with_validation(
+            manager=manager,
+            component_key=component_key,
+            html=html,
+            css=css,
+            js=js,
+        )
+    )
+
+    # Record API inputs for future re-resolution on file changes
+    manager.record_api_inputs(component_key, css, js)
+
+    return component_key
+
+
+def _create_component_callable(
+    name: str,
+    *,
+    html: str | None = None,
+    css: str | None = None,
+    js: str | None = None,
+) -> Callable[..., Any]:
+    """Create a component callable, handling both lookup and registration cases.
+
+    Parameters
+    ----------
+    name : str
+        A short, descriptive identifier for the component.
+    html : str | None
+        Inline HTML markup for the component root.
+    css : str | None
+        Inline CSS (string) or a string path/glob to a file under ``asset_dir``;
+        see :func:`_register_component` for path validation semantics.
+    js : str | None
+        Inline JavaScript (string) or a string path/glob to a file under
+        ``asset_dir``; see :func:`_register_component` for path validation semantics.
+
+    Returns
+    -------
+    Callable[..., Any]
+        A function that, when called inside a Streamlit script, mounts the
+        component and returns its state.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If a component is not found in the registry.
+    """
+    component_key = _register_component(name=name, html=html, css=css, js=js)
+
+    # The inner callable that mounts the component.
+    def _mount_component(
+        *,
+        key: str | None = None,
+        data: Any | None = None,
+        default: dict[str, Any] | None = None,
+        width: Width = "stretch",
+        height: Height = "content",
+        isolate_styles: bool = True,
+        **on_callbacks: WidgetCallback | None,
+    ) -> BidiComponentResult:
+        """Mount the component.
+
+        Parameters
+        ----------
+        key : str or None
+            An optional string to use as the unique key for the component.
+        data : Any or None
+            Data to pass to the component (JSON-serializable).
+        default : dict[str, Any] or None
+            A dictionary of default values for state properties. Keys must
+            correspond to valid state names (those with on_*_change callbacks).
+        width : Width
+            The width of the component.
+        height : Height
+            The height of the component.
+        isolate_styles : bool
+            Whether to sandbox the component styles in a shadow-root. Defaults to
+            True.
+        **on_callbacks : WidgetCallback
+            Callback functions for handling component events. Use pattern
+            on_{state_name}_change (e.g., on_click_change, on_value_change).
+
+        Returns
+        -------
+        BidiComponentResult
+            Component state.
+        """
+        import streamlit as st
+
+        return st._bidi_component(
+            component_key,
+            key=key,
+            isolate_styles=isolate_styles,
+            data=data,
+            default=default,
+            width=width,
+            height=height,
+            **on_callbacks,
+        )
+
+    # Ensure the function remains compatible with the shared public callable type.
+    # Static type assertion to ensure the callable matches the shared signature
+    _typed_check_mount_component: BidiComponentCallable = _mount_component
+
+    return _mount_component
+
+
+def component(
+    name: str,
+    *,
+    html: str | None = None,
+    css: str | None = None,
+    js: str | None = None,
+) -> BidiComponentCallable:
+    """Register a st.components.v2 component and return a callable to mount it.
+
+    Parameters
+    ----------
+    name : str
+        A short, descriptive identifier for the component.
+    html : str | None
+        Inline HTML markup for the component root.
+    css : str | None
+        Inline CSS (string) or an asset-dir-relative path/glob to a ``.css``
+        file under the component's manifest-declared ``asset_dir``. Globs must
+        resolve to exactly one file within ``asset_dir``; absolute paths and
+        traversal are rejected.
+    js : str | None
+        Inline JavaScript (string) or an asset-dir-relative path/glob to a
+        ``.js`` file under the component's manifest-declared ``asset_dir``.
+        Globs must resolve to exactly one file within ``asset_dir``; absolute
+        paths and traversal are rejected.
+
+    Returns
+    -------
+    Callable[..., BidiComponentResult]
+        A function that, when called inside a Streamlit script, mounts the
+        component and returns its state as a ``BidiComponentResult``.
+    """
+    return _create_component_callable(name, html=html, css=css, js=js)
+
+
+__all__ = [
+    "component",
+]

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -60,6 +60,14 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_r
 from streamlit.runtime.state import register_widget
 
 if TYPE_CHECKING:
+    from streamlit.components.v2.types import (
+        BidiComponentData,
+        BidiComponentDefaults,
+        BidiComponentKey,
+        ComponentIsolateStyles,
+    )
+
+if TYPE_CHECKING:
     # Define DeltaGenerator for type checking the dg property
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.runtime.state.common import WidgetCallback
@@ -113,10 +121,10 @@ class BidiComponentMixin:
     def _bidi_component(
         self,
         component_name: str,
-        key: str | None = None,
-        isolate_styles: bool = True,
-        data: Any | None = None,
-        default: dict[str, Any] | None = None,
+        key: BidiComponentKey = None,
+        isolate_styles: ComponentIsolateStyles = True,
+        data: BidiComponentData = None,
+        default: BidiComponentDefaults = None,
         width: Width = "stretch",
         height: Height = "content",
         **kwargs: WidgetCallback | None,

--- a/lib/streamlit/components/v2/bidi_component/state.py
+++ b/lib/streamlit/components/v2/bidi_component/state.py
@@ -32,13 +32,20 @@ class BidiComponentState(TypedDict, total=False):
 
 
 class BidiComponentResult(AttributeDictionary):
-    """Rich return object for ``st.bidi_component``.
+    """Rich return object for ``st._bidi_component``.
 
     It behaves like a regular :class:`dict` *and* allows attribute-style
     access to its keys, mirroring the behaviour of
     :class:`streamlit.util.AttributeDictionary`. It surfaces both trigger and
     state values as top-level entries so they can be accessed via either key or
     attribute access.
+
+    Parameters
+    ----------
+    state_vals : dict[str, Any] or None
+        A dictionary of state values from the component.
+    trigger_vals : dict[str, Any] or None
+        A dictionary of trigger values from the component.
     """
 
     def __init__(

--- a/lib/streamlit/components/v2/types.py
+++ b/lib/streamlit/components/v2/types.py
@@ -1,0 +1,98 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared typing utilities for the `st.components.v2` API.
+
+This module exposes common, user-facing argument types and callable
+signatures used by the bidirectional component API. Import these types to
+annotate code that constructs kwargs dictionaries for components, or when
+authoring wrappers/utilities around `st.components.v2.component`.
+
+The goal is to keep the public argument surface documented in one place and
+reusable across both the user-facing factory in `components/v2/__init__.py`
+and the internal implementation in `components/v2/bidi_component/main.py`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.bidi_component.state import BidiComponentResult
+    from streamlit.elements.lib.layout_utils import Height, Width
+    from streamlit.runtime.state.common import WidgetCallback
+
+
+# Individual argument type aliases to make reuse ergonomic across modules.
+BidiComponentKey = str | None
+BidiComponentData = Any | None
+BidiComponentDefaults = dict[str, Any] | None
+ComponentIsolateStyles = bool
+
+
+class BidiComponentCallable(Protocol):
+    """Signature of the callable returned by ``st.components.v2.component``.
+
+    Parameters
+    ----------
+    key : str | None, optional
+        An optional string to use as the unique key for the component. If
+        omitted, a key is generated based on execution order.
+    data : Any | None, optional
+        Data to pass to the component. May be JSON-serializable primitives or
+        containers, bytes-like, or dataframe-like objects that can be
+        serialised to Arrow.
+    default : dict[str, Any] | None, optional
+        Default values for state properties. Keys must correspond to valid
+        state names (those with ``on_{state}_change`` callbacks). Trigger
+        values do not support defaults.
+    width : Literal["stretch", "content"] | int, optional
+        Desired width. One of ``"stretch"``, ``"content"``, or a pixel value.
+    height : Literal["stretch", "content"] | int, optional
+        Desired height. One of ``"stretch"``, ``"content"``, or a pixel value.
+    isolate_styles : bool, optional
+        Whether to sandbox the component styles in a shadow root. Defaults to
+        ``True``.
+    **on_callbacks : WidgetCallback | None
+        Event-specific callbacks with the naming pattern
+        ``on_{event_name}_change`` (for example: ``on_click_change``,
+        ``on_value_change``). Only names that follow this pattern are
+        recognized. Values must be callables that accept no arguments.
+
+    Returns
+    -------
+    BidiComponentResult
+        Component state object that exposes state values and trigger values.
+    """
+
+    def __call__(
+        self,
+        *,
+        key: BidiComponentKey = None,
+        data: BidiComponentData = None,
+        default: BidiComponentDefaults = None,
+        width: Width = "stretch",
+        height: Height = "content",
+        isolate_styles: ComponentIsolateStyles = True,
+        **on_callbacks: WidgetCallback | None,
+    ) -> BidiComponentResult: ...
+
+
+__all__ = [
+    "BidiComponentCallable",
+    "BidiComponentData",
+    "BidiComponentDefaults",
+    "BidiComponentKey",
+    "ComponentIsolateStyles",
+]

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -14,11 +14,17 @@
 
 from __future__ import annotations
 
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
 import pytest
 
+import streamlit as st
 from streamlit import _main as st_main
 from streamlit.components.v2.bidi_component.constants import EVENT_DELIM
 from streamlit.components.v2.bidi_component.main import _make_trigger_id
+from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_registry import BidiComponentDefinition
 from streamlit.errors import (
     BidiComponentInvalidCallbackNameError,
@@ -46,7 +52,10 @@ def test_make_trigger_id_with_invalid_chars():
         _make_trigger_id("base_id", f"click{EVENT_DELIM}event")
 
 
-class BidiComponentTest(DeltaGeneratorTestCase):
+class BidiComponentInvalidCallbackNameErrorTest(DeltaGeneratorTestCase):
+    """Test that BidiComponentInvalidCallbackNameError is raised when invalid
+    callback names are provided."""
+
     def setUp(self):
         super().setUp()
         registry = Runtime.instance().bidi_component_registry
@@ -72,3 +81,702 @@ class BidiComponentTest(DeltaGeneratorTestCase):
                 key="key2",
                 on__change=lambda: None,
             )
+
+
+class BidiComponentTest(DeltaGeneratorTestCase):
+    """Test the bidi_component functionality."""
+
+    def setUp(self):
+        super().setUp()
+        # Create a mock component manager for testing
+        self.mock_component_manager = BidiComponentManager()
+
+        # Patch the Runtime to return our mock component manager
+        self.runtime_patcher = patch.object(
+            Runtime, "instance", return_value=MagicMock()
+        )
+        self.mock_runtime = self.runtime_patcher.start()
+        self.mock_runtime.return_value.bidi_component_registry = (
+            self.mock_component_manager
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        self.runtime_patcher.stop()
+
+    def test_component_with_js_content_only(self):
+        """Test component with only JavaScript content."""
+        # Register a component with JS content only
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="js_only_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Call the component
+        st._bidi_component("js_only_component")
+
+        # Verify the proto was enqueued
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "js_only_component"
+        assert bidi_component_proto.js_content == "console.log('hello world');"
+        assert bidi_component_proto.html_content == ""
+
+    def test_component_with_html_content_only(self):
+        """Test component with only HTML content."""
+        # Register a component with HTML content only
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="html_only_component",
+                html="<div>Hello World</div>",
+            )
+        )
+
+        # Call the component
+        st._bidi_component("html_only_component")
+
+        # Verify the proto was enqueued
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "html_only_component"
+        assert bidi_component_proto.html_content == "<div>Hello World</div>"
+        assert bidi_component_proto.js_content == ""
+
+    def test_component_with_js_url_only(self):
+        """Test component with only JavaScript URL."""
+        # Create a mock component definition with js_url
+        mock_component_def = MagicMock(spec=BidiComponentDefinition)
+        mock_component_def.js_content = None
+        mock_component_def.js_url = "index.js"
+        mock_component_def.html_content = None
+        mock_component_def.css_content = None
+        mock_component_def.css_url = None
+        mock_component_def.isolate_styles = True
+
+        # Mock the registry to return our component
+        with patch.object(
+            self.mock_component_manager, "get", return_value=mock_component_def
+        ):
+            # Call the component
+            st._bidi_component("js_url_component")
+
+            # Verify the proto was enqueued
+            delta = self.get_delta_from_queue()
+            bidi_component_proto = delta.new_element.bidi_component
+            assert bidi_component_proto.component_name == "js_url_component"
+            assert bidi_component_proto.js_source_path == "index.js"
+            assert bidi_component_proto.html_content == ""
+
+    def test_component_with_both_js_and_html(self):
+        """Test component with both JavaScript and HTML content."""
+        # Register a component with both JS and HTML content
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="full_component",
+                js="console.log('hello world');",
+                html="<div>Hello World</div>",
+                css="div { color: red; }",
+            )
+        )
+
+        # Call the component
+        st._bidi_component("full_component")
+
+        # Verify the proto was enqueued
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "full_component"
+        assert bidi_component_proto.js_content == "console.log('hello world');"
+        assert bidi_component_proto.html_content == "<div>Hello World</div>"
+        assert bidi_component_proto.css_content == "div { color: red; }"
+
+    def test_component_with_no_js_or_html_raises_exception(self):
+        """Test that component with neither JS nor HTML content raises StreamlitAPIException."""
+        # Register a component with only CSS content (no JS or HTML)
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="css_only_component",
+                css="div { color: red; }",
+            )
+        )
+
+        # Call the component and expect an exception
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st._bidi_component("css_only_component")
+
+        # Verify the error message
+        error_message = str(exc_info.value)
+        assert "css_only_component" in error_message
+        assert "must have either JavaScript content" in error_message
+        assert (
+            "(`js_content` or `js_url`) or HTML content (`html_content`)"
+            in error_message
+        )
+
+    def test_component_with_empty_js_and_html_raises_exception(self):
+        """Test that component with empty JS and HTML content raises StreamlitAPIException."""
+        # Create a mock component definition with empty content
+        mock_component_def = MagicMock(spec=BidiComponentDefinition)
+        mock_component_def.js_content = ""  # Empty string
+        mock_component_def.js_url = None
+        mock_component_def.html_content = ""  # Empty string
+        mock_component_def.css_content = "div { color: red; }"
+        mock_component_def.css_url = None
+        mock_component_def.isolate_styles = True
+
+        # Mock the registry to return our component
+        with patch.object(
+            self.mock_component_manager, "get", return_value=mock_component_def
+        ):
+            # Call the component and expect an exception
+            with pytest.raises(StreamlitAPIException) as exc_info:
+                st._bidi_component("empty_component")
+
+            # Verify the error message
+            error_message = str(exc_info.value)
+            assert "empty_component" in error_message
+            assert "must have either JavaScript content" in error_message
+
+    def test_unregistered_component_raises_value_error(self):
+        """Test that calling an unregistered component raises ValueError."""
+        # Call a component that doesn't exist
+        with pytest.raises(
+            ValueError, match="Component 'nonexistent_component' is not registered"
+        ):
+            st._bidi_component("nonexistent_component")
+
+    def test_component_with_key(self):
+        """Test component with a user-specified key."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="keyed_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Call the component with a key
+        st._bidi_component("keyed_component", key="my_key")
+
+        # Verify the proto was enqueued with the correct ID
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "keyed_component"
+        # The ID should be deterministic based on the key
+        assert bidi_component_proto.id is not None
+
+    def test_component_with_scalar_data(self):
+        """Test component with scalar data parameter serialized as JSON."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="data_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Use a simple scalar value which is treated as DataFormat.UNKNOWN and therefore JSON-encoded
+        test_data = "hello streamlit"
+        st._bidi_component("data_component", data=test_data)
+
+        # Verify the proto was enqueued with the data
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "data_component"
+        # Data should be JSON serialized inside the `json` oneof field
+        assert bidi_component_proto.WhichOneof("data") == "json"
+        assert bidi_component_proto.json == '"hello streamlit"'
+
+    def test_component_with_dict_data_json(self):
+        """Test component with dict data serialized as JSON."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="dict_data_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        test_dict = {"message": "hello", "count": 42}
+        st._bidi_component("dict_data_component", data=test_dict)
+
+        delta = self.get_delta_from_queue()
+        proto = delta.new_element.bidi_component
+        assert proto.component_name == "dict_data_component"
+        # Should choose JSON path
+        assert proto.WhichOneof("data") == "json"
+
+        assert json.loads(proto.json) == test_dict
+
+    def test_component_with_arrow_data(self):
+        """Test component with dataframe-like data serialized to Arrow."""
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="arrow_data_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Use a simple Pandas DataFrame which should be detected as dataframe-like
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        st._bidi_component("arrow_data_component", data=df)
+
+        # Verify the proto was enqueued with Arrow data
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "arrow_data_component"
+        assert bidi_component_proto.WhichOneof("data") == "arrow_data"
+        # The Arrow bytes should be non-empty
+        assert len(bidi_component_proto.arrow_data.data) > 0
+
+    def test_component_with_bytes_data(self):
+        """Test component with raw bytes data passed through unchanged."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="bytes_data_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Raw bytes payload
+        binary_payload = b"\x00\x01\x02streamlit"
+        st._bidi_component("bytes_data_component", data=binary_payload)
+
+        # Verify the proto was enqueued with bytes data
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "bytes_data_component"
+        assert bidi_component_proto.WhichOneof("data") == "bytes"
+        assert bidi_component_proto.bytes == binary_payload
+
+    def test_component_with_callbacks(self):
+        """Test component with callback handlers."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="callback_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callback
+        on_click_callback = MagicMock()
+
+        # Call the component with event-specific callback
+        result = st._bidi_component(
+            "callback_component",
+            on_click_change=on_click_callback,
+        )
+
+        # Verify the result
+        assert hasattr(result, "click")
+
+        # Verify the proto was enqueued with registered handler names
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "callback_component"
+
+    def test_component_with_dict_containing_dataframe(self):
+        """Test component with dict containing dataframe - should use mixed data serialization."""
+
+        import pandas as pd
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="dict_with_df_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mixed data with dataframe automatically detected
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        mixed_data = {
+            "config": {"title": "My Chart", "theme": "dark"},
+            "dataframe": df,  # This should be automatically detected and converted
+            "metadata": {"rows": 3, "cols": 2},
+        }
+
+        st._bidi_component("dict_with_df_component", data=mixed_data)
+
+        # Verify the proto was enqueued with mixed data
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "dict_with_df_component"
+        assert bidi_component_proto.WhichOneof("data") == "mixed"
+
+        # Verify the mixed data structure
+        mixed_proto = bidi_component_proto.mixed
+        assert mixed_proto.json is not None
+        assert len(mixed_proto.arrow_blobs) == 1
+
+        # Parse the JSON to verify placeholder structure
+        parsed_json = json.loads(mixed_proto.json)
+        assert parsed_json["config"]["title"] == "My Chart"
+        assert parsed_json["metadata"]["rows"] == 3
+        # The dataframe should be replaced with a placeholder
+        assert "__streamlit_arrow_ref__" in parsed_json["dataframe"]
+
+    def test_component_with_multiple_dataframes_in_dict(self):
+        """Test component with dict containing multiple dataframes."""
+
+        import pandas as pd
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="multi_df_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mixed data with multiple dataframes
+        df1 = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        df2 = pd.DataFrame({"c": [4, 5, 6], "d": ["p", "q", "r"]})
+
+        mixed_data = {
+            "config": {"title": "My Chart", "theme": "dark"},
+            "sales_data": df1,  # Should be automatically detected
+            "inventory_data": df2,  # Should be automatically detected
+            "metadata": {"rows": 3, "cols": 2},
+        }
+
+        st._bidi_component("multi_df_component", data=mixed_data)
+
+        # Verify the proto was enqueued with mixed data
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "multi_df_component"
+        assert bidi_component_proto.WhichOneof("data") == "mixed"
+
+        # Verify the mixed data structure
+        mixed_proto = bidi_component_proto.mixed
+        assert mixed_proto.json is not None
+        assert len(mixed_proto.arrow_blobs) == 2  # Two dataframes
+
+        # Parse the JSON to verify placeholder structure
+        parsed_json = json.loads(mixed_proto.json)
+        assert parsed_json["config"]["title"] == "My Chart"
+        assert parsed_json["config"]["theme"] == "dark"
+        assert parsed_json["metadata"]["rows"] == 3
+        # Both dataframes should be replaced with placeholders
+        assert "__streamlit_arrow_ref__" in parsed_json["sales_data"]
+        assert "__streamlit_arrow_ref__" in parsed_json["inventory_data"]
+
+    def test_component_with_dict_without_dataframes(self):
+        """Test component with dict containing no dataframes - should use JSON serialization."""
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="json_only_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create data with no dataframes
+        data = {
+            "config": {"theme": "dark", "height": 400},
+            "labels": ["A", "B", "C"],
+            "settings": {"enabled": True},
+            "metadata": {"version": "1.0"},
+        }
+
+        st._bidi_component("json_only_component", data=data)
+
+        # Verify the proto was enqueued with JSON serialization
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "json_only_component"
+        assert bidi_component_proto.WhichOneof("data") == "json"
+
+        # Parse the JSON to verify it matches original data
+
+        parsed_json = json.loads(bidi_component_proto.json)
+        assert parsed_json == data
+
+    def test_component_with_list_data(self):
+        """Test component with list data - should use JSON serialization."""
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="list_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create list data (no automatic dataframe detection for lists)
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        list_data = [
+            {"name": "dataset1", "values": [1, 2, 3]},
+            {"name": "dataset2", "values": [4, 5, 6]},
+            df,  # This dataframe will be converted to JSON via fallback
+        ]
+
+        st._bidi_component("list_component", data=list_data)
+
+        # Verify the proto was enqueued with JSON serialization
+        # (since we only detect dataframes in first level of dicts)
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "list_component"
+        assert bidi_component_proto.WhichOneof("data") == "json"
+
+        # The data should be JSON-serialized as a string (due to DataFrame fallback)
+        import json
+
+        parsed_json = json.loads(bidi_component_proto.json)
+        assert isinstance(parsed_json, str)  # It's a string representation
+        assert "dataset1" in parsed_json
+        assert "dataset2" in parsed_json
+
+    def test_component_with_tuple_data(self):
+        """Test component with tuple data - should use JSON serialization."""
+
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="tuple_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create tuple data (no automatic dataframe detection for tuples)
+        df = pd.DataFrame({"value": [42]})
+        tuple_data = ("metadata", df, {"extra": "info"})
+
+        st._bidi_component("tuple_component", data=tuple_data)
+
+        # Verify the proto was enqueued with JSON serialization
+        # (since we only detect dataframes in first level of dicts)
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "tuple_component"
+        assert bidi_component_proto.WhichOneof("data") == "json"
+
+        # The data should be JSON-serialized as a string (due to DataFrame fallback)
+        import json
+
+        parsed_json = json.loads(bidi_component_proto.json)
+
+        # The tuple with DataFrame gets converted to string representation
+        assert isinstance(parsed_json, str)
+        assert "metadata" in parsed_json
+        assert "extra" in parsed_json
+        assert "info" in parsed_json
+
+    def test_component_with_dict_no_arrow_refs_uses_json(self):
+        """Test that dictionaries without ArrowReference objects use regular JSON serialization."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="json_only_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create dictionary without any ArrowReference objects
+        regular_data = {
+            "config": {"title": "Chart", "enabled": True},
+            "values": [1, 2, 3, 4],
+            "metadata": {"count": 4},
+        }
+
+        st._bidi_component("json_only_component", data=regular_data)
+
+        # Verify the proto uses regular JSON serialization
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.WhichOneof("data") == "json"
+
+        parsed_data = json.loads(bidi_component_proto.json)
+        assert parsed_data == regular_data
+
+    def test_default_with_valid_callbacks(self):
+        """Test that default works correctly with valid callback names."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="default_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callbacks
+        on_selected_change = MagicMock()
+        on_search_change = MagicMock()
+
+        # Call the component with default
+        result = st._bidi_component(
+            "default_component",
+            default={
+                "selected": ["item1", "item2"],
+                "search": "default search",
+            },
+            on_selected_change=on_selected_change,
+            on_search_change=on_search_change,
+        )
+
+        # Verify the result contains default values
+        assert result["selected"] == ["item1", "item2"]
+        assert result["search"] == "default search"
+
+    def test_default_validation_error(self):
+        """Test that invalid keys in default raise StreamlitAPIException."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="validation_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callback for only one state
+        on_valid_change = MagicMock()
+
+        # Call the component with invalid default key
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st._bidi_component(
+                "validation_component",
+                default={
+                    "valid": "this is ok",
+                    "invalid": "this should fail",  # No on_invalid_change callback
+                },
+                on_valid_change=on_valid_change,
+            )
+
+        # Verify the error message
+        error_message = str(exc_info.value)
+        assert "invalid" in error_message
+        assert "not a valid state name" in error_message
+        assert "Available state names: `['valid']`" in error_message
+
+    def test_default_no_callbacks_error(self):
+        """Test that default with no callbacks raises StreamlitAPIException."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="no_callbacks_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Call the component with default but no callbacks
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st._bidi_component(
+                "no_callbacks_component",
+                default={"some_state": "value"},
+            )
+
+        # Verify the error message mentions no available state names
+        error_message = str(exc_info.value)
+        assert "some_state" in error_message
+        assert "not a valid state name" in error_message
+        assert "Available state names: `none`" in error_message
+
+    def test_default_none_is_valid(self):
+        """Test that default=None works correctly."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="none_default_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callback
+        on_test_change = MagicMock()
+
+        # Call the component with default=None
+        result = st._bidi_component(
+            "none_default_component",
+            default=None,
+            on_test_change=on_test_change,
+        )
+
+        # Should work without error and have empty state
+        assert result["test"] is None
+
+    def test_default_empty_dict(self):
+        """Test that empty default dict works correctly."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="empty_default_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callback
+        on_test_change = MagicMock()
+
+        # Call the component with empty default
+        result = st._bidi_component(
+            "empty_default_component",
+            default={},
+            on_test_change=on_test_change,
+        )
+
+        # Should work without error
+        assert result["test"] is None
+
+    def test_default_with_none_values(self):
+        """Test that None values in default are properly handled."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="none_values_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callback
+        on_nullable_change = MagicMock()
+
+        # Call the component with None default value
+        result = st._bidi_component(
+            "none_values_component",
+            default={"nullable": None},
+            on_nullable_change=on_nullable_change,
+        )
+
+        # Verify None is properly set as default
+        assert result["nullable"] is None
+
+    def test_default_complex_values(self):
+        """Test that complex values in default work correctly."""
+        # Register a component
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="complex_default_component",
+                js="console.log('hello world');",
+            )
+        )
+
+        # Create mock callbacks
+        on_list_state_change = MagicMock()
+        on_dict_state_change = MagicMock()
+
+        # Call the component with complex default values
+        complex_list = [1, 2, {"nested": "value"}]
+        complex_dict = {"key": "value", "nested": {"data": [1, 2, 3]}}
+
+        result = st._bidi_component(
+            "complex_default_component",
+            default={
+                "list_state": complex_list,
+                "dict_state": complex_dict,
+            },
+            on_list_state_change=on_list_state_change,
+            on_dict_state_change=on_dict_state_change,
+        )
+
+        # Verify complex values are properly set
+        assert result["list_state"] == complex_list
+        assert result["dict_state"] == complex_dict

--- a/lib/tests/streamlit/components/v2/test_component_api_paths.py
+++ b/lib/tests/streamlit/components/v2/test_component_api_paths.py
@@ -1,0 +1,209 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.components.v2 import component as component_api
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+from streamlit.errors import StreamlitAPIException, StreamlitComponentRegistryError
+from streamlit.runtime import Runtime
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _with_runtime_manager(manager):
+    """Create a patcher for the Runtime to inject a mock component manager."""
+    return patch.object(
+        Runtime, "instance", return_value=MagicMock(bidi_component_registry=manager)
+    )
+
+
+def test_api_accepts_paths_inside_asset_dir(tmp_path: Path) -> None:
+    """API should accept js/css paths that resolve inside manifest-declared asset_dir."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    # Package with asset_dir
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    js_file = asset_dir / "index-abc.js"
+    css_file = asset_dir / "index.css"
+    js_file.write_text("export default function(){}")
+    css_file.write_text(".x{}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    # Sanity: asset root is registered
+    assert manager.get_component_asset_root("pkg.slider") is not None
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        # Provide asset-dir-relative paths (relative to asset_dir root)
+        comp = component_api(name="pkg.slider", js="index-abc.js", css="index.css")
+    assert callable(comp)
+
+
+def test_api_rejects_paths_outside_asset_dir(tmp_path: Path) -> None:
+    """API should reject js/css paths outside the manifest asset_dir."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    outside_file = tmp_path / "outside.js"
+    outside_file.write_text("export default function(){}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        with pytest.raises(StreamlitComponentRegistryError):
+            component_api(name="pkg.slider", js=str(outside_file))
+
+
+def test_api_glob_expands_to_single_file(tmp_path: Path) -> None:
+    """API should expand globs inside asset_dir to exactly one file."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "index-1.js").write_text("export default function(){}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        comp = component_api(name="pkg.slider", js="index-*.js")
+    assert callable(comp)
+
+
+def test_api_rejects_absolute_paths(tmp_path: Path) -> None:
+    """API must reject absolute file paths for js/css inputs."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    js_file = asset_dir / "index.js"
+    js_file.write_text("export default function(){}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    abs_js = str(js_file.resolve())
+    abs_css = str((asset_dir / "index.css").resolve())
+    (asset_dir / "index.css").write_text(".x{}")
+
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        with pytest.raises(StreamlitComponentRegistryError):
+            component_api(name="pkg.slider", js=abs_js)
+        with pytest.raises(StreamlitComponentRegistryError):
+            component_api(name="pkg.slider", css=abs_css)
+
+
+def test_api_errors_when_missing_manifest_registration(tmp_path: Path) -> None:
+    """If component is not declared in pyproject.toml, file-backed API must error."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    # No manifest registration for manager
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    js_file = asset_dir / "index.js"
+    js_file.write_text("export default function(){}")
+
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        with pytest.raises(StreamlitAPIException):
+            component_api(name="pkg.slider", js=str(js_file))
+
+
+def test_api_rejects_non_string_types(tmp_path: Path) -> None:
+    """Reject non-string, non-None values for js/css parameters."""
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+    manager.clear()
+
+    package_root = tmp_path / "pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "index.js").write_text("export default function(){}")
+
+    manifest = ComponentManifest(
+        name="pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="slider", asset_dir="assets")],
+    )
+    manager.register_from_manifest(manifest, package_root)
+
+    with (
+        patch.object(Runtime, "exists", return_value=True),
+        _with_runtime_manager(manager),
+    ):
+        with pytest.raises(StreamlitAPIException):
+            component_api(name="pkg.slider", js=123)  # type: ignore[arg-type]
+        with pytest.raises(StreamlitAPIException):
+            component_api(name="pkg.slider", css=["invalid"])  # type: ignore[arg-type]

--- a/lib/tests/streamlit/components/v2/test_component_manager.py
+++ b/lib/tests/streamlit/components/v2/test_component_manager.py
@@ -19,10 +19,15 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from streamlit.components.v2 import component as component_api
 from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_registry import BidiComponentDefinition
 from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _setup_manager_with_manifest(tmp_path: Path) -> tuple[BidiComponentManager, str]:
@@ -224,3 +229,101 @@ def test_on_components_changed_preserves_html_and_resolves_assets(
     # Content properties must be None for file-backed entries
     assert d.css_content is None
     assert d.js_content is None
+
+
+def _make_manifest(pkg_name: str, comp_name: str, asset_dir: str) -> ComponentManifest:
+    """Create a ComponentManifest for testing."""
+    return ComponentManifest(
+        name=pkg_name,
+        version="0.0.1",
+        components=[ComponentConfig(name=comp_name, asset_dir=asset_dir)],
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    """Write content to a file, creating parent directories if needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_re_resolves_js_glob_on_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that JS glob paths are re-resolved on component changes."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        assets = root / "assets"
+        js_dir = assets / "js"
+
+        # Initial file
+        first_js = js_dir / "index-abc123.js"
+        _write(first_js, "console.log('abc');")
+
+        # Register manifest with asset_dir
+        manager = BidiComponentManager()
+        manifest = _make_manifest("pkg", "comp", asset_dir="assets")
+        manager.register_from_manifest(manifest, root)
+
+        # Bind public API to our manager instance
+        monkeypatch.setattr(
+            "streamlit.components.v2.get_bidi_component_manager",
+            lambda: manager,
+        )
+
+        # Register runtime API with a JS glob under asset_dir
+        component_api("pkg.comp", js="js/index-*.js")
+        initial = manager.get("pkg.comp")
+        assert initial is not None
+        assert initial.js is not None
+        assert initial.js.endswith("index-abc123.js")
+        assert initial.js_url == "js/index-abc123.js"
+
+        # Simulate a new build replacing the hashed file
+        first_js.unlink()
+        second_js = js_dir / "index-def456.js"
+        _write(second_js, "console.log('def');")
+
+        # Trigger change handling
+        manager._on_components_changed(["pkg.comp"])  # type: ignore[attr-defined]
+
+        updated = manager.get("pkg.comp")
+        assert updated is not None
+        assert updated.js is not None
+        assert updated.js.endswith("index-def456.js")
+        assert updated.js_url == "js/index-def456.js"
+
+
+def test_re_resolution_no_match_keeps_previous(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that re-resolution with no match preserves the previous value."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        assets = root / "assets"
+        js_dir = assets / "js"
+
+        # Initial file
+        first_js = js_dir / "index-abc123.js"
+        _write(first_js, "console.log('abc');")
+
+        manager = BidiComponentManager()
+        manifest = _make_manifest("pkg2", "comp", asset_dir="assets")
+        manager.register_from_manifest(manifest, root)
+
+        monkeypatch.setattr(
+            "streamlit.components.v2.get_bidi_component_manager",
+            lambda: manager,
+        )
+
+        component_api("pkg2.comp", js="js/index-*.js")
+        baseline = manager.get("pkg2.comp")
+        assert baseline is not None
+        assert baseline.js is not None
+        assert baseline.js.endswith("index-abc123.js")
+
+        # Remove the only matching file -> glob would have zero matches now
+        first_js.unlink()
+
+        manager._on_components_changed(["pkg2.comp"])  # type: ignore[attr-defined]
+
+        # Definition should remain unchanged
+        after = manager.get("pkg2.comp")
+        assert after is not None
+        assert after.js is not None
+        assert after.js.endswith("index-abc123.js")

--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from streamlit.components.v2 import component
 from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_path_utils import ComponentPathUtils
 from streamlit.components.v2.component_registry import (
@@ -30,7 +31,7 @@ from streamlit.components.v2.component_registry import (
     BidiComponentRegistry,
 )
 from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
-from streamlit.errors import StreamlitComponentRegistryError
+from streamlit.errors import StreamlitAPIException, StreamlitComponentRegistryError
 
 
 def _mk_file(path: os.PathLike[str] | str, content: bytes | str = b"x") -> str:
@@ -359,7 +360,7 @@ def temp_manager_setup() -> dict:
     temp_dir.cleanup()
 
 
-def test_string_content() -> None:
+def test_string_content(temp_test_files) -> None:
     """Test component instantiation with direct string content."""
     comp = BidiComponentDefinition(
         name="test",
@@ -440,6 +441,30 @@ def test_mixed_content(temp_test_files) -> None:
 
     assert len(comp.source_paths) == 1
     assert comp.source_paths["js"] == os.path.dirname(temp_test_files["js_path"])
+
+
+def test_public_api_path_object_rejection() -> None:
+    """Verify the public API rejects non-string path-like objects."""
+    from pathlib import Path
+
+    with pytest.raises(StreamlitAPIException) as exc_info:
+        component("test", js=Path("test.js"))
+    msg = str(exc_info.value)
+    assert "string or None" in msg
+    assert "string path or glob" in msg
+
+    with pytest.raises(StreamlitAPIException) as exc_info:
+        component("test", css=Path("test.css"))
+    msg = str(exc_info.value)
+    assert "string or None" in msg
+    assert "string path or glob" in msg
+
+    # Still raise for other invalid types
+    with pytest.raises(StreamlitAPIException):
+        component("test", js=123)  # Integer instead of string/Path
+
+    with pytest.raises(StreamlitAPIException):
+        component("test", css=["invalid", "list"])  # List instead of string/Path
 
 
 def test_register_from_manifest_basic(temp_manager_setup) -> None:
@@ -841,3 +866,50 @@ def test_security_validation() -> None:
 
         with pytest.raises(StreamlitComponentRegistryError):
             ComponentPathUtils.resolve_glob_pattern("/etc/passwd", temp_path)
+
+
+@pytest.mark.parametrize(
+    ("target_field", "second_args", "expect_present_field"),
+    [
+        ("html", {"js": "export default function(){}"}, "js"),
+        ("css", {"js": "export default function(){}"}, "js"),
+        ("js", {"html": "<div>Updated</div>"}, "html"),
+    ],
+)
+def test_runtime_override_removes_field(
+    monkeypatch, target_field, second_args, expect_present_field
+) -> None:
+    """Verify that removing a field in a subsequent registration clears it.
+
+    We first register a component with multiple fields set. Then, we call the
+    public API again omitting the target field. The registry should update the
+    definition so that the target field is None, rather than preserving it.
+    """
+    from streamlit.components.v2 import component as component_api
+    from streamlit.components.v2.component_manager import BidiComponentManager
+
+    manager = BidiComponentManager()
+
+    # Patch the component API to use our local manager instance.
+    monkeypatch.setattr(
+        "streamlit.components.v2.get_bidi_component_manager",
+        lambda: manager,
+    )
+
+    # Initial registration includes all three fields to keep flexibility
+    component_api(
+        "my_component",
+        html="<h1>Hello World</h1>",
+        css=".title{color:red;}",
+        js="export default function(){}",
+    )
+
+    # Subsequent registration provides only a non-target field to keep valid
+    component_api("my_component", **second_args)
+
+    definition = manager.get("my_component")
+    assert definition is not None
+    # Target field should be cleared
+    assert getattr(definition, target_field) is None
+    # Provided non-target field should remain present
+    assert getattr(definition, expect_present_field) is not None

--- a/lib/tests/streamlit/components/v2/test_default_state.py
+++ b/lib/tests/streamlit/components/v2/test_default_state.py
@@ -1,0 +1,188 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the `default` parameter in Components V2."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.components.v2 import component
+from streamlit.components.v2.component_manager import BidiComponentManager
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime import Runtime
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+class DefaultStateIntegrationTest(DeltaGeneratorTestCase):
+    """Integration tests for `default` using the public component API."""
+
+    def setUp(self) -> None:
+        """Set up a fresh component manager patched into the Runtime singleton."""
+        super().setUp()
+        self.mock_component_manager = BidiComponentManager()
+        self.runtime_patcher = patch.object(
+            Runtime, "instance", return_value=MagicMock()
+        )
+        self.mock_runtime = self.runtime_patcher.start()
+        self.mock_runtime.return_value.bidi_component_registry = (
+            self.mock_component_manager
+        )
+
+    def tearDown(self) -> None:
+        """Tear down the runtime patcher."""
+        super().tearDown()
+        self.runtime_patcher.stop()
+
+    def test_component_with_default_basic(self) -> None:
+        """Test basic `default` functionality with the public API."""
+        # Declare a component
+        my_component = component(
+            "test_component",
+            js="console.log('test');",
+        )
+
+        # Create mock callbacks
+        on_value_change = MagicMock()
+        on_enabled_change = MagicMock()
+
+        # Use the component with default
+        result = my_component(
+            default={
+                "value": 42,
+                "enabled": False,
+            },
+            on_value_change=on_value_change,
+            on_enabled_change=on_enabled_change,
+        )
+
+        # Verify defaults are applied
+        assert result["value"] == 42
+        assert result["enabled"] is False
+
+    def test_component_default_validation(self) -> None:
+        """Test that `default` key validation works with the public API."""
+        # Declare a component
+        my_component = component(
+            "validation_test_component",
+            js="console.log('validation test');",
+        )
+
+        # Create callback for only one state
+        on_valid_change = MagicMock()
+
+        # Try to use invalid default
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            my_component(
+                default={
+                    "valid": "this is ok",
+                    "invalid": "this should fail",
+                },
+                on_valid_change=on_valid_change,
+            )
+
+        # Verify the error message
+        error_message = str(exc_info.value)
+        assert "invalid" in error_message
+        assert "not a valid state name" in error_message
+
+    def test_component_default_with_data(self) -> None:
+        """Test that `default` works correctly with the `data` parameter."""
+        # Declare a component
+        my_component = component(
+            "data_and_defaults_component",
+            js="console.log('data and defaults');",
+        )
+
+        # Create callbacks
+        on_selection_change = MagicMock()
+        on_mode_change = MagicMock()
+
+        # Use both data and default
+        result = my_component(
+            data={"items": ["a", "b", "c"]},
+            default={
+                "selection": [],
+                "mode": "single",
+            },
+            on_selection_change=on_selection_change,
+            on_mode_change=on_mode_change,
+        )
+
+        # Verify defaults are applied
+        assert result["selection"] == []
+        assert result["mode"] == "single"
+
+        # Verify the proto contains both data and component setup
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name.endswith(
+            "data_and_defaults_component"
+        )
+
+    def test_component_default_complex_types(self) -> None:
+        """Test `default` with complex data types like lists and dicts."""
+        # Declare a component
+        my_component = component(
+            "complex_types_component",
+            js="console.log('complex types');",
+        )
+
+        # Create callbacks
+        on_items_change = MagicMock()
+        on_config_change = MagicMock()
+
+        # Complex default values
+        default_items = [{"id": 1, "name": "Item 1"}, {"id": 2, "name": "Item 2"}]
+        default_config = {
+            "theme": "dark",
+            "settings": {"auto_save": True, "timeout": 30},
+        }
+
+        # Use the component
+        result = my_component(
+            default={
+                "items": default_items,
+                "config": default_config,
+            },
+            on_items_change=on_items_change,
+            on_config_change=on_config_change,
+        )
+
+        # Verify complex defaults are preserved
+        assert result["items"] == default_items
+        assert result["config"] == default_config
+        assert result["config"]["settings"]["auto_save"] is True
+
+    def test_component_default_none_values(self) -> None:
+        """Test `default` with None values using the public API."""
+        # Declare a component
+        my_component = component(
+            "none_values_component",
+            js="console.log('none values');",
+        )
+
+        # Create callback
+        on_nullable_change = MagicMock()
+
+        # Use None as default value
+        result = my_component(
+            default={"nullable": None},
+            on_nullable_change=on_nullable_change,
+        )
+
+        # Verify None is properly handled
+        assert result["nullable"] is None


### PR DESCRIPTION
## Describe your changes

Added the `st.components.v2.components` API for creating bidirectional components:

- Support for both inline and file-based assets (HTML, CSS, JS)
- Path/glob resolution for component assets

The implementation is the public-facing API.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive test suite for the new API including:
  - Tests for component registration and resolution
  - Tests for path handling and security validation
  - Tests for default state handling
  - Tests for component serialization and deserialization
  - Tests for error handling and validation

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.