### PR TITLE
[feat] Track telemetry for ccv2 instances

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -331,6 +331,10 @@ def _get_command_telemetry(
     ):
         name = f"component:{self_arg.name}"
 
+    if name == "_bidi_component" and len(args) > 0 and isinstance(args[0], str):
+        component_name = args[0]
+        name = f"component_v2:{component_name}"
+
     return Command(name=name, args=arguments)
 
 

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -219,6 +219,21 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             == 'k: "disabled"\nt: "bool"\nm: "val:True"'
         )
 
+    def test_get_command_telemetry_custom_component_v2(self):
+        """Test getting command telemetry for Custom Components v2 via _get_command_telemetry."""
+        # Create a mock bidi_component function that appears to be from streamlit
+        mock_bidi_component = MagicMock()
+        mock_bidi_component.__module__ = "streamlit.components.v2.bidi_component"
+
+        # Test with a Custom Components v2 call
+        command_metadata = metrics_util._get_command_telemetry(
+            mock_bidi_component, "_bidi_component", "my_custom_component", key="test"
+        )
+
+        assert command_metadata.name == "component_v2:my_custom_component"
+        assert len(command_metadata.args) == 1
+        assert str(command_metadata.args[0]).strip() == 'k: "key"\nt: "str"\nm: "len:4"'
+
     def test_create_page_profile_message(self):
         """Test creating the page profile message via create_page_profile_message."""
         forward_msg = metrics_util.create_page_profile_message(


### PR DESCRIPTION
## Describe your changes

Added telemetry tracking for Custom Components v2 by detecting calls to `_bidi_component` and extracting the component name from the first argument. This allows us to track usage of specific v2 components with the format `component_v2:{component_name}` in our telemetry data. This naming convention was confirmed by [stakeholders](https://snowflake.slack.com/archives/C03RMGWNT6V/p1752679887293759?thread_ts=1752627355.746069&cid=C03RMGWNT6V).

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added a new test case `test_get_command_telemetry_custom_component_v2` that verifies the correct telemetry name is generated for Custom Components v2 calls.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.