### PR TITLE
Update ty type-checker to 0.0.1a22

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -344,11 +344,11 @@ def _test_shift_click_point_selection_scatter_chart_displays_selection(
     chart.scroll_into_view_if_needed()
     chart.click(position={"x": 264, "y": 162})
     wait_for_app_run(app)
-    chart.click(position={"x": 310, "y": 175}, modifiers=["Shift"])
+    chart.click(position={"x": 310, "y": 175}, modifiers=["Shift"])  # ty: ignore[invalid-argument-type]
     wait_for_app_run(app)
-    chart.click(position={"x": 402, "y": 194}, modifiers=["Shift"])
+    chart.click(position={"x": 402, "y": 194}, modifiers=["Shift"])  # ty: ignore[invalid-argument-type]
     wait_for_app_run(app)
-    chart.click(position={"x": 181, "y": 94}, modifiers=["Shift"])
+    chart.click(position={"x": 181, "y": 94}, modifiers=["Shift"])  # ty: ignore[invalid-argument-type]
     wait_for_app_run(app)
 
     # move the mouse away so that we do not have any hover-menu effects on the chart when taking the screenshot.

--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,6 +1,6 @@
 pre-commit
 # We fix ty to a version since its still in preview and likely breaks our CI on updates:
-ty==0.0.1a16
+ty==0.0.1a22
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.14.0
 # We are pinning the upper version to not break our CI on updates,

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -318,7 +318,7 @@ def _navigation(
     else:
         nav_sections = {
             section: [convert_to_streamlit_page(p) for p in section_pages]
-            for section, section_pages in pages.items()  # ty: ignore[possibly-unbound-attribute]
+            for section, section_pages in pages.items()
         }
     page_list = pages_from_nav_sections(nav_sections)
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -171,7 +171,8 @@ class DataEditorSerde:
         # Convert the keys (numerical row positions) to integers.
         # The keys are strings because they are serialized to JSON.
         data_editor_state["edited_rows"] = {
-            int(k): v for k, v in data_editor_state["edited_rows"].items()
+            int(k): v
+            for k, v in data_editor_state["edited_rows"].items()  # ty: ignore[possibly-missing-attribute]
         }
         return data_editor_state
 

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -805,7 +805,7 @@ class SliderMixin:
             if data_type in (
                 SliderProto.DATETIME,
                 SliderProto.DATE,
-            ) and max_value - min_value < timedelta(days=1):
+            ) and max_value - min_value < timedelta(days=1):  # ty: ignore[unsupported-operator]
                 step = timedelta(minutes=15)
         if format is None:
             format = cast("str", defaults[data_type]["format"])  # noqa: A001


### PR DESCRIPTION
## Describe your changes

Updates the `ty` Python type checker to the latest version.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
