### PR TITLE
Show hex color indicators in inline code, similar to GitHub

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -398,6 +398,46 @@ describe("StreamlitMarkdown", () => {
     const markdownContainer = screen.getByTestId("stMarkdownContainer")
     expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
   })
+  it("renders hex color indicator for valid 6-digit hex colors in backticks", () => {
+    const source = "The primary color is `#0969DA` and secondary is `#FF5733`"
+    const { container } = render(<StreamlitMarkdown source={source} allowHTML={false} />)
+
+    // Check that the hex codes are rendered
+    expect(screen.getByText("#0969DA")).toBeInTheDocument()
+    expect(screen.getByText("#FF5733")).toBeInTheDocument()
+
+    // Check that colored dots are present (span elements with backgroundColor)
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(2)
+
+    // Verify the colors are correct
+    expect(colorDots[0]).toHaveStyle({ backgroundColor: '#0969DA' })
+    expect(colorDots[1]).toHaveStyle({ backgroundColor: '#FF5733' })
+  })
+
+  it("does not render hex color indicator for non-hex code", () => {
+    const source = "This is `regular code` not a color"
+    const { container } = render(<StreamlitMarkdown source={source} allowHTML={false} />)
+
+    const codeElement = screen.getByText("regular code")
+    expect(codeElement).toBeInTheDocument()
+
+    // Should not have any color indicator spans
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(0)
+  })
+
+  it("renders hex color indicator for 3-digit hex colors", () => {
+    const source = "Short color `#F00` is valid"
+    const { container } = render(<StreamlitMarkdown source={source} allowHTML={false} />)
+
+    expect(screen.getByText("#F00")).toBeInTheDocument()
+
+    // Check that colored dot is present
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(1)
+    expect(colorDots[0]).toHaveStyle({ backgroundColor: '#F00' })
+  })
 
   it("renders regular text sizing when largerLabel is true", () => {
     const source = "Here is some checkbox label text"

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -125,6 +125,15 @@ export interface Props {
 }
 
 /**
+ * Detects if a string is a valid hex color code.
+ * Supports both 3-digit (#RGB) and 6-digit (#RRGGBB) formats.
+ */
+function isHexColor(text: string): boolean {
+  const hexColorPattern = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+  return hexColorPattern.test(text.trim())
+}
+
+/**
  * A rehype plugin to add an `inline` property to code blocks.
  * This is used to distinguish between inline code and code blocks.
  * It is needed for versions of react-markdown from v9 onwards.
@@ -342,6 +351,7 @@ export type CustomCodeTagProps = JSX.IntrinsicElements["code"] &
 
 /**
  * Renders code tag with highlighting based on requested language.
+ * Also renders a colored dot next to hex color codes.
  */
 export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   inline,
@@ -350,16 +360,33 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   ...props
 }) => {
   const match = /language-(\w+)/.exec(className || "")
-
   const codeText = String(children).replace(/^\n/, "").replace(/\n$/, "")
-
   const language = match?.[1] || ""
+
+  // Check if this is an inline code block with a hex color
+  const isHexColorCode = inline && isHexColor(codeText)
+
   return !inline ? (
     <StreamlitSyntaxHighlighter language={language} showLineNumbers={false}>
       {codeText}
     </StreamlitSyntaxHighlighter>
   ) : (
     <StyledInlineCode className={className} {...omit(props, "node")}>
+      {isHexColorCode && (
+        <span
+          style={{
+            display: "inline-block",
+            width: "0.75em",
+            height: "0.75em",
+            borderRadius: "50%",
+            backgroundColor: codeText.trim(),
+            marginRight: "0.35em",
+            verticalAlign: "middle",
+            border: "1px solid rgba(0, 0, 0, 0.1)",
+          }}
+          aria-hidden="true"
+        />
+      )}
       {children}
     </StyledInlineCode>
   )


### PR DESCRIPTION
## Describe your changes

This PR adds support for displaying colored dots next to hex color codes in inline code (backticks), matching GitHub's behavior. When users write hex colors like `#0969DA` or `#F00` in markdown, a small colored circle now appears before the hex code, making it easier to visualize colors at a glance.

**Implementation details:**
- Added `isHexColor()` utility function to detect valid 3-digit and 6-digit hex color formats
- Modified `CustomCodeTag` component to render a colored dot for valid hex colors in inline code
- The dot uses a circular shape (0.75em diameter) with the hex color as background
- Added subtle border for visibility on light backgrounds
- Used `aria-hidden="true"` for accessibility (decorative element)

**User experience:**
- Works seamlessly with existing markdown rendering
- Only applies to inline code (backticks), not code blocks
- Supports both `#RGB` and `#RRGGBB` formats
- No impact on non-hex inline code

## GitHub Issue Link

Closes #11643

## Testing Plan

**Unit Tests (JS):**
- ✅ Added test for 6-digit hex colors (`#0969DA`, `#FF5733`)
- ✅ Added test for 3-digit hex colors (`#F00`)
- ✅ Added test to verify non-hex code doesn't render color indicators
- ✅ Tests verify both presence of colored dots and correct background colors

**Manual Testing:**
The feature can be tested by writing markdown with hex colors:
```python
st.markdown("The primary color is `#0969DA` and accent is `#FF5733`")
st.markdown("Short format: `#F00` also works")
st.markdown("Regular code: `not a color` should not show a dot")