### PR TITLE
Implement transient spinners

### DIFF
--- a/e2e_playwright/appnode_hierarchy.py
+++ b/e2e_playwright/appnode_hierarchy.py
@@ -38,6 +38,9 @@ mode = st.selectbox(
         "insert_between",
         "long_compute",
         "placeholder_updates",
+        "simple_transient_spinner",
+        "complex_transient_spinner",
+        "chat_transient_spinner",
     ],
     key="scenario_mode",
 )
@@ -75,6 +78,77 @@ def render_placeholder_updates() -> None:
         ph.markdown("placeholder-filled")
 
 
+def render_simple_transient_spinner() -> None:
+    st.button("Rerun")
+    if "has_ran" not in st.session_state:
+        with st.spinner("Spinner (delta path 0 0)"):
+            time.sleep(5)  # Just to make the bug easier to see.
+            st.write("Hello world 1! (delta path 0 1)")
+
+        st.session_state.has_ran = True
+
+    else:
+        st.write("Hello world 2! (delta path 0 0)")
+        time.sleep(5)  # Just to make the bug easier to see.
+
+        del st.session_state.has_ran
+
+
+def render_complex_transient_spinner() -> None:
+    if st.button("Rerun with spinners"):
+        st.session_state.has_ran = True
+    if st.button("Rerun without spinners"):
+        st.session_state.has_ran = False
+
+    if st.session_state.get("has_ran", True):
+        with st.spinner("Loading..."):
+            time.sleep(0.5)
+            for i in range(2):
+                time.sleep(1)
+                st.write(i)
+            "some text"
+        st.button("Rerun 1")
+        with st.spinner("Loading..."):
+            time.sleep(0.5)
+            for i in range(2):
+                time.sleep(0.3)
+                st.write(i)
+            "some text"
+        st.button("Rerun 2")
+    else:
+        for i in range(2):
+            time.sleep(1)
+            st.write(i)
+        "some text"
+        st.button("Rerun 1")
+        for i in range(2):
+            time.sleep(1)
+            st.write(i)
+        "some text"
+        st.button("Rerun 2")
+
+
+def render_chat_transient_spinner() -> None:
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+
+    if prompt := st.chat_input("Say something"):
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        st.chat_message("user").write(prompt)
+        with st.chat_message("assistant"):
+            with st.spinner("Thinking..."):
+                time.sleep(3)
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": f"Echo: {prompt}"}
+                )
+
+                st.write(f"Echo: {prompt}")
+
+
 if mode == "swap_element":
     render_swap_element()
 elif mode == "insert_between":
@@ -83,3 +157,9 @@ elif mode == "long_compute":
     render_long_compute()
 elif mode == "placeholder_updates":
     render_placeholder_updates()
+elif mode == "simple_transient_spinner":
+    render_simple_transient_spinner()
+elif mode == "complex_transient_spinner":
+    render_complex_transient_spinner()
+elif mode == "chat_transient_spinner":
+    render_chat_transient_spinner()

--- a/e2e_playwright/appnode_hierarchy_test.py
+++ b/e2e_playwright/appnode_hierarchy_test.py
@@ -103,3 +103,71 @@ def test_placeholder_updates_do_not_leave_stale_elements(app: Page) -> None:
     expect(app.get_by_test_id("stMarkdown").nth(0)).to_have_text("placeholder-top")
     expect(app.get_by_test_id("stMarkdown").nth(1)).to_have_text("placeholder-filled")
     expect(app.get_by_test_id("stMarkdown").nth(2)).to_have_text("placeholder-bottom")
+
+
+def test_simple_transient_spinner_does_not_leave_stale_elements(app: Page) -> None:
+    _select_mode(app, "simple_transient_spinner")
+
+    # Initial state
+    expect(app.get_by_text("Hello world 1! (delta path 0 1)")).to_be_visible()
+
+    get_button(app, "Rerun").click()
+
+    # The app sleeps for 5s in the else block.
+    # We check for stale elements after 0.5s.
+    app.wait_for_timeout(500)
+
+    expect(app.get_by_text("Hello world 2! (delta path 0 0)")).to_be_visible()
+
+    # Verify no stale elements. We don't wait because the script run will eventually remove the stale elements.
+    expect(app.locator("[data-stale='true']")).to_have_count(0, timeout=1)
+    expect(app.get_by_text("Hello world 1! (delta path 0 1)")).not_to_be_visible()
+
+
+def test_complex_transient_spinner_interrupted_does_not_leave_stale_elements(
+    app: Page,
+) -> None:
+    _select_mode(app, "complex_transient_spinner")
+
+    # Run without spinners first
+    get_button(app, "Rerun without spinners").click()
+    wait_for_app_run(app)
+
+    # Run with spinners
+    get_button(app, "Rerun with spinners").click()
+    # Interrupt it (run without spinners)
+    # This button might be disabled if we don't act fast or if the app blocks.
+    # Assuming standard behavior where we can interrupt.
+    get_button(app, "Rerun without spinners").click()
+
+    wait_for_app_run(app)
+
+    # Verify no unexpected stale element out of order.
+    # Verify no stale elements. We don't wait because the script run will eventually remove the stale elements.
+    expect(app.locator("[data-stale='true']")).to_have_count(0, timeout=1)
+    expect(app.get_by_text("some text")).to_have_count(2)
+
+
+def test_chat_transient_spinner_does_not_leave_stale_elements(app: Page) -> None:
+    _select_mode(app, "chat_transient_spinner")
+
+    chat_input = app.get_by_test_id("stChatInput").locator("textarea")
+
+    # Type content and enter
+    chat_input.fill("Message 1")
+    chat_input.press("Enter")
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Echo: Message 1")).to_be_visible()
+
+    # Type more content and enter
+    chat_input.fill("Message 2")
+    chat_input.press("Enter")
+
+    # Wait 0.5s and verify no stale elements
+    app.wait_for_timeout(500)
+    # Verify no stale elements. We don't wait because the script run will eventually remove the stale elements.
+    expect(app.locator("[data-stale='true']")).to_have_count(0, timeout=1)
+
+    wait_for_app_run(app)
+    expect(app.get_by_text("Echo: Message 2")).to_be_visible()

--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -26,6 +26,46 @@ if st.button("Run spinner with time"):
     with st.spinner("Loading...", show_time=True):
         time.sleep(2)
 
+if st.button("Run double spinner"):
+    with st.spinner("Loading..."):
+        with st.spinner("Also loading..."):
+            time.sleep(3)
+
+        time.sleep(3)
+
+if st.button("Run markdown updated with spinner"):
+    placeholder = st.markdown("Some Text")
+    with placeholder.spinner("something"):
+        time.sleep(2)
+
+if st.button("Run spinner in with st.empty block"):
+    with st.empty():
+        with st.spinner("spinner in empty block"):
+            time.sleep(2)
+            st.markdown("Some More Text")
+
+if st.button("Run spinner in fragment"):
+
+    @st.fragment
+    def test_fragment():
+        with st.spinner("Loading..."):
+            time.sleep(2)
+
+        st.button("Run fragment")
+
+    test_fragment()
+
+
+if st.button("Run spinner before fragment"):
+    with st.spinner("Loading..."):
+        time.sleep(2)
+
+        @st.fragment
+        def test_fragment():
+            st.button("Run fragment")
+
+        test_fragment()
+
 st.header("Spinner - width examples")
 
 if st.button("Run spinner with content width (default)"):

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import check_top_level_class, get_button
 
 
@@ -40,6 +40,106 @@ def test_spinner_time(app: Page):
     app.wait_for_timeout(200)
     updated_text = app.get_by_test_id("stSpinner").text_content()
     assert initial_text != updated_text
