### PR TITLE
Implement visitTransientNode on RenderNodeVisitor

### DIFF
--- a/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
+++ b/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { BlockNode } from "~lib/AppNode"
+import { BlockNode, TransientNode } from "~lib/AppNode"
 import { ComponentRegistry } from "~lib/components/widgets/CustomComponent"
 import { FileUploadClient } from "~lib/FileUploadClient"
 import { mockEndpoints, mockSessionInfo } from "~lib/mocks/mocks"
@@ -255,7 +255,7 @@ describe("RenderNodeVisitor", () => {
       expect(result[0]).not.toBeNull()
       expect(React.isValidElement(result[0])).toBe(true)
       // Check that the props contain disableFullscreenMode: true
-      const props = (result[0] as React.ReactElement).props
+      const props = result[0].props
       expect(props.disableFullscreenMode).toBe(true)
     })
 
@@ -310,6 +310,104 @@ describe("RenderNodeVisitor", () => {
         expect(element).not.toBeNull()
         expect(React.isValidElement(element)).toBe(true)
       })
+    })
+  })
+
+  describe("visitTransientNode", () => {
+    it("renders transient elements and anchor with expected keys and order", () => {
+      const transient1 = text("t1")
+      const transient2 = text("t2")
+      const anchorEl = text("anchor")
+      const transientNode = new TransientNode("run-1", anchorEl, [
+        transient1,
+        transient2,
+      ])
+
+      const rootBlock = block([])
+      const mockProps = createMockProps(rootBlock)
+      const visitor = new RenderNodeVisitor(mockProps)
+
+      const result = visitor.visitTransientNode(transientNode)
+
+      if (!Array.isArray(result)) {
+        throw new Error("Expected visitTransientNode to return an array")
+      }
+      expect(result).toHaveLength(3)
+
+      // Transient children get deterministic keys transient-0, transient-1
+      expect((result[0] as React.ReactElement).key).toBe("transient-0")
+      expect((result[1] as React.ReactElement).key).toBe("transient-1")
+      // Anchor is visited by the same visitor and thus uses the current index as key ("0")
+      expect((result[2] as React.ReactElement).key).toBe("0")
+
+      // Visitor collects transient elements first, then the anchor
+      expect(visitor.reactElements).toHaveLength(3)
+      expect(visitor.reactElements[0]).toBe(result[0])
+      expect(visitor.reactElements[1]).toBe(result[1])
+      expect(visitor.reactElements[2]).toBe(result[2])
+    })
+
+    it("returns only transients when there is no anchor", () => {
+      const transient1 = text("t1")
+      const transientNode = new TransientNode("run-2", undefined, [transient1])
+
+      const rootBlock = block([])
+      const mockProps = createMockProps(rootBlock)
+      const visitor = new RenderNodeVisitor(mockProps)
+
+      const result = visitor.visitTransientNode(transientNode)
+
+      if (!Array.isArray(result)) {
+        throw new Error("Expected visitTransientNode to return an array")
+      }
+      expect(result).toHaveLength(1)
+      expect((result[0] as React.ReactElement).key).toBe("transient-0")
+      // Only one element collected in visitor as well
+      expect(visitor.reactElements).toHaveLength(1)
+      expect(visitor.reactElements[0]).toBe(result[0])
+    })
+
+    it("increments transient keys across multiple calls", () => {
+      const t1 = text("t1")
+      const t2 = text("t2")
+
+      const node1 = new TransientNode("run-a", undefined, [t1])
+      const node2 = new TransientNode("run-a", undefined, [t2])
+
+      const rootBlock = block([])
+      const mockProps = createMockProps(rootBlock)
+      const visitor = new RenderNodeVisitor(mockProps)
+
+      const r1 = visitor.visitTransientNode(node1)
+      const r2 = visitor.visitTransientNode(node2)
+
+      if (!Array.isArray(r1) || !Array.isArray(r2)) {
+        throw new Error("Expected visitTransientNode to return arrays")
+      }
+      expect((r1[0] as React.ReactElement).key).toBe("transient-0")
+      expect((r2[0] as React.ReactElement).key).toBe("transient-1")
+    })
+
+    it("supports a BlockNode anchor", () => {
+      const transient1 = text("t1")
+      const anchorBlock = block([text("child-of-anchor")])
+      const transientNode = new TransientNode("run-3", anchorBlock, [
+        transient1,
+      ])
+
+      const rootBlock = block([])
+      const mockProps = createMockProps(rootBlock)
+      const visitor = new RenderNodeVisitor(mockProps)
+
+      const result = visitor.visitTransientNode(transientNode)
+
+      if (!Array.isArray(result)) {
+        throw new Error("Expected visitTransientNode to return an array")
+      }
+      expect(result).toHaveLength(2)
+      expect((result[0] as React.ReactElement).key).toBe("transient-0")
+      // Anchor BlockNode will be the first visited element in this visitor; key should be "0"
+      expect((result[1] as React.ReactElement).key).toBe("0")
     })
   })
 })

--- a/frontend/lib/src/components/core/Block/RenderNodeVisitor.tsx
+++ b/frontend/lib/src/components/core/Block/RenderNodeVisitor.tsx
@@ -25,7 +25,11 @@ import ElementNodeRenderer from "./ElementNodeRenderer"
 
 import { BlockPropsWithoutWidth } from "."
 
