### PR TITLE
[feat] Add shared hooks to handle DOM manipulation for CCv2

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext, useEffect, useMemo, useRef } from "react"
+
+import { LibContext } from "~lib/components/core/LibContext"
+import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
+import { handleError } from "~lib/components/widgets/BidiComponent/utils/error"
+import { LOG } from "~lib/components/widgets/BidiComponent/utils/logger"
+import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+
+/**
+ * Inject HTML content including script tags
+ *
+ * Security model
+ * ----------------
+ * This hook injects HTML and CSS authored by users or third parties as part of
+ * a Custom Component v2 instance. Streamlit does not sanitize or validate this
+ * content and makes no guarantees about what is injected. It executes with
+ * normal DOM privileges.
+ *
+ * If you need to render untrusted input safely, do not use this hook without
+ * implementing your own sanitization/escaping strategy.
+ */
+const injectHtmlContent = (html: string, container: HTMLElement): void => {
+  try {
+    const range = document.createRange()
+    const fragment = range.createContextualFragment(html)
+    container.appendChild(fragment)
+  } catch (error) {
+    LOG.warn(
+      "createContextualFragment failed, falling back to innerHTML",
+      error
+    )
+    container.innerHTML = html
+  }
+}
+
+/**
+ * Handle and render CCv2-provided HTML and CSS into `containerRef`.
+ *
+ * Purpose
+ * -------
+ * Renders the HTML string and either inline CSS or a linked CSS file for a
+ * Custom Component v2 instance. Manages element lifecycle and error propagation
+ * while minimizing unnecessary re-renders.
+ *
+ * Security model
+ * --------------
+ * - Accepts author-supplied HTML (which may include <script> tags) and CSS.
+ *   Streamlit does not sanitize or validate this content.
+ * - Injected content runs with the normal DOM privileges of the current page or
+ *   shadow root. Use only with trusted component bundles or sanitize the
+ *   content yourself before passing it here.
+ *
+ * When to use
+ * -----------
+ * - In CCv2 to mount a component's HTML/CSS assets into the provided container.
+ *
+ * When NOT to use
+ * ---------------
+ * - Outside of the CCv2 lifecycle.
+ * - For arbitrary or end-user-supplied content that must be sandboxed or
+ *   sanitized.
+ *
+ * @param containerRef - Parent `HTMLElement` or `ShadowRoot` to append the
+ *   content container into.
+ * @param setError - Callback used to surface processing or load errors.
+ * @param skip - When true, skip injecting/updating content for this effect
+ *   cycle.
+ * @returns A ref to the div that contains the injected HTML/CSS.
+ */
+export const useHandleHtmlAndCssContent = ({
+  containerRef,
+  setError,
+  skip = false,
+}: {
+  containerRef: React.RefObject<HTMLElement | ShadowRoot>
+  setError: (error: Error) => void
+  skip?: boolean
+}): React.MutableRefObject<HTMLDivElement | null> => {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  const {
+    htmlContent: html,
+    cssContent,
+    cssSourcePath,
+    componentName,
+  } = useRequiredContext(BidiComponentContext)
+
+  const {
+    componentRegistry: { getBidiComponentURL },
+  } = useContext(LibContext)
+
+  /**
+   * Calculate this in a useMemo to reduce unnecessary re-runs of the useEffect
+   */
+  const cssLinkHref = useMemo(() => {
+    if (!cssSourcePath) {
+      return undefined
+    }
+
+    return getBidiComponentURL(componentName, cssSourcePath)
+  }, [componentName, cssSourcePath, getBidiComponentURL])
+
+  useEffect(() => {
+    if (skip) {
+      return
+    }
+
+    const parent = containerRef.current
+    if (!parent) {
+      return
+    }
+
+    try {
+      if (contentRef.current && contentRef.current.parentNode === parent) {
+        parent.removeChild(contentRef.current)
+      }
+
+      contentRef.current = document.createElement("div")
+
+      if (html) {
+        const htmlDiv = document.createElement("div")
+        // SECURITY NOTE: `html` is authored by users/third parties; we do not sanitize it.
+        injectHtmlContent(html, htmlDiv)
+        contentRef.current.appendChild(htmlDiv)
+      }
+
+      if (cssContent) {
+        const styleElement = document.createElement("style")
+        styleElement.textContent = cssContent
+        contentRef.current.appendChild(styleElement)
+      } else if (cssLinkHref) {
+        const linkElement = document.createElement("link")
+        linkElement.href = cssLinkHref
+        linkElement.rel = "stylesheet"
+        linkElement.onerror = () => {
+          handleError(
+            new Error(`Failed to load CSS from ${cssLinkHref}`),
+            setError
+          )
+        }
+        contentRef.current.appendChild(linkElement)
+      }
+
+      parent.appendChild(contentRef.current)
+    } catch (error) {
+      handleError(error, setError, "Failed to process HTML/CSS content")
+    }
+  }, [html, cssContent, containerRef, cssLinkHref, setError, skip])
+
+  return contentRef
+}

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext, useEffect, useMemo } from "react"
+
+import { v4 as uuidv4 } from "uuid"
+
+import {
+  ComponentArgs,
+  ComponentState,
+  OptionalComponentCleanupFunction,
+} from "@streamlit/component-v2-lib"
+
+import { LibContext } from "~lib/components/core/LibContext"
+import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
+import { blobUrlManager } from "~lib/components/widgets/BidiComponent/utils/blobUrl"
+import {
+  handleError,
+  normalizeError,
+} from "~lib/components/widgets/BidiComponent/utils/error"
+import { makeTriggerAggregatorId } from "~lib/components/widgets/BidiComponent/utils/idBuilder"
+import { LOG } from "~lib/components/widgets/BidiComponent/utils/logger"
+import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+import type { WidgetStateManager } from "~lib/WidgetStateManager"
+
+/**
+ * Security model
+ * ----------------
+ * This hook executes JavaScript authored by users or third parties as part of a
+ * Custom Component v2 instance. Streamlit does not sanitize or validate this
+ * content and makes no guarantees about what is executed. Inline JS is loaded
+ * via a Blob URL and external files via a module script; both run with normal
+ * DOM privileges.
+ *
+ * If you need to handle untrusted input, do not use this function without your
+ * own sanitization/defense-in-depth strategy.
+ */
+const loadAndRunModule = async <T extends ComponentState>({
+  componentId,
+  componentIdForWidgetMgr,
+  componentName,
+  data,
+  formId,
+  fragmentId,
+  getWidgetValue,
+  moduleUrl,
+  parentElement,
+  widgetMgr,
+}: {
+  componentId: string
+  componentIdForWidgetMgr: string
+  componentName: string
+  data: unknown
+  getWidgetValue: () => T
+  formId: string | undefined
+  fragmentId: string | undefined
+  moduleUrl: string
+  parentElement: HTMLElement | ShadowRoot
+  widgetMgr: WidgetStateManager
+}): Promise<OptionalComponentCleanupFunction> => {
+  const module = await import(/* @vite-ignore */ moduleUrl)
+
+  if (!module) {
+    throw new Error("JS module does not exist.")
+  }
+
+  if (!module.default || typeof module.default !== "function") {
+    throw new Error("JS module does not have a default export function.")
+  }
+
+  const setStateValue = <T extends ComponentState>(
+    name: string,
+    value: T[keyof T]
+  ): void => {
+    let newValue: T = {} as T
+
+    try {
+      const existingValue = getWidgetValue()
+
+      newValue = { ...existingValue, [name]: value } as T
+    } catch (error) {
+      LOG.error(`Failed to get existing value for ${name}`, error)
+      newValue = { [name]: value } as T
+    }
+
+    void widgetMgr.setJsonValue(
+      { id: componentIdForWidgetMgr, formId },
+      newValue,
+      { fromUi: true },
+      fragmentId
+    )
+  }
+
+  const setTriggerValue = <T extends ComponentState>(
+    name: string,
+    value: T[keyof T]
+  ): void => {
+    // IMPORTANT: Triggers are not allowed inside forms in Streamlit's execution
+    // model. Native buttons cannot be placed in forms, and form semantics defer
+    // updates until submit. To align CCv2 with existing behavior without
+    // changing global runtime semantics, we no-op trigger calls when the
+    // component is rendered inside a form. Developers should use setStateValue
+    // and the form submit button to commit changes.
+    if (formId) {
+      LOG.warn(
+        "BidiComponent: setTriggerValue ignored inside st.form. Triggers are not allowed in forms; use setStateValue and form submit instead."
+      )
+      return
+    }
+    const triggerId = makeTriggerAggregatorId(componentIdForWidgetMgr)
+    void widgetMgr.setTriggerValue(
+      { id: triggerId, formId },
+      { fromUi: true },
+      fragmentId,
+      { event: name, value }
+    )
+  }
+
+  return module.default({
+    name: componentName,
+    data,
+    key: componentId,
+    parentElement,
+    setStateValue,
+    setTriggerValue,
+  } satisfies ComponentArgs)
+}
+
+/**
+ * Load and execute CCv2 JavaScript for a component instance.
+ *
+ * Purpose
+ * -------
+ * Loads either inline JS (via Blob URL) or an external JS module URL and
+ * executes its default export to bootstrap a Custom Component v2 instance.
+ * Provides helpers for state updates and trigger events and wires errors into
+ * the component error surface.
+ *
+ * Security model
+ * --------------
+ * - Executes author-provided JavaScript with normal DOM privileges. Streamlit
+ *   does not sanitize or validate this code. Inline sources are loaded via a
+ *   Blob URL; external sources use a `<script type="module">` element and
+ *   dynamic `import()`.
+ * - Treat this as trusted code execution. If you must handle untrusted input,
+ *   sandbox or otherwise constrain execution yourself.
+ *
+ * When to use
+ * -----------
+ * - In CCv2 to initialize a component's runtime JS and integrate with
+ *   Streamlit's widget state management and trigger system.
+ *
+ * When NOT to use
+ * ---------------
+ * - Outside of the CCv2 lifecycle.
+ * - For arbitrary user-supplied JavaScript or content requiring isolation.
+ *
+ * @param containerRef - Parent `HTMLElement` or `ShadowRoot` where the module
+ *   can attach its UI.
+ * @param setError - Callback to report load/execute errors.
+ * @param skip - When true, skip loading/executing for this effect cycle.
+ */
+export const useHandleJsContent = ({
+  containerRef,
+  setError,
+  skip = false,
+}: {
+  containerRef: React.RefObject<HTMLElement | ShadowRoot>
+  setError: (error: Error) => void
+  skip?: boolean
+}): void => {
+  const thisUuid = useMemo(() => uuidv4(), [])
+  const componentId = `st-bidi-component-${thisUuid}`
+
+  const {
+    componentName,
+    data,
+    formId,
+    fragmentId,
+    getWidgetValue,
+    id,
+    jsContent: inlineJsContent,
+    jsSourcePath,
+    theme,
+    widgetMgr,
+  } = useRequiredContext(BidiComponentContext)
+
+  const {
+    componentRegistry: { getBidiComponentURL },
+  } = useContext(LibContext)
+
+  const externalJsSourcePathUrl = useMemo(() => {
+    if (!jsSourcePath) {
+      return undefined
+    }
+    return getBidiComponentURL(componentName, jsSourcePath)
+  }, [componentName, jsSourcePath, getBidiComponentURL])
+
+  useEffect(() => {
+    const { current: containerRefCurrent } = containerRef
+
+    if (
+      skip ||
+      (!inlineJsContent && !externalJsSourcePathUrl) ||
+      !containerRefCurrent
+    ) {
+      return
+    }
+
+    let isMounted = true
+    let cleanup: OptionalComponentCleanupFunction
+    let scriptElement: HTMLScriptElement | undefined
+
+    const run = async (): Promise<void> => {
+      try {
+        if (inlineJsContent) {
+          const { url } = blobUrlManager.getOrCreateUrlForJs(
+            inlineJsContent,
+            `st-bidi-${componentName}`
+          )
+
+          cleanup = await loadAndRunModule({
+            componentId,
+            componentIdForWidgetMgr: id,
+            componentName,
+            data,
+            formId,
+            fragmentId,
+            getWidgetValue,
+            moduleUrl: url,
+            parentElement: containerRefCurrent,
+            widgetMgr,
+          })
+        } else if (externalJsSourcePathUrl) {
+          const scriptUrl = externalJsSourcePathUrl
+
+          try {
+            // Load the script
+            await new Promise<void>((resolve, reject) => {
+              scriptElement = document.createElement("script")
+              scriptElement.type = "module"
+              scriptElement.src = scriptUrl
+              scriptElement.async = true
+              scriptElement.onload = () => resolve()
+              scriptElement.onerror = () =>
+                reject(
+                  new Error(
+                    `Failed to load script from ${externalJsSourcePathUrl}`
+                  )
+                )
+              document.head.appendChild(scriptElement)
+            })
+
+            // Run the module
+            cleanup = await loadAndRunModule({
+              componentId,
+              componentIdForWidgetMgr: id,
+              componentName,
+              data,
+              formId,
+              fragmentId,
+              getWidgetValue,
+              moduleUrl: scriptUrl,
+              parentElement: containerRefCurrent,
+              widgetMgr,
+            })
+          } catch (error) {
+            throw normalizeError(
+              error,
+              `Failed to load or execute script from ${externalJsSourcePathUrl}`
+            )
+          }
+        }
+      } catch (error) {
+        if (isMounted) {
+          handleError(error, setError)
+        }
+      }
+    }
+
+    void run()
+
+    // Cleanup function
+    return () => {
+      isMounted = false
+
+      if (cleanup) {
+        void Promise.resolve(cleanup)
+          .then(result => {
+            result?.()
+          })
+          .catch(error => {
+            LOG.error(`Failed to run cleanup for element ${id}`, error)
+          })
+      }
+
+      if (scriptElement?.parentNode) {
+        scriptElement.parentNode.removeChild(scriptElement)
+      }
+    }
+  }, [
+    componentId,
+    componentName,
+    containerRef,
+    data,
+    formId,
+    fragmentId,
+    getWidgetValue,
+    id,
+    inlineJsContent,
+    externalJsSourcePathUrl,
+    setError,
+    skip,
+    widgetMgr,
+    // We want to re-run the JS content on theme changes to ensure that any
+    // theme-dependent JS logic can be applied at the proper lifecycle time.
+    theme,
+  ])
+}

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/blobUrl.test.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/blobUrl.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { BlobUrlManager } from "./blobUrl"
+
+describe("BlobUrlManager", () => {
+  let manager: BlobUrlManager
+
+  beforeEach(() => {
+    manager = new BlobUrlManager()
+    let counter = 0
+    // Why mock global URL.createObjectURL?
+    // - jsdom in Vitest does not provide a full Blob URL implementation.
+    // - In Node test environments, URL.createObjectURL can be undefined or behave
+    //   differently than in browsers, which would yield undefined URLs and make
+    //   our assertions flaky or impossible.
+    // - We stub it to produce deterministic blob: URLs so tests are stable and
+    //   focus on our caching logic rather than environment quirks.
+    vi.stubGlobal("URL", {
+      ...(globalThis.URL as unknown as object),
+      createObjectURL: vi.fn(() => `blob:mock-${counter++}`),
+    } as unknown as typeof URL)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("computes a stable hash for the same content", () => {
+    const a1 = manager.getOrCreateUrlForJs("console.log('a')", "test").hash
+    const a2 = manager.getOrCreateUrlForJs("console.log('a')", "test").hash
+    expect(a1).toBe(a2)
+  })
+
+  it("produces a different hash for different content", () => {
+    const a = manager.getOrCreateUrlForJs("console.log('a')", "test").hash
+    const b = manager.getOrCreateUrlForJs("console.log('b')", "test").hash
+    expect(a).not.toBe(b)
+  })
+
+  it("caches and reuses blob URLs for identical content", () => {
+    const first = manager.getOrCreateUrlForJs(
+      "export default () => {}",
+      "test"
+    )
+    const second = manager.getOrCreateUrlForJs(
+      "export default () => {}",
+      "test"
+    )
+    expect(first.hash).toBe(second.hash)
+    expect(first.url).toBe(second.url)
+  })
+
+  it("creates different blob URLs for different content", () => {
+    const first = manager.getOrCreateUrlForJs("export default 1", "test")
+    const second = manager.getOrCreateUrlForJs("export default 2", "test")
+    expect(first.hash).not.toBe(second.hash)
+    expect(typeof first.url).toBe("string")
+    expect(typeof second.url).toBe("string")
+    expect(first.url).not.toBe(second.url)
+  })
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/blobUrl.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/blobUrl.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BlobUrlManager is responsible for creating and caching Blob URLs for inline
+ * JavaScript content. It provides:
+ * - Content-addressed caching keyed by a 32-bit FNV-1a hash of the content
+ * - Automatic addition of a //# sourceURL comment to improve stack traces
+ * - A simple API that returns both the blob URL and the content hash
+ *
+ * Notes:
+ * - Blob URLs are cached for the lifetime of the page to avoid module cache
+ *   churn when the same content is re-evaluated (e.g., re-renders).
+ * - Revoking Blob URLs is intentionally omitted because imported ESM modules
+ *   remain cached by URL; revoking would not unload them and can cause errors
+ *   if attempted while still referenced.
+ */
+export class BlobUrlManager {
+  private readonly hashSeed = 0x811c9dc5 >>> 0
+  private readonly hashPrime = 0x01000193
+  private readonly cache: Map<string, string> = new Map()
+
+  /**
+   * Compute a fast, deterministic 32-bit FNV-1a hash for the provided string.
+   * The result is returned as an unsigned hexadecimal string.
+   */
+  private computeHash(input: string): string {
+    let hash = this.hashSeed
+
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i)
+      hash = Math.imul(hash >>> 0, this.hashPrime) >>> 0
+    }
+
+    return (hash >>> 0).toString(16)
+  }
+
+  /**
+   * Return a cached Blob URL for the given JavaScript content, or create a new
+   * Blob if it does not exist yet.
+   *
+   * - Appends a sourceURL comment derived from labelBase and a content hash to
+   *   improve debugging and stack traces in devtools.
+   * - The returned object contains both the Blob URL and the computed hash.
+   */
+  public getOrCreateUrlForJs(
+    content: string,
+    labelBase: string
+  ): { url: string; hash: string } {
+    const hash = this.computeHash(content)
+    const cachedUrl = this.cache.get(hash)
+
+    if (cachedUrl) {
+      return { url: cachedUrl, hash }
+    }
+
+    const labeledContent = `${content}\n//# sourceURL=${labelBase}-${hash}.js`
+    const blob = new Blob([labeledContent], { type: "text/javascript" })
+    const url = URL.createObjectURL(blob)
+
+    this.cache.set(hash, url)
+
+    return { url, hash }
+  }
+}
+
+export const blobUrlManager = new BlobUrlManager()


### PR DESCRIPTION
## Describe your changes

Added two new hooks for CCv2 to handle HTML, CSS, and JavaScript content from the user's component:

1. `useHandleHtmlAndCssContent`: Safely injects HTML content (including script tags) and CSS into the component container. It supports both inline CSS and external CSS files.
2. `useHandleJsContent`: Manages JavaScript content execution for CCv2. It supports both inline JS and external JS files, and provides proper lifecycle management with cleanup functions.

These hooks provide a clean separation of concerns for handling different types of content in BidiComponents, with proper error handling and resource cleanup.

## GitHub Issue Link (if applicable)

## Testing Plan

- These code paths are tested when they are actually used by the composed component in https://github.com/streamlit/streamlit/pull/12756

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.