### PR TITLE
Add Visitor pattern to AppNodes with a Debug Visitor

### DIFF
--- a/frontend/lib/src/render-tree/AppNode.interface.ts
+++ b/frontend/lib/src/render-tree/AppNode.interface.ts
@@ -16,6 +16,8 @@
 
 import { Element } from "@streamlit/protobuf"
 
+import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
+
 /**
  * The Generic ID of the script run this node was generated in.
  */
@@ -119,4 +121,21 @@ export interface AppNode {
    * Otherwise, a new Set will be created and will be returned.
    */
   getElements(elementSet?: Set<Element>): Set<Element>
+
+  /**
+   * Accept a visitor.
+   * @param visitor - The visitor to accept.
+   * @returns The result of the visitor's visit{AppNodeType} method.
+   * @example
+   * const visitor = new DebugVisitor()
+   * const result = blockNode.accept(visitor)
+   * console.log(result)
+   */
+  accept<T>(visitor: AppNodeVisitor<T>): T
+
+  /**
+   * Print a tree-like representation of this node and its children for debugging.
+   * Uses the DebugVisitor internally.
+   */
+  debug(): string
 }

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -661,4 +661,31 @@ describe("AppRoot", () => {
       )
     })
   })
+
+  describe("AppRoot.debug", () => {
+    it("prints labeled child sections with tree output", () => {
+      const out = ROOT.debug()
+
+      // Header
+      expect(out.startsWith("AppRoot\n")).toBe(true)
+
+      // main
+      expect(out).toContain("├── main:\n")
+      expect(out).toContain("│   └── BlockNode [2 children]")
+      expect(out).toContain('ElementNode [text] "1"')
+      expect(out).toContain('ElementNode [text] "2"')
+
+      // sidebar
+      expect(out).toContain("├── sidebar:\n")
+      expect(out).toContain("│   └── BlockNode [0 children]")
+
+      // event
+      expect(out).toContain("├── event:\n")
+      expect(out).toContain("│   └── BlockNode [0 children]")
+
+      // bottom
+      expect(out).toContain("└── bottom:\n")
+      expect(out).toContain("    └── BlockNode [0 children]")
+    })
+  })
 })

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -33,11 +33,10 @@ import {
   makeElementWithInfoText,
 } from "~lib/util/utils"
 
-import { AppNode } from "./AppNode.interface"
+import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
-
-const NO_SCRIPT_RUN_ID = "NO_SCRIPT_RUN_ID"
+import { DebugVisitor } from "./visitors/DebugVisitor"
 
 interface LogoMetadata {
   // Associated scriptHash that created the logo
@@ -422,5 +421,43 @@ export class AppRoot {
       this.root.setIn(deltaPath, elementNode, scriptRunId),
       this.appLogo
     )
+  }
+
+  private getChildName(child: AppNode): string {
+    switch (child) {
+      case this.main:
+        return "main"
+      case this.sidebar:
+        return "sidebar"
+      case this.event:
+        return "event"
+      case this.bottom:
+        return "bottom"
+      default:
+        return "unknown"
+    }
+  }
+
+  /**
+   * Returns a string representation of the AppRoot structure for debugging purposes.
+   * This method traverses the AppRoot tree and outputs a formatted string
+   * showing the hierarchy of its child nodes.
+   *
+   * @returns {string} A formatted string representing the AppRoot structure.
+   */
+  public debug(): string {
+    let result = "AppRoot\n"
+    this.root.children.forEach((child, index) => {
+      const isLast = index === this.root.children.length - 1
+      const childName = this.getChildName(child)
+      const connector = isLast ? "└── " : "├── "
+      const childPrefix = isLast ? "    " : "│   "
+
+      result += `${connector}${childName}:\n`
+      const visitor = new DebugVisitor(childPrefix, true)
+      result += child.accept(visitor)
+    })
+
+    return result
   }
 }

--- a/frontend/lib/src/render-tree/BlockNode.test.ts
+++ b/frontend/lib/src/render-tree/BlockNode.test.ts
@@ -71,4 +71,46 @@ describe("BlockNode", () => {
       )
     })
   })
