### PR TITLE
Custom Dark Theme - support light/dark config inheritance & populate new session msg

### DIFF
--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -377,7 +377,7 @@ def _invalid_theme_option_warning(
     if section_name == "theme":
         full_option_name = f"{section_name}.{option_name}"
     elif "." in section_name:
-        # Handle subsections like "sidebar.light" -> "theme.sidebar.light.{option_name}"
+        # Handle subsections like "light.sidebar" -> "theme.light.sidebar.{option_name}"
         full_option_name = f"theme.{section_name}.{option_name}"
     else:
         # Handle sections like "sidebar" -> "theme.sidebar.{option_name}"
@@ -403,14 +403,14 @@ def _validate_theme_section_recursive(
     valid_subsection: str | None = None,
 ) -> None:
     """
-    Recursively validate a theme section and its options/subsections.
+    Recursively validate a theme section and its subsection/options.
 
     Args:
         section_configs: The section configs to validate
-        section_path: Path like 'sidebar', 'light', 'sidebar.light'
+        section_path: Path like 'sidebar', 'light', 'light.sidebar'
         file_path_or_url: Theme file path for error messages
         section_options: Valid options for this section
-        filtered_parent: Parent dict in filtered theme to populate
+        filtered_parent: Parent section to populate/filter out invalid options
         valid_subsection: Valid subsection (only "sidebar" for "light" and "dark" sections)
 
     Raises StreamlitInvalidThemeSectionError if an invalid subsection is found.
@@ -475,7 +475,7 @@ def _validate_theme_file_content(
     valid_main_options, valid_section_options = _get_valid_theme_options(
         config_options_template
     )
-    # Valid sections and subsections
+    # Valid theme sections
     valid_sections = {"sidebar", "light", "dark"}
 
     theme_section = theme_content.get("theme", {})
@@ -488,7 +488,7 @@ def _validate_theme_file_content(
     for option_name, option_value in theme_section.items():
         # This is a section like theme.sidebar, theme.light, theme.dark
         if isinstance(option_value, dict):
-            # Invalid subsection: raise error
+            # Invalid section: raise error
             if option_name not in valid_sections:
                 raise StreamlitInvalidThemeSectionError(
                     option_name,
@@ -499,7 +499,7 @@ def _validate_theme_file_content(
             if option_name not in filtered_theme_section:
                 filtered_theme_section[option_name] = {}
 
-            # Only light and dark can have sidebar subsection
+            # Subsection can only be sidebar from within light and dark sections
             subsection = "sidebar" if option_name in {"light", "dark"} else None
 
             _validate_theme_section_recursive(
@@ -522,7 +522,7 @@ def _validate_theme_file_content(
             filtered_theme_section.pop(option_name, None)
 
         else:
-            # Valid main theme option - check color values
+            # Valid main theme option - if color config, check color value
             full_option_name = f"theme.{option_name}"
             if "color" in full_option_name.lower():
                 _check_color_value(option_value, full_option_name)
@@ -665,8 +665,8 @@ def _set_theme_options_recursive(
 ) -> None:
     """
     Recursively set theme options from nested dictionary in process_theme_inheritance().
-    This utility function traverses nested theme configuration sections/subsections
-    and sets each option using the provided set_option_func..
+    This utility function traverses nested theme configuration sections/subsection
+    and sets each option using the provided set_option_func.
     """
     for option_name, option_value in options_dict.items():
         if option_name == "base" and prefix == "theme":

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -400,7 +400,7 @@ def _validate_theme_section_recursive(
     file_path_or_url: str,
     section_options: set[str],
     filtered_parent: dict[str, Any],
-    valid_subsection: str | None = None,
+    allow_sidebar_subsection: bool = False,
 ) -> None:
     """
     Recursively validate a theme section and its subsection/options.
@@ -411,14 +411,14 @@ def _validate_theme_section_recursive(
         file_path_or_url: Theme file path for error messages
         section_options: Valid options for this section
         filtered_parent: Parent section to populate/filter out invalid options
-        valid_subsection: Valid subsection (only "sidebar" for "light" and "dark" sections)
+        allow_sidebar_subsection: Allow sidebar subsection (only "light" and "dark" sections)
 
     Raises StreamlitInvalidThemeSectionError if an invalid subsection is found.
     """
     for option_name, option_value in section_configs.items():
         if isinstance(option_value, dict):
             # This is a subsection
-            if not valid_subsection or option_name not in valid_subsection:
+            if not allow_sidebar_subsection or option_name != "sidebar":
                 raise StreamlitInvalidThemeSectionError(
                     f"theme.{section_path}.{option_name}",
                     file_path_or_url,
@@ -434,7 +434,7 @@ def _validate_theme_section_recursive(
                 file_path_or_url,
                 section_options,
                 filtered_parent[option_name],
-                None,  # Subsections can't have further subsections
+                False,  # sidebar subsection can't have further subsections
             )
         elif option_name not in section_options:
             # This is an invalid section option
@@ -500,7 +500,7 @@ def _validate_theme_file_content(
                 filtered_theme_section[option_name] = {}
 
             # Subsection can only be sidebar from within light and dark sections
-            subsection = "sidebar" if option_name in {"light", "dark"} else None
+            allow_sidebar_subsection = option_name in {"light", "dark"}
 
             _validate_theme_section_recursive(
                 option_value,
@@ -508,7 +508,7 @@ def _validate_theme_file_content(
                 file_path_or_url,
                 valid_section_options,
                 filtered_theme_section[option_name],
-                subsection,
+                allow_sidebar_subsection,
             )
 
         elif option_name not in valid_main_options:

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -281,6 +281,8 @@ def _iterate_theme_config_options(
     """
     Iterate through theme config options, yielding (option_path, value) pairs.
     Returns: theme.primaryColor, #ff0000, ...
+
+    Leveraged by _extract_current_theme_config() to retrieve main config.toml theme options.
     """
     for opt_name, opt_val in config_options.items():
         if opt_name.startswith("theme.") and opt_val.value is not None:
@@ -319,35 +321,37 @@ def _extract_current_theme_config(
 
 
 def _get_valid_theme_options(
-    config_options_template: dict[str, ConfigOption], section: str = "main"
-) -> set[str]:
-    """Get the set of valid theme configuration options for a specific section.
+    config_options_template: dict[str, ConfigOption],
+) -> tuple[set[str], set[str]]:
+    """Get the valid theme configuration options for main theme and theme sections.
 
     Extracts valid theme options from the config options template to ensure they
     stay in sync with the actual theme options defined via _create_theme_options() calls.
 
-    Returns a set of valid theme option names for a specific section (without the "theme." prefix)
+    Returns a tuple ( main_theme_options, sidebar_theme_options )
+    where main_theme_options is a set of valid theme options for the main theme (without the "theme." prefix)
+    and sidebar_theme_options is a set of valid theme options for the sidebar/light/dark sections
     """
-    valid_options = set()
+    # Extract options dynamically from the config template
+    main_theme_options = set()
+    section_theme_options = set()
 
     # Extract theme options from the config template
     for option_key in config_options_template:
         if option_key.startswith("theme."):
             parts = option_key.split(".")
-            if section == "main" and len(parts) == 2:
-                # Direct theme option like "theme.primaryColor"
+            # Direct theme options like "theme.primaryColor"
+            if parts[0] == "theme" and len(parts) == 2:
                 _, option_name = parts
-                valid_options.add(option_name)
-            elif (
-                section in ("sidebar", "light", "dark")
-                and len(parts) == 3
-                and parts[1] == section
-            ):
-                # Subsection option like "theme.sidebar.primaryColor", "theme.light.primaryColor", etc.
+                main_theme_options.add(option_name)
+            # Subsection options like "theme.sidebar.primaryColor"
+            elif parts[0] == "theme" and parts[1] == "sidebar" and len(parts) == 3:
+                # All subsections (sidebar, light, dark, sidebar.light, sidebar.dark)
+                # get the same options as theme.sidebar (which excludes main-only options)
                 _, _, option_name = parts
-                valid_options.add(option_name)
+                section_theme_options.add(option_name)
 
-    return valid_options
+    return main_theme_options, section_theme_options
 
 
 def _invalid_theme_option_warning(
@@ -358,11 +362,14 @@ def _invalid_theme_option_warning(
 ) -> None:
     """Log a warning for an invalid theme option."""
 
-    full_option_name = (
-        f"{section_name}.{option_name}"
-        if section_name == "theme"
-        else f"theme.{section_name}.{option_name}"
-    )
+    if section_name == "theme":
+        full_option_name = f"{section_name}.{option_name}"
+    elif "." in section_name:
+        # Handle subsections like "sidebar.light" -> "theme.sidebar.light.{option_name}"
+        full_option_name = f"theme.{section_name}.{option_name}"
+    else:
+        # Handle sections like "sidebar" -> "theme.sidebar.{option_name}"
+        full_option_name = f"theme.{section_name}.{option_name}"
 
     valid_options_list = "\n".join(f"  • {opt}" for opt in sorted(valid_options))
     _get_logger().warning(
@@ -373,6 +380,65 @@ def _invalid_theme_option_warning(
         section_name,
         valid_options_list,
     )
+
+
+def _validate_theme_section_recursive(
+    section_configs: dict[str, Any],
+    section_path: str,
+    file_path_or_url: str,
+    section_options: set[str],
+    filtered_parent: dict[str, Any],
+    valid_subsections: set[str] | None = None,
+) -> None:
+    """
+    Recursively validate a theme section and its options/subsections.
+
+    Args:
+        section_configs: The section configs to validate
+        section_path: Path like 'sidebar', 'light', 'sidebar.light'
+        file_path_or_url: Theme file path for error messages
+        section_options: Valid options for this section type
+        filtered_parent: Parent dict in filtered theme to populate
+        valid_subsections: Valid subsections (only for 'sidebar' section)
+    """
+    for option_name, option_value in section_configs.items():
+        if isinstance(option_value, dict):
+            # This is a subsection
+            if not valid_subsections or option_name not in valid_subsections:
+                raise StreamlitAPIException(
+                    f"Theme file {file_path_or_url} contains invalid theme "
+                    f"subsection: 'theme.{section_path}.{option_name}'.\n\n"
+                    f"Valid subsections are only sidebar.light and sidebar.dark"
+                )
+
+            # Create and validate the subsection's options
+            if option_name not in filtered_parent:
+                filtered_parent[option_name] = {}
+
+            _validate_theme_section_recursive(
+                option_value,
+                f"{section_path}.{option_name}",
+                file_path_or_url,
+                section_options,
+                filtered_parent[option_name],
+                None,  # Subsections can't have further subsections
+            )
+        elif option_name not in section_options:
+            # This is an invalid section option
+            _invalid_theme_option_warning(
+                option_name,
+                file_path_or_url,
+                section_options,
+                section_path,
+            )
+            # Remove the invalid option from the filtered theme
+            filtered_parent.pop(option_name, None)
+        else:
+            # Valid option - add to filtered theme and check color values
+            filtered_parent[option_name] = option_value
+            full_option_name = f"theme.{section_path}.{option_name}"
+            if "color" in full_option_name.lower():
+                _check_color_value(option_value, full_option_name)
 
 
 def _validate_theme_file_content(
@@ -392,8 +458,13 @@ def _validate_theme_file_content(
     -------
         A filtered copy of the theme content with invalid options removed.
     """
-    valid_main_options = _get_valid_theme_options(config_options_template, "main")
-    valid_subsections = {"sidebar", "light", "dark"}
+    # Get valid options for each type of section
+    valid_main_options, valid_section_options = _get_valid_theme_options(
+        config_options_template
+    )
+    # Valid sections and subsections
+    valid_sections = {"sidebar", "light", "dark"}
+    valid_subsections = {"light", "dark"}
 
     theme_section = theme_content.get("theme", {})
 
@@ -403,55 +474,43 @@ def _validate_theme_file_content(
 
     # Validate theme options
     for option_name, option_value in theme_section.items():
-        # Handle subsection (valid subsection is only sidebar for now)
+        # This is a section like theme.sidebar, theme.light, theme.dark
         if isinstance(option_value, dict):
             # Invalid subsection: raise error
-            if option_name not in valid_subsections:
+            if option_name not in valid_sections:
                 raise StreamlitAPIException(
-                    f"Theme file {file_path_or_url} contains invalid theme subsection: '{option_name}'.\n\n"
-                    f"Valid subsections are: {valid_subsections}"
+                    f"Theme file {file_path_or_url} contains invalid theme section: '{option_name}'.\n\n"
+                    f"Valid sections are: {valid_sections}"
                 )
 
-            # Rename option_name for clarity - it's actually the section name in this case (i.e. sidebar)
-            section_name = option_name
+            # Create the section in our filtered theme and validate it
+            if option_name not in filtered_theme_section:
+                filtered_theme_section[option_name] = {}
 
-            # Get valid options for this specific subsection
-            valid_section_options = _get_valid_theme_options(
-                config_options_template, section_name
+            # Only sidebar can have subsections
+            subsections = valid_subsections if option_name == "sidebar" else None
+
+            _validate_theme_section_recursive(
+                option_value,
+                option_name,
+                file_path_or_url,
+                valid_section_options,
+                filtered_theme_section[option_name],
+                subsections,
             )
 
-            # Validate options within the subsection
-            for section_option, section_value in option_value.items():
-                if section_option not in valid_section_options:
-                    _invalid_theme_option_warning(
-                        section_option,
-                        file_path_or_url,
-                        valid_section_options,
-                        section_name,
-                    )
-                    # Remove invalid option from filtered theme
-                    if (
-                        section_name in filtered_theme_section
-                        and section_option in filtered_theme_section[section_name]
-                    ):
-                        del filtered_theme_section[section_name][section_option]
-                # Check color options for subsection
-                full_option_name = f"theme.{section_name}.{section_option}"
-                if "color" in full_option_name.lower():
-                    _check_color_value(section_value, full_option_name)
+        elif option_name not in valid_main_options:
+            # Invalid main theme option
+            _invalid_theme_option_warning(
+                option_name,
+                file_path_or_url,
+                valid_main_options,
+            )
+            # Remove the invalid option from the filtered theme
+            filtered_theme_section.pop(option_name, None)
 
-        # Handle main theme options
         else:
-            if option_name not in valid_main_options:
-                _invalid_theme_option_warning(
-                    option_name,
-                    file_path_or_url,
-                    valid_main_options,
-                )
-                # Remove invalid option from filtered theme
-                if option_name in filtered_theme_section:
-                    del filtered_theme_section[option_name]
-            # Check color options for direct theme option
+            # Valid main theme option - check color values
             full_option_name = f"theme.{option_name}"
             if "color" in full_option_name.lower():
                 _check_color_value(option_value, full_option_name)
@@ -584,6 +643,31 @@ def _apply_theme_inheritance(
     return _deep_merge_theme_dicts(base_theme, override_theme)
 
 
+def _set_theme_options_recursive(
+    options_dict: dict[str, Any], prefix: str, set_option_func: Any, source: str
+) -> None:
+    """
+    Recursively set theme options from nested dictionary in process_theme_inheritance().
+    This utility function traverses nested theme configuration sections/subsections
+    and sets each option using the provided set_option_func..
+    """
+    for option_name, option_value in options_dict.items():
+        if option_name == "base" and prefix == "theme":
+            # Base is handled separately in theme inheritance
+            continue
+
+        current_key = f"{prefix}.{option_name}" if prefix else option_name
+
+        if isinstance(option_value, dict):
+            # Recursively handle nested sections
+            _set_theme_options_recursive(
+                option_value, current_key, set_option_func, source
+            )
+        else:
+            # Set the actual config option
+            set_option_func(current_key, option_value, source)
+
+
 # Theme configuration - handles theme.base
 
 
@@ -678,28 +762,10 @@ def process_theme_inheritance(
             )
 
         # Set the merged theme options using recursive helper
-        def _set_theme_options_recursive(
-            options_dict: dict[str, Any], prefix: str
-        ) -> None:
-            """Recursively set theme options from nested dictionary structure."""
-            for option_name, option_value in options_dict.items():
-                if option_name == "base" and prefix == "theme":
-                    # Base is already handled above
-                    continue
-
-                current_key = f"{prefix}.{option_name}" if prefix else option_name
-
-                if isinstance(option_value, dict):
-                    # Recursively handle nested sections
-                    _set_theme_options_recursive(option_value, current_key)
-                else:
-                    # Set the actual config option
-                    set_option_func(
-                        current_key, option_value, f"theme file: {base_value}"
-                    )
-
         theme_section = merged_theme.get("theme", {})
-        _set_theme_options_recursive(theme_section, "theme")
+        _set_theme_options_recursive(
+            theme_section, "theme", set_option_func, f"theme file: {base_value}"
+        )
 
         # Finally, restore theme options set by env vars and command line flags (highest precedence)
         for opt_name, opt_data in high_precedence_theme_options.items():

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
 from streamlit import cli_util, url_util
 from streamlit.config_option import ConfigOption
 from streamlit.elements.lib.color_util import is_css_color_like
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import (
+    StreamlitInvalidThemeError,
+    StreamlitInvalidThemeOptionError,
+    StreamlitInvalidThemeSectionError,
+)
 
 # Maximum size for theme files (1MB). Theme files should be small configuration
 # files containing only theme options, not large data files.
@@ -213,32 +217,34 @@ def _check_color_value(value: Any, option_name: str) -> None:
 
     Validates that the value is a string (or list of strings, in the case of
     chartCategoricalColors and chartSequentialColors) and is not empty.
-    Logs warnings for potentially invalid colors, since we do more comprehensive validation on the frontend.
 
     Handles both single color strings (like primaryColor, backgroundColor)
     and arrays of color strings (like chartCategoricalColors, chartSequentialColors).
 
-    Raises StreamlitAPIException for type errors or empty values.
-    Does not return anything - used purely for validation side effects.
+    Raises StreamlitInvalidThemeOptionError for type errors or empty values.
+    Logs warnings for potentially invalid colors, since we do more comprehensive
+    validation on the frontend.
+
+    No return value - used purely for validation side effects in _validate_theme_file_content
     """
     logger = _get_logger()
 
     # Handle array color options (chartCategoricalColors, chartSequentialColors)
     if isinstance(value, list):
         if not value:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidThemeOptionError(
                 f"Theme option '{option_name}' cannot be an empty array"
             )
 
         for i, color in enumerate(value):
             if not isinstance(color, str):
-                raise StreamlitAPIException(
+                raise StreamlitInvalidThemeOptionError(
                     f"Theme option '{option_name}[{i}]' must be a string, got {type(color).__name__}: {color}"
                 )
 
             color_str = color.strip()
             if not color_str:
-                raise StreamlitAPIException(
+                raise StreamlitInvalidThemeOptionError(
                     f"Theme option '{option_name}[{i}]' cannot be empty"
                 )
 
@@ -256,14 +262,16 @@ def _check_color_value(value: Any, option_name: str) -> None:
 
     # Handle single color options (primaryColor, backgroundColor, etc.)
     if not isinstance(value, str):
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeOptionError(
             f"Theme option '{option_name}' must be a string or array of strings, got {type(value).__name__}: {value}"
         )
 
     value_str: str = value.strip()
 
     if not value_str:
-        raise StreamlitAPIException(f"Theme option '{option_name}' cannot be empty")
+        raise StreamlitInvalidThemeOptionError(
+            f"Theme option '{option_name}' cannot be empty"
+        )
 
     # Lightweight color validation with warning
     if not is_css_color_like(value_str):
@@ -323,14 +331,18 @@ def _extract_current_theme_config(
 def _get_valid_theme_options(
     config_options_template: dict[str, ConfigOption],
 ) -> tuple[set[str], set[str]]:
-    """Get the valid theme configuration options for main theme and theme sections.
+    """
+    Get the valid theme configuration options for main theme and theme sections.
 
     Extracts valid theme options from the config options template to ensure they
     stay in sync with the actual theme options defined via _create_theme_options() calls.
 
-    Returns a tuple ( main_theme_options, sidebar_theme_options )
+    Returns a tuple ( main_theme_options, section_theme_options )
     where main_theme_options is a set of valid theme options for the main theme (without the "theme." prefix)
-    and sidebar_theme_options is a set of valid theme options for the sidebar/light/dark sections
+    and section_theme_options is a set of valid theme options for the sections/subsections (sidebar, light, dark,
+    sidebar.light, sidebar.dark).
+
+    Note: All non-main theme sections have the same valid options, so we only need to extract them once.
     """
     # Extract options dynamically from the config template
     main_theme_options = set()
@@ -360,7 +372,7 @@ def _invalid_theme_option_warning(
     valid_options: set[str],
     section_name: str = "theme",
 ) -> None:
-    """Log a warning for an invalid theme option."""
+    """Helper function to log a warning for an invalid theme option."""
 
     if section_name == "theme":
         full_option_name = f"{section_name}.{option_name}"
@@ -397,18 +409,19 @@ def _validate_theme_section_recursive(
         section_configs: The section configs to validate
         section_path: Path like 'sidebar', 'light', 'sidebar.light'
         file_path_or_url: Theme file path for error messages
-        section_options: Valid options for this section type
+        section_options: Valid options for this section
         filtered_parent: Parent dict in filtered theme to populate
         valid_subsections: Valid subsections (only for 'sidebar' section)
+
+    Raises StreamlitInvalidThemeSectionError if an invalid subsection is found.
     """
     for option_name, option_value in section_configs.items():
         if isinstance(option_value, dict):
             # This is a subsection
             if not valid_subsections or option_name not in valid_subsections:
-                raise StreamlitAPIException(
-                    f"Theme file {file_path_or_url} contains invalid theme "
-                    f"subsection: 'theme.{section_path}.{option_name}'.\n\n"
-                    f"Valid subsections are only sidebar.light and sidebar.dark"
+                raise StreamlitInvalidThemeSectionError(
+                    f"theme.{section_path}.{option_name}",
+                    file_path_or_url,
                 )
 
             # Create and validate the subsection's options
@@ -449,7 +462,7 @@ def _validate_theme_file_content(
     """
     Validate that a theme file contains only valid theme sections and config options.
 
-    If invalid sections are found in the theme file, a StreamlitAPIException is raised.
+    If invalid sections are found in the theme file, a StreamlitInvalidThemeSectionError is raised.
 
     If invalid config options are found in the theme file, a warning is logged with the valid
     options for the given section.
@@ -478,9 +491,9 @@ def _validate_theme_file_content(
         if isinstance(option_value, dict):
             # Invalid subsection: raise error
             if option_name not in valid_sections:
-                raise StreamlitAPIException(
-                    f"Theme file {file_path_or_url} contains invalid theme section: '{option_name}'.\n\n"
-                    f"Valid sections are: {valid_sections}"
+                raise StreamlitInvalidThemeSectionError(
+                    option_name,
+                    file_path_or_url,
                 )
 
             # Create the section in our filtered theme and validate it
@@ -531,7 +544,7 @@ def _load_theme_file(
     """
 
     def _raise_missing_toml() -> None:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             "The 'toml' package is required to load theme files. "
             "Please install it with 'pip install toml'."
         )
@@ -540,13 +553,13 @@ def _load_theme_file(
         raise FileNotFoundError(f"Theme file not found: {file_path_or_url}")
 
     def _raise_missing_theme_section() -> None:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeSectionError(
             f"Theme file {file_path_or_url} must contain a [theme] section"
         )
 
     def _raise_file_too_large() -> None:
         content_size = len(content.encode("utf-8"))
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             f"Theme file {file_path_or_url} is too large ({content_size:,} bytes). "
             f"Maximum allowed size is {_MAX_THEME_FILE_SIZE_BYTES:,} bytes (1MB). "
             f"Theme files should contain only configuration options, not large data."
@@ -598,15 +611,20 @@ def _load_theme_file(
 
         return filtered_theme
 
-    except (StreamlitAPIException, FileNotFoundError):
+    except (
+        StreamlitInvalidThemeError,
+        StreamlitInvalidThemeOptionError,
+        StreamlitInvalidThemeSectionError,
+        FileNotFoundError,
+    ):
         # Re-raise these specific exceptions
         raise
     except urllib.error.URLError as e:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             f"Could not load theme file from URL {file_path_or_url}: {e}"
         ) from e
     except Exception as e:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             f"Error loading theme file {file_path_or_url}: {e}"
         ) from e
 
@@ -700,7 +718,7 @@ def process_theme_inheritance(
         return
 
     def _raise_invalid_nested_base() -> None:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             f"Theme file {base_value} cannot reference another theme file in its base property. "
             f"Only 'light' and 'dark' are allowed in referenced theme files."
         )
@@ -771,12 +789,17 @@ def process_theme_inheritance(
         for opt_name, opt_data in high_precedence_theme_options.items():
             set_option_func(opt_name, opt_data["value"], opt_data["where_defined"])
 
-    except (StreamlitAPIException, FileNotFoundError):
+    except (
+        StreamlitInvalidThemeError,
+        StreamlitInvalidThemeOptionError,
+        StreamlitInvalidThemeSectionError,
+        FileNotFoundError,
+    ):
         # Re-raise expected user errors as-is to preserve specific error messages
         raise
     except Exception as e:
         _get_logger().exception("Error processing theme inheritance")
         # Only wrap unexpected errors (not our specific validation errors)
-        raise StreamlitAPIException(
+        raise StreamlitInvalidThemeError(
             f"Failed to process theme inheritance from {base_value}: {e}"
         ) from e

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -212,8 +212,7 @@ def _clean_paragraphs(txt: str) -> list[str]:
 
 
 def _check_color_value(value: Any, option_name: str) -> None:
-    """
-    Lightweight check of theme color config option values.
+    """Validate theme color configuration option values.
 
     Validates that the value is a string (or list of strings, in the case of
     chartCategoricalColors and chartSequentialColors) and is not empty.
@@ -221,11 +220,23 @@ def _check_color_value(value: Any, option_name: str) -> None:
     Handles both single color strings (like primaryColor, backgroundColor)
     and arrays of color strings (like chartCategoricalColors, chartSequentialColors).
 
-    Raises StreamlitInvalidThemeOptionError for type errors or empty values.
-    Logs warnings for potentially invalid colors, since we do more comprehensive
-    validation on the frontend.
+    Parameters
+    ----------
+    value : Any
+        The color value to validate. Can be a string or list of strings.
+    option_name : str
+        The name of the theme option being validated (e.g., "theme.primaryColor").
 
-    No return value - used purely for validation side effects in _validate_theme_file_content
+    Raises
+    ------
+    StreamlitInvalidThemeOptionError
+        If the value is not a string/list of strings, is empty, or contains
+        empty values in the case of arrays.
+
+    Notes
+    -----
+    Logs warnings for potentially invalid colors, since more comprehensive
+    validation happens on the frontend.
     """
     logger = _get_logger()
 
@@ -331,18 +342,28 @@ def _extract_current_theme_config(
 def _get_valid_theme_options(
     config_options_template: dict[str, ConfigOption],
 ) -> tuple[set[str], set[str]]:
-    """
-    Get the valid theme configuration options for main theme and theme sections.
+    """Get valid theme configuration options for main theme and theme sections.
 
     Extracts valid theme options from the config options template to ensure they
     stay in sync with the actual theme options defined via _create_theme_options() calls.
 
-    Returns a tuple ( main_theme_options, section_theme_options )
-    where main_theme_options is a set of valid theme options for the main theme (without the "theme." prefix)
-    and section_theme_options is a set of valid theme options for the sections/subsections (sidebar, light, dark,
-    light.sidebar, dark.sidebar).
+    Parameters
+    ----------
+    config_options_template : dict[str, ConfigOption]
+        Template of all available configuration options.
 
-    Note: All non-main theme sections have the same valid options, so we only need to extract them once.
+    Returns
+    -------
+    tuple[set[str], set[str]]
+        A tuple (main_theme_options, section_theme_options) where:
+        - main_theme_options: Valid theme options for the main theme (without "theme." prefix)
+        - section_theme_options: Valid theme options for sections/subsections
+          (sidebar, light, dark, light.sidebar, dark.sidebar)
+
+    Notes
+    -----
+    All non-main theme sections have the same valid options, so we only need to
+    extract them once.
     """
     # Extract options dynamically from the config template
     main_theme_options = set()
@@ -376,11 +397,9 @@ def _invalid_theme_option_warning(
 
     if section_name == "theme":
         full_option_name = f"{section_name}.{option_name}"
-    elif "." in section_name:
-        # Handle subsections like "light.sidebar" -> "theme.light.sidebar.{option_name}"
-        full_option_name = f"theme.{section_name}.{option_name}"
     else:
         # Handle sections like "sidebar" -> "theme.sidebar.{option_name}"
+        # or subsections like "light.sidebar" -> "theme.light.sidebar.{option_name}"
         full_option_name = f"theme.{section_name}.{option_name}"
 
     valid_options_list = "\n".join(f"  • {opt}" for opt in sorted(valid_options))
@@ -402,18 +421,27 @@ def _validate_theme_section_recursive(
     filtered_parent: dict[str, Any],
     allow_sidebar_subsection: bool = False,
 ) -> None:
-    """
-    Recursively validate a theme section and its subsection/options.
+    """Recursively validate a theme section and its subsection/options.
 
-    Args:
-        section_configs: The section configs to validate
-        section_path: Path like 'sidebar', 'light', 'light.sidebar'
-        file_path_or_url: Theme file path for error messages
-        section_options: Valid options for this section
-        filtered_parent: Parent section to populate/filter out invalid options
-        allow_sidebar_subsection: Allow sidebar subsection (only "light" and "dark" sections)
+    Parameters
+    ----------
+    section_configs : dict[str, Any]
+        The section configs to validate.
+    section_path : str
+        Path like 'sidebar', 'light', 'light.sidebar'.
+    file_path_or_url : str
+        Theme file path for error messages.
+    section_options : set[str]
+        Valid options for this section.
+    filtered_parent : dict[str, Any]
+        Parent section to populate/filter out invalid options.
+    allow_sidebar_subsection : bool, optional
+        Allow sidebar subsection (only "light" and "dark" sections), by default False.
 
-    Raises StreamlitInvalidThemeSectionError if an invalid subsection is found.
+    Raises
+    ------
+    StreamlitInvalidThemeSectionError
+        If an invalid subsection is found.
     """
     for option_name, option_value in section_configs.items():
         if isinstance(option_value, dict):

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -340,7 +340,7 @@ def _get_valid_theme_options(
     Returns a tuple ( main_theme_options, section_theme_options )
     where main_theme_options is a set of valid theme options for the main theme (without the "theme." prefix)
     and section_theme_options is a set of valid theme options for the sections/subsections (sidebar, light, dark,
-    sidebar.light, sidebar.dark).
+    light.sidebar, dark.sidebar).
 
     Note: All non-main theme sections have the same valid options, so we only need to extract them once.
     """
@@ -358,7 +358,7 @@ def _get_valid_theme_options(
                 main_theme_options.add(option_name)
             # Subsection options like "theme.sidebar.primaryColor"
             elif parts[0] == "theme" and parts[1] == "sidebar" and len(parts) == 3:
-                # All subsections (sidebar, light, dark, sidebar.light, sidebar.dark)
+                # All subsections (sidebar, light, dark, light.sidebar, dark.sidebar)
                 # get the same options as theme.sidebar (which excludes main-only options)
                 _, _, option_name = parts
                 section_theme_options.add(option_name)
@@ -400,7 +400,7 @@ def _validate_theme_section_recursive(
     file_path_or_url: str,
     section_options: set[str],
     filtered_parent: dict[str, Any],
-    valid_subsections: set[str] | None = None,
+    valid_subsection: str | None = None,
 ) -> None:
     """
     Recursively validate a theme section and its options/subsections.
@@ -411,14 +411,14 @@ def _validate_theme_section_recursive(
         file_path_or_url: Theme file path for error messages
         section_options: Valid options for this section
         filtered_parent: Parent dict in filtered theme to populate
-        valid_subsections: Valid subsections (only for 'sidebar' section)
+        valid_subsection: Valid subsection (only "sidebar" for "light" and "dark" sections)
 
     Raises StreamlitInvalidThemeSectionError if an invalid subsection is found.
     """
     for option_name, option_value in section_configs.items():
         if isinstance(option_value, dict):
             # This is a subsection
-            if not valid_subsections or option_name not in valid_subsections:
+            if not valid_subsection or option_name not in valid_subsection:
                 raise StreamlitInvalidThemeSectionError(
                     f"theme.{section_path}.{option_name}",
                     file_path_or_url,
@@ -477,7 +477,6 @@ def _validate_theme_file_content(
     )
     # Valid sections and subsections
     valid_sections = {"sidebar", "light", "dark"}
-    valid_subsections = {"light", "dark"}
 
     theme_section = theme_content.get("theme", {})
 
@@ -500,8 +499,8 @@ def _validate_theme_file_content(
             if option_name not in filtered_theme_section:
                 filtered_theme_section[option_name] = {}
 
-            # Only sidebar can have subsections
-            subsections = valid_subsections if option_name == "sidebar" else None
+            # Only light and dark can have sidebar subsection
+            subsection = "sidebar" if option_name in {"light", "dark"} else None
 
             _validate_theme_section_recursive(
                 option_value,
@@ -509,7 +508,7 @@ def _validate_theme_file_content(
                 file_path_or_url,
                 valid_section_options,
                 filtered_theme_section[option_name],
-                subsections,
+                subsection,
             )
 
         elif option_name not in valid_main_options:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -531,13 +531,32 @@ class StreamlitValueError(LocalizableStreamlitException):
 
 
 # config
-class StreamlitInvalidThemeSectionError(LocalizableStreamlitException):
-    """Exception raised when an invalid theme configuration is provided."""
+class StreamlitInvalidThemeError(LocalizableStreamlitException):
+    """Exception raised for general theme errors."""
 
-    def __init__(self, option_name: str) -> None:
+    def __init__(self, message: str) -> None:
         super().__init__(
-            "Invalid theme section: `{option_name}`. "
-            "Valid patterns are: `theme`, `theme.light`, `theme.dark`, `theme.sidebar`, `theme.light.sidebar`, "
+            message,
+        )
+
+
+class StreamlitInvalidThemeOptionError(LocalizableStreamlitException):
+    """Exception raised when an invalid theme config option is provided."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+        )
+
+
+class StreamlitInvalidThemeSectionError(LocalizableStreamlitException):
+    """Exception raised when an invalid theme section is provided."""
+
+    def __init__(self, option_name: str, file_path_or_url: str = "config.toml") -> None:
+        super().__init__(
+            "Invalid theme section: `{option_name}` found in {file_path_or_url}. "
+            "Valid sections are: `theme`, `theme.light`, `theme.dark`, `theme.sidebar`, `theme.light.sidebar`, "
             "and `theme.dark.sidebar`.",
             option_name=option_name,
+            file_path_or_url=file_path_or_url,
         )

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -755,16 +755,15 @@ class AppSession:
             msg.new_session.custom_theme.sidebar,
             f"theme.{config.CustomThemeCategories.SIDEBAR.value}",
         )
-
-        # [theme.sidebar.light] configs
+        # [theme.light.sidebar] configs
         _populate_theme_msg(
-            msg.new_session.custom_theme.sidebar.light,
-            f"theme.{config.CustomThemeCategories.SIDEBAR_LIGHT.value}",
+            msg.new_session.custom_theme.light.sidebar,
+            f"theme.{config.CustomThemeCategories.LIGHT_SIDEBAR.value}",
         )
-        # [theme.sidebar.dark] configs
+        # [theme.dark.sidebar] configs
         _populate_theme_msg(
-            msg.new_session.custom_theme.sidebar.dark,
-            f"theme.{config.CustomThemeCategories.SIDEBAR_DARK.value}",
+            msg.new_session.custom_theme.dark.sidebar,
+            f"theme.{config.CustomThemeCategories.DARK_SIDEBAR.value}",
         )
 
         # Immutable session data. We send this every time a new session is

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -736,10 +736,35 @@ class AppSession:
             msg.new_session, pages or self._pages_manager.get_pages()
         )
         _populate_config_msg(msg.new_session.config)
+
+        # Handles theme sections
+        # [theme] configs
         _populate_theme_msg(msg.new_session.custom_theme)
+        # [theme.light] configs
+        _populate_theme_msg(
+            msg.new_session.custom_theme.light,
+            f"theme.{config.CustomThemeCategories.LIGHT.value}",
+        )
+        # [theme.dark] configs
+        _populate_theme_msg(
+            msg.new_session.custom_theme.dark,
+            f"theme.{config.CustomThemeCategories.DARK.value}",
+        )
+        # [theme.sidebar] configs
         _populate_theme_msg(
             msg.new_session.custom_theme.sidebar,
             f"theme.{config.CustomThemeCategories.SIDEBAR.value}",
+        )
+
+        # [theme.sidebar.light] configs
+        _populate_theme_msg(
+            msg.new_session.custom_theme.sidebar.light,
+            f"theme.{config.CustomThemeCategories.SIDEBAR_LIGHT.value}",
+        )
+        # [theme.sidebar.dark] configs
+        _populate_theme_msg(
+            msg.new_session.custom_theme.sidebar.dark,
+            f"theme.{config.CustomThemeCategories.SIDEBAR_DARK.value}",
         )
 
         # Immutable session data. We send this every time a new session is

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -31,7 +31,11 @@ from parameterized import parameterized
 from streamlit import config, config_util, env_util
 from streamlit.config import CustomThemeCategories, ShowErrorDetailsConfigOptions
 from streamlit.config_option import ConfigOption
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidThemeSectionError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidThemeError,
+    StreamlitInvalidThemeSectionError,
+)
 
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
@@ -524,8 +528,8 @@ class ConfigTest(unittest.TestCase):
             "theme.dark.sidebar.light",
         ]
     )
-    def test_parsing_toml_with_invalid_theme_nesting(self, section_path):
-        """Test that invalid theme nesting patterns are rejected."""
+    def test_parsing_toml_with_invalid_theme_sections(self, section_path):
+        """Test that invalid theme section patterns are rejected."""
         toml_content = f"""
         [{section_path}]
         primaryColor = "#FF0000"
@@ -2058,6 +2062,10 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
         [theme.sidebar]
         primaryColor = "#ff4444"
         backgroundColor = "#111111"
+
+        [theme.sidebar.dark]
+        blueColor = "#4169e1"
+        greenColor = "#355E3B"
         """
 
         with self._theme_file(base_theme_content, "base_theme.toml") as base_theme_file:
@@ -2075,6 +2083,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             [theme.sidebar]
             backgroundColor = "#222222"
             # primaryColor should come from base theme
+
+            [theme.sidebar.dark]
+            blueColor = "#ADD8E6"
             """
 
             with self._config_patches(config_toml, theme_files=[base_theme_file]):
@@ -2103,6 +2114,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 assert (
                     config.get_option("theme.borderColor") == "#333333"
                 )  # From base theme (no override)
+                assert (
+                    config.get_option("theme.sidebar.dark.blueColor") == "#ADD8E6"
+                )  # Config override
 
                 # Sidebar precedence
                 assert (
@@ -2111,6 +2125,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 assert (
                     config.get_option("theme.sidebar.backgroundColor") == "#222222"
                 )  # Config override
+                assert (
+                    config.get_option("theme.sidebar.dark.greenColor") == "#355E3B"
+                )  # From base theme (no override)
 
                 # Verify where_defined is correct
                 assert "theme file:" in config.get_where_defined(
@@ -2189,6 +2206,108 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 assert (
                     "command-line"
                     in config.get_where_defined("theme.borderColor").lower()
+                )
+                assert (
+                    "command-line"
+                    in config.get_where_defined("theme.linkColor").lower()
+                )
+
+    def test_theme_complex_inheritance_preserves_env_var_and_flag_precedence(self):
+        """Test that theme inheritance with sections/subsections preserves environment
+        variables and command line flags."""
+        theme_content = """
+        [theme]
+        base = "dark"
+        primaryColor = "#00ff00"
+
+        [theme.light]
+        font = "sans-serif"
+        backgroundColor = "#000000"
+
+        [theme.dark]
+        font = "serif"
+
+        [theme.sidebar]
+        textColor = "#ffffff"
+        borderColor = "#333333"
+
+        [theme.sidebar.light]
+        borderColor = "#999999"
+
+        [theme.sidebar.dark]
+        linkColor = "#cccccc"
+        """
+
+        with self._theme_file(theme_content) as theme_file:
+            # Config file references theme file and sets some overrides
+            config_toml = f"""
+            [theme]
+            base = "{theme_file}"
+            primaryColor = "#ff0000"
+
+            [theme.dark]
+            linkColor = "#7851A9"
+
+            [theme.sidebar]
+            textColor = "#cccccc"
+
+            [theme.sidebar.light]
+            borderColor = "#888888"
+
+            [theme.sidebar.dark]
+            linkColor = "#ADD8E6"
+            """
+
+            # Simulate environment variable and command line flag (higher precedence)
+            options_from_flags = {
+                # Env var would be processed as flag by Click framework
+                "theme.primaryColor": "#ff6b6b",  # Should override base/config toml
+                "theme.light.font": "Arial",  # Should override theme file's "sans-serif"
+                "theme.sidebar.borderColor": "#999999",  # Should override theme file's "#333333"
+                "theme.dark.linkColor": "#CD1C18",  # Should override theme file's "#7851A9"
+                "theme.sidebar.dark.linkColor": "#4169e1",  # Should override config file's "#ADD8E6"
+                "theme.linkColor": "#0066cc",  # New value not in theme file or config
+            }
+
+            with self._config_patches(config_toml, theme_files=[theme_file]):
+                config.get_config_options(
+                    force_reparse=True, options_from_flags=options_from_flags
+                )
+
+                # Verify correct precedence hierarchy:
+                # 1. Theme file base values
+                assert config.get_option("theme.base") == "dark"  # From theme file
+                assert config.get_option("theme.light.backgroundColor") == "#000000"
+                assert config.get_option("theme.dark.font") == "serif"
+
+                # 2. Config file overrides
+                assert config.get_option("theme.sidebar.textColor") == "#cccccc"
+                assert config.get_option("theme.sidebar.light.borderColor") == "#888888"
+
+                # 3. Environment variables and command line flags (higher precedence)
+                assert config.get_option("theme.primaryColor") == "#ff6b6b"
+                assert config.get_option("theme.light.font") == "Arial"
+                assert config.get_option("theme.dark.linkColor") == "#CD1C18"
+                assert config.get_option("theme.sidebar.borderColor") == "#999999"
+                assert config.get_option("theme.sidebar.dark.linkColor") == "#4169e1"
+                assert config.get_option("theme.linkColor") == "#0066cc"
+
+                # Verify where_defined is correct
+                assert (
+                    "theme file"
+                    in config.get_where_defined("theme.light.backgroundColor").lower()
+                )
+                assert (
+                    "theme file"
+                    in config.get_where_defined("theme.sidebar.textColor").lower()
+                )
+                assert (
+                    "command-line"
+                    in config.get_where_defined("theme.primaryColor").lower()
+                )
+                assert (
+                    "command-line"
+                    in config.get_where_defined("theme.light.font").lower()
                 )
                 assert (
                     "command-line"
@@ -2333,7 +2452,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             """
 
             with self._config_patches(config_toml, theme_files=[theme_file]):
-                with pytest.raises(StreamlitAPIException) as cm:
+                with pytest.raises(StreamlitInvalidThemeError) as cm:
                     config.get_config_options()
 
                 assert "cannot reference another theme file" in str(cm.value)
@@ -2356,10 +2475,10 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             """
 
             with self._config_patches(config_toml, theme_files=[theme_file]):
-                with pytest.raises(StreamlitAPIException) as cm:
+                with pytest.raises(StreamlitInvalidThemeSectionError) as cm:
                     config.get_config_options()
 
-                assert "invalid theme section" in str(cm.value)
+                assert "Invalid theme section" in str(cm.value)
                 assert "invalidSection" in str(cm.value)
 
     def test_theme_base_no_theme_section_error(self):
@@ -2376,7 +2495,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             """
 
             with self._config_patches(config_toml, theme_files=[theme_file]):
-                with pytest.raises(StreamlitAPIException) as cm:
+                with pytest.raises(StreamlitInvalidThemeSectionError) as cm:
                     config.get_config_options()
 
                 assert "must contain a [theme] section" in str(cm.value)
@@ -2398,7 +2517,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             """
 
             with self._config_patches(config_toml, theme_files=[malformed_theme_file]):
-                with pytest.raises(StreamlitAPIException) as cm:
+                with pytest.raises(StreamlitInvalidThemeError) as cm:
                     config.get_config_options()
 
                 assert "Error loading theme file" in str(cm.value)
@@ -2419,7 +2538,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
         """
 
         with self._config_patches(config_toml):
-            with pytest.raises(StreamlitAPIException) as cm:
+            with pytest.raises(StreamlitInvalidThemeError) as cm:
                 config.get_config_options()
 
             assert "Could not load theme file from URL" in str(cm.value)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -2063,7 +2063,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
         primaryColor = "#ff4444"
         backgroundColor = "#111111"
 
-        [theme.sidebar.dark]
+        [theme.dark.sidebar]
         blueColor = "#4169e1"
         greenColor = "#355E3B"
         """
@@ -2084,7 +2084,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             backgroundColor = "#222222"
             # primaryColor should come from base theme
 
-            [theme.sidebar.dark]
+            [theme.dark.sidebar]
             blueColor = "#ADD8E6"
             """
 
@@ -2115,7 +2115,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                     config.get_option("theme.borderColor") == "#333333"
                 )  # From base theme (no override)
                 assert (
-                    config.get_option("theme.sidebar.dark.blueColor") == "#ADD8E6"
+                    config.get_option("theme.dark.sidebar.blueColor") == "#ADD8E6"
                 )  # Config override
 
                 # Sidebar precedence
@@ -2126,7 +2126,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                     config.get_option("theme.sidebar.backgroundColor") == "#222222"
                 )  # Config override
                 assert (
-                    config.get_option("theme.sidebar.dark.greenColor") == "#355E3B"
+                    config.get_option("theme.dark.sidebar.greenColor") == "#355E3B"
                 )  # From base theme (no override)
 
                 # Verify where_defined is correct
@@ -2231,10 +2231,10 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
         textColor = "#ffffff"
         borderColor = "#333333"
 
-        [theme.sidebar.light]
+        [theme.light.sidebar]
         borderColor = "#999999"
 
-        [theme.sidebar.dark]
+        [theme.dark.sidebar]
         linkColor = "#cccccc"
         """
 
@@ -2251,10 +2251,10 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
             [theme.sidebar]
             textColor = "#cccccc"
 
-            [theme.sidebar.light]
+            [theme.light.sidebar]
             borderColor = "#888888"
 
-            [theme.sidebar.dark]
+            [theme.dark.sidebar]
             linkColor = "#ADD8E6"
             """
 
@@ -2265,7 +2265,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 "theme.light.font": "Arial",  # Should override theme file's "sans-serif"
                 "theme.sidebar.borderColor": "#999999",  # Should override theme file's "#333333"
                 "theme.dark.linkColor": "#CD1C18",  # Should override theme file's "#7851A9"
-                "theme.sidebar.dark.linkColor": "#4169e1",  # Should override config file's "#ADD8E6"
+                "theme.dark.sidebar.linkColor": "#4169e1",  # Should override config file's "#ADD8E6"
                 "theme.linkColor": "#0066cc",  # New value not in theme file or config
             }
 
@@ -2282,14 +2282,14 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
 
                 # 2. Config file overrides
                 assert config.get_option("theme.sidebar.textColor") == "#cccccc"
-                assert config.get_option("theme.sidebar.light.borderColor") == "#888888"
+                assert config.get_option("theme.light.sidebar.borderColor") == "#888888"
 
                 # 3. Environment variables and command line flags (higher precedence)
                 assert config.get_option("theme.primaryColor") == "#ff6b6b"
                 assert config.get_option("theme.light.font") == "Arial"
                 assert config.get_option("theme.dark.linkColor") == "#CD1C18"
                 assert config.get_option("theme.sidebar.borderColor") == "#999999"
-                assert config.get_option("theme.sidebar.dark.linkColor") == "#4169e1"
+                assert config.get_option("theme.dark.sidebar.linkColor") == "#4169e1"
                 assert config.get_option("theme.linkColor") == "#0066cc"
 
                 # Verify where_defined is correct

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -2338,14 +2338,14 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
 
                 assert "cannot reference another theme file" in str(cm.value)
 
-    def test_theme_base_invalid_subsection(self):
-        """Test error when theme file contains invalid subsections."""
+    def test_theme_base_invalid_section(self):
+        """Test error when theme file contains invalid sections."""
         theme_content = """
         [theme]
         base = "dark"
         primaryColor = "#00ff41"
 
-        [theme.invalidSubsection]
+        [theme.invalidSection]
         primaryColor = "#ff0000"
         """
 
@@ -2359,8 +2359,8 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 with pytest.raises(StreamlitAPIException) as cm:
                     config.get_config_options()
 
-                assert "invalid theme subsection" in str(cm.value)
-                assert "invalidSubsection" in str(cm.value)
+                assert "invalid theme section" in str(cm.value)
+                assert "invalidSection" in str(cm.value)
 
     def test_theme_base_no_theme_section_error(self):
         """Test error when theme file is missing [theme] section."""

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -763,7 +763,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         args = warning_call[0][1:]
 
         assert "invalid theme option" in format_string
-        assert "test_theme.toml" in args[0]  # file_pat h_or_url
+        assert "test_theme.toml" in args[0]  # file_path_or_url
         assert "theme.light.invalidSectionOption" in args[1]  # full_option_name
         assert "light" in args[2]  # section_name
 

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -575,7 +575,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
 
     def test_get_valid_theme_options(self):
         """Test that _get_valid_theme_options extracts all valid theme options."""
-        valid_options = config_util._get_valid_theme_options(self.config_template)
+        main_options, _ = config_util._get_valid_theme_options(self.config_template)
 
         # Test subset of expected core theme options
         expected_options = {
@@ -593,20 +593,18 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             "violetBackgroundColor",
             "violetTextColor",
         }
-        assert expected_options.issubset(valid_options)
+        assert expected_options.issubset(main_options)
 
         # Does not include section names
-        assert "sidebar" not in valid_options
+        assert "sidebar" not in main_options
 
         # Test that all options are strings
-        for option in valid_options:
+        for option in main_options:
             assert isinstance(option, str)
 
     def test_get_valid_theme_options_main_section(self):
         """Test _get_valid_theme_options for main section specifically."""
-        main_options = config_util._get_valid_theme_options(
-            self.config_template, "main"
-        )
+        main_options, _ = config_util._get_valid_theme_options(self.config_template)
 
         # These should be in main section
         expected_main_only = {
@@ -634,11 +632,9 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             f"but got {len(main_options)}"
         )
 
-    def test_get_valid_theme_options_sidebar_section(self):
-        """Test _get_valid_theme_options for sidebar section specifically."""
-        sidebar_options = config_util._get_valid_theme_options(
-            self.config_template, "sidebar"
-        )
+    def test_get_valid_theme_options_section(self):
+        """Test _get_valid_theme_options for sections (sidebar, light, dark) specifically."""
+        _, section_options = config_util._get_valid_theme_options(self.config_template)
 
         # These are some options that should be in sidebar section
         expected_sidebar = {
@@ -655,7 +651,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             "greenBackgroundColor",
             "greenTextColor",
         }
-        assert expected_sidebar.issubset(sidebar_options)
+        assert expected_sidebar.issubset(section_options)
 
         # These are all the options that should NOT be in sidebar section
         main_only_options = {
@@ -667,13 +663,13 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             "chartCategoricalColors",
             "chartSequentialColors",
         }
-        assert main_only_options.isdisjoint(sidebar_options)
+        assert main_only_options.isdisjoint(section_options)
 
         # Test that we get the expected number of theme.sidebar options
         expected_count = self._get_expected_theme_options_count(section="theme.sidebar")
-        assert len(sidebar_options) == expected_count, (
+        assert len(section_options) == expected_count, (
             f"Expected {expected_count} theme.sidebar options based on config template, "
-            f"but got {len(sidebar_options)}"
+            f"but got {len(section_options)}"
         )
 
     def test_validate_theme_file_content_with_valid_content(self):
@@ -723,12 +719,64 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         # Verify valid option was preserved
         assert filtered_theme["theme"]["primaryColor"] == "#ff0000"
 
+    def test_validate_theme_file_content_invalid_section(self):
+        """Test validation rejects invalid theme sections."""
+        theme_content = {
+            "theme": {
+                "primaryColor": "#ff0000",
+                "invalidSection": {"primaryColor": "#00ff00"},
+            }
+        }
+
+        with pytest.raises(StreamlitAPIException) as cm:
+            config_util._validate_theme_file_content(
+                theme_content, "test_theme.toml", self.config_template
+            )
+
+        assert "invalid theme section" in str(cm.value)
+        assert "invalidSection" in str(cm.value)
+
+    def test_validate_theme_file_content_invalid_section_option(self):
+        """Test validation triggers warning for invalid section options."""
+        theme_content = {
+            "theme": {
+                "primaryColor": "#ff0000",
+                "light": {
+                    "invalidSectionOption": "value",
+                },
+            }
+        }
+
+        with patch("streamlit.config_util._get_logger") as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+            filtered_theme = config_util._validate_theme_file_content(
+                theme_content, "test_theme.toml", self.config_template
+            )
+            mock_logger.warning.assert_called_once()
+
+        warning_call = mock_logger.warning.call_args
+        format_string = warning_call[0][0]
+        args = warning_call[0][1:]
+
+        assert "invalid theme option" in format_string
+        assert "test_theme.toml" in args[0]  # file_pat h_or_url
+        assert "theme.light.invalidSectionOption" in args[1]  # full_option_name
+        assert "light" in args[2]  # section_name
+
+        # Verify invalid section option was removed from filtered theme
+        assert "invalidSectionOption" not in filtered_theme["theme"]["light"]
+        # Verify valid main option was preserved
+        assert filtered_theme["theme"]["primaryColor"] == "#ff0000"
+
     def test_validate_theme_file_content_invalid_subsection(self):
         """Test validation rejects invalid theme subsections."""
         theme_content = {
             "theme": {
                 "primaryColor": "#ff0000",
-                "invalidSubsection": {"primaryColor": "#00ff00"},
+                "sidebar": {
+                    "primaryColor": "#00ff00",
+                    "invalidSubsection": {"primaryColor": "#0000ff"},
+                },
             }
         }
 
@@ -738,7 +786,46 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             )
 
         assert "invalid theme subsection" in str(cm.value)
-        assert "invalidSubsection" in str(cm.value)
+        assert "sidebar.invalidSubsection" in str(cm.value)
+
+    def test_validate_theme_file_content_invalid_subsection_option(self):
+        """Test validation triggers warning for invalid subsection options."""
+        theme_content = {
+            "theme": {
+                "primaryColor": "#ff0000",
+                "sidebar": {
+                    "primaryColor": "#00ff00",
+                    "light": {
+                        "invalidSubsectionOption": "value",
+                    },
+                },
+            }
+        }
+
+        with patch("streamlit.config_util._get_logger") as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+            filtered_theme = config_util._validate_theme_file_content(
+                theme_content, "test_theme.toml", self.config_template
+            )
+            mock_logger.warning.assert_called_once()
+
+        warning_call = mock_logger.warning.call_args
+        format_string = warning_call[0][0]
+        args = warning_call[0][1:]
+
+        assert "invalid theme option" in format_string
+        assert "test_theme.toml" in args[0]  # file_path_or_url
+        assert (
+            "theme.sidebar.light.invalidSubsectionOption" in args[1]
+        )  # full_option_name
+        assert "sidebar.light" in args[2]  # section_name
+
+        # Verify invalid subsection option was removed from filtered theme
+        assert (
+            "invalidSubsectionOption" not in filtered_theme["theme"]["sidebar"]["light"]
+        )
+        # Verify valid main option was preserved
+        assert filtered_theme["theme"]["primaryColor"] == "#ff0000"
 
     def test_validate_theme_file_content_invalid_sidebar_option(self):
         """Test validation rejects invalid sidebar options."""
@@ -1107,6 +1194,101 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
 
         # Primary color should be the merged result (config override wins)
         assert set_calls_dict.get("theme.primaryColor") == "#override"
+
+    @patch("streamlit.config_util._load_theme_file")
+    def test_process_theme_inheritance_successful_complex_merge(self, mock_load_theme):
+        """Test successful theme inheritance processing with a complex merge."""
+        base_option = ConfigOption("theme.base", description="", default_val=None)
+        base_option.set_value("custom_theme.toml", "test")
+
+        primary_option = ConfigOption(
+            "theme.primaryColor", description="", default_val=None
+        )
+        primary_option.set_value("#override", "config.toml")
+
+        light_option = ConfigOption(
+            "theme.light.linkColor", description="", default_val=None
+        )
+        light_option.set_value("#light_link_override", "config.toml")
+
+        sidebar_option = ConfigOption(
+            "theme.sidebar.primaryColor", description="", default_val=None
+        )
+        sidebar_option.set_value("#sidebar_override", "config.toml")
+        sidebar_light_option = ConfigOption(
+            "theme.sidebar.light.borderColor", description="", default_val=None
+        )
+        sidebar_light_option.set_value("#sidebar_light_override", "config.toml")
+
+        config_options = {
+            "theme.base": base_option,
+            "theme.primaryColor": primary_option,
+            "theme.light.linkColor": light_option,
+            "theme.sidebar.primaryColor": sidebar_option,
+            "theme.sidebar.light.borderColor": sidebar_light_option,
+        }
+
+        # Mock loaded theme file
+        mock_load_theme.return_value = {
+            "theme": {
+                "base": "dark",
+                "primaryColor": "#base_color",
+                "backgroundColor": "#from_theme_file",
+                "light": {
+                    "primaryColor": "#light_primary_color",
+                    "linkColor": "#light_link_color",
+                },
+                "dark": {
+                    "primaryColor": "#dark_primary_color",
+                    "linkColor": "#dark_link_color",
+                },
+                "sidebar": {
+                    "primaryColor": "#sidebar_base_color",
+                    "light": {
+                        "borderColor": "#light_border_color",
+                    },
+                    "dark": {
+                        "borderColor": "#dark_border_color",
+                    },
+                },
+            }
+        }
+
+        set_option_calls = []
+
+        def mock_set_option(key, value, source):
+            set_option_calls.append((key, value, source))
+
+        config_util.process_theme_inheritance(
+            config_options, self.config_template, mock_set_option
+        )
+
+        # Verify that theme options were set correctly
+        set_calls_dict = {call[0]: call[1] for call in set_option_calls}
+
+        # Base should be set from theme file
+        assert set_calls_dict.get("theme.base") == "dark"
+
+        # Theme and sidebar primary colors should be the merged result (config override wins)
+        assert set_calls_dict.get("theme.primaryColor") == "#override"
+        assert set_calls_dict.get("theme.sidebar.primaryColor") == "#sidebar_override"
+
+        # Background color should come from base theme file
+        assert set_calls_dict.get("theme.backgroundColor") == "#from_theme_file"
+
+        # Config options should include the new section/subsections
+        assert set_calls_dict.get("theme.light.primaryColor") == "#light_primary_color"
+        assert set_calls_dict.get("theme.light.linkColor") == "#light_link_override"
+        assert set_calls_dict.get("theme.dark.primaryColor") == "#dark_primary_color"
+        assert set_calls_dict.get("theme.dark.linkColor") == "#dark_link_color"
+        assert (
+            # override from config.toml should apply in subsubsection
+            set_calls_dict.get("theme.sidebar.light.borderColor")
+            == "#sidebar_light_override"
+        )
+        assert (
+            set_calls_dict.get("theme.sidebar.dark.borderColor") == "#dark_border_color"
+        )
 
     @patch("streamlit.config_util._load_theme_file")
     def test_process_theme_inheritance_nested_sections(self, mock_load_theme):

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -29,7 +29,11 @@ from parameterized import parameterized
 
 from streamlit import config, config_util
 from streamlit.config_option import ConfigOption
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidThemeOptionError,
+    StreamlitInvalidThemeSectionError,
+)
 
 CONFIG_OPTIONS_TEMPLATE = config._config_options_template
 CONFIG_SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
@@ -428,7 +432,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         self, value, option_name: str, expected_error: str
     ):
         """Test _check_color_value raises exceptions for type errors and empty values."""
-        with pytest.raises(StreamlitAPIException) as cm:
+        with pytest.raises(StreamlitInvalidThemeOptionError) as cm:
             config_util._check_color_value(value, option_name)
         assert expected_error in str(cm.value)
 
@@ -728,12 +732,12 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             }
         }
 
-        with pytest.raises(StreamlitAPIException) as cm:
+        with pytest.raises(StreamlitInvalidThemeSectionError) as cm:
             config_util._validate_theme_file_content(
                 theme_content, "test_theme.toml", self.config_template
             )
 
-        assert "invalid theme section" in str(cm.value)
+        assert "Invalid theme section" in str(cm.value)
         assert "invalidSection" in str(cm.value)
 
     def test_validate_theme_file_content_invalid_section_option(self):
@@ -780,12 +784,12 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             }
         }
 
-        with pytest.raises(StreamlitAPIException) as cm:
+        with pytest.raises(StreamlitInvalidThemeSectionError) as cm:
             config_util._validate_theme_file_content(
                 theme_content, "test_theme.toml", self.config_template
             )
 
-        assert "invalid theme subsection" in str(cm.value)
+        assert "Invalid theme section" in str(cm.value)
         assert "sidebar.invalidSubsection" in str(cm.value)
 
     def test_validate_theme_file_content_invalid_subsection_option(self):

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -777,7 +777,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         theme_content = {
             "theme": {
                 "primaryColor": "#ff0000",
-                "sidebar": {
+                "light": {
                     "primaryColor": "#00ff00",
                     "invalidSubsection": {"primaryColor": "#0000ff"},
                 },
@@ -790,22 +790,23 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             )
 
         assert "Invalid theme section" in str(cm.value)
-        assert "sidebar.invalidSubsection" in str(cm.value)
+        assert "light.invalidSubsection" in str(cm.value)
 
     def test_validate_theme_file_content_invalid_subsection_option(self):
         """Test validation triggers warning for invalid subsection options."""
         theme_content = {
             "theme": {
                 "primaryColor": "#ff0000",
-                "sidebar": {
-                    "primaryColor": "#00ff00",
-                    "light": {
+                "dark": {
+                    "sidebar": {
                         "invalidSubsectionOption": "value",
                     },
                 },
+                "sidebar": {
+                    "primaryColor": "#00ff00",
+                },
             }
         }
-
         with patch("streamlit.config_util._get_logger") as mock_get_logger:
             mock_logger = mock_get_logger.return_value
             filtered_theme = config_util._validate_theme_file_content(
@@ -820,13 +821,13 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         assert "invalid theme option" in format_string
         assert "test_theme.toml" in args[0]  # file_path_or_url
         assert (
-            "theme.sidebar.light.invalidSubsectionOption" in args[1]
+            "theme.dark.sidebar.invalidSubsectionOption" in args[1]
         )  # full_option_name
-        assert "sidebar.light" in args[2]  # section_name
+        assert "dark.sidebar" in args[2]  # section_name
 
         # Verify invalid subsection option was removed from filtered theme
         assert (
-            "invalidSubsectionOption" not in filtered_theme["theme"]["sidebar"]["light"]
+            "invalidSubsectionOption" not in filtered_theme["theme"]["dark"]["sidebar"]
         )
         # Verify valid main option was preserved
         assert filtered_theme["theme"]["primaryColor"] == "#ff0000"
@@ -1220,7 +1221,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         )
         sidebar_option.set_value("#sidebar_override", "config.toml")
         sidebar_light_option = ConfigOption(
-            "theme.sidebar.light.borderColor", description="", default_val=None
+            "theme.light.sidebar.borderColor", description="", default_val=None
         )
         sidebar_light_option.set_value("#sidebar_light_override", "config.toml")
 
@@ -1229,7 +1230,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             "theme.primaryColor": primary_option,
             "theme.light.linkColor": light_option,
             "theme.sidebar.primaryColor": sidebar_option,
-            "theme.sidebar.light.borderColor": sidebar_light_option,
+            "theme.light.sidebar.borderColor": sidebar_light_option,
         }
 
         # Mock loaded theme file
@@ -1241,19 +1242,19 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
                 "light": {
                     "primaryColor": "#light_primary_color",
                     "linkColor": "#light_link_color",
+                    "sidebar": {
+                        "borderColor": "#light_sidebar_border_color",
+                    },
                 },
                 "dark": {
                     "primaryColor": "#dark_primary_color",
                     "linkColor": "#dark_link_color",
+                    "sidebar": {
+                        "borderColor": "#dark_sidebar_border_color",
+                    },
                 },
                 "sidebar": {
                     "primaryColor": "#sidebar_base_color",
-                    "light": {
-                        "borderColor": "#light_border_color",
-                    },
-                    "dark": {
-                        "borderColor": "#dark_border_color",
-                    },
                 },
             }
         }
@@ -1287,11 +1288,12 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         assert set_calls_dict.get("theme.dark.linkColor") == "#dark_link_color"
         assert (
             # override from config.toml should apply in subsubsection
-            set_calls_dict.get("theme.sidebar.light.borderColor")
+            set_calls_dict.get("theme.light.sidebar.borderColor")
             == "#sidebar_light_override"
         )
         assert (
-            set_calls_dict.get("theme.sidebar.dark.borderColor") == "#dark_border_color"
+            set_calls_dict.get("theme.dark.sidebar.borderColor")
+            == "#dark_sidebar_border_color"
         )
 
     @patch("streamlit.config_util._load_theme_file")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -746,7 +746,12 @@ def _mock_get_options_for_section(
 
     if overrides.get("sidebar") is not None:
         for k, v in overrides.get("sidebar").items():
-            sidebar_theme_opts[k] = v
+            # Don't apply nested subsection dictionaries as theme options
+            if k not in {
+                "light",
+                "dark",
+            }:
+                sidebar_theme_opts[k] = v
 
     theme_opts = {
         "backgroundColor": "white",
@@ -843,7 +848,8 @@ def _mock_get_options_for_section(
     }
 
     for k, v in overrides.items():
-        if k != "sidebar":
+        # Don't apply nested section dictionaries as theme options
+        if k not in {"sidebar", "light", "dark"}:
             theme_opts[k] = v
 
     def get_options_for_section(section):
@@ -851,6 +857,30 @@ def _mock_get_options_for_section(
             return theme_opts
         if section == "theme.sidebar":
             return sidebar_theme_opts
+        # Handle new theme sections with proper nested overrides
+        # Using sidebar_theme_opts vs theme_opts since [theme] has some options
+        # that are unique to it (i.e. base)
+        if section == "theme.light":
+            section_opts = sidebar_theme_opts.copy()
+            if "light" in overrides:
+                section_opts.update(overrides["light"])
+            return section_opts
+        if section == "theme.dark":
+            section_opts = sidebar_theme_opts.copy()
+            if "dark" in overrides:
+                section_opts.update(overrides["dark"])
+            return section_opts
+        # Handle new theme subsections with proper nested overrides
+        if section == "theme.sidebar.light":
+            section_opts = sidebar_theme_opts.copy()
+            if "sidebar" in overrides and "light" in overrides["sidebar"]:
+                section_opts.update(overrides["sidebar"]["light"])
+            return section_opts
+        if section == "theme.sidebar.dark":
+            section_opts = sidebar_theme_opts.copy()
+            if "sidebar" in overrides and "dark" in overrides["sidebar"]:
+                section_opts.update(overrides["sidebar"]["dark"])
+            return section_opts
         return config.get_options_for_section(section)
 
     return get_options_for_section
@@ -1784,6 +1814,255 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         assert not new_session_msg.custom_theme.sidebar.HasField("base_font_size")
         assert not new_session_msg.custom_theme.sidebar.HasField("base_font_weight")
         assert not new_session_msg.custom_theme.sidebar.HasField("show_sidebar_border")
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_can_specify_light_theme_options(self, patched_config):
+        """Test that theme.light section options are populated correctly."""
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "light": {
+                        "primaryColor": "#ff0000",
+                        "backgroundColor": "#ffffff",
+                        "textColor": "#000000",
+                        "font": "serif",
+                    }
+                }
+            )
+        )
+
+        msg = ForwardMsg()
+        new_session_msg = msg.new_session
+        app_session._populate_theme_msg(
+            new_session_msg.custom_theme.light, "theme.light"
+        )
+
+        assert new_session_msg.custom_theme.light.primary_color == "#ff0000"
+        assert new_session_msg.custom_theme.light.background_color == "#ffffff"
+        assert new_session_msg.custom_theme.light.text_color == "#000000"
+        assert new_session_msg.custom_theme.light.body_font == "serif"
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_can_specify_dark_theme_options(self, patched_config):
+        """Test that theme.dark section options are populated correctly."""
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "dark": {
+                        "primaryColor": "#00ff00",
+                        "backgroundColor": "#000000",
+                        "textColor": "#ffffff",
+                        "font": "monospace",
+                    }
+                }
+            )
+        )
+
+        msg = ForwardMsg()
+        new_session_msg = msg.new_session
+        app_session._populate_theme_msg(new_session_msg.custom_theme.dark, "theme.dark")
+
+        assert new_session_msg.custom_theme.dark.primary_color == "#00ff00"
+        assert new_session_msg.custom_theme.dark.background_color == "#000000"
+        assert new_session_msg.custom_theme.dark.text_color == "#ffffff"
+        assert new_session_msg.custom_theme.dark.body_font == "monospace"
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_can_specify_sidebar_light_theme_options(self, patched_config):
+        """Test that theme.sidebar.light section options are populated correctly."""
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "sidebar": {
+                        "light": {
+                            "primaryColor": "#0000ff",
+                            "backgroundColor": "#f8f9fa",
+                            "textColor": "#212529",
+                            "font": "sans-serif",
+                            "baseRadius": "0.25rem",
+                        }
+                    }
+                }
+            )
+        )
+
+        msg = ForwardMsg()
+        new_session_msg = msg.new_session
+        app_session._populate_theme_msg(
+            new_session_msg.custom_theme.sidebar.light, "theme.sidebar.light"
+        )
+
+        assert new_session_msg.custom_theme.sidebar.light.primary_color == "#0000ff"
+        assert new_session_msg.custom_theme.sidebar.light.background_color == "#f8f9fa"
+        assert new_session_msg.custom_theme.sidebar.light.text_color == "#212529"
+        assert new_session_msg.custom_theme.sidebar.light.body_font == "sans-serif"
+        assert new_session_msg.custom_theme.sidebar.light.base_radius == "0.25rem"
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_can_specify_sidebar_dark_theme_options(self, patched_config):
+        """Test that theme.sidebar.dark section options are populated correctly."""
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "sidebar": {
+                        "dark": {
+                            "primaryColor": "#ffff00",
+                            "backgroundColor": "#212529",
+                            "textColor": "#f8f9fa",
+                            "font": "monospace",
+                            "baseRadius": "0.5rem",
+                        }
+                    }
+                }
+            )
+        )
+
+        msg = ForwardMsg()
+        new_session_msg = msg.new_session
+        app_session._populate_theme_msg(
+            new_session_msg.custom_theme.sidebar.dark, "theme.sidebar.dark"
+        )
+
+        assert new_session_msg.custom_theme.sidebar.dark.primary_color == "#ffff00"
+        assert new_session_msg.custom_theme.sidebar.dark.background_color == "#212529"
+        assert new_session_msg.custom_theme.sidebar.dark.text_color == "#f8f9fa"
+        assert new_session_msg.custom_theme.sidebar.dark.body_font == "monospace"
+        assert new_session_msg.custom_theme.sidebar.dark.base_radius == "0.5rem"
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_new_theme_sections_handle_none_values(self, patched_config):
+        """Test that new theme sections handle None values correctly."""
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "light": {
+                        "primaryColor": None,
+                        "backgroundColor": None,
+                        "textColor": None,
+                        "font": None,
+                    },
+                    "dark": {
+                        "primaryColor": None,
+                        "backgroundColor": None,
+                        "textColor": None,
+                        "font": None,
+                    },
+                    "sidebar": {
+                        "light": {
+                            "primaryColor": None,
+                            "backgroundColor": None,
+                            "textColor": None,
+                            "font": None,
+                        },
+                        "dark": {
+                            "primaryColor": None,
+                            "backgroundColor": None,
+                            "textColor": None,
+                            "font": None,
+                        },
+                    },
+                }
+            )
+        )
+
+        # Test each new section handles None values
+        test_cases = [
+            ("theme.light", lambda msg: msg.custom_theme.light),
+            ("theme.dark", lambda msg: msg.custom_theme.dark),
+            ("theme.sidebar.light", lambda msg: msg.custom_theme.sidebar.light),
+            ("theme.sidebar.dark", lambda msg: msg.custom_theme.sidebar.dark),
+        ]
+
+        for section, theme_obj_getter in test_cases:
+            with self.subTest(section=section):
+                msg = ForwardMsg()
+                new_session_msg = msg.new_session
+                theme_obj = theme_obj_getter(new_session_msg)
+                app_session._populate_theme_msg(theme_obj, section)
+
+                # When values are None, string fields are set to empty string (proto3 behavior)
+                assert theme_obj.primary_color == ""
+                assert theme_obj.background_color == ""
+                assert theme_obj.text_color == ""
+                assert theme_obj.body_font == ""
+
+    @patch("streamlit.runtime.app_session.config")
+    def test_new_theme_sections_support_all_color_options(self, patched_config):
+        """Test that new theme sections support all color palette options."""
+        color_overrides = {
+            "redColor": "#ff0000",
+            "orangeColor": "#ffa500",
+            "yellowColor": "#ffff00",
+            "blueColor": "#0000ff",
+            "greenColor": "#00ff00",
+            "violetColor": "#8a2be2",
+            "grayColor": "#808080",
+            "redBackgroundColor": "#ffe6e6",
+            "orangeBackgroundColor": "#fff2e6",
+            "yellowBackgroundColor": "#fffee6",
+            "blueBackgroundColor": "#e6e6ff",
+            "greenBackgroundColor": "#e6ffe6",
+            "violetBackgroundColor": "#f2e6ff",
+            "grayBackgroundColor": "#f5f5f5",
+            "redTextColor": "#ff0000",
+            "orangeTextColor": "#ffa500",
+            "yellowTextColor": "#ffff00",
+            "blueTextColor": "#0000ff",
+            "greenTextColor": "#00ff00",
+            "violetTextColor": "#8a2be2",
+            "grayTextColor": "#808080",
+        }
+
+        patched_config.get_options_for_section.side_effect = (
+            _mock_get_options_for_section(
+                {
+                    "light": color_overrides,
+                    "dark": color_overrides,
+                    "sidebar": {
+                        "light": color_overrides,
+                        "dark": color_overrides,
+                    },
+                }
+            )
+        )
+
+        # Test that all new sections support the full color palette
+        test_cases = [
+            ("theme.light", lambda msg: msg.custom_theme.light),
+            ("theme.dark", lambda msg: msg.custom_theme.dark),
+            ("theme.sidebar.light", lambda msg: msg.custom_theme.sidebar.light),
+            ("theme.sidebar.dark", lambda msg: msg.custom_theme.sidebar.dark),
+        ]
+
+        for section, theme_obj_getter in test_cases:
+            with self.subTest(section=section):
+                msg = ForwardMsg()
+                new_session_msg = msg.new_session
+                theme_obj = theme_obj_getter(new_session_msg)
+                app_session._populate_theme_msg(theme_obj, section)
+
+                # Verify all color options are populated
+                assert theme_obj.red_color == "#ff0000"
+                assert theme_obj.orange_color == "#ffa500"
+                assert theme_obj.yellow_color == "#ffff00"
+                assert theme_obj.blue_color == "#0000ff"
+                assert theme_obj.green_color == "#00ff00"
+                assert theme_obj.violet_color == "#8a2be2"
+                assert theme_obj.gray_color == "#808080"
+                assert theme_obj.red_background_color == "#ffe6e6"
+                assert theme_obj.orange_background_color == "#fff2e6"
+                assert theme_obj.yellow_background_color == "#fffee6"
+                assert theme_obj.blue_background_color == "#e6e6ff"
+                assert theme_obj.green_background_color == "#e6ffe6"
+                assert theme_obj.violet_background_color == "#f2e6ff"
+                assert theme_obj.gray_background_color == "#f5f5f5"
+                assert theme_obj.red_text_color == "#ff0000"
+                assert theme_obj.orange_text_color == "#ffa500"
+                assert theme_obj.yellow_text_color == "#ffff00"
+                assert theme_obj.blue_text_color == "#0000ff"
+                assert theme_obj.green_text_color == "#00ff00"
+                assert theme_obj.violet_text_color == "#8a2be2"
+                assert theme_obj.gray_text_color == "#808080"
 
     @patch("streamlit.runtime.app_session._LOGGER")
     @patch("streamlit.runtime.app_session.config")

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -696,10 +696,27 @@ class AppSessionTest(unittest.TestCase):
 def _mock_get_options_for_section(
     overrides: dict[str, Any] | None = None,
 ) -> Callable[..., Any]:
+    """Mock config.get_options_for_section for testing.
+
+    Expected override structure:
+        {
+            "sidebar": {...},        # Options for theme.sidebar
+            "light": {               # Options for theme.light
+                "sidebar": {...},    # Options for theme.light.sidebar
+                ...other options...
+            },
+            "dark": {                # Options for theme.dark
+                "sidebar": {...},    # Options for theme.dark.sidebar
+                ...other options...
+            },
+            ...other theme options...
+        }
+    """
     if not overrides:
         overrides = {}
 
-    sidebar_theme_opts = {
+    # Default options for sections (excluding main theme which has unique options like base)
+    section_default_opts = {
         "backgroundColor": "white",
         "baseRadius": "1.2rem",
         "buttonRadius": "medium",
@@ -744,16 +761,8 @@ def _mock_get_options_for_section(
         "codeTextColor": "#7defa1",
     }
 
-    if overrides.get("sidebar") is not None:
-        for k, v in overrides.get("sidebar").items():
-            # Don't apply nested subsection dictionaries as theme options
-            if k not in {
-                "light",
-                "dark",
-            }:
-                sidebar_theme_opts[k] = v
-
-    theme_opts = {
+    # Main theme options (includes unique options like base, baseFontSize, etc.)
+    theme_default_opts = {
         "backgroundColor": "white",
         "base": "dark",
         "baseFontSize": 14,
@@ -847,40 +856,50 @@ def _mock_get_options_for_section(
         "grayTextColor": "#d5dae5",
     }
 
-    for k, v in overrides.items():
-        # Don't apply nested section dictionaries as theme options
-        if k not in {"sidebar", "light", "dark"}:
-            theme_opts[k] = v
+    def _apply_overrides(base: dict, overrides_dict: dict, exclude_keys: set) -> dict:
+        """Apply overrides to base dict, excluding specified keys."""
+        result = base.copy()
+        for k, v in overrides_dict.items():
+            if k not in exclude_keys:
+                result[k] = v
+        return result
 
-    def get_options_for_section(section):
+    def get_options_for_section(section: str) -> dict:
         if section == "theme":
-            return theme_opts
+            # Apply root-level overrides, excluding nested sections
+            return _apply_overrides(
+                theme_default_opts, overrides, {"sidebar", "light", "dark"}
+            )
+
         if section == "theme.sidebar":
-            return sidebar_theme_opts
-        # Handle new theme sections with proper nested overrides
-        # Using sidebar_theme_opts vs theme_opts since [theme] has some options
-        # that are unique to it (i.e. base)
+            # Apply sidebar overrides if present
+            return _apply_overrides(
+                section_default_opts, overrides.get("sidebar", {}), set()
+            )
+
         if section == "theme.light":
-            section_opts = sidebar_theme_opts.copy()
-            if "light" in overrides:
-                section_opts.update(overrides["light"])
-            return section_opts
+            # Apply light overrides, excluding nested sidebar
+            return _apply_overrides(
+                section_default_opts, overrides.get("light", {}), {"sidebar"}
+            )
+
         if section == "theme.dark":
-            section_opts = sidebar_theme_opts.copy()
-            if "dark" in overrides:
-                section_opts.update(overrides["dark"])
-            return section_opts
-        # Handle new theme subsections with proper nested overrides
-        if section == "theme.sidebar.light":
-            section_opts = sidebar_theme_opts.copy()
-            if "sidebar" in overrides and "light" in overrides["sidebar"]:
-                section_opts.update(overrides["sidebar"]["light"])
-            return section_opts
-        if section == "theme.sidebar.dark":
-            section_opts = sidebar_theme_opts.copy()
-            if "sidebar" in overrides and "dark" in overrides["sidebar"]:
-                section_opts.update(overrides["sidebar"]["dark"])
-            return section_opts
+            # Apply dark overrides, excluding nested sidebar
+            return _apply_overrides(
+                section_default_opts, overrides.get("dark", {}), {"sidebar"}
+            )
+
+        if section == "theme.light.sidebar":
+            # Apply light.sidebar overrides if present
+            light_sidebar = overrides.get("light", {}).get("sidebar", {})
+            return _apply_overrides(section_default_opts, light_sidebar, set())
+
+        if section == "theme.dark.sidebar":
+            # Apply dark.sidebar overrides if present
+            dark_sidebar = overrides.get("dark", {}).get("sidebar", {})
+            return _apply_overrides(section_default_opts, dark_sidebar, set())
+
+        # Fallback to real config for any other sections
         return config.get_options_for_section(section)
 
     return get_options_for_section
@@ -1868,13 +1887,13 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         assert new_session_msg.custom_theme.dark.body_font == "monospace"
 
     @patch("streamlit.runtime.app_session.config")
-    def test_can_specify_sidebar_light_theme_options(self, patched_config):
-        """Test that theme.sidebar.light section options are populated correctly."""
+    def test_can_specify_light_sidebar_theme_options(self, patched_config):
+        """Test that theme.light.sidebar section options are populated correctly."""
         patched_config.get_options_for_section.side_effect = (
             _mock_get_options_for_section(
                 {
-                    "sidebar": {
-                        "light": {
+                    "light": {
+                        "sidebar": {
                             "primaryColor": "#0000ff",
                             "backgroundColor": "#f8f9fa",
                             "textColor": "#212529",
@@ -1889,23 +1908,23 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         msg = ForwardMsg()
         new_session_msg = msg.new_session
         app_session._populate_theme_msg(
-            new_session_msg.custom_theme.sidebar.light, "theme.sidebar.light"
+            new_session_msg.custom_theme.light.sidebar, "theme.light.sidebar"
         )
 
-        assert new_session_msg.custom_theme.sidebar.light.primary_color == "#0000ff"
-        assert new_session_msg.custom_theme.sidebar.light.background_color == "#f8f9fa"
-        assert new_session_msg.custom_theme.sidebar.light.text_color == "#212529"
-        assert new_session_msg.custom_theme.sidebar.light.body_font == "sans-serif"
-        assert new_session_msg.custom_theme.sidebar.light.base_radius == "0.25rem"
+        assert new_session_msg.custom_theme.light.sidebar.primary_color == "#0000ff"
+        assert new_session_msg.custom_theme.light.sidebar.background_color == "#f8f9fa"
+        assert new_session_msg.custom_theme.light.sidebar.text_color == "#212529"
+        assert new_session_msg.custom_theme.light.sidebar.body_font == "sans-serif"
+        assert new_session_msg.custom_theme.light.sidebar.base_radius == "0.25rem"
 
     @patch("streamlit.runtime.app_session.config")
-    def test_can_specify_sidebar_dark_theme_options(self, patched_config):
-        """Test that theme.sidebar.dark section options are populated correctly."""
+    def test_can_specify_dark_sidebar_theme_options(self, patched_config):
+        """Test that theme.dark.sidebar section options are populated correctly."""
         patched_config.get_options_for_section.side_effect = (
             _mock_get_options_for_section(
                 {
-                    "sidebar": {
-                        "dark": {
+                    "dark": {
+                        "sidebar": {
                             "primaryColor": "#ffff00",
                             "backgroundColor": "#212529",
                             "textColor": "#f8f9fa",
@@ -1920,14 +1939,14 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         msg = ForwardMsg()
         new_session_msg = msg.new_session
         app_session._populate_theme_msg(
-            new_session_msg.custom_theme.sidebar.dark, "theme.sidebar.dark"
+            new_session_msg.custom_theme.dark.sidebar, "theme.dark.sidebar"
         )
 
-        assert new_session_msg.custom_theme.sidebar.dark.primary_color == "#ffff00"
-        assert new_session_msg.custom_theme.sidebar.dark.background_color == "#212529"
-        assert new_session_msg.custom_theme.sidebar.dark.text_color == "#f8f9fa"
-        assert new_session_msg.custom_theme.sidebar.dark.body_font == "monospace"
-        assert new_session_msg.custom_theme.sidebar.dark.base_radius == "0.5rem"
+        assert new_session_msg.custom_theme.dark.sidebar.primary_color == "#ffff00"
+        assert new_session_msg.custom_theme.dark.sidebar.background_color == "#212529"
+        assert new_session_msg.custom_theme.dark.sidebar.text_color == "#f8f9fa"
+        assert new_session_msg.custom_theme.dark.sidebar.body_font == "monospace"
+        assert new_session_msg.custom_theme.dark.sidebar.base_radius == "0.5rem"
 
     @patch("streamlit.runtime.app_session.config")
     def test_new_theme_sections_handle_none_values(self, patched_config):
@@ -1940,21 +1959,19 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
                         "backgroundColor": None,
                         "textColor": None,
                         "font": None,
+                        "sidebar": {
+                            "primaryColor": None,
+                            "backgroundColor": None,
+                            "textColor": None,
+                            "font": None,
+                        },
                     },
                     "dark": {
                         "primaryColor": None,
                         "backgroundColor": None,
                         "textColor": None,
                         "font": None,
-                    },
-                    "sidebar": {
-                        "light": {
-                            "primaryColor": None,
-                            "backgroundColor": None,
-                            "textColor": None,
-                            "font": None,
-                        },
-                        "dark": {
+                        "sidebar": {
                             "primaryColor": None,
                             "backgroundColor": None,
                             "textColor": None,
@@ -1969,8 +1986,8 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         test_cases = [
             ("theme.light", lambda msg: msg.custom_theme.light),
             ("theme.dark", lambda msg: msg.custom_theme.dark),
-            ("theme.sidebar.light", lambda msg: msg.custom_theme.sidebar.light),
-            ("theme.sidebar.dark", lambda msg: msg.custom_theme.sidebar.dark),
+            ("theme.light.sidebar", lambda msg: msg.custom_theme.light.sidebar),
+            ("theme.dark.sidebar", lambda msg: msg.custom_theme.dark.sidebar),
         ]
 
         for section, theme_obj_getter in test_cases:
@@ -2016,13 +2033,15 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         patched_config.get_options_for_section.side_effect = (
             _mock_get_options_for_section(
                 {
-                    "light": color_overrides,
-                    "dark": color_overrides,
-                    "sidebar": {
-                        "light": color_overrides,
-                        "dark": color_overrides,
+                    "light": {
+                        "sidebar": color_overrides,
+                        **color_overrides,
                     },
-                }
+                    "dark": {
+                        "sidebar": color_overrides,
+                        **color_overrides,
+                    },
+                },
             )
         )
 
@@ -2030,8 +2049,8 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         test_cases = [
             ("theme.light", lambda msg: msg.custom_theme.light),
             ("theme.dark", lambda msg: msg.custom_theme.dark),
-            ("theme.sidebar.light", lambda msg: msg.custom_theme.sidebar.light),
-            ("theme.sidebar.dark", lambda msg: msg.custom_theme.sidebar.dark),
+            ("theme.light.sidebar", lambda msg: msg.custom_theme.light.sidebar),
+            ("theme.dark.sidebar", lambda msg: msg.custom_theme.dark.sidebar),
         ]
 
         for section, theme_obj_getter in test_cases:


### PR DESCRIPTION
## Describe your changes
**Part 2 of Custom Dark Theme Feature** 
PR handles setting of theme config values for all sections - `[theme]`, `[theme.sidebar]`, `[theme.light]`, `[theme.dark]`, `[theme.light.sidebar]`,`[theme.dark.sidebar]` - in new session message / proper section precedence between a base theme `.toml` file, `config.toml`, CLI flags & env vars.

This PR finishes handling of theme configs for respective sections, producing the expected nested structure (`themeInput` example below). This will be used by the FE in the next PR.
```protobuf
    {
        "base": "light",  
        "primaryColor": "blue",  
        "sidebar": {...},        # Config options from theme.sidebar
        "light": {               # Config options from theme.light
            ...other options...
            "sidebar": {...},    # Config options from theme.light.sidebar
        },
        "dark": {                # Config options from theme.dark
            ...other options...
            "sidebar": {...},    # Config options from theme.dark.sidebar
        },
        ...other theme options...
    }
```

## Testing Plan
- Python Unit Tests: ✅ Added
- Manual Testing: ✅  
