### PR TITLE
Make st.logout use end_session_endpoint if provided in OIDC config (V2)

### DIFF
--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -301,8 +301,9 @@ def logout() -> None:
     """Logout the current user.
 
     This command removes the user's information from ``st.user``,
-    deletes their identity cookie, and redirects them back to your app's home
-    page. This creates a new session.
+    deletes their identity cookie, and redirects them to perform a proper
+    logout from the OAuth provider (if available) before returning to your
+    app's home page. This creates a new session.
 
     If the user has multiple sessions open in the same browser,
     ``st.user`` will not be cleared in any other session.
@@ -311,8 +312,9 @@ def logout() -> None:
     ``st.logout()`` within that session to update ``st.user``.
 
     .. Note::
-        This does not log the user out of their underlying account from the
-        identity provider.
+        If the OAuth provider supports OIDC end_session_endpoint in their
+        server metadata, the user will be logged out from the identity provider
+        as well. If not available, only local logout is performed.
 
     Example
     -------

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -247,9 +247,9 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                 # See the NOTE in the docstring of the `select_subprotocol` method above
                 # for a detailed explanation of why this is done.
                 existing_session_id = ws_protocols[2]
-        except KeyError:
+        except (KeyError, json.JSONDecodeError):
             # Just let existing_session_id=None if we run into any error while trying to
-            # extract it from the Sec-Websocket-Protocol header.
+            # extract it from the Sec-Websocket-Protocol header or parsing cookie JSON.
             pass
 
         # Map in any user-configured headers. Note that these override anything coming

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -181,10 +181,13 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
 
     def _get_redirect_uri(self) -> str | None:
         auth_section = get_secrets_auth_section()
-        if not auth_section or not auth_section.get("redirect_uri"):
+        if not auth_section:
             return None
 
-        redirect_uri: str = auth_section["redirect_uri"]
+        redirect_uri = get_redirect_uri(auth_section)
+        if not redirect_uri:
+            return None
+
         if not redirect_uri.endswith("/oauth2callback"):
             _LOGGER.warning("Redirect URI does not end with /oauth2callback")
             return None

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -24,6 +24,7 @@ from streamlit.auth_util import (
     clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
+    get_cookie_with_chunks,
     get_redirect_uri,
     get_secrets_auth_section,
     set_cookie_with_chunks,
@@ -178,7 +179,7 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         else:
             self.redirect_to_base()
 
-    def _get_redirect_root(self) -> str | None:
+    def _get_redirect_uri(self) -> str | None:
         auth_section = get_secrets_auth_section()
         if not auth_section or not auth_section.get("redirect_uri"):
             return None
@@ -188,18 +189,11 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             _LOGGER.warning("Redirect URI does not end with /oauth2callback")
             return None
 
-        return redirect_uri.removesuffix("oauth2callback")
-
-    def get_cookie_value(self, name: str) -> bytes | None:
-        try:
-            return self.get_signed_cookie(name)
-        except AttributeError:
-            return self.get_secure_cookie(name)
+        return redirect_uri
 
     def _get_provider_logout_url(self) -> str | None:
         """Get the OAuth provider's logout URL from OIDC metadata."""
-
-        cookie_value = self.get_cookie_value(AUTH_COOKIE_NAME)
+        cookie_value = get_cookie_with_chunks(self._get_signed_cookie, AUTH_COOKIE_NAME)
 
         if not cookie_value:
             return None
@@ -219,18 +213,23 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
                 _LOGGER.info("No end_session_endpoint found for provider %s", provider)
                 return None
 
-            redirect_root = self._get_redirect_root()
-            if redirect_root is None:
+            # Use redirect_uri (i.e. /oauth2callback) for post_logout_redirect_uri
+            # This is safer than redirecting to root as some providers seem to
+            # require url to be in a whitelist /oauth2callback should be whitelisted
+            redirect_uri = self._get_redirect_uri()
+            if redirect_uri is None:
                 _LOGGER.info("Redirect url could not be determined")
                 return None
 
             logout_params = {
                 "client_id": client.client_id,
-                "post_logout_redirect_uri": redirect_root,
+                "post_logout_redirect_uri": redirect_uri,
             }
 
             # Add id_token_hint to logout params if it is available
