### PR TITLE
[feat] Add Isolated and NonIsolated components

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/IsolatedComponent.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/IsolatedComponent.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC, memo, useEffect, useRef, useState } from "react"
+
+import ErrorElement from "~lib/components/shared/ErrorElement"
+import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
+import { useHandleHtmlAndCssContent } from "~lib/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent"
+import { useHandleJsContent } from "~lib/components/widgets/BidiComponent/hooks/useHandleJsContent"
+import { handleError } from "~lib/components/widgets/BidiComponent/utils/error"
+import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+
+import { StyledBidiComponentWrapper } from "./styled-components"
+
+/**
+ * Isolated BidiComponent: encapsulates content in a Shadow DOM to avoid style
+ * and DOM leakage. Initializes a shadow root, then delegates HTML/CSS/JS
+ * handling to hooks. Errors are surfaced via the ErrorElement.
+ */
+export const IsolatedComponent: FC = memo(() => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const shadowRootRef = useRef<ShadowRoot | null>(null)
+  const [isShadowRootReady, setIsShadowRootReady] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const { id } = useRequiredContext(BidiComponentContext)
+
+  // Set up Shadow DOM
+  useEffect(() => {
+    if (!containerRef.current) {
+      return
+    }
+
+    try {
+      // Don't try to attach a shadow root if the element already has one
+      if (containerRef.current.shadowRoot) {
+        shadowRootRef.current = containerRef.current.shadowRoot
+        setIsShadowRootReady(true)
+        return
+      }
+
+      shadowRootRef.current = containerRef.current.attachShadow({
+        mode: "open",
+      })
+      setIsShadowRootReady(true)
+    } catch (err) {
+      handleError(err, setError, "Failed to create shadow DOM")
+    }
+  }, [id])
+
+  const skip = !isShadowRootReady || !!error
+
+  useHandleHtmlAndCssContent({ containerRef: shadowRootRef, setError, skip })
+  useHandleJsContent({ containerRef: shadowRootRef, setError, skip })
+
+  if (error) {
+    return (
+      <ErrorElement
+        name="BidiComponent Error"
+        message={error.message}
+        stack={error.stack}
+      />
+    )
+  }
+
+  return (
+    <StyledBidiComponentWrapper
+      ref={containerRef}
+      data-testid="stBidiComponentIsolated"
+    />
+  )
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/NonIsolatedComponent.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/NonIsolatedComponent.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC, memo, useRef, useState } from "react"
+
+import ErrorElement from "~lib/components/shared/ErrorElement"
+import { useHandleHtmlAndCssContent } from "~lib/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent"
+import { useHandleJsContent } from "~lib/components/widgets/BidiComponent/hooks/useHandleJsContent"
+
+import { StyledBidiComponentWrapper } from "./styled-components"
+
+/**
+ * Non-isolated BidiComponent: renders into the regular DOM (no Shadow DOM).
+ * Delegates handling of HTML, CSS, and JS content to dedicated hooks and
+ * surfaces any errors via the ErrorElement.
+ */
+export const NonIsolatedComponent: FC = memo(() => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const skip = !!error
+
+  useHandleHtmlAndCssContent({ containerRef, setError, skip })
+  useHandleJsContent({ containerRef, setError, skip })
+
+  if (error) {
+    return (
+      <ErrorElement
+        name="BidiComponent Error"
+        message={error.message}
+        stack={error.stack}
+      />
+    )
+  }
+
+  return (
+    <StyledBidiComponentWrapper
+      ref={containerRef}
+      data-testid="stBidiComponentRegular"
+    />
+  )
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/styled-components.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/styled-components.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+import { StreamlitThemeCssProperties } from "@streamlit/component-v2-lib"
+
+type StyledThemeCssProviderProps = {
+  cssCustomProperties: StreamlitThemeCssProperties
+}
+
+export const StyledThemeCssProvider = styled.div(
+  ({ cssCustomProperties }: StyledThemeCssProviderProps) => ({
+    ...cssCustomProperties,
+    /**
+     * Since this div is only used for applying CSS custom properties to the
+     * children, we don't want to add any additional styling or unnecessary DOM
+     * elements to the layout tree.
+     */
+    display: "contents",
+  })
+)
+
+/**
+ * Used to propagate the width and height of the StyledElementContainer to the
+ * custom component instance.
+ */
+export const StyledBidiComponentWrapper = styled.div({
+  width: "100%",
+  height: "100%",
+})


### PR DESCRIPTION
## Describe your changes

Added isolated and non-isolated component implementations for the CCv2 widget. This includes:

1. `IsolatedComponent.tsx` - A component that uses Shadow DOM for content isolation
2. `NonIsolatedComponent.tsx` - A component that renders content directly without isolation
3. `styled-components.ts` - Shared styled components for both implementations

The isolated component creates a shadow root for content encapsulation, while the non-isolated version renders directly to a div. Both components use shared hooks for handling HTML, CSS, and JavaScript content.

## GitHub Issue Link (if applicable)

## Testing Plan

- These code paths are tested when they are actually used by the composed component in https://github.com/streamlit/streamlit/pull/12756 and in the e2e tests https://github.com/streamlit/streamlit/pull/12758

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.