### PR TITLE
[refactor] Add useWaveformController hook and tests

### DIFF
--- a/frontend/lib/src/components/audio/core/types.ts
+++ b/frontend/lib/src/components/audio/core/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type RecordingState = "idle" | "recording"
+
+export interface WaveformControllerEvents {
+  onPermissionDenied?: () => void
+  onError?: (error: Error) => void
+  onRecordStart?: () => void
+  onRecordReady?: (blob: Blob) => void
+  onApprove?: (wav: Blob) => void
+  onCancel?: () => void
+  onProgressMs?: (ms: number) => void
+  onPlaybackPlay?: () => void
+  onPlaybackPause?: () => void
+  onPlaybackFinish?: () => void
+}
+
+export interface WaveformController {
+  readonly state: RecordingState
+  readonly isPlaybackPlaying: boolean
+
+  start(): Promise<void>
+
+  stop(): Promise<Blob>
+
+  approve(blob?: Blob): Promise<void>
+
+  cancel(): void
+
+  playback: {
+    isPlaying(): boolean
+    play(): Promise<void>
+    pause(): void
+    load(source: Blob | ArrayBuffer | string): Promise<void>
+    getCurrentTimeMs(): number
+    getDurationMs(): number
+  }
+
+  setEventHandlers(events: WaveformControllerEvents): void
+}

--- a/frontend/lib/src/components/audio/core/useWaveformController.test.tsx
+++ b/frontend/lib/src/components/audio/core/useWaveformController.test.tsx
@@ -16,7 +16,7 @@
 
 import { ReactNode } from "react"
 
-import { act, renderHook } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import ThemeProvider from "~lib/components/core/ThemeProvider"
@@ -198,7 +198,7 @@ describe("useWaveformController", () => {
     expect(result.current.isPlaybackPlaying).toBe(false)
   })
 