+
+  describe("BlockNode.accept", () => {
+    it("calls visitBlockNode on the visitor", () => {
+      const node = block([text("child1"), text("child2")])
+      const mockVisitor = {
+        visitElementNode: vi.fn().mockReturnValue("element-result"),
+        visitBlockNode: vi.fn().mockReturnValue("block-result"),
+      }
+
+      const result = node.accept(mockVisitor)
+
+      expect(mockVisitor.visitBlockNode).toHaveBeenCalledWith(node)
+      expect(mockVisitor.visitElementNode).not.toHaveBeenCalled()
+      expect(result).toEqual("block-result")
+    })
+
+    it("allows visitor to return the same node", () => {
+      const node = block([text("child")])
+      const identityVisitor = {
+        visitElementNode: vi.fn(),
+        visitBlockNode: vi.fn().mockReturnValue(node),
+      }
+
+      const result = node.accept(identityVisitor)
+
+      expect(result).toBe(node)
+    })
+
+    it("can return a modified BlockNode through visitor", () => {
+      const originalNode = block([text("child1"), text("child2")])
+      const transformVisitor = {
+        visitElementNode: vi.fn(),
+        visitBlockNode: vi.fn().mockReturnValue(block([text("transformed")])),
+      }
+
+      const result = originalNode.accept(transformVisitor)
+
+      expect(result).not.toBe(originalNode)
+      expect(result.children).toHaveLength(1)
+      expect(result.getIn([0])).toBeTextNode("transformed")
+    })
+  })
 })

--- a/frontend/lib/src/render-tree/BlockNode.ts
+++ b/frontend/lib/src/render-tree/BlockNode.ts
@@ -19,6 +19,8 @@ import { Block as BlockProto, Element } from "@streamlit/protobuf"
 import { isNullOrUndefined, notUndefined } from "~lib/util/utils"
 
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
+import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
+import { DebugVisitor } from "./visitors/DebugVisitor"
 
 /**
  * A container AppNode that holds children.
@@ -192,5 +194,28 @@ export class BlockNode implements AppNode {
     }
 
     return elementSet
+  }
+
+  /**
+   * Accept a visitor.
+   * @param visitor - The visitor to accept.
+   * @returns The result of the visitor's visitBlockNode method.
+   * @example
+   * const visitor = new DebugVisitor()
+   * const result = blockNode.accept(visitor)
+   * console.log(result)
+   */
+  public accept<T>(visitor: AppNodeVisitor<T>): T {
+    return visitor.visitBlockNode(this)
+  }
+
+  /**
+   * Returns a string representation of this BlockNode and its children,
+   * primarily for debugging or logging purposes.
+   *
+   * @returns {string} A debug string describing the structure of this BlockNode.
+   */
+  public debug(): string {
+    return this.accept(new DebugVisitor())
   }
 }

--- a/frontend/lib/src/render-tree/ElementNode.test.ts
+++ b/frontend/lib/src/render-tree/ElementNode.test.ts
@@ -419,3 +419,43 @@ describe("ElementNode", () => {
     })
   })
 })
