### PR TITLE
[feat] Add the BidiComponentContextProvider implementation

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/BidiComponentContextProvider.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/BidiComponentContextProvider.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC, memo, PropsWithChildren, useCallback, useMemo } from "react"
+
+import type { BidiComponent as BidiComponentProto } from "@streamlit/protobuf"
+
+import {
+  BidiComponentContext,
+  BidiComponentContextShape,
+} from "~lib/components/widgets/BidiComponent/BidiComponentContext"
+import { LOG } from "~lib/components/widgets/BidiComponent/utils/logger"
+import { parseBidiComponentData } from "~lib/components/widgets/BidiComponent/utils/parseBidiComponentData"
+import { extractComponentsV2Theme } from "~lib/components/widgets/BidiComponent/utils/theme"
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { ensureError } from "~lib/util/ErrorHandling"
+import { WidgetInfo, WidgetStateManager } from "~lib/WidgetStateManager"
+
+export type BidiComponentContextProviderProps = PropsWithChildren<{
+  element: BidiComponentProto
+  widgetMgr: WidgetStateManager
+  fragmentId: string | undefined
+}>
+
+export const BidiComponentContextProvider: FC<BidiComponentContextProviderProps> =
+  memo(({ element, children, widgetMgr, fragmentId }) => {
+    const {
+      arrowData,
+      bytes,
+      componentName,
+      cssContent,
+      cssSourcePath,
+      data,
+      htmlContent,
+      id,
+      jsContent,
+      json,
+      jsSourcePath,
+      mixed,
+    } = element
+
+    const widgetInfo = useMemo<WidgetInfo>(() => {
+      return {
+        id: element.id,
+        formId: element.formId,
+      }
+    }, [element.id, element.formId])
+
+    const getWidgetValue = useCallback(() => {
+      const raw = widgetMgr.getJsonValue(widgetInfo)
+
+      if (!raw) {
+        return {}
+      }
+
+      try {
+        return JSON.parse(raw)
+      } catch (e) {
+        const err = ensureError(e)
+        LOG.warn(
+          "Failed to parse widget JSON value; returning empty object.",
+          {
+            widgetId: widgetInfo.id,
+            formId: widgetInfo.formId,
+            error: err.message,
+          }
+        )
+        return {}
+      }
+    }, [widgetInfo, widgetMgr])
+
+    // We depend on primitive values and the inner payloads of protobuf wrappers
+    // (e.g. `arrowData?.data`, `mixed?.json`, `mixed?.arrowBlobs`) instead of
+    // the wrapper objects themselves.
+    // Protobuf may recreate wrapper objects on each update, which would
+    // invalidate memoization even when the actual payloads are unchanged.
+    // Narrowing deps reduces false invalidations.
+    // Note: this does not fully guarantee stability for reference-typed values
+    // like `Uint8Array` (e.g. `arrowData?.data`), whose references may still
+    // change across updates. It does guarantee stability for primitives/strings
+    // (e.g. `mixed?.json`), since Object.is compares them by value.
+    // Overall, this avoids unnecessary JSON.parse and mixed-data reconstruction
+    // when the payloads haven't changed, even if wrappers are re-instantiated.
+    const parsedData = useMemo(() => {
+      return parseBidiComponentData({
+        arrowBlobs: mixed?.arrowBlobs || undefined,
+        arrowData: arrowData?.data || undefined,
+        bytes,
+        data,
+        json,
+        mixedJson: mixed?.json || undefined,
+      })
+    }, [data, json, arrowData?.data, bytes, mixed?.json, mixed?.arrowBlobs])
+
+    const emotionTheme = useEmotionTheme()
+    const theme = useMemo(() => {
+      return extractComponentsV2Theme(emotionTheme)
+    }, [emotionTheme])
+
+    const contextValue = useMemo<BidiComponentContextShape>(() => {
+      return {
+        componentName,
+        cssContent: cssContent?.trim(),
+        cssSourcePath: cssSourcePath || undefined,
+        data: parsedData,
+        fragmentId,
+        getWidgetValue,
+        htmlContent: htmlContent?.trim(),
+        id,
+        formId: element.formId || undefined,
+        jsContent: jsContent || undefined,
+        jsSourcePath: jsSourcePath || undefined,
+        theme,
+        widgetMgr,
+      }
+    }, [
+      componentName,
+      cssContent,
+      cssSourcePath,
+      fragmentId,
+      getWidgetValue,
+      htmlContent,
+      id,
+      element.formId,
+      jsContent,
+      jsSourcePath,
+      parsedData,
+      theme,
+      widgetMgr,
+    ])
+
+    return (
+      <BidiComponentContext.Provider value={contextValue}>
+        {children}
+      </BidiComponentContext.Provider>
+    )
+  })

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/parseBidiComponentData.test.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/parseBidiComponentData.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  parseBidiComponentData,
+  type ParseBidiComponentDataArgs,
+} from "./parseBidiComponentData"
+import { reconstructMixedData } from "./reconstructMixedData"
+
+vi.mock("./reconstructMixedData")
+
+const mockedReconstructMixedData = vi.mocked(reconstructMixedData)
+
+const createArgs = (
+  overrides: Partial<ParseBidiComponentDataArgs> = {}
+): ParseBidiComponentDataArgs => ({
+  data: undefined,
+  json: undefined,
+  arrowData: undefined,
+  bytes: undefined,
+  mixedJson: undefined,
+  arrowBlobs: undefined,
+  ...overrides,
+})
+
+describe("parseBidiComponentData", () => {
+  beforeEach(() => {
+    mockedReconstructMixedData.mockReset()
+  })
+
+  it.each([
+    {
+      description: "parses json data when provided",
+      args: createArgs({ data: "json", json: '{"foo": 1}' }),
+      expected: { foo: 1 },
+    },
+    {
+      description: "returns null for json data when the payload is empty",
+      args: createArgs({ data: "json", json: "" }),
+      expected: null,
+    },
+    {
+      description: "returns arrow data bytes when provided",
+      args: createArgs({
+        data: "arrowData",
+        arrowData: new Uint8Array([1, 2, 3]),
+      }),
+      expected: new Uint8Array([1, 2, 3]),
+    },
+    {
+      description: "returns null when arrow data is missing",
+      args: createArgs({ data: "arrowData" }),
+      expected: null,
+    },
+    {
+      description: "returns raw bytes when provided",
+      args: createArgs({ data: "bytes", bytes: new Uint8Array([4, 5, 6]) }),
+      expected: new Uint8Array([4, 5, 6]),
+    },
+    {
+      description: "returns null when bytes payload is empty",
+      args: createArgs({ data: "bytes" }),
+      expected: null,
+    },
+  ])("$description", ({ args, expected }) => {
+    const result = parseBidiComponentData(args)
+
+    if (expected instanceof Uint8Array) {
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect(Array.from(result as Uint8Array)).toEqual(Array.from(expected))
+    } else {
+      expect(result).toEqual(expected)
+    }
+  })
+
+  it("reconstructs mixed data when json payload exists", () => {
+    const parsedJson = { foo: "bar" }
+    const arrowBlobs = {
+      table: { data: new Uint8Array([7, 8, 9]) },
+    }
+    mockedReconstructMixedData.mockReturnValue(parsedJson)
+
+    const result = parseBidiComponentData(
+      createArgs({
+        data: "mixed",
+        mixedJson: JSON.stringify(parsedJson),
+        arrowBlobs,
+      })
+    )
+
+    expect(mockedReconstructMixedData).toHaveBeenCalledWith(parsedJson, {
+      table: arrowBlobs.table?.data,
+    })
+    expect(result).toEqual(parsedJson)
+  })
+
+  it("returns null when mixed json payload is missing", () => {
+    const result = parseBidiComponentData(
+      createArgs({
+        data: "mixed",
+        arrowBlobs: { table: { data: new Uint8Array([1]) } } as never,
+      })
+    )
+
+    expect(mockedReconstructMixedData).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+
+  it("returns null when mixed data is missing", () => {
+    const result = parseBidiComponentData(createArgs({ data: "mixed" }))
+
+    expect(result).toBeNull()
+    expect(mockedReconstructMixedData).not.toHaveBeenCalled()
+  })
+
+  it("returns null for data type 'any'", () => {
+    const result = parseBidiComponentData(createArgs({ data: "any" }))
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when data type is undefined", () => {
+    const result = parseBidiComponentData(createArgs())
+
+    expect(result).toBeNull()
+  })
+
+  it("throws when data type is unexpected", () => {
+    expect(() => {
+      parseBidiComponentData(createArgs({ data: "unexpected" as never }))
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Reached a branch with non-exhaustive item: unexpected]`
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/parseBidiComponentData.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/parseBidiComponentData.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  BidiComponent as BidiComponentProto,
+  IArrowData,
+} from "@streamlit/protobuf"
+
+import { assertNever } from "~lib/util/assertNever"
+
+import { reconstructMixedData } from "./reconstructMixedData"
+
+type BaseParseArgs = Pick<BidiComponentProto, "json" | "bytes">
+
+type BidiComponentDataField = BidiComponentProto["data"]
+
+export type ParseBidiComponentDataArgs = BaseParseArgs & {
+  arrowBlobs?: Record<string, IArrowData>
+  arrowData?: IArrowData["data"] | undefined
+  data?: BidiComponentDataField | "mixed"
+  mixedJson?: string
+}
+
+export type ParsedComponentData = unknown
+
+/**
+ * Parses the data payload provided to a Custom Component v2 instance.
+ */
+export const parseBidiComponentData = ({
+  arrowBlobs,
+  arrowData,
+  bytes,
+  data,
+  json,
+  mixedJson,
+}: ParseBidiComponentDataArgs): ParsedComponentData => {
+  switch (data) {
+    case "json":
+      return json ? JSON.parse(json) : null
+    case "arrowData":
+      return arrowData ?? null
+    case "bytes":
+      return bytes ?? null
+    case "mixed": {
+      if (mixedJson && arrowBlobs) {
+        if (mixedJson) {
+          const jsonData = JSON.parse(mixedJson)
+
+          const arrowBlobsMap: Record<string, Uint8Array> = {}
+          if (arrowBlobs) {
+            Object.entries(arrowBlobs).forEach(([key, arrowProto]) => {
+              if (arrowProto?.data) {
+                arrowBlobsMap[key] = arrowProto.data
+              }
+            })
+          }
+
+          return reconstructMixedData(jsonData, arrowBlobsMap)
+        }
+      }
+      return null
+    }
+    // `any` and `undefined` data types are artifacts of the Protobuf, and are
+    // not necessary to be handled by the component.
+    case "any":
+    case undefined:
+      return null
+    default:
+      assertNever(data)
+  }
+
+  return undefined
+}


### PR DESCRIPTION
## Describe your changes

Added a new BidiComponentContextProvider component and utility functions for parsing data. The provider creates a context with all necessary data and functions for CCv2 instances, including:

- Component metadata (name, ID, form ID)
- Content (HTML, CSS, JS)
- Data parsing from various formats (JSON, Arrow, bytes, mixed)
- Widget state management
- Theme information

Also implemented a comprehensive data parser with tests that handles different data types:
- JSON data
- Arrow data
- Raw bytes
- Mixed data (combining JSON with Arrow blobs)

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests: Added comprehensive tests for the `parseBidiComponentData` utility, covering all data types and edge cases
- The context provider is a pure component that passes data through, so will be tested by later PRs

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.