### PR TITLE
[feat] Wire up BidiComponent to ElementNodeRenderer

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -24,6 +24,7 @@ import {
   Arrow as ArrowProto,
   AudioInput as AudioInputProto,
   Audio as AudioProto,
+  BidiComponent as BidiComponentProto,
   BokehChart as BokehChartProto,
   ButtonGroup as ButtonGroupProto,
   Button as ButtonProto,
@@ -160,6 +161,10 @@ const TimeInput = lazy(() => import("~lib/components/widgets/TimeInput"))
 const NumberInput = lazy(() => import("~lib/components/widgets/NumberInput"))
 const StreamlitSyntaxHighlighter = lazy(
   () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+)
+
+const BidiComponent = lazy(
+  () => import("~lib/components/widgets/BidiComponent")
 )
 
 export interface ElementNodeRendererProps extends BaseBlockProps {
@@ -552,7 +557,6 @@ const RawElementNodeRenderer = (
         />
       )
     }
-
     case "componentInstance":
       return (
         <ComponentInstance
@@ -691,6 +695,18 @@ const RawElementNodeRenderer = (
       )
     }
 
+    case "bidiComponent": {
+      const bidiComponentProto = node.element
+        .bidiComponent as BidiComponentProto
+
+      return (
+        <BidiComponent
+          key={bidiComponentProto.id}
+          element={bidiComponentProto}
+          {...widgetProps}
+        />
+      )
+    }
     default:
       throw new Error(`Unrecognized Element type ${node.element.type}`)
   }

--- a/frontend/lib/src/components/widgets/BidiComponent/index.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "~lib/components/widgets/BidiComponent/BidiComponent"
+export { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
+export type { BidiComponentContextShape } from "~lib/components/widgets/BidiComponent/BidiComponentContext"

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -46,10 +46,9 @@ INSTALL_REQUIRES = [
     "pillow>=7.1.0, <13",
     # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
     "protobuf>=3.20, <7",
-    # pyarrow is not semantically versioned, gets new major versions frequently, and
-    # doesn't tend to break the API on major version upgrades, so we don't put an
-    # upper bound on it.
-    "pyarrow>=7.0",
+    # pyarrow v22 is causing 2 test failures in dataframe_util_test.py and arrow_dataframe_test.py.
+    # temporarily restrict to <22 to avoid breaking changes.
+    "pyarrow>=7.0, <22",
     "requests>=2.27, <3",
     "tenacity>=8.1.0, <10",
     # Starting from Python 3.11, Python has built in support for reading TOML files.


### PR DESCRIPTION
## Describe your changes

Added support for CCv2 components in the frontend by:
- Adding the necessary imports and lazy loading for the component
- Implementing the renderer case for `bidiComponent` type in `ElementNodeRenderer.tsx`
- Setting up the component context and exports

## GitHub Issue Link (if applicable)

## Testing Plan

- Will be tested by the e2e tests in the next PR

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.