-            tokens_cookie_value = self.get_cookie_value(TOKENS_COOKIE_NAME)
+            tokens_cookie_value = get_cookie_with_chunks(
+                self._get_signed_cookie, TOKENS_COOKIE_NAME
+            )
             if tokens_cookie_value:
                 try:
                     tokens = json.loads(tokens_cookie_value)
@@ -238,7 +237,10 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
                     if id_token:
                         logout_params["id_token_hint"] = id_token
                 except (json.JSONDecodeError, TypeError):
-                    pass
+                    _LOGGER.exception(
+                        "Error, invalid tokens cookie value.",
+                    )
+                    return None
 
             return f"{end_session_endpoint}?{urlencode(logout_params)}"
 
@@ -250,10 +252,16 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
 class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
     async def get(self) -> None:
         provider = self._get_provider_by_state()
+        if provider is None:
+            # This could be a logout redirect (no state parameter) or invalid state
+            # In both cases, redirect to base
+            self.redirect_to_base()
+            return
+
         origin = self._get_origin_from_secrets()
         if origin is None:
             _LOGGER.error(
-                "Error, misconfigured origin for `redirect_uri` in secrets. ",
+                "Error, misconfigured origin for `redirect_uri` in secrets.",
             )
             self.redirect_to_base()
             return
@@ -296,13 +304,14 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             self.set_auth_cookie(cookie_value, tokens)
             # Keep tokens in a separate cookie to avoid hitting the size limit
         else:
-            _LOGGER.error(
-                "Error, missing user info.",
-            )
+            _LOGGER.error("Error, missing user info.")
         self.redirect_to_base()
 
     def _get_provider_by_state(self) -> str | None:
-        state_code_from_url = self.get_argument("state")
+        state_code_from_url = self.get_argument("state", None)
+        if state_code_from_url is None:
+            return None
+
         current_cache_keys = list(auth_cache.get_dict().keys())
         state_provider_mapping = {}
         for key in current_cache_keys:

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -283,16 +283,6 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             self.redirect_to_base()
             return
 
-        if provider is None:
-            # See https://github.com/streamlit/streamlit/issues/13101
-            _LOGGER.warning(
-                "Missing provider for OAuth callback; this often indicates a stale "
-                "or replayed callback (for example, from browser back/forward "
-                "navigation).",
-            )
-            self.redirect_to_base()
-            return
-
         client, _ = create_oauth_client(provider)
         token = client.authorize_access_token(self)
         user = cast("dict[str, Any]", token.get("userinfo"))

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -190,12 +190,16 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
 
         return redirect_uri.removesuffix("oauth2callback")
 
+    def get_cookie_value(self, name: str) -> bytes | None:
+        try:
+            return self.get_signed_cookie(name)
+        except AttributeError:
+            return self.get_secure_cookie(name)
+
     def _get_provider_logout_url(self) -> str | None:
         """Get the OAuth provider's logout URL from OIDC metadata."""
-        try:
-            cookie_value = self.get_signed_cookie(AUTH_COOKIE_NAME)
-        except AttributeError:  # Backward compatibility with Tornado < 6.3.0
-            cookie_value = self.get_secure_cookie(AUTH_COOKIE_NAME)
+
+        cookie_value = self.get_cookie_value(AUTH_COOKIE_NAME)
 
         if not cookie_value:
             return None
@@ -223,8 +227,18 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             logout_params = {
                 "client_id": client.client_id,
                 "post_logout_redirect_uri": redirect_root,
-                # Not using id_token_hint as we don't store the id token
             }
+
+            # Add id_token_hint to logout params if it is available
+            tokens_cookie_value = self.get_cookie_value(TOKENS_COOKIE_NAME)
+            if tokens_cookie_value:
+                try:
+                    tokens = json.loads(tokens_cookie_value)
+                    id_token = tokens.get("id_token")
+                    if id_token:
+                        logout_params["id_token_hint"] = id_token
+                except (json.JSONDecodeError, TypeError):
+                    pass
 
             return f"{end_session_endpoint}?{urlencode(logout_params)}"
 

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 from __future__ import annotations
 
+import json
 from typing import Any, Final, cast
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import tornado.web
 
@@ -170,7 +171,63 @@ class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):
 class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
     def get(self) -> None:
         self.clear_auth_cookie()