-  it("should return 0 for getCurrentTimeMs when no playback", () => {
+  it("should return 0 for getCurrentTimeMs in initial state", () => {
     const { result } = renderHook(
       () =>
         useWaveformController({
@@ -304,12 +304,10 @@ describe("useWaveformController", () => {
       { wrapper }
     )
 
-    // Wait for initialization attempt
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100))
+    // Wait for initialization attempt and error to be reported
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalled()
     })
-
-    expect(onError).toHaveBeenCalled()
     expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
     expect(onError.mock.calls[0][0].message).toContain(
       "WaveSurfer init failed"

--- a/frontend/lib/src/components/audio/core/useWaveformController.test.tsx
+++ b/frontend/lib/src/components/audio/core/useWaveformController.test.tsx
@@ -1,0 +1,393 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from "react"
+
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import ThemeProvider from "~lib/components/core/ThemeProvider"
+import { mockTheme } from "~lib/mocks/mockTheme"
+
+import { useWaveformController } from "./useWaveformController"
+
+// Mock WaveSurfer and RecordPlugin
+vi.mock("wavesurfer.js", () => ({
+  default: {
+    create: vi.fn(),
+  },
+}))
+
+vi.mock("wavesurfer.js/dist/plugins/record", () => ({
+  default: {
+    create: vi.fn(),
+  },
+}))
+
+// Mock theme utils
+vi.mock("~lib/theme/utils", () => ({
+  convertRemToPx: (rem: string) => parseFloat(rem) * 16,
+}))
+
+describe("useWaveformController", () => {
+  let mockContainerRef: { current: HTMLDivElement | null }
+  let mockEvents: {
+    onPermissionDenied?: () => void
+    onError?: (error: Error) => void
+    onRecordStart?: () => void
+    onRecordReady?: (blob: Blob) => void
+    onApprove?: (wav: Blob) => void
+    onCancel?: () => void
+    onProgressMs?: (ms: number) => void
+    onPlaybackPlay?: () => void
+    onPlaybackPause?: () => void
+    onPlaybackFinish?: () => void
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
+  )
+
+  beforeEach(() => {
+    mockContainerRef = { current: document.createElement("div") }
+    mockEvents = {
+      onPermissionDenied: vi.fn(),
+      onError: vi.fn(),
+      onRecordStart: vi.fn(),
+      onRecordReady: vi.fn(),
+      onApprove: vi.fn(),
+      onCancel: vi.fn(),
+      onProgressMs: vi.fn(),
+      onPlaybackPlay: vi.fn(),
+      onPlaybackPause: vi.fn(),
+      onPlaybackFinish: vi.fn(),
+    }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should initialize with idle state", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.state).toBe("idle")
+  })
+
+  it("should have playback methods", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.playback).toBeDefined()
+    expect(typeof result.current.playback.isPlaying).toBe("function")
+    expect(typeof result.current.playback.play).toBe("function")
+    expect(typeof result.current.playback.pause).toBe("function")
+    expect(typeof result.current.playback.load).toBe("function")
+    expect(typeof result.current.playback.getCurrentTimeMs).toBe("function")
+    expect(typeof result.current.playback.getDurationMs).toBe("function")
+  })
+
+  it("should have control methods", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(typeof result.current.start).toBe("function")
+    expect(typeof result.current.stop).toBe("function")
+    expect(typeof result.current.approve).toBe("function")
+    expect(typeof result.current.cancel).toBe("function")
+    expect(typeof result.current.setEventHandlers).toBe("function")
+  })
+
+  it("should update events via setEventHandlers", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    const newEvents = {
+      onError: vi.fn(),
+    }
+
+    act(() => {
+      result.current.setEventHandlers(newEvents)
+    })
+
+    expect(result.current).toBeDefined()
+  })
+
+  it("should call cancel and update state on cancel()", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(result.current.state).toBe("idle")
+    expect(mockEvents.onCancel).toHaveBeenCalled()
+  })
+
+  it("should throw error when approving without recording", async () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    await expect(result.current.approve()).rejects.toThrow(
+      "No recorded audio to approve"
+    )
+  })
+
+  it("should return false for isPlaying when not playing", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.playback.isPlaying()).toBe(false)
+    expect(result.current.isPlaybackPlaying).toBe(false)
+  })
+
+  it("should return 0 for getCurrentTimeMs when no playback", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.playback.getCurrentTimeMs()).toBe(0)
+  })
+
+  it("should return 0 for getDurationMs when no recording", () => {
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.playback.getDurationMs()).toBe(0)
+  })
+
+  it("destroys WaveSurfer and Record backend on unmount", async () => {
+    const mockWaveSurferInstance = {
+      destroy: vi.fn(),
+      on: vi.fn(),
+      un: vi.fn(),
+      registerPlugin: vi.fn(),
+      empty: vi.fn(),
+      pause: vi.fn(),
+    }
+
+    const mockRecordPlugin = {
+      destroy: vi.fn(),
+      on: vi.fn(),
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+    }
+
+    const WaveSurferModule = await import("wavesurfer.js")
+    const RecordPluginModule = await import(
+      "wavesurfer.js/dist/plugins/record"
+    )
+
+    // Mock the WaveSurfer.create to return our mock instance
+    const createMock = WaveSurferModule.default.create as ReturnType<
+      typeof vi.fn
+    >
+    createMock.mockReturnValue(mockWaveSurferInstance)
+    const recordCreateMock = RecordPluginModule.default.create as ReturnType<
+      typeof vi.fn
+    >
+    recordCreateMock.mockReturnValue(mockRecordPlugin)
+
+    mockWaveSurferInstance.registerPlugin.mockReturnValue(mockRecordPlugin)
+
+    const { unmount } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    // Wait for initialization
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    // Unmount the component
+    unmount()
+
+    // Verify destroy was called on WaveSurfer
+    expect(mockWaveSurferInstance.destroy).toHaveBeenCalledTimes(1)
+    expect(mockRecordPlugin.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it("handles errors from WaveSurfer initialization", async () => {
+    const onError = vi.fn()
+    const WaveSurferModule = await import("wavesurfer.js")
+
+    // Reset the mock first
+    const createMock = WaveSurferModule.default.create as ReturnType<
+      typeof vi.fn
+    >
+    createMock.mockReset()
+
+    // Make WaveSurfer.create throw an error
+    createMock.mockImplementationOnce(() => {
+      throw new Error("WaveSurfer init failed")
+    })
+
+    renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: { ...mockEvents, onError },
+        }),
+      { wrapper }
+    )
+
+    // Wait for initialization attempt
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    })
+
+    expect(onError).toHaveBeenCalled()
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect(onError.mock.calls[0][0].message).toContain(
+      "WaveSurfer init failed"
+    )
+  })
+
+  it("propagates playback events", async () => {
+    const mockWaveSurferInstance = {
+      destroy: vi.fn(),
+      on: vi.fn(),
+      un: vi.fn(),
+      registerPlugin: vi.fn(),
+      empty: vi.fn(),
+      pause: vi.fn(),
+    }
+
+    const waveEventHandlers = new Map<string, (...args: unknown[]) => void>()
+    mockWaveSurferInstance.on.mockImplementation(
+      (event: string, handler: (...args: unknown[]) => void) => {
+        waveEventHandlers.set(event, handler)
+      }
+    )
+
+    const mockRecordPlugin = {
+      destroy: vi.fn(),
+      on: vi.fn(),
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+    }
+
+    mockRecordPlugin.on.mockImplementation(() => {})
+
+    const WaveSurferModule = await import("wavesurfer.js")
+    const RecordPluginModule = await import(
+      "wavesurfer.js/dist/plugins/record"
+    )
+
+    const createMock = WaveSurferModule.default.create as ReturnType<
+      typeof vi.fn
+    >
+    createMock.mockReturnValue(mockWaveSurferInstance)
+
+    const recordCreateMock = RecordPluginModule.default.create as ReturnType<
+      typeof vi.fn
+    >
+    recordCreateMock.mockReturnValue(mockRecordPlugin)
+
+    mockWaveSurferInstance.registerPlugin.mockReturnValue(mockRecordPlugin)
+
+    const { result } = renderHook(
+      () =>
+        useWaveformController({
+          containerRef: mockContainerRef,
+          events: mockEvents,
+        }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    act(() => {
+      waveEventHandlers.get("play")?.()
+    })
+    expect(mockEvents.onPlaybackPlay).toHaveBeenCalledTimes(1)
+    expect(result.current.isPlaybackPlaying).toBe(true)
+
+    act(() => {
+      waveEventHandlers.get("pause")?.()
+    })
+    expect(mockEvents.onPlaybackPause).toHaveBeenCalledTimes(1)
+    expect(result.current.isPlaybackPlaying).toBe(false)
+
+    act(() => {
+      waveEventHandlers.get("finish")?.()
+    })
+    expect(mockEvents.onPlaybackFinish).toHaveBeenCalledTimes(1)
+    expect(result.current.isPlaybackPlaying).toBe(false)
+  })
+})

