### PR TITLE
[test] Add CCv2 Playwright tests

### DIFF
--- a/e2e_playwright/bidi_components/__init__.py
+++ b/e2e_playwright/bidi_components/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -1,0 +1,570 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+import streamlit as st
+
+if TYPE_CHECKING:
+    from streamlit.components.v2.bidi_component import BidiComponentResult
+    from streamlit.elements.lib.layout_utils import Height, Width
+    from streamlit.runtime.state.common import WidgetCallback
+
+
+st.header("Custom Components v2 - Basics")
+
+
+# ---------------------------------------------------------------------------
+# Shared: simple stateful component (range + text) used in multiple sections
+# ---------------------------------------------------------------------------
+_STATEFUL_JS = """
+let hasMounted = {}
+
+export default function(component) {
+  const { parentElement, setStateValue, data, key } = component
+
+  const rangeInput = parentElement.querySelector('#range')
+  const textInput = parentElement.querySelector('#text')
+
+  const hasMountedForKey = hasMounted[key]
+
+  if (typeof data?.initialRange !== 'undefined' && !hasMountedForKey) {
+    rangeInput.value = String(data.initialRange)
+  }
+  if (typeof data?.initialText !== 'undefined' && !hasMountedForKey) {
+    textInput.value = String(data.initialText)
+  }
+
+  const handleRangeChange = (event) => {
+    setStateValue('range', event.target.value)
+  }
+
+  const handleTextChange = (event) => {
+    setStateValue('text', event.target.value)
+  }
+
+  rangeInput.addEventListener('change', handleRangeChange)
+  textInput.addEventListener('input', handleTextChange)
+
+  hasMounted[key] = true
+
+  return () => {
+    rangeInput.removeEventListener('change', handleRangeChange)
+    textInput.removeEventListener('input', handleTextChange)
+  }
+}
+"""
+
+_STATEFUL_HTML = """
+<div>
+  <label for="range">Range</label>
+  <input type="range" id="range" min="0" max="100" value="50" />
+  <label for="text">Text</label>
+  <input type="text" id="text" value="Text input" />
+  <!-- Accessible labels used for selection in tests (no data-testids) -->
+</div>
+"""
+
+_STATEFUL_CMP = st.components.v2.component(
+    "bidi_stateful",
+    js=_STATEFUL_JS,
+    html=_STATEFUL_HTML,
+)
+
+
+def stateful_component(
+    *,
+    key: str | None = None,
+    data: Any | None = None,
+    on_range_change: WidgetCallback | None = None,
+    on_text_change: WidgetCallback | None = None,
+    width: Width = "stretch",
+    height: Height = "content",
+    default: dict[str, Any] | None = None,
+) -> BidiComponentResult:
+    return _STATEFUL_CMP(
+        isolate_styles=True,
+        key=key,
+        data=data,
+        on_range_change=on_range_change,
+        on_text_change=on_text_change,
+        width=width,
+        height=height,
+        default=default,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared: trigger component (foo/bar/both)
+# ---------------------------------------------------------------------------
+_TRIGGER_JS = """
+export default function(component) {
+  const { parentElement, setTriggerValue } = component
+
+  const handleClickFoo = () => { setTriggerValue('foo', true) }
+  const handleClickBar = () => { setTriggerValue('bar', true) }
+  const handleClickBoth = () => { setTriggerValue('foo', true); setTriggerValue('bar', true) }
+
+  const fooButton = parentElement.querySelector('#foo-button')
+  const barButton = parentElement.querySelector('#bar-button')
+  const bothButton = parentElement.querySelector('#both-button')
+
+  fooButton.addEventListener('click', handleClickFoo)
+  barButton.addEventListener('click', handleClickBar)
+  bothButton.addEventListener('click', handleClickBoth)
+
+  return () => {
+    fooButton.removeEventListener('click', handleClickFoo)
+    barButton.removeEventListener('click', handleClickBar)
+    bothButton.removeEventListener('click', handleClickBoth)
+  }
+}
+"""
+
+_TRIGGER_HTML = """
+<div>
+  <button id="foo-button">Trigger foo</button>
+  <button id="bar-button">Trigger bar</button>
+  <button id="both-button">Trigger both</button>
+</div>
+"""
+
+_TRIGGER_CMP = st.components.v2.component(
+    "bidi_trigger", js=_TRIGGER_JS, html=_TRIGGER_HTML
+)
+
+
+def trigger_component(
+    *,
+    key: str | None = None,
+    data: Any | None = None,
+    on_foo_change: WidgetCallback | None = None,
+    on_bar_change: WidgetCallback | None = None,
+) -> BidiComponentResult:
+    return _TRIGGER_CMP(
+        isolate_styles=True,
+        key=key,
+        data=data,
+        on_foo_change=on_foo_change,
+        on_bar_change=on_bar_change,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared: form/fragment component used inside contexts
+# ---------------------------------------------------------------------------
+_CTX_JS = """
+export default function(component) {
+  const { parentElement, setStateValue, setTriggerValue, data } = component
+
+  const contextName = data?.contextName ? String(data.contextName) : ''
+  const textInput = parentElement.querySelector('#text-input')
+  const setTextBtn = parentElement.querySelector('#set-text-btn')
+  const triggerBtn = parentElement.querySelector('#trigger-btn')
+
+  if (setTextBtn) setTextBtn.textContent = `Set text${contextName ? ` (${contextName})` : ''}`
+  if (triggerBtn) triggerBtn.textContent = `Trigger click${contextName ? ` (${contextName})` : ''}`
+
+  const onSetText = () => {
+    const value = (textInput && 'value' in textInput) ? textInput.value : ''
+    setStateValue('text', value)
+  }
+
+  const onTrigger = () => { setTriggerValue('clicked', true) }
+
+  setTextBtn?.addEventListener('click', onSetText)
+  triggerBtn?.addEventListener('click', onTrigger)
+
+  return () => {
+    setTextBtn?.removeEventListener('click', onSetText)
+    triggerBtn?.removeEventListener('click', onTrigger)
+  }
+}
+"""
+
+_CTX_HTML = """
+<label for="text-input">Inner Text</label>
+<input id="text-input" type="text" value="hello" />
+<div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+  <button id="set-text-btn">Set text</button>
+  <button id="trigger-btn">Trigger click</button>
+</div>
+"""
+
+_CTX_CMP = st.components.v2.component(
+    name="bidi_ctx",
+    js=_CTX_JS,
+    html=_CTX_HTML,
+)
+
+
+def ctx_component(
+    *,
+    key: str | None = None,
+    data: Any | None = None,
+    on_text_change: WidgetCallback | None = None,
+    on_clicked_change: WidgetCallback | None = None,
+) -> BidiComponentResult:
+    return _CTX_CMP(
+        isolate_styles=True,
+        key=key,
+        data=data,
+        on_text_change=on_text_change,
+        on_clicked_change=on_clicked_change,
+    )
+
+
+with st.container():
+    st.subheader("Stateful")
+
+    if "stateful_range_change_count" not in st.session_state:
+        st.session_state.stateful_range_change_count = 0
+    if "stateful_text_change_count" not in st.session_state:
+        st.session_state.stateful_text_change_count = 0
+
+    def _stateful_handle_range_change() -> None:
+        st.session_state.stateful_range_change_count += 1
+
+    def _stateful_handle_text_change() -> None:
+        st.session_state.stateful_text_change_count += 1
+
+    stateful_result = stateful_component(
+        key="stateful_component_1",
+        on_range_change=_stateful_handle_range_change,
+        on_text_change=_stateful_handle_text_change,
+    )
+
+    st.write(f"Result: {stateful_result}")
+    st.text(f"session_state: {st.session_state.get('stateful_component_1')}")
+    st.write(f"Range change count: {st.session_state.stateful_range_change_count}")
+    st.write(f"Text change count: {st.session_state.stateful_text_change_count}")
+st.divider()
+
+
+with st.container():
+    st.subheader("Trigger")
+
+    if "trigger_foo_count" not in st.session_state:
+        st.session_state.trigger_foo_count = 0
+    if "trigger_bar_count" not in st.session_state:
+        st.session_state.trigger_bar_count = 0
+    if "trigger_last_on_foo_change_processed" not in st.session_state:
+        st.session_state.trigger_last_on_foo_change_processed = None
+    if "trigger_last_on_bar_change_processed" not in st.session_state:
+        st.session_state.trigger_last_on_bar_change_processed = None
+
+    def _handle_foo_change() -> None:
+        st.session_state.trigger_foo_count += 1
+        st.session_state.trigger_last_on_foo_change_processed = time.strftime(
+            "%H:%M:%S"
+        )
+
+    def _handle_bar_change() -> None:
+        st.session_state.trigger_bar_count += 1
+        st.session_state.trigger_last_on_bar_change_processed = time.strftime(
+            "%H:%M:%S"
+        )
+
+    trigger_result = trigger_component(
+        key="trigger_component_1",
+        on_foo_change=_handle_foo_change,
+        on_bar_change=_handle_bar_change,
+    )
+
+    st.write(f"Result: {trigger_result}")
+    st.write(f"Foo count: {st.session_state.trigger_foo_count}")
+    st.write(
+        f"Last on_foo_change callback processed at: {st.session_state.trigger_last_on_foo_change_processed}"
+    )
+    st.write(f"Bar count: {st.session_state.trigger_bar_count}")
+    st.write(
+        f"Last on_bar_change callback processed at: {st.session_state.trigger_last_on_bar_change_processed}"
+    )
+    st.text(f"Session state: {st.session_state.get('trigger_component_1')}")
+
+    st.button("st.button trigger")
+
+
+st.divider()
+
+with st.container():
+    st.subheader("Form context (defer state; triggers ignored by CCv2 semantics)")
+
+    if "form_text_changes" not in st.session_state:
+        st.session_state.form_text_changes = 0
+    if "form_clicked_changes" not in st.session_state:
+        st.session_state.form_clicked_changes = 0
+
+    def _handle_form_text_change() -> None:
+        st.session_state.form_text_changes += 1
+
+    def _handle_form_clicked_change() -> None:
+        # This should not be invoked for CCv2 triggers inside forms.
+        st.session_state.form_clicked_changes += 1
+
+    with st.form(key="bidi_form", clear_on_submit=False):
+        form_result = ctx_component(
+            key="in_form",
+            data={"contextName": "Form"},
+            on_text_change=_handle_form_text_change,
+            on_clicked_change=_handle_form_clicked_change,
+        )
+        st.form_submit_button("Submit Form")
+
+    st.write(f"Form Result: {form_result}")
+    st.text(f"Form session state: {st.session_state.get('in_form')}")
+    st.write(f"Form Text changes: {st.session_state.form_text_changes}")
+    st.write(f"Form Clicked count: {st.session_state.form_clicked_changes}")
+
+
+st.divider()
+
+with st.container():
+    st.subheader("Fragment context (partial reruns and local counters)")
+
+    if "frag_text_changes" not in st.session_state:
+        st.session_state.frag_text_changes = 0
+    if "frag_clicked_changes" not in st.session_state:
+        st.session_state.frag_clicked_changes = 0
+    if "runs" not in st.session_state:
+        st.session_state.runs = 0
+    st.session_state.runs += 1
+
+    @st.fragment()
+    def render_fragment() -> None:
+        frag_result = ctx_component(
+            key="in_fragment",
+            data={"contextName": "Fragment"},
+            on_text_change=lambda: _inc("frag_text_changes"),
+            on_clicked_change=lambda: _inc("frag_clicked_changes"),
+        )
+        st.write(f"Fragment Result: {frag_result}")
+        st.text(f"Fragment session state: {st.session_state.get('in_fragment')}")
+        st.write(f"Fragment Text changes: {st.session_state.frag_text_changes}")
+        st.write(f"Fragment Clicked count: {st.session_state.frag_clicked_changes}")
+
+    def _inc(name: str) -> None:
+        st.session_state[name] = int(st.session_state.get(name, 0)) + 1
+
+    render_fragment()
+
+    st.write(f"Runs: {st.session_state.runs}")
+
+
+st.divider()
+
+with st.container():
+    st.subheader("Remount behavior (unmount/remount sequence with persistent state)")
+
+    def _remount_stateful_component(
+        *,
+        key: str,
+    ) -> BidiComponentResult:
+        # Resolve initial values: prefer session_state if available, else fall back to default values
+        state_value = st.session_state.get(key)
+        initial_defaults: dict[str, Any] = {"range": 10, "text": "hello"}
+        if isinstance(state_value, dict):
+            initial_defaults.update(state_value)
+
+        return stateful_component(
+            key=key,
+            on_range_change=lambda: _inc("remount_range_change_count"),
+            on_text_change=lambda: _inc("remount_text_change_count"),
+            default={"range": 10, "text": "hello"},
+            data={
+                "initialRange": initial_defaults.get("range", 10),
+                "initialText": initial_defaults.get("text", "hello"),
+            },
+        )
+
+    if "remount_range_change_count" not in st.session_state:
+        st.session_state.remount_range_change_count = 0
+    if "remount_text_change_count" not in st.session_state:
+        st.session_state.remount_text_change_count = 0
+
+    # Standard unmount/remount pattern
+    if st.button("Create some elements to unmount component"):
+        for _ in range(3):
+            time.sleep(1)
+            st.write("Another element")
+
+    remount_key = "remount_component_1"
+    st.write("Above the component")
+    remount_result = _remount_stateful_component(key=remount_key)
+    st.write(f"Result: {remount_result}")
+    st.text(f"session_state: {st.session_state.get(remount_key)}")
+    st.write(f"Range change count: {st.session_state.remount_range_change_count}")
+    st.write(f"Text change count: {st.session_state.remount_text_change_count}")
+
+
+st.divider()
+
+with st.container():
+    st.subheader("Basic (broad CSS + mixed state/trigger)")
+
+    # Default values mirror the original default app
+    _BASIC_DEFAULT = {
+        "formValues": {
+            "range": 20,
+            "text": "Text input",
+        },
+    }
+
+    _BASIC_JS = """
+export default function(component) {
+  const { data, parentElement, setStateValue, setTriggerValue } = component
+
+  const form = parentElement.querySelector("form")
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const formValues = {
+      range: event.target.range.value,
+      text: event.target.text.value,
+    }
+    setStateValue("formValues", formValues)
+  }
+
+  form.addEventListener("submit", handleSubmit)
+
+  const handleClick = () => {
+    setTriggerValue("clicked", true)
+  }
+
+  parentElement.addEventListener("click", handleClick)
+
+  return () => {
+    form.removeEventListener("submit", handleSubmit)
+    parentElement.removeEventListener("click", handleClick)
+  }
+}
+"""
+
+    _BASIC_HTML = f"""
+<h1>Hello World</h1>
+<form>
+  <label for="range">Range</label>
+  <input type="range" id="range" name="range" min="0" max="100" value="{_BASIC_DEFAULT["formValues"]["range"]}" />
+  <label for="text">Text</label>
+  <input type="text" id="text" name="text" value="{_BASIC_DEFAULT["formValues"]["text"]}" />
+  <button type="submit">Submit form</button>
+  <!-- Accessible labels used for selection in tests (no data-testids) -->
+</form>
+"""
+
+    # Intentionally broad CSS rules to verify style isolation
+    _BASIC_CSS = """
+div {
+    color: var(--st-primary-color);
+    background-color: var(--st-background-color);
+}
+"""
+
+    _BASIC_CMP = st.components.v2.component(
+        name="bidi_basic",
+        js=_BASIC_JS,
+        html=_BASIC_HTML,
+        css=_BASIC_CSS,
+    )
+
+    def basic_component(
+        *,
+        key: str | None = None,
+        data: Any | None = None,
+        on_formValues_change: WidgetCallback | None = None,  # noqa: N803
+        on_clicked_change: WidgetCallback | None = None,
+        default: dict[str, Any] | None = None,
+    ) -> BidiComponentResult:
+        return _BASIC_CMP(
+            isolate_styles=True,
+            key=key,
+            data=data,
+            on_formValues_change=on_formValues_change,
+            on_clicked_change=on_clicked_change,
+            default=default,
+        )
+
+    if "basic_click_count" not in st.session_state:
+        st.session_state.basic_click_count = 0
+
+    def _handle_basic_click() -> None:
+        st.session_state.basic_click_count += 1
+
+    # Changes of formValues are captured but do not update an extra counter
+    def _handle_basic_change() -> None:
+        pass
+
+    basic_result = basic_component(
+        key="basic_component_1",
+        data={"label": "Some data from python"},
+        on_formValues_change=_handle_basic_change,
+        on_clicked_change=_handle_basic_click,
+        default=_BASIC_DEFAULT,
+    )
+
+    st.write(f"Result: {basic_result}")
+    st.text(f"session_state: {st.session_state.get('basic_component_1')}")
+    st.write(f"Click count: {st.session_state.basic_click_count}")
+
+
+st.divider()
+
+with st.container():
+    st.subheader("Arrow serialization")
+
+    # Component that receives two DataFrames and a label and renders
+    # their schema and row data, verifying Arrow serialization.
+    _ARROW_JS = """
+export default function(component) {
+  const { parentElement, data } = component
+
+  const root = parentElement.querySelector("#my-arrow-component")
+
+  const { df, df2, label } = data;
+  const cols = df.schema.fields.map((f) => f.name);
+  const rows = df.toArray();
+  const cols2 = df2.schema.fields.map((f) => f.name);
+  const rows2 = df2.toArray();
+
+  root.innerText = `Label: ${label}\nCols: ${cols}\nRows: ${rows}\nCols2: ${cols2}\nRows2: ${rows2}`
+}
+"""
+
+    _ARROW_HTML = """
+<div id="my-arrow-component"></div>
+"""
+
+    _ARROW_CMP = st.components.v2.component(
+        name="my_arrow_component",
+        js=_ARROW_JS,
+        html=_ARROW_HTML,
+    )
+
+    def arrow_component(*, key: str, data: Any) -> BidiComponentResult:
+        return _ARROW_CMP(key=key, data=data)
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    df2 = pd.DataFrame({"b": [4, 5, 6]})
+
+    arrow_component(
+        key="my_arrow_component",
+        data={
+            "df": df,
+            "df2": df2,
+            "label": "Hello World",
+        },
+    )

--- a/e2e_playwright/bidi_components/basics_test.py
+++ b/e2e_playwright/bidi_components/basics_test.py
@@ -1,0 +1,226 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.shared.app_utils import click_form_button
+
+
+def section(app: Page, heading_name: str) -> Locator:
+    """Return the stLayoutWrapper that contains the given heading.
+
+    Uses a containment filter to scope DOM queries to the specific section.
+    """
+    heading = app.get_by_role("heading", name=heading_name, exact=True)
+    return app.locator("[data-testid='stLayoutWrapper']").filter(has=heading).first
+
+
+def test_stateful_interactions(app: Page) -> None:
+    # Initial values
+    stateful = section(app, "Stateful")
+    expect(stateful.get_by_label("Range").first).to_have_value("50")
+    expect(stateful.get_by_label("Text").first).to_have_value("Text input")
+
+    expect(
+        stateful.get_by_text("Result: {'range': None, 'text': None}")
+    ).to_be_visible()
+    expect(stateful.get_by_text("session_state: {}")).to_be_visible()
+    expect(stateful.get_by_text("Range change count: 0")).to_be_visible()
+    expect(stateful.get_by_text("Text change count: 0")).to_be_visible()
+
+    # Change Range value (only range changes)
+    stateful.get_by_label("Range").first.fill("10")
+    expect(stateful.get_by_label("Range").first).to_have_value("10")
+    expect(
+        stateful.get_by_text("Result: {'range': '10', 'text': None}")
+    ).to_be_visible()
+    expect(stateful.get_by_text("session_state: {'range': '10'}")).to_be_visible()
+    expect(stateful.get_by_text("Range change count: 1")).to_be_visible()
+    expect(stateful.get_by_text("Text change count: 0")).to_be_visible()
+
+    # Change Text value (only text changes)
+    stateful.get_by_label("Text").first.fill("Hello")
+    expect(stateful.get_by_label("Text").first).to_have_value("Hello")
+    expect(
+        stateful.get_by_text("Result: {'range': '10', 'text': 'Hello'}")
+    ).to_be_visible()
+    expect(
+        stateful.get_by_text("session_state: {'range': '10', 'text': 'Hello'}")
+    ).to_be_visible()
+    expect(stateful.get_by_text("Range change count: 1")).to_be_visible()
+    expect(stateful.get_by_text("Text change count: 1")).to_be_visible()
+
+    # Trigger an unrelated rerun via a Streamlit button; values remain
+    app.get_by_text("st.button trigger").click()
+    expect(
+        stateful.get_by_text("Result: {'range': '10', 'text': 'Hello'}")
+    ).to_be_visible()
+    expect(stateful.get_by_text("session_state: {'range': '10', 'text': 'Hello'}"))
+    expect(stateful.get_by_text("Range change count: 1")).to_be_visible()
+    expect(stateful.get_by_text("Text change count: 1")).to_be_visible()
+
+
+def test_trigger_interactions(app: Page) -> None:
+    """Test the interactions with trigger callbacks and state in the Bidi Component."""
+    trigger = section(app, "Trigger")
+
+    expect(trigger.get_by_text("Foo count: 0")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 0")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': None, 'bar': None}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {}")).to_be_visible()
+
+    trigger.get_by_text("Trigger foo").click()
+    expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 0")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {'foo': True}"))
+
+    trigger.get_by_text("Trigger bar").click()
+    expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 1")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': None, 'bar': True}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {'bar': True}"))
+
+    # Trigger foo again so it has a different value from bar
+    trigger.get_by_text("Trigger foo").click()
+    expect(trigger.get_by_text("Foo count: 2")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 1")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {'foo': True}"))
+
+    trigger.get_by_text("Trigger both").click()
+    expect(trigger.get_by_text("Foo count: 3")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 2")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': True, 'bar': True}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {'foo': True, 'bar': True}"))
+
+    # Trigger a streamlit button to ensure the trigger values in the Bidi Component get reset
+    trigger.get_by_text("st.button trigger").click()
+    expect(trigger.get_by_text("Foo count: 3")).to_be_visible()
+    expect(trigger.get_by_text("Bar count: 2")).to_be_visible()
+    expect(trigger.get_by_text("Result: {'foo': None, 'bar': None}")).to_be_visible()
+    expect(trigger.get_by_text("Session state: {}"))
+
+
+def test_form_interactions_deferred_until_submit(app: Page) -> None:
+    form = section(
+        app,
+        "Form context (defer state; triggers ignored by CCv2 semantics)",
+    )
+
+    # Initial state
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(form.get_by_text("Form Text changes: 0")).to_be_visible()
+    expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
+
+    # Before submitting the form, interactions should NOT trigger a rerun.
+    form.get_by_text("Set text (Form)").click()
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(form.get_by_text("Form Text changes: 0")).to_be_visible()
+
+    # Triggers are disallowed in forms for CCv2; this must be a no-op.
+    form.get_by_text("Trigger click (Form)").click()
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
+
+    # Also the displayed state should still be empty before submit.
+    expect(form.get_by_text("Form session state: {}"))
+
+    # Submit the form and verify rerun + updates (only stateful changes apply).
+    click_form_button(app, "Submit Form")
+
+    expect(app.get_by_text("Runs: 2")).to_be_visible()
+    # Trigger callback remains unchanged due to no-op in form.
+    expect(form.get_by_text("Form Text changes: 1")).to_be_visible()
+    expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
+
+    # Session state should now contain values set by the component.
+    expect(form.get_by_text("Form session state:")).not_to_have_text(
+        "Form session state: {}"
+    )
+    expect(form.get_by_text("Form session state:")).to_contain_text("text")
+
+
+def test_fragment_interactions_rerun_only_fragment(app: Page) -> None:
+    fragment = section(app, "Fragment context (partial reruns and local counters)")
+
+    # Initial state for fragments
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(fragment.get_by_text("Fragment session state: {}"))
+    expect(fragment.get_by_text("Fragment Text changes: 0")).to_be_visible()
+    expect(fragment.get_by_text("Fragment Clicked count: 0")).to_be_visible()
+
+    # Interact inside fragment: should update fragment content and callbacks,
+    # but NOT increment global runs.
+    fragment.get_by_text("Set text (Fragment)").click()
+    # Fragment state updates immediately
+    expect(fragment.get_by_text("Fragment session state:")).not_to_have_text(
+        "Fragment session state: {}"
+    )
+    expect(fragment.get_by_text("Fragment Text changes: 1")).to_be_visible()
+    # Assert Runs remains 1
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+    fragment.get_by_text("Trigger click (Fragment)").click()
+    # Trigger inside fragment updates fragment-local UI/state; full Runs remains 1.
+    expect(fragment.get_by_text("Fragment Clicked count: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+
+def test_basic_initial_and_submission(app: Page) -> None:
+    basic = section(app, "Basic (broad CSS + mixed state/trigger)")
+
+    # Initial defaults from the component's HTML
+    expect(basic.get_by_label("Range")).to_have_value("20")
+    expect(basic.get_by_label("Text")).to_have_value("Text input")
+
+    # Verify initial result/session_state reflects provided defaults
+    result = basic.get_by_text("Result:")
+    expect(result).to_contain_text("'formValues'")
+    expect(result).to_contain_text("'range': 20")
+    expect(result).to_contain_text("'text': 'Text input'")
+    expect(result).to_contain_text("'clicked': None")
+
+    session_state = basic.get_by_text("session_state:")
+    expect(session_state).to_contain_text("'formValues'")
+    expect(session_state).to_contain_text("'range': 20")
+    expect(session_state).to_contain_text("'text': 'Text input'")
+    expect(basic.get_by_text("Click count: 0")).to_be_visible()
+
+    # Change inputs then submit the form and ensure stateful value updates
+    basic.get_by_label("Range").fill("55")
+    basic.get_by_label("Text").fill("Updated")
+    basic.get_by_role("button", name="Submit form").click()
+
+    result = basic.get_by_text("Result:")
+    expect(result).to_contain_text("'clicked': True")
+    expect(result).to_contain_text("'formValues'")
+    expect(result).to_contain_text("'range': '55'")
+    expect(result).to_contain_text("'text': 'Updated'")
+
+    session_state = basic.get_by_text("session_state:")
+    expect(session_state).to_contain_text("'clicked': True")
+    expect(session_state).to_contain_text("'formValues'")
+    expect(session_state).to_contain_text("'range': '55'")
+    expect(session_state).to_contain_text("'text': 'Updated'")
+    expect(basic.get_by_text("Click count: 1")).to_be_visible()
+
+
+def test_arrow_serialization_works(app: Page) -> None:
+    """Verify the consolidated Arrow component renders expected content."""
+    arrow = section(app, "Arrow serialization")
+    expect(arrow.get_by_text("Cols: a")).to_be_visible()
+    expect(arrow.get_by_text('Rows: {"a": 1},{"a": 2},{"a": 3}')).to_be_visible()
+    expect(arrow.get_by_text("Cols2: b")).to_be_visible()
+    expect(arrow.get_by_text('Rows2: {"b": 4},{"b": 5},{"b": 6}')).to_be_visible()
+    expect(arrow.get_by_text("Label: Hello World")).to_be_visible()

--- a/e2e_playwright/bidi_components/error_handling.py
+++ b/e2e_playwright/bidi_components/error_handling.py
@@ -1,0 +1,44 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+st.header("Custom Components v2 - Error Handling")
+
+st.divider()
+with st.container():
+    st.subheader("Errors (intentionally broken components)")
+
+    # Incorrect JS (no default export)
+    _incorrect_js = st.components.v2.component(
+        "incorrectJsComponent",
+        html="""<h1>The JS is incorrect</h1>""",
+        js="""
+            function Foo() {
+                // I am some JS without a default export
+            }
+        """,
+    )
+    _incorrect_js()
+
+    # Incorrect CSS path
+    _incorrect_css = st.components.v2.component(
+        "incorrectCssPathComponent",
+        html="""<h1>The CSS path is incorrect</h1>""",
+        css=Path(__file__).parent / "incorrect_css_path.css",  # type: ignore[arg-type]
+    )
+    _incorrect_css()

--- a/e2e_playwright/bidi_components/error_handling_test.py
+++ b/e2e_playwright/bidi_components/error_handling_test.py
@@ -1,0 +1,30 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+
+def test_error_handling_messages(app: Page) -> None:
+    expect(
+        app.get_by_text(
+            "BidiComponent Error: JS module does not have a default export function."
+        )
+    ).to_be_visible()
+
+    expect(
+        app.get_by_text(
+            "streamlit.errors.StreamlitAPIException: css parameter must be a string or None. "
+            "Pass a string path or glob."
+        )
+    ).to_be_visible()

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -1,0 +1,77 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import streamlit as st
+from streamlit.components.v2.bidi_component import BidiComponentResult
+
+interactive_text_input_definition = st.components.v2.component(
+    "interactive_text_input",
+    html="""
+    <label for='txt'>Enter text:</label>
+    <input id='txt' type='text' />
+    """,
+    js="""
+    export default function(component) {
+        const { setStateValue, parentElement, data, key } = component;
+
+        const label = parentElement.querySelector('label');
+        label.innerText = data.label;
+
+        const input = parentElement.querySelector('input');
+        // Set input value from data if changed
+        if (input.value !== data.value) {
+            input.value = data.value ?? '';
+        };
+
+        // Update value on Enter (submit)
+        input.onkeydown = (e) => {
+            if (e.key === 'Enter') {
+                setStateValue('value', e.target.value);
+            }
+        };
+    }
+    """,
+)
+
+
+def interactive_text_input(
+    label: str, initial_value: str, key: str
+) -> BidiComponentResult:
+    component_state = st.session_state.get(key, {})
+    data = {
+        "label": label,
+        "value": component_state.get("value", initial_value),
+    }
+    result = interactive_text_input_definition(data=data, key=key)
+
+    return result
+
+
+if st.button("Make it say Hello World"):
+    st.session_state["my_text_input"]["value"] = "Hello World"
+
+if st.button("Clear text"):
+    st.session_state["my_text_input"]["value"] = ""
+
+user_input = interactive_text_input(
+    "Enter something", "Initial Text", key="my_text_input"
+)
+
+st.write("You entered:", user_input)
+
+if st.button("Should throw an error"):
+    st.session_state.my_text_input.value = 12345
+
+st.write(st.session_state)

--- a/e2e_playwright/bidi_components/session_state_interactions_test.py
+++ b/e2e_playwright/bidi_components/session_state_interactions_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    expect_exception,
+    expect_no_exception,
+    get_element_by_key,
+)
+
+
+def test_session_state_interactions_flow(app: Page) -> None:
+    # Locate the component by its key and its internal elements
+    component = get_element_by_key(app, "my_text_input")
+    label = component.locator("label")
+    input_el = component.locator("input#txt")
+
+    # 1) Initial render
+    expect(label).to_have_text("Enter something")
+    expect(input_el).to_have_value("Initial Text")
+    expect_no_exception(app)
+
+    # 2) User submit (type + Enter)
+    input_el.fill("Foo")
+    input_el.press("Enter")
+    wait_for_app_run(app)
+    expect(input_el).to_have_value("Foo")
+    expect_no_exception(app)
+
+    # 3) Python updates flow back to the component
+    click_button(app, "Make it say Hello World")
+    expect(input_el).to_have_value("Hello World")
+
+    # 4) Clear via Python
+    click_button(app, "Clear text")
+    expect(input_el).to_have_value("")
+
+    # 5) Post-mount mutation error when modifying session_state
+    click_button(app, "Should throw an error")
+    expect_exception(app, "cannot be modified")
+
+    # 6) Recovery after error (valid user submit works again)
+    input_el.fill("Bar")
+    input_el.press("Enter")
+    wait_for_app_run(app)
+    expect(input_el).to_have_value("Bar")
+    expect_no_exception(app)


### PR DESCRIPTION
## Describe your changes

Added end-to-end tests for bidirectional components (CCv2) to validate core functionality and error handling. The tests cover:

1. Stateful components with persistent state
2. Trigger-based components for event handling
3. Form context integration with deferred state updates
4. Fragment context with partial reruns
5. Component remounting with state persistence
6. CSS isolation and styling
7. Arrow data serialization
8. Error handling for invalid component configurations

## Testing Plan

- E2E Tests: Added comprehensive Playwright tests that validate all core bidirectional component behaviors including state management, event handling, context integration, and error handling.
- The tests verify that components correctly maintain state across reruns, handle events properly in different contexts (forms, fragments), and display appropriate error messages when misconfigured.
- Tests also validate that Arrow data serialization works correctly for passing pandas DataFrames between Python and JavaScript.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.