### PR TITLE
Migrate getIn to GetNodeByDeltaPathVisitor

### DIFF
--- a/frontend/lib/src/render-tree/AppNode.interface.ts
+++ b/frontend/lib/src/render-tree/AppNode.interface.ts
@@ -86,12 +86,6 @@ export interface AppNode {
   readonly deltaMsgReceivedAt?: number
 
   /**
-   * Return the AppNode for the given index path, or undefined if the path
-   * is invalid.
-   */
-  getIn(path: number[]): AppNode | undefined
-
-  /**
    * Return a copy of this node with a new element set at the given index
    * path. Throws an error if the path is invalid.
    */

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -30,6 +30,7 @@ import {
   text,
 } from "./test-utils"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
+import { GetNodeByDeltaPathVisitor } from "./visitors/GetNodeByDeltaPathVisitor"
 
 // prettier-ignore
 const BLOCK = block([
@@ -71,7 +72,9 @@ describe("AppRoot", () => {
       const empty = AppRoot.empty(FAKE_SCRIPT_HASH)
 
       expect(empty.main.children.length).toBe(1)
-      const child = empty.main.getIn([0]) as ElementNode
+      const child = GetNodeByDeltaPathVisitor.getNodeAtPath(empty.main, [
+        0,
+      ]) as ElementNode
       expect(child.element.skeleton).not.toBeNull()
 
       expect(empty.sidebar.isEmpty).toBe(true)
@@ -116,7 +119,9 @@ describe("AppRoot", () => {
       const empty = AppRoot.empty(FAKE_SCRIPT_HASH)
 
       expect(empty.main.children.length).toBe(1)
-      const child = empty.main.getIn([0]) as ElementNode
+      const child = GetNodeByDeltaPathVisitor.getNodeAtPath(empty.main, [
+        0,
+      ]) as ElementNode
       expect(child.element.alert).toBeDefined()
 
       expect(empty.sidebar.isEmpty).toBe(true)
@@ -132,7 +137,9 @@ describe("AppRoot", () => {
       const empty = AppRoot.empty(FAKE_SCRIPT_HASH)
 
       expect(empty.main.children.length).toBe(1)
-      const child = empty.main.getIn([0]) as ElementNode
+      const child = GetNodeByDeltaPathVisitor.getNodeAtPath(empty.main, [
+        0,
+      ]) as ElementNode
       expect(child.element.skeleton).not.toBeNull()
 
       expect(empty.sidebar.isEmpty).toBe(true)
@@ -185,7 +192,9 @@ describe("AppRoot", () => {
       ).filterMainScriptElements(FAKE_SCRIPT_HASH)
 
       // We should now only have a single element, inside a single block
-      expect(newRoot.main.getIn([1, 1])).toBeTextNode("newElement!")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 1])
+      ).toBeTextNode("newElement!")
       expect(newRoot.getElements().size).toBe(3)
     })
 
@@ -201,7 +210,9 @@ describe("AppRoot", () => {
       ).filterMainScriptElements(FAKE_SCRIPT_HASH)
 
       // We should now only have a single element, inside a single block
-      expect(newRoot.main.getIn([1, 1])).toBeUndefined()
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 1])
+      ).toBeUndefined()
       expect(newRoot.getElements().size).toBe(2)
     })
   })
@@ -217,17 +228,30 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as ElementNode
       expect(newNode).toBeTextNode("newElement!")
 
       // Check that our new scriptRunId has been set only on the touched nodes
       expect(newRoot.main.scriptRunId).toBe("new_session_id")
       expect(newRoot.main.fragmentId).toBe(undefined)
       expect(newRoot.main.deltaMsgReceivedAt).toBe(undefined)
-      expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
-      expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
-      expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
-      expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [0])?.scriptRunId
+      ).toBe(NO_SCRIPT_RUN_ID)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1])?.scriptRunId
+      ).toBe("new_session_id")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 0])
+          ?.scriptRunId
+      ).toBe(NO_SCRIPT_RUN_ID)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 1])
+          ?.scriptRunId
+      ).toBe("new_session_id")
       expect(newNode.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
       expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     })
