### PR TITLE
[feat] Add support for multiple callbacks on frontend

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom"
 import { enableMapSet, enablePatches } from "immer"
+import { getLogger } from "loglevel"
 import { Mock } from "vitest"
 
 import {
@@ -102,23 +104,29 @@ describe("Widget State Manager", () => {
   }
 
   /** Assert calls of our callback functions. */
-  const assertCallbacks = ({ insideForm }: { insideForm: boolean }): void => {
+  const assertCallbacks = async ({
+    insideForm,
+  }: {
+    insideForm: boolean
+  }): Promise<void> => {
     if (insideForm) {
       expect(sendBackMsg).not.toHaveBeenCalled()
     } else {
-      expect(sendBackMsg).toHaveBeenCalledTimes(1)
-      expect(sendBackMsg).toHaveBeenCalledWith(
-        expect.anything(),
-        undefined, // fragmentId
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(sendBackMsg).toHaveBeenCalledTimes(1)
+        expect(sendBackMsg).toHaveBeenCalledWith(
+          expect.anything(),
+          undefined, // fragmentId
+          undefined,
+          undefined
+        )
+      })
     }
   }
 
   it.each([false, true])(
-    "sets string value correctly (insideForm=%p)",
-    insideForm => {
+    "sets string value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setStringValue(
         widget,
@@ -127,37 +135,37 @@ describe("Widget State Manager", () => {
         undefined
       )
       expect(widgetMgr.getStringValue(widget)).toBe("mockStringValue")
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets boolean value correctly (insideForm=%p)",
-    insideForm => {
+    "sets boolean value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
       expect(widgetMgr.getBoolValue(widget)).toBe(true)
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets int value correctly (insideForm=%p)",
-    insideForm => {
+    "sets int value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setIntValue(widget, 100, { fromUi: true }, undefined)
       expect(widgetMgr.getIntValue(widget)).toBe(100)
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets float value correctly (insideForm=%p)",
-    insideForm => {
+    "sets double value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setDoubleValue(widget, 3.14, { fromUi: true }, undefined)
       expect(widgetMgr.getDoubleValue(widget)).toBe(3.14)
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
@@ -171,12 +179,12 @@ describe("Widget State Manager", () => {
 
     // @ts-expect-error
     expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
-    assertCallbacks({ insideForm: false })
+    await assertCallbacks({ insideForm: false })
   })
 
   it.each([false, true])(
-    "sets string array value correctly (insideForm=%p)",
-    insideForm => {
+    "sets string array value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setStringArrayValue(
         widget,
@@ -191,13 +199,13 @@ describe("Widget State Manager", () => {
         "bar",
         "baz",
       ])
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets int array value correctly (insideForm=%p)",
-    insideForm => {
+    "sets int array value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setIntArrayValue(
         widget,
@@ -206,13 +214,13 @@ describe("Widget State Manager", () => {
         undefined
       )
       expect(widgetMgr.getIntArrayValue(widget)).toEqual([4, 5, 6])
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets float array value correctly (insideForm=%p)",
-    insideForm => {
+    "sets double array value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setDoubleArrayValue(
         widget,
@@ -223,13 +231,13 @@ describe("Widget State Manager", () => {
         undefined
       )
       expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([1.1, 2.2, 3.3])
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets ArrowTable value correctly (insideForm=%p)",
-    insideForm => {
+    "sets ArrowTable value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setArrowValue(
         widget,
@@ -238,13 +246,13 @@ describe("Widget State Manager", () => {
         undefined
       )
       expect(widgetMgr.getArrowValue(widget)).toEqual(MOCK_ARROW_TABLE)
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets JSON value correctly (insideForm=%p)",
-    insideForm => {
+    "sets JSON value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setJsonValue(
         widget,
@@ -255,23 +263,23 @@ describe("Widget State Manager", () => {
         undefined
       )
       expect(widgetMgr.getJsonValue(widget)).toBe(JSON.stringify(MOCK_JSON))
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets bytes value correctly (insideForm=%p)",
-    insideForm => {
+    "sets bytes value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setBytesValue(widget, MOCK_BYTES, { fromUi: true }, undefined)
       expect(widgetMgr.getBytesValue(widget)).toEqual(MOCK_BYTES)
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
   it.each([false, true])(
-    "sets FileUploaderState value correctly (insideForm=%p)",
-    insideForm => {
+    "sets FileUploaderState value correctly (insideForm=%s)",
+    async insideForm => {
       const widget = getWidget({ insideForm })
       widgetMgr.setFileUploaderStateValue(
         widget,
@@ -284,7 +292,7 @@ describe("Widget State Manager", () => {
       expect(widgetMgr.getFileUploaderStateValue(widget)).toEqual(
         MOCK_FILE_UPLOADER_STATE
       )
-      assertCallbacks({ insideForm })
+      await assertCallbacks({ insideForm })
     }
   )
 
@@ -376,7 +384,7 @@ describe("Widget State Manager", () => {
         setterMethod: "setFileUploaderStateValue",
         value: MOCK_FILE_UPLOADER_STATE,
       },
-    ])("%p", async ({ setterMethod, value }) => {
+    ])("%s", async ({ setterMethod, value }) => {
       // @ts-expect-error
       await widgetMgr[setterMethod](
         MOCK_WIDGET,
@@ -386,12 +394,14 @@ describe("Widget State Manager", () => {
         },
         "myFragmentId"
       )
-      expect(sendBackMsg).toHaveBeenCalledWith(
-        expect.anything(),
-        "myFragmentId",
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(sendBackMsg).toHaveBeenCalledWith(
+          expect.anything(),
+          "myFragmentId",
+          undefined,
+          undefined
+        )
+      })
     })
 
     // This test isn't parameterized like the ones above because setTriggerValue
@@ -431,7 +441,7 @@ describe("Widget State Manager", () => {
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(JSON.stringify(45))
     })
 
-    it("sets float value as JSON correctly", () => {
+    it("sets double value as JSON correctly", () => {
       widgetMgr.setJsonValue(MOCK_WIDGET, 3.14, { fromUi: true }, undefined)
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(JSON.stringify(3.14))
     })
@@ -462,7 +472,7 @@ describe("Widget State Manager", () => {
       )
     })
 
-    it("sets float array value as JSON correctly", () => {
+    it("sets double array value as JSON correctly", () => {
       widgetMgr.setJsonValue(
         MOCK_WIDGET,
         [1.1, 2.2, 3.3],
@@ -1135,5 +1145,296 @@ describe("WidgetStateDict", () => {
         },
       ],
     })
+  })
+})
+
+// New tests for isolated batched JSON APIs
+describe("Trigger JSON payloads (aggregated)", () => {
+  let sendBackMsg: Mock
+  let widgetMgr: WidgetStateManager
+
+  beforeEach(() => {
+    sendBackMsg = vi.fn()
+    widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg: sendBackMsg,
+      formsDataChanged: vi.fn(),
+    })
+  })
+
+  it("setTriggerValue(payload): uses jsonTriggerValue field", async () => {
+    const widget = { id: "batchedTriggerWidget", formId: "" }
+
+    await widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragT", {
+      t: 1,
+    })
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedTriggerWidget",
+            jsonTriggerValue: JSON.stringify([{ t: 1 }]),
+          },
+        ],
+      },
+      "fragT",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setJsonValue and setTriggerValue(payload): coalesce to one back message", async () => {
+    const widget = { id: "jsonAndTriggerCoalesce", formId: "" }
+    const jsonValue = { foo: "bar" }
+    const triggerPayload = { baz: 42 }
+
+    widgetMgr.setJsonValue(widget, jsonValue, { fromUi: true }, "fragJT")
+
+    const triggerPromise = widgetMgr.setTriggerValue(
+      widget,
+      { fromUi: true },
+      "fragJT",
+      triggerPayload
+    )
+
+    await triggerPromise
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "jsonAndTriggerCoalesce",
+            jsonValue: JSON.stringify(jsonValue),
+            jsonTriggerValue: JSON.stringify([triggerPayload]),
+          },
+        ],
+      },
+      "fragJT",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setTriggerValue(payload): aggregates multiple payloads into a JSON array in one macrotask", async () => {
+    const widget = { id: "batchedTriggerAgg", formId: "" }
+
+    const p1 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragAgg", {
+      a: 1,
+    })
+    const p2 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragAgg", {
+      b: 2,
+    })
+
+    await Promise.all([p1, p2])
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedTriggerAgg",
+            jsonTriggerValue: JSON.stringify([{ a: 1 }, { b: 2 }]),
+          },
+        ],
+      },
+      "fragAgg",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setTriggerValue(payload): aggregates three payloads and sends once", async () => {
+    const widget = { id: "batchedTriple", formId: "" }
+
+    const p1 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "frag3", {
+      x: 1,
+    })
+    const p2 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "frag3", {
+      y: 2,
+    })
+    const p3 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "frag3", {
+      z: 3,
+    })
+
+    await Promise.all([p1, p2, p3])
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedTriple",
+            jsonTriggerValue: JSON.stringify([{ x: 1 }, { y: 2 }, { z: 3 }]),
+          },
+        ],
+      },
+      "frag3",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setTriggerValue(payload): batches even when fragments differ, using the first fragment id", async () => {
+    // Note that this flow shouldn't actually happen in practice. We shouldn't
+    // be updating multiple fragments in the same macrotask. This test is
+    // written now to test the behavior of the code, but it can change in the
+    // future if we decide to change the behavior.
+    const widget = { id: "batchedFragment", formId: "" }
+
+    const p1 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "f1", {
+      a: 1,
+    })
+    const p2 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "f2", {
+      b: 2,
+    })
+
+    await Promise.all([p1, p2])
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedFragment",
+            jsonTriggerValue: JSON.stringify([{ a: 1 }, { b: 2 }]),
+          },
+        ],
+      },
+      "f1",
+      undefined,
+      undefined
+    )
+  })
+
+  it("logs a warning and uses the first fragmentId when batch contains mixed fragmentIds", async () => {
+    const logger = getLogger("WidgetStateManager")
+    const warnSpy = vi.spyOn(logger, "warn")
+
+    const widget = { id: "warnMixedFragments", formId: "" }
+
+    const p1 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragA", {
+      a: true,
+    })
+    const p2 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragB", {
+      b: true,
+    })
+
+    await Promise.all([p1, p2])
+
+    // Uses the first fragment id
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      expect.anything(),
+      "fragA",
+      undefined,
+      undefined
+    )
+
+    // Logs exactly one warning for the batch
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const [msg, usedFragment] = warnSpy.mock.calls[0]
+    expect(String(msg)).toContain("Multiple different fragmentIds")
+    expect(usedFragment).toBe("fragA")
+
+    warnSpy.mockRestore()
+  })
+
+  it("setTriggerValue(payload): retains existing fragment id if subsequent calls omit it", async () => {
+    const widget = { id: "batchedFragmentFallback", formId: "" }
+
+    const p1 = widgetMgr.setTriggerValue(widget, { fromUi: true }, "fKeep", {
+      first: true,
+    })
+    const p2 = widgetMgr.setTriggerValue(widget, { fromUi: true }, undefined, {
+      second: true,
+    })
+
+    await Promise.all([p1, p2])
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedFragmentFallback",
+            jsonTriggerValue: JSON.stringify([
+              { first: true },
+              { second: true },
+            ]),
+          },
+        ],
+      },
+      "fKeep",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setTriggerValue(payload): merges with existing scalar jsonTriggerValue", async () => {
+    const widget = { id: "batchedScalarPrev", formId: "" }
+
+    // Pre-seed an existing scalar jsonTriggerValue
+    ;(
+      widgetMgr as unknown as {
+        widgetStates: {
+          createState: (id: string) => { jsonTriggerValue?: string }
+        }
+      }
+    ).widgetStates.createState(widget.id).jsonTriggerValue = JSON.stringify({
+      prev: 1,
+    })
+
+    await widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragS", {
+      next: 2,
+    })
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedScalarPrev",
+            jsonTriggerValue: JSON.stringify([{ prev: 1 }, { next: 2 }]),
+          },
+        ],
+      },
+      "fragS",
+      undefined,
+      undefined
+    )
+  })
+
+  it("setTriggerValue(payload): parse failure falls back to [prevString, payload]", async () => {
+    const widget = { id: "batchedParseFail", formId: "" }
+
+    // Pre-seed an invalid JSON string as previous value
+    ;(
+      widgetMgr as unknown as {
+        widgetStates: {
+          createState: (id: string) => { jsonTriggerValue?: string }
+        }
+      }
+    ).widgetStates.createState(widget.id).jsonTriggerValue = "NOT JSON"
+
+    await widgetMgr.setTriggerValue(widget, { fromUi: true }, "fragPF", {
+      ok: true,
+    })
+
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    expect(sendBackMsg).toHaveBeenCalledWith(
+      {
+        widgets: [
+          {
+            id: "batchedParseFail",
+            jsonTriggerValue: JSON.stringify(["NOT JSON", { ok: true }]),
+          },
+        ],
+      },
+      "fragPF",
+      undefined,
+      undefined
+    )
   })
 })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -15,6 +15,7 @@
  */
 
 import { Draft, produce } from "immer"
