### PR TITLE
Implement visitTransientNode on SetNodeByDeltaPathVisitor

### DIFF
--- a/frontend/lib/src/render-tree/AppNode.interface.ts
+++ b/frontend/lib/src/render-tree/AppNode.interface.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { TransientNode } from "./TransientNode"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
 
 /**
@@ -95,6 +96,11 @@ export interface AppNode {
    * console.log(result)
    */
   accept<T>(visitor: AppNodeVisitor<T>): T
+
+  /**
+   * Replace a transient node with the given node.
+   */
+  replaceTransientNodeWithSelf(node: TransientNode): AppNode
 
   /**
    * Print a tree-like representation of this node and its children for debugging.

--- a/frontend/lib/src/render-tree/BlockNode.test.ts
+++ b/frontend/lib/src/render-tree/BlockNode.test.ts
@@ -16,6 +16,7 @@
 
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { block, text } from "./test-utils"
+import { TransientNode } from "./TransientNode"
 import { GetNodeByDeltaPathVisitor } from "./visitors/GetNodeByDeltaPathVisitor"
 import { SetNodeByDeltaPathVisitor } from "./visitors/SetNodeByDeltaPathVisitor"
 
@@ -121,5 +122,41 @@ describe("BlockNode", () => {
         GetNodeByDeltaPathVisitor.getNodeAtPath(result, [0])
       ).toBeTextNode("transformed")
     })
+  })
+})
+
+describe("BlockNode.replaceTransientNodeWithSelf", () => {
+  it("returns this when transient node scriptRunId differs", () => {
+    const b = block([text("c")], "runA")
+    const t = new TransientNode("runB", text("anchor"), [text("t")], 1)
+    const result = b.replaceTransientNodeWithSelf(t)
+    expect(result).toBe(b)
+  })
+
+  it("returns this when transient node is effectively empty (no anchor, no transients)", () => {
+    const b = block([], "runA")
+    const t = new TransientNode("runA", undefined, [], 1)
+    const result = b.replaceTransientNodeWithSelf(t)
+    expect(result).toBe(b)
+  })
+
+  it("returns TransientNode anchored to this block with filtered transients", () => {
+    const runId = "cur"
+    const b = block([], runId)
+    const keep = text("keep", runId)
+    const drop = text("drop", "old")
+    const t = new TransientNode(
+      runId,
+      text("old-anchor", "old"),
+      [keep, drop],
+      99
+    )
+
+    const result = b.replaceTransientNodeWithSelf(t) as TransientNode
+    expect(result).toBeInstanceOf(TransientNode)
+    expect(result.anchor).toBe(b)
+    expect(result.transientNodes).toEqual([keep])
+    expect(result.scriptRunId).toBe(runId)
+    expect(result.deltaMsgReceivedAt).toBe(99)
   })
 })

--- a/frontend/lib/src/render-tree/BlockNode.ts
+++ b/frontend/lib/src/render-tree/BlockNode.ts
@@ -17,7 +17,10 @@
 import { Block as BlockProto } from "@streamlit/protobuf"
 
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
+import { ElementNode } from "./ElementNode"
+import { TransientNode } from "./TransientNode"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
+import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 
 /**
@@ -56,6 +59,41 @@ export class BlockNode implements AppNode {
   /** True if this Block has no children. */
   public get isEmpty(): boolean {
     return this.children.length === 0
+  }
+
+  public replaceTransientNodeWithSelf(node: TransientNode): AppNode {
+    if (node.scriptRunId !== this.scriptRunId) {
+      // This TransientNode was not defined in this script run, so we return the block node
+      // to replace everything
+      return this
+    }
+
+    // It's essentially an empty transient node, so we return the block node
+    if (node.transientNodes.length === 0) {
+      return this
+    }
+
+    // At this point, we should clear the transient nodes that are stale
+    const newTransientNodes = node.updateTransientNodes(
+      element =>
+        element.accept(new ClearStaleNodeVisitor(this.scriptRunId)) as
+          | ElementNode
+          | undefined
+    )
+
+    // The resulting transient node is empty, so we return this node
+    if (newTransientNodes.length === 0) {
+      return this
+    }
+
+    // In this case, the transient node is to be included, but we are
+    // providing a new anchor node.
+    return new TransientNode(
+      this.scriptRunId,
+      this,
+      newTransientNodes,
+      node.deltaMsgReceivedAt
+    )
   }
 
   /**

--- a/frontend/lib/src/render-tree/ElementNode.test.ts
+++ b/frontend/lib/src/render-tree/ElementNode.test.ts
@@ -25,6 +25,7 @@ import {
   arrowVegaLiteChart,
   text,
 } from "./test-utils"
+import { TransientNode } from "./TransientNode"
 
 describe("ElementNode", () => {
   describe("ElementNode.quiverElement", () => {
@@ -460,5 +461,41 @@ describe("ElementNode.accept", () => {
     const result = node.accept(nullVisitor)
 
     expect(result).toBeUndefined()
+  })
+})
+
+describe("ElementNode.replaceTransientNodeWithSelf", () => {
+  it("returns this when transient node scriptRunId differs", () => {
+    const el = text("a", "runA")
+    const t = new TransientNode("runB", text("anchor"), [text("t")], 1)
+    const result = el.replaceTransientNodeWithSelf(t)
+    expect(result).toBe(el)
+  })
+
+  it("returns this when transient node has no transients", () => {
+    const el = text("a", "runA")
+    const t = new TransientNode("runA", text("anchor"), [], 1)
+    const result = el.replaceTransientNodeWithSelf(t)
+    expect(result).toBe(el)
+  })
+
+  it("returns TransientNode anchored to this element with filtered transients", () => {
+    const runId = "cur"
+    const el = text("a", runId)
+    const keep = text("keep", runId)
+    const drop = text("drop", "old")
+    const t = new TransientNode(
+      runId,
+      text("old-anchor", "old"),
+      [keep, drop],
+      42
+    )
+
+    const result = el.replaceTransientNodeWithSelf(t) as TransientNode
+    expect(result).toBeInstanceOf(TransientNode)
+    expect(result.anchor).toBe(el)
+    expect(result.transientNodes).toEqual([keep])
+    expect(result.scriptRunId).toBe(runId)
+    expect(result.deltaMsgReceivedAt).toBe(42)
   })
 })

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -33,7 +33,9 @@ import {
 import { Quiver } from "~lib/dataframes/Quiver"
 
 import { AppNode } from "./AppNode.interface"
+import { TransientNode } from "./TransientNode"
 import { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
+import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 
 /**
@@ -216,6 +218,42 @@ export class ElementNode implements AppNode {
    */
   public debug(): string {
     return this.accept(new DebugVisitor())
+  }
+
+  public replaceTransientNodeWithSelf(node: TransientNode): AppNode {
+    if (node.scriptRunId !== this.scriptRunId) {
+      // This TransientNode was not defined in this script run, so we return the element node
+      // to replace everything
+      return this
+    }
+
+    // It's essentially an empty transient node, so we return the element node
+    if (node.transientNodes.length === 0) {
+      return this
+    }
+
+    // At this point, we should clear the transient nodes that are stale
+    const newTransientNodes = node.updateTransientNodes(
+      element =>
+        // All transient nodes should be ElementNodes
+        element.accept(new ClearStaleNodeVisitor(this.scriptRunId)) as
+          | ElementNode
+          | undefined
+    )
+
+    // The resulting transient node is empty, so we return this node
+    if (newTransientNodes.length === 0) {
+      return this
+    }
+
+    // In this case, we require the transient node to be included, but we are providing
+    // a new anchor node
+    return new TransientNode(
+      this.scriptRunId,
+      this,
+      newTransientNodes,
+      node.deltaMsgReceivedAt
+    )
   }
 }
 

