### PR TITLE
Add OIDC refresh user/token functionality

### DIFF
--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -50,6 +50,7 @@ _LOGGER: Final = logger.get_logger(__name__)
 
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
 AUTH_LOGOUT_ENDPOINT: Final = "/auth/logout"
+AUTH_REFRESH_ENDPOINT: Final = "/auth/refresh"
 
 
 @gather_metrics("login")
@@ -701,6 +702,51 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         """Access exposed tokens via a dict-like object."""
         user_info = _get_user_info()
         return TokensProxy(cast("dict[str, str]", user_info.get("tokens", {})))
+
+    def refresh(self) -> None:
+        """Refresh the current user's access token and user information.
+
+        This method attempts to refresh the user's OAuth access token and update
+        the user information stored in ``st.user``. It uses the refresh token
+        (if available) to obtain a new access token and updated user information
+        from the OAuth provider, then updates the authentication cookies.
+
+        This is meant to be used in the background, like when starting a new session.
+        For that reason, if no refresh token is available or the refresh fails,
+        nothing happens.
+
+        Examples
+        --------
+        **Example: Refresh on each session**
+
+        Refresh the current user's tokens and update user information:
+
+        >>> import streamlit as st
+        >>>
+        >>> if st.user.is_logged_in and not st.session_state.get("fresh_user"):
+        >>>     st.session_state["fresh_user"] = True
+        >>>     st.user.refresh()
+
+        .. Note::
+            - This command requires that the user is already logged in via ``st.login()``.
+            - The OAuth provider must support refresh tokens for this to work properly.
+            - Some providers may not return updated user information on token refresh.
+            - This command will update all tokens, including access tokens and refresh tokens.
+        """
+        context = _get_script_run_ctx()
+        if context is not None:
+            context.user_info.clear()
+            session_id = context.session_id
+
+            if runtime.exists():
+                instance = runtime.get_instance()
+                instance.clear_user_info_for_session(session_id)
+
+            base_path = config.get_option("server.baseUrlPath")
+
+            fwd_msg = ForwardMsg()
+            fwd_msg.auth_redirect.url = make_url_path(base_path, AUTH_REFRESH_ENDPOINT)
+            context.enqueue(fwd_msg)
 
 
 has_shown_experimental_user_warning = False

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -17,7 +17,9 @@ import json
 from typing import Any, Final, cast
 from urllib.parse import urlencode, urlparse
 
+import requests
 import tornado.web
+from authlib import jose
 
 from streamlit.auth_util import (
     AuthCache,
@@ -340,3 +342,107 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             redirect_uri_parsed.scheme + "://" + redirect_uri_parsed.netloc
         )
         return origin_from_redirect_uri
+
+
+class AuthRefreshHandler(AuthHandlerMixin, tornado.web.RequestHandler):
+    def get_new_tokens(
+        self, client: TornadoOAuth2App, refresh_token: str
+    ) -> dict[str, Any] | None:
+        try:
+            metadata = client.load_server_metadata()
+            token_endpoint = metadata.get("token_endpoint")
+            if not token_endpoint:
+                _LOGGER.error("No token endpoint available for refresh")
+                return None
+
+            refresh_data = {
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client.client_id,
+                "client_secret": client.client_secret,
+            }
+
+            response = requests.post(
+                token_endpoint,
+                data=refresh_data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
+            )
+
+            if response.status_code != 200:
+                _LOGGER.error(
+                    "Token refresh failed with status %i", response.status_code
+                )
+                return None
+
+            new_tokens = response.json()
+            new_tokens = {k: v for k, v in new_tokens.items() if k.endswith("_token")}
+            return new_tokens
+        except Exception:
+            _LOGGER.exception("Token refresh failed")
+            return None
+
+    def decode_id_token(
+        self, client: TornadoOAuth2App, id_token: str
+    ) -> dict[str, Any]:
+        jwks_uri = client.server_metadata.get("jwks_uri")
+        jwks = requests.get(jwks_uri, timeout=10).json()
+        return jose.jwt.decode(id_token, key=jwks)
+
+    def get(self) -> None:
+        """Handle token refresh requests."""
+        try:
+            user_cookie_value = self.get_signed_cookie(AUTH_COOKIE_NAME)
+            tokens_cookie_value = self.get_signed_cookie(TOKENS_COOKIE_NAME)
+        except AttributeError:  # Backward compatibility with Tornado < 6.3.0
+            user_cookie_value = self.get_secure_cookie(AUTH_COOKIE_NAME)
+            tokens_cookie_value = self.get_secure_cookie(TOKENS_COOKIE_NAME)
+
+        if not user_cookie_value or not tokens_cookie_value:
+            _LOGGER.error("Missing authentication cookies for token refresh")
+            self.redirect_to_base()
+            return
+
+        try:
+            current_user_info = json.loads(user_cookie_value)
+            current_tokens = json.loads(tokens_cookie_value)
+        except json.JSONDecodeError:
+            _LOGGER.exception("Invalid authentication cookies for token refresh")
+            self.redirect_to_base()
+            return
+
+        provider = current_user_info.get("provider")
+        if provider is None:
+            _LOGGER.error("Missing or invalid provider for token refresh")
+            self.redirect_to_base()
+            return
+        client, _ = create_oauth_client(provider)
+
+        refresh_token = current_tokens.get("refresh_token")
+        if not refresh_token:
+            _LOGGER.info("No refresh token found")
+            self.redirect_to_base()
+            return
+
+        new_tokens = self.get_new_tokens(client, refresh_token)
+        if not new_tokens:
+            _LOGGER.info("Refreshing tokens failed")
+            self.redirect_to_base()
+            return
+
+        updated_tokens = {**current_tokens, **new_tokens}
+        updated_user_info = current_user_info.copy()
+
+        if "id_token" in new_tokens:
+            try:
+                new_userinfo = self.decode_id_token(client, new_tokens["id_token"])
+                updated_user_info.update(new_userinfo)
+            except Exception:
+                _LOGGER.exception("Failed to decode id token")
+        else:
+            _LOGGER.info("No id token in new tokens")
+
+        self.set_auth_cookie(updated_user_info, updated_tokens)
+        _LOGGER.info("Successfully refreshed user tokens")
+
+        self.redirect_to_base()

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -155,6 +155,7 @@ SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
 OAUTH2_CALLBACK_ENDPOINT: Final = "/oauth2callback"
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
 AUTH_LOGOUT_ENDPOINT: Final = "/auth/logout"
