### PR TITLE
[feat] Add backend infrastructure and proto for audio in ChatInput

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -52,6 +52,7 @@ from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
 from streamlit.proto.Common_pb2 import ChatInputValue as ChatInputValueProto
 from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStateProto
+from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime.metrics_util import gather_metrics
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
 class ChatInputValue(MutableMapping[str, Any]):
     text: str
     files: list[UploadedFile]
+    audio: UploadedFile | None = None
 
     def __len__(self) -> int:
         return len(vars(self))
@@ -81,7 +83,7 @@ class ChatInputValue(MutableMapping[str, Any]):
     def __iter__(self) -> Iterator[str]:
         return iter(vars(self))
 
-    def __getitem__(self, item: str) -> str | list[UploadedFile]:
+    def __getitem__(self, item: str) -> str | list[UploadedFile] | UploadedFile | None:
         try:
             return getattr(self, item)  # type: ignore[no-any-return]
         except AttributeError:
@@ -96,7 +98,7 @@ class ChatInputValue(MutableMapping[str, Any]):
         except AttributeError:
             raise KeyError(f"Invalid key: {key}") from None
 
-    def to_dict(self) -> dict[str, str | list[UploadedFile]]:
+    def to_dict(self) -> dict[str, str | list[UploadedFile] | UploadedFile | None]:
         return vars(self)
 
 