--- a/frontend/lib/src/render-tree/TransientNode.test.ts
+++ b/frontend/lib/src/render-tree/TransientNode.test.ts
@@ -120,4 +120,49 @@ describe("TransientNode", () => {
       expect(viaVisitor).toBe(debug)
     })
   })
+
+  describe("replaceTransientNodeWithSelf", () => {
+    it("returns combined this when this is as new or newer (or timestamps missing)", () => {
+      const anchorThis = text("this-anchor")
+      const t1 = text("t1")
+      const current = new TransientNode("run-a", anchorThis, [t1], 200)
+
+      const anchorOther = text("other-anchor")
+      const other = new TransientNode(
+        "run-b",
+        anchorOther,
+        [text("ignore")],
+        100
+      )
+
+      const replaced = current.replaceTransientNodeWithSelf(
+        other
+      ) as TransientNode
+
+      expect(replaced).not.toBe(other)
+      expect(replaced.scriptRunId).toBe("run-a")
+      expect(replaced.transientNodes).toEqual([t1])
+      expect(replaced.deltaMsgReceivedAt).toBe(200)
+      expect(replaced.anchor).toBe(anchorThis)
+    })
+
+    it("uses other anchor if this has no anchor when combining", () => {
+      const otherAnchor = text("anchor")
+      const current = new TransientNode("run-a", undefined, [text("t")], 300)
+      const other = new TransientNode("run-b", otherAnchor, [text("x")], 100)
+
+      const replaced = current.replaceTransientNodeWithSelf(
+        other
+      ) as TransientNode
+      expect(replaced.anchor).toBe(otherAnchor)
+    })
+
+    it("returns the other node when other is newer", () => {
+      const current = new TransientNode("run-a", text("a"), [text("t")], 50)
+      const other = new TransientNode("run-b", text("b"), [text("x")], 100)
+
+      const replaced = current.replaceTransientNodeWithSelf(other)
+      expect(replaced).toBe(other)
+    })
+  })
 })