+import { getLogger } from "loglevel"
 import { Long, util } from "protobufjs"
 import { Signal, SignalConnection } from "typed-signals"
 
@@ -31,7 +32,11 @@ import {
   WidgetStates,
 } from "@streamlit/protobuf"
 
-import { isValidFormId, notNullOrUndefined } from "~lib/util/utils"
+import {
+  isNullOrUndefined,
+  isValidFormId,
+  notNullOrUndefined,
+} from "~lib/util/utils"
 export interface Source {
   fromUi: boolean
 }
@@ -69,6 +74,8 @@ export function createFormsData(): FormsData {
     submitButtons: new Map(),
   }
 }
+
+const LOG = getLogger("WidgetStateManager")
 
 /**
  * A Dictionary that maps widgetID -> WidgetState, and provides some utility
@@ -193,6 +200,37 @@ export class WidgetStateManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   private readonly elementStates = new Map<string, Map<string, any>>()
 
+  /**
+   * Debouncing helpers for trigger widgets.
+   *
+   * Multiple calls to `setTriggerValue` that happen within the same
+   * JavaScript macrotask (for example, when a single click handler invokes
+   * `setTriggerValue` several times for different trigger names) should be
+   * batched into a single `updateWidgets` message. Otherwise, each call would
+   * schedule its own `setTimeout(…, 0)` which results in multiple
+   * `updateWidgets` messages being sent in quick succession. The Streamlit
+   * backend only handles the *latest* message before rerunning the script,
+   * which means earlier triggers can be lost. We fix this by batching.
+   */
+  private pendingTriggerIds = new Set<string>()
+
+  /** Promise resolvers that should run once the pending trigger batch has
+   *  been flushed to the backend. */
+  private triggerFlushResolvers: Array<() => void> = []
+
+  /** Indicates whether we already scheduled a macrotask-level flush. */
+  private flushScheduled = false
+
+  /** The fragmentId associated with the currently scheduled flush (if any). */
+  private scheduledFragmentId: string | undefined
+
+  /**
+   * Tracks whether we've already logged a mixed-fragmentId warning for the
+   * currently scheduled batch. This prevents spamming the console if multiple
+   * conflicting calls happen in the same macrotask.
+   */
+  private hasFragmentIdConflict = false
+
   constructor(props: Props) {
     this.props = props
     this.formsData = createFormsData()
@@ -282,53 +320,116 @@ export class WidgetStateManager {
     }
   }
 
