### PR TITLE
[feat] Add buildBidiComponentURL support on frontend

### DIFF
--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -74,6 +74,10 @@ class Endpoints implements StreamlitEndpoints {
     return path
   }
 
+  public buildBidiComponentURL(componentName: string, path: string): string {
+    return path
+  }
+
   public buildMediaURL(url: string): string {
     return url
   }

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -27,6 +27,9 @@ const mockEndpoints = {
   setStaticConfigUrl: vi.fn(),
   sendClientErrorToHost: vi.fn(),
   checkSourceUrlResponse: vi.fn(),
+  buildBidiComponentURL: vi.fn(
+    (componentName: string, path: string) => `${componentName}/${path}`
+  ),
   buildComponentURL: vi.fn(
     (componentName: string, path: string) => `${componentName}/${path}`
   ),

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -47,6 +47,7 @@ interface Props {
 const MEDIA_ENDPOINT = "/media"
 const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file"
 const COMPONENT_ENDPOINT_BASE = "/component"
+const BIDI_COMPONENT_ENDPOINT_BASE = "/_stcore/bidi-components"
 
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
 export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
@@ -142,6 +143,13 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     return buildHttpUri(
       this.requireServerUri(),
       `${COMPONENT_ENDPOINT_BASE}/${componentName}/${path}`
+    )
+  }
+
+  public buildBidiComponentURL(componentName: string, path: string): string {
+    return buildHttpUri(
+      this.requireServerUri(),
+      `${BIDI_COMPONENT_ENDPOINT_BASE}/${componentName}/${path}`
     )
   }
 

--- a/frontend/connection/src/testUtils.ts
+++ b/frontend/connection/src/testUtils.ts
@@ -27,6 +27,7 @@ export function mockEndpoints(
     sendClientErrorToHost: vi.fn(),
     checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
+    buildBidiComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildDownloadUrl: vi.fn(),
     buildFileUploadURL: vi.fn(),

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -105,6 +105,13 @@ export interface StreamlitEndpoints {
   buildComponentURL(componentName: string, path: string): string
 
   /**
+   * Return a URL to fetch data for the given bidirectional component.
+   * @param componentName The registered name of the component.
+   * @param path The path of the component resource to fetch, e.g. "script.js".
+   */
+  buildBidiComponentURL(componentName: string, path: string): string
+
+  /**
    * Construct a URL for a media file.
    * @param url a relative or absolute URL. If `url` is absolute, it will be
    * returned unchanged. Otherwise, the return value will be a URL for fetching

--- a/frontend/lib/src/FileUploadClient.test.ts
+++ b/frontend/lib/src/FileUploadClient.test.ts
@@ -40,6 +40,7 @@ describe("FileUploadClient Upload", () => {
         sendClientErrorToHost: vi.fn(),
         checkSourceUrlResponse: vi.fn(),
         buildComponentURL: vi.fn(),
+        buildBidiComponentURL: vi.fn(),
         buildMediaURL: vi.fn(),
         buildDownloadUrl: vi.fn(),
         buildFileUploadURL: vi.fn(),

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -67,6 +67,13 @@ export interface StreamlitEndpoints {
   buildComponentURL(componentName: string, path: string): string
 
   /**
+   * Return a URL to fetch data for the given bidirectional component.
+   * @param componentName The registered name of the component.
+   * @param path The path of the component resource to fetch, e.g. "script.js".
+   */
+  buildBidiComponentURL(componentName: string, path: string): string
+
+  /**
    * Construct a URL for a media file.
    * @param url a relative or absolute URL. If `url` is absolute, it will be
    * returned unchanged. Otherwise, the return value will be a URL for fetching

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -145,6 +145,7 @@ const noOpEndpoints: StreamlitEndpoints = {
   sendClientErrorToHost: () => {},
   checkSourceUrlResponse: () => Promise.resolve(),
   buildComponentURL: () => "",
+  buildBidiComponentURL: () => "",
   buildMediaURL: () => "",
   buildDownloadUrl: () => "",
   buildFileUploadURL: () => "",

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -98,6 +98,14 @@ export class ComponentRegistry {
     return this.endpoints.buildComponentURL(componentName, path)
   }
 
+  /** Return a URL for fetching a resource for the given bidirectional component. */
+  public getBidiComponentURL = (
+    componentName: string,
+    path: string
+  ): string => {
+    return this.endpoints.buildBidiComponentURL(componentName, path)
+  }
+
   private onMessageEvent = (event: MessageEvent): void => {
     if (
       isNullOrUndefined(event.data) ||

--- a/frontend/lib/src/mocks/mocks.ts
+++ b/frontend/lib/src/mocks/mocks.ts
@@ -58,6 +58,7 @@ export function mockEndpoints(
     sendClientErrorToHost: vi.fn(),
     checkSourceUrlResponse: vi.fn(),
     buildComponentURL: vi.fn(),
+    buildBidiComponentURL: vi.fn(),
     buildMediaURL: vi.fn(),
     buildDownloadUrl: vi.fn(),
     buildFileUploadURL: vi.fn(),


### PR DESCRIPTION
## Describe your changes

Added FE support for CCv2 components by implementing a new `buildBidiComponentURL` method in the `StreamlitEndpoints` interface. This method constructs URLs for fetching data from bidirectional components using the `/_stcore/bidi-components` endpoint base.

The implementation includes:
- Adding the method to the `StreamlitEndpoints` interface
- Implementing the method in `DefaultStreamlitEndpoints`
- Adding a corresponding method in `ComponentRegistry`
- Updating mock implementations in test files

## GitHub Issue Link (if applicable)

## Testing Plan

- The changes are primarily interface additions with straightforward implementations
- Updated existing test files to include the new method
- The implementation follows the same pattern as the existing `buildComponentURL` method

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.