### PR TITLE
[feat] Styling customizations for `st.space`

### DIFF
--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -172,13 +172,33 @@ export const StyledElementContainerLayoutWrapper: FC<
     node.element.widthConfig,
   ])
 
-  const styles = useLayoutStyles({
+  let styles = useLayoutStyles({
     element: node.element,
     subElement:
       (node.element?.type && node.element[node.element.type]) || undefined,
     styleOverrides,
     minStretchBehavior,
   })
+
+  // Special handling for space elements: apply only relevant dimension
+  // to prevent unintended cross-axis spacing
+  if (node.element.type === "space") {
+    if (isInHorizontalLayout) {
+      // In horizontal layout: keep width, clear height
+      // This prevents unwanted vertical spacing
+      styles = {
+        ...styles,
+        height: "auto",
+      }
+    } else {
+      // In vertical layout (default): keep height, clear width
+      // This prevents unwanted horizontal spacing
+      styles = {
+        ...styles,
+        width: "auto",
+      }
+    }
+  }
 
   return <StyledElementContainer {...rest} {...styles} />
 }

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -88,6 +88,15 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
           display: "none",
         }
       : {}),
+    ...(elementType === "space"
+      ? {
+          // Space elements should have minimal cross-axis dimensions.
+          // The FlexContext logic in StyledElementContainerLayoutWrapper handles
+          // the primary dimension (width for horizontal, height for vertical).
+          minWidth: 0,
+          minHeight: 0,
+        }
+      : {}),
     ...(GLOBAL_ELEMENTS.includes(elementType)
       ? {
           // Global elements are rendered in their delta position, but they


### PR DESCRIPTION
## Describe your changes

`st.space` has some unique requirements. The element should have only width or height depending on the direction of the parent container (vertical = height, horizontal = width). 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

E2E tests cover this in later PRs. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