-export type OptionalReactElement = ReactElement | null
+export type OptionalReactElements =
+  | ReactElement
+  | ReactElement[]
+  | null
+  | undefined
 
 /**
  * A visitor that renders AppNodes as React elements.
@@ -44,30 +48,42 @@ export type OptionalReactElement = ReactElement | null
  * ```
  */
 export class RenderNodeVisitor
-  implements AppNodeVisitor<OptionalReactElement>
+  implements AppNodeVisitor<OptionalReactElements>
 {
   private readonly props: BlockPropsWithoutWidth
+  private elementKeyOverride?: string
   private readonly elementKeySet: Set<string>
-  public readonly reactElements: OptionalReactElement[]
+  public readonly reactElements: ReactElement[]
   private index: number
+  private transientElementCount: number
 
-  constructor(props: BlockPropsWithoutWidth) {
+  constructor(props: BlockPropsWithoutWidth, elementKeyOverride?: string) {
     this.props = props
+    this.elementKeyOverride = elementKeyOverride
     this.elementKeySet = new Set<string>()
-    this.reactElements = [] as OptionalReactElement[]
+    this.reactElements = []
     // Initialize index to 0 as we will use it as a key in the React component
     this.index = 0
+    this.transientElementCount = 0
   }
 
   private getCurrentKey(elementId?: string): string {
-    const key = elementId || this.index.toString()
-    // Increment this.index to be used for the next key
-    this.index += 1
-
-    return key
+    return this.elementKeyOverride || elementId || this.index.toString()
   }
 
-  visitBlockNode(node: BlockNode): OptionalReactElement {
+  private conformToArray(elements: OptionalReactElements): ReactElement[] {
+    if (!elements) {
+      return []
+    }
+
+    if (Array.isArray(elements)) {
+      return elements
+    }
+
+    return [elements]
+  }
+
+  visitBlockNode(node: BlockNode): OptionalReactElements {
     // Put node in childProps instead of passing as a node={node} prop in React to
     // guarantee it doesn't get overwritten by {...childProps}.
     const childProps = {
@@ -76,18 +92,39 @@ export class RenderNodeVisitor
     }
 
     const key = this.getCurrentKey()
+    this.index += 1
     const renderer = <BlockNodeRenderer key={key} {...childProps} />
     this.reactElements.push(renderer)
 
     return renderer
   }
 
-  visitTransientNode(_node: TransientNode): OptionalReactElement {
-    // Transient nodes are rendered outside of the context this visitor is used in
-    return null
+  visitTransientNode(node: TransientNode): OptionalReactElements {
+    const transientReactElements: OptionalReactElements = []
+    node.transientNodes.forEach(element => {
+      const keyOverride = this.getCurrentKey(
+        `transient-${this.transientElementCount}`
+      )
+      this.transientElementCount += 1
+      const transientReactElement = element.accept(
+        new RenderNodeVisitor(this.props, keyOverride)
+      )
+      transientReactElements.push(
+        ...this.conformToArray(transientReactElement)
+      )
+    })
+
+    // Add the transient elements to the react elements.
+    // The anchor element will be added later.
+    this.reactElements.push(...transientReactElements)
+
+    const anchorReactElement = node.anchor?.accept(this)
+    transientReactElements.push(...this.conformToArray(anchorReactElement))
+
+    return transientReactElements
   }
 
-  visitElementNode(node: ElementNode): OptionalReactElement {
+  visitElementNode(node: ElementNode): OptionalReactElements {
     // Put node in childProps instead of passing as a node={node} prop in React to
     // guarantee it doesn't get overwritten by {...childProps}.
     const childProps = {
@@ -96,6 +133,7 @@ export class RenderNodeVisitor
     }
 
     const key = this.getCurrentKey(getElementId(node.element))
+    this.index += 1
     // Avoid rendering the same element twice. We assume the first one is the one we want
     // because the page is rendered top to bottom, so a valid widget would be rendered
     // correctly and we assume the second one is therefore stale (or throw an error).
@@ -128,9 +166,7 @@ export class RenderNodeVisitor
    *   return <>{RenderNodeVisitor.collectReactElements(props, false)}</>
    * }
    */
-  static collectReactElements(
-    props: BlockPropsWithoutWidth
-  ): OptionalReactElement[] {
+  static collectReactElements(props: BlockPropsWithoutWidth): ReactElement[] {
     if (!props.node.children) {
       return []
     }


### PR DESCRIPTION
## Describe your changes

Added support for rendering `TransientNode` elements in the `RenderNodeVisitor` class. This implementation:

- Adds a new `visitTransientNode` method that properly renders both transient elements and their anchor
- Ensures transient elements get unique keys with a `transient-{n}` format
- Maintains proper element collection order in the visitor
- Supports both cases where an anchor may or may not be present

Updated the `OptionalReactElement` type to `OptionalReactElements` to better handle arrays of elements that can be returned from visitor methods.

## Testing Plan

- Added comprehensive unit tests for the new `visitTransientNode` method
- Tests cover key generation, element ordering, multiple transient node handling, and different anchor scenarios
- Existing tests were updated to accommodate the type changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.