### PR TITLE
Clean up flaky test markers

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -222,9 +222,6 @@ def test_interval_area_chart_displays_selection_text(app: Page):
     expect_prefixed_markdown(app, expected_prefix, expected_selection)
 
 
-# The altair chart seems to sometimes be rendered too small in the
-# initial rendering.
-@pytest.mark.flaky(reruns=3)
 def test_point_histogram_chart_displays_selection_text(app: Page):
     chart = _get_selection_point_histogram(app)
 
@@ -237,9 +234,6 @@ def test_point_histogram_chart_displays_selection_text(app: Page):
     expect_prefixed_markdown(app, expected_prefix, expected_selection)
 
 
-# The altair chart seems to sometimes be rendered too small in the
-# initial rendering.
-@pytest.mark.flaky(reruns=3)
 def test_interval_histogram_chart_displays_selection_text(app: Page):
     chart = _get_selection_interval_histogram(app)
 

--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -64,7 +64,6 @@ def test_check_top_level_class(app: Page):
 
 # Webkit is quite flaky, potentially pointing to a bug
 # see the other comments in the test script
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.skip_browser("webkit")
 def test_chart_tooltip_styling(app: Page, assert_snapshot: ImageCompareFunction):
     """Check that the chart tooltip styling is correct."""

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -370,7 +370,7 @@ def test_file_upload_error_message_disallowed_files(
     expect(app.get_by_text("json files are not allowed.")).to_be_visible()
 
 
-@pytest.mark.skip_browser("chromium")  # Webkit CI file upload issue
+@pytest.mark.skip_browser("chromium")
 def test_file_upload_error_message_file_too_large(app: Page):
     """Test that shows error message for files exceeding max size limit."""
 

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -370,7 +370,7 @@ def test_file_upload_error_message_disallowed_files(
     expect(app.get_by_text("json files are not allowed.")).to_be_visible()
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.skip_browser("chromium")  # Webkit CI file upload issue
 def test_file_upload_error_message_file_too_large(app: Page):
     """Test that shows error message for files exceeding max size limit."""
 

--- a/e2e_playwright/st_dataframe_dimensions_test.py
+++ b/e2e_playwright/st_dataframe_dimensions_test.py
@@ -76,7 +76,7 @@ def test_data_frame_resizing(app: Page):
     expect(dataframe_element).to_have_css("height", "200px")
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.skip_browser("firefox")
 def test_data_frame_rendering(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that st.dataframe should render as expected with width and height."""
     stretch_dataframe = app.get_by_test_id("stDataFrame").nth(14)

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -235,19 +235,19 @@ def test_calls_callback_on_change(app: Page):
     calendar.click()
     wait_for_app_run(app)
 
-    expect_markdown(app, "Value 12: 1970-01-02")
-    expect_markdown(app, "Date Input Changed: True")
+    expect_prefixed_markdown(app, "Value 12:", "1970-01-02")
+    expect_prefixed_markdown(app, "Date Input Changed:", "True")
 
     # Change different date input to trigger delta path change
     first_date_input_field = get_date_input(app, "Single date").locator("input")
     first_date_input_field.fill("1971/01/03")
     wait_for_app_run(app)
 
-    expect_markdown(app, "Value 1: 1971-01-03")
+    expect_prefixed_markdown(app, "Value 1:", "1971-01-03")
 
     # Test if value is still correct after delta path change
-    expect_markdown(app, "Value 12: 1970-01-02")
-    expect_markdown(app, "Date Input Changed: False")
+    expect_prefixed_markdown(app, "Value 12:", "1970-01-02")
+    expect_prefixed_markdown(app, "Date Input Changed:", "False")
 
 
 def test_single_date_calendar_picker_rendering(

--- a/e2e_playwright/st_layouts_container_various_elements_test.py
+++ b/e2e_playwright/st_layouts_container_various_elements_test.py
@@ -73,6 +73,7 @@ def test_layouts_container_with_map(app: Page, assert_snapshot: ImageCompareFunc
     )
 
 
+@pytest.mark.flaky(reruns=3)
 def test_layouts_container_expanders(app: Page, assert_snapshot: ImageCompareFunction):
     """Test expander functionality in containers that contain expanders."""
     expect(app.get_by_test_id("stExpander")).to_have_count(3)
@@ -86,7 +87,7 @@ def test_layouts_container_expanders(app: Page, assert_snapshot: ImageCompareFun
         expander = container_expanders.first
         expect(expander).to_be_visible()
         expander.click()
-        app.wait_for_timeout(3000)
+        app.wait_for_timeout(5000)
 
         assert_snapshot(
             container,

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -15,7 +15,11 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
-from e2e_playwright.shared.app_utils import click_button, expect_markdown
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    expect_markdown,
+    expect_prefixed_markdown,
+)
 
 
 def _expect_initial_reruns_finished(app: Page):
@@ -25,7 +29,7 @@ def _expect_initial_reruns_finished(app: Page):
 
 
 def _expect_initial_reruns_count_text(app: Page):
-    expect_markdown(app, "app run count: 4")
+    expect_prefixed_markdown(app, "app run count:", "4")
 
 
 def test_st_rerun_restarts_the_session_when_invoked(app: Page):
@@ -57,12 +61,12 @@ def test_rerun_works_in_try_except_block(app: Page):
     click_button(app, "rerun try_fragment")
     # the rerun in the try-block worked as expected, so the session_state count
     # incremented
-    expect_markdown(app, "app run count: 5")
+    expect_prefixed_markdown(app, "app run count:", "5")
 
 
 def test_state_retained_on_app_scoped_rerun(app: Page):
     # Sanity check 1
-    expect_markdown(app, "selectbox selection: None")
+    expect_prefixed_markdown(app, "selectbox selection:", "None")
 
     # Click on the selectbox and select the first option.
     app.get_by_test_id("stSelectbox").first.locator("input").click()

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -252,24 +252,29 @@ def test_calls_callback_on_change(app: Page):
     """Test that it correctly calls the callback on change."""
     text_area = get_element_by_key(app, "text_area_9")
     text_area_field = text_area.locator("textarea").first
+    expect(text_area_field).to_be_visible()
 
     text_area_field.fill("hello world")
     text_area_field.press("Control+Enter")
+    wait_for_app_run(app)
 
-    expect_markdown(app, "value 9: hello world")
-    expect_markdown(app, "text area changed: True")
+    expect_prefixed_markdown(app, "value 9:", "hello world")
+    expect_prefixed_markdown(app, "text area changed:", "True")
 
     # Change different widget to trigger delta path change
     first_text_area = get_text_area(app, "text area 1 (default)")
     first_text_area_field = first_text_area.locator("textarea").first
+    expect(first_text_area_field).to_be_visible()
+
     first_text_area_field.fill("hello world")
     first_text_area_field.press("Control+Enter")
+    wait_for_app_run(app)
 
-    expect_markdown(app, "value 1: hello world")
+    expect_prefixed_markdown(app, "value 1:", "hello world")
 
     # Test if value is still correct after delta path change
-    expect_markdown(app, "value 9: hello world")
-    expect_markdown(app, "text area changed: False")
+    expect_prefixed_markdown(app, "value 9:", "hello world")
+    expect_prefixed_markdown(app, "text area changed:", "False")
 
 
 def test_text_area_in_form_with_submit_by_enter(app: Page):

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
@@ -248,29 +247,33 @@ def test_text_input_shows_state_value(app: Page):
     )
 
 
-@pytest.mark.flaky(reruns=3)
 def test_calls_callback_on_change(app: Page):
     """Test that it correctly calls the callback on change."""
     text_input_field = get_element_by_key(app, "text_input_9").locator("input").first
+    expect(text_input_field).to_be_visible()
 
     text_input_field.fill("hello world")
     text_input_field.press("Enter")
+    wait_for_app_run(app)
 
-    expect_markdown(app, "value 9: hello world")
-    expect_markdown(app, "text input changed: True")
+    expect_prefixed_markdown(app, "value 9:", "hello world")
+    expect_prefixed_markdown(app, "text input changed:", "True")
 
-    # Change differentwidget to trigger delta path change
+    # Change different widget to trigger delta path change
     first_text_input_field = (
         get_text_input(app, "text input 1 (default)").locator("input").first
     )
+    expect(first_text_input_field).to_be_visible()
+
     first_text_input_field.fill("hello world")
     first_text_input_field.press("Enter")
+    wait_for_app_run(app)
 
-    expect_markdown(app, "value 1: hello world")
+    expect_prefixed_markdown(app, "value 1:", "hello world")
 
     # Test if value is still correct after delta path change
-    expect_markdown(app, "value 9: hello world")
-    expect_markdown(app, "text input changed: False")
+    expect_prefixed_markdown(app, "value 9:", "hello world")
+    expect_prefixed_markdown(app, "text input changed:", "False")
 
 
 def test_text_input_in_form_with_submit_by_enter(app: Page):

--- a/e2e_playwright/st_video_test.py
+++ b/e2e_playwright/st_video_test.py
@@ -72,7 +72,6 @@ def test_video_width_configurations(app: Page, assert_snapshot: ImageCompareFunc
 
 # Chromium miss codecs required to play that mp3 videos
 # https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.skip_browser("chromium")
 def test_video_rendering(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that `st.video` renders correctly via screenshots matching."""

--- a/e2e_playwright/theming/custom_main_colors_test.py
+++ b/e2e_playwright/theming/custom_main_colors_test.py
@@ -64,7 +64,9 @@ def configure_custom_theme_colors():
 def test_custom_theme_colors(app: Page, assert_snapshot: ImageCompareFunction):
     # Set bigger viewport to better show app content
     app.set_viewport_size({"width": 1280, "height": 1000})
+    # Add a small timeout to allow elements to adjust to the new viewport size
+    app.wait_for_timeout(2000)
     # Make sure that all elements are rendered and no skeletons are shown:
     expect_no_skeletons(app, timeout=25000)
 
-    assert_snapshot(app, name="custom_main_colors_app", image_threshold=0.0003)
+    assert_snapshot(app, name="custom_main_colors_app")


### PR DESCRIPTION
## Describe your changes

Cleans up a couple of flaky test markers used on tests that are no longer flaky. Also attempts to fix some flakiness and uses some browser ignores instead of `pytest.mark.flaky` if only a single browser is flaky.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