-  /* Sometimes users change an input field and directly click on a button - which uses the trigger value -
-   * to trigger a rerun. We wrap the code that sends the trigger update in `setTimeout` so that trigger-based
-   * updates will be executed at the end of JavaScript's event loop. Callbacks for other elements, for example,
-   * the onBlur event of an input field, will be deterministically executed first in the event loop since they
-   * were encountered first in the sequential execution and will be executed FIFO from the task queue.
-   *
-   * Returns a promise that is resolved as soon as the timeout was triggered, mainly to make this easier to test.
-   * in our unit tests.
-   */
-  private setTriggerValueAtEndOfEventLoop(
-    widget: WidgetInfo,
-    source: Source,
-    fragmentId: string | undefined
-  ): Promise<void> {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        this.onWidgetValueChanged(widget.formId, source, fragmentId)
-        this.deleteWidgetState(widget.id)
-        resolve()
-      }, 0)
-    })
-  }
-
   public setChatInputValue(
     widget: WidgetInfo,
     value: IChatInputValue,
     source: Source,
     fragmentId: string | undefined
   ): void {
+    // ------------------------------------------------------------------
+    // ChatInput behaves like a trigger widget: its value should be sent to
+    // the backend exactly once and then be cleared so that subsequent
+    // reruns receive an "empty" value. With the introduction of batched
+    // trigger handling, we align ChatInput with the same mechanism used by
+    // `setTriggerValue` to avoid race conditions when multiple updates are
+    // emitted within the same macrotask.
+    // ------------------------------------------------------------------
+
+    // 1. Store the value in a temporary WidgetState proto.
     this.createWidgetState(widget, source).chatInputValue = new ChatInputValue(
       value
     )
-    this.onWidgetValueChanged(widget.formId, source, fragmentId)
-    this.deleteWidgetState(widget.id)
+
+    // 2. Mark this widget ID so that it is cleaned-up after the pending
+    //    batch flush. The `scheduleFlush` helper already takes care of
+    //    deleting all IDs present in `pendingTriggerIds` once the update
+    //    message has been sent.
+    this.pendingTriggerIds.add(widget.id)
+
+    // 3. Schedule (or reuse) a macrotask-level flush so that ChatInput
+    //    updates are coalesced with other trigger/value updates that happen
+    //    during the same event loop tick.
+    this.scheduleFlush(fragmentId)
   }
 
   /**
-   * Sets the trigger value for the given widget ID to true, sends a rerunScript message
-   * to the server, and then immediately unsets the trigger value.
+   * 1. Boolean trigger
+   *    setTriggerValue(widgetInfo, { fromUi: true }, fragmentId)
+   *
+   * 2. Payload (JSON-encoded) trigger
+   *    setTriggerValue(widgetInfo, { fromUi: true }, fragmentId, payload)
+   *
+   *    `payload` can be any JSON-serialisable value. For Bidi Component v2
+   *    we always transport payloads via the protobuf `json_trigger_value`
+   *    field as a JSON-stringified array of payload objects. Multiple calls
+   *    within the same macrotask are batched into that array. If `payload`
+   *    is omitted (or `undefined`) we fall back to the boolean
+   *    `trigger_value=true` behaviour.
    */
