### PR TITLE
Fix file watcher issue with common path check

### DIFF
--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -403,10 +403,16 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                         if os.path.commonpath([path, abs_changed_path]) == path:
                             changed_path_info = info
                             break
-                    except ValueError:
+                    except ValueError as ex:
                         # On Windows, os.path.commonpath raises ValueError when paths
                         # are on different drives. In that case, the changed path
                         # cannot be inside the watched directory.
+                        _LOGGER.debug(
+                            "Ignoring changed path %s.\nWatched_paths: %s",
+                            abs_changed_path,
+                            self._watched_paths,
+                            exc_info=ex,
+                        )
                         continue
 
         # If we still haven't found a matching path, ignore this event

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -397,12 +397,17 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             # directories themselves.
             if changed_path_info is None:
                 for path, info in self._watched_paths.items():
-                    if (
-                        os.path.isdir(path)
-                        and os.path.commonpath([path, abs_changed_path]) == path
-                    ):
-                        changed_path_info = info
-                        break
+                    if not os.path.isdir(path):
+                        continue
+                    try:
+                        if os.path.commonpath([path, abs_changed_path]) == path:
+                            changed_path_info = info
+                            break
+                    except ValueError:
+                        # On Windows, os.path.commonpath raises ValueError when paths
+                        # are on different drives. In that case, the changed path
+                        # cannot be inside the watched directory.
+                        continue
 
         # If we still haven't found a matching path, ignore this event
         if changed_path_info is None:

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -479,3 +479,40 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         # The test succeeds if no exceptions were thrown.
         assert t1.is_alive() is False
         assert t2.is_alive() is False
+
+    @mock.patch("os.path.isdir")
+    def test_handles_value_error_from_commonpath(self, mock_is_dir):
+        """Ensure mixed-drive-like paths (commonpath ValueError) don't crash and are ignored.
+
+        We simulate Windows mixed-drive behavior by forcing os.path.commonpath to raise
+        ValueError. The event should be ignored and no callback invoked.
+        """
+        watched_dir = "/watched"
+        mock_is_dir.side_effect = lambda p: p == watched_dir
+
+        cb = mock.Mock()
+
+        # Ensure initial md5/mtime allow watcher creation
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(watched_dir, cb)
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        fo._observer.schedule.assert_called_once()
+
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        # Simulate an event on a different "drive" by making commonpath raise
+        with mock.patch(
+            "streamlit.watcher.event_based_path_watcher.os.path.commonpath",
+            side_effect=ValueError,
+        ):
+            ev = events.FileSystemEvent("/other_drive/some_file.py")
+            ev.event_type = events.EVENT_TYPE_MODIFIED
+            folder_handler.on_modified(ev)
+
+        # The event is ignored; callback not called and no exception raised
+        cb.assert_not_called()
+
+        ro.close()


### PR DESCRIPTION
## Describe your changes

Improves error handling to prevent issues with `commonpath` operation on windows during file watching.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/12731

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
