### PR TITLE
Selection widgets return copies

### DIFF
--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -615,6 +615,8 @@ class ButtonGroupMixin:
             options or an empty list. If the ``selection_mode`` is
             ``"single"``, this is a selected option or ``None``.
 
+            This contains copies of the selected options, not the originals.
+
         Examples
         --------
         **Example 1: Multi-select pills**
@@ -841,6 +843,8 @@ class ButtonGroupMixin:
             If the ``selection_mode`` is ``multi``, this is a list of selected
             options or an empty list. If the ``selection_mode`` is
             ``"single"``, this is a selected option or ``None``.
+
+            This contains copies of the selected options, not the originals.
 
         Examples
         --------

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -370,7 +370,9 @@ class MultiSelectMixin:
         Returns
         -------
         list
-            A list with the selected options
+            A list of the selected options.
+
+            The list contains copies of the selected options, not the originals.
 
         Examples
         --------

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -272,6 +272,8 @@ class RadioMixin:
         any
             The selected option or ``None`` if no option is selected.
 
+            This is a copy of the selected option, not the original.
+
         Example
         -------
         >>> import streamlit as st

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -264,6 +264,8 @@ class SelectSliderMixin:
             The current value of the slider widget. The return type will match
             the data type of the value parameter.
 
+            This contains copies of the selected options, not the originals.
+
         Examples
         --------
         >>> import streamlit as st

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -404,6 +404,8 @@ class SelectboxMixin:
         any
             The selected option or ``None`` if no option is selected.
 
+            This is a copy of the selected option, not the original.
+
         Examples
         --------
         **Example 1: Use a basic selectbox widget**


### PR DESCRIPTION
## Describe your changes
Clarify that selection widgets return copies of selections.

## GitHub Issue Link (if applicable)
Clarifies #3703 and #12585


## Testing Plan
n/a docs only

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