-        self.redirect_to_base()
+
+        provider_logout_url = self._get_provider_logout_url()
+        if provider_logout_url:
+            self.redirect(provider_logout_url)
+        else:
+            self.redirect_to_base()
+
+    def _get_redirect_root(self) -> str | None:
+        auth_section = get_secrets_auth_section()
+        if not auth_section or not auth_section.get("redirect_uri"):
+            return None
+
+        redirect_uri: str = auth_section["redirect_uri"]
+        if not redirect_uri.endswith("/oauth2callback"):
+            _LOGGER.warning("Redirect URI does not end with /oauth2callback")
+            return None
+
+        return redirect_uri.removesuffix("oauth2callback")
+
+    def _get_provider_logout_url(self) -> str | None:
+        """Get the OAuth provider's logout URL from OIDC metadata."""
+        try:
+            cookie_value = self.get_signed_cookie(AUTH_COOKIE_NAME)
+        except AttributeError:  # Backward compatibility with Tornado < 6.3.0
+            cookie_value = self.get_secure_cookie(AUTH_COOKIE_NAME)
+
+        if not cookie_value:
+            return None
+
+        try:
+            user_info = json.loads(cookie_value)
+            provider = user_info.get("provider")
+            if not provider:
+                return None
+
+            client, _ = create_oauth_client(provider)
+
+            metadata = client.load_server_metadata()
+            end_session_endpoint = metadata.get("end_session_endpoint")
+
+            if not end_session_endpoint:
+                _LOGGER.info("No end_session_endpoint found for provider %s", provider)
+                return None
+
+            redirect_root = self._get_redirect_root()
+            if redirect_root is None:
+                _LOGGER.info("Redirect url could not be determined")
+                return None
+
+            logout_params = {"post_logout_redirect_uri": redirect_root}
+
+            # Not using id_token_hint as we don't store the id token
+            return f"{end_session_endpoint}?{urlencode(logout_params)}"
+
+        except Exception as e:
+            _LOGGER.warning("Failed to get provider logout URL: %s", e)
+            return None
 
 
 class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
@@ -215,7 +272,7 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         token = client.authorize_access_token(self)
         user = cast("dict[str, Any]", token.get("userinfo"))
 
-        cookie_value = dict(user, origin=origin, is_logged_in=True)
+        cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
         tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
 
         if user:

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -220,9 +220,12 @@ class AuthLogoutHandler(AuthHandlerMixin, tornado.web.RequestHandler):
                 _LOGGER.info("Redirect url could not be determined")
                 return None
 
-            logout_params = {"post_logout_redirect_uri": redirect_root}
+            logout_params = {
+                "client_id": client.client_id,
+                "post_logout_redirect_uri": redirect_root,
+                # Not using id_token_hint as we don't store the id token
+            }
 
-            # Not using id_token_hint as we don't store the id token
             return f"{end_session_endpoint}?{urlencode(logout_params)}"
 
         except Exception as e:

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -25,8 +25,10 @@ from tornado.httputil import HTTPHeaders
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime, SessionClientDisconnectedError
-from streamlit.web.server.browser_websocket_handler import TornadoClientContext
-from streamlit.web.server.server import BrowserWebSocketHandler
+from streamlit.web.server.browser_websocket_handler import (
+    BrowserWebSocketHandler,
+    TornadoClientContext,
+)
 from tests.streamlit.web.server.server_test_case import ServerTestCase
 from tests.testutil import patch_config_options
 
@@ -228,6 +230,36 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             context2 = websocket_handler.client_context
 
             assert context1 is context2
+
+    @patch_config_options({"server.enableXsrfProtection": True})
+    @tornado.testing.gen_test
+    async def test_malformed_cookie_json_is_handled_gracefully(self):
+        """Test that malformed JSON in auth cookie doesn't crash the connection."""
+        with self._patch_app_session():
+            await self.server.start()
+
+            with (
+                patch.object(
+                    BrowserWebSocketHandler,
+                    "get_signed_cookie",
+                    return_value=b"not valid json {{{",
+                ),
+                patch.object(
+                    BrowserWebSocketHandler,
+                    "_validate_xsrf_token",
+                    return_value=True,
+                ),
+                patch.object(
+                    self.server._runtime, "connect_session"
+                ) as patched_connect_session,
+            ):
+                await self.ws_connect()
+
+                # Connection should succeed with empty user_info
+                patched_connect_session.assert_called_once()
+                call_kwargs = patched_connect_session.call_args.kwargs
+                # user_info should be empty since cookie parsing failed
+                assert call_kwargs["user_info"] == {}
 
 
 class TornadoClientContextTest(tornado.testing.AsyncTestCase):

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -179,12 +179,13 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
         return_value=(
             MagicMock(
+                client_id="test_client_id",
                 load_server_metadata=MagicMock(
                     return_value={
                         # Use a fake ese-provider as google does not use end_session_endpoint
                         "end_session_endpoint": "https://ese-provider.example.com/logout"
                     }
-                )
+                ),
             ),
             "",
         ),
