### PR TITLE
Convert clearStaleNodes to ClearStaleNodesVisitor

### DIFF
--- a/frontend/lib/src/render-tree/AppNode.interface.ts
+++ b/frontend/lib/src/render-tree/AppNode.interface.ts
@@ -92,16 +92,6 @@ export interface AppNode {
   setIn(path: number[], node: AppNode, scriptRunId: string): AppNode
 
   /**
-   * Recursively remove children nodes whose scriptRunId is no longer current.
-   * If this node should no longer exist, return undefined.
-   */
-  clearStaleNodes(
-    currentScriptRunId: string,
-    fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: string
-  ): AppNode | undefined
-
-  /**
    * Accept a visitor.
    * @param visitor - The visitor to accept.
    * @returns The result of the visitor's visit{AppNodeType} method.

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -776,6 +776,56 @@ describe("AppRoot", () => {
         ).children
       ).toHaveLength(3)
     })
+
+    it("uses ClearStaleNodeVisitor internally", () => {
+      // Create a more complex tree with multiple nodes
+      const delta1 = makeProto(DeltaProto, {
+        newElement: { text: { body: "element1" } },
+      })
+      const delta2 = makeProto(DeltaProto, {
+        newElement: { text: { body: "element2" } },
+      })
+
+      // Add elements with different script run IDs
+      const rootWithElements = ROOT.applyDelta(
+        "run_id_1",
+        delta1,
+        forwardMsgMetadata([0, 0])
+      ).applyDelta("run_id_2", delta2, forwardMsgMetadata([0, 1]))
+
+      // Before clearing: should have both elements
+      expect(rootWithElements.getElements().size).toBe(2) // 2 new elements
+
+      // Clear stale nodes - only keep elements from run_id_2
+      const clearedRoot = rootWithElements.clearStaleNodes("run_id_2", [])
+
+      // After clearing: should only have element2 (from run_id_2)
+      expect(clearedRoot.getElements().size).toBe(1)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(clearedRoot.main, [0])
+      ).toBeTextNode("element2")
+    })
+
+    it("preserves non-stale nodes during visitor traversal", () => {
+      const delta = makeProto(DeltaProto, {
+        newElement: { text: { body: "current_element" } },
+      })
+      const currentRunId = "current_run"
+
+      const rootWithCurrent = ROOT.applyDelta(
+        currentRunId,
+        delta,
+        forwardMsgMetadata([0, 0])
+      )
+
+      // Clear stale nodes with same run ID - element should be preserved
+      const clearedRoot = rootWithCurrent.clearStaleNodes(currentRunId, [])
+
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(clearedRoot.main, [0])
+      ).toBeTextNode("current_element")
+      expect(clearedRoot.getElements().size).toBe(1)
+    })
   })
 
   describe("AppRoot.getElements", () => {
@@ -797,78 +847,65 @@ describe("AppRoot", () => {
         ])
       )
     })
-  })
-
-  it("uses visitor pattern internally", () => {
-    // Create a more complex structure to test visitor traversal
-    const delta1 = makeProto(DeltaProto, {
-      newElement: { text: { body: "main_element" } },
+    it("uses visitor pattern internally", () => {
+      // Create a more complex structure to test visitor traversal
+      const delta1 = makeProto(DeltaProto, {
+        newElement: { text: { body: "main_element" } },
+      })
+      const delta2 = makeProto(DeltaProto, {
+        newElement: { text: { body: "sidebar_element" } },
+      })
+      const rootWithElements = ROOT.applyDelta(
+        "test_run",
+        delta1,
+        forwardMsgMetadata([0, 0]) // main section
+      ).applyDelta(
+        "test_run",
+        delta2,
+        forwardMsgMetadata([1, 0]) // sidebar section
+      )
+      const elements = rootWithElements.getElements()
+      // Should find elements from main, sidebar, and the original ROOT elements
+      // one new insert overwrote an existing main element; the sidebar insert
+      // added a new one
+      expect(elements.size).toBe(3)
+      // Verify we can find the sidebar element specifically
+      const elementsArray = Array.from(elements)
+      const sidebarElement = elementsArray.find(
+        el => el.text?.body === "sidebar_element"
+      )
+      expect(sidebarElement).toBeDefined()
     })
-    const delta2 = makeProto(DeltaProto, {
-      newElement: { text: { body: "sidebar_element" } },
+
+    it("demonstrates visitor pattern flexibility", () => {
+      // Show that we can use ElementsSetVisitor directly on parts of the tree
+      const mainElements = ElementsSetVisitor.collectElements(ROOT.main)
+      const sidebarElements = ElementsSetVisitor.collectElements(ROOT.sidebar)
+      // Should have elements in main, none in sidebar for basic ROOT
+      expect(mainElements.size).toBe(2) // The original elements from ROOT
+      expect(sidebarElements.size).toBe(0)
+      // Combined should equal getElements() result
+      const combinedSize = mainElements.size + sidebarElements.size
+      expect(ROOT.getElements().size).toBe(combinedSize)
     })
-
-    const rootWithElements = ROOT.applyDelta(
-      "test_run",
-      delta1,
-      forwardMsgMetadata([0, 0]) // main section
-    ).applyDelta(
-      "test_run",
-      delta2,
-      forwardMsgMetadata([1, 0]) // sidebar section
-    )
-
-    const elements = rootWithElements.getElements()
-
-    // Should find elements from main, sidebar, and the original ROOT elements
-    // one new insert overwrote an existing main element; the sidebar insert
-    // added a new one
-    expect(elements.size).toBe(3)
-
-    // Verify we can find the sidebar element specifically
-    const elementsArray = Array.from(elements)
-    const sidebarElement = elementsArray.find(
-      el => el.text?.body === "sidebar_element"
-    )
-
-    expect(sidebarElement).toBeDefined()
-  })
-
-  it("demonstrates visitor pattern flexibility", () => {
-    // Show that we can use ElementsSetVisitor directly on parts of the tree
-    const mainElements = ElementsSetVisitor.collectElements(ROOT.main)
-    const sidebarElements = ElementsSetVisitor.collectElements(ROOT.sidebar)
-
-    // Should have elements in main, none in sidebar for basic ROOT
-    expect(mainElements.size).toBe(2) // The original elements from ROOT
-    expect(sidebarElements.size).toBe(0)
-
-    // Combined should equal getElements() result
-    const combinedSize = mainElements.size + sidebarElements.size
-    expect(ROOT.getElements().size).toBe(combinedSize)
   })
 
   describe("AppRoot.debug", () => {
     it("prints labeled child sections with tree output", () => {
       const out = ROOT.debug()
-
       // Header
       expect(out.startsWith("AppRoot\n")).toBe(true)
-
       // main
       expect(out).toContain("├── main:\n")
       expect(out).toContain("│   └── BlockNode [2 children]")
       expect(out).toContain('ElementNode [text] "1"')
       expect(out).toContain('ElementNode [text] "2"')
-
       // sidebar
       expect(out).toContain("├── sidebar:\n")
       expect(out).toContain("│   └── BlockNode [0 children]")
-
       // event
       expect(out).toContain("├── event:\n")
       expect(out).toContain("│   └── BlockNode [0 children]")
-
       // bottom
       expect(out).toContain("└── bottom:\n")
       expect(out).toContain("    └── BlockNode [0 children]")

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -36,6 +36,7 @@ import {
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
+import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
 import { FilterMainScriptElementsVisitor } from "./visitors/FilterMainScriptElementsVisitor"
@@ -272,10 +273,10 @@ export class AppRoot {
   }
 
   private ensureBlockNode(
-    node: BlockNode | undefined,
+    node: AppNode | undefined,
     mainScriptHash: string = this.mainScriptHash
   ): BlockNode {
-    return node ?? new BlockNode(mainScriptHash)
+    return (node as BlockNode) ?? new BlockNode(mainScriptHash)
   }
 
   /**
@@ -312,18 +313,13 @@ export class AppRoot {
     currentScriptRunId: string,
     fragmentIdsThisRun?: Array<string>
   ): AppRoot {
-    const main =
-      this.main.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode(this.mainScriptHash)
-    const sidebar =
-      this.sidebar.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode(this.mainScriptHash)
-    const event =
-      this.event.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode(this.mainScriptHash)
-    const bottom =
-      this.bottom.clearStaleNodes(currentScriptRunId, fragmentIdsThisRun) ||
-      new BlockNode(this.mainScriptHash)
+    const visitor = new ClearStaleNodeVisitor(
+      currentScriptRunId,
+      fragmentIdsThisRun
+    )
+    const newChildren = this.root.children.map(node =>
+      this.ensureBlockNode(node.accept(visitor))
+    )
 
     // Check if we're running a fragment, ensure logo isn't cleared as stale (Issue #10350/#10382)
     const isFragmentRun = fragmentIdsThisRun && fragmentIdsThisRun.length > 0
@@ -336,7 +332,7 @@ export class AppRoot {
       this.mainScriptHash,
       new BlockNode(
         this.mainScriptHash,
-        [main, sidebar, event, bottom],
+        newChildren,
         new BlockProto({ allowEmpty: true }),
         currentScriptRunId
       ),

--- a/frontend/lib/src/render-tree/BlockNode.ts
+++ b/frontend/lib/src/render-tree/BlockNode.ts
@@ -16,8 +16,6 @@
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
-import { notUndefined } from "~lib/util/utils"
-
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
 import { DebugVisitor } from "./visitors/DebugVisitor"
@@ -90,58 +88,6 @@ export class BlockNode implements AppNode {
       newChildren,
       this.deltaBlock,
       scriptRunId,
-      this.fragmentId,
-      this.deltaMsgReceivedAt
-    )
-  }
-
-  public clearStaleNodes(
-    currentScriptRunId: string,
-    fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: string
-  ): BlockNode | undefined {
-    if (!fragmentIdsThisRun?.length) {
-      // If we're not currently running a fragment, then we can remove any blocks
-      // that don't correspond to currentScriptRunId.
-      if (this.scriptRunId !== currentScriptRunId) {
-        return undefined
-      }
-    } else {
-      // Otherwise, we are currently running a fragment, and our behavior
-      // depends on the fragmentId of this BlockNode.
-
-      // The parent block was modified but this element wasn't, so it's stale.
-      if (fragmentIdOfBlock && this.scriptRunId !== currentScriptRunId) {
-        return undefined
-      }
-
-      // This block is modified by the current run, so we indicate this to our children in case
-      // they were not modified by the current run, which means they are stale.
-      if (
-        this.fragmentId &&
-        fragmentIdsThisRun.includes(this.fragmentId) &&
-        this.scriptRunId === currentScriptRunId
-      ) {
-        fragmentIdOfBlock = this.fragmentId
-      }
-    }
-
-    // Recursively clear our children.
-    const newChildren = this.children
-      .map(child => {
-        return child.clearStaleNodes(
-          currentScriptRunId,
-          fragmentIdsThisRun,
-          fragmentIdOfBlock
-        )
-      })
-      .filter(notUndefined)
-
-    return new BlockNode(
-      this.activeScriptHash,
-      newChildren,
-      this.deltaBlock,
-      currentScriptRunId,
       this.fragmentId,
       this.deltaMsgReceivedAt
     )

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -125,28 +125,6 @@ export class ElementNode implements AppNode {
     throw new Error("'setIn' cannot be called on an ElementNode")
   }
 
-  public clearStaleNodes(
-    currentScriptRunId: string,
-    fragmentIdsThisRun?: Array<string>,
-    fragmentIdOfBlock?: string
-  ): ElementNode | undefined {
-    if (fragmentIdsThisRun?.length) {
-      // If we're currently running a fragment, nodes unrelated to the fragment
-      // shouldn't be cleared. This can happen when,
-      //   1. This element doesn't correspond to a fragment at all.
-      //   2. This element is a fragment but is in no path that was modified.
-      //   3. This element belongs to a path that was modified, but it was modified in the same run.
-      if (
-        !this.fragmentId ||
-        !fragmentIdOfBlock ||
-        this.scriptRunId === currentScriptRunId
-      ) {
-        return this
-      }
-    }
-    return this.scriptRunId === currentScriptRunId ? this : undefined
-  }
-
   public arrowAddRows(
     namedDataSet: ArrowNamedDataSet,
     scriptRunId: string

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Element, ForwardMsgMetadata } from "@streamlit/protobuf"
+
+import { BlockNode } from "src/render-tree/BlockNode"
+import { ElementNode } from "src/render-tree/ElementNode"
+import { block, makeProto, text } from "src/render-tree/test-utils"
+
+import { ClearStaleNodeVisitor } from "./ClearStaleNodeVisitor"
+
+describe("ClearStaleNodeVisitor", () => {
+  describe("visitElementNode", () => {
+    it("returns the element if it matches the current script run ID", () => {
+      const currentRunId = "current_run"
+      const element = text("test", currentRunId)
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitElementNode(element)
+
+      expect(result).toBe(element)
+    })
+
+    it("returns undefined for elements with different script run ID", () => {
+      const currentRunId = "current_run"
+      const staleElement = text("stale", "old_run")
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitElementNode(staleElement)
+
+      expect(result).toBeUndefined()
+    })
+
+    describe("when running fragments", () => {
+      it("returns element if it doesn't have a fragment ID", () => {
+        const currentRunId = "current_run"
+        const element = text("no_fragment", "old_run")
+        const visitor = new ClearStaleNodeVisitor(currentRunId, ["fragment1"])
+
+        const result = visitor.visitElementNode(element)
+
+        expect(result).toBe(element)
+      })
+
+      it("returns element if fragmentIdOfBlock is not set", () => {
+        const currentRunId = "current_run"
+        const element = new ElementNode(
+          makeProto(Element, { text: { body: "with_fragment" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "fragment1"
+        )
+        const visitor = new ClearStaleNodeVisitor(currentRunId, ["fragment1"])
+
+        const result = visitor.visitElementNode(element)
+
+        expect(result).toBe(element)
+      })
+
+      it("returns element if it matches current script run ID", () => {
+        const currentRunId = "current_run"
+        const element = new ElementNode(
+          makeProto(Element, { text: { body: "current" } }),
+          ForwardMsgMetadata.create(),
+          currentRunId,
+          "script_hash",
+          "fragment1"
+        )
+        const visitor = new ClearStaleNodeVisitor(
+          currentRunId,
+          ["fragment1"],
+          "fragment1"
+        )
+
+        const result = visitor.visitElementNode(element)
+
+        expect(result).toBe(element)
+      })
+
+      it("returns undefined for stale element in fragment context", () => {
+        const currentRunId = "current_run"
+        const staleElement = new ElementNode(
+          makeProto(Element, { text: { body: "stale" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "fragment1"
+        )
+        const visitor = new ClearStaleNodeVisitor(
+          currentRunId,
+          ["fragment1"],
+          "fragment1"
+        )
+
+        const result = visitor.visitElementNode(staleElement)
+
+        expect(result).toBeUndefined()
+      })
+    })
+  })
+
+  describe("visitBlockNode", () => {
+    it("returns undefined for block with different script run ID", () => {
+      const currentRunId = "current_run"
+      const staleBlock = block([text("child")], "old_run")
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitBlockNode(staleBlock)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("returns new block with filtered children for current run ID", () => {
+      const currentRunId = "current_run"
+      const currentElement = text("current", currentRunId)
+      const staleElement = text("stale", "old_run")
+      const blockNode = new BlockNode(
+        "script_hash",
+        [currentElement, staleElement],
+        undefined,
+        currentRunId
+      )
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitBlockNode(blockNode) as BlockNode
+
+      expect(result).toBeDefined()
+      expect(result.children).toHaveLength(1)
+      expect(result.children[0]).toBe(currentElement)
+    })
+
+    it("returns same node reference when children are unchanged (performance optimization)", () => {
+      const currentRunId = "current_run"
+      const currentElement1 = text("current1", currentRunId)
+      const currentElement2 = text("current2", currentRunId)
+      const blockNode = new BlockNode(
+        "script_hash",
+        [currentElement1, currentElement2],
+        undefined,
+        currentRunId
+      )
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitBlockNode(blockNode) as BlockNode
+
+      // Performance optimization: when no children are filtered, return the same node reference
+      expect(result).toBe(blockNode)
+    })
+
+    it("preserves block structure with nested children", () => {
+      const currentRunId = "current_run"
+      const innerBlock = block([text("inner", currentRunId)], currentRunId)
+      const outerBlock = new BlockNode(
+        "script_hash",
+        [innerBlock, text("outer", "old_run")],
+        undefined,
+        currentRunId
+      )
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitBlockNode(outerBlock) as BlockNode
+
+      expect(result).toBeDefined()
+      expect(result.children).toHaveLength(1)
+      expect(result.children[0]).toBeInstanceOf(BlockNode)
+      expect((result.children[0] as BlockNode).children).toHaveLength(1)
+    })
+
+    it("returns same node reference for nested blocks when all children are unchanged", () => {
+      const currentRunId = "current_run"
+      const innerBlock = block([text("inner", currentRunId)], currentRunId)
+      const outerBlock = new BlockNode(
+        "script_hash",
+        [innerBlock, text("outer", currentRunId)],
+        undefined,
+        currentRunId
+      )
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+
+      const result = visitor.visitBlockNode(outerBlock) as BlockNode
+
+      // Performance optimization: when all nested children are unchanged, return the same node reference
+      expect(result).toBe(outerBlock)
+      expect(result.children).toHaveLength(2)
+      // Inner block should also be the same reference due to optimization
+      expect(result.children[0]).toBe(innerBlock)
+    })
+
+    describe("fragment handling", () => {
+      it("handles fragment block correctly", () => {
+        const currentRunId = "current_run"
+        const fragmentId = "fragment1"
+        const fragmentBlock = new BlockNode(
+          "script_hash",
+          [text("fragment_child", currentRunId)],
+          undefined,
+          currentRunId,
+          fragmentId
+        )
+        const visitor = new ClearStaleNodeVisitor(currentRunId, [fragmentId])
+
+        const result = visitor.visitBlockNode(fragmentBlock) as BlockNode
+
+        expect(result).toBeDefined()
+        expect(result.fragmentId).toBe(fragmentId)
+        expect(result.children).toHaveLength(1)
+      })
+
+      it("removes stale block in fragment context", () => {
+        const currentRunId = "current_run"
+        const fragmentId = "fragment1"
+        const staleBlock = new BlockNode(
+          "script_hash",
+          [text("stale_child", "old_run")],
+          undefined,
+          "old_run",
+          fragmentId
+        )
+        const visitor = new ClearStaleNodeVisitor(
+          currentRunId,
+          [fragmentId],
+          fragmentId
+        )
+
+        const result = visitor.visitBlockNode(staleBlock)
+
+        expect(result).toBeUndefined()
+      })
+
+      it("creates new visitor for fragment children", () => {
+        const currentRunId = "current_run"
+        const fragmentId = "fragment1"
+        const childElement = text("child", "old_run")
+        const fragmentBlock = new BlockNode(
+          "script_hash",
+          [childElement],
+          undefined,
+          currentRunId,
+          fragmentId
+        )
+        const visitor = new ClearStaleNodeVisitor(currentRunId, [fragmentId])
+
+        const result = visitor.visitBlockNode(fragmentBlock) as BlockNode
+
+        expect(result).toBeDefined()
+        // Child element should be preserved because it doesn't have a fragment ID
+        // and we're not in a fragment context yet (fragmentIdOfBlock is not set)
+        expect(result.children).toHaveLength(1)
+      })
+    })
+  })
+
+  describe("integration scenarios", () => {
+    it("clears complex nested structure correctly", () => {
+      const currentRunId = "current_run"
+      const staleRunId = "stale_run"
+
+      // Create a complex tree structure
+      const currentText = text("current", currentRunId)
+      const staleText = text("stale", staleRunId)
+      const mixedBlock = new BlockNode(
+        "script_hash",
+        [currentText, staleText],
+        undefined,
+        currentRunId
+      )
+      const staleBlock = block([text("all_stale", staleRunId)], staleRunId)
+      const rootBlock = new BlockNode(
+        "script_hash",
+        [mixedBlock, staleBlock],
+        undefined,
+        currentRunId
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+      const result = visitor.visitBlockNode(rootBlock) as BlockNode
+
+      expect(result).toBeDefined()
+      expect(result.children).toHaveLength(1) // staleBlock should be removed
+      expect((result.children[0] as BlockNode).children).toHaveLength(1) // only currentText should remain
+      expect((result.children[0] as BlockNode).children[0]).toBe(currentText)
+    })
+
+    it("handles empty results gracefully", () => {
+      const currentRunId = "current_run"
+      const allStaleBlock = new BlockNode(
+        "script_hash",
+        [text("stale1", "old_run"), text("stale2", "another_old_run")],
+        undefined,
+        "old_run"
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+      const result = visitor.visitBlockNode(allStaleBlock)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("preserves all elements when all are current", () => {
+      const currentRunId = "current_run"
+      const element1 = text("current1", currentRunId)
+      const element2 = text("current2", currentRunId)
+      const block1 = new BlockNode(
+        "script_hash",
+        [element1],
+        undefined,
+        currentRunId
+      )
+      const block2 = new BlockNode(
+        "script_hash",
+        [element2],
+        undefined,
+        currentRunId
+      )
+      const rootBlock = new BlockNode(
+        "script_hash",
+        [block1, block2],
+        undefined,
+        currentRunId
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+      const result = visitor.visitBlockNode(rootBlock) as BlockNode
+
+      expect(result).toBeDefined()
+      expect(result.children).toHaveLength(2)
+      expect((result.children[0] as BlockNode).children[0]).toBe(element1)
+      expect((result.children[1] as BlockNode).children[0]).toBe(element2)
+    })
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppNode, BlockNode, ElementNode } from "~lib/AppNode"
+import { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
+
+/**
+ * Visitor that clears stale nodes from the render tree. It does this by:
+ *
+ * 1. If we're not currently running a fragment, then we can remove any nodes
+ *    that don't correspond to currentScriptRunId.
+ * 2. If we are currently running a fragment, and the parent block was modified but this element wasn't,
+ *    then it's stale.
+ * 3. If we are currently running a fragment, and this block is modified by the current run,
+ *    then we indicate this to our children in case they were not modified by the current run,
+ *    which means they are stale.
+ * 4. We recursively clear our children.
+ *
+ * Usage:
+ * ```typescript
+ * const visitor = new ClearStaleNodeVisitor(currentScriptRunId, fragmentIdsThisRun, fragmentIdOfBlock)
+ * const newNode = node.accept(visitor)
+ * // newNode will be undefined if the node should be filtered out
+ * ```
+ */
+export class ClearStaleNodeVisitor
+  implements AppNodeVisitor<AppNode | undefined>
+{
+  private readonly currentScriptRunId: string
+  private readonly fragmentIdsThisRun: string[]
+  private fragmentIdOfBlock?: string
+
+  constructor(
+    currentScriptRunId: string,
+    fragmentIdsThisRun?: string[],
+    fragmentIdOfBlock?: string
+  ) {
+    this.currentScriptRunId = currentScriptRunId
+    this.fragmentIdsThisRun = fragmentIdsThisRun ?? []
+    this.fragmentIdOfBlock = fragmentIdOfBlock
+  }
+
+  get isFragmentRun(): boolean {
+    return this.fragmentIdsThisRun.length > 0
+  }
+
+  visitBlockNode(node: BlockNode): AppNode | undefined {
+    let clearStaleNodeVisitor: ClearStaleNodeVisitor | null = null
+
+    if (!this.isFragmentRun) {
+      // If we're not currently running a fragment, then we can remove any blocks
+      // that don't correspond to currentScriptRunId.
+      if (node.scriptRunId !== this.currentScriptRunId) {
+        return undefined
+      }
+    } else {
+      // Otherwise, we are currently running a fragment, and our behavior
+      // depends on the fragmentId of this BlockNode.
+
+      // The parent block was modified but this element wasn't, so it's stale.
+      if (
+        this.fragmentIdOfBlock &&
+        node.scriptRunId !== this.currentScriptRunId
+      ) {
+        return undefined
+      }
+
+      // This block is modified by the current run, so we indicate this to our children in case
+      // they were not modified by the current run, which means they are stale.
+      if (
+        node.fragmentId &&
+        this.fragmentIdsThisRun.includes(node.fragmentId) &&
+        node.scriptRunId === this.currentScriptRunId
+      ) {
+        clearStaleNodeVisitor = new ClearStaleNodeVisitor(
+          this.currentScriptRunId,
+          this.fragmentIdsThisRun,
+          node.fragmentId
+        )
+      }
+    }
+
+    // Recursively clear our children.
+    const newChildren: AppNode[] = []
+    let childrenChanged = false
+    node.children.forEach(child => {
+      const filteredChild = child.accept(clearStaleNodeVisitor ?? this)
+      if (filteredChild !== child) {
+        childrenChanged = true
+      }
+      if (filteredChild !== undefined) {
+        newChildren.push(filteredChild)
+      }
+    })
+
+    // Performance optimization: If the children haven't changed, return the same node.
+    if (!childrenChanged) {
+      return node
+    }
+
+    return new BlockNode(
+      node.activeScriptHash,
+      newChildren,
+      node.deltaBlock,
+      this.currentScriptRunId,
+      node.fragmentId,
+      node.deltaMsgReceivedAt
+    )
+  }
+
+  visitElementNode(node: ElementNode): AppNode | undefined {
+    if (this.isFragmentRun) {
+      // If we're currently running a fragment, nodes unrelated to the fragment
+      // shouldn't be cleared. This can happen when,
+      //   1. This element doesn't correspond to a fragment at all.
+      //   2. This element is a fragment but is in no path that was modified.
+      //   3. This element belongs to a path that was modified, but it was modified in the same run.
+      if (
+        !node.fragmentId ||
+        !this.fragmentIdOfBlock ||
+        node.scriptRunId === this.currentScriptRunId
+      ) {
+        return node
+      }
+    }
+    return node.scriptRunId === this.currentScriptRunId ? node : undefined
+  }
+}


### PR DESCRIPTION
## Describe your changes

Migrates the `clearStaleNodes` method to the Clear Stale Nodes Visitor

## Testing Plan

- JS Unit Tests added
- E2E Tests should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
