### PR TITLE
Ensure entry CSS file is index.css

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -114,17 +114,21 @@ export default defineConfig({
         entryFileNames: `static/js/[name]${HASH}.js`,
         // Ensure assetFileNames is also configured if you're handling asset files
         assetFileNames: assetInfo => {
+          // For CSS files, place them in the /static/css/ directory
           if (assetInfo.name?.endsWith(".css")) {
-            // Ensure the entry file is named index.css.
-            // We can infer it based on the originalFileName
-            // being index.html (the root html file).
+            // If OMIT_HASH_FROM_MAIN_FILES is set, we don't want to include the
+            // hash in the filename of the entry file at the minimum. There could
+            // be other files with the same name that cause a conflict, which would
+            // increment the entry file to index2.css, etc. This ensures the entry
+            // file is named index.css in this case.
             if (
               assetInfo.names.includes("index.css") &&
               assetInfo.originalFileNames.includes("index.html")
             ) {
               return `static/css/[name]${HASH}[extname]`
             }
-            // For CSS files, place them in the /static/css/ directory
+
+            // For chunk css files, include the hash in the filename.
             return `static/css/[name].[hash][extname]`
           }
 

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -115,8 +115,17 @@ export default defineConfig({
         // Ensure assetFileNames is also configured if you're handling asset files
         assetFileNames: assetInfo => {
           if (assetInfo.name?.endsWith(".css")) {
+            // Ensure the entry file is named index.css.
+            // We can infer it based on the originalFileName
+            // being index.html (the root html file).
+            if (
+              assetInfo.names.includes("index.css") &&
+              assetInfo.originalFileNames.includes("index.html")
+            ) {
+              return `static/css/[name]${HASH}[extname]`
+            }
             // For CSS files, place them in the /static/css/ directory
-            return `static/css/[name]${HASH}[extname]`
+            return `static/css/[name].[hash][extname]`
           }
 
           // For other assets, use the /static/media/ directory


### PR DESCRIPTION
## Describe your changes

From 1.47 to 1.48, an index.css caused a conflict that made the entry file not index.css. We enforce this in the vite config by detecting the file and ensuring the name is index.css and the other css files contain a hash.

## Testing Plan

- Automated Tests should pass.
- Verified use case of index.css will work
- Verified use case of index.css on local development

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