@@ -240,17 +264,30 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode).toBeDefined()
 
       // Check that our new scriptRunId has been set only on the touched nodes
       expect(newRoot.main.scriptRunId).toBe("new_session_id")
       expect(newRoot.main.fragmentId).toBe(undefined)
       expect(newRoot.main.deltaMsgReceivedAt).toBe(undefined)
-      expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
-      expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
-      expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
-      expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [0])?.scriptRunId
+      ).toBe(NO_SCRIPT_RUN_ID)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1])?.scriptRunId
+      ).toBe("new_session_id")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 0])
+          ?.scriptRunId
+      ).toBe(NO_SCRIPT_RUN_ID)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 1])
+          ?.scriptRunId
+      ).toBe("new_session_id")
       expect(newNode.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
       expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     })
@@ -276,7 +313,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1, 0])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode).toBeDefined()
       expect(newNode.deltaBlock.type).toBe("expandable")
       expect(newNode.children.length).toBe(1)
@@ -291,7 +331,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const replacedBlock = newRoot2.main.getIn([1, 1]) as BlockNode
+      const replacedBlock = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot2.main,
+        [1, 1]
+      ) as BlockNode
       expect(replacedBlock).toBeDefined()
       expect(replacedBlock.deltaBlock.type).toBe("tabContainer")
       expect(replacedBlock.children.length).toBe(0)
@@ -318,7 +361,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1, 0])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode).toBeDefined()
       expect(newNode.deltaBlock.type).toBe("expandable")
       expect(newNode.children.length).toBe(1)
@@ -337,7 +383,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const replacedBlock = newRoot2.main.getIn([1, 1]) as BlockNode
+      const replacedBlock = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot2.main,
+        [1, 1]
+      ) as BlockNode
       expect(replacedBlock).toBeDefined()
       expect(replacedBlock.deltaBlock.type).toBe("expandable")
       expect(replacedBlock.children.length).toBe(1)
@@ -354,13 +403,17 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1], NEW_FAKE_SCRIPT_HASH)
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as ElementNode
       expect(newNode).toBeDefined()
 
       // Check that our new other nodes are not affected by the new script hash
-      expect(newRoot.main.getIn([1, 0])?.activeScriptHash).toBe(
-        FAKE_SCRIPT_HASH
-      )
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 0])
+          ?.activeScriptHash
+      ).toBe(FAKE_SCRIPT_HASH)
       expect(newNode.activeScriptHash).toBe(NEW_FAKE_SCRIPT_HASH)
     })
 
@@ -373,13 +426,17 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1], NEW_FAKE_SCRIPT_HASH)
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode).toBeDefined()
 
       // Check that our new scriptRunId has been set only on the touched nodes
-      expect(newRoot.main.getIn([1, 0])?.activeScriptHash).toBe(
-        FAKE_SCRIPT_HASH
-      )
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1, 0])
+          ?.activeScriptHash
+      ).toBe(FAKE_SCRIPT_HASH)
       expect(newNode.activeScriptHash).toBe(NEW_FAKE_SCRIPT_HASH)
     })
 
@@ -394,7 +451,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as ElementNode
       expect(newNode.fragmentId).toBe("myFragmentId")
     })
 
@@ -409,7 +469,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode.fragmentId).toBe("myFragmentId")
     })
 
@@ -425,7 +488,10 @@ describe("AppRoot", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-      const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as BlockNode
       expect(newNode.deltaMsgReceivedAt).toBe(timestamp)
     })
   })
@@ -443,7 +509,9 @@ describe("AppRoot", () => {
       ).clearStaleNodes("new_session_id", [])
 
       // We should now only have a single element, inside a single block
-      expect(newRoot.main.getIn([0, 0])).toBeTextNode("newElement!")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [0, 0])
+      ).toBeTextNode("newElement!")
       expect(newRoot.getElements().size).toBe(1)
     })
 
