### PR TITLE
Migrate getElements to the ElementsSetVisitor

### DIFF
--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -18,6 +18,7 @@ import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 import { AppNode, BlockNode } from "~lib/AppNode"
 import { Direction } from "~lib/components/core/Layout/utils"
 import { FileUploadClient } from "~lib/FileUploadClient"
+import { ElementsSetVisitor } from "~lib/render-tree/visitors/ElementsSetVisitor"
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { EmotionTheme, getDividerColors } from "~lib/theme"
@@ -93,7 +94,7 @@ export function assignDividerColor(
   const autoColorKeys = Object.keys(autoColorMap)
   let dividerIndex = 0
 
-  Array.from(node.getElements()).forEach(element => {
+  for (const element of ElementsSetVisitor.collectElements(node)) {
     const divider = element.heading?.divider
     if (element.type === "heading" && divider) {
       if (divider === "auto") {
@@ -107,7 +108,7 @@ export function assignDividerColor(
         element.heading.divider = allColorMap[divider]
       }
     }
-  })
+  }
 }
 export interface BaseBlockProps {
   /**

--- a/frontend/lib/src/render-tree/AppNode.interface.ts
+++ b/frontend/lib/src/render-tree/AppNode.interface.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { Element } from "@streamlit/protobuf"
-
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
 
 /**
@@ -114,13 +112,6 @@ export interface AppNode {
     fragmentIdsThisRun?: Array<string>,
     fragmentIdOfBlock?: string
   ): AppNode | undefined
-
-  /**
-   * Return a Set of all the Elements contained in the tree.
-   * If an existing Set is passed in, that Set will be mutated and returned.
-   * Otherwise, a new Set will be created and will be returned.
-   */
-  getElements(elementSet?: Set<Element>): Set<Element>
 
   /**
    * Accept a visitor.

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -29,6 +29,7 @@ import {
   makeProto,
   text,
 } from "./test-utils"
+import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
 
 // prettier-ignore
 const BLOCK = block([
@@ -660,6 +661,55 @@ describe("AppRoot", () => {
         ])
       )
     })
+  })
+
+  it("uses visitor pattern internally", () => {
+    // Create a more complex structure to test visitor traversal
+    const delta1 = makeProto(DeltaProto, {
+      newElement: { text: { body: "main_element" } },
+    })
+    const delta2 = makeProto(DeltaProto, {
+      newElement: { text: { body: "sidebar_element" } },
+    })
+
+    const rootWithElements = ROOT.applyDelta(
+      "test_run",
+      delta1,
+      forwardMsgMetadata([0, 0]) // main section
+    ).applyDelta(
+      "test_run",
+      delta2,
+      forwardMsgMetadata([1, 0]) // sidebar section
+    )
+
+    const elements = rootWithElements.getElements()
+
+    // Should find elements from main, sidebar, and the original ROOT elements
+    // one new insert overwrote an existing main element; the sidebar insert
+    // added a new one
+    expect(elements.size).toBe(3)
+
+    // Verify we can find the sidebar element specifically
+    const elementsArray = Array.from(elements)
+    const sidebarElement = elementsArray.find(
+      el => el.text?.body === "sidebar_element"
+    )
+
+    expect(sidebarElement).toBeDefined()
+  })
+
+  it("demonstrates visitor pattern flexibility", () => {
+    // Show that we can use ElementsSetVisitor directly on parts of the tree
+    const mainElements = ElementsSetVisitor.collectElements(ROOT.main)
+    const sidebarElements = ElementsSetVisitor.collectElements(ROOT.sidebar)
+
+    // Should have elements in main, none in sidebar for basic ROOT
+    expect(mainElements.size).toBe(2) // The original elements from ROOT
+    expect(sidebarElements.size).toBe(0)
+
+    // Combined should equal getElements() result
+    const combinedSize = mainElements.size + sidebarElements.size
+    expect(ROOT.getElements().size).toBe(combinedSize)
   })
 
   describe("AppRoot.debug", () => {

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -37,6 +37,7 @@ import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
 import { DebugVisitor } from "./visitors/DebugVisitor"
+import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
 
 interface LogoMetadata {
   // Associated scriptHash that created the logo
@@ -337,12 +338,15 @@ export class AppRoot {
 
   /** Return a Set containing all Elements in the tree. */
   public getElements(): Set<Element> {
-    const elements = new Set<Element>()
-    this.main.getElements(elements)
-    this.sidebar.getElements(elements)
-    this.event.getElements(elements)
-    this.bottom.getElements(elements)
-    return elements
+    const visitor = new ElementsSetVisitor()
+
+    // Visit each major section of the app
+    this.main.accept(visitor)
+    this.sidebar.accept(visitor)
+    this.event.accept(visitor)
+    this.bottom.accept(visitor)
+
+    return visitor.elements
   }
 
   private addElement(

--- a/frontend/lib/src/render-tree/BlockNode.ts
+++ b/frontend/lib/src/render-tree/BlockNode.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Block as BlockProto, Element } from "@streamlit/protobuf"
+import { Block as BlockProto } from "@streamlit/protobuf"
 
-import { isNullOrUndefined, notUndefined } from "~lib/util/utils"
+import { notUndefined } from "~lib/util/utils"
 
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
@@ -182,18 +182,6 @@ export class BlockNode implements AppNode {
       this.fragmentId,
       this.deltaMsgReceivedAt
     )
-  }
-
-  public getElements(elementSet?: Set<Element>): Set<Element> {
-    if (isNullOrUndefined(elementSet)) {
-      elementSet = new Set<Element>()
-    }
-
-    for (const child of this.children) {
-      child.getElements(elementSet)
-    }
-
-    return elementSet
   }
 
   /**

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -31,7 +31,6 @@ import {
   WrappedNamedDataset,
 } from "~lib/components/elements/ArrowVegaLiteChart"
 import { Quiver } from "~lib/dataframes/Quiver"
-import { isNullOrUndefined } from "~lib/util/utils"
 
 import { AppNode } from "./AppNode.interface"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
@@ -160,14 +159,6 @@ export class ElementNode implements AppNode {
       }
     }
     return this.scriptRunId === currentScriptRunId ? this : undefined
-  }
-
-  public getElements(elements?: Set<Element>): Set<Element> {
-    if (isNullOrUndefined(elements)) {
-      elements = new Set<Element>()
-    }
-    elements.add(this.element)
-    return elements
   }
 
   public arrowAddRows(

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { block, text } from "~lib/render-tree/test-utils"
+
+import { ElementsSetVisitor } from "./ElementsSetVisitor"
+
+describe("ElementsSetVisitor", () => {
+  describe("visitElementNode", () => {
+    it("adds element to the visitor's set", () => {
+      const element = text("test")
+      const visitor = new ElementsSetVisitor()
+
+      const result = visitor.visitElementNode(element)
+
+      expect(result).toBe(visitor.elements) // Returns the same set reference
+      expect(visitor.elements.size).toBe(1)
+      expect(visitor.elements.has(element.element)).toBe(true)
+    })
+
+    it("accumulates multiple elements", () => {
+      const element1 = text("first")
+      const element2 = text("second")
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitElementNode(element1)
+      visitor.visitElementNode(element2)
+
+      expect(visitor.elements.size).toBe(2)
+      expect(visitor.elements.has(element1.element)).toBe(true)
+      expect(visitor.elements.has(element2.element)).toBe(true)
+    })
+
+    it("handles duplicate elements correctly", () => {
+      const element = text("duplicate")
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitElementNode(element)
+      visitor.visitElementNode(element)
+
+      // Set should still have only one element since sets prevent duplicates
+      expect(visitor.elements.size).toBe(1)
+      expect(visitor.elements.has(element.element)).toBe(true)
+    })
+  })
+
+  describe("visitBlockNode", () => {
+    it("returns the visitor's set for empty block", () => {
+      const emptyBlock = block([])
+      const visitor = new ElementsSetVisitor()
+
+      const result = visitor.visitBlockNode(emptyBlock)
+
+      expect(result).toBe(visitor.elements)
+      expect(visitor.elements.size).toBe(0)
+    })
+
+    it("collects elements from all children", () => {
+      const child1 = text("child1")
+      const child2 = text("child2")
+      const blockNode = block([child1, child2])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(blockNode)
+
+      expect(visitor.elements.size).toBe(2)
+      expect(visitor.elements.has(child1.element)).toBe(true)
+      expect(visitor.elements.has(child2.element)).toBe(true)
+    })
+
+    it("handles nested block structures", () => {
+      const innerElement = text("inner")
+      const dupeElement = innerElement
+      const outerElement = text("outer")
+      const innerBlock = block([innerElement])
+      const outerBlock = block([outerElement, innerBlock, dupeElement])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(outerBlock)
+
+      // Ensure the dupe element is removed
+      expect(visitor.elements.size).toBe(2)
+      expect(visitor.elements.has(innerElement.element)).toBe(true)
+      expect(visitor.elements.has(outerElement.element)).toBe(true)
+    })
+
+    it("accumulates multiple elements when inside block nodes", () => {
+      const existingElement = text("existing")
+      const blockElement = text("from_block")
+      const blockNode = block([blockElement])
+      const visitor = new ElementsSetVisitor()
+
+      // First add an existing element
+      visitor.visitElementNode(existingElement)
+      // Then visit the block
+      visitor.visitBlockNode(blockNode)
+
+      expect(visitor.elements.size).toBe(2)
+      expect(visitor.elements.has(existingElement.element)).toBe(true)
+      expect(visitor.elements.has(blockElement.element)).toBe(true)
+    })
+  })
+
+  describe("collectElements static method", () => {
+    it("collects elements from ElementNode", () => {
+      const element = text("test")
+      const elements = ElementsSetVisitor.collectElements(element)
+
+      expect(elements.size).toBe(1)
+      expect(elements.has(element.element)).toBe(true)
+    })
+
+    it("collects elements from BlockNode", () => {
+      const child1 = text("child1")
+      const child2 = text("child2")
+      const blockNode = block([child1, child2])
+
+      const elements = ElementsSetVisitor.collectElements(blockNode)
+
+      expect(elements.size).toBe(2)
+      expect(elements.has(child1.element)).toBe(true)
+      expect(elements.has(child2.element)).toBe(true)
+    })
+
+    it("handles nested structures", () => {
+      const innerElement = text("inner")
+      const dupeElement = innerElement
+      const outerElement = text("outer")
+      const innerBlock = block([innerElement])
+      const outerBlock = block([outerElement, innerBlock, dupeElement])
+
+      const elements = ElementsSetVisitor.collectElements(outerBlock)
+
+      // Ensure the dupe element is removed
+      expect(elements.size).toBe(2)
+      expect(elements.has(innerElement.element)).toBe(true)
+      expect(elements.has(outerElement.element)).toBe(true)
+    })
+
+    it("returns empty set for empty block", () => {
+      const emptyBlock = block([])
+
+      const elements = ElementsSetVisitor.collectElements(emptyBlock)
+
+      expect(elements.size).toBe(0)
+    })
+  })
+
+  describe("performance and mutability", () => {
+    it("uses the same set instance throughout", () => {
+      const element1 = text("first")
+      const element2 = text("second")
+      const visitor = new ElementsSetVisitor()
+      const originalSet = visitor.elements
+
+      visitor.visitElementNode(element1)
+      visitor.visitElementNode(element2)
+
+      expect(visitor.elements).toBe(originalSet) // Same reference
+      expect(visitor.elements.size).toBe(2)
+    })
+
+    it("efficiently handles large trees", () => {
+      // Create a tree with many elements
+      const elements = Array.from({ length: 100 }, (_, i) =>
+        text(`element${i}`)
+      )
+      const blockNode = block(elements)
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(blockNode)
+
+      expect(visitor.elements.size).toBe(100)
+      elements.forEach(element => {
+        expect(visitor.elements.has(element.element)).toBe(true)
+      })
+    })
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Element } from "@streamlit/protobuf"
+
+import { AppNode } from "~lib/render-tree/AppNode.interface"
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
+
+/**
+ * A visitor that collects all Elements from an AppNode tree.
+ *
+ * This visitor uses a mutable Set for performance, accumulating elements
+ * as it traverses the tree. The visitor methods return the Set directly
+ * for convenience, but the return value only needs to be used at the end
+ * of the traversal.
+ *
+ * Usage:
+ * ```typescript
+ * const visitor = new ElementsSetVisitor()
+ * rootNode.accept(visitor)
+ * const elements = visitor.elements
+ * ```
+ */
+export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
+  public readonly elements: Set<Element>
+
+  constructor() {
+    this.elements = new Set<Element>()
+  }
+
+  visitElementNode(node: ElementNode): Set<Element> {
+    this.elements.add(node.element)
+    return this.elements
+  }
+
+  visitBlockNode(node: BlockNode): Set<Element> {
+    // Visit each child and accumulate elements in our mutable set
+    for (const child of node.children) {
+      child.accept(this)
+    }
+    return this.elements
+  }
+
+  /**
+   * Static convenience method to collect all elements from a node tree.
+   */
+  static collectElements(node: AppNode): Set<Element> {
+    const visitor = new ElementsSetVisitor()
+    node.accept(visitor)
+    return visitor.elements
+  }
+}


### PR DESCRIPTION
## Describe your changes

Performing an easy migration with the gathering of all elements on the page to an ElementsSetVisitor.

## Testing Plan

- JS Unit tests are added for the visitor
- Other tests including e2e should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
