### PR TITLE
Implement visitTransientNode on most visitors

### DIFF
--- a/frontend/lib/src/render-tree/TransientNode.test.ts
+++ b/frontend/lib/src/render-tree/TransientNode.test.ts
@@ -50,6 +50,42 @@ describe("TransientNode", () => {
     })
   })
 
+  describe("updateTransientNodes", () => {
+    it("maps over transient nodes and filters undefined results", () => {
+      const e1 = text("one")
+      const e2 = text("two")
+      const e3 = text("three")
+      const node = new TransientNode("run-x", text("anchor"), [e1, e2, e3], 10)
+
+      const result = node.updateTransientNodes(el => {
+        if (el.element.text?.body === "two") return el
+        return undefined
+      })
+
+      expect(result).toEqual([e2])
+      // Original list remains unchanged
+      expect(node.transientNodes).toEqual([e1, e2, e3])
+    })
+
+    it("returns newly mapped ElementNodes without mutating original list", () => {
+      const e1 = text("one")
+      const e2 = text("two")
+      const node = new TransientNode("run-y", text("anchor"), [e1, e2], 20)
+
+      const mapped = node.updateTransientNodes(el => {
+        const body = el.element.text?.body ?? ""
+        return text(`${body}!`)
+      })
+
+      expect(mapped).toHaveLength(2)
+      expect(mapped[0].element.text?.body).toBe("one!")
+      expect(mapped[1].element.text?.body).toBe("two!")
+      // Ensure originals are intact
+      expect(node.transientNodes[0].element.text?.body).toBe("one")
+      expect(node.transientNodes[1].element.text?.body).toBe("two")
+    })
+  })
+
   describe("accept + debug", () => {
     it("accepts a visitor and returns its value", () => {
       const node = new TransientNode("run-v", text("a"), [], 1)

--- a/frontend/lib/src/render-tree/TransientNode.ts
+++ b/frontend/lib/src/render-tree/TransientNode.ts
@@ -51,6 +51,26 @@ export class TransientNode implements AppNode {
     this.activeScriptHash = undefined
   }
 
+  /**
+   * Updates the transient nodes by applying a function to each transient node.
+   * If the function returns undefined, the transient node is removed from the list.
+   * @param update - A function that takes an ElementNode and returns an ElementNode or undefined.
+   * @returns A new array of transient nodes.
+   */
+  public updateTransientNodes(
+    update: (node: ElementNode) => ElementNode | undefined
+  ): ElementNode[] {
+    const newTransientNodes: ElementNode[] = []
+    this.transientNodes.forEach(element => {
+      const updatedElement = update(element)
+      if (updatedElement) {
+        newTransientNodes.push(updatedElement)
+      }
+    })
+
+    return newTransientNodes
+  }
+
   accept<T>(visitor: AppNodeVisitor<T>): T {
     return visitor.visitTransientNode(this)
   }

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -16,6 +16,8 @@
 
 import { Element, ForwardMsgMetadata } from "@streamlit/protobuf"
 
+import { TransientNode } from "~lib/render-tree/TransientNode"
+
 import { BlockNode } from "src/render-tree/BlockNode"
 import { ElementNode } from "src/render-tree/ElementNode"
 import { block, makeProto, text } from "src/render-tree/test-utils"
@@ -261,6 +263,46 @@ describe("ClearStaleNodeVisitor", () => {
         // and we're not in a fragment context yet (fragmentIdOfBlock is not set)
         expect(result.children).toHaveLength(1)
       })
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("returns undefined when both anchor and transients are stale", () => {
+      const t = new TransientNode(
+        "runA",
+        text("a", "old"),
+        [text("t1", "old")],
+        1
+      )
+      const visitor = new ClearStaleNodeVisitor("current")
+      const result = visitor.visitTransientNode(t)
+      expect(result).toBeUndefined()
+    })
+
+    it("returns anchor when only anchor is current and all transients are stale", () => {
+      const anchor = text("a", "current")
+      const t = new TransientNode(
+        "runA",
+        anchor,
+        [text("t1", "old"), text("t2", "old")],
+        1
+      )
+      const visitor = new ClearStaleNodeVisitor("current")
+      const result = visitor.visitTransientNode(t)
+      expect(result).toBe(anchor)
+    })
+
+    it("returns new TransientNode when some transients remain current", () => {
+      const anchor = text("a", "old")
+      const keep = text("keep", "cur")
+      const drop = text("drop", "old")
+      const t = new TransientNode("runA", anchor, [keep, drop], 7)
+      const visitor = new ClearStaleNodeVisitor("cur")
+      const result = visitor.visitTransientNode(t) as TransientNode
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.anchor).toBeUndefined() // anchor was stale
+      expect(result.transientNodes).toEqual([keep])
+      expect(result.deltaMsgReceivedAt).toBe(7)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -139,7 +139,29 @@ export class ClearStaleNodeVisitor
     return node.scriptRunId === this.currentScriptRunId ? node : undefined
   }
 
-  visitTransientNode(_node: TransientNode): AppNode | undefined {
-    throw new Error("Method not implemented.")
+  visitTransientNode(node: TransientNode): AppNode | undefined {
+    // Check whether the anchor element and transient elements are stale
+    const anchorNode = node.anchor?.accept(this)
+    const transientNodes = node.updateTransientNodes(element => {
+      return element.accept(this) as ElementNode | undefined
+    })
+
+    // Everything is stale
+    if (!anchorNode && transientNodes.length === 0) {
+      return undefined
+    }
+
+    // All the transient elements are stale, but not the anchor element
+    // so we return the anchor element
+    if (transientNodes.length === 0) {
+      return anchorNode
+    }
+
+    return new TransientNode(
+      node.scriptRunId,
+      anchorNode,
+      transientNodes,
+      node.deltaMsgReceivedAt
+    )
   }
 }

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { block, text } from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { ElementsSetVisitor } from "./ElementsSetVisitor"
 
@@ -111,6 +112,31 @@ describe("ElementsSetVisitor", () => {
       expect(visitor.elements.size).toBe(2)
       expect(visitor.elements.has(existingElement.element)).toBe(true)
       expect(visitor.elements.has(blockElement.element)).toBe(true)
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("collects elements from transient list and anchor", () => {
+      const t1 = text("t1")
+      const t2 = text("t2")
+      const anchor = text("anchor")
+      const transient = new TransientNode("run", anchor, [t1, t2], 1)
+
+      const visitor = new ElementsSetVisitor()
+      const result = visitor.visitTransientNode(transient)
+
+      expect(result).toBe(visitor.elements)
+      expect(visitor.elements.has(t1.element)).toBe(true)
+      expect(visitor.elements.has(t2.element)).toBe(true)
+      expect(visitor.elements.has(anchor.element)).toBe(true)
+    })
+
+    it("handles missing anchor and empty transient list", () => {
+      const transient = new TransientNode("run", undefined, [], 1)
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitTransientNode(transient)
+      expect(visitor.elements.size).toBe(0)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -57,8 +57,16 @@ export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
     return this.elements
   }
 
-  visitTransientNode(_node: TransientNode): Set<Element> {
-    throw new Error("Method not implemented.")
+  visitTransientNode(node: TransientNode): Set<Element> {
+    // Add all transient elements to the set
+    node.transientNodes.forEach(element => {
+      element.accept(this)
+    })
+
+    // Also visit the anchor ElementNode to collect its element
+    node.anchor?.accept(this)
+
+    return this.elements
   }
 
   /**

--- a/frontend/lib/src/render-tree/visitors/FilterMainScriptElementsVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/FilterMainScriptElementsVisitor.test.ts
@@ -17,6 +17,7 @@
 import { BlockNode } from "~lib/render-tree/BlockNode"
 import { ElementNode } from "~lib/render-tree/ElementNode"
 import { block, text } from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { FilterMainScriptElementsVisitor } from "./FilterMainScriptElementsVisitor"
 
@@ -206,6 +207,88 @@ describe("FilterMainScriptElementsVisitor", () => {
       expect(result).toBeInstanceOf(BlockNode)
       expect(result.children).toHaveLength(0)
       expect(result.isEmpty).toBe(true)
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("returns undefined when both anchor and transients are filtered out", () => {
+      const t = new TransientNode(
+        "run",
+        new ElementNode(
+          text("a").element,
+          text("a").metadata,
+          "run",
+          OTHER_SCRIPT_HASH
+        ),
+        [
+          new ElementNode(
+            text("t").element,
+            text("t").metadata,
+            "run",
+            OTHER_SCRIPT_HASH
+          ),
+        ],
+        1
+      )
+      const visitor = new FilterMainScriptElementsVisitor(MAIN_SCRIPT_HASH)
+      const result = visitor.visitTransientNode(t)
+      expect(result).toBeUndefined()
+    })
+
+    it("returns anchor when transients are filtered and anchor matches", () => {
+      const anchor = new ElementNode(
+        text("a").element,
+        text("a").metadata,
+        "run",
+        MAIN_SCRIPT_HASH
+      )
+      const t = new TransientNode(
+        "run",
+        anchor,
+        [
+          new ElementNode(
+            text("t").element,
+            text("t").metadata,
+            "run",
+            OTHER_SCRIPT_HASH
+          ),
+        ],
+        1
+      )
+
+      const visitor = new FilterMainScriptElementsVisitor(MAIN_SCRIPT_HASH)
+      const result = visitor.visitTransientNode(t)
+      expect(result).toBe(anchor)
+    })
+
+    it("returns new TransientNode when some transients match and anchor is filtered", () => {
+      const anchor = new ElementNode(
+        text("a").element,
+        text("a").metadata,
+        "run",
+        OTHER_SCRIPT_HASH
+      )
+      const keep = new ElementNode(
+        text("keep").element,
+        text("keep").metadata,
+        "run",
+        MAIN_SCRIPT_HASH
+      )
+      const drop = new ElementNode(
+        text("drop").element,
+        text("drop").metadata,
+        "run",
+        OTHER_SCRIPT_HASH
+      )
+
+      const t = new TransientNode("run", anchor, [keep, drop], 9)
+      const visitor = new FilterMainScriptElementsVisitor(MAIN_SCRIPT_HASH)
+      const result = visitor.visitTransientNode(t) as TransientNode
+
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.anchor).toBeUndefined()
+      expect(result.transientNodes).toEqual([keep])
+      expect(result.deltaMsgReceivedAt).toBe(9)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/FilterMainScriptElementsVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/FilterMainScriptElementsVisitor.ts
@@ -81,8 +81,29 @@ export class FilterMainScriptElementsVisitor
     )
   }
 
-  visitTransientNode(_node: TransientNode): AppNode | undefined {
-    throw new Error("Method not implemented.")
+  visitTransientNode(node: TransientNode): AppNode | undefined {
+    // visit both the anchor and the transient nodes to possibly filter them out
+    const anchorNode = node.anchor?.accept(this)
+    const transientNodes = node.updateTransientNodes(element => {
+      return element.accept(this) as ElementNode | undefined
+    })
+
+    // Everything is filtered out
+    if (!anchorNode && transientNodes.length === 0) {
+      return undefined
+    }
+
+    // All the transient nodes are filtered out, but not the anchor node
+    if (transientNodes.length === 0) {
+      return anchorNode
+    }
+
+    return new TransientNode(
+      node.scriptRunId,
+      anchorNode,
+      transientNodes,
+      node.deltaMsgReceivedAt
+    )
   }
 
   /**

--- a/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.test.ts
@@ -16,6 +16,7 @@
 
 import { BlockNode } from "~lib/render-tree/BlockNode"
 import { block, text } from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { GetNodeByDeltaPathVisitor } from "./GetNodeByDeltaPathVisitor"
 
@@ -175,6 +176,48 @@ describe("GetNodeByDeltaPathVisitor", () => {
       const result = GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [])
 
       expect(result).toBeUndefined()
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("returns anchor when the path is empty", () => {
+      const t1 = text("t1")
+      const anchor = text("anchor")
+      const transient = new TransientNode("run", anchor, [t1], 1)
+      const visitor = new GetNodeByDeltaPathVisitor([])
+
+      const result = visitor.visitTransientNode(transient)
+      expect(result).toBe(anchor)
+    })
+
+    it("returns undefined for invalid index", () => {
+      const transient = new TransientNode(
+        "run",
+        text("anchor"),
+        [text("t1")],
+        1
+      )
+      expect(
+        new GetNodeByDeltaPathVisitor([-1]).visitTransientNode(transient)
+      ).toBeUndefined()
+      expect(
+        new GetNodeByDeltaPathVisitor([5]).visitTransientNode(transient)
+      ).toBeUndefined()
+    })
+
+    it("handles deeper paths by continuing recursion and still returns anchor", () => {
+      const t2 = text("t2")
+      const transient = new TransientNode(
+        "run",
+        new BlockNode("script_hash", [text("t1"), t2]),
+        // Transient nodes are not part of the delta path, so they are not visited
+        [text("t3"), text("t4")]
+      )
+
+      const result = new GetNodeByDeltaPathVisitor([1]).visitTransientNode(
+        transient
+      )
+      expect(result).toBe(t2)
     })
   })
 })

--- a/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/GetNodeByDeltaPathVisitor.ts
@@ -66,8 +66,14 @@ export class GetNodeByDeltaPathVisitor
     return node.children[currentIndex].accept(childVisitor)
   }
 
-  visitTransientNode(_node: TransientNode): AppNode | undefined {
-    throw new Error("Method not implemented.")
+  visitTransientNode(node: TransientNode): AppNode | undefined {
+    if (this.deltaPath.length === 0) {
+      return node.anchor
+    }
+
+    // The anchor node represents the delta path target, so we
+    // traverse through it to find the target node.
+    return node.anchor?.accept(this)
   }
 
   /**


### PR DESCRIPTION
## Describe your changes

We can implement some of the details for Transient Nodes in the visitors. We ignore two places:

- **SetNodeByDeltaPathVisitor** - This is a bit complicated and it will be separated out.
- **RenderNodeVisitor** - This will be adjusted with the new key setup needed for Transient objects to work properly

## Testing Plan

- Unit tests for the changes are implemented
- All remaining tests must pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