@@ -197,6 +199,40 @@ def _pop_upload_files(
     return collected_files
 
 
+def _pop_audio_file(
+    audio_file_info: UploadedFileInfoProto | None,
+) -> UploadedFile | None:
+    """Extract and return a single audio file from the protobuf message.
+
+    Similar to _pop_upload_files but handles a single audio file instead of a list.
+    """
+    if audio_file_info is None:
+        return None
+
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return None
+
+    file_recs_list = ctx.uploaded_file_mgr.get_files(
+        session_id=ctx.session_id,
+        file_ids=[audio_file_info.file_id],
+    )
+
+    if len(file_recs_list) == 0:
+        return None
+
+    file_rec = file_recs_list[0]
+    uploaded_file = UploadedFile(file_rec, audio_file_info.file_urls)
+
+    if hasattr(ctx.uploaded_file_mgr, "remove_file"):
+        ctx.uploaded_file_mgr.remove_file(
+            session_id=ctx.session_id,
+            file_id=audio_file_info.file_id,
+        )
+
+    return uploaded_file
+
+
 @dataclass
 class ChatInputSerde:
     accept_files: bool = False
@@ -214,9 +250,15 @@ class ChatInputSerde:
             if self.allowed_types and not isinstance(file, DeletedFile):
                 enforce_filename_restriction(file.name, self.allowed_types)
 
+        # Extract audio file separately from the audio_file_info field
+        audio_file = _pop_audio_file(
+            ui_value.audio_file_info if ui_value.HasField("audio_file_info") else None
+        )
+
         return ChatInputValue(
             text=ui_value.data,
             files=uploaded_files,
+            audio=audio_file,
         )
 
     def serialize(self, v: str | None) -> ChatInputValueProto:
@@ -604,6 +646,11 @@ class ChatMixin:
             https://doc-chat-input-session-state.streamlit.app/
             height: 350px
         """
+        if accept_file not in {True, False, "multiple", "directory"}:
+            raise StreamlitAPIException(
+                "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
+            )
+
         key = to_key(key)
 
         check_widget_policies(
@@ -613,11 +660,6 @@ class ChatMixin:
             default_value=None,
             writes_allowed=True,
         )
-
-        if accept_file not in {True, False, "multiple", "directory"}:
-            raise StreamlitAPIException(
-                "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
-            )
 
         ctx = get_script_run_ctx()
 
@@ -685,7 +727,7 @@ class ChatMixin:
             accept_files=accept_file in {True, "multiple", "directory"},
             allowed_types=file_type,
         )
-        widget_state = register_widget(  # type: ignore[misc]
+        widget_state = register_widget(
             chat_input_proto.id,
             on_change_handler=on_submit,
             args=args,
@@ -694,7 +736,7 @@ class ChatMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="chat_input_value",
-        )
+        )  # type: ignore[misc]
 
         validate_width(width)
         layout_config = LayoutConfig(width=width)

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -666,11 +666,6 @@ class ChatMixin:
             https://doc-chat-input-session-state.streamlit.app/
             height: 350px
         """
-        if accept_file not in {True, False, "multiple", "directory"}:
-            raise StreamlitAPIException(
-                "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
-            )
-
         key = to_key(key)
 
         check_widget_policies(
@@ -680,6 +675,11 @@ class ChatMixin:
             default_value=None,
             writes_allowed=True,
         )
+
+        if accept_file not in {True, False, "multiple", "directory"}:
+            raise StreamlitAPIException(
+                "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
+            )
 
         ctx = get_script_run_ctx()
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -240,6 +240,10 @@ def _pop_audio_file(
             f"Expected one of {valid_mime_types}."
         )
 
+    # Remove the file from the manager after creating the UploadedFile object.
+    # Note: remove_file is not part of the UploadedFileManager Protocol, but is
+    # implemented by MemoryUploadedFileManager. We use hasattr to maintain
+    # compatibility with potential alternative implementations.
     if hasattr(ctx.uploaded_file_mgr, "remove_file"):
         ctx.uploaded_file_mgr.remove_file(
             session_id=ctx.session_id,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -248,6 +248,12 @@ def _pop_audio_file(
     -------
     UploadedFile or None
         The extracted audio file if available, None otherwise.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If the uploaded audio file does not have a `.wav` extension or its MIME type is not
+        one of the accepted WAV types (`audio/wav`, `audio/wave`, `audio/x-wav`).
     """
     if audio_file_info is None:
         return None

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -55,6 +55,9 @@ from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStatePro
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
+from streamlit.runtime.memory_uploaded_file_manager import (
+    MemoryUploadedFileManager,
+)
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import (
@@ -222,7 +225,11 @@ def _pop_upload_files(
             uploaded_file = UploadedFile(maybe_file_rec, f.file_urls)
             collected_files.append(uploaded_file)
 
-            if hasattr(ctx.uploaded_file_mgr, "remove_file"):
+            # Remove file from manager after creating UploadedFile object.
+            # Only MemoryUploadedFileManager implements remove_file.
+            # This explicit type check ensures we only use this cleanup logic
+            # with manager types we've explicitly approved.
+            if isinstance(ctx.uploaded_file_mgr, MemoryUploadedFileManager):
                 ctx.uploaded_file_mgr.remove_file(
                     session_id=ctx.session_id,
                     file_id=f.file_id,
@@ -288,10 +295,10 @@ def _pop_audio_file(
         )
 
     # Remove the file from the manager after creating the UploadedFile object.
-    # Note: remove_file is not part of the UploadedFileManager Protocol, but is
-    # implemented by MemoryUploadedFileManager. We use hasattr to maintain
-    # compatibility with potential alternative implementations.
-    if audio_file_info and hasattr(ctx.uploaded_file_mgr, "remove_file"):
+    # Only MemoryUploadedFileManager implements remove_file (not part of the
+    # UploadedFileManager Protocol). This explicit type check ensures we only
+    # use this cleanup logic with manager types we've explicitly approved.
+    if audio_file_info and isinstance(ctx.uploaded_file_mgr, MemoryUploadedFileManager):
         ctx.uploaded_file_mgr.remove_file(
             session_id=ctx.session_id,
             file_id=audio_file_info.file_id,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -84,6 +84,27 @@ _ACCEPTED_AUDIO_MIME_TYPES: frozenset[str] = frozenset(
 
 @dataclass
 class ChatInputValue(MutableMapping[str, Any]):
+    """Represents the value returned by `st.chat_input` after user interaction.
+
+    This dataclass contains the user's input text, any files uploaded, and optionally
+    an audio recording. It provides a dict-like interface for accessing and modifying
+    its attributes.
+
+    Attributes
+    ----------
+    text : str
+        The text input provided by the user.
+    files : list[UploadedFile]
+        A list of files uploaded by the user.
+    audio : UploadedFile or None, optional
+        An audio recording uploaded by the user, if any.
+
+    Notes
+    -----
+    - Supports dict-like access via `__getitem__`, `__setitem__`, and `__delitem__`.
+    - Use `to_dict()` to convert the value to a standard dictionary.
+    """
+
     text: str
     files: list[UploadedFile]
     audio: UploadedFile | None = None

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -71,6 +71,17 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
+# Audio file validation constants
+_ACCEPTED_AUDIO_EXTENSION: str = ".wav"
+_ACCEPTED_AUDIO_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        "audio/wav",
+        "audio/wave",
+        "audio/x-wav",
+    }
+)
+
+
 @dataclass
 class ChatInputValue(MutableMapping[str, Any]):
     text: str
@@ -236,18 +247,17 @@ def _pop_audio_file(
     uploaded_file = UploadedFile(file_rec, audio_file_info.file_urls)
 
     # Validate that the file is a WAV file by checking extension and MIME type
-    if not uploaded_file.name.lower().endswith(".wav"):
+    if not uploaded_file.name.lower().endswith(_ACCEPTED_AUDIO_EXTENSION):
         raise StreamlitAPIException(
             f"Invalid file extension for audio input: `{uploaded_file.name}`. "
-            "Only WAV files (.wav) are accepted."
+            f"Only WAV files ({_ACCEPTED_AUDIO_EXTENSION}) are accepted."
         )
 
     # Validate MIME type (browsers may send different variations of WAV MIME types)
-    valid_mime_types = {"audio/wav", "audio/wave", "audio/x-wav"}
-    if uploaded_file.type not in valid_mime_types:
+    if uploaded_file.type not in _ACCEPTED_AUDIO_MIME_TYPES:
         raise StreamlitAPIException(
             f"Invalid MIME type for audio input: `{uploaded_file.type}`. "
-            f"Expected one of {valid_mime_types}."
+            f"Expected one of {_ACCEPTED_AUDIO_MIME_TYPES}."
         )
 
     # Remove the file from the manager after creating the UploadedFile object.

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -205,6 +205,7 @@ def _pop_audio_file(
     """Extract and return a single audio file from the protobuf message.
 
     Similar to _pop_upload_files but handles a single audio file instead of a list.
+    Validates that the uploaded file is a WAV file.
     """
     if audio_file_info is None:
         return None
@@ -223,6 +224,21 @@ def _pop_audio_file(
 
     file_rec = file_recs_list[0]
     uploaded_file = UploadedFile(file_rec, audio_file_info.file_urls)
+
+    # Validate that the file is a WAV file by checking extension and MIME type
+    if not uploaded_file.name.lower().endswith(".wav"):
+        raise StreamlitAPIException(
+            f"Invalid file extension for audio input: `{uploaded_file.name}`. "
+            "Only WAV files (.wav) are accepted."
+        )
+
+    # Validate MIME type (browsers may send different variations of WAV MIME types)
+    valid_mime_types = {"audio/wav", "audio/wave", "audio/x-wav"}
+    if uploaded_file.type not in valid_mime_types:
+        raise StreamlitAPIException(
+            f"Invalid MIME type for audio input: `{uploaded_file.type}`. "
+            f"Expected one of {valid_mime_types}."
+        )
 
     if hasattr(ctx.uploaded_file_mgr, "remove_file"):
         ctx.uploaded_file_mgr.remove_file(

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -206,6 +206,16 @@ def _pop_audio_file(
 
     Similar to _pop_upload_files but handles a single audio file instead of a list.
     Validates that the uploaded file is a WAV file.
+
+    Parameters
+    ----------
+    audio_file_info : UploadedFileInfoProto or None
+        The protobuf message containing information about the uploaded audio file.
+
+    Returns
+    -------
+    UploadedFile or None
+        The extracted audio file if available, None otherwise.
     """
     if audio_file_info is None:
         return None
@@ -244,7 +254,7 @@ def _pop_audio_file(
     # Note: remove_file is not part of the UploadedFileManager Protocol, but is
     # implemented by MemoryUploadedFileManager. We use hasattr to maintain
     # compatibility with potential alternative implementations.
-    if hasattr(ctx.uploaded_file_mgr, "remove_file"):
+    if audio_file_info and hasattr(ctx.uploaded_file_mgr, "remove_file"):
         ctx.uploaded_file_mgr.remove_file(
             session_id=ctx.session_id,
             file_id=audio_file_info.file_id,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -747,7 +747,7 @@ class ChatMixin:
             accept_files=accept_file in {True, "multiple", "directory"},
             allowed_types=file_type,
         )
-        widget_state = register_widget(
+        widget_state = register_widget(  # type: ignore[misc]
             chat_input_proto.id,
             on_change_handler=on_submit,
             args=args,
@@ -756,7 +756,7 @@ class ChatMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="chat_input_value",
-        )  # type: ignore[misc]
+        )
 
         validate_width(width)
         layout_config = LayoutConfig(width=width)

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -632,3 +632,61 @@ class ChatTest(DeltaGeneratorTestCase):
         )
         c2 = self.get_delta_from_queue().new_element.chat_input
         assert c2.file_type == [".py", ".md", ".txt"]
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_audio_file(self, deserialize_patch):
+        """Test that audio file is properly handled by ChatInputValue."""
+        rec = UploadedFileRec("audio0", "recording.wav", "audio/wav", b"audio data")
+
+        audio_file = UploadedFile(
+            rec, FileURLsProto(file_id="audio0", delete_url="d0", upload_url="u0")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="", files=[], audio=audio_file
+        )
+
+        return_val = st.chat_input(accept_file="multiple")
+
+        assert return_val.audio == audio_file
+        assert return_val.audio.name == "recording.wav"
+        assert return_val.audio.type == "audio/wav"
+        assert return_val.audio.getvalue() == b"audio data"
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_audio_file_none(self, deserialize_patch):
+        """Test that ChatInputValue handles None audio file correctly."""
+        deserialize_patch.return_value = ChatInputValue(
+            text="hello", files=[], audio=None
+        )
+
+        return_val = st.chat_input(accept_file="multiple")
+
+        assert return_val.audio is None
+        assert return_val.text == "hello"
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_with_audio(self, deserialize_patch):
+        """Test ChatInputValue dict-like interface with audio field."""
+        rec = UploadedFileRec("audio0", "recording.wav", "audio/wav", b"audio data")
+        audio_file = UploadedFile(
+            rec, FileURLsProto(file_id="audio0", delete_url="d0", upload_url="u0")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="test", files=[], audio=audio_file
+        )
+
+        return_val = st.chat_input(accept_file="multiple")
+
+        # Test dict-like access
+        assert return_val["audio"] == audio_file
+        assert return_val["text"] == "test"
+        assert "audio" in return_val
+        assert len(return_val) == 3  # text, files, audio
+
+        # Test to_dict
+        as_dict = return_val.to_dict()
+        assert as_dict["audio"] == audio_file
+        assert as_dict["text"] == "test"
+        assert as_dict["files"] == []

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -47,4 +47,7 @@ message ChatInput {
 
   // Max file size allowed by server config
   int32 max_upload_size_mb = 11;
+
+  // Whether to show audio recording button
+  bool accept_audio = 12;
 }

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -102,5 +102,5 @@ message FileUploaderState {
 message ChatInputValue {
   optional string data = 1;
   optional FileUploaderState file_uploader_state = 2;
-
+  optional UploadedFileInfo audio_file_info = 3;
 }


### PR DESCRIPTION
## Describe your changes

Added python support for audio files in the chat input component. 

Key changes:

- Added `audio` field to `ChatInputValue` class to store a single audio file
- Implemented `_pop_audio_file` function to extract audio files from protobuf messages
- Updated serialization/deserialization logic to handle audio files
- Added `accept_audio` flag to the ChatInput proto
- Updated type annotations to accommodate the new audio file field
- Added comprehensive tests for the audio file functionality

## Testing Plan

- Unit Tests: Added Python tests to verify the audio file handling in `ChatInputValue`, including:
    - Testing that audio files are properly handled and accessible
    - Verifying the behavior when audio is None
    - Testing the dict-like interface with the new audio field
    - Confirming that the to_dict method properly includes the audio field

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.