### PR TITLE
Ignore flaky e2e color picker test for firefox

### DIFF
--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -240,6 +240,7 @@ def test_color_picker_width_examples(
     )
 
 
+@pytest.mark.skip_browser("firefox")
 def test_dynamic_color_picker_props(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that the color picker can be updated dynamically while keeping the state."""
     dynamic_color_picker = get_element_by_key(app, "dynamic_color_picker_with_key")


### PR DESCRIPTION
## Describe your changes

The `test_dynamic_color_picker_props` test is flaky on firefox because of subpixel screenshots. Ignoring it in firefox.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
