### PR TITLE
[fix] conda build failure by adding setuptools dependency

### DIFF
--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -37,6 +37,7 @@ build:
 requirements:
   host:
     - pip
+    - setuptools
     - python {{ package_data.get('python_requires') }}
   run:
     {% for req in package_data.get('install_requires', []) %}


### PR DESCRIPTION
## Describe your changes

Fixes the conda package build failure by adding `setuptools` to the conda recipe's host requirements.

**Root Cause:**
The conda build was failing with:
```
BackendUnavailable: Cannot import 'setuptools.build_meta'
```

This occurred because Python 3.12+ no longer bundles setuptools by default, and the conda build environment (using Python 3.14) was missing this required build dependency.

**Changes Made:**

- Added `setuptools` to the `host` requirements in `lib/conda-recipe/meta.yaml`
- This ensures setuptools is available during the conda package build process
- Allows pip to successfully import the build backend and complete the installation

## GitHub Issue Link (if applicable)

N/A - Fixes CI build failure identified in build logs

## Testing Plan

- [x] Manual verification - checked that setuptools is a standard build requirement for Python packages using pyproject.toml with setuptools.build_meta
- [ ] CI build verification - awaiting CI build to confirm the fix works

**Additional Notes:**

This is a minimal, targeted fix that addresses the immediate build failure. The change follows standard conda packaging practices for Python 3.12+ compatibility.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