-  public setTriggerValue(
+
+  public setTriggerValue<T extends Record<string, unknown>>(
     widget: WidgetInfo,
     source: Source,
-    fragmentId: string | undefined
+    fragmentId: string | undefined,
+    value?: T
   ): Promise<void> {
-    this.createWidgetState(widget, source).triggerValue = true
-    return this.setTriggerValueAtEndOfEventLoop(widget, source, fragmentId)
+    // If we already have a pending trigger for this widget in the current
+    // macrotask, append to it instead of overwriting so multiple triggers are
+    // delivered in a single backend message.
+    let widgetState = this.getWidgetState(widget)
+    if (widgetState === undefined) {
+      widgetState = this.createWidgetState(widget, source)
+    }
+
+    if (value === undefined) {
+      // Simple boolean trigger.
+      widgetState.triggerValue = true
+    } else {
+      // Custom Components v2: always encode payloads as a JSON array.
+      // To batch multiple trigger events in the same macrotask, we store
+      // payloads as a JSON-stringified array. On each call, we parse
+      // the existing string, append the new payload, and re-stringify.
+      const nextPayloadObject = value
+
+      try {
+        if (isNullOrUndefined(widgetState.jsonTriggerValue)) {
+          // First payload -> start an array.
+          widgetState.jsonTriggerValue = JSON.stringify([nextPayloadObject])
+        } else {
+          // Subsequent payloads -> append to existing array
+          const prevRaw = widgetState.jsonTriggerValue
+          const prevParsed = JSON.parse(prevRaw)
+          const prevArray = Array.isArray(prevParsed)
+            ? prevParsed
+            : [prevParsed]
+          prevArray.push(nextPayloadObject)
+          widgetState.jsonTriggerValue = JSON.stringify(prevArray)
+        }
+      } catch (error) {
+        // In the unlikely event prior state was not valid JSON, fall back to a 2-item array.
+        LOG.error(
+          "Failed to parse or stringify widgetState.jsonTriggerValue:",
+          error
+        )
+        widgetState.jsonTriggerValue = JSON.stringify([
+          widgetState.jsonTriggerValue,
+          nextPayloadObject,
+        ])
+      }
+    }
+
+    // --------------------------------------------------------------
+    // Batch trigger updates fired during the same JavaScript macrotask.
+    // --------------------------------------------------------------
+    this.pendingTriggerIds.add(widget.id)
+
+    return new Promise(resolve => {
+      // Queue resolver so callers still get the same promise-based API.
+      this.triggerFlushResolvers.push(resolve)
+
+      // Schedule (or reuse) a macrotask-level flush.
+      this.scheduleFlush(fragmentId)
+    })
   }
 
   public getBoolValue(widget: WidgetInfo): boolean | undefined {
@@ -588,7 +689,8 @@ export class WidgetStateManager {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
     } else if (source.fromUi) {
-      this.sendUpdateWidgetsMessage(fragmentId)
+      // Batch value changes that occur within the same JavaScript macrotask.
+      this.scheduleFlush(fragmentId)
     }
   }
 
@@ -836,6 +938,64 @@ export class WidgetStateManager {
     } else {
       this.elementStates.delete(elementId)
     }
+  }
+
+  /**
+   * Schedule a macrotask-level flush of pending widget updates (triggers and
+   * regular value changes). Multiple calls within the same macrotask will be
+   * coalesced into a single `updateWidgets` message.
+   */
+  private scheduleFlush(fragmentId: string | undefined): void {
+    // Update the stored fragmentId if we don't have one yet. If multiple calls
+    // happen and at least one of them specifies a fragmentId, we keep the
+    // first non-undefined value.
+    if (this.scheduledFragmentId === undefined) {
+      this.scheduledFragmentId = fragmentId
+    }
+
+    // If we already have a scheduled fragmentId and a new (different) one is
+    // provided in the same macrotask, log a warning and proceed with the first
+    // one. This acknowledges a rare edge case where multiple components could
+    // trigger updates tied to different fragments in one batch. We've decided
+    // to prefer to warn rather than throw; this leaves us exposed to potential
+    // bugs in very unusual setups. We can tighten this in the future if
+    // real-world issues arise.
+    if (
+      this.scheduledFragmentId !== undefined &&
+      fragmentId !== undefined &&
+      fragmentId !== this.scheduledFragmentId &&
+      !this.hasFragmentIdConflict
+    ) {
+      LOG.warn(
+        "Unexpected state: Multiple different fragmentIds detected in a single batch of widget updates. Proceeding with flushing updates using fragmentId '%s' for this batch.",
+        this.scheduledFragmentId
+      )
+      this.hasFragmentIdConflict = true
+    }
+
+    if (this.flushScheduled) {
+      return
+    }
+
+    this.flushScheduled = true
+
+    setTimeout(() => {
+      // Send a *single* widgets update containing **all** pending updates.
+      this.sendUpdateWidgetsMessage(this.scheduledFragmentId)
+
+      // Clean-up temporary trigger widget states so they don't leak into future updates.
+      this.pendingTriggerIds.forEach(id => this.deleteWidgetState(id))
+      this.pendingTriggerIds.clear()
+
+      // Resolve all promises that were waiting for this flush.
+      this.triggerFlushResolvers.forEach(r => r())
+      this.triggerFlushResolvers = []
+
+      // Reset scheduling flags.
+      this.flushScheduled = false
+      this.scheduledFragmentId = undefined
+      this.hasFragmentIdConflict = false
+    }, 0)
   }
 }
 

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom"
+
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"
 
 import { mockTheme } from "~lib/mocks/mockTheme"
