### PR TITLE
Create RenderNodeVisitor

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useContext } from "react"
+import React, { ReactElement, useContext } from "react"
 
 import classNames from "classnames"
 
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
-import { AppNode, BlockNode, ElementNode } from "~lib/AppNode"
+import { BlockNode } from "~lib/AppNode"
 import {
   FlexContext,
   FlexContextProvider,
@@ -43,9 +43,9 @@ import Tabs, { TabProps } from "~lib/components/elements/Tabs"
 import Form from "~lib/components/widgets/Form"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useScrollToBottom } from "~lib/hooks/useScrollToBottom"
-import { getElementId, notNullOrUndefined } from "~lib/util/utils"
+import { notNullOrUndefined } from "~lib/util/utils"
 
-import ElementNodeRenderer from "./ElementNodeRenderer"
+import { RenderNodeVisitor } from "./RenderNodeVisitor"
 import {
   StyledColumn,
   StyledFlexContainerBlock,
@@ -72,60 +72,15 @@ const ChildRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
   // Handle cycling of colors for dividers:
   assignDividerColor(props.node, useEmotionTheme())
 
-  // Capture all the element ids to avoid rendering the same element twice
-  const elementKeySet = new Set<string>()
+  const disableFullscreenMode =
+    libConfig.disableFullscreenMode || props.disableFullscreenMode
 
   return (
     <>
-      {props.node.children?.map((node: AppNode, index: number): ReactNode => {
-        const disableFullscreenMode =
-          libConfig.disableFullscreenMode || props.disableFullscreenMode
-
-        // Base case: render a leaf node.
-        if (node instanceof ElementNode) {
-          // Put node in childProps instead of passing as a node={node} prop in React to
-          // guarantee it doesn't get overwritten by {...childProps}.
-          const childProps = {
-            ...props,
-            disableFullscreenMode,
-            node,
-          }
-
-          const key = getElementId(node.element) || index.toString()
-          // Avoid rendering the same element twice. We assume the first one is the one we want
-          // because the page is rendered top to bottom, so a valid widget would be rendered
-          // correctly and we assume the second one is therefore stale (or throw an error).
-          // Also, our setIn logic pushes stale widgets down in the list of elements, so the
-          // most recent one should always come first.
-          if (elementKeySet.has(key)) {
-            return null
-          }
-
-          elementKeySet.add(key)
-
-          return <ElementNodeRenderer key={key} {...childProps} />
-        }
-
-        // Recursive case: render a block, which can contain other blocks
-        // and elements.
-        if (node instanceof BlockNode) {
-          // Put node in childProps instead of passing as a node={node} prop in React to
-          // guarantee it doesn't get overwritten by {...childProps}.
-          const childProps = {
-            ...props,
-            disableFullscreenMode,
-            node,
-          }
-
-          // TODO: Update to match React best practices
-          // eslint-disable-next-line @eslint-react/no-array-index-key, @typescript-eslint/no-use-before-define
-          return <BlockNodeRenderer key={index} {...childProps} />
-        }
-
-        // We don't have any other node types!
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions -- TODO: Fix this
-        throw new Error(`Unrecognized AppNode: ${node}`)
-      })}
+      {RenderNodeVisitor.collectReactElements(
+        props,
+        Boolean(disableFullscreenMode)
+      )}
     </>
   )
 }
