### PR TITLE
Add `pinned` parameter to `MultiselectColumn`

### DIFF
--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -1732,6 +1732,7 @@ def MultiselectColumn(
     help: str | None = None,
     disabled: bool | None = None,
     required: bool | None = None,
+    pinned: bool | None = None,
     default: Iterable[str] | None = None,
     options: Iterable[str] | None = None,
     accept_new_options: bool | None = None,
@@ -1787,6 +1788,12 @@ def MultiselectColumn(
     required : bool or None
         Whether edited cells in the column need to have a value. If True, an edited cell
         can only be submitted if it has a value other than None. Defaults to False.
+
+    pinned : bool or None
+        Whether the column is pinned. A pinned column will stay visible on the
+        left side no matter where the user scrolls. If this is ``None``
+        (default), Streamlit will decide: index columns are pinned, and data
+        columns are not pinned.
 
     default : Iterable of str or None
         Specifies the default value in this column when a new row is added by the user.

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -1950,6 +1950,7 @@ def MultiselectColumn(
         help=help,
         disabled=disabled,
         required=required,
+        pinned=pinned,
         default=None if default is None else list(default),
         type_config=MultiselectColumnConfig(
             type="multiselect",

--- a/lib/tests/streamlit/elements/lib/column_types_test.py
+++ b/lib/tests/streamlit/elements/lib/column_types_test.py
@@ -502,6 +502,7 @@ class ColumnTypesTest(unittest.TestCase):
                 help="Help text",
                 disabled=False,
                 required=True,
+                pinned=True,
                 default=["a", "b"],
                 options=["a", "b", "c"],
                 accept_new_options=True,
@@ -512,6 +513,7 @@ class ColumnTypesTest(unittest.TestCase):
             "help": "Help text",
             "disabled": False,
             "required": True,
+            "pinned": True,
             "default": ["a", "b"],
             "type_config": {
                 "type": "multiselect",


### PR DESCRIPTION
## Describe your changes

This adds the `pinned` parameter to the `MultiselectColumn`, which was accidentally missed when implementing it.

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
