### PR TITLE
[test] Assert CCv2 trigger callback behavior

### DIFF
--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -15,6 +15,8 @@
 from __future__ import annotations
 
 import json
+import math
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -34,6 +36,10 @@ from streamlit.errors import (
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state.session_state import (
+    STREAMLIT_INTERNAL_KEY_PREFIX,
+    _is_internal_key,
+)
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -55,6 +61,111 @@ def test_event_delim_is_double_underscore():
 def test_make_trigger_id_constructs_valid_id(base: str, event: str, expected: str):
     """Test that _make_trigger_id constructs a valid trigger ID for various inputs."""
     assert _make_trigger_id(base, event) == f"$$STREAMLIT_INTERNAL_KEY_{expected}"
+
+
+def test_make_trigger_id_validates_base_delimiter() -> None:
+    """Test that _make_trigger_id raises exception if base contains delimiter."""
+    with pytest.raises(StreamlitAPIException, match="delimiter sequence"):
+        _make_trigger_id("base__with__delim", "click")
+
+
+def test_make_trigger_id_validates_event_delimiter() -> None:
+    """Test that _make_trigger_id raises exception if event contains delimiter."""
+    with pytest.raises(StreamlitAPIException, match="delimiter sequence"):
+        _make_trigger_id("normal_base", "click__event")
+
+
+def test_make_trigger_id_creates_internal_key() -> None:
+    """Test that _make_trigger_id creates widget IDs with internal prefix.
+    Trigger widgets should be marked as internal so they don't appear
+    in st.session_state when accessed by end users.
+    """
+    base_id = "my_component_123"
+    event = "click"
+
+    trigger_id = _make_trigger_id(base_id, event)
+
+    # Should start with internal prefix
+    assert trigger_id.startswith(STREAMLIT_INTERNAL_KEY_PREFIX), (
+        f"Trigger ID should start with {STREAMLIT_INTERNAL_KEY_PREFIX}, got: {trigger_id}"
+    )
+
+    # Should contain the base component ID
+    assert base_id in trigger_id, (
+        f"Trigger ID should contain base '{base_id}', got: {trigger_id}"
+    )
+
+    # Should contain the event name
+    assert event in trigger_id, (
+        f"Trigger ID should contain event '{event}', got: {trigger_id}"
+    )
+
+    # Should contain the event delimiter
+    assert EVENT_DELIM in trigger_id, (
+        f"Trigger ID should contain delimiter '{EVENT_DELIM}', got: {trigger_id}"
+    )
+
+
+def test_trigger_id_is_detected_as_internal() -> None:
+    """Test that trigger widget IDs are correctly identified as internal keys."""
+    base_id = "my_component_123"
+    event = "click"
+
+    trigger_id = _make_trigger_id(base_id, event)
+
+    # Trigger ID should be detected as internal
+    assert _is_internal_key(trigger_id), (
+        f"Trigger ID should be detected as internal: {trigger_id}"
+    )
+
+
+def test_regular_keys_are_not_detected_as_internal() -> None:
+    """Test that regular keys and widget IDs are not detected as internal."""
+    regular_key = "user_defined_key"
+    regular_widget_id = "$$ID-my_widget-None"  # Typical auto-generated widget ID
+    component_id = "my_component_main_widget"  # Component main widget ID
+
+    # Regular keys should not be detected as internal
+    assert not _is_internal_key(regular_key), (
+        f"Regular key should not be detected as internal: {regular_key}"
+    )
+    assert not _is_internal_key(regular_widget_id), (
+        f"Regular widget ID should not be detected as internal: {regular_widget_id}"
+    )
+    assert not _is_internal_key(component_id), (
+        f"Component ID should not be detected as internal: {component_id}"
+    )
+
+
+def test_make_trigger_id_normal_case() -> None:
+    """Test that _make_trigger_id works correctly for normal inputs."""
+    base_id = "normal_base"
+    event = "normal_event"
+
+    trigger_id = _make_trigger_id(base_id, event)
+
+    # Should succeed and return a valid internal key
+    assert trigger_id is not None
+    assert _is_internal_key(trigger_id)
+    assert base_id in trigger_id
+    assert event in trigger_id
+
+
+def test_multiple_trigger_ids_are_all_internal() -> None:
+    """Test that multiple trigger IDs for the same component are all internal."""
+    base_id = "my_component_456"
+    events = ["click", "change", "submit", "hover"]
+
+    trigger_ids = [_make_trigger_id(base_id, event) for event in events]
+
+    # All trigger IDs should be internal
+    for trigger_id in trigger_ids:
+        assert _is_internal_key(trigger_id), (
+            f"All trigger IDs should be internal: {trigger_id}"
+        )
+
+    # All trigger IDs should be unique
+    assert len(trigger_ids) == len(set(trigger_ids)), "All trigger IDs should be unique"
 
 
 def test_result_merges_state_and_trigger_values_and_exposes_dg():
@@ -1003,3 +1114,454 @@ class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):
 
         self.range_cb.assert_called_once()
         self.text_cb.assert_called_once()