--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -1,0 +1,457 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import type WaveSurfer from "wavesurfer.js"
+
+import {
+  type PlayerEvents,
+  WaveSurferPlayer,
+} from "~lib/components/audio/backends/WaveSurferPlayer"
+import { WaveSurferRecordBackend } from "~lib/components/audio/backends/WaveSurferRecordBackend"
+import { encodeToWav } from "~lib/components/audio/core/encodeToWav"
+import type {
+  RecordingState,
+  WaveformController,
+  WaveformControllerEvents,
+} from "~lib/components/audio/core/types"
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { blend, convertRemToPx } from "~lib/theme/utils"
+
+const BAR_WIDTH = 4
+const BAR_GAP = 4
+const BAR_RADIUS = 8
+const CURSOR_WIDTH = 0
+const WAVEFORM_PADDING = 4
+const DEFAULT_SAMPLE_RATE = 16000
+
+interface ReadyResolver {
+  resolve: () => void
+  reject: (error: Error) => void
+}
+
+interface UseWaveformControllerParams {
+  containerRef: RefObject<HTMLElement>
+  sampleRate?: number | null
+  events?: WaveformControllerEvents
+}
+
+export function useWaveformController({
+  containerRef,
+  sampleRate,
+  events,
+}: UseWaveformControllerParams): WaveformController {
+  const theme = useEmotionTheme()
+
+  const [currentState, setCurrentState] = useState<RecordingState>("idle")
+  const [currentBlob, setCurrentBlob] = useState<Blob | null>(null)
+  const [isPlaybackPlaying, setIsPlaybackPlaying] = useState(false)
+
+  const wavesurferRef = useRef<WaveSurfer | null>(null)
+  const recordBackendRef = useRef<WaveSurferRecordBackend | null>(null)
+  const playerRef = useRef<WaveSurferPlayer | null>(null)
+  const eventsRef = useRef<WaveformControllerEvents>(events || {})
+  const isInitializedRef = useRef(false)
+  const readyResolversRef = useRef<Set<ReadyResolver>>(new Set())
+  const isPlaybackModeRef = useRef(false)
+
+  // Use the provided sample rate if specified; if undefined, fall back to DEFAULT_SAMPLE_RATE; if null, use null.
+  const effectiveSampleRate =
+    sampleRate === undefined ? DEFAULT_SAMPLE_RATE : sampleRate
+
+  useEffect(() => {
+    eventsRef.current = events || {}
+  }, [events])
+
+  const notifyReady = useCallback((): void => {
+    const resolvers = Array.from(readyResolversRef.current)
+    readyResolversRef.current.clear()
+    resolvers.forEach(resolver => {
+      resolver.resolve()
+    })
+  }, [])
+
+  const notifyReadyError = useCallback((error: Error): void => {
+    setIsPlaybackPlaying(false)
+    const resolvers = Array.from(readyResolversRef.current)
+    readyResolversRef.current.clear()
+    resolvers.forEach(resolver => {
+      resolver.reject(error)
+    })
+  }, [])
+
+  const configurePlayerEvents = useCallback(
+    (player: WaveSurferPlayer): void => {
+      const playerEvents: PlayerEvents = {
+        onPlay: () => {
+          setIsPlaybackPlaying(true)
+          eventsRef.current.onPlaybackPlay?.()
+        },
+        onPause: () => {
+          setIsPlaybackPlaying(false)
+          eventsRef.current.onPlaybackPause?.()
+        },
+        onFinish: () => {
+          setIsPlaybackPlaying(false)
+          eventsRef.current.onPlaybackFinish?.()
+        },
+        onReady: () => {
+          notifyReady()
+        },
+        onError: (error: Error) => {
+          setIsPlaybackPlaying(false)
+          notifyReadyError(error)
+          eventsRef.current.onError?.(error)
+        },
+      }
+
+      player.setEventHandlers(playerEvents)
+    },
+    [notifyReady, notifyReadyError]
+  )
+
+  const initializeWaveSurfer = useCallback(async (): Promise<void> => {
+    if (isInitializedRef.current || !containerRef.current) {
+      return
+    }
+
+    try {
+      const [WaveSurferModule, RecordPluginModule] = await Promise.all([
+        import("wavesurfer.js"),
+        import("wavesurfer.js/dist/plugins/record"),
+      ])
+      const WaveSurfer = WaveSurferModule.default
+      const RecordPluginClass = RecordPluginModule.default
+
+      const ws = WaveSurfer.create({
+        container: containerRef.current,
+        waveColor: theme.colors.primary,
+        progressColor: theme.colors.bodyText,
+        height:
+          convertRemToPx(theme.sizes.largestElementHeight) -
+          2 * WAVEFORM_PADDING,
+        barWidth: BAR_WIDTH,
+        barGap: BAR_GAP,
+        barRadius: BAR_RADIUS,
+        cursorWidth: CURSOR_WIDTH,
+        interact: true,
+      })
+
+      wavesurferRef.current = ws
+      isPlaybackModeRef.current = false
+
+      const recordBackend = new WaveSurferRecordBackend({
+        sampleRate: effectiveSampleRate,
+      })
+      recordBackend.initialize(ws, RecordPluginClass)
+      recordBackend.setEventHandlers({
+        onRecordProgress: (ms: number) => {
+          eventsRef.current.onProgressMs?.(ms)
+        },
+        onPermissionDenied: () => {
+          eventsRef.current.onPermissionDenied?.()
+          setCurrentState("idle")
+        },
+        onError: (error: Error) => {
+          eventsRef.current.onError?.(error)
+          setCurrentState("idle")
+        },
+      })
+      recordBackendRef.current = recordBackend
+
+      const player = new WaveSurferPlayer()
+      player.initialize(ws)
+      playerRef.current = player
+
+      configurePlayerEvents(player)
+
+      isInitializedRef.current = true
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      eventsRef.current.onError?.(err)
+      throw err
+    }
+  }, [containerRef, theme, effectiveSampleRate, configurePlayerEvents])
+
+  useEffect(() => {
+    initializeWaveSurfer().catch(() => {})
+    const readyResolvers = readyResolversRef.current
+
+    return (): void => {
+      readyResolvers.clear()
+      setIsPlaybackPlaying(false)
+      if (recordBackendRef.current) {
+        recordBackendRef.current.destroy()
+        recordBackendRef.current = null
+      }
+      if (playerRef.current) {
+        playerRef.current.destroy()
+        playerRef.current = null
+      }
+      if (wavesurferRef.current) {
+        wavesurferRef.current.destroy()
+        wavesurferRef.current = null
+      }
+      isInitializedRef.current = false
+      isPlaybackModeRef.current = false
+    }
+  }, [initializeWaveSurfer])
+
+  useEffect(() => {
+    const ws = wavesurferRef.current
+    if (!ws) {
+      return
+    }
+
+    if (currentState === "recording") {
+      ws.setOptions({
+        waveColor: theme.colors.primary,
+        progressColor: theme.colors.primary,
+      })
+      return
+    }
+
+    if (isPlaybackModeRef.current) {
+      ws.setOptions({
+        interact: true,
+        waveColor: blend(theme.colors.fadedText40, theme.colors.secondaryBg),
+        progressColor: theme.colors.bodyText,
+      })
+      return
+    }
+
+    ws.setOptions({
+      waveColor: theme.colors.primary,
+      progressColor: theme.colors.bodyText,
+    })
+  }, [
+    currentState,
+    theme.colors.bodyText,
+    theme.colors.fadedText40,
+    theme.colors.primary,
+    theme.colors.secondaryBg,
+  ])
+
+  const start = useCallback(async (): Promise<void> => {
+    if (currentState === "recording") {
+      return
+    }
+
+    if (!isInitializedRef.current) {
+      await initializeWaveSurfer()
+    }
+
+    if (!recordBackendRef.current) {
+      throw new Error("Record backend not initialized")
+    }
+
+    // Reset waveform color for recording mode
+    if (wavesurferRef.current) {
+      wavesurferRef.current.setOptions({
+        waveColor: theme.colors.primary,
+        progressColor: theme.colors.primary,
+      })
+    }
+
+    isPlaybackModeRef.current = false
+
+    await recordBackendRef.current.startRecording()
+    setCurrentState("recording")
+    setCurrentBlob(null)
+    setIsPlaybackPlaying(false)
+    eventsRef.current.onRecordStart?.()
+  }, [currentState, initializeWaveSurfer, theme.colors.primary])
+
+  const resetPlayer = useCallback((): void => {
+    if (playerRef.current && wavesurferRef.current) {
+      playerRef.current.destroy()
+      playerRef.current = new WaveSurferPlayer()
+      playerRef.current.initialize(wavesurferRef.current)
+      readyResolversRef.current.clear()
+      setIsPlaybackPlaying(false)
+      configurePlayerEvents(playerRef.current)
+    }
+    isPlaybackModeRef.current = false
+  }, [configurePlayerEvents])
+
+  const enterPlaybackMode = useCallback((): void => {
+    playerRef.current?.seekToStart()
+    setIsPlaybackPlaying(false)
+    isPlaybackModeRef.current = true
+    if (wavesurferRef.current) {
+      wavesurferRef.current.setOptions({
+        interact: true,
+        waveColor: blend(theme.colors.fadedText40, theme.colors.secondaryBg),
+        progressColor: theme.colors.bodyText,
+      })
+    }
+  }, [
+    theme.colors.bodyText,
+    theme.colors.fadedText40,
+    theme.colors.secondaryBg,
+  ])
+
+  const stop = useCallback(async (): Promise<Blob> => {
+    if (currentState !== "recording") {
+      throw new Error("Not currently recording")
+    }
+
+    if (!recordBackendRef.current || !playerRef.current) {
+      throw new Error("Backends not initialized")
+    }
+
+    try {
+      const rawBlob = await recordBackendRef.current.stopRecording()
+      setCurrentBlob(rawBlob)
+
+      await new Promise<void>((resolve, reject) => {
+        if (!playerRef.current) {
+          reject(new Error("Player not initialized"))
+          return
+        }
+
+        const resolver: ReadyResolver = {
+          resolve: () => {
+            readyResolversRef.current.delete(resolver)
+            resolve()
+          },
+          reject: (error: Error) => {
+            readyResolversRef.current.delete(resolver)
+            reject(error)
+          },
+        }
+
+        readyResolversRef.current.add(resolver)
+
+        playerRef.current.load(rawBlob).catch(error => {
+          readyResolversRef.current.delete(resolver)
+          reject(error instanceof Error ? error : new Error(String(error)))
+        })
+      })
+
+      setCurrentState("idle") // Recording stopped, back to idle state
+      setIsPlaybackPlaying(false)
+      enterPlaybackMode()
+
+      eventsRef.current.onRecordReady?.(rawBlob)
+      return rawBlob
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      setIsPlaybackPlaying(false)
+      throw err
+    }
+  }, [currentState, enterPlaybackMode])
+
+  const approve = useCallback(
+    async (blob?: Blob): Promise<void> => {
+      const blobToUse = blob ?? currentBlob
+      if (!blobToUse) {
+        throw new Error("No recorded audio to approve")
+      }
+
+      try {
+        const wav = await encodeToWav(blobToUse, effectiveSampleRate)
+        eventsRef.current.onApprove?.(wav)
+
+        setCurrentBlob(null)
+        setCurrentState("idle")
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        eventsRef.current.onError?.(err)
+        throw err
+      }
+    },
+    [currentBlob, effectiveSampleRate]
+  )
+
+  const cancel = useCallback((): void => {
+    if (currentState === "recording") {
+      recordBackendRef.current?.cancelRecording()
+    }
+
+    resetPlayer()
+    setCurrentBlob(null)
+    setCurrentState("idle")
+    setIsPlaybackPlaying(false)
+    isPlaybackModeRef.current = false
+    eventsRef.current.onCancel?.()
+  }, [currentState, resetPlayer])
+
+  const playback = {
+    isPlaying: useCallback((): boolean => {
+      return playerRef.current?.getIsPlaying() ?? false
+    }, []),
+
+    play: useCallback(async (): Promise<void> => {
+      if (!playerRef.current) {
+        throw new Error("Player not initialized")
+      }
+      await playerRef.current.play()
+    }, []),
+
+    pause: useCallback((): void => {
+      playerRef.current?.pause()
+    }, []),
+
+    load: useCallback(
+      async (source: Blob | ArrayBuffer | string): Promise<void> => {
+        if (!isInitializedRef.current) {
+          await initializeWaveSurfer()
+        }
+        if (!playerRef.current) {
+          throw new Error("Player not initialized")
+        }
+
+        await playerRef.current.load(source)
+        enterPlaybackMode()
+      },
+      [enterPlaybackMode, initializeWaveSurfer]
+    ),
+
+    getCurrentTimeMs: useCallback((): number => {
+      return playerRef.current?.getCurrentTime() ?? 0
+    }, []),
+
+    getDurationMs: useCallback((): number => {
+      return playerRef.current?.getDuration() ?? 0
+    }, []),
+  }
+
+  const setEventHandlers = useCallback(
+    (newEvents: WaveformControllerEvents): void => {
+      eventsRef.current = newEvents
+    },
+    []
+  )
+
+  return {
+    state: currentState,
+    isPlaybackPlaying,
+    start,
+    stop,
+    approve,
+    cancel,
+    playback,
+    setEventHandlers,
+  }
+}

