### PR TITLE
[feat] Add util function to support Theming in CCv2

### DIFF
--- a/frontend/component-v2-lib/src/theme.ts
+++ b/frontend/component-v2-lib/src/theme.ts
@@ -82,6 +82,15 @@ export interface StreamlitTheme {
   greenBackgroundColor: string
   violetBackgroundColor: string
   grayBackgroundColor: string
+
+  // Text colors
+  redTextColor: string
+  orangeTextColor: string
+  yellowTextColor: string
+  blueTextColor: string
+  greenTextColor: string
+  violetTextColor: string
+  grayTextColor: string
 }
 
 /**

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, expectTypeOf, it } from "vitest"
+
+import { StreamlitTheme } from "@streamlit/component-v2-lib"
+import { ICustomThemeConfig } from "@streamlit/protobuf"
+
+import {
+  extractComponentsV2Theme,
+  objectToCssCustomProperties,
+} from "~lib/components/widgets/BidiComponent/utils/theme"
+import { mockTheme } from "~lib/mocks/mockTheme"
+
+describe("BidiComponent/utils/theme", () => {
+  describe("objectToCssCustomProperties", () => {
+    const createTheme = (
+      overrides: Partial<StreamlitTheme> = {}
+    ): StreamlitTheme => ({
+      primaryColor: "#ff0000",
+      backgroundColor: "#ffffff",
+      secondaryBackgroundColor: "#f0f0f0",
+      textColor: "#000000",
+      linkColor: "#0000ff",
+      linkUnderline: true,
+      font: "Source Sans Pro, sans-serif",
+      headingFont: "Source Sans Pro, sans-serif",
+      codeFont: "Source Code Pro, monospace",
+      baseRadius: "0.5rem",
+      buttonRadius: "0.5rem",
+      baseFontSize: "16px",
+      baseFontWeight: 400,
+      codeFontWeight: 400,
+      codeFontSize: "0.875rem",
+      headingFontSizes: [
+        "2.75rem",
+        "2.25rem",
+        "1.75rem",
+        "1.5rem",
+        "1.25rem",
+        "1rem",
+      ],
+      headingFontWeights: [700, 600, 600, 600, 600, 600],
+      borderColor: "#eeeeee",
+      borderColorLight: "#f5f5f5",
+      dataframeBorderColor: "#f0f0f0",
+      dataframeHeaderBackgroundColor: "#fafafa",
+      codeBackgroundColor: "#f7f7f7",
+      codeTextColor: "#00aa00",
+      headingColor: "#111111",
+      chartCategoricalColors: Array(10).fill("#000000"),
+      chartSequentialColors: Array(10).fill("#111111"),
+      redColor: "#ff0000",
+      orangeColor: "#ff8800",
+      yellowColor: "#ffee00",
+      blueColor: "#0000ff",
+      greenColor: "#00ff00",
+      violetColor: "#aa00ff",
+      grayColor: "#888888",
+      redBackgroundColor: "rgba(255,0,0,0.1)",
+      orangeBackgroundColor: "rgba(255,136,0,0.1)",
+      yellowBackgroundColor: "rgba(255,238,0,0.1)",
+      blueBackgroundColor: "rgba(0,0,255,0.1)",
+      greenBackgroundColor: "rgba(0,255,0,0.1)",
+      violetBackgroundColor: "rgba(170,0,255,0.1)",
+      grayBackgroundColor: "rgba(136,136,136,0.1)",
+
+      redTextColor: "#ff0000",
+      orangeTextColor: "#ff8800",
+      yellowTextColor: "#ffee00",
+      blueTextColor: "#0000ff",
+      greenTextColor: "#00ff00",
+      violetTextColor: "#aa00ff",
+      grayTextColor: "#888888",
+      ...overrides,
+    })
+
+    it("converts theme to CSS custom properties", () => {
+      const input = createTheme()
+      const result = objectToCssCustomProperties(input)
+      expect(result["--st-primary-color"]).toBe("#ff0000")
+      expect(result["--st-background-color"]).toBe("#ffffff")
+      expect(result["--st-font"]).toBe("Source Sans Pro, sans-serif")
+
+      // This is an optional property, so if it doesn't exist, it should not be included in the result
+      expect(Object.keys(result)).not.toContain("--st-widget-border-color")
+    })
+
+    it.each([
+      [true, "1"],
+      [false, "0"],
+    ])("serializes boolean linkUnderline %s to '%s'", (value, expected) => {
+      const result = objectToCssCustomProperties(
+        createTheme({ linkUnderline: value })
+      )
+      expect(result["--st-link-underline"]).toBe(expected)
+      expectTypeOf(result["--st-link-underline"]).toEqualTypeOf<string>()
+    })
+
+    it.each<[key: keyof StreamlitTheme, value: number, expectedKey: string]>([
+      ["baseFontWeight", 500, "--st-base-font-weight"],
+      ["codeFontWeight", 700, "--st-code-font-weight"],
+    ])("stringifies number %s", (propName, value, expectedKey) => {
+      const overrides = { [propName]: value } as Partial<StreamlitTheme>
+      const result = objectToCssCustomProperties(createTheme(overrides))
+      const dict = result as unknown as Record<string, string>
+      expect(dict[expectedKey]).toBe(String(value))
+    })
+
+    it("serializes baseFontSize with px unit", () => {
+      const result = objectToCssCustomProperties(
+        createTheme({ baseFontSize: "14px" })
+      )
+      expect(result["--st-base-font-size"]).toBe("14px")
+    })
+
+    it.each<
+      [
+        key: keyof StreamlitTheme,
+        value: string[] | number[],
+        expectedKey: string,
+      ]
+    >([
+      [
+        "headingFontSizes",
+        ["3rem", "2.5rem", "2rem", "1.5rem", "1.25rem", "1rem"],
+        "--st-heading-font-sizes",
+      ],
+      [
+        "headingFontWeights",
+        [800, 700, 600, 600, 600, 500],
+        "--st-heading-font-weights",
+      ],
+      [
+        "chartCategoricalColors",
+        [
+          "#111111",
+          "#222222",
+          "#333333",
+          "#444444",
+          "#555555",
+          "#666666",
+          "#777777",
+          "#888888",
+          "#999999",
+          "#aaaaaa",
+        ],
+        "--st-chart-categorical-colors",
+      ],
+    ])(
+      "serializes array %s as comma-joined string",
+      (propName, value, key) => {
+        const overrides = {
+          [propName]: value as never,
+        } as Partial<StreamlitTheme>
+        const result = objectToCssCustomProperties(createTheme(overrides))
+        const dict = result as unknown as Record<string, string>
+        expect(dict[key]).toBe((value as (string | number)[]).join(","))
+      }
+    )
+
+    it("supports custom prefix", () => {
+      const result = objectToCssCustomProperties(createTheme(), "--custom")
+      const custom = result as unknown as Record<string, string>
+      expect(custom["--custom-primary-color"]).toBe("#ff0000")
+      expect(custom["--custom-background-color"]).toBe("#ffffff")
+      expect(custom["--custom-text-color"]).toBe("#000000")
+    })
+  })
+
+  // Protobuf sync enforcement for Components V2 theme mapping
+  //
+  // Source of truth: `CustomThemeConfig` in
+  // `proto/streamlit/proto/NewSession.proto`. The generated TS interface
+  // (`ICustomThemeConfig`) comes from `@streamlit/protobuf`. This suite ensures
+  // that any new theme field added in the protobuf is either (a) mapped in
+  // `extractComponentsV2Theme`, or (b) explicitly ignored here with rationale.
+  // This keeps the mapping self-documenting and future-proof.
+  //
+  // When a failure happens:
+  // - Type failure (missing key in the guard):
+  //   1) Add the new key to `allProtoFieldsGuard` below.
+  //   2) Either map it in `extractComponentsV2Theme` or add it to
+  //      `protoFieldsToIgnore` with a brief justification.
+  // - Test failure (expected key not mapped):
+  //   1) Add the mapping in `extractComponentsV2Theme`, or
+  //   2) Add the key to `protoFieldsToIgnore` if we intentionally do not expose
+  //      it.
+  //
+  // Goal: Newly added theming options are acknowledged and handled
+  // deliberately.
+  describe("#extractComponentsV2Theme", () => {
+    // These are fields from the CustomThemeConfig proto message that we don't
+    // expect to be present in the extracted theme object.
+    const protoFieldsToIgnore: Array<keyof ICustomThemeConfig> = [
+      "base",
+      "font",
+      "bodyFont",
+      "widgetBackgroundColor",
+      "widgetBorderColor",
+      "radii",
+      "fontFaces",
+      "fontSources",
+      "fontSizes",
+      "skeletonBackgroundColor",
+      "showWidgetBorder",
+      "showSidebarBorder",
+      "sidebar",
+      "light",
+      "dark",
+    ]
+
+    // This is a helper object that ensures we have an exhaustive list of all
+    // keys from the ICustomThemeConfig interface. If a new field is added to
+    // the protobuf, this object will fail to compile until the new key is
+    // added.
+    const allProtoFieldsGuard: Record<keyof ICustomThemeConfig, null> = {
+      primaryColor: null,
+      backgroundColor: null,
+      secondaryBackgroundColor: null,
+      textColor: null,
+      linkColor: null,
+      linkUnderline: null,
+      font: null,
+      headingFont: null,
+      bodyFont: null,
+      codeFont: null,
+      base: null,
+      baseRadius: null,
+      buttonRadius: null,
+      baseFontSize: null,
+      baseFontWeight: null,
+      codeFontWeight: null,
+      codeFontSize: null,
+      headingFontSizes: null,
+      headingFontWeights: null,
+
+      borderColor: null,
+      dataframeBorderColor: null,
+      dataframeHeaderBackgroundColor: null,
+      widgetBorderColor: null,
+      widgetBackgroundColor: null,
+      showWidgetBorder: null,
+      redColor: null,
+      orangeColor: null,
+      yellowColor: null,
+      blueColor: null,
+      greenColor: null,
+      violetColor: null,
+      grayColor: null,
+
+      redBackgroundColor: null,
+      orangeBackgroundColor: null,
+      yellowBackgroundColor: null,
+      blueBackgroundColor: null,
+      greenBackgroundColor: null,
+      violetBackgroundColor: null,
+      grayBackgroundColor: null,
+
+      redTextColor: null,
+      orangeTextColor: null,
+      yellowTextColor: null,
+      blueTextColor: null,
+      greenTextColor: null,
+      violetTextColor: null,
+      grayTextColor: null,
+
+      codeBackgroundColor: null,
+      codeTextColor: null,
+
+      chartCategoricalColors: null,
+      chartSequentialColors: null,
+
+      fontFaces: null,
+      fontSizes: null,
+      fontSources: null,
+      radii: null,
+      showSidebarBorder: null,
+      skeletonBackgroundColor: null,
+
+      sidebar: null,
+      light: null,
+      dark: null,
+    }
+    const allProtoFields = Object.keys(
+      allProtoFieldsGuard
+    ) as (keyof ICustomThemeConfig)[]
+
+    it("contains a mapping for all themeable properties from protobuf", () => {
+      const extractedTheme = extractComponentsV2Theme(mockTheme.emotion)
+      const extractedThemeKeys = Object.keys(extractedTheme)
+
+      const expectedThemeKeys = allProtoFields.filter(
+        field => !protoFieldsToIgnore.includes(field)
+      )
+
+      expectedThemeKeys.forEach(expectedKey => {
+        expect(extractedThemeKeys).toContain(expectedKey)
+      })
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import kebabCase from "lodash/kebabCase"
+
+import {
+  StreamlitTheme,
+  StreamlitThemeCssProperties,
+} from "@streamlit/component-v2-lib"
+
+import { EmotionTheme } from "~lib/theme"
+
+/**
+ * Converts an object to CSS custom properties
+ * with the --st- prefix and kebab-case naming
+ */
+export const objectToCssCustomProperties = (
+  obj: StreamlitTheme,
+  prefix = "--st"
+): StreamlitThemeCssProperties => {
+  const result: Record<string, string> = {}
+
+  Object.entries(obj).forEach(([key, value]: [string, unknown]) => {
+    const kebabKey = kebabCase(key)
+    const propertyName = `${prefix}-${kebabKey}`
+
+    if (typeof value === "boolean") {
+      result[propertyName] = value ? "1" : "0"
+      return
+    }
+
+    result[propertyName] = String(value)
+  })
+
+  return result as StreamlitThemeCssProperties
+}
+
+/**
+ * Extracts only the properties defined in Components V2 Theme from the emotion theme.
+ *
+ * Note: Protobuf sync enforcement and remediation steps live in
+ * `frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts`.
+ * See that file for guidance when types/tests fail due to new theme fields.
+ */
+export const extractComponentsV2Theme = (
+  theme: EmotionTheme
+): StreamlitTheme => {
+  return {
+    primaryColor: theme.colors.primary,
+    backgroundColor: theme.colors.bgColor,
+    secondaryBackgroundColor: theme.colors.secondaryBg,
+    textColor: theme.colors.bodyText,
+    linkColor: theme.colors.link,
+    linkUnderline: theme.linkUnderline,
+    headingFont: theme.genericFonts.headingFont,
+    codeFont: theme.genericFonts.codeFont,
+    baseRadius: theme.radii.default,
+    buttonRadius: theme.radii.button,
+    baseFontSize:
+      typeof theme.fontSizes.baseFontSize === "number"
+        ? `${theme.fontSizes.baseFontSize}px`
+        : String(theme.fontSizes.baseFontSize),
+    baseFontWeight: theme.fontWeights.normal,
+    codeFontWeight: theme.fontWeights.code,
+    codeFontSize: theme.fontSizes.codeFontSize,
+    headingFontSizes: [
+      theme.fontSizes.h1FontSize,
+      theme.fontSizes.h2FontSize,
+      theme.fontSizes.h3FontSize,
+      theme.fontSizes.h4FontSize,
+      theme.fontSizes.h5FontSize,
+      theme.fontSizes.h6FontSize,
+    ],
+    headingFontWeights: [
+      theme.fontWeights.h1FontWeight,
+      theme.fontWeights.h2FontWeight,
+      theme.fontWeights.h3FontWeight,
+      theme.fontWeights.h4FontWeight,
+      theme.fontWeights.h5FontWeight,
+      theme.fontWeights.h6FontWeight,
+    ],
+    borderColor: theme.colors.borderColor,
+    dataframeBorderColor: theme.colors.dataframeBorderColor,
+    dataframeHeaderBackgroundColor:
+      theme.colors.dataframeHeaderBackgroundColor,
+    codeBackgroundColor: theme.colors.codeBackgroundColor,
+    font: theme.genericFonts.bodyFont,
+    chartCategoricalColors: theme.colors.chartCategoricalColors,
+    chartSequentialColors: theme.colors.chartSequentialColors,
+
+    headingColor: theme.colors.headingColor,
+    borderColorLight: theme.colors.borderColorLight,
+    codeTextColor: theme.colors.codeTextColor,
+
+    widgetBorderColor: theme.colors.widgetBorderColor,
+
+    redColor: theme.colors.redColor,
+    orangeColor: theme.colors.orangeColor,
+    yellowColor: theme.colors.yellowColor,
+    blueColor: theme.colors.blueColor,
+    greenColor: theme.colors.greenColor,
+    violetColor: theme.colors.violetColor,
+    grayColor: theme.colors.grayColor,
+    redBackgroundColor: theme.colors.redBackgroundColor,
+    orangeBackgroundColor: theme.colors.orangeBackgroundColor,
+    yellowBackgroundColor: theme.colors.yellowBackgroundColor,
+    blueBackgroundColor: theme.colors.blueBackgroundColor,
+    greenBackgroundColor: theme.colors.greenBackgroundColor,
+    violetBackgroundColor: theme.colors.violetBackgroundColor,
+    grayBackgroundColor: theme.colors.grayBackgroundColor,
+
+    redTextColor: theme.colors.redTextColor,
+    orangeTextColor: theme.colors.orangeTextColor,
+    yellowTextColor: theme.colors.yellowTextColor,
+    blueTextColor: theme.colors.blueTextColor,
+    greenTextColor: theme.colors.greenTextColor,
+    violetTextColor: theme.colors.violetTextColor,
+    grayTextColor: theme.colors.grayTextColor,
+  }
+}


### PR DESCRIPTION
## Describe your changes

Added theme utility functions for CCv2 to support setting CSS custom properties from the current Streamlit theme:

1. `objectToCssCustomProperties`: Converts a StreamlitTheme object to CSS custom properties with configurable prefix
2. `extractComponentsV2Theme`: Extracts properties from the Emotion theme to create a StreamlitTheme object

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive tests for `objectToCssCustomProperties` covering various data types (strings, numbers, booleans, arrays) and custom prefix support
- The implementation is fully covered by the included unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.