@@ -215,10 +216,11 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.code == 302
         assert '_streamlit_user="";' in response.headers["Set-Cookie"]
 
-        # Should redirect to provider's logout URL with post_logout_redirect_uri
+        # Should redirect to provider's logout URL with post_logout_redirect_uri and client_id
         location = response.headers["Location"]
         assert location.startswith("https://ese-provider.example.com/logout")
         assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+        assert "client_id=test_client_id" in location
 
         # Verify create_oauth_client was called with the correct provider
         mock_create_oauth_client.assert_called_once_with("ese-provider")

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -219,7 +219,10 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         # Should redirect to provider's logout URL with post_logout_redirect_uri and client_id
         location = response.headers["Location"]
         assert location.startswith("https://ese-provider.example.com/logout")
-        assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+        assert (
+            "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501%2Foauth2callback"
+            in location
+        )
         assert "client_id=test_client_id" in location
         assert "id_token_hint" not in location
 
@@ -264,10 +267,10 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         # Create headers with both signed cookies
         signed_cookie = create_signed_value(
-            "test_cookie_secret", AUTH_COOKIE_NAME, cookie_value
+            "test_secret", AUTH_COOKIE_NAME, cookie_value
         ).decode("utf-8")
         signed_tokens_cookie = create_signed_value(
-            "test_cookie_secret", TOKENS_COOKIE_NAME, tokens_value
+            "test_secret", TOKENS_COOKIE_NAME, tokens_value
         ).decode("utf-8")
 
         headers = tornado.httputil.HTTPHeaders()
@@ -284,7 +287,10 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         # Should redirect to provider's logout URL with post_logout_redirect_uri, client_id, and id_token_hint
         location = response.headers["Location"]
         assert location.startswith("https://ese-provider.example.com/logout")
-        assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+        assert (
+            "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501%2Foauth2callback"
+            in location
+        )
         assert "client_id=test_client_id" in location
         assert "id_token_hint=test_id_token_12345" in location
 
@@ -411,9 +417,10 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.headers["Location"] == "/"
 
     def test_auth_callback_failure_missing_state(self):
-        """Test auth callback failure missing state."""
+        """Test auth callback redirects to base when state is missing (logout redirect)."""
         response = self.fetch("/oauth2callback", follow_redirects=False)
-        assert response.code == 400
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
 
     @patch.object(AuthCallbackHandler, "set_auth_cookie")
     def test_auth_callback_with_error_query_param(self, mock_set_auth_cookie):

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -32,7 +32,7 @@ from streamlit.web.server.oauth_authlib_routes import (
     AuthLoginHandler,
     AuthLogoutHandler,
 )
-from streamlit.web.server.server_util import AUTH_COOKIE_NAME
+from streamlit.web.server.server_util import AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME
 
 
 class SecretMock(dict):
@@ -221,6 +221,72 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert location.startswith("https://ese-provider.example.com/logout")
         assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
         assert "client_id=test_client_id" in location