--- a/frontend/lib/src/render-tree/TransientNode.ts
+++ b/frontend/lib/src/render-tree/TransientNode.ts
@@ -78,4 +78,26 @@ export class TransientNode implements AppNode {
   public debug(): string {
     return this.accept(new DebugVisitor())
   }
+
+  // Combine the information of the node with the updated information
+  // of *this* node
+  public replaceTransientNodeWithSelf(node: TransientNode): AppNode {
+    if (
+      !this.deltaMsgReceivedAt ||
+      !node.deltaMsgReceivedAt ||
+      this.deltaMsgReceivedAt >= node.deltaMsgReceivedAt
+    ) {
+      // Replace with this node's information, but keep the anchor if it is not being replaced
+
+      return new TransientNode(
+        this.scriptRunId,
+        this.anchor ?? node.anchor,
+        this.transientNodes,
+        this.deltaMsgReceivedAt
+      )
+    }
+
+    // Return the original node since it was more recent
+    return node
+  }
 }

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
@@ -16,6 +16,7 @@
 
 import { BlockNode } from "~lib/render-tree/BlockNode"
 import { block, text } from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { GetNodeByDeltaPathVisitor } from "./GetNodeByDeltaPathVisitor"
 import { SetNodeByDeltaPathVisitor } from "./SetNodeByDeltaPathVisitor"
@@ -434,6 +435,41 @@ describe("SetNodeByDeltaPathVisitor", () => {
       expect(nestedResult.scriptRunId).toBe("update_run_id")
       expect(nestedResult.fragmentId).toBe("nested_fragment")
       expect(nestedResult.deltaMsgReceivedAt).toBe(9876543210)
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("drills through anchor when remaining path exists", () => {
+      const inner = block([text("child")])
+      const t = new TransientNode("run", inner, [text("t1")], 1)
+      const nodeToSet = text("new_child")
+      const visitor = new SetNodeByDeltaPathVisitor([0, 0], nodeToSet, "run")
+
+      const result = visitor.visitTransientNode(t) as BlockNode
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(result, [0])
+      ).toBeTextNode("new_child")
+    })
+
+    it("throws when drilling required but no anchor exists", () => {
+      const t = new TransientNode("run", undefined, [text("t1")], 1)
+      const nodeToSet = text("x")
+      // Use a path with a remaining segment after the first index to force drill
+      const visitor = new SetNodeByDeltaPathVisitor([0, 1], nodeToSet, "run")
+      expect(() => visitor.visitTransientNode(t)).toThrow(
+        "TransientNode has no anchor to set node at"
+      )
+    })
+
+    it("delegates to nodeToSet.replaceTransientNodeWithSelf when path consumed", () => {
+      const t = new TransientNode("run", text("anchor"), [text("t1")], 5)
+      const nodeToSet = new BlockNode("hash", [])
+      const spy = vi.spyOn(nodeToSet, "replaceTransientNodeWithSelf")
+      const visitor = new SetNodeByDeltaPathVisitor([0], nodeToSet, "run")
+
+      // Path consumed after slicing in visitTransientNode; this should call replaceTransientNodeWithSelf
+      visitor.visitTransientNode(t)
+      expect(spy).toHaveBeenCalledWith(t)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
@@ -88,8 +88,28 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
     )
   }
 
-  visitTransientNode(_node: TransientNode): AppNode {
-    throw new Error("Method not implemented.")
+  visitTransientNode(node: TransientNode): AppNode {
+    const [, ...remainingPath] = this.deltaPath
+
+    // If we need to drill down, we will travel through the anchor.
+    if (remainingPath.length > 0) {
+      if (node.anchor) {
+        return node.anchor.accept(
+          new SetNodeByDeltaPathVisitor(
+            remainingPath,
+            this.nodeToSet,
+            this.scriptRunId
+          )
+        )
+      }
+
+      throw new Error("TransientNode has no anchor to set node at")
+    }
+
+    // At this point, we know the nodeToSet is to replace the transient node
+    // so we let the node decide how to best replace the transient node
+    // This is especially important for transient nodes to reconcile themselves
+    return this.nodeToSet.replaceTransientNodeWithSelf(node)
   }
 
   /**


### PR DESCRIPTION
## Describe your changes

Implemented the `replaceTransientNodeWithSelf` method on all `AppNode` implementations to properly handle transient node replacement during delta updates. This method allows nodes to decide how to best replace a transient node with themselves, which is crucial for maintaining proper state during incremental updates.

Key changes:
- Added `replaceTransientNodeWithSelf` to the `AppNode` interface
- Implemented the method in `BlockNode`, `ElementNode`, and `TransientNode` classes
- Updated `SetNodeByDeltaPathVisitor` to use this method when replacing transient nodes
- Added comprehensive tests for all implementations

## Testing Plan

- Unit Tests: Added extensive test coverage for the new `replaceTransientNodeWithSelf` method in all node types
- Tests verify correct behavior for different scenarios:
  - When script run IDs differ
  - When transient nodes are empty
  - When nodes need to be filtered
  - When timestamps determine which node to keep

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.