@@ -391,7 +393,7 @@ describe("PlotlyChart utils", () => {
   })
 
   describe("sendEmptySelection", () => {
-    it("sets empty selection state", () => {
+    it("sets empty selection state", async () => {
       const sendRerunBackMsg = vi.fn()
       const widgetMgr = new WidgetStateManager({
         sendRerunBackMsg,
@@ -407,24 +409,26 @@ describe("PlotlyChart utils", () => {
         '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}'
       )
 
-      // Verify rerun message is sent with correct widget states
-      expect(sendRerunBackMsg).toHaveBeenCalledWith(
-        {
-          widgets: [
-            {
-              id: "plotly_chart",
-              stringValue:
-                '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
-            },
-          ],
-        },
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        // Verify rerun message is sent with correct widget states
+        expect(sendRerunBackMsg).toHaveBeenCalledWith(
+          {
+            widgets: [
+              {
+                id: "plotly_chart",
+                stringValue:
+                  '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
-    it("sets empty selection state and sends rerun with fragmentId", () => {
+    it("sets empty selection state and sends rerun with fragmentId", async () => {
       const sendRerunBackMsg = vi.fn()
       const widgetMgr = new WidgetStateManager({
         sendRerunBackMsg,
@@ -442,20 +446,22 @@ describe("PlotlyChart utils", () => {
       )
 
       // Verify rerun message is sent with correct widget states and fragmentId
-      expect(sendRerunBackMsg).toHaveBeenCalledWith(
-        {
-          widgets: [
-            {
-              id: "plotly_chart",
-              stringValue:
-                '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
-            },
-          ],
-        },
-        fragmentId,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(sendRerunBackMsg).toHaveBeenCalledWith(
+          {
+            widgets: [
+              {
+                id: "plotly_chart",
+                stringValue:
+                  '{"selection":{"points":[],"point_indices":[],"box":[],"lasso":[]}}',
+              },
+            ],
+          },
+          fragmentId,
+          undefined,
+          undefined
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
## Describe your changes

This PR adds the ability to send multiple callback updates in a single task from the frontend. This prevents race conditions where multiple trigger updates sent in the same macrotask could result in only the latest one being processed by the backend.

This is important for CCv2 because components can set multiple pieces of state in the same macrotask, such as:

```tsx
setTriggerValue("foo", true);
setTriggerValue("bar", false);
setStateValue("baz", 123);
```

Key changes:
- Added batching mechanism for widget updates
- Implemented JSON payload aggregation for trigger widgets
- Aligned ChatInput behavior with the same batching mechanism
- Updated tests to use async/await with waitFor to properly test asynchronous widget updates

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive test suite for the new batched trigger functionality, including tests for:
  - Single trigger payloads
  - Multiple aggregated payloads
  - Coalescing JSON values with trigger values
  - Edge cases like parse failures and fragment ID handling
- A few existing tests were updated to use async/await pattern with waitFor to properly test the asynchronous widget update behavior

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.