+        assert "id_token_hint" not in location
+
+        # Verify create_oauth_client was called with the correct provider
+        mock_create_oauth_client.assert_called_once_with("ese-provider")
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                load_server_metadata=MagicMock(
+                    return_value={
+                        # Use a fake ese-provider as google does not use end_session_endpoint
+                        "end_session_endpoint": "https://ese-provider.example.com/logout"
+                    }
+                ),
+            ),
+            "",
+        ),
+    )
+    def test_logout_with_id_token_hint(self, mock_create_oauth_client):
+        """Test logout handler includes id_token_hint when available in tokens cookie."""
+        # Create a signed cookie with provider info
+        cookie_data = {
+            "provider": "ese-provider",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+            "email": "test@example.com",
+        }
+
+        # Create tokens cookie with id_token
+        tokens_data = {
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",
+            "id_token": "test_id_token_12345",
+        }
+
+        # Set the signed cookies
+        cookie_value = json.dumps(cookie_data)
+        tokens_value = json.dumps(tokens_data)
+
+        # Create headers with both signed cookies
+        signed_cookie = create_signed_value(
+            "test_cookie_secret", AUTH_COOKIE_NAME, cookie_value
+        ).decode("utf-8")
+        signed_tokens_cookie = create_signed_value(
+            "test_cookie_secret", TOKENS_COOKIE_NAME, tokens_value
+        ).decode("utf-8")
+
+        headers = tornado.httputil.HTTPHeaders()
+        headers.add(
+            "Cookie",
+            f"{AUTH_COOKIE_NAME}={signed_cookie}; {TOKENS_COOKIE_NAME}={signed_tokens_cookie}",
+        )
+
+        response = self.fetch("/auth/logout", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert '_streamlit_user="";' in response.headers["Set-Cookie"]
+
+        # Should redirect to provider's logout URL with post_logout_redirect_uri, client_id, and id_token_hint
+        location = response.headers["Location"]
+        assert location.startswith("https://ese-provider.example.com/logout")
+        assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+        assert "client_id=test_client_id" in location
+        assert "id_token_hint=test_id_token_12345" in location
 
         # Verify create_oauth_client was called with the correct provider
         mock_create_oauth_client.assert_called_once_with("ese-provider")

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -144,6 +144,13 @@ class LoginHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.headers["Location"] == "/"
 
 
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
 class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):
         return tornado.web.Application(
@@ -157,12 +164,112 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
             cookie_secret="test_secret",
         )
 