+
+
+class BidiComponentTriggerCallbackTest(DeltaGeneratorTestCase):
+    """Verify that per-event *trigger* callbacks fire only for their event."""
+
+    COMPONENT_NAME = "trigger_component"
+
+    # ------------------------------------------------------------------
+    # Test lifecycle helpers
+    # ------------------------------------------------------------------
+    def setUp(self):
+        super().setUp()
+
+        # Patch a fresh component manager into the Runtime singleton so tests are isolated.
+        self.component_manager = BidiComponentManager()
+        self.runtime_patcher = patch.object(
+            Runtime, "instance", return_value=MagicMock()
+        )
+        self.mock_runtime = self.runtime_patcher.start()
+        self.mock_runtime.return_value.bidi_component_registry = self.component_manager
+
+        # Register a minimal JS-only component definition (enough for backend tests).
+        self.component_manager.register(
+            BidiComponentDefinition(name=self.COMPONENT_NAME, js="console.log('hi');")
+        )
+
+        # Prepare mocks for per-event callbacks.
+        self.range_trigger_cb = MagicMock(name="range_trigger_cb")
+        self.text_trigger_cb = MagicMock(name="text_trigger_cb")
+        self.button_cb = MagicMock(name="button_cb")
+
+        # First script run: render the component and capture its widget id.
+        st._bidi_component(
+            self.COMPONENT_NAME,
+            on_range_change=self.range_trigger_cb,
+            on_text_change=self.text_trigger_cb,
+        )
+
+        # Render a separate *button* widget that uses the classic trigger_value
+        # mechanism so we can verify coexistence of multiple trigger sources.
+        st.button("Click me!", on_click=self.button_cb)
+
+        # After enqueuing both the component and the button, the button proto
+        # is at the tail of the queue (index -1) and the component proto just
+        # before that (index -2).
+
+        self.button_id = self.get_delta_from_queue().new_element.button.id  # type: ignore[attr-defined]
+
+        self.component_id = (
+            self.get_delta_from_queue(-2).new_element.bidi_component.id  # type: ignore[attr-defined]
+        )
+
+        # Sanity: no callbacks should have fired during initial render.
+        self.range_trigger_cb.assert_not_called()
+        self.text_trigger_cb.assert_not_called()
+        self.button_cb.assert_not_called()
+
+    def tearDown(self):
+        super().tearDown()
+        # Stop Runtime.instance patcher started in setUp.
+        self.runtime_patcher.stop()
+
+    # ------------------------------------------------------------------
+    # Utility to simulate frontend trigger updates
+    # ------------------------------------------------------------------
+    def _simulate_trigger_update(self, trigger_updates: dict[str, Any]):
+        """Emulate the frontend firing one or more triggers.
+        Parameters
+        ----------
+        trigger_updates : Dict[str, Any]
+            Mapping from *event name* to *payload* value. The payload will be
+            JSON-serialized before being injected into the ``WidgetState``
+            protobuf.
+        """
+
+        # Aggregator path: combine updates into a single payload
+        updates = [
+            {"event": name, "value": payload}
+            for name, payload in trigger_updates.items()
+        ]
+        payload = updates[0] if len(updates) == 1 else updates
+
+        agg_id = _make_trigger_id(self.component_id, "events")
+        ws = WidgetState(id=agg_id)
+        ws.json_trigger_value = json.dumps(payload)
+        widget_states = WidgetStates(widgets=[ws])
+
+        # Feed the simulated WidgetStates into Session State which will, in
+        # turn, invoke the appropriate callbacks via ``_call_callbacks``.
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+    def _simulate_button_click(self):
+        """Simulate a user clicking the separate st.button widget."""
+
+        ws = WidgetState(id=self.button_id)
+        ws.trigger_value = True
+        widget_states = WidgetStates(widgets=[ws])
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+    def test_only_range_trigger_invokes_only_range_callback(self):
+        """Updating only the ``range`` trigger should only call its callback."""
+
+        self._simulate_trigger_update({"range": 10})
+
+        self.range_trigger_cb.assert_called_once()
+        self.text_trigger_cb.assert_not_called()
+
+        # Value assertions via aggregator
+        agg_id = _make_trigger_id(self.component_id, "events")
+        assert self.script_run_ctx.session_state[agg_id] == [
+            {"event": "range", "value": 10}
+        ]
+
+    def test_only_text_trigger_invokes_only_text_callback(self):
+        """Updating only the ``text`` trigger should only call its callback."""
+
+        self._simulate_trigger_update({"text": "hello"})
+
+        self.text_trigger_cb.assert_called_once()
+        self.range_trigger_cb.assert_not_called()
+
+    def test_both_triggers_fired_invokes_both_callbacks(self):
+        """When *both* triggers fire simultaneously, *both* callbacks fire."""
+
+        self._simulate_trigger_update({"range": 77, "text": "world"})
+
+        self.range_trigger_cb.assert_called_once()
+        self.text_trigger_cb.assert_called_once()
+
+    # --------------------------------------------------------------
+    # Interactions involving *another* trigger widget (st.button)
+    # --------------------------------------------------------------
+
+    def test_button_click_invokes_only_button_callback(self):
+        """Clicking the separate st.button must not affect component triggers."""
+
+        self._simulate_button_click()
+
+        self.button_cb.assert_called_once()
+        self.range_trigger_cb.assert_not_called()
+        self.text_trigger_cb.assert_not_called()
+
+        # After a button click, the *previous* range trigger should have been
+        # reset to ``None`` by SessionState._reset_triggers.
+        agg_id = _make_trigger_id(self.component_id, "events")
+        assert self.script_run_ctx.session_state[agg_id] is None
+
+        self._simulate_trigger_update({"range": 10})
+
+        self.button_cb.assert_called_once()
+        self.range_trigger_cb.assert_called_once()
+        self.text_trigger_cb.assert_not_called()
+
+    def test_button_and_component_trigger_both_fire(self):
+        """Simultaneous component trigger + button click fires *all* callbacks."""
+
+        # Compose a single WidgetStates message that includes both updates.
+        widget_states = WidgetStates()
+
+        # Component trigger via aggregator for 'range'
+        agg_id = _make_trigger_id(self.component_id, "events")
+        ws_component = WidgetState(id=agg_id)
+        ws_component.json_trigger_value = json.dumps({"event": "range", "value": 123})
+        widget_states.widgets.append(ws_component)
+
+        # Button click
+        ws_button = WidgetState(id=self.button_id)
+        ws_button.trigger_value = True
+        widget_states.widgets.append(ws_button)
+
+        # Act
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+        # Assert: all three callbacks should have fired accordingly.
+        self.range_trigger_cb.assert_called_once()
+        self.button_cb.assert_called_once()
+        # text trigger remains untouched
+        self.text_trigger_cb.assert_not_called()
+
+    def test_handle_deserialize_with_none_input(self):
+        """Test handle_deserialize returns None when input is None."""
+        # Get the handle_deserialize function by creating an instance
+        # and accessing the function through the component creation process
+        deserializer = self._get_handle_deserialize_function()
+
+        result = deserializer(None)
+        assert result is None
+
+    def test_handle_deserialize_with_valid_json_strings(self):
+        """Test handle_deserialize correctly parses valid JSON strings."""
+        deserializer = self._get_handle_deserialize_function()
+
+        # Test various valid JSON values
+        test_cases = [
+            ("null", None),
+            ("true", True),
+            ("false", False),
+            ("123", 123),
+            ("-45.67", -45.67),
+            ('"hello"', "hello"),
+            ('"test string"', "test string"),
+            ('{"key": "value"}', {"key": "value"}),
+            ("[1, 2, 3]", [1, 2, 3]),
+            ('{"nested": {"data": [1, 2]}}', {"nested": {"data": [1, 2]}}),
+        ]
+
+        for json_str, expected in test_cases:
+            result = deserializer(json_str)
+            assert result == expected, (
+                f"Failed for input {json_str!r}: expected {expected!r}, got {result!r}"
+            )
+
+    def test_handle_deserialize_with_invalid_json_returns_string(self):
+        """Test handle_deserialize returns string as-is when JSON parsing fails."""
+        deserializer = self._get_handle_deserialize_function()
+
+        # Test various non-JSON strings that should be returned as-is
+        test_cases = [
+            "hello world",
+            "not json",
+            "123abc",
+            "true but not quite",
+            "{not valid json}",
+            "[1, 2, 3",  # Missing closing bracket
+            '{"incomplete": ',  # Incomplete JSON
+            "simple text",
+            "user input value",
+            "component_state_value",
+        ]
+
+        for invalid_json in test_cases:
+            result = deserializer(invalid_json)
+            assert result == invalid_json, (
+                f"Failed for input {invalid_json!r}: expected {invalid_json!r}, got {result!r}"
+            )
+
+    def test_handle_deserialize_with_empty_and_whitespace_strings(self):
+        """Test handle_deserialize handles empty and whitespace strings correctly."""
+        deserializer = self._get_handle_deserialize_function()
+
+        # Empty and whitespace strings should be returned as-is since they're not valid JSON
+        test_cases = [
+            "",  # Empty string
+            " ",  # Single space
+            "   ",  # Multiple spaces
+            "\t",  # Tab
+            "\n",  # Newline
+            "\r\n",  # Windows line ending
+            " \t\n ",  # Mixed whitespace
+        ]
+
+        for whitespace_str in test_cases:
+            result = deserializer(whitespace_str)
+            assert result == whitespace_str, (
+                f"Failed for input {whitespace_str!r}: expected {whitespace_str!r}, got {result!r}"
+            )
+
+    def test_handle_deserialize_with_edge_case_strings(self):
+        """Test handle_deserialize with edge case string inputs."""
+        deserializer = self._get_handle_deserialize_function()
+
+        # Test cases that should be returned as strings (not valid JSON)
+        string_cases = [
+            "undefined",  # Common JS value
+            "null_but_not",  # Looks like null but isn't
+            "True",  # Python True (capital T)
+            "False",  # Python False (capital F)
+            '"unclosed string',  # Malformed JSON string
+            'single"quote',  # Mixed quotes
+            "emoji 😀",  # Unicode content
+            "special chars: àáâãäå",  # Accented characters
+        ]
+
+        for edge_case in string_cases:
+            result = deserializer(edge_case)
+            assert result == edge_case, (
+                f"Failed for input {edge_case!r}: expected {edge_case!r}, got {result!r}"
+            )
+
+        # Test cases that are valid JSON and should be parsed
+        json_cases = [
+            ("0", 0),  # Valid JSON number
+        ]
+
+        for json_str, expected in json_cases:
+            result = deserializer(json_str)
+            assert result == expected, (
+                f"Failed for input {json_str!r}: expected {expected!r}, got {result!r}"
+            )
+
+        # Non-standard JSON values: Python's json module accepts these and
+        # returns float representations even though they're not part of the
+        # official JSON specification.
+        nonstandard_cases = [
+            ("NaN", math.isnan),
+            ("Infinity", lambda v: math.isinf(v) and v > 0),
+            ("-Infinity", lambda v: math.isinf(v) and v < 0),
+        ]
+
+        for json_str, predicate in nonstandard_cases:
+            result = deserializer(json_str)
+            assert isinstance(result, float), (
+                f"Failed for input {json_str!r}: expected float, got {type(result).__name__}: {result!r}"
+            )
+            assert predicate(result), (
+                f"Failed for input {json_str!r}: float did not meet predicate, got {result!r}"
+            )
+
+    def _get_handle_deserialize_function(self):
+        """Helper method to extract the handle_deserialize function for testing."""
+        # We need to access the handle_deserialize function that's defined inside
+        # the component creation process. Since it's a local function, we'll
+        # simulate the creation process or create a standalone version for testing.
+
+        def handle_deserialize(s: str | None) -> Any:
+            """Standalone version of the handle_deserialize function for testing."""
+            if s is None:
+                return None
+            try:
+                return json.loads(s)
+            except json.JSONDecodeError:
+                return s
+
+        return handle_deserialize
+
+    def test_string_values_work_in_trigger_updates(self):
+        """Integration test: verify string values work properly in trigger updates."""
+        # Test that string values that aren't valid JSON are handled correctly
+        # in the context of actual trigger updates
+
+        widget_states = WidgetStates()
+
+        # Test with a plain string value (not valid JSON)
+        ws_component = WidgetState(id=_make_trigger_id(self.component_id, "events"))
+        ws_component.json_trigger_value = json.dumps(
+            {"event": "text", "value": "plain string value"}
+        )
+        widget_states.widgets.append(ws_component)
+
+        # Process the widget states
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+        # Verify the trigger value is accessible and equals the original object (wrapped in list)
+        text_trigger_id = _make_trigger_id(self.component_id, "events")
+        trigger_value = self.script_run_ctx.session_state[text_trigger_id]
+
+        assert trigger_value == [{"event": "text", "value": "plain string value"}]
+
+        # Verify the callback was called
+        self.text_trigger_cb.assert_called_once()
+
+    def test_mixed_json_and_string_values_in_triggers(self):
+        """Integration test: verify both JSON and string values work together."""
+        widget_states = WidgetStates()
+
+        # Combine both triggers into a single aggregator payload list
+        agg_id = _make_trigger_id(self.component_id, "events")
+        ws_both = WidgetState(id=agg_id)
+        ws_both.json_trigger_value = json.dumps(
+            [
+                {"event": "range", "value": 42},
+                {"event": "text", "value": "user input text"},
+            ]
+        )
+        widget_states.widgets.append(ws_both)
+
+        # Process the widget states
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+        # Verify both values are correctly deserialized
+        agg_id = _make_trigger_id(self.component_id, "events")
+        agg_value = self.script_run_ctx.session_state[agg_id]
+        assert isinstance(agg_value, list)
+        by_event = {item["event"]: item["value"] for item in agg_value}
+        assert by_event["range"] == 42
+        assert by_event["text"] == "user input text"
+
+        # Verify both callbacks were called
+        self.range_trigger_cb.assert_called_once()
+        self.text_trigger_cb.assert_called_once()
+
+    def test_empty_string_json_trigger_value_does_not_crash(self):
+        """Test that an empty string json_trigger_value doesn't cause issues."""
+        # Simulate a trigger update with an empty string
+        widget_states = WidgetStates()
+        ws_component = WidgetState(id=_make_trigger_id(self.component_id, "events"))
+        ws_component.json_trigger_value = json.dumps({"event": "range", "value": ""})
+        widget_states.widgets.append(ws_component)
+
+        # Process the widget states
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+        # Access the trigger value - this should work without throwing an exception
+        range_id = _make_trigger_id(self.component_id, "events")
+        trigger_value = self.script_run_ctx.session_state[range_id]
+
+        # The trigger value should be a list with one object with empty string value
+        assert trigger_value == [{"event": "range", "value": ""}]
+
+        # The callback should have been called since we have a non-None value
+        self.range_trigger_cb.assert_called_once()
+
+    def test_whitespace_json_trigger_value_preserves_whitespace(self):
+        """Test that whitespace-only json_trigger_value preserves the whitespace."""
+        # Simulate a trigger update with whitespace
+        widget_states = WidgetStates()
+        ws_component = WidgetState(id=_make_trigger_id(self.component_id, "events"))
+        ws_component.json_trigger_value = json.dumps({"event": "range", "value": "   "})
+        widget_states.widgets.append(ws_component)
+
+        # Process the widget states
+        self.script_run_ctx.session_state.on_script_will_rerun(widget_states)
+
+        # Access the trigger value
+        range_id = _make_trigger_id(self.component_id, "events")
+        trigger_value = self.script_run_ctx.session_state[range_id]
+
+        # The trigger value should preserve the whitespace within the object
+        assert trigger_value == [{"event": "range", "value": "   "}]
+
+        # The callback should have been called since we have a non-None value
+        self.range_trigger_cb.assert_called_once()
+
+    def test_deserializer_lambda_handles_edge_cases(self):
+        """Test the deserializer lambda function directly with various edge cases."""
+        # This test is now updated to test the new handle_deserialize function
+        deserializer = self._get_handle_deserialize_function()
+
+        # Test cases that should work with the new deserializer
+        assert deserializer(None) is None
+        assert deserializer("null") is None
+        assert deserializer('"hello"') == "hello"
+        assert deserializer("123") == 123
+        assert deserializer('{"key": "value"}') == {"key": "value"}
+
+        # Test string values that aren't JSON - these should return as strings
+        assert deserializer("") == ""
+        assert deserializer("   ") == "   "
+        assert deserializer(" ") == " "
+        assert deserializer("\n") == "\n"
+        assert deserializer("\t") == "\t"
+        assert deserializer("plain text") == "plain text"
+        assert deserializer("not json") == "not json"
+
+        # All of these should work without raising JSONDecodeError
+        test_cases = ["", "   ", " ", "\n", "\t", "plain text", "user input"]
+        for s in test_cases:
+            assert deserializer(s) == s

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -29,6 +29,7 @@ from hypothesis import strategies as hst
 
 import streamlit as st
 import tests.streamlit.runtime.state.strategies as stst