@@ -297,7 +252,9 @@ export interface BlockPropsWithoutWidth extends BaseBlockProps {
 const LARGE_STRETCH_BEHAVIOR = ["tabContainer"]
 const MEDIUM_STRETCH_BEHAVIOR = ["chatInput"]
 
-const BlockNodeRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
+export const BlockNodeRenderer = (
+  props: BlockPropsWithoutWidth
+): ReactElement => {
   const { node } = props
   const { scriptRunState, scriptRunId, fragmentIdsThisRun } =
     useContext(ScriptRunContext)

--- a/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
+++ b/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { BlockNode } from "~lib/AppNode"
+import { FileUploadClient } from "~lib/FileUploadClient"
+import { mockEndpoints, mockSessionInfo } from "~lib/mocks/mocks"
+import { block, text, textInput } from "~lib/render-tree/test-utils"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import { RenderNodeVisitor } from "./RenderNodeVisitor"
+
+import { BlockPropsWithoutWidth } from "./index"
+
+// Mock props for testing
+const sessionInfo = mockSessionInfo()
+const createMockProps = (node: BlockNode): BlockPropsWithoutWidth => ({
+  node,
+  endpoints: mockEndpoints(),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: () => {},
+    formsDataChanged: () => {},
+  }),
+  uploadClient: new FileUploadClient({
+    sessionInfo,
+    endpoints: mockEndpoints(),
+    formsWithPendingRequestsChanged: () => {},
+  }),
+  widgetsDisabled: false,
+})
+
+describe("RenderNodeVisitor", () => {
+  describe("constructor", () => {
+    it("creates visitor with initial state", () => {
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      expect(visitor.reactElements).toEqual([])
+      expect(visitor.reactElements).toHaveLength(0)
+    })
+  })
+
+  describe("visitElementNode", () => {
+    it("returns React element for ElementNode", () => {
+      const elementNode = text("test element")
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result = visitor.visitElementNode(elementNode)
+
+      expect(result).not.toBeNull()
+      expect(React.isValidElement(result)).toBe(true)
+      expect(visitor.reactElements).toHaveLength(1)
+      expect(visitor.reactElements[0]).toBe(result)
+    })
+
+    it("increments index after visiting ElementNode", () => {
+      const elementNode1 = text("element 1")
+      const elementNode2 = text("element 2")
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result1 = visitor.visitElementNode(elementNode1)
+      const result2 = visitor.visitElementNode(elementNode2)
+
+      expect(result1).not.toBe(result2)
+      expect(visitor.reactElements).toHaveLength(2)
+      expect(visitor.reactElements[0]).toBe(result1)
+      expect(visitor.reactElements[1]).toBe(result2)
+    })
+
+    it("handles duplicate element keys by filtering out duplicates", () => {
+      // Create two identical text elements - they should have the same internal structure
+      const element1 = textInput("same text", "same_id")
+      const element2 = textInput("same text", "same_id")
+
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result1 = visitor.visitElementNode(element1)
+      const result2 = visitor.visitElementNode(element2)
+
+      // Only one widget should be rendered
+      expect(visitor.reactElements).toHaveLength(1)
+      expect(result1).not.toBeNull()
+      expect(React.isValidElement(result1)).toBe(true)
+      expect(visitor.reactElements[0]).toBe(result1)
+      expect(result2).toBeNull()
+    })
+
+    it("uses the widget id as the key", () => {
+      const element = textInput("same text", "same_id")
+
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result = visitor.visitElementNode(element)
+
+      expect(visitor.reactElements).toHaveLength(1)
+      expect(result).not.toBeNull()
+      expect(React.isValidElement(result)).toBe(true)
+      expect(visitor.reactElements[0]).toBe(result)
+      expect((result as React.ReactElement).key).toBe(
+        element.element?.textInput?.id
+      )
+    })
+  })
+
+  describe("visitBlockNode", () => {
+    it("returns React element for BlockNode", () => {
+      const blockNode = block([text("child")])
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result = visitor.visitBlockNode(blockNode)
+
+      expect(result).not.toBeNull()
+      expect(React.isValidElement(result)).toBe(true)
+      expect(visitor.reactElements).toHaveLength(1)
+      expect(visitor.reactElements[0]).toBe(result)
+    })
+
+    it("increments index after visiting BlockNode", () => {
+      const blockNode1 = block([text("child1")])
+      const blockNode2 = block([text("child2")])
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result1 = visitor.visitBlockNode(blockNode1)
+      const result2 = visitor.visitBlockNode(blockNode2)
+
+      expect(result1).not.toBe(result2)
+      expect(visitor.reactElements).toHaveLength(2)
+      expect(visitor.reactElements[0]).toBe(result1)
+      expect(visitor.reactElements[1]).toBe(result2)
+    })
+
+    it("uses index as key for BlockNode", () => {
+      const blockNode = block([])
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const result = visitor.visitBlockNode(blockNode)
+
+      expect(result).not.toBeNull()
+      expect(React.isValidElement(result)).toBe(true)
+      // The key should be "0" for the first block
+      expect((result as React.ReactElement).key).toBe("0")
+    })
+
+    it("passes disableFullscreenMode prop correctly", () => {
+      const blockNode = block([])
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, true)
+
+      const result = visitor.visitBlockNode(blockNode)
+
+      expect(result).not.toBeNull()
+      expect(React.isValidElement(result)).toBe(true)
+      // Check that the props contain disableFullscreenMode: true
+      const props = (result as React.ReactElement).props
+      expect(props.disableFullscreenMode).toBe(true)
+    })
+  })
+
+  describe("mixed node types", () => {
+    it("handles visiting multiple different node types", () => {
+      const elementNode = text("element")
+      const blockNode = block([text("block child")])
+
+      const mockBlock = block([])
+      const mockProps = createMockProps(mockBlock)
+      const visitor = new RenderNodeVisitor(mockProps, false)
+
+      const elementResult = visitor.visitElementNode(elementNode)
+      const blockResult = visitor.visitBlockNode(blockNode)
+
+      expect(elementResult).not.toBeNull()
+      expect(React.isValidElement(elementResult)).toBe(true)
+      expect(blockResult).not.toBeNull()
+      expect(React.isValidElement(blockResult)).toBe(true)
+
+      expect(visitor.reactElements).toHaveLength(2)
+      expect(visitor.reactElements[0]).toBe(elementResult)
+      expect(visitor.reactElements[1]).toBe(blockResult)
+    })
+  })
+
+  describe("static collectReactElements", () => {
+    it("returns empty array for block with no children", () => {
+      const emptyBlock = block([])
+      const mockProps = createMockProps(emptyBlock)
+
+      const result = RenderNodeVisitor.collectReactElements(mockProps, false)
+
+      expect(result).toEqual([])
+    })
+
+    it("collects React elements from block children", () => {
+      const childBlock = block([text("child element")])
+      const parentBlock = block([
+        text("element 1"),
+        childBlock,
+        text("element 2"),
+      ])
+      const mockProps = createMockProps(parentBlock)
+
+      const result = RenderNodeVisitor.collectReactElements(mockProps, false)
+
+      expect(result).toHaveLength(3)
+      result.forEach(element => {
+        expect(element).not.toBeNull()
+        expect(React.isValidElement(element)).toBe(true)
+      })
+    })
+
+    it("handles disableFullscreenMode flag", () => {
+      const parentBlock = block([text("element")])
+      const mockProps = createMockProps(parentBlock)
+
+      const result = RenderNodeVisitor.collectReactElements(mockProps, true)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).not.toBeNull()
+      expect(React.isValidElement(result[0])).toBe(true)
+      // Check that the props contain disableFullscreenMode: true
+      const props = (result[0] as React.ReactElement).props
+      expect(props.disableFullscreenMode).toBe(true)
+    })
+
+    it("creates new visitor instance for each call", () => {
+      const parentBlock = block([text("element")])
+      const mockProps = createMockProps(parentBlock)
+
+      const result1 = RenderNodeVisitor.collectReactElements(mockProps, false)
+      const result2 = RenderNodeVisitor.collectReactElements(mockProps, false)
+
+      expect(result1).toHaveLength(1)
+      expect(result2).toHaveLength(1)
+      // Results should be different instances (new React elements created)
+      expect(result1[0]).not.toBe(result2[0])
+    })
+
+    it("handles complex nested structure", () => {
+      const deepElement = text("deep element")
+      const nestedBlock = block([deepElement])
+      const parentBlock = block([
+        text("element 1"),
+        nestedBlock,
+        text("element 2"),
+        block([text("another nested element")]),
+      ])
+      const mockProps = createMockProps(parentBlock)
+
+      const result = RenderNodeVisitor.collectReactElements(mockProps, false)
+
+      // Should have 4 elements: 2 text elements + 2 block elements
+      expect(result).toHaveLength(4)
+      result.forEach(element => {
+        expect(element).not.toBeNull()
+        expect(React.isValidElement(element)).toBe(true)
+      })
+    })
+  })
+
+  describe("integration with render tree", () => {
+    it("works with render tree test utilities", () => {
+      const testBlock = block([
+        text("first"),
+        block([text("nested")]),
+        text("last"),
+      ])
+      const mockProps = createMockProps(testBlock)
+
+      const result = RenderNodeVisitor.collectReactElements(mockProps, false)
+
+      expect(result).toHaveLength(3)
+      result.forEach(element => {
+        expect(element).not.toBeNull()
+        expect(React.isValidElement(element)).toBe(true)
+      })
+    })
+  })
+})