-    def test_logout_success(self):
-        """Test logout handler success clear cookie."""
+    def test_logout_success_no_cookie(self):
+        """Test logout handler success with no auth cookie."""
         response = self.fetch("/auth/logout", follow_redirects=False)
         assert response.code == 302
         assert response.headers["Location"] == "/"
         assert '_streamlit_user="";' in response.headers["Set-Cookie"]
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                load_server_metadata=MagicMock(
+                    return_value={
+                        # Use a fake ese-provider as google does not use end_session_endpoint
+                        "end_session_endpoint": "https://ese-provider.example.com/logout"
+                    }
+                )
+            ),
+            "",
+        ),
+    )
+    def test_logout_with_oidc_end_session_endpoint(self, mock_create_oauth_client):
+        """Test logout handler redirects to provider's end_session_endpoint when available."""
+        # Create a signed cookie with provider info
+        import json
+
+        from streamlit.web.server.server_util import AUTH_COOKIE_NAME
+
+        cookie_data = {
+            "provider": "ese-provider",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+            "email": "test@example.com",
+        }
+
+        # Set the signed cookie
+        cookie_value = json.dumps(cookie_data)
+
+        # Create headers with the signed cookie
+        import tornado.httputil
+        from tornado.web import create_signed_value
+
+        signed_cookie = create_signed_value(
+            "test_secret", AUTH_COOKIE_NAME, cookie_value
+        ).decode("utf-8")
+
+        headers = tornado.httputil.HTTPHeaders()
+        headers.add("Cookie", f"{AUTH_COOKIE_NAME}={signed_cookie}")
+
+        response = self.fetch("/auth/logout", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert '_streamlit_user="";' in response.headers["Set-Cookie"]
+
+        # Should redirect to provider's logout URL with post_logout_redirect_uri
+        location = response.headers["Location"]
+        assert location.startswith("https://ese-provider.example.com/logout")
+        assert "post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8501" in location
+
+        # Verify create_oauth_client was called with the correct provider
+        mock_create_oauth_client.assert_called_once_with("ese-provider")
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(load_server_metadata=MagicMock(return_value={})),
+            "",
+        ),
+    )
+    def test_logout_fallback_no_end_session_endpoint(self, mock_create_oauth_client):
+        """Test logout handler falls back to local logout when no end_session_endpoint."""
+        # Create a signed cookie with provider info
+        import json
+
+        from streamlit.web.server.server_util import AUTH_COOKIE_NAME
+
+        cookie_data = {
+            "provider": "google",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+            "email": "test@example.com",
+        }
+
+        # Set the signed cookie
+        self.get_app().settings["cookie_secret"] = "test_secret"
+        cookie_value = json.dumps(cookie_data)
+
+        # Create headers with the signed cookie
+        import tornado.httputil
+        from tornado.web import create_signed_value
+
+        signed_cookie = create_signed_value(
+            "test_secret", AUTH_COOKIE_NAME, cookie_value
+        ).decode("utf-8")
+
+        headers = tornado.httputil.HTTPHeaders()
+        headers.add("Cookie", f"{AUTH_COOKIE_NAME}={signed_cookie}")
+
+        response = self.fetch("/auth/logout", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"  # Fallback to base
+        assert '_streamlit_user="";' in response.headers["Set-Cookie"]
+
+        # Verify create_oauth_client was called with the correct provider
+        mock_create_oauth_client.assert_called_once_with("google")
 
 
 @patch(
@@ -225,6 +332,7 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "email": "test@example.com",
                 "origin": "http://localhost:8501",
                 "is_logged_in": True,
+                "provider": "google",
             },
             {
                 "access_token": "test_access_token",

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -14,12 +14,15 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import tornado.httpserver
+import tornado.httputil
 import tornado.testing
 import tornado.web
 import tornado.websocket
+from tornado.web import create_signed_value
 
 from streamlit.auth_util import encode_provider_token
 from streamlit.web.server import oauth_authlib_routes
@@ -29,6 +32,7 @@ from streamlit.web.server.oauth_authlib_routes import (
     AuthLoginHandler,
     AuthLogoutHandler,
 )
+from streamlit.web.server.server_util import AUTH_COOKIE_NAME
 
 
 class SecretMock(dict):
@@ -188,10 +192,6 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def test_logout_with_oidc_end_session_endpoint(self, mock_create_oauth_client):
         """Test logout handler redirects to provider's end_session_endpoint when available."""
         # Create a signed cookie with provider info
-        import json
-
-        from streamlit.web.server.server_util import AUTH_COOKIE_NAME
-
         cookie_data = {
             "provider": "ese-provider",
             "origin": "http://localhost:8501",
@@ -203,9 +203,6 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         cookie_value = json.dumps(cookie_data)
 
         # Create headers with the signed cookie
-        import tornado.httputil
-        from tornado.web import create_signed_value
-
         signed_cookie = create_signed_value(
             "test_secret", AUTH_COOKIE_NAME, cookie_value
         ).decode("utf-8")
@@ -236,10 +233,6 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def test_logout_fallback_no_end_session_endpoint(self, mock_create_oauth_client):
         """Test logout handler falls back to local logout when no end_session_endpoint."""
         # Create a signed cookie with provider info
-        import json
-
-        from streamlit.web.server.server_util import AUTH_COOKIE_NAME
-
         cookie_data = {
             "provider": "google",
             "origin": "http://localhost:8501",
@@ -252,9 +245,6 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         cookie_value = json.dumps(cookie_data)
 
         # Create headers with the signed cookie
-        import tornado.httputil
-        from tornado.web import create_signed_value
-
         signed_cookie = create_signed_value(
             "test_secret", AUTH_COOKIE_NAME, cookie_value
         ).decode("utf-8")


### PR DESCRIPTION
## Describe your changes

Currently, st.logout ignores end_session_endpoint (ESE) in the OIDC configuration. 
This can cause issues, as some OIDC providers keep their own cookies and skip the login screen if they have an active session. 

This change:
a) Writes the name of provider into the session cookie (so it would be clear which provider the user is currently logged into)
b) Makes st.logout redirect to ESE if one is provided

This is a revised version of https://github.com/streamlit/streamlit/pull/11901 to adress the issues raised in https://github.com/streamlit/streamlit/issues/12144#issuecomment-3172828767
Most notably:
1) client_id is added to ESE request (original issue, with attempted fix at https://github.com/streamlit/streamlit/pull/12182)
2) id_token_hint is also added (addressing https://github.com/streamlit/streamlit/issues/12144#issuecomment-3172828767)
3) ESE request redirect target it changed to /oauth2callback (adressing https://github.com/streamlit/streamlit/issues/12144#issuecomment-3164241186)

This is a follow-up to https://github.com/streamlit/streamlit/pull/12044 

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/11900

## Testing Plan

- unit tests added both for a case where ESE is provided as well as when not

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.