+AUTH_REFRESH_ENDPOINT: Final = "/auth/refresh"
 
 
 class RetriesExceededError(Exception):
@@ -446,6 +447,7 @@ class Server:
                 AuthCallbackHandler,
                 AuthLoginHandler,
                 AuthLogoutHandler,
+                AuthRefreshHandler,
             )
 
             routes.extend(
@@ -463,6 +465,11 @@ class Server:
                     (
                         make_url_path_regex(base, AUTH_LOGOUT_ENDPOINT),
                         AuthLogoutHandler,
+                        {"base_url": base},
+                    ),
+                    (
+                        make_url_path_regex(base, AUTH_REFRESH_ENDPOINT),
+                        AuthRefreshHandler,
                         {"base_url": base},
                     ),
                 ]

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -399,3 +399,11 @@ class UserInfoTokensTest(DeltaGeneratorTestCase):
             assert isinstance(tokens_prop, TokensProxy)
             assert isinstance(tokens_key, TokensProxy)
             assert tokens_prop.id == tokens_key.id
+
+    def test_user_refresh_method(self):
+        """Test that st.user.refresh() sends correct proto message."""
+        st.user.refresh()
+
+        c = self.get_message_from_queue().auth_redirect
+
+        assert c.url.startswith("/auth/refresh")

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -29,6 +29,7 @@ from streamlit.web.server.oauth_authlib_routes import (
     AuthCallbackHandler,
     AuthLoginHandler,
     AuthLogoutHandler,
+    AuthRefreshHandler,
 )
 from streamlit.web.server.server_util import AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME
 
@@ -429,3 +430,337 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 302
         assert response.headers["Location"] == "/"