--- a/frontend/lib/src/components/core/Block/RenderNodeVisitor.tsx
+++ b/frontend/lib/src/components/core/Block/RenderNodeVisitor.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement } from "react"
+
+import { BlockNode, ElementNode } from "~lib/AppNode"
+import { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
+import { getElementId } from "~lib/util/utils"
+
+import { BlockNodeRenderer } from "./Block"
+import ElementNodeRenderer from "./ElementNodeRenderer"
+
+import { BlockPropsWithoutWidth } from "."
+
+export type OptionalReactElement = ReactElement | null
+
+/**
+ * A visitor that renders AppNodes as React elements.
+ *
+ * Unlike other visitors in render-tree/visitors/, this visitor is
+ * React-specific and located in components/ to maintain dependency
+ * boundaries.
+ *
+ * This visitor accumulates React elements in a mutable array and tracks
+ * rendered element IDs to prevent duplicate rendering of widgets.
+ *
+ * Usage:
+ * ```typescript
+ * const elements = RenderNodeVisitor.collectReactElements(props, disableFullscreen)
+ * return <>{elements}</>
+ * ```
+ */
+export class RenderNodeVisitor
+  implements AppNodeVisitor<OptionalReactElement>
+{
+  private readonly props: BlockPropsWithoutWidth
+  private readonly disableFullscreenMode: boolean
+  private readonly elementKeySet: Set<string>
+  public readonly reactElements: OptionalReactElement[]
+  private index: number
+
+  constructor(props: BlockPropsWithoutWidth, disableFullscreenMode: boolean) {
+    this.props = props
+    this.disableFullscreenMode = disableFullscreenMode
+    this.elementKeySet = new Set<string>()
+    this.reactElements = [] as OptionalReactElement[]
+    // Initialize index to 0 as we will use it as a key in the React component
+    this.index = 0
+  }
+
+  private getCurrentKey(elementId?: string): string {
+    const key = elementId || this.index.toString()
+    // Increment this.index to be used for the next key
+    this.index += 1
+
+    return key
+  }
+
+  visitBlockNode(node: BlockNode): OptionalReactElement {
+    // Put node in childProps instead of passing as a node={node} prop in React to
+    // guarantee it doesn't get overwritten by {...childProps}.
+    const childProps = {
+      ...this.props,
+      disableFullscreenMode: this.disableFullscreenMode,
+      node,
+    }
+
+    const key = this.getCurrentKey()
+    const renderer = <BlockNodeRenderer key={key} {...childProps} />
+    this.reactElements.push(renderer)
+
+    return renderer
+  }
+
+  visitElementNode(node: ElementNode): OptionalReactElement {
+    // Put node in childProps instead of passing as a node={node} prop in React to
+    // guarantee it doesn't get overwritten by {...childProps}.
+    const childProps = {
+      ...this.props,
+      disableFullscreenMode: this.disableFullscreenMode,
+      node,
+    }
+
+    const key = this.getCurrentKey(getElementId(node.element))
+    // Avoid rendering the same element twice. We assume the first one is the one we want
+    // because the page is rendered top to bottom, so a valid widget would be rendered
+    // correctly and we assume the second one is therefore stale (or throw an error).
+    // Also, our setIn logic pushes stale widgets down in the list of elements, so the
+    // most recent one should always come first.
+    if (this.elementKeySet.has(key)) {
+      return null
+    }
+
+    this.elementKeySet.add(key)
+
+    const renderer = <ElementNodeRenderer key={key} {...childProps} />
+    this.reactElements.push(renderer)
+
+    return renderer
+  }
+
+  /**
+   * Convenience method to render all children of a block as React elements.
+   *
+   * This is the primary entry point for rendering - it creates a visitor,
+   * traverses all children, and returns the accumulated React elements.
+   *
+   * @param props - Block props containing the node to render
+   * @param disableFullscreenMode - Whether to disable fullscreen mode for elements
+   * @returns Array of React elements ready to render (may include nulls for duplicates)
+   *
+   * @example
+   * const ChildRenderer = (props) => {
+   *   return <>{RenderNodeVisitor.collectReactElements(props, false)}</>
+   * }
+   */
+  static collectReactElements(
+    props: BlockPropsWithoutWidth,
+    disableFullscreenMode: boolean
+  ): OptionalReactElement[] {
+    if (!props.node.children) {
+      return []
+    }
+
+    const visitor = new RenderNodeVisitor(props, disableFullscreenMode)
+    // Visit all the children nodes and collect the react elements
+    props.node.children.forEach(childNode => childNode.accept(visitor))
+
+    return visitor.reactElements
+  }
+}

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -21,10 +21,14 @@ import {
   Element,
   ForwardMsgMetadata,
   IArrowVegaLiteChart,
+  TextInput as TextInputProto,
 } from "@streamlit/protobuf"
 
 import { UNICODE } from "~lib/mocks/arrow"
-import { isNullOrUndefined } from "~lib/util/utils"
+import {
+  GENERATED_ELEMENT_ID_PREFIX,
+  isNullOrUndefined,
+} from "~lib/util/utils"
 
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
@@ -38,6 +42,29 @@ export function text(
   scriptRunId = NO_SCRIPT_RUN_ID
 ): ElementNode {
   const element = makeProto(Element, { text: { body: textArg } })
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create(),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
+}
+
+/** Create a text input element node with the given properties. */
+export function textInput(
+  label: string,
+  id: string = "some_id",
+  scriptRunId = NO_SCRIPT_RUN_ID
+): ElementNode {
+  const element = makeProto(Element, {
+    textInput: {
+      id: `${GENERATED_ELEMENT_ID_PREFIX}-${id}-key`,
+      label,
+      default: "",
+      placeholder: "Placeholder",
+      type: TextInputProto.Type.DEFAULT,
+    },
+  })
   return new ElementNode(
     element,
     ForwardMsgMetadata.create(),

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -30,7 +30,7 @@ import { isNullOrUndefined, notNullOrUndefined } from "@streamlit/utils"
 import { assertNever } from "./assertNever"
 
 // This prefix should be in sync with the value on the python side:
-const GENERATED_ELEMENT_ID_PREFIX = "$$ID"
+export const GENERATED_ELEMENT_ID_PREFIX = "$$ID"
 
 /**
  * Wraps a function to allow it to be called, at most, once per interval


### PR DESCRIPTION
## Describe your changes

Now, we introduce a new visitor for rendering the block react node. We made this separate from the render-tree folder because we did not want to make React a dependency. This is great because we can break out the render-tree to a separate package someday.

## Testing Plan

- JS Unit Tests for the RenderNode Visitor
- E2E tests should ensure the rendering logic remains correct

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
