### PR TITLE
[feat] Update `useLayoutStyles` to support REM type

### DIFF
--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -867,6 +867,119 @@ describe("#useLayoutStyles", () => {
       })
     })
 
+    describe("that has remWidth in widthConfig", () => {
+      it.each([
+        [
+          new streamlit.WidthConfig({ remWidth: 2.5 }),
+          getDefaultStyles({ width: "2.5rem" }),
+        ],
+        [
+          new streamlit.WidthConfig({ remWidth: 0.75 }),
+          getDefaultStyles({ width: "0.75rem" }),
+        ],
+        [
+          new streamlit.WidthConfig({ remWidth: 4.25 }),
+          getDefaultStyles({ width: "4.25rem" }),
+        ],
+      ])(
+        "and with a widthConfig value of %o, returns %o",
+        (widthConfig, expected) => {
+          const element = new MockElement({ widthConfig })
+          const { result } = renderHook(() => useLayoutStyles({ element }))
+          expect(result.current).toEqual(expected)
+        }
+      )
+    })
+
+    describe("that has remHeight in heightConfig", () => {
+      it.each([
+        [
+          new streamlit.HeightConfig({ remHeight: 2.5 }),
+          getDefaultStyles({ height: "2.5rem" }),
+        ],
+        [
+          new streamlit.HeightConfig({ remHeight: 0.75 }),
+          getDefaultStyles({ height: "0.75rem" }),
+        ],
+        [
+          new streamlit.HeightConfig({ remHeight: 4.25 }),
+          getDefaultStyles({ height: "4.25rem" }),
+        ],
+      ])(
+        "and with a heightConfig value of %o, returns %o",
+        (heightConfig, expected) => {
+          const element = new MockElement({ heightConfig })
+          const { result } = renderHook(() => useLayoutStyles({ element }))
+          expect(result.current).toEqual(expected)
+        }
+      )
+    })
+
+    describe("flex property with rem dimensions", () => {
+      it("should include flex for horizontal direction with rem width", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ remWidth: 2.5 }),
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }), {
+          wrapper: withFlexContextProvider(Direction.HORIZONTAL),
+        })
+        expect(result.current.flex).toBe("0 0 2.5rem")
+        expect(result.current.width).toBe("2.5rem")
+      })
+
+      it("should include flex for vertical direction with rem height", () => {
+        const element = new MockElement({
+          heightConfig: new streamlit.HeightConfig({ remHeight: 4.25 }),
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }), {
+          wrapper: withFlexContextProvider(Direction.VERTICAL),
+        })
+        expect(result.current.flex).toBe("0 0 4.25rem")
+        expect(result.current.height).toBe("4.25rem")
+      })
+
+      it("should not include flex for vertical direction with rem width", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ remWidth: 2.5 }),
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }), {
+          wrapper: withFlexContextProvider(Direction.VERTICAL),
+        })
+        expect(result.current.flex).toBeUndefined()
+        expect(result.current.width).toBe("2.5rem")
+      })
+
+      it("should not include flex for horizontal direction with rem height", () => {
+        const element = new MockElement({
+          heightConfig: new streamlit.HeightConfig({ remHeight: 4.25 }),
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }), {
+          wrapper: withFlexContextProvider(Direction.HORIZONTAL),
+        })
+        expect(result.current.flex).toBeUndefined()
+        expect(result.current.height).toBe("4.25rem")
+      })
+    })
+
+    describe("with both rem width and rem height", () => {
+      it("applies both rem dimensions correctly", () => {
+        const element = new MockElement({
+          widthConfig: new streamlit.WidthConfig({ remWidth: 2.5 }),
+          heightConfig: new streamlit.HeightConfig({ remHeight: 4.25 }),
+        })
+        const { result } = renderHook(() => useLayoutStyles({ element }), {
+          wrapper: withFlexContextProvider(Direction.VERTICAL),
+        })
+        expect(result.current).toEqual(
+          getDefaultStyles({
+            width: "2.5rem",
+            height: "4.25rem",
+            flex: "0 0 4.25rem",
+          })
+        )
+      })
+    })
+
     describe("with styleOverrides", () => {
       it("applies style overrides to computed styles", () => {
         const element = new MockElement({

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.ts
@@ -18,6 +18,8 @@ import { useContext, useMemo } from "react"
 
 import { Block as BlockProto, Element, streamlit } from "@streamlit/protobuf"
 
+import { assertNever } from "~lib/util/assertNever"
+
 import { FlexContext, IFlexContext } from "./FlexContext"
 import { Direction, MinFlexElementWidth } from "./utils"
 
@@ -53,12 +55,16 @@ enum DimensionType {
   PIXEL = "pixel",
   STRETCH = "stretch",
   CONTENT = "content",
+  REM = "rem",
+  AUTO = "auto",
 }
 
-type LayoutDimensionConfig = {
-  type: DimensionType | undefined
-  pixels?: number | undefined
-}
+type LayoutDimensionConfig =
+  | { type: DimensionType.STRETCH }
+  | { type: DimensionType.CONTENT }
+  | { type: DimensionType.PIXEL; pixels: number }
+  | { type: DimensionType.REM; rem: number }
+  | { type: DimensionType.AUTO }
 
 const getWidth = (
   element: Element | BlockProto,
@@ -66,12 +72,15 @@ const getWidth = (
   // level element.
   subElement?: SubElement
 ): LayoutDimensionConfig => {
+  // The current behaviour is for useContainerWidth to take precedence over
+  // width, see arrow.py for reference.
+  if (subElement?.useContainerWidth) {
+    return { type: DimensionType.STRETCH }
+  }
+
   // We need to support old width configurations for backwards compatibility,
   // since some integrations cache the messages and we want to ensure that the FE
   // can still support old message formats.
-  let pixels: number | undefined
-  let type: DimensionType | undefined
-
   const isStretch =
     element.widthConfig?.useStretch || subElement?.widthConfig?.useStretch
   const isContent =
@@ -80,33 +89,35 @@ const getWidth = (
     element?.widthConfig?.pixelWidth ||
     subElement?.widthConfig?.pixelWidth ||
     element.widthConfig?.pixelWidth === 0
+  const isRem = element.widthConfig?.remWidth
 
   if (isStretch) {
-    type = DimensionType.STRETCH
+    return { type: DimensionType.STRETCH }
   } else if (isContent) {
-    type = DimensionType.CONTENT
+    return { type: DimensionType.CONTENT }
+  } else if (isRem && isPositiveNumber(element.widthConfig?.remWidth)) {
+    return { type: DimensionType.REM, rem: element.widthConfig.remWidth }
   } else if (isPixel && isPositiveNumber(element.widthConfig?.pixelWidth)) {
-    type = DimensionType.PIXEL
-    pixels = element.widthConfig?.pixelWidth
+    return {
+      type: DimensionType.PIXEL,
+      pixels: element.widthConfig.pixelWidth,
+    }
   } else if (
     isPixel &&
     isPositiveNumber(subElement?.widthConfig?.pixelWidth)
   ) {
-    type = DimensionType.PIXEL
-    pixels = subElement?.widthConfig?.pixelWidth
+    return {
+      type: DimensionType.PIXEL,
+      pixels: subElement.widthConfig.pixelWidth,
+    }
   } else if (
     isNonZeroPositiveNumber(subElement?.width) &&
     !element.widthConfig
   ) {
-    pixels = subElement?.width
-    type = DimensionType.PIXEL
+    return { type: DimensionType.PIXEL, pixels: subElement.width }
   }
-  // The current behaviour is for useContainerWidth to take precedence over
-  // width, see arrow.py for reference.
-  if (subElement?.useContainerWidth) {
-    type = DimensionType.STRETCH
-  }
-  return { pixels, type }
+
+  return { type: DimensionType.AUTO }
 }
 
 const getHeight = (
@@ -118,62 +129,71 @@ const getHeight = (
   // We need to support old height configurations for backwards compatibility,
   // since some integrations cache the messages and we want to ensure that the FE
   // can still support old message formats.
-  let pixels: number | undefined
-  let type: DimensionType | undefined
-
   const isStretch = !!element.heightConfig?.useStretch
   const isContent = !!element.heightConfig?.useContent
   const isPixel =
     !!element.heightConfig?.pixelHeight ||
     element.heightConfig?.pixelHeight === 0
+  const isRem = element.heightConfig?.remHeight
 
   if (isStretch) {
-    type = DimensionType.STRETCH
+    return { type: DimensionType.STRETCH }
   } else if (isContent) {
-    type = DimensionType.CONTENT
+    return { type: DimensionType.CONTENT }
+  } else if (isRem && isPositiveNumber(element.heightConfig?.remHeight)) {
+    return { type: DimensionType.REM, rem: element.heightConfig.remHeight }
   } else if (isPixel && isPositiveNumber(element.heightConfig?.pixelHeight)) {
-    type = DimensionType.PIXEL
-    pixels = element.heightConfig?.pixelHeight
+    return {
+      type: DimensionType.PIXEL,
+      pixels: element.heightConfig.pixelHeight,
+    }
   } else if (
     isNonZeroPositiveNumber(subElement?.height) &&
     !element.heightConfig
   ) {
-    pixels = subElement?.height
-    type = DimensionType.PIXEL
+    return { type: DimensionType.PIXEL, pixels: subElement.height }
   }
 
-  return { pixels, type }
+  return { type: DimensionType.AUTO }
 }
 
 const getFlex = (
-  widthType: DimensionType | undefined,
-  widthPixels: number | undefined,
-  heightType: DimensionType | undefined,
-  heightPixels: number | undefined,
+  widthConfig: LayoutDimensionConfig,
+  heightConfig: LayoutDimensionConfig,
   direction: Direction | undefined,
   minStretchBehavior?: MinFlexElementWidth
 ): string | undefined => {
-  if (
-    widthType === DimensionType.PIXEL &&
-    direction === Direction.HORIZONTAL
-  ) {
-    return `0 0 ${widthPixels}px`
-  } else if (
-    heightType === DimensionType.PIXEL &&
-    direction === Direction.VERTICAL
-  ) {
-    return `0 0 ${heightPixels}px`
-  } else if (
-    widthType === DimensionType.CONTENT &&
-    direction === Direction.HORIZONTAL
-  ) {
-    return "0 0 fit-content"
-  } else if (
-    widthType === DimensionType.STRETCH &&
-    direction === Direction.HORIZONTAL
-  ) {
-    return `1 1 ${minStretchBehavior ?? "fit-content"}`
+  if (direction === Direction.HORIZONTAL) {
+    switch (widthConfig.type) {
+      case DimensionType.PIXEL:
+        return `0 0 ${widthConfig.pixels}px`
+      case DimensionType.REM:
+        return `0 0 ${widthConfig.rem}rem`
+      case DimensionType.CONTENT:
+        return "0 0 fit-content"
+      case DimensionType.STRETCH:
+        return `1 1 ${minStretchBehavior ?? "fit-content"}`
+      case DimensionType.AUTO:
+        return undefined
+      default:
+        assertNever(widthConfig)
+    }
+  } else if (direction === Direction.VERTICAL) {
+    switch (heightConfig.type) {
+      case DimensionType.PIXEL:
+        return `0 0 ${heightConfig.pixels}px`
+      case DimensionType.REM:
+        return `0 0 ${heightConfig.rem}rem`
+      case DimensionType.CONTENT:
+      case DimensionType.STRETCH:
+      case DimensionType.AUTO:
+        return undefined
+      default:
+        assertNever(heightConfig)
+    }
   }
+
+  return undefined
 }
 
 const getDirection = (
@@ -208,40 +228,57 @@ export const useLayoutStyles = ({
       }
     }
 
-    const { pixels: commandWidth, type: widthType } = getWidth(
-      element,
-      subElement
-    )
-    let width: React.CSSProperties["width"] = "auto"
-    if (widthType === DimensionType.STRETCH) {
-      width = "100%"
-    } else if (widthType === DimensionType.PIXEL) {
-      width = `${commandWidth}px`
-    } else if (widthType === DimensionType.CONTENT) {
-      width = "fit-content"
+    const widthConfig = getWidth(element, subElement)
+    let width: React.CSSProperties["width"]
+
+    switch (widthConfig.type) {
+      case DimensionType.STRETCH:
+        width = "100%"
+        break
+      case DimensionType.REM:
+        width = `${widthConfig.rem}rem`
+        break
+      case DimensionType.PIXEL:
+        width = `${widthConfig.pixels}px`
+        break
+      case DimensionType.CONTENT:
+        width = "fit-content"
+        break
+      case DimensionType.AUTO:
+        width = "auto"
+        break
+      default:
+        assertNever(widthConfig)
     }
 
-    const { pixels: commandHeight, type: heightType } = getHeight(
-      element,
-      subElement
-    )
-    let height: React.CSSProperties["height"] = "auto"
+    const heightConfig = getHeight(element, subElement)
+    let height: React.CSSProperties["height"]
     let overflow: React.CSSProperties["overflow"] = "visible"
 
-    if (heightType === DimensionType.STRETCH) {
-      height = "100%"
-    } else if (heightType === DimensionType.CONTENT) {
-      height = "auto"
-    } else if (heightType === DimensionType.PIXEL) {
-      height = `${commandHeight}px`
-      overflow = "auto"
+    switch (heightConfig.type) {
+      case DimensionType.STRETCH:
+        height = "100%"
+        break
+      case DimensionType.CONTENT:
+        height = "auto"
+        break
+      case DimensionType.REM:
+        height = `${heightConfig.rem}rem`
+        break
+      case DimensionType.PIXEL:
+        height = `${heightConfig.pixels}px`
+        overflow = "auto"
+        break
+      case DimensionType.AUTO:
+        height = "auto"
+        break
+      default:
+        assertNever(heightConfig)
     }
 
     const flex = getFlex(
-      widthType,
-      commandWidth,
-      heightType,
-      commandHeight,
+      widthConfig,
+      heightConfig,
       getDirection(flexContext),
       minStretchBehavior
     )


### PR DESCRIPTION
## Describe your changes

Adds support to `useLayoutStyles` for REM type in preparation for `st.space` which will support REM options.

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python) ✅ 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