+
+
+def test_double_spinner(app: Page):
+    """Test that nested spinners appear in the correct order."""
+    get_button(app, "Run double spinner").click()
+
+    spinners = app.get_by_test_id("stSpinner")
+    expect(spinners).to_have_count(2)
+    expect(spinners.nth(0)).to_have_text("Loading...")
+    expect(spinners.nth(1)).to_have_text("Also loading...")
+
+
+def test_spinner_on_markdown(app: Page):
+    """Test that running a spinner on a locked cursor (st.markdown) updates correctly."""
+    get_button(app, "Run markdown updated with spinner").click()
+
+    spinners = app.get_by_test_id("stSpinner")
+    expect(spinners).to_have_count(1)
+    expect(spinners.nth(0)).to_have_text("something")
+    # Expect markdown to still be visible
+    markdown_elements = app.get_by_test_id("stMarkdown")
+    expect(markdown_elements).to_have_count(1)
+    expect(markdown_elements.nth(0)).to_have_text("Some Text")
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    # markdown remains visible
+    markdown_elements = app.get_by_test_id("stMarkdown")
+    expect(markdown_elements).to_have_count(1)
+    expect(markdown_elements.nth(0)).to_have_text("Some Text")
+
+
+def test_spinner_in_empty_block(app: Page):
+    """Test that running a spinner in a st.empty block updates correctly."""
+    get_button(app, "Run spinner in with st.empty block").click()
+
+    spinners = app.get_by_test_id("stSpinner")
+    expect(spinners).to_have_count(1)
+    expect(spinners.nth(0)).to_have_text("spinner in empty block")
+    # Expect empty block to still be visible
+    empty_elements = app.get_by_test_id("stEmpty")
+    expect(empty_elements).to_have_count(1)
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    # empty block is cleared (and replaced with markdown)
+    empty_elements = app.get_by_test_id("stEmpty")
+    expect(empty_elements).to_have_count(0)
+
+    markdown_elements = app.get_by_test_id("stMarkdown")
+    expect(markdown_elements).to_have_count(1)
+    expect(markdown_elements.nth(0)).to_have_text("Some More Text")
+
+
+def test_spinner_in_fragment(app: Page):
+    """Test that running a spinner in a fragment updates correctly."""
+    get_button(app, "Run spinner in fragment").click()
+
+    spinners = app.get_by_test_id("stSpinner")
+    expect(spinners).to_have_count(1)
+    expect(spinners.nth(0)).to_have_text("Loading...")
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Run fragment")).to_be_visible()
+
+    get_button(app, "Run fragment").click()
+    expect(app.get_by_test_id("stSpinner")).to_have_count(1)
+    expect(app.get_by_test_id("stSpinner").nth(0)).to_have_text("Loading...")
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Run fragment")).to_be_visible()
+
+
+def test_spinner_before_fragment(app: Page):
+    """Test that running a spinner before a fragment does not make the spinner re-appear."""
+    get_button(app, "Run spinner before fragment").click()
+
+    spinners = app.get_by_test_id("stSpinner")
+    expect(spinners).to_have_count(1)
+    expect(spinners.nth(0)).to_have_text("Loading...")
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Run fragment")).to_be_visible()
+
+    get_button(app, "Run fragment").click()
+    # spinners eventually disappear, so we shorten the timeout
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0, timeout=1000)
+
+    wait_for_app_run(app)
+
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Run fragment")).to_be_visible()
 
 
 def test_spinner_width_content(app: Page):

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -29,6 +29,7 @@ import {
   makeProto,
   text,
 } from "./test-utils"
+import { TransientNode } from "./TransientNode"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
 import { GetNodeByDeltaPathVisitor } from "./visitors/GetNodeByDeltaPathVisitor"
 
@@ -289,6 +290,38 @@ describe("AppRoot", () => {
           ?.scriptRunId
       ).toBe("new_session_id")
       expect(newNode.activeScriptHash).toBe(FAKE_SCRIPT_HASH)
+      expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
+    })
+
+    it("handles 'newTransient' deltas", () => {
+      const delta = makeProto(DeltaProto, {
+        newTransient: {
+          elements: [{ text: { body: "transientElement!" } }],
+        },
+      })
+      const newRoot = ROOT.applyDelta(
+        "new_session_id",
+        delta,
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      const newNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        newRoot.main,
+        [1, 1]
+      ) as TransientNode
+      expect(newNode).toBeInstanceOf(TransientNode)
+      expect(newNode.transientNodes).toHaveLength(1)
+      expect(newNode.transientNodes[0]).toBeTextNode("transientElement!")
+
+      // Check that our new scriptRunId has been set only on the touched nodes
+      expect(newRoot.main.scriptRunId).toBe("new_session_id")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [0])?.scriptRunId
+      ).toBe(NO_SCRIPT_RUN_ID)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(newRoot.main, [1])?.scriptRunId
+      ).toBe("new_session_id")
+      expect(newNode.scriptRunId).toBe("new_session_id")
       expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     })
 

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -21,6 +21,7 @@ import {
   Element,
   ForwardMsgMetadata,
   Logo,
+  Transient as TransientProto,
 } from "@streamlit/protobuf"
 
 import { ensureError } from "~lib/util/ErrorHandling"
@@ -36,6 +37,7 @@ import {
 import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
+import { TransientNode } from "./TransientNode"
 import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
@@ -247,6 +249,18 @@ export class AppRoot {
         )
       }
 
+      case "newTransient": {
+        const transient = delta.newTransient as TransientProto
+        return this.addTransient(
+          deltaPath,
+          scriptRunId,
+          transient,
+          metadata,
+          activeScriptHash,
+          delta.fragmentId
+        )
+      }
+
       case "arrowAddRows": {
         try {
           return this.arrowAddRows(
@@ -421,6 +435,43 @@ export class AppRoot {
         this.root,
         deltaPath,
         blockNode,
+        scriptRunId
+      ) as BlockNode,
+      this.appLogo
+    )
+  }
+
+  addTransient(
+    deltaPath: number[],
+    scriptRunId: string,
+    transient: TransientProto,
+    metadata: ForwardMsgMetadata,
+    activeScriptHash: string,
+    fragmentId?: string,
+    deltaMsgReceivedAt?: number
+  ): AppRoot {
+    const transientNode = new TransientNode(
+      scriptRunId,
+      undefined, // We do not have an anchor yet
+      transient.elements.map(
+        element =>
+          new ElementNode(
+            element as Element,
+            metadata,
+            scriptRunId,
+            activeScriptHash,
+            fragmentId
+          )
+      ),
+      deltaMsgReceivedAt
+    )
+
+    return new AppRoot(
+      this.mainScriptHash,
+      SetNodeByDeltaPathVisitor.setNodeAtPath(
+        this.root,
+        deltaPath,
+        transientNode,
         scriptRunId
       ) as BlockNode,
       this.appLogo

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
@@ -35,13 +35,6 @@ describe("SetNodeByDeltaPathVisitor", () => {
       )
       expect(visitor).toBeDefined()
     })
-
-    it("throws error when deltaPath is empty", () => {
-      const nodeToSet = text("new")
-      expect(
-        () => new SetNodeByDeltaPathVisitor([], nodeToSet, "test_run_id")
-      ).toThrow("deltaPath cannot be empty")
-    })
   })
 
   describe("visitElementNode", () => {
@@ -55,8 +48,41 @@ describe("SetNodeByDeltaPathVisitor", () => {
       )
 
       expect(() => visitor.visitElementNode(elementNode)).toThrow(
-        "'SetNodeByDeltaPathVisitor' cannot visit an ElementNode"
+        "'setIn' cannot be called on an ElementNode"
       )
+    })
+
+    it("replaces element when delta path is empty", () => {
+      const elementNode = text("element")
+      const nodeToSet = text("new")
+      const visitor = new SetNodeByDeltaPathVisitor(
+        [],
+        nodeToSet,
+        "test_run_id"
+      )
+
+      expect(visitor.visitElementNode(elementNode)).toBe(nodeToSet)
+    })
+
+    it("wraps element node as anchor when setting TransientNode without anchor", () => {
+      const elementNode = text("element")
+      const transientNode = new TransientNode(
+        "run_id",
+        undefined, // No anchor provided
+        [text("t1")],
+        123
+      )
+      const visitor = new SetNodeByDeltaPathVisitor(
+        [],
+        transientNode,
+        "run_id"
+      )
+
+      // Should wrap elementNode as the anchor
+      const result = visitor.visitElementNode(elementNode) as TransientNode
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.anchor).toBe(elementNode)
+      expect(result.transientNodes).toEqual(transientNode.transientNodes)
     })
   })
 