@@ -573,20 +641,57 @@ describe("AppRoot", () => {
 
       const pruned = root.clearStaleNodes("new_session_id", ["my_fragment_id"])
 
-      expect(pruned.main.getIn([0])).toBeInstanceOf(BlockNode)
-      expect((pruned.main.getIn([0]) as BlockNode).children).toHaveLength(3)
-      expect(pruned.main.getIn([0, 0])).toBeTextNode("oldElement!")
-      expect(pruned.main.getIn([0, 1])).toBeTextNode("oldElement2!")
-      expect(pruned.main.getIn([0, 2])).toBeTextNode("oldElement4!")
-
-      expect(pruned.main.getIn([1])).toBeInstanceOf(BlockNode)
-      expect((pruned.main.getIn([1]) as BlockNode).children).toHaveLength(1)
-      expect(pruned.main.getIn([1, 0])).toBeTextNode("newElement!")
-
-      expect(pruned.main.getIn([2])).toBeInstanceOf(BlockNode)
-      expect((pruned.main.getIn([2]) as BlockNode).children).toHaveLength(1)
       expect(
-        (pruned.main.getIn([2, 0]) as BlockNode).deltaBlock.tab?.label
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [0])
+      ).toBeInstanceOf(BlockNode)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [
+            0,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(3)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [0, 0])
+      ).toBeTextNode("oldElement!")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [0, 1])
+      ).toBeTextNode("oldElement2!")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [0, 2])
+      ).toBeTextNode("oldElement4!")
+
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [1])
+      ).toBeInstanceOf(BlockNode)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [
+            1,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(1)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [1, 0])
+      ).toBeTextNode("newElement!")
+
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [2])
+      ).toBeInstanceOf(BlockNode)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [
+            2,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(1)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(
+            pruned.main,
+            [2, 0]
+          ) as BlockNode
+        ).deltaBlock.tab?.label
       ).toContain("tab1")
     })
 
@@ -637,27 +742,58 @@ describe("AppRoot", () => {
           forwardMsgMetadata([0, 1, 3])
         )
 
-      expect((newRoot.main.getIn([1]) as BlockNode).children).toHaveLength(4)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [
+            1,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(4)
 
       const pruned = newRoot.clearStaleNodes("new_session_id", [
         "my_fragment_id",
       ])
 
-      expect(pruned.main.getIn([0])).toBeInstanceOf(BlockNode)
-      expect((pruned.main.getIn([0]) as BlockNode).children).toHaveLength(1)
-      expect(pruned.main.getIn([1])).toBeInstanceOf(BlockNode)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [0])
+      ).toBeInstanceOf(BlockNode)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [
+            0,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(1)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [1])
+      ).toBeInstanceOf(BlockNode)
       // the stale nested fragment child should have been pruned