--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -189,12 +189,11 @@ export function useWaveformController({
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error))
       eventsRef.current.onError?.(err)
-      throw err
     }
   }, [containerRef, theme, effectiveSampleRate, configurePlayerEvents])
 
   useEffect(() => {
-    initializeWaveSurfer().catch(() => {})
+    void initializeWaveSurfer()
     const readyResolvers = readyResolversRef.current
 
     return (): void => {

--- a/frontend/lib/src/components/audio/index.ts
+++ b/frontend/lib/src/components/audio/index.ts
@@ -15,3 +15,9 @@
  */
 
 export { encodeToWav } from "./core/encodeToWav"
+export type {
+  WaveformController,
+  WaveformControllerEvents,
+  RecordingState,
+} from "./core/types"
+export { useWaveformController } from "./core/useWaveformController"


### PR DESCRIPTION
## Describe your changes

**TLDR: This PR utilizes the new classes introduced in** #12727**, and packages them in an easy to use hook for consumption by** **`st.audio_input`** **which can be seen in #12729**

This pull request introduces comprehensive unit tests for the `useWaveformController` React hook and makes the hook available for import from the audio component index. The new tests ensure the reliability of audio waveform recording and playback controls, covering initialization, method presence, event handling, error propagation, and resource cleanup.

The most important changes are:

**Testing and Reliability Improvements**

- Added a full-featured test suite for `useWaveformController` in `useWaveformController.test.tsx`, covering initialization, playback and control methods, event updates, error handling, and resource cleanup, using Vitest and React Testing Library.

**Public API Enhancement**

- Exported `useWaveformController` from the audio module's index file, making it accessible for use in other parts of the application.

<!-- If it's a visual change, please include a screenshot or video! -->

## Testing Plan

Covered by JS tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.