@@ -193,6 +219,45 @@ describe("SetNodeByDeltaPathVisitor", () => {
         GetNodeByDeltaPathVisitor.getNodeAtPath(result, [1])
       ).toStrictEqual(GetNodeByDeltaPathVisitor.getNodeAtPath(BLOCK, [1]))
     })
+
+    it("replaces block node with nodeToSet when delta path is empty", () => {
+      const originalBlock = block([text("1")])
+      const nodeToSet = text("replacement")
+      const visitor = new SetNodeByDeltaPathVisitor([], nodeToSet, "run_id")
+
+      const result = visitor.visitBlockNode(originalBlock)
+      expect(result).toBe(nodeToSet)
+    })
+
+    it("inserts TransientNode before child when anchors do not match", () => {
+      const childA = text("A")
+      const childB = text("B")
+      const blockNode = block([childA, childB])
+
+      // TransientNode with a pre-set anchor that is DIFFERENT from childA
+      const otherAnchor = text("other")
+      const transientNode = new TransientNode(
+        "run_id",
+        otherAnchor,
+        [text("t1")],
+        123
+      )
+
+      const visitor = new SetNodeByDeltaPathVisitor(
+        [0],
+        transientNode,
+        "run_id"
+      )
+
+      const result = visitor.visitBlockNode(blockNode) as BlockNode
+
+      // Logic check: Since the returned TransientNode's anchor (otherAnchor)
+      // does not match the original child (childA), it should be inserted BEFORE childA.
+      expect(result.children).toHaveLength(3)
+      expect(result.children[0]).toBe(transientNode) // Inserted
+      expect(result.children[1]).toBe(childA) // Original preserved/shifted
+      expect(result.children[2]).toBe(childB)
+    })
   })
 
   describe("recursive behavior", () => {
@@ -311,7 +376,7 @@ describe("SetNodeByDeltaPathVisitor", () => {
           nodeToSet,
           "test_run_id"
         )
-      ).toThrow("'SetNodeByDeltaPathVisitor' cannot visit an ElementNode")
+      ).toThrow("'setIn' cannot be called on an ElementNode")
     })
 
     it("creates new visitor instance for each static call", () => {

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import { AppNode } from "~lib/render-tree/AppNode.interface"
-import { BlockNode } from "~lib/render-tree/BlockNode"
-import { ElementNode } from "~lib/render-tree/ElementNode"
-import { TransientNode } from "~lib/render-tree/TransientNode"
+import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
 
 import { AppNodeVisitor } from "./AppNodeVisitor.interface"
 
@@ -37,55 +34,28 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
   private readonly scriptRunId: string
 
   constructor(deltaPath: number[], nodeToSet: AppNode, scriptRunId: string) {
-    if (deltaPath.length === 0) {
-      throw new Error("deltaPath cannot be empty")
-    }
     this.deltaPath = deltaPath
     this.nodeToSet = nodeToSet
     this.scriptRunId = scriptRunId
   }
 
-  visitElementNode(_node: ElementNode): AppNode {
-    // ElementNodes are leaf nodes - they cannot have children set
-    throw new Error("'SetNodeByDeltaPathVisitor' cannot visit an ElementNode")
-  }
+  visitElementNode(node: ElementNode): AppNode {
+    if (this.deltaPath.length > 0) {
+      throw new Error("'setIn' cannot be called on an ElementNode")
+    }
 
-  visitBlockNode(node: BlockNode): AppNode {
-    const [currentIndex, ...remainingPath] = this.deltaPath
-
-    // Validate the index
-    if (currentIndex < 0 || currentIndex > node.children.length) {
-      throw new Error(
-        `Bad delta path index ${currentIndex} (should be between [0, ${node.children.length}])`
+    // We are setting the element. If we are setting a transient node,
+    // we have an opportunity to set the anchor.
+    if (this.nodeToSet instanceof TransientNode && !this.nodeToSet.anchor) {
+      return new TransientNode(
+        this.scriptRunId,
+        node,
+        this.nodeToSet.transientNodes,
+        this.nodeToSet.deltaMsgReceivedAt
       )
     }
 
-    // Create a copy of the children array
-    const newChildren = node.children.slice()
-
-    if (remainingPath.length === 0) {
-      // Base case: we're at the target location, set the node
-      newChildren[currentIndex] = this.nodeToSet
-    } else {
-      // Recursive case: continue down the path
-      const childVisitor = new SetNodeByDeltaPathVisitor(
-        remainingPath,
-        this.nodeToSet,
-        this.scriptRunId
-      )
-      newChildren[currentIndex] =
-        newChildren[currentIndex].accept(childVisitor)
-    }
-
-    // Create a new BlockNode with the updated children
-    return new BlockNode(
-      node.activeScriptHash,
-      newChildren,
-      node.deltaBlock,
-      this.scriptRunId,
-      node.fragmentId,
-      node.deltaMsgReceivedAt
-    )
+    return this.nodeToSet
   }
 
   visitTransientNode(node: TransientNode): AppNode {
@@ -110,6 +80,78 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
     // so we let the node decide how to best replace the transient node
     // This is especially important for transient nodes to reconcile themselves
     return this.nodeToSet.replaceTransientNodeWithSelf(node)
+  }
+
+  visitBlockNode(node: BlockNode): AppNode {
+    if (this.deltaPath.length === 0) {
+      return this.nodeToSet
+    }
+
+    const [currentIndex, ...remainingPath] = this.deltaPath
+
+    // Validate the index
+    if (currentIndex < 0 || currentIndex > node.children.length) {
+      throw new Error(
+        `Bad delta path index ${currentIndex} (should be between [0, ${node.children.length}])`
+      )
+    }
+
+    // Create a copy of the children array
+    let newChildren: AppNode[] = []
+    const childVisitor = new SetNodeByDeltaPathVisitor(
+      remainingPath,
+      this.nodeToSet,
+      this.scriptRunId
+    )
+
+    // If the child at the current index is undefined, we assume we are out of bounds
+    // This may be just an element being added at the end of the block.
+    // So, we can just replace it with the nodeToSet assuming the path is valid.
+    if (!node.children[currentIndex]) {
+      if (remainingPath.length > 0) {
+        throw new Error("Cannot set a node at a delta path")
+      }
+
+      newChildren = node.children.slice()
+      newChildren[currentIndex] = this.nodeToSet
+    } else {
+      let index = 0
+      while (index < node.children.length) {
+        const child = node.children[index]
+
+        if (index !== currentIndex) {
+          newChildren.push(child)
+          index++
+          continue
+        }
+
+        const nextChild = child.accept(childVisitor)
+        if (
+          !(child instanceof TransientNode) &&
+          nextChild instanceof TransientNode &&
+          nextChild.anchor !== child
+        ) {
+          // This will be an insertion of the new transient
+          // and not affect the existing non-transient child
+          newChildren.push(nextChild)
+          newChildren.push(child)
+        } else {
+          // This will be a replacement
+          newChildren.push(nextChild)
+        }
+        index++
+      }
+    }
+
+    // Create a new BlockNode with the updated children
+    return new BlockNode(
+      node.activeScriptHash,
+      newChildren,
+      node.deltaBlock,
+      this.scriptRunId,
+      node.fragmentId,
+      node.deltaMsgReceivedAt
+    )
   }
 
   /**

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -14,10 +14,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from streamlit import util
+from streamlit.proto.Element_pb2 import Element
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def make_delta_path(
@@ -53,12 +57,76 @@ def get_container_cursor(
     return cursor
 
 
+T = TypeVar("T")
+
+
+class SparseList(Generic[T]):
+    """A list-like data structure that only stores non-empty items."""
+
+    def __init__(self) -> None:
+        self._data: dict[int, T] = {}
+
+    def __setitem__(self, index: int, value: T) -> None:
+        if not isinstance(index, int) or index < 0:
+            raise IndexError("SparseList indices must be non-negative integers")
+
+        self._data[index] = value
+
+    def __getitem__(self, index: int) -> T:
+        if index not in self._data:
+            raise KeyError(f"Index {index} is empty")
+
+        return self._data[index]
+
+    def __delitem__(self, index: int) -> None:
+        if index in self._data:
+            del self._data[index]
+        else:
+            raise KeyError(f"Index {index} is empty")
+
+    def __iter__(self) -> Iterator[T]:
+        # Iterate in index order.
+        for index in sorted(self._data):
+            yield self._data[index]
+
+    def __len__(self) -> int:
+        # number of filled items
+        return len(self._data)
+
+    def items(self) -> Iterator[tuple[int, T]]:
+        """Iterate through (index, value) for filled entries."""
+        for index in sorted(self._data):
+            yield index, self._data[index]
+
+    def __contains__(self, index: int) -> bool:
+        return index in self._data
+
+    def __repr__(self) -> str:
+        items = ", ".join(f"{i}: {v}" for i, v in self.items())
+        return f"SparseList({{{items}}})"
+
+
 class Cursor:
     """A pointer to a delta location in the app.
 
     When adding an element to the app, you should always call
     get_locked_cursor() on that element's respective Cursor.
+
+    Parameters
+    ----------
+    transient_index: int | None
+      The running index of the transient elements.
+    transient_elements: SparseList[Element] | None
+      The list of active transient elements.
     """
+
+    def __init__(
+        self,
+        transient_index: int | None = None,
+        transient_elements: SparseList[Element] | None = None,
+    ) -> None:
+        self._transient_index: int | None = transient_index
+        self._transient_elements = transient_elements or SparseList[Element]()
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -91,8 +159,24 @@ class Cursor:
     def is_locked(self) -> bool:
         raise NotImplementedError()
 
+    @property
+    def transient_elements(self) -> SparseList[Element]:
+        return self._transient_elements
+
+    @property
+    def transient_index(self) -> int:
+        return 0 if self._transient_index is None else self._transient_index
+
     def get_locked_cursor(self, **props: Any) -> LockedCursor:
         raise NotImplementedError()
+
+    def get_transient_cursor(self) -> Cursor:
+        if self._transient_index is None:
+            self._transient_index = 0
+        else:
+            self._transient_index += 1
+
+        return self
 
     @property
     def props(self) -> Any:
@@ -105,7 +189,13 @@ class Cursor:
 
 
 class RunningCursor(Cursor):
-    def __init__(self, root_container: int, parent_path: tuple[int, ...] = ()) -> None:
+    def __init__(
+        self,
+        root_container: int,
+        parent_path: tuple[int, ...] = (),
+        transient_index: int | None = None,
+        transient_elements: SparseList[Element] | None = None,
+    ) -> None:
         """A moving pointer to a delta location in the app.
 
         RunningCursors auto-increment to the next available location when you
@@ -118,8 +208,13 @@ class RunningCursor(Cursor):
         parent_path: tuple of ints
           The full path of this cursor, consisting of the IDs of all ancestors.
           The 0th item is the topmost ancestor.
+        transient_index: int | None
+          The running index of the transient elements.
+        transient_elements: SparseList[Element]
+          The list of active transient elements.
 
         """
+        super().__init__(transient_index, transient_elements)
         self._root_container = root_container
         self._parent_path = parent_path
         self._index = 0
@@ -149,6 +244,8 @@ class RunningCursor(Cursor):
         )
 
         self._index += 1
+        self._transient_index = None
+        self._transient_elements = SparseList[Element]()
 
         return locked_cursor
 
@@ -159,6 +256,8 @@ class LockedCursor(Cursor):
         root_container: int,
         parent_path: tuple[int, ...] = (),
         index: int = 0,
+        transient_index: int | None = None,
+        transient_elements: SparseList[Element] | None = None,
         **props: Any,
     ) -> None:
         """A locked pointer to a location in the app.
@@ -174,12 +273,17 @@ class LockedCursor(Cursor):
           The full path of this cursor, consisting of the IDs of all ancestors. The
           0th item is the topmost ancestor.
         index: int
+        transient_index: int | None
+          The running index of the transient elements.
+        transient_elements: SparseList[Element]
+          The list of active transient elements.
         **props: any
           Anything else you want to store in this cursor. This is a temporary
           measure that will go away when we implement improved return values
           for elements.
 
         """
+        super().__init__(transient_index, transient_elements)
         self._root_container = root_container
         self._index = index
         self._parent_path = parent_path
@@ -201,10 +305,10 @@ class LockedCursor(Cursor):
     def is_locked(self) -> bool:
         return True
 
-    def get_locked_cursor(self, **props: Any) -> LockedCursor:
-        self._props = props
-        return self
-
     @property
     def props(self) -> Any:
         return self._props
+
+    def get_locked_cursor(self, **props: Any) -> LockedCursor:
+        self._props = props
+        return self

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from collections.abc import Callable, Iterable
 from copy import deepcopy
 from typing import (
@@ -100,8 +101,9 @@ from streamlit.elements.widgets.slider import SliderMixin
 from streamlit.elements.widgets.text_widgets import TextWidgetsMixin
 from streamlit.elements.widgets.time_widgets import TimeWidgetsMixin
 from streamlit.elements.write import WriteMixin
-from streamlit.errors import StreamlitAPIException
-from streamlit.proto import Block_pb2, ForwardMsg_pb2
+from streamlit.errors import NoSessionContext, StreamlitAPIException
+from streamlit.proto import Block_pb2
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime import caching
 from streamlit.runtime.scriptrunner import enqueue_message as _enqueue_message
@@ -115,6 +117,7 @@ if TYPE_CHECKING:
     from streamlit.cursor import Cursor
     from streamlit.elements.lib.built_in_chart_utils import AddRowsMetadata
     from streamlit.elements.lib.layout_utils import LayoutConfig
+    from streamlit.proto.Element_pb2 import Element as ElementProto
 
 MAX_DELTA_BYTES: Final[int] = 14 * 1024 * 1024  # 14MB
 
@@ -123,6 +126,7 @@ Value = TypeVar("Value")
 # Type aliases for Ancestor Block Types
 BlockType: TypeAlias = str
 AncestorBlockTypes: TypeAlias = Iterable[BlockType]
+ForwardMsgCreator: TypeAlias = Callable[[], ForwardMsg]
 
 
 _use_warning_has_been_displayed: bool = False
@@ -431,6 +435,13 @@ class DeltaGenerator(
     def id(self) -> str:
         return str(id(self))
 
+    def _get_transient_cursor(self) -> cursor.Cursor:
+        cursor = self._active_dg._cursor
+        if cursor is None:
+            raise NoSessionContext("Cursor is not set")
+
+        return cursor.get_transient_cursor()
+
     def _get_delta_path_str(self) -> str:
         """Returns the element's delta path as a string like "[0, 2, 3, 1]".
 
@@ -486,7 +497,7 @@ class DeltaGenerator(
         _maybe_print_fragment_callback_warning()
 
         # Copy the marshalled proto into the overall msg proto
-        msg = ForwardMsg_pb2.ForwardMsg()
+        msg = ForwardMsg()
         msg_el_proto = getattr(msg.delta.new_element, delta_type)
         msg_el_proto.CopyFrom(element_proto)
 
@@ -567,7 +578,7 @@ class DeltaGenerator(
         if dg._root_container is None or dg._cursor is None:
             return dg
 
-        msg = ForwardMsg_pb2.ForwardMsg()
+        msg = ForwardMsg()
         msg.metadata.delta_path[:] = dg._cursor.delta_path
         msg.delta.add_block.CopyFrom(block_proto)
 
@@ -609,6 +620,68 @@ class DeltaGenerator(
         )
 
         return block_dg
+
+    def _transient(
+        self,
+        element_proto: ElementProto,
+        layout_config: LayoutConfig | None = None,
+    ) -> tuple[ForwardMsgCreator, ForwardMsgCreator]:
+        """Provides the factory functions for creating and clearing transient elements.
+        It preserves the delta path, transient index, and the set of transient elements.
+
+        Returns a tuple of two functions:
+        - create_transient_element: Creates the new transient element.
+        - clear_transient_element: Clears the transient element.
+        """
+        transient_cursor = self._get_transient_cursor()
+        delta_path = transient_cursor.delta_path
+        transient_index = transient_cursor.transient_index
+        transient_elements = transient_cursor.transient_elements
+
+        if layout_config:
+            if layout_config.height is not None:
+                element_proto.height_config.CopyFrom(
+                    get_height_config(layout_config.height)
+                )
+            if layout_config.width is not None:
+                element_proto.width_config.CopyFrom(
+                    get_width_config(layout_config.width)
+                )
+
+        # Revalidate the use of the lock here in the event
+        # better support threading/multiprocessing in Streamlit
+        transient_lock = threading.Lock()
+
+        def create_transient_element() -> ForwardMsg:
+            with transient_lock:
+                transient_elements[transient_index] = element_proto
+
+                create_msg = ForwardMsg()
+                create_msg.metadata.delta_path[:] = delta_path
+                create_msg.metadata.cacheable = False
+                # Make sure the transient message is set as it will
+                # not be set if there are no transient elements
+                create_msg.delta.new_transient.SetInParent()
+                for e in transient_elements:
+                    create_msg.delta.new_transient.elements.add().CopyFrom(e)
+
+            return create_msg
+
+        def clear_transient_element() -> ForwardMsg:
+            with transient_lock:
+                if transient_index in transient_elements:
+                    del transient_elements[transient_index]
+
+                clear_msg = ForwardMsg()
+                clear_msg.metadata.delta_path[:] = delta_path
+                clear_msg.metadata.cacheable = False
+                clear_msg.delta.new_transient.SetInParent()
+                for e in transient_elements:
+                    clear_msg.delta.new_transient.elements.add().CopyFrom(e)
+
+            return clear_msg
+
+        return create_transient_element, clear_transient_element
 
 
 def _writes_directly_to_sidebar(dg: DeltaGenerator) -> bool:

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -23,7 +23,11 @@ from streamlit.elements.lib.layout_utils import (
     Width,
     validate_width,
 )
-from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.errors import NoSessionContext
+from streamlit.proto.Element_pb2 import Element as ElementProto
+from streamlit.proto.Spinner_pb2 import Spinner as SpinnerProto
+from streamlit.runtime.scriptrunner import add_script_run_ctx, enqueue_message
+from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -96,49 +100,51 @@ class SpinnerMixin:
             height: 210px
 
         """
-        from streamlit.proto.Spinner_pb2 import Spinner as SpinnerProto
-        from streamlit.string_util import clean_text
-
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)
 
-        message = self.dg.empty()
+        spinner_proto = SpinnerProto()
+        spinner_proto.text = clean_text(text)
+        spinner_proto.cache = _cache
+        spinner_proto.show_time = show_time
+        element_proto = ElementProto()
+        element_proto.spinner.CopyFrom(spinner_proto)
+
+        # Ensure we are targeting the correct DeltaGenerator
+        # even though we will wait to enqueue the message
+        try:
+            create_transient, clear_transient = self.dg._transient(
+                element_proto,
+                layout_config=layout_config,
+            )
+        except NoSessionContext:
+            # Means we are not in a script thread, so we will just yield and return
+            yield
+            return
 
         display_message = True
         display_message_lock = threading.Lock()
-
+        timer: threading.Timer | None = None
         try:
 
             def set_message() -> None:
                 with display_message_lock:
                     if display_message:
-                        spinner_proto = SpinnerProto()
-                        spinner_proto.text = clean_text(text)
-                        spinner_proto.cache = _cache
-                        spinner_proto.show_time = show_time
-                        message._enqueue(
-                            "spinner", spinner_proto, layout_config=layout_config
-                        )
+                        # Ignore the DeltaGenerator conveniences because Transients are special
+                        enqueue_message(create_transient())
 
-            add_script_run_ctx(threading.Timer(DELAY_SECS, set_message)).start()
-
+            timer = threading.Timer(DELAY_SECS, set_message)
+            add_script_run_ctx(timer)
+            timer.start()
             # Yield control back to the context.
             yield
         finally:
-            if display_message_lock:
-                with display_message_lock:
-                    display_message = False
-                if "chat_message" in set(message._active_dg._ancestor_block_types):
-                    # Temporary stale element fix:
-                    # For chat messages, we are resetting the spinner placeholder to an
-                    # empty container instead of an empty placeholder (st.empty) to have
-                    # it removed from the delta path. Empty containers are ignored in the
-                    # frontend since they are configured with allow_empty=False. This
-                    # prevents issues with stale elements caused by the spinner being
-                    # rendered only in some situations (e.g. for caching).
-                    message.container()
-                else:
-                    message.empty()
+            if timer:
+                timer.cancel()
+            with display_message_lock:
+                display_message = False
+
+                enqueue_message(clear_transient())
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -188,7 +188,7 @@ def _is_composable_message(msg: ForwardMsg) -> bool:
     # operation can raise errors, and we don't have a good way of handling
     # those errors in the message queue.
     delta_type = msg.delta.WhichOneof("type")
-    return delta_type not in {"add_rows", "arrow_add_rows"}
+    return delta_type not in {"add_rows", "arrow_add_rows", "new_transient"}
 
 
 def _maybe_compose_delta_msgs(

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -1,0 +1,207 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.cursor import (
+    LockedCursor,
+    RunningCursor,
+    SparseList,
+    get_container_cursor,
+    make_delta_path,
+)
+from streamlit.proto.RootContainer_pb2 import RootContainer
+
+
+class TestSparseList:
+    def test_set_and_get_item(self) -> None:
+        """Test setting and getting items in SparseList."""
+        sl = SparseList()
+        sl[0] = "a"
+        sl[2] = "c"
+
+        assert sl[0] == "a"
+        assert sl[2] == "c"
+        with pytest.raises(KeyError):
+            _ = sl[1]
+
+    def test_set_invalid_index(self):
+        """Test setting invalid indices raises IndexError."""
+        sl = SparseList()
+        with pytest.raises(IndexError):
+            sl[-1] = "fail"
+        with pytest.raises(IndexError):
+            sl["not_int"] = "fail"  # type: ignore
+
+    def test_del_item(self):
+        """Test deleting items."""
+        sl = SparseList()
+        sl[0] = "a"
+        del sl[0]
+        with pytest.raises(KeyError):
+            _ = sl[0]
+        with pytest.raises(KeyError):
+            del sl[1]
+
+    def test_len(self):
+        """Test length of SparseList."""
+        sl = SparseList()
+        sl[0] = "a"
+        sl[10] = "b"
+        assert len(sl) == 2
+
+    def test_iteration(self):
+        """Test iteration over SparseList."""
+        sl = SparseList()
+        sl[2] = "c"
+        sl[0] = "a"
+        sl[1] = "b"
+
+        assert list(sl) == ["a", "b", "c"]
+        assert list(sl.items()) == [(0, "a"), (1, "b"), (2, "c")]
+
+    def test_contains(self):
+        """Test __contains__."""
+        sl = SparseList()
+        sl[0] = "a"
+        assert 0 in sl
+        assert 1 not in sl
+
+    def test_repr(self):
+        """Test __repr__."""
+        sl = SparseList()
+        sl[0] = "a"
+        sl[2] = "c"
+        assert repr(sl) == "SparseList({0: a, 2: c})"
+
+
+class TestCursorFunctions:
+    def test_make_delta_path(self):
+        """Test make_delta_path."""
+        path = make_delta_path(RootContainer.MAIN, (1, 2), 3)
+        assert path == [RootContainer.MAIN, 1, 2, 3]
+
+    @patch("streamlit.cursor.get_script_run_ctx")
+    def test_get_container_cursor_no_ctx(self, mock_get_ctx):
+        """Test get_container_cursor when no context exists."""
+        mock_get_ctx.return_value = None
+        cursor = get_container_cursor(RootContainer.MAIN)
+        assert cursor is None
+
+    def test_get_container_cursor_none_root(self):
+        """Test get_container_cursor with None root."""
+        cursor = get_container_cursor(None)
+        assert cursor is None
+
+    @patch("streamlit.cursor.get_script_run_ctx")
+    def test_get_container_cursor_creates_new(self, mock_get_ctx):
+        """Test get_container_cursor creates a new cursor if not present."""
+        mock_ctx = MagicMock()
+        mock_ctx.cursors = {}
+        mock_get_ctx.return_value = mock_ctx
+
+        cursor = get_container_cursor(RootContainer.MAIN)
+        assert isinstance(cursor, RunningCursor)
+        assert cursor.root_container == RootContainer.MAIN
+        assert RootContainer.MAIN in mock_ctx.cursors
+        assert mock_ctx.cursors[RootContainer.MAIN] == cursor
+
+    @patch("streamlit.cursor.get_script_run_ctx")
+    def test_get_container_cursor_returns_existing(self, mock_get_ctx):
+        """Test get_container_cursor returns existing cursor."""
+        mock_ctx = MagicMock()
+        existing_cursor = RunningCursor(RootContainer.MAIN)
+        mock_ctx.cursors = {RootContainer.MAIN: existing_cursor}
+        mock_get_ctx.return_value = mock_ctx
+
+        cursor = get_container_cursor(RootContainer.MAIN)
+        assert cursor == existing_cursor
+
+
+class TestRunningCursor:
+    def test_initialization(self):
+        """Test initialization of RunningCursor."""
+        cursor = RunningCursor(RootContainer.MAIN, (1, 2))
+        assert cursor.root_container == RootContainer.MAIN
+        assert cursor.parent_path == (1, 2)
+        assert cursor.index == 0
+        assert cursor.delta_path == [RootContainer.MAIN, 1, 2, 0]
+        assert not cursor.is_locked
+        assert len(cursor.transient_elements) == 0
+
+    def test_get_locked_cursor(self):
+        """Test get_locked_cursor from RunningCursor."""
+        cursor = RunningCursor(RootContainer.MAIN)
+
+        # First lock
+        locked1 = cursor.get_locked_cursor(foo="bar")
+        assert isinstance(locked1, LockedCursor)
+        assert locked1.index == 0
+        assert locked1.props == {"foo": "bar"}
+        assert cursor.index == 1
+
+        # Second lock
+        locked2 = cursor.get_locked_cursor()
+        assert locked2.index == 1
+        assert cursor.index == 2
+
+    def test_get_transient_cursor(self):
+        """Test get_transient_cursor from RunningCursor."""
+        cursor = RunningCursor(RootContainer.MAIN)
+
+        # First transient
+        t1 = cursor.get_transient_cursor()
+        assert t1 == cursor
+        assert cursor.transient_index == 0
+
+        # Second transient
+        cursor.get_transient_cursor()
+        assert cursor.transient_index == 1
+
+    def test_locked_cursor_resets_transient(self):
+        """Test that get_locked_cursor resets transient state."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor.get_transient_cursor()
+        cursor.transient_elements[0] = "element"  # Simulate adding element
+        assert cursor.transient_index == 0
+        assert len(cursor.transient_elements) == 1
+
+        cursor.get_locked_cursor()
+        # Should be reset
+        assert cursor.transient_index == 0
+        assert len(cursor.transient_elements) == 0
+
+
+class TestLockedCursor:
+    def test_initialization(self):
+        """Test initialization of LockedCursor."""
+        cursor = LockedCursor(RootContainer.MAIN, (1,), 5, foo="bar")
+        assert cursor.root_container == RootContainer.MAIN
+        assert cursor.parent_path == (1,)
+        assert cursor.index == 5
+        assert cursor.is_locked
+        assert cursor.props == {"foo": "bar"}
+
+    def test_get_locked_cursor(self):
+        """Test get_locked_cursor from LockedCursor."""
+        cursor = LockedCursor(RootContainer.MAIN, index=5)
+
+        locked = cursor.get_locked_cursor(new_prop="value")
+        assert locked == cursor
+        assert cursor.index == 5  # Index doesn't change
+        assert cursor.props == {"new_prop": "value"}

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -43,6 +43,7 @@ from streamlit.errors import (
     StreamlitDuplicateElementKey,
 )
 from streamlit.logger import get_logger
+from streamlit.proto.Element_pb2 import Element as ElementProto
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.Text_pb2 import Text as TextProto
@@ -1094,3 +1095,69 @@ class DeltaGeneratorImageTest(DeltaGeneratorTestCase):
             StreamlitAPIException, match=r"Cannot pair 2 captions with 5 images."
         ):
             st.image([url] * 5, caption=[caption] * 2)
+
+    def test_transient_creation(self):
+        """Test that _transient creates a transient element."""
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+        element = ElementProto()
+        element.text.body = "transient text"
+
+        create_cb, _ = dg._transient(element)
+        msg = create_cb()
+
+        assert msg.delta.new_transient.elements[0].text.body == "transient text"
+        assert msg.metadata.delta_path == make_delta_path(RootContainer.MAIN, (), 0)
+
+    def test_transient_deletion(self):
+        """Test that _transient deletion works."""
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+        element = ElementProto()
+        element.text.body = "transient text"
+
+        create_cb, clear_cb = dg._transient(element)
+        create_cb()
+        msg = clear_cb()
+
+        assert len(msg.delta.new_transient.elements) == 0
+        assert msg.metadata.delta_path == make_delta_path(RootContainer.MAIN, (), 0)
+
+    def test_multiple_transient_elements(self):
+        """Test multiple transient elements at the same cursor."""
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+
+        element1 = ElementProto()
+        element1.text.body = "text1"
+        create_cb1, clear_cb1 = dg._transient(element1)
+
+        element2 = ElementProto()
+        element2.text.body = "text2"
+        create_cb2, _clear_cb2 = dg._transient(element2)
+
+        msg1 = create_cb1()
+        assert len(msg1.delta.new_transient.elements) == 1
+        assert msg1.delta.new_transient.elements[0].text.body == "text1"
+
+        msg2 = create_cb2()
+        assert len(msg2.delta.new_transient.elements) == 2
+        assert msg2.delta.new_transient.elements[0].text.body == "text1"
+        assert msg2.delta.new_transient.elements[1].text.body == "text2"
+
+        msg3 = clear_cb1()
+        assert len(msg3.delta.new_transient.elements) == 1
+        assert msg3.delta.new_transient.elements[0].text.body == "text2"
+
+    def test_transient_layout_config(self):
+        """Test that _transient handles layout config."""
+        from streamlit.elements.lib.layout_utils import LayoutConfig
+
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+        element = ElementProto()
+        element.text.body = "transient text"
+        layout = LayoutConfig(width=100, height=200)
+
+        create_cb, _ = dg._transient(element, layout_config=layout)
+        msg = create_cb()
+
+        transient_element = msg.delta.new_transient.elements[0]
+        assert transient_element.width_config.pixel_width == 100
+        assert transient_element.height_config.pixel_height == 200

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -174,7 +174,7 @@ NON_WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("latex", lambda: st.latex("Hello")),
     ("markdown", lambda: st.markdown("Hello")),
     ("write", lambda: st.write("Hello")),
-    ("write_stream", lambda: st.write_stream([])),
+    ("write_stream", lambda: st.write_stream(["foo", "bar"])),
     # alerts
     ("error", lambda: st.error("Hello")),
     ("info", lambda: st.info("Hello")),

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -298,7 +298,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.dataframe(df, on_select="rerun"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -366,7 +366,7 @@ class ButtonTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.button("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/cache_spinner_test.py
+++ b/lib/tests/streamlit/elements/cache_spinner_test.py
@@ -60,8 +60,8 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
         @st.cache_data(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
             time.sleep(TEST_DELAY_SECS)
-            el = self.get_delta_from_queue().new_element
-            assert el.spinner.show_time is True
+            el = self.get_delta_from_queue().new_transient
+            assert el.elements[0].spinner.show_time is True
             return 3
 
         function_with_spinner_and_time()
@@ -72,8 +72,8 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
         @st.cache_data(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
             time.sleep(TEST_DELAY_SECS)
-            el = self.get_delta_from_queue().new_element
-            assert el.spinner.show_time is False
+            el = self.get_delta_from_queue().new_transient
+            assert el.elements[0].spinner.show_time is False
             return 3
 
         function_with_spinner_and_no_time()
@@ -84,8 +84,8 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
         @st.cache_resource(show_spinner=True, show_time=True)
         def function_with_spinner_and_time():
             time.sleep(TEST_DELAY_SECS)
-            el = self.get_delta_from_queue().new_element
-            assert el.spinner.show_time is True
+            el = self.get_delta_from_queue().new_transient
+            assert el.elements[0].spinner.show_time is True
             return 3
 
         function_with_spinner_and_time()
@@ -96,8 +96,8 @@ class CacheSpinnerTest(DeltaGeneratorTestCase):
         @st.cache_resource(show_spinner=True, show_time=False)
         def function_with_spinner_and_no_time():
             time.sleep(TEST_DELAY_SECS)
-            el = self.get_delta_from_queue().new_element
-            assert el.spinner.show_time is False
+            el = self.get_delta_from_queue().new_transient
+            assert el.elements[0].spinner.show_time is False
             return 3
 
         function_with_spinner_and_no_time()

--- a/lib/tests/streamlit/elements/camera_input_test.py
+++ b/lib/tests/streamlit/elements/camera_input_test.py
@@ -74,7 +74,7 @@ class CameraInputTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.camera_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -204,7 +204,7 @@ class ChatTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.chat_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -219,7 +219,7 @@ hello
         st.cache_data(lambda: st.checkbox("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 
@@ -228,7 +228,7 @@ hello
         st.cache_data(lambda: st.toggle("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -116,7 +116,7 @@ class ColorPickerTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.color_picker("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1055,7 +1055,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.data_editor(pd.DataFrame()))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -330,7 +330,7 @@ class DateInputTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.date_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/download_button_test.py
+++ b/lib/tests/streamlit/elements/download_button_test.py
@@ -84,7 +84,7 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.download_button("the label", data="juststring"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -245,7 +245,7 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.file_uploader("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/markdown_test.py
+++ b/lib/tests/streamlit/elements/markdown_test.py
@@ -108,7 +108,7 @@ class StMarkdownAPITest(DeltaGeneratorTestCase):
     def test_works_with_element_replay(self):
         """Test that element replay works for a markdown element."""
 
-        @st.cache_data
+        @st.cache_data(show_spinner=False)
         def cache_element():
             st.markdown("some markdown")
 

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -352,7 +352,7 @@ class Multiselectbox(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.multiselect("the label", ["Coffee", "Tea", "Water"]))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -477,7 +477,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.number_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -88,7 +88,7 @@ class PyDeckTest(DeltaGeneratorTestCase):
         trace0 = go.Scatter(x=[1, 2, 3, 4], y=[10, 15, 13, 17])
         data = [trace0]
 
-        @st.cache_data
+        @st.cache_data(show_spinner=False)
         def cache_element():
             st.plotly_chart(data)
 
@@ -210,7 +210,7 @@ class PyDeckTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.plotly_chart(data, on_select="rerun"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -251,7 +251,7 @@ class RadioTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.radio("the label", ["option 1", "option 2"]))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -268,7 +268,7 @@ class SliderTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.select_slider("the label", ["option 1", "option 2"]))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -269,7 +269,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.selectbox("the label", ["Coffee", "Tea", "Water"]))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -310,7 +310,7 @@ class SliderTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.slider("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -273,7 +273,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.text_area("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -248,7 +248,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.text_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -156,7 +156,7 @@ class TimeInputTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.time_input("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -169,7 +169,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
         df = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
         chart = alt.Chart(df).mark_bar().encode(x="a", y="b")
 
-        @st.cache_data
+        @st.cache_data(show_spinner=False)
         def cache_element():
             st.altair_chart(chart)
 
@@ -455,7 +455,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.altair_chart(chart, on_select="rerun"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 
@@ -1210,7 +1210,7 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
         )()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -406,7 +406,7 @@ class FormSubmitButtonTest(DeltaGeneratorTestCase):
         cached_function()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-2).new_element.exception
+        el = self.get_delta_from_queue(-3).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -742,12 +742,16 @@ class CacheDataMessageReplayTest(DeltaGeneratorTestCase):
     ):
         """Test that it works with element replay if used as non-widget element."""
 
-        if element_name == "toast":
-            # The toast element is not supported in the cache_data API
-            # since elements on the event dg are not supported.
+        if element_name in ("toast", "spinner", "logo", "echo"):
+            # These elements are not supported in the cache_data API
+            #   - toast only corresponds to the event dg
+            #   - spinner is transient and not replayed
+            #   - logo is not replayed because it's not tied to a specific dg
+            #   - echo does not produce an element unless it's executed with code
+
             return
 
-        @st.cache_data
+        @st.cache_data(show_spinner=False)
         def cache_element():
             element_producer()
 
@@ -804,7 +808,7 @@ class CacheDataMessageReplayTest(DeltaGeneratorTestCase):
         expected_width = 400
         expected_height = 200
 
-        @st.cache_data
+        @st.cache_data(show_spinner=False)
         def cache_code_with_layout():
             st.code(
                 "print('Hello, World!')", width=expected_width, height=expected_height

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -305,11 +305,11 @@ class CacheResourceStatsProviderTest(unittest.TestCase):
         assert get_resource_cache_stats_provider().get_stats() == []
 
     def test_multiple_stats(self):
-        @st.cache_resource
+        @st.cache_resource(show_spinner=False)
         def foo(count):
             return [3.14] * count
 
-        @st.cache_resource
+        @st.cache_resource(show_spinner=False)
         def bar():
             return threading.Lock()
 
@@ -378,12 +378,15 @@ class CacheResourceMessageReplayTest(DeltaGeneratorTestCase):
     ):
         """Test that it works with element replay if used as non-widget element."""
 
-        if element_name == "toast":
-            # The toast element is not supported in the cache_data API
-            # since elements on the event dg are not supported.
+        if element_name in ("toast", "spinner", "logo", "echo"):
+            # These elements are not supported in the cache_resource API
+            #   - toast only corresponds to the event dg
+            #   - spinner is transient and not replayed
+            #   - logo is not replayed because it's not tied to a specific dg
+            #   - echo does not produce an element unless it's executed with code
             return
 
-        @st.cache_resource
+        @st.cache_resource(show_spinner=False)
         def cache_element():
             element_producer()
 
@@ -442,7 +445,7 @@ class CacheResourceMessageReplayTest(DeltaGeneratorTestCase):
         expected_width = 300
         expected_height = 150
 
-        @st.cache_resource
+        @st.cache_resource(show_spinner=False)
         def cache_resource_code_with_layout():
             # Use code element with both width and height since it supports both
             st.code(

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -669,21 +669,21 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         outer(3)
         assert not self.forward_msg_queue.is_empty()
 
-        # The spinner uses an empty element and shows the spinner only
+        # The spinner uses a transient element and shows the spinner only
         # after a timeout. Instead of mocking the time and waiting for the
-        # timeout, we check for the empty element in the queue as the spinner's
-        # surrogate.
-        empty_elements_count = 0
+        # timeout, we check for the transient element with an empty set
+        # of elements. This represents the spinner element disappearing.
+        transient_elements_count = 0
         for msg in self.forward_msg_queue._queue:
             if (
                 msg.HasField("delta")
-                and msg.delta.HasField("new_element")
-                and msg.delta.new_element.HasField("empty")
+                and msg.delta.HasField("new_transient")
+                and len(msg.delta.new_transient.elements) == 0
             ):
-                empty_elements_count += 1
+                transient_elements_count += 1
         # Since we automatically prevent spinners for nested cached functions,
-        # there should only be a single empty element.
-        assert empty_elements_count == 1
+        # there should only be a single transient spinner element.
+        assert transient_elements_count == 1
 
 
 class CommonCacheTTLTest(unittest.TestCase):

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -30,56 +30,39 @@ class SpinnerTest(DeltaGeneratorTestCase):
         with st.spinner("some text"):
             # Without the timeout, the spinner is sometimes not available
             time.sleep(0.7)
-            el = self.get_delta_from_queue().new_element
+            el = self.get_delta_from_queue().new_transient.elements[0]
             assert el.spinner.text == "some text"
             assert not el.spinner.cache
         # Check if it gets reset to st.empty()
         last_delta = self.get_delta_from_queue()
-        assert last_delta.HasField("new_element")
-        assert last_delta.new_element.WhichOneof("type") == "empty"
+        assert last_delta.HasField("new_transient")
+        assert len(last_delta.new_transient.elements) == 0
         assert not el.spinner.show_time
-
-    def test_spinner_within_chat_message(self):
-        """Test st.spinner in st.chat_message resets to empty container block."""
-        with st.chat_message("user"), st.spinner("some text"):
-            # Without the timeout, the spinner is sometimes not available
-            time.sleep(0.7)
-            el = self.get_delta_from_queue().new_element
-            assert el.spinner.text == "some text"
-            assert not el.spinner.cache
-        # Check that the element gets reset to an empty container block:
-        last_delta = self.get_delta_from_queue()
-        assert last_delta.HasField("add_block")
-        # The block should have `allow_empty` set to false,
-        # which means that it will be ignored on the frontend in case
-        # it the container is empty. This is the desired behavior
-        # for spinner
-        assert not last_delta.add_block.allow_empty
 
     def test_spinner_for_caching(self):
         """Test st.spinner in cache functions."""
         with st.spinner("some text", _cache=True):
             # Without the timeout, the spinner is sometimes not available
             time.sleep(0.7)
-            el = self.get_delta_from_queue().new_element
+            el = self.get_delta_from_queue().new_transient.elements[0]
             assert el.spinner.text == "some text"
             assert el.spinner.cache
         # Check if it gets reset to st.empty()
         last_delta = self.get_delta_from_queue()
-        assert last_delta.HasField("new_element")
-        assert last_delta.new_element.WhichOneof("type") == "empty"
+        assert last_delta.HasField("new_transient")
+        assert len(last_delta.new_transient.elements) == 0
 
     def test_spinner_time(self):
         """Test st.spinner with show_time."""
         with st.spinner("some text", show_time=True):
             time.sleep(0.7)
-            el = self.get_delta_from_queue().new_element
+            el = self.get_delta_from_queue().new_transient.elements[0]
             assert el.spinner.text == "some text"
             assert el.spinner.show_time
         # Check if it gets reset to st.empty()
         last_delta = self.get_delta_from_queue()
-        assert last_delta.HasField("new_element")
-        assert last_delta.new_element.WhichOneof("type") == "empty"
+        assert last_delta.HasField("new_transient")
+        assert len(last_delta.new_transient.elements) == 0
 
     def test_spinner_with_width(self):
         """Test st.spinner with different width types."""
@@ -98,7 +81,7 @@ class SpinnerTest(DeltaGeneratorTestCase):
             with self.subTest(width_value=width_value):
                 with st.spinner(f"test text {index}", width=width_value):
                     time.sleep(0.7)
-                    el = self.get_delta_from_queue().new_element
+                    el = self.get_delta_from_queue().new_transient.elements[0]
                     assert el.spinner.text == f"test text {index}"
 
                     assert (
@@ -138,7 +121,7 @@ class SpinnerTest(DeltaGeneratorTestCase):
         """Test that st.spinner defaults to content width."""
         with st.spinner("test text"):
             time.sleep(0.7)
-            el = self.get_delta_from_queue().new_element
+            el = self.get_delta_from_queue().new_transient.elements[0]
             assert el.spinner.text == "test text"
             assert (
                 el.width_config.WhichOneof("width_spec")

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -32,7 +32,8 @@ from PIL import Image
 import streamlit as st
 from streamlit import type_util
 from streamlit.error_util import handle_uncaught_app_exception
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import NoSessionContext, StreamlitAPIException
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.state import QueryParamsProxy, SessionStateProxy
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_test_cases import (
@@ -412,12 +413,16 @@ class StreamlitWriteTest(unittest.TestCase):
 
     def test_spinner(self):
         """Test st.spinner."""
-        # TODO(armando): Test that the message is actually passed to
-        # message.warning
-        with patch("streamlit.delta_generator.DeltaGenerator.empty") as e:
-            with st.spinner("some message"):
-                time.sleep(0.15)
-            e.assert_called_once_with()
+        with patch("streamlit.delta_generator.DeltaGenerator._transient") as t:
+            t.return_value = (ForwardMsg, ForwardMsg)
+            try:
+                with st.spinner("some message"):
+                    time.sleep(0.15)
+            except NoSessionContext:
+                # This happens on the clear call, so we can safely ignore it.
+                pass
+            # Spinner now uses _transient instead of empty
+            t.assert_called()
 
     def test_sidebar(self):
         """Test st.write in the sidebar."""

--- a/proto/streamlit/proto/Delta.proto
+++ b/proto/streamlit/proto/Delta.proto
@@ -23,6 +23,7 @@ import "streamlit/proto/Block.proto";
 import "streamlit/proto/Element.proto";
 import "streamlit/proto/NamedDataSet.proto";
 import "streamlit/proto/ArrowNamedDataSet.proto";
+import "streamlit/proto/Transient.proto";
 
 // A change to an element.
 message Delta {
@@ -32,6 +33,9 @@ message Delta {
 
     // Append a new block to the frontend.
     Block add_block = 6;
+
+    // Append a new transient element (e.g. spinner) to the frontend.
+    Transient new_transient = 9;
 
     // Append data to a DataFrame in for current element. The element to add to
     // is identified by the ID field, above. The dataframe is identified either

--- a/proto/streamlit/proto/Transient.proto
+++ b/proto/streamlit/proto/Transient.proto
@@ -1,0 +1,27 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "TransientProto";
+
+import "streamlit/proto/Element.proto";
+
+message Transient {
+  // The list of currently active transient elements (e.g. spinners) at one delta path position
+  repeated Element elements = 1;
+}


### PR DESCRIPTION
## Describe your changes

Implemented a new transient element system to improve the spinner component. This change:

- Adds a `TransientNode` to the render tree to handle temporary UI elements
- Refactors the spinner implementation to use the new transient system instead of empty placeholders
- Ensures spinners are properly ordered and cleaned up when their context exits
- Moves spinner from a standalone import to a mixin on DeltaGenerator

This approach provides a more robust way to handle temporary UI elements like spinners, preventing stale elements and ensuring proper cleanup.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9239
- Closes https://github.com/streamlit/streamlit/issues/10199

## Testing Plan

- Unit Tests: Added comprehensive tests for the new `TransientNode` and updated `AppRoot` functionality in `AppRoot.test.ts`
- Updated existing spinner tests to work with the new transient implementation
- Manual testing of spinner behavior in various contexts (regular, nested, caching)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.