### PR TITLE
[feat] Add constants and helper utils for CCv2 frontend

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/constants.test.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/constants.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the shared EVENT_DELIM constant used within BidiComponent helpers.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  ARROW_REF_KEY,
+  EVENT_DELIM,
+} from "~lib/components/widgets/BidiComponent/constants"
+
+describe("EVENT_DELIM constant", () => {
+  it("should be defined", () => {
+    expect(EVENT_DELIM).toBe("__")
+  })
+})
+
+describe("ARROW_REF_KEY constant", () => {
+  it("should be defined and equal '__streamlit_arrow_ref__'", () => {
+    expect(ARROW_REF_KEY).toBe("__streamlit_arrow_ref__")
+  })
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/constants.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared constant that is used to delimit the event name from the base id.
+ * This value **must** stay in sync with its Python counterpart defined in
+ * `streamlit.components.v2.bidi_component`.
+ */
+export const EVENT_DELIM = "__" as const
+
+/**
+ * Shared constant that is used to identify ArrowReference objects in the data
+ * structure. This value **must** stay in sync with its Python counterpart
+ * defined in `streamlit.components.v2.bidi_component`.
+ */
+export const ARROW_REF_KEY = "__streamlit_arrow_ref__" as const
+
+/**
+ * Shared constant that is used to prefix internal Streamlit keys.
+ * This value **must** stay in sync with its Python counterpart defined in
+ * `streamlit.runtime.state.session_state`.
+ */
+export const STREAMLIT_INTERNAL_KEY_PREFIX =
+  "$$STREAMLIT_INTERNAL_KEY" as const

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/error.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/error.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LOG } from "~lib/components/widgets/BidiComponent/utils/logger"
+
+/**
+ * Normalize errors to a standard Error object
+ */
+export const normalizeError = (error: unknown, context?: string): Error => {
+  if (error instanceof Error) {
+    return error
+  }
+
+  const message = context ? `${context}: ${String(error)}` : String(error)
+  return new Error(message)
+}
+
+/**
+ * Centralized error handler to log and set error state
+ */
+export const handleError = (
+  error: unknown,
+  setError: (error: Error) => void,
+  context?: string
+): void => {
+  const normalizedError = normalizeError(error, context)
+  LOG.error(`BidiComponent Error: ${normalizedError.message}`, error)
+  setError(normalizedError)
+}

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/idBuilder.test.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/idBuilder.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { STREAMLIT_INTERNAL_KEY_PREFIX } from "~lib/components/widgets/BidiComponent/constants"
+import {
+  makeTriggerAggregatorId,
+  TRIGGER_AGGREGATOR_SUFFIX,
+} from "~lib/components/widgets/BidiComponent/utils/idBuilder"
+
+describe("utils/idBuilder", () => {
+  describe("makeTriggerAggregatorId", () => {
+    it("creates aggregator IDs with internal prefix to hide them from session state", () => {
+      expect(makeTriggerAggregatorId("myComponent")).toBe(
+        `${STREAMLIT_INTERNAL_KEY_PREFIX}_myComponent__${TRIGGER_AGGREGATOR_SUFFIX}`
+      )
+    })
+
+    it("concatenates base and suffix with the expected format", () => {
+      const aggregatorIds = [
+        makeTriggerAggregatorId("component123"),
+        makeTriggerAggregatorId("anotherComponent"),
+      ]
+
+      aggregatorIds.forEach(aggregatorId => {
+        // Should start with internal prefix
+        expect(aggregatorId).toMatch(
+          new RegExp(`^\\$\\$STREAMLIT_INTERNAL_KEY_`)
+        )
+        // Should contain the delimiter
+        expect(aggregatorId).toMatch(/__/)
+        // Should be structured as prefix_base__events
+        expect(aggregatorId).toMatch(
+          new RegExp(
+            `^\\$\\$STREAMLIT_INTERNAL_KEY_[^_]+__${TRIGGER_AGGREGATOR_SUFFIX}$`
+          )
+        )
+      })
+    })
+
+    it("throws when base contains the delimiter", () => {
+      expect(() => makeTriggerAggregatorId("bad__base")).toThrow()
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/idBuilder.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/idBuilder.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  EVENT_DELIM,
+  STREAMLIT_INTERNAL_KEY_PREFIX,
+} from "~lib/components/widgets/BidiComponent/constants"
+
+/**
+ * Suffix used for the trigger-aggregator widget id.
+ */
+export const TRIGGER_AGGREGATOR_SUFFIX = "events" as const
+
+/**
+ * Build the trigger-aggregator widget id given a component's base id.
+ *
+ * Aggregator widgets are marked as internal by prefixing with the internal key prefix,
+ * so they won't be exposed in st.session_state to end users.
+ *
+ * @throws {Error} If base contains the delimiter. This prevents ambiguous ids.
+ */
+export function makeTriggerAggregatorId(base: string): string {
+  if (base.includes(EVENT_DELIM)) {
+    throw new Error(
+      "Base component id must not contain the delimiter sequence"
+    )
+  }
+
+  return `${STREAMLIT_INTERNAL_KEY_PREFIX}_${base}${EVENT_DELIM}${TRIGGER_AGGREGATOR_SUFFIX}`
+}

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/logger.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/logger.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getLogger } from "loglevel"
+
+export const LOG = getLogger("BidiComponent")


### PR DESCRIPTION
## Describe your changes

Added foundational utilities for the CCv2 frontend implementation:

1. Created constants module with shared values that must stay in sync with Python counterparts:
   - `EVENT_DELIM`: Delimiter for event names and base IDs
   - `ARROW_REF_KEY`: Identifier for ArrowReference objects
   - `STREAMLIT_INTERNAL_KEY_PREFIX`: Prefix for internal Streamlit keys

2. Implemented utility functions:
   - Error handling utilities for normalizing and handling errors
   - ID builder functions to create trigger aggregator IDs with proper formatting
   - Logger setup for BidiComponent-specific logging

3. Added comprehensive tests for constants and ID builder utilities

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive tests for constants and ID builder utilities
- These utilities will be used by the BidiComponent system which will have its own tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.