-      expect((pruned.main.getIn([1]) as BlockNode).children).toHaveLength(3)
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(pruned.main, [
+            1,
+          ]) as BlockNode
+        ).children
+      ).toHaveLength(3)
     })
   })
 
   describe("AppRoot.getElements", () => {
-    it("returns all elements", () => {
+    it("returns all elements using ElementsSetVisitor", () => {
       // We have elements at main.[0] and main.[1, 0]
       expect(ROOT.getElements()).toEqual(
         new Set([
-          (ROOT.main.getIn([0]) as ElementNode).element,
-          (ROOT.main.getIn([1, 0]) as ElementNode).element,
+          (
+            GetNodeByDeltaPathVisitor.getNodeAtPath(ROOT.main, [
+              0,
+            ]) as ElementNode
+          ).element,
+          (
+            GetNodeByDeltaPathVisitor.getNodeAtPath(
+              ROOT.main,
+              [1, 0]
+            ) as ElementNode
+          ).element,
         ])
       )
     })

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -38,6 +38,7 @@ import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
+import { GetNodeByDeltaPathVisitor } from "./visitors/GetNodeByDeltaPathVisitor"
 
 interface LogoMetadata {
   // Associated scriptHash that created the logo
@@ -379,7 +380,10 @@ export class AppRoot {
     fragmentId?: string,
     deltaMsgReceivedAt?: number
   ): AppRoot {
-    const existingNode = this.root.getIn(deltaPath)
+    const existingNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+      this.root,
+      deltaPath
+    )
 
     // If we're replacing an existing Block of the same type, this new Block
     // inherits the existing Block's children. This preserves two things:
@@ -413,8 +417,14 @@ export class AppRoot {
     namedDataSet: ArrowNamedDataSet,
     scriptRunId: string
   ): AppRoot {
-    const existingNode = this.root.getIn(deltaPath) as ElementNode
-    if (isNullOrUndefined(existingNode)) {
+    const existingNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+      this.root,
+      deltaPath
+    )
+    if (
+      isNullOrUndefined(existingNode) ||
+      !(existingNode instanceof ElementNode)
+    ) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`Can't arrowAddRows: invalid deltaPath: ${deltaPath}`)
     }

--- a/frontend/lib/src/render-tree/BlockNode.test.ts
+++ b/frontend/lib/src/render-tree/BlockNode.test.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { NO_SCRIPT_RUN_ID } from "./AppNode.interface"
+import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { block, text } from "./test-utils"
+import { GetNodeByDeltaPathVisitor } from "./visitors/GetNodeByDeltaPathVisitor"
 
 // prettier-ignore
 const BLOCK = block([
@@ -25,44 +26,31 @@ const BLOCK = block([
   ]),
 ])
 
+function getIn(node: AppNode, path: number[]): AppNode | undefined {
+  return GetNodeByDeltaPathVisitor.getNodeAtPath(node, path)
+}
+
 describe("BlockNode", () => {
-  describe("BlockNode.getIn", () => {
-    it("handles shallow paths", () => {
-      const node = BLOCK.getIn([0])
-      expect(node).toBeTextNode("1")
-    })
-
-    it("handles deep paths", () => {
-      const node = BLOCK.getIn([1, 0])
-      expect(node).toBeTextNode("2")
-    })
-
-    it("returns undefined for invalid paths", () => {
-      const node = BLOCK.getIn([2, 3, 4])
-      expect(node).toBeUndefined()
-    })
-  })
-
   describe("BlockNode.setIn", () => {
     it("handles shallow paths", () => {
       const newBlock = BLOCK.setIn([0], text("new"), NO_SCRIPT_RUN_ID)
-      expect(newBlock.getIn([0])).toBeTextNode("new")
+      expect(getIn(newBlock, [0])).toBeTextNode("new")
 
       // Check BLOCK..newBlock diff is as expected.
       expect(newBlock).not.toStrictEqual(BLOCK)
-      expect(newBlock.getIn([1])).toStrictEqual(BLOCK.getIn([1]))
+      expect(getIn(newBlock, [1])).toStrictEqual(getIn(BLOCK, [1]))
     })
 
     it("handles deep paths", () => {
       const newBlock = BLOCK.setIn([1, 1], text("new"), NO_SCRIPT_RUN_ID)
-      expect(newBlock.getIn([1, 1])).toBeTextNode("new")
+      expect(getIn(newBlock, [1, 1])).toBeTextNode("new")
 
       // Check BLOCK..newBlock diff is as expected
       expect(newBlock).not.toStrictEqual(BLOCK)
-      expect(newBlock.getIn([0])).toStrictEqual(BLOCK.getIn([0]))
-      expect(newBlock.getIn([1])).not.toStrictEqual(BLOCK.getIn([1]))
-      expect(newBlock.getIn([1, 0])).toStrictEqual(BLOCK.getIn([1, 0]))
-      expect(newBlock.getIn([1, 1])).not.toStrictEqual(BLOCK.getIn([1, 1]))
+      expect(getIn(newBlock, [0])).toStrictEqual(getIn(BLOCK, [0]))
+      expect(getIn(newBlock, [1])).not.toStrictEqual(getIn(BLOCK, [1]))
+      expect(getIn(newBlock, [1, 0])).toStrictEqual(getIn(BLOCK, [1, 0]))
+      expect(getIn(newBlock, [1, 1])).not.toStrictEqual(getIn(BLOCK, [1, 1]))
     })
 
     it("throws an error for invalid paths", () => {
@@ -110,7 +98,9 @@ describe("BlockNode", () => {
 
       expect(result).not.toBe(originalNode)
       expect(result.children).toHaveLength(1)
-      expect(result.getIn([0])).toBeTextNode("transformed")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(result, [0])
+      ).toBeTextNode("transformed")
     })
   })
 })

--- a/frontend/lib/src/render-tree/BlockNode.ts
+++ b/frontend/lib/src/render-tree/BlockNode.ts
@@ -60,23 +60,6 @@ export class BlockNode implements AppNode {
     return this.children.length === 0
   }
 
-  public getIn(path: number[]): AppNode | undefined {
-    if (path.length === 0) {
-      return undefined
-    }
-
-    const childIndex = path[0]
-    if (childIndex < 0 || childIndex >= this.children.length) {
-      return undefined
-    }
-
-    if (path.length === 1) {
-      return this.children[childIndex]
-    }
-
-    return this.children[childIndex].getIn(path.slice(1))
-  }
-
   public setIn(path: number[], node: AppNode, scriptRunId: string): BlockNode {
     if (path.length === 0) {
       throw new Error(`empty path!`)

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -121,10 +121,6 @@ export class ElementNode implements AppNode {
     return toReturn
   }
 
-  public getIn(): AppNode | undefined {
-    return undefined
-  }
-
   public setIn(): AppNode {
     throw new Error("'setIn' cannot be called on an ElementNode")
   }

--- a/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { block, text } from "~lib/render-tree/test-utils"
+
+import { GetNodeByDeltaPathVisitor } from "./GetNodeByDeltaPathVisitor"
+
+// Test data setup following the existing pattern
+const BLOCK = block([text("1"), block([text("2"), text("3")])])
+
+describe("GetNodeByDeltaPathVisitor", () => {
+  describe("visitElementNode", () => {
+    it("always returns undefined for ElementNode", () => {
+      const elementNode = text("element")
+      const visitor = new GetNodeByDeltaPathVisitor([0])
+
+      const result = visitor.visitElementNode(elementNode)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined for ElementNode even with empty path", () => {
+      const elementNode = text("element")
+      const visitor = new GetNodeByDeltaPathVisitor([])
+
+      const result = visitor.visitElementNode(elementNode)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("visitBlockNode", () => {
+    it("returns undefined for empty path", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("gets node at shallow path", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([0])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeTextNode("1")
+    })
+
+    it("gets node at deep path", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([1, 0])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeTextNode("2")
+    })
+
+    it("gets second node at deep path", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([1, 1])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeTextNode("3")
+    })
+
+    it("returns undefined for invalid child index - negative", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([-1])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined for invalid child index - too large", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([3])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined for invalid deep path", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([1, 3])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("handles boundary index (exact length)", () => {
+      const visitor = new GetNodeByDeltaPathVisitor([2])
+      const result = visitor.visitBlockNode(BLOCK)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("works with empty block", () => {
+      const emptyBlock = new BlockNode("script_hash", [])
+      const visitor = new GetNodeByDeltaPathVisitor([0])
+      const result = visitor.visitBlockNode(emptyBlock)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns a block node if needed", () => {
+      // Create a deeper structure
+      const deepBlock = block([
+        text("level1"),
+        block([text("level2-0"), block([text("level3-0"), text("level3-1")])]),
+      ])
+
+      const visitor = new GetNodeByDeltaPathVisitor([1, 1, 0])
+      const result = visitor.visitBlockNode(deepBlock)
+
+      expect(result).toBeTextNode("level3-0")
+    })
+
+    it("handles deep path traversal", () => {
+      const deepBlock = block([
+        text("level1"),
+        block([text("level2-0"), block([text("level3-0"), text("level3-1")])]),
+      ])
+
+      const visitor = new GetNodeByDeltaPathVisitor([1, 1, 1])
+      const result = visitor.visitBlockNode(deepBlock)
+
+      expect(result).toBeTextNode("level3-1")
+    })
+
+    it("handles very deep nested structure", () => {
+      const veryDeepBlock = block([
+        block([block([block([text("very-deep")])])]),
+      ])
+
+      const visitor = new GetNodeByDeltaPathVisitor([0, 0, 0, 0])
+      const result = visitor.visitBlockNode(veryDeepBlock)
+
+      expect(result).toBeTextNode("very-deep")
+    })
+  })
+
+  describe("static getNodeAtPath", () => {
+    it("gets node using static method with shallow path", () => {
+      const result = GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [0])
+
+      expect(result).toBeTextNode("1")
+    })
+
+    it("gets node using static method with deep path", () => {
+      const result = GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [1, 1])
+
+      expect(result).toBeTextNode("3")
+    })
+
+    it("returns undefined using static method for invalid path", () => {
+      const result = GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [2, 3, 4])
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined when used on ElementNode via static method", () => {
+      const element = text("element")
+      const result = GetNodeByDeltaPathVisitor.getNodeAtPath(element, [0])
+
+      expect(result).toBeUndefined()
+    })
+
+    it("handles empty path with static method", () => {
+      const result = GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [])
+
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppNode } from "~lib/render-tree/AppNode.interface"
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+
+import { AppNodeVisitor } from "./AppNodeVisitor.interface"
+
+/**
+ * A visitor that retrieves a node at a specific delta path.
+ *
+ * Usage:
+ * ```typescript
+ * const visitor = new GetNodeByDeltaPathVisitor([1, 2, 0])
+ * const foundNode = rootNode.accept(visitor)
+ * ```
+ */
+export class GetNodeByDeltaPathVisitor
+  implements AppNodeVisitor<AppNode | undefined>
+{
+  private readonly deltaPath: number[]
+
+  constructor(deltaPath: number[]) {
+    this.deltaPath = deltaPath
+  }
+
+  visitElementNode(_node: ElementNode): AppNode | undefined {
+    // ElementNodes have no children, so there is nothing to check
+    return undefined
+  }
+
+  visitBlockNode(node: BlockNode): AppNode | undefined {
+    if (this.deltaPath.length === 0) {
+      return undefined
+    }
+
+    const [currentIndex, ...remainingPath] = this.deltaPath
+
+    // Check if the index is valid
+    if (currentIndex < 0 || currentIndex >= node.children.length) {
+      return undefined
+    }
+
+    if (remainingPath.length === 0) {
+      // Base case: we've consumed the entire path (at target location), return the target node
+      return node.children[currentIndex]
+    }
+
+    // Recursive case: create a new visitor and continue traversal
+    const childVisitor = new GetNodeByDeltaPathVisitor(remainingPath)
+    return node.children[currentIndex].accept(childVisitor)
+  }
+
+  /**
+   * Static convenience method to get a node at a delta path.
+   */
+  static getNodeAtPath(
+    rootNode: AppNode,
+    deltaPath: number[]
+  ): AppNode | undefined {
+    const visitor = new GetNodeByDeltaPathVisitor(deltaPath)
+    return rootNode.accept(visitor)
+  }
+}


### PR DESCRIPTION
## Describe your changes

A little more complicated than the ElementSet Visitor, but this change updates the getIn Method to a GetNodeByDeltaPath visitor.

## Testing Plan

- JS tests are updated
- E2E tests should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