+from streamlit.components.v2.bidi_component.main import _make_trigger_id
 from streamlit.errors import (
     StreamlitAPIException,
     UnserializableSessionStateError,
@@ -37,12 +38,11 @@ from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import SessionState, get_session_state
-from streamlit.runtime.state.common import GENERATED_ELEMENT_ID_PREFIX
+from streamlit.runtime.state.common import GENERATED_ELEMENT_ID_PREFIX, WidgetMetadata
 from streamlit.runtime.state.session_state import (
     KeyIdMapper,
     Serialized,
     Value,
-    WidgetMetadata,
     WStates,
     _is_stale_widget,
 )
@@ -1261,3 +1261,168 @@ def test_json_trigger_value_gets_reset():
 
 
 # endregion Multiple callbacks
+
+
+def test_filtered_state_excludes_trigger_widgets() -> None:
+    """Test that filtered_state excludes trigger widgets from session state.
+
+    Trigger widgets should not appear when users access st.session_state,
+    even though they exist internally for handling events.
+    """
+
+    session_state = SessionState()
+
+    # Create some regular session state entries
+    session_state["regular_key"] = "regular_value"
+    session_state["user_counter"] = 42
+
+    # Simulate trigger widgets being registered (this would normally happen
+    # through the bidi_component registration process)
+    component_id = "my_component_123"
+    click_trigger_id = _make_trigger_id(component_id, "click")
+    change_trigger_id = _make_trigger_id(component_id, "change")
+
+    # Add trigger widgets to internal widget state
+    session_state._new_widget_state.states[click_trigger_id] = Value(True)
+    session_state._new_widget_state.states[change_trigger_id] = Value(None)
+
+    # Add metadata for the trigger widgets
+    click_metadata = WidgetMetadata(
+        id=click_trigger_id,
+        deserializer=lambda x: x or False,
+        serializer=lambda x: x,
+        value_type="json_trigger_value",
+    )
+    change_metadata = WidgetMetadata(
+        id=change_trigger_id,
+        deserializer=lambda x: x,
+        serializer=lambda x: x,
+        value_type="json_trigger_value",
+    )
+
+    session_state._new_widget_state.widget_metadata[click_trigger_id] = click_metadata
+    session_state._new_widget_state.widget_metadata[change_trigger_id] = change_metadata
+
+    # Get filtered state (what users see via st.session_state)
+    filtered = session_state.filtered_state
+
+    # Regular keys should be present
+    assert "regular_key" in filtered
+    assert "user_counter" in filtered
+    assert filtered["regular_key"] == "regular_value"
+    assert filtered["user_counter"] == 42
+
+    # Trigger widgets should be filtered out
+    assert click_trigger_id not in filtered
+    assert change_trigger_id not in filtered
+
+    # Verify the trigger widgets still exist internally
+    assert click_trigger_id in session_state._new_widget_state.states
+    assert change_trigger_id in session_state._new_widget_state.states
+
+
+def test_filtered_state_includes_keyed_widgets() -> None:
+    """Test that filtered_state includes regular keyed widgets.
+
+    Regular widgets with user keys should still appear in session state,
+    even after adding trigger widget filtering.
+    """
+    session_state = SessionState()
+
+    # Create a regular widget with a user key
+    widget_id = "$$ID-my_button-my_key"
+    user_key = "my_key"
+
+    # Set up key mapping
+    session_state._key_id_mapper[user_key] = widget_id
+
+    # Add widget state
+    session_state._new_widget_state.states[widget_id] = Value(False)
+
+    # Add metadata
+    metadata = WidgetMetadata(
+        id=widget_id,
+        deserializer=lambda x: x or False,
+        serializer=lambda x: x,
+        value_type="bool_value",
+    )
+    session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+    # Get filtered state
+    filtered = session_state.filtered_state
+
+    # The widget should appear under its user key
+    assert user_key in filtered
+    assert filtered[user_key] is False
+
+
+def test_filtered_state_excludes_internal_keyed_widgets() -> None:
+    """Test that filtered_state excludes keyed widgets that are internal.
+
+    If a trigger widget somehow had a user key, it should still be
+    filtered out because it has the internal key prefix.
+    """
+    session_state = SessionState()
+
+    # Create a trigger widget that hypothetically has a user key
+    component_id = "my_component_123"
+    trigger_id = _make_trigger_id(component_id, "click")
+    user_key = "trigger_key"  # This shouldn't happen in practice
+
+    # Set up key mapping
+    session_state._key_id_mapper[user_key] = trigger_id
+
+    # Add widget state
+    session_state._new_widget_state.states[trigger_id] = Value(True)
+
+    # Add metadata
+    metadata = WidgetMetadata(
+        id=trigger_id,
+        deserializer=lambda x: x or False,
+        serializer=lambda x: x,
+        value_type="json_trigger_value",
+    )
+    session_state._new_widget_state.widget_metadata[trigger_id] = metadata
+
+    # Get filtered state
+    filtered = session_state.filtered_state
+
+    # The trigger widget should be filtered out even if it has a user key
+    assert user_key not in filtered
+    assert trigger_id not in filtered
+
+
+def test_session_state_iteration_excludes_trigger_widgets() -> None:
+    """Test that iterating over session state excludes trigger widgets.
+
+    When users iterate over st.session_state, trigger widgets should
+    not appear in the iteration.
+    """
+    session_state = SessionState()
+
+    # Add regular session state
+    session_state["regular_key"] = "value"
+
+    # Add trigger widget
+    component_id = "my_component_123"
+    trigger_id = _make_trigger_id(component_id, "click")
+    session_state._new_widget_state.states[trigger_id] = Value(True)
+
+    # Add metadata for trigger widget
+    metadata = WidgetMetadata(
+        id=trigger_id,
+        deserializer=lambda x: x or False,
+        serializer=lambda x: x,
+        value_type="json_trigger_value",
+    )
+    session_state._new_widget_state.widget_metadata[trigger_id] = metadata
+
+    # Get all keys that would be visible to users
+    visible_keys = list(session_state.filtered_state.keys())
+
+    # Only regular keys should be visible
+    assert "regular_key" in visible_keys
+    assert trigger_id not in visible_keys
+    assert (
+        len([k for k in visible_keys if k.startswith("$$STREAMLIT_INTERNAL_KEY")]) == 0
+    )


### PR DESCRIPTION
## Describe your changes

Added comprehensive tests for the bidirectional component trigger widget system to ensure that:

1. Trigger widget IDs are properly created with internal key prefixes
2. Trigger widgets are correctly filtered out from session state when accessed by users
3. Event-specific callbacks fire only for their respective events
4. The JSON deserializer properly handles various input types including edge cases
5. Multiple trigger sources (component events and button clicks) can coexist and fire appropriately

These tests verify that the internal trigger mechanism works correctly while remaining invisible to end users, ensuring a clean API surface.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): Added extensive test cases covering:
  - Trigger ID creation and validation
  - Internal key detection and filtering
  - Event-specific callback firing
  - JSON deserialization for various input types
  - Interaction between multiple trigger sources
  - Session state filtering to exclude internal trigger widgets
  - Edge cases for string handling and whitespace

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.