+
+
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
+class AuthRefreshHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/auth/refresh",
+                    AuthRefreshHandler,
+                    {"base_url": ""},
+                )
+            ],
+            cookie_secret="test_cookie_secret",
+        )
+
+    def _create_signed_cookies(
+        self, user_info: dict, tokens: dict
+    ) -> tornado.httputil.HTTPHeaders:
+        """Helper to create signed cookies for testing."""
+        import tornado.httputil
+        from tornado.web import create_signed_value
+
+        from streamlit.web.server.server_util import (
+            AUTH_COOKIE_NAME,
+            TOKENS_COOKIE_NAME,
+        )
+
+        user_cookie = create_signed_value(
+            "test_cookie_secret", AUTH_COOKIE_NAME, json.dumps(user_info)
+        ).decode("utf-8")
+
+        tokens_cookie = create_signed_value(
+            "test_cookie_secret", TOKENS_COOKIE_NAME, json.dumps(tokens)
+        ).decode("utf-8")
+
+        headers = tornado.httputil.HTTPHeaders()
+        headers.add(
+            "Cookie",
+            f"{AUTH_COOKIE_NAME}={user_cookie}; {TOKENS_COOKIE_NAME}={tokens_cookie}",
+        )
+
+        return headers
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_refresh_success(
+        self, mock_set_auth_cookie, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test successful token refresh."""
+        # Mock successful token refresh response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "new_refresh_token",
+            "expires_in": 3600,
+        }
+        mock_requests_post.return_value = mock_response
+
+        # Create test cookies
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {
+            "access_token": "old_access_token",
+            "refresh_token": "old_refresh_token",
+        }
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        # Verify response
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+        # Verify token refresh was called correctly
+        mock_requests_post.assert_called_once()
+        call_args = mock_requests_post.call_args
+        assert call_args[0][0] == "https://provider.com/token"
+        assert call_args[1]["data"]["grant_type"] == "refresh_token"
+        assert call_args[1]["data"]["refresh_token"] == "old_refresh_token"
+        assert call_args[1]["data"]["client_id"] == "test_client_id"
+        assert call_args[1]["data"]["client_secret"] == "test_client_secret"
+
+        # Verify auth cookie was set with updated tokens
+        mock_set_auth_cookie.assert_called_once()
+        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
+        assert updated_user_info == user_info
+        assert updated_tokens["access_token"] == "new_access_token"
+        assert updated_tokens["refresh_token"] == "new_refresh_token"
+
+    def test_refresh_missing_cookies(self):
+        """Test refresh handler with missing authentication cookies."""
+        response = self.fetch("/auth/refresh", follow_redirects=False)
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_missing_refresh_token(self):
+        """Test refresh handler with missing refresh token."""
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token"}  # Missing refresh_token
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    def test_refresh_token_endpoint_error(
+        self, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test refresh handler when token endpoint returns error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_requests_post.return_value = mock_response
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_invalid_json_cookies(self):
+        """Test refresh handler with invalid JSON in cookies."""
+        from tornado.web import create_signed_value
+
+        headers = tornado.httputil.HTTPHeaders()
+        invalid_user_cookie = create_signed_value(
+            "test_cookie_secret", AUTH_COOKIE_NAME, "invalid json"
+        ).decode("utf-8")
+        invalid_tokens_cookie = create_signed_value(
+            "test_cookie_secret", TOKENS_COOKIE_NAME, "invalid json"
+        ).decode("utf-8")
+
+        headers.add(
+            "Cookie",
+            f"{AUTH_COOKIE_NAME}={invalid_user_cookie}; {TOKENS_COOKIE_NAME}={invalid_tokens_cookie}",
+        )
+
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_missing_provider(self):
+        """Test refresh handler with missing provider in user info."""
+        user_info = {
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+            # Missing provider field
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                load_server_metadata=MagicMock(return_value={})  # No token_endpoint
+            ),
+            "",
+        ),
+    )
+    def test_refresh_no_token_endpoint(self, mock_create_oauth_client):
+        """Test refresh handler when provider has no token endpoint."""
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    def test_refresh_network_exception(
+        self, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test refresh handler when network request raises exception."""
+        mock_requests_post.side_effect = Exception("Network error")
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.get")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+                server_metadata={"jwks_uri": "https://provider.com/jwks"},
+            ),
+            "",
+        ),
+    )
+    @patch("streamlit.web.server.oauth_authlib_routes.jose.jwt.decode")
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_refresh_id_token_decode_failure(
+        self,
+        mock_set_auth_cookie,
+        mock_jwt_decode,
+        mock_create_oauth_client,
+        mock_requests_get,
+        mock_requests_post,
+    ):
+        """Test refresh handler when ID token decoding fails."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "new_refresh_token",
+            "id_token": "new_id_token",
+        }
+        mock_requests_post.return_value = mock_response
+
+        mock_jwks_response = MagicMock()
+        mock_jwks_response.json.return_value = {"keys": []}
+        mock_requests_get.return_value = mock_jwks_response
+
+        mock_jwt_decode.side_effect = Exception("Invalid token")
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "old_token", "refresh_token": "old_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        # Should still succeed even if ID token decoding fails
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+        # Verify auth cookie was set with tokens but unchanged user info
+        mock_set_auth_cookie.assert_called_once()
+        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
+        assert (
+            updated_user_info == user_info
+        )  # Should be unchanged due to decode failure
+        assert updated_tokens["access_token"] == "new_access_token"
+        assert updated_tokens["refresh_token"] == "new_refresh_token"
+        assert updated_tokens["id_token"] == "new_id_token"


### PR DESCRIPTION
## Describe your changes

Add a command (`st.user.refresh()`) to use the refresh token to refresh both the tokens and the user info

This was separated out of https://github.com/streamlit/streamlit/pull/12044 at the request of maintainers. 

Needs a product decision on where to place the command - either top level st.refresh_user() or st.user.refresh() (or some third option). 

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/12043

## Testing Plan

- Unit tests present
- Manually tested to work for my own use case

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