+
+describe("ElementNode.accept", () => {
+  it("calls visitElementNode on the visitor", () => {
+    const node = text("test")
+    const mockVisitor = {
+      visitElementNode: vi.fn().mockReturnValue("element-result"),
+      visitBlockNode: vi.fn().mockReturnValue("block-result"),
+    }
+
+    const result = node.accept(mockVisitor)
+
+    expect(mockVisitor.visitElementNode).toHaveBeenCalledWith(node)
+    expect(mockVisitor.visitBlockNode).not.toHaveBeenCalled()
+    expect(result).toEqual("element-result")
+  })
+
+  it("allows visitor to return the same node", () => {
+    const node = text("test")
+    const identityVisitor = {
+      visitElementNode: vi.fn().mockReturnValue(node),
+      visitBlockNode: vi.fn(),
+    }
+
+    const result = node.accept(identityVisitor)
+
+    expect(result).toBe(node)
+  })
+
+  it("allows visitor to return undefined", () => {
+    const node = text("test")
+    const nullVisitor = {
+      visitElementNode: vi.fn().mockReturnValue(undefined),
+      visitBlockNode: vi.fn(),
+    }
+
+    const result = node.accept(nullVisitor)
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -34,6 +34,8 @@ import { Quiver } from "~lib/dataframes/Quiver"
 import { isNullOrUndefined } from "~lib/util/utils"
 
 import { AppNode } from "./AppNode.interface"
+import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
+import { DebugVisitor } from "./visitors/DebugVisitor"
 
 /**
  * A leaf AppNode. Contains a single element to render.
@@ -240,6 +242,29 @@ export class ElementNode implements AppNode {
           : newDataSetQuiver
       }
     })
+  }
+
+  /**
+   * Accept a visitor.
+   * @param visitor - The visitor to accept.
+   * @returns The result of the visitor's visitElementNode method.
+   * @example
+   * const visitor = new DebugVisitor()
+   * const result = elementNode.accept(visitor)
+   * console.log(result)
+   */
+  public accept<T>(visitor: AppNodeVisitor<T>): T {
+    return visitor.visitElementNode(this)
+  }
+
+  /**
+   * Returns a string representation of this ElementNode for debugging purposes.
+   * This method can be used to log or inspect the state of the node.
+   *
+   * @returns {string} A debug string describing this node.
+   */
+  public debug(): string {
+    return this.accept(new DebugVisitor())
   }
 }
 

--- a/frontend/lib/src/render-tree/visitors/AppNodeVisitor.interface.ts
+++ b/frontend/lib/src/render-tree/visitors/AppNodeVisitor.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+
+export interface AppNodeVisitor<T> {
+  visitBlockNode(node: BlockNode): T
+  visitElementNode(node: ElementNode): T
+}

--- a/frontend/lib/src/render-tree/visitors/DebugVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/DebugVisitor.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Element, ForwardMsgMetadata } from "@streamlit/protobuf"
+
+import { NO_SCRIPT_RUN_ID } from "~lib/render-tree/AppNode.interface"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+import { block, FAKE_SCRIPT_HASH, text } from "~lib/render-tree/test-utils"
+
+import { DebugVisitor, MAX_HASH_LENGTH } from "./DebugVisitor"
+
+// Helper to create an ElementNode with optional overrides that are not exposed by test-utils.
+function makeElementNode({
+  element,
+  scriptRunId = NO_SCRIPT_RUN_ID,
+  activeScriptHash = FAKE_SCRIPT_HASH,
+  fragmentId,
+}: {
+  element: Element
+  scriptRunId?: string
+  activeScriptHash?: string
+  fragmentId?: string
+}): ElementNode {
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    activeScriptHash,
+    fragmentId
+  )
+}
+
+describe("DebugVisitor.visitElementNode", () => {
+  it("prints basic element info with type", () => {
+    const node = text("hello")
+    const out = node.accept(new DebugVisitor())
+    expect(out).toBe(
+      `└── ElementNode [text] "hello" (activeScriptHash: ${FAKE_SCRIPT_HASH.substring(0, MAX_HASH_LENGTH)})\n`
+    )
+  })
+
+  it("prints text body and truncates when longer than 30 chars", () => {
+    const long = "a".repeat(35)
+    const element = new Element({ text: { body: long } })
+    const node = makeElementNode({ element })
+
+    const out = node.accept(new DebugVisitor())
+    expect(out).toContain('ElementNode [text] "')
+    expect(out).toContain(`${"a".repeat(30)}...`) // truncated
+  })
+
+  it("includes scriptRunId hash when not NO_SCRIPT_RUN_ID", () => {
+    const runId = "1234567890abcdef"
+    const node = text("x", runId)
+    const out = node.accept(new DebugVisitor())
+    expect(out).toContain(`(run: ${runId.substring(0, MAX_HASH_LENGTH)})`)
+  })
+
+  it("includes fragmentId and activeScriptHash (shortened)", () => {
+    const element = new Element({ text: { body: "frag" } })
+    const node = makeElementNode({
+      element,
+      fragmentId: "abcdef123456",
+      activeScriptHash: "deadbeefcafefeed",
+    })
+
+    const out = node.accept(new DebugVisitor())
+    expect(out).toContain("(fragment: abcdef)")
+    expect(out).toContain("(activeScriptHash: deadbe)")
+  })
+
+  it("respects prefix and connector for non-last child", () => {
+    const node = text("middle")
+    const out = node.accept(new DebugVisitor("│   ", false))
+    expect(out.startsWith("│   ├── ElementNode")).toBe(true)
+  })
+})
+
+describe("DebugVisitor.visitBlockNode", () => {
+  it("prints child count and iterates children with proper connectors", () => {
+    const tree = block([
+      text("one"),
+      block([text("two-a"), text("two-b")]),
+      text("three"),
+    ])
+
+    const out = tree.accept(new DebugVisitor())
+
+    // Root line
+    expect(out.split("\n")[0]).toBe("└── BlockNode [3 children]")
+
+    // Check connectors and indentation for children
+    expect(out).toContain('├── ElementNode [text] "one"')
+    expect(out).toContain("├── BlockNode [2 children]")
+    expect(out).toContain('│   ├── ElementNode [text] "two-a"')
+    expect(out).toContain('│   └── ElementNode [text] "two-b"')
+    expect(out).toContain('└── ElementNode [text] "three"')
+  })
+
+  it("includes run hash when scriptRunId is set on block", () => {
+    const runId = "1234567890abcdef"
+    const b = block([text("c")], runId)
+    const out = b.accept(new DebugVisitor())
+    expect(out.split("\n")[0]).toContain(
+      `(run: ${runId.substring(0, MAX_HASH_LENGTH)})`
+    )
+  })
+})
+
+describe("DebugVisitor.generateDebugString", () => {
+  it("delegates to visitor with provided prefix and isLast", () => {
+    const root = block([text("a"), text("b")])
+
+    const out = DebugVisitor.generateDebugString(root, "X   ", false)
+
+    // Root should start with provided prefix and non-last connector
+    expect(out.startsWith("X   ├── BlockNode")).toBe(true)
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/DebugVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/DebugVisitor.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppNode, NO_SCRIPT_RUN_ID } from "~lib/render-tree/AppNode.interface"
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+
+import { AppNodeVisitor } from "./AppNodeVisitor.interface"
+
+export const MAX_HASH_LENGTH = 6
+
+/**
+ * Visitor that generates a tree-like debug representation of AppNodes.
+ */
+export class DebugVisitor implements AppNodeVisitor<string> {
+  private readonly prefix: string
+  private readonly isLast: boolean
+
+  constructor(prefix = "", isLast = true) {
+    this.prefix = prefix
+    this.isLast = isLast
+  }
+
+  visitBlockNode(node: BlockNode): string {
+    const connector = this.isLast ? "└── " : "├── "
+    const childPrefix = this.prefix + (this.isLast ? "    " : "│   ")
+
+    let result = `${this.prefix}${connector}BlockNode [${node.children.length} children]`
+    if (node.scriptRunId !== NO_SCRIPT_RUN_ID) {
+      result += ` (run: ${node.scriptRunId.substring(0, MAX_HASH_LENGTH)})`
+    }
+    result += "\n"
+
+    node.children.forEach((child, index) => {
+      const isLastChild = index === node.children.length - 1
+      const visitor = new DebugVisitor(childPrefix, isLastChild)
+      result += child.accept(visitor)
+    })
+
+    return result
+  }
+
+  visitElementNode(node: ElementNode): string {
+    const connector = this.isLast ? "└── " : "├── "
+    let result = `${this.prefix}${connector}ElementNode [${node.element.type}]`
+
+    if (node.element.type === "text" && node.element.text?.body) {
+      const text =
+        node.element.text.body.length > 30
+          ? `${node.element.text.body.slice(0, 30)}...`
+          : node.element.text.body
+      result += ` "${text}"`
+    }
+
+    if (node.scriptRunId !== NO_SCRIPT_RUN_ID) {
+      result += ` (run: ${node.scriptRunId.substring(0, MAX_HASH_LENGTH)})`
+    }
+
+    if (node.fragmentId) {
+      result += ` (fragment: ${node.fragmentId.substring(0, MAX_HASH_LENGTH)})`
+    }
+    result += ` (activeScriptHash: ${node.activeScriptHash.substring(0, MAX_HASH_LENGTH)})`
+
+    result += "\n"
+    return result
+  }
+
+  /**
+   * Static helper method to generate debug output for any AppNode.
+   */
+  static generateDebugString(
+    node: AppNode,
+    prefix = "",
+    isLast = true
+  ): string {
+    const visitor = new DebugVisitor(prefix, isLast)
+    return node.accept(visitor)
+  }
+}


### PR DESCRIPTION
## Describe your changes

This change introduces the [Visitor Design Pattern](https://refactoring.guru/design-patterns/visitor) to our App Node hierarchy. This allows having one file represent an operation across all of the node types rather having to edit every node file (and lose context).

To keep the PR small and not touch other methods, I created a DebugVisitor that is designed to print out the node hierarchy (which I think will be useful in debugging). It also demonstrates the purpose of the design pattern.

## Testing Plan

- Unit Tests (JS and/or Python) - Adds JS unit tests for the Debug Visitor and the AppRoot.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
