### PR TITLE
[feat] Integrate audio recording into ChatInput widget

### DIFF
--- a/frontend/lib/src/components/ChatInput/logger.ts
+++ b/frontend/lib/src/components/ChatInput/logger.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getLogger } from "loglevel"
+
+export const LOG = getLogger("ChatInput")

--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -484,6 +484,13 @@ export function useWaveformController({
     []
   )
 
+  // Cleanup on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      destroy()
+    }
+  }, [destroy])
+
   return {
     state: currentState,
     isPlaybackPlaying,

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.test.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.test.tsx
@@ -104,17 +104,17 @@ describe("AudioInput Recording Journey", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -351,17 +351,17 @@ describe("AudioInput Playback Journey", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -524,17 +524,17 @@ describe("AudioInput Upload & Abort", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -710,17 +710,17 @@ describe("AudioInput Memory Management", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -873,17 +873,17 @@ describe("AudioInput Form Integration", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -991,17 +991,17 @@ describe("AudioInput Error Handling", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {
@@ -1105,17 +1105,17 @@ describe("AudioInput Widget State", () => {
       },
     }),
     approve: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn(),
-    destroy: vi.fn(),
+    cancel: vi.fn().mockReturnValue(undefined),
+    destroy: vi.fn().mockReturnValue(undefined),
     playback: {
       isPlaying: vi.fn().mockImplementation(() => isPlaybackPlaying),
       play: vi.fn().mockResolvedValue(undefined),
-      pause: vi.fn(),
+      pause: vi.fn().mockReturnValue(undefined),
       load: vi.fn().mockResolvedValue(undefined),
       getCurrentTimeMs: vi.fn().mockReturnValue(0),
       getDurationMs: vi.fn().mockReturnValue(0),
     },
-    setEventHandlers: vi.fn(),
+    setEventHandlers: vi.fn().mockReturnValue(undefined),
   })
 
   beforeEach(() => {

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -111,64 +111,9 @@ const AudioInput: React.FC<Props> = ({
   const uploadAbortControllerRef = useRef<AbortController | null>(null)
   const currentBlobUrlRef = useRef<string | null>(null)
   const playbackTimerRef = useRef<number | null>(null)
-  const transcodeAndUploadFileRef = useRef<(wav: Blob) => Promise<void>>()
 
   const widgetId = element.id
   const widgetFormId = element.formId
-
-  const controller = useWaveformController({
-    containerRef,
-    sampleRate: element.sampleRate ?? undefined,
-    events: {
-      onPermissionDenied: () => {
-        setHasNoMicPermissions(true)
-      },
-      onError: () => {
-        setIsError(true)
-      },
-      onRecordStart: () => {
-        setRecordingTime(STARTING_TIME_STRING)
-        setProgressTime(STARTING_TIME_STRING)
-      },
-      onRecordReady: () => {
-        const duration = formatTime(controller.playback.getDurationMs())
-        setRecordingTime(duration)
-        setProgressTime(duration)
-      },
-      onApprove: async (wav: Blob) => {
-        await transcodeAndUploadFileRef.current?.(wav)
-      },
-      onCancel: () => {
-        setRecordingTime(STARTING_TIME_STRING)
-        setProgressTime(STARTING_TIME_STRING)
-      },
-      onProgressMs: (ms: number) => {
-        setRecordingTime(formatTime(ms))
-      },
-      onPlaybackPause: () => {
-        setProgressTime(formatTime(controller.playback.getCurrentTimeMs()))
-      },
-      onPlaybackFinish: () => {
-        setProgressTime(formatTime(controller.playback.getDurationMs()))
-      },
-    },
-  })
-
-  const {
-    state,
-    isPlaybackPlaying,
-    start: startController,
-    stop: stopController,
-    approve: approveController,
-    cancel: cancelController,
-    playback: {
-      play: playbackPlayFn,
-      pause: playbackPauseFn,
-      load: playbackLoadFn,
-      getCurrentTimeMs: playbackGetCurrentTimeMsFn,
-      getDurationMs: playbackGetDurationMsFn,
-    },
-  } = controller
 
   const transcodeAndUploadFile = useCallback(
     async (wavBlob: Blob) => {
@@ -199,6 +144,7 @@ const AudioInput: React.FC<Props> = ({
           }
           currentBlobUrlRef.current = blobUrl
         } catch {
+          // Blob URL creation failed - error state will be set below
           setIsError(true)
           setIsUploading(false)
           if (notNullOrUndefined(widgetFormId))
@@ -247,6 +193,7 @@ const AudioInput: React.FC<Props> = ({
             setDeleteFileUrl(upload.fileUrl.deleteUrl)
           }
         } catch {
+          // File upload failed - set error state unless request was cancelled
           if (!abortController.signal.aborted) {
             setIsError(true)
           }
@@ -258,6 +205,7 @@ const AudioInput: React.FC<Props> = ({
           }
         }
       } catch {
+        // Unexpected error during upload process - cleanup and set error state
         if (!abortController.signal.aborted) {
           setIsError(true)
           setIsUploading(false)
@@ -277,7 +225,70 @@ const AudioInput: React.FC<Props> = ({
     ]
   )
 
-  transcodeAndUploadFileRef.current = transcodeAndUploadFile
+  const controllerRef = useRef<ReturnType<
+    typeof useWaveformController
+  > | null>(null)
+
+  const controller = useWaveformController({
+    containerRef,
+    sampleRate: element.sampleRate ?? undefined,
+    events: {
+      onPermissionDenied: () => {
+        setHasNoMicPermissions(true)
+      },
+      onError: () => {
+        setIsError(true)
+      },
+      onRecordStart: () => {
+        setRecordingTime(STARTING_TIME_STRING)
+        setProgressTime(STARTING_TIME_STRING)
+      },
+      onRecordReady: () => {
+        const duration = formatTime(
+          controllerRef.current?.playback.getDurationMs() ?? 0
+        )
+        setRecordingTime(duration)
+        setProgressTime(duration)
+      },
+      onApprove: transcodeAndUploadFile,
+      onCancel: () => {
+        setRecordingTime(STARTING_TIME_STRING)
+        setProgressTime(STARTING_TIME_STRING)
+      },
+      onProgressMs: (ms: number) => {
+        setRecordingTime(formatTime(ms))
+      },
+      onPlaybackPause: () => {
+        setProgressTime(
+          formatTime(controllerRef.current?.playback.getCurrentTimeMs() ?? 0)
+        )
+      },
+      onPlaybackFinish: () => {
+        setProgressTime(
+          formatTime(controllerRef.current?.playback.getDurationMs() ?? 0)
+        )
+      },
+    },
+  })
+
+  // Update the ref after controller is initialized
+  controllerRef.current = controller
+
+  const {
+    state,
+    isPlaybackPlaying,
+    start: startController,
+    stop: stopController,
+    approve: approveController,
+    cancel: cancelController,
+    playback: {
+      play: playbackPlayFn,
+      pause: playbackPauseFn,
+      load: playbackLoadFn,
+      getCurrentTimeMs: playbackGetCurrentTimeMsFn,
+      getDurationMs: playbackGetDurationMsFn,
+    },
+  } = controller
 
   const handleClear = useCallback(
     async ({
@@ -384,6 +395,7 @@ const AudioInput: React.FC<Props> = ({
           setProgressTime(formatTime(durationMs))
         }
       } catch {
+        // Playback loading failed - likely a corrupted recording or browser issue
         if (!cancelled) {
           setIsError(true)
         }
@@ -418,6 +430,10 @@ const AudioInput: React.FC<Props> = ({
         cancelAnimationFrame(playbackTimerRef.current)
         playbackTimerRef.current = null
       }
+      if (currentBlobUrlRef.current) {
+        URL.revokeObjectURL(currentBlobUrlRef.current)
+        currentBlobUrlRef.current = null
+      }
     }
   }, [])
 
@@ -436,6 +452,7 @@ const AudioInput: React.FC<Props> = ({
         await playbackPlayFn()
       }
     } catch {
+      // Playback control error - set error state for user feedback
       setIsError(true)
     }
   }, [
@@ -465,6 +482,7 @@ const AudioInput: React.FC<Props> = ({
       const { blob } = await stopController()
       await approveController(blob)
     } catch {
+      // Stop recording or approval error - set error state for user feedback
       setIsError(true)
     }
   }, [approveController, stopController])

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen, waitFor } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import {
@@ -25,6 +25,10 @@ import {
   IChatInputValue,
 } from "@streamlit/protobuf"
 
+import type {
+  RecordingState,
+  WaveformController,
+} from "~lib/components/audio/core/types"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import {
   createDirectoryFiles,
@@ -69,7 +73,7 @@ const getProps = (
         })
       )
     }),
-    deleteFile: vi.fn(),
+    deleteFile: vi.fn().mockResolvedValue(undefined),
   },
   ...widgetProps,
 })
@@ -753,6 +757,100 @@ describe("ChatInput widget", () => {
     // Wait for upload to complete
     await waitFor(() => {
       expect(submitButton).not.toBeDisabled()
+    })
+  })
+
+  it("shows spinner and disables buttons during audio upload", async () => {
+    // Mock uploadFile to return a controllable promise
+    let resolveUpload: (() => void) | undefined
+    const uploadPromise = new Promise<void>(resolve => {
+      resolveUpload = resolve
+    })
+
+    const props = getProps({
+      acceptAudio: true,
+    })
+
+    // Override uploadFile to use our controllable promise
+    props.uploadClient.uploadFile = vi.fn().mockReturnValue(uploadPromise)
+
+    // Mock the waveform controller with proper typing
+    const mockController: WaveformController = {
+      state: "idle" as RecordingState,
+      isPlaybackPlaying: false,
+      mountRef: { current: null },
+      playback: {
+        isPlaying: vi.fn().mockReturnValue(false),
+        play: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockReturnValue(undefined),
+        load: vi.fn().mockResolvedValue(undefined),
+        getDurationMs: vi.fn().mockReturnValue(5000),
+        getCurrentTimeMs: vi.fn().mockReturnValue(0),
+      },
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue({
+        blob: new Blob(["audio data"], { type: "audio/wav" }),
+        meta: {
+          durationMs: 5000,
+          sampleRate: 44100,
+          mimeType: "audio/wav",
+          size: 1024,
+        },
+      }),
+      approve: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockReturnValue(undefined),
+      destroy: vi.fn().mockReturnValue(undefined),
+      setEventHandlers: vi.fn().mockReturnValue(undefined),
+    }
+
+    // Mock useWaveformController
+    const useWaveformController = await import("~lib/components/audio")
+    vi.spyOn(useWaveformController, "useWaveformController").mockReturnValue(
+      mockController
+    )
+
+    render(<ChatInput {...props} />)
+
+    // Get the approve button (it won't be visible initially since we're not recording)
+    // We need to trigger the recording flow and get the approve callback
+    // Instead, let's directly test by triggering the onApprove event from the mock
+
+    // Find the calls to useWaveformController and get the onApprove callback
+    const mockCalls = (
+      useWaveformController.useWaveformController as ReturnType<typeof vi.fn>
+    ).mock.calls
+    const lastCallArgs = mockCalls[mockCalls.length - 1]
+    const { events } = lastCallArgs[0]
+    const onApprove = events?.onApprove
+
+    // Create a mock audio blob
+    const audioBlob = new Blob(["audio data"], { type: "audio/wav" })
+
+    // Trigger the approve event (this starts the upload)
+    let approvePromise: Promise<void> | undefined
+    await act(async () => {
+      approvePromise = onApprove?.(audioBlob)
+      // Wait a tick to let state updates propagate
+      await Promise.resolve()
+    })
+
+    // Check that buttons are disabled during upload
+    await waitFor(() => {
+      const submitButton = screen.getByTestId("stChatInputSubmitButton")
+      expect(submitButton).toBeDisabled()
+    })
+
+    // Resolve the upload
+    await act(async () => {
+      resolveUpload?.()
+      if (approvePromise) {
+        await approvePromise
+      }
+    })
+
+    // After upload completes, verify upload was called
+    await waitFor(() => {
+      expect(props.uploadClient.uploadFile).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -638,7 +638,7 @@ function ChatInput({
             {/* Input instructions - hidden during recording */}
             {controller.state !== "recording" &&
               width > theme.breakpoints.hideWidgetDetails && (
-                <StyledInputInstructionsContainer>
+                <StyledInputInstructionsContainer acceptAudio={acceptAudio}>
                   <InputInstructions
                     dirty={dirty}
                     value={value}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -40,7 +40,7 @@ import {
 
 import { useWaveformController } from "~lib/components/audio"
 import { LOG } from "~lib/components/ChatInput/logger"
-import { StyledChatAudioWave } from "~lib/components/ChatInput/styled-components"
+import { StyledChatAudioWave } from "./styled-components"
 import Icon, { StyledSpinnerIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
 import {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -40,7 +40,7 @@ import {
 
 import { useWaveformController } from "~lib/components/audio"
 import { LOG } from "~lib/components/ChatInput/logger"
-import { StyledChatAudioWave } from "./styled-components"
+
 import Icon, { StyledSpinnerIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
 import {
@@ -67,6 +67,7 @@ import ChatUploadedFiles from "./fileUpload/ChatUploadedFiles"
 import { createDropHandler } from "./fileUpload/createDropHandler"
 import { createUploadFileHandler } from "./fileUpload/createFileUploadHandler"
 import {
+  StyledChatAudioWave,
   StyledChatInput,
   StyledChatInputContainer,
   StyledInputInstructionsContainer,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -626,9 +626,12 @@ function ChatInput({
                       paddingLeft: theme.spacing.none,
                       paddingBottom: theme.spacing.sm,
                       paddingTop: theme.spacing.sm,
-                      // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
-                      // and some additional margin between the icon and the text (spacing.sm).
-                      paddingRight: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
+                      // Calculate the right padding to account for button(s) on the right
+                      // Each button is: iconSizes.xl + 2 * spacing.sm
+                      // When acceptAudio is true, there are 2 buttons (mic + send) with extra margin
+                      paddingRight: acceptAudio
+                        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + 2 * ${theme.spacing.sm})`
+                        : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
                     },
                   },
                 }}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -25,7 +25,7 @@ import React, {
   useState,
 } from "react"
 
-import { Send } from "@emotion-icons/material-rounded"
+import { Check, Close, Mic, Send } from "@emotion-icons/material-rounded"
 import { Textarea as UITextArea } from "baseui/textarea"
 import { useDropzone } from "react-dropzone"
 
@@ -38,7 +38,10 @@ import {
   UploadedFileInfo as UploadedFileInfoProto,
 } from "@streamlit/protobuf"
 
-import Icon from "~lib/components/shared/Icon"
+import { useWaveformController } from "~lib/components/audio"
+import { LOG } from "~lib/components/ChatInput/logger"
+import { StyledChatAudioWave } from "~lib/components/ChatInput/styled-components"
+import Icon, { StyledSpinnerIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
 import {
   UploadedStatus,
@@ -69,6 +72,7 @@ import {
   StyledInputInstructionsContainer,
   StyledSendIconButton,
   StyledSendIconButtonContainer,
+  StyledWaveformContainer,
 } from "./styled-components"
 
 export interface Props {
@@ -103,6 +107,9 @@ function ChatInput({
 
   const counterRef = useRef(0)
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
+  const processedSetValueRef = useRef(false)
+  const waveformContainerRef = useRef<HTMLDivElement>(null)
+  const uploadAbortControllerRef = useRef<AbortController | null>(null)
 
   const { width, elementRef } = useCalculatedDimensions()
   const { innerWidth, innerHeight } = useWindowDimensionsContext()
@@ -111,6 +118,19 @@ function ChatInput({
   const [value, setValue] = useState(element.default)
   const [files, setFiles] = useState<UploadFileInfo[]>([])
   const [fileDragged, setFileDragged] = useState(false)
+  const [audioUploading, setAudioUploading] = useState(false)
+
+  // Read acceptAudio from the element configuration
+  const acceptAudio = element.acceptAudio ?? false
+
+  // Cleanup: abort any in-progress uploads on unmount
+  useEffect(() => {
+    return () => {
+      if (uploadAbortControllerRef.current) {
+        uploadAbortControllerRef.current.abort()
+      }
+    }
+  }, [])
 
   const autoExpand = useTextInputAutoExpand({
     textareaRef: chatInputRef,
@@ -142,6 +162,28 @@ function ChatInput({
     []
   )
 
+  const deleteUploadedFile = useCallback(
+    (file: UploadFileInfo): void => {
+      // Abort ongoing upload if file is still uploading
+      if (file.status.type === "uploading") {
+        file.status.abortController.abort()
+      }
+
+      // Delete file from server if it was successfully uploaded
+      if (file.status.type === "uploaded" && file.status.fileUrls.deleteUrl) {
+        // Fire-and-forget deletion - errors are not critical to user flow
+        uploadClient
+          .deleteFile(file.status.fileUrls.deleteUrl)
+          .catch(error => {
+            // Log deletion errors for observability, but don't block the user
+            // File may already be deleted or server unavailable
+            LOG.error("Failed to delete file from server", error)
+          })
+      }
+    },
+    [uploadClient]
+  )
+
   const deleteFile = useCallback(
     (fileId: number): void => {
       setFiles(prevFiles => {
@@ -150,43 +192,32 @@ function ChatInput({
           return prevFiles
         }
 
-        if (file.status.type === "uploading") {
-          // Cancel request as the file hasn't been uploaded.
-          // However, it may have been received by the server so we'd still
-          // send out a request to delete it.
-          file.status.abortController.abort()
-        }
-
-        if (
-          file.status.type === "uploaded" &&
-          file.status.fileUrls.deleteUrl
-        ) {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Fix this
-          uploadClient.deleteFile(file.status.fileUrls.deleteUrl)
-        }
+        // Handle abort/deletion using shared helper
+        deleteUploadedFile(file)
 
         return prevFiles.filter(fileArg => fileArg.id !== fileId)
       })
     },
-    [uploadClient]
+    [deleteUploadedFile]
   )
 
-  const createChatInputWidgetFilesValue = (): FileUploaderStateProto => {
-    const uploadedFileInfo: UploadedFileInfoProto[] = files
-      .filter(f => f.status.type === "uploaded")
-      .map(f => {
-        const { name, size, status } = f
-        const { fileId, fileUrls } = status as UploadedStatus
-        return new UploadedFileInfoProto({
-          fileId,
-          fileUrls,
-          name,
-          size,
+  const createChatInputWidgetFilesValue =
+    useCallback((): FileUploaderStateProto => {
+      const uploadedFileInfo: UploadedFileInfoProto[] = files
+        .filter(f => f.status.type === "uploaded")
+        .map(f => {
+          const { name, size, status } = f
+          const { fileId, fileUrls } = status as UploadedStatus
+          return new UploadedFileInfoProto({
+            fileId,
+            fileUrls,
+            name,
+            size,
+          })
         })
-      })
 
-    return new FileUploaderStateProto({ uploadedFileInfo })
-  }
+      return new FileUploaderStateProto({ uploadedFileInfo })
+    }, [files])
 
   const getNextLocalFileId = (): number => {
     return counterRef.current++
@@ -274,32 +305,129 @@ function ChatInput({
     maxSize: maxFileSize,
   })
 
-  const handleSubmit = (): void => {
-    // We want the chat input to always be in focus
-    // even if the user clicks the submit button
-    if (chatInputRef.current) {
-      chatInputRef.current.focus()
-    }
+  const submitChatInput = useCallback(
+    (audioInfo?: UploadedFileInfoProto): void => {
+      // We want the chat input to always be in focus
+      // even if the user clicks the submit button
+      if (chatInputRef.current) {
+        chatInputRef.current.focus()
+      }
 
-    if (!dirty || disabled) {
-      return
-    }
+      // Allow submission if:
+      // - dirty=true (user typed text or uploaded files), OR
+      // - audioInfo is provided (audio was just recorded and uploaded)
+      // Audio bypasses the dirty check because it's uploaded and submitted
+      // immediately without being added to the files state.
+      if ((!dirty && !audioInfo) || disabled) {
+        return
+      }
 
-    const composedValue: IChatInputValue = {
-      data: value,
-      fileUploaderState: createChatInputWidgetFilesValue(),
-    }
+      const filesValue = createChatInputWidgetFilesValue()
 
-    widgetMgr.setChatInputValue(
+      const composedValue: IChatInputValue = {
+        data: value,
+        fileUploaderState: filesValue,
+        audioFileInfo: audioInfo,
+      }
+
+      widgetMgr.setChatInputValue(
+        element,
+        composedValue,
+        { fromUi: true },
+        fragmentId
+      )
+      setFiles([])
+      setValue("")
+      autoExpand.clearScrollHeight()
+    },
+    [
+      dirty,
+      disabled,
+      value,
+      createChatInputWidgetFilesValue,
+      widgetMgr,
       element,
-      composedValue,
-      { fromUi: true },
-      fragmentId
-    )
-    setFiles([])
-    setValue("")
-    autoExpand.clearScrollHeight()
-  }
+      fragmentId,
+      autoExpand,
+    ]
+  )
+
+  // Handle audio approval and upload
+  const handleAudioApprove = useCallback(
+    async (wav: Blob): Promise<void> => {
+      // Convert blob to File
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+      const audioFile = new File([wav], `audio-${timestamp}.wav`, {
+        type: "audio/wav",
+      })
+
+      try {
+        setAudioUploading(true)
+
+        // 1. Fetch upload URL
+        const fileURLsArray = await uploadClient.fetchFileURLs([audioFile])
+
+        if (fileURLsArray.length === 0) {
+          throw new Error("Failed to get upload URL for audio file")
+        }
+
+        const fileUrls = fileURLsArray[0]
+
+        // 2. Upload audio file with progress tracking
+        uploadAbortControllerRef.current = new AbortController()
+        await uploadClient.uploadFile(
+          {
+            formId: "",
+            ...element,
+          },
+          fileUrls.uploadUrl as string,
+          audioFile,
+          () => {
+            // Progress callback - track upload progress (could display percentage if needed)
+          },
+          uploadAbortControllerRef.current.signal
+        )
+
+        // 3. Create audio file info
+        const audioInfo = new UploadedFileInfoProto({
+          fileId: fileUrls.fileId as string,
+          fileUrls,
+          name: audioFile.name,
+          size: audioFile.size,
+        })
+
+        // 4. Submit immediately with audio info
+        submitChatInput(audioInfo)
+      } catch (error) {
+        LOG.error("Audio upload failed:", error)
+        // Refocus on input after error
+        if (chatInputRef.current) {
+          chatInputRef.current.focus()
+        }
+      } finally {
+        setAudioUploading(false)
+      }
+    },
+    [uploadClient, element, submitChatInput]
+  )
+
+  // Memoize events to ensure fresh closures when dependencies change
+  const controllerEvents = useMemo(
+    () => ({
+      onApprove: handleAudioApprove,
+    }),
+    [handleAudioApprove]
+  )
+
+  // Create waveform controller for audio recording
+  const controller = useWaveformController({
+    containerRef: waveformContainerRef,
+    events: controllerEvents,
+  })
+
+  const handleSubmit = useCallback((): void => {
+    submitChatInput()
+  }, [submitChatInput])
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
     const { metaKey, ctrlKey, shiftKey } = e
@@ -324,15 +452,50 @@ function ChatInput({
     autoExpand.updateScrollHeight()
   }
 
+  const handleMicClick = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (!acceptAudio || disabled || controller.state === "recording") {
+        return
+      }
+
+      // Error handling is done via controller events (onError, onPermissionDenied)
+      await controller.start()
+    },
+    [acceptAudio, disabled, controller]
+  )
+
+  const handleRecordingCancel = useCallback(() => {
+    controller.cancel()
+    if (chatInputRef.current) {
+      chatInputRef.current.focus()
+    }
+  }, [controller])
+
+  const handleRecordingApprove = useCallback(async () => {
+    // Stop recording and get the blob
+    const { blob } = await controller.stop()
+    // Approve the recording (encodes to WAV and triggers onApprove event which handles upload)
+    // Error handling is done via controller events (onError) and in the onApprove handler for upload errors
+    await controller.approve(blob)
+  }, [controller])
+
+  // Handle setValue command from backend
+  // This runs when element.setValue is true, indicating the backend wants to set a new value
   useEffect(() => {
-    if (element.setValue) {
-      // We are intentionally setting this to avoid regularly calling this effect.
-      // TODO: Update to match React best practices
-      // eslint-disable-next-line react-hooks/react-compiler
-      element.setValue = false
+    if (element.setValue && !processedSetValueRef.current) {
+      // Mark this setValue as processed to avoid re-processing
+      processedSetValueRef.current = true
       const val = element.value || ""
       setValue(val)
     }
+  }, [element.setValue, element.value])
+
+  // Reset the processed flag when element reference changes (new widget instance)
+  useEffect(() => {
+    processedSetValueRef.current = false
   }, [element])
 
   useEffect(() => {
@@ -398,8 +561,20 @@ function ChatInput({
             inputHeight={autoExpand.height}
           />
         ) : (
-          <StyledChatInput extended={autoExpand.isExtended}>
-            {acceptFile === AcceptFileValue.None ? null : (
+          <StyledChatInput
+            extended={
+              autoExpand.isExtended || controller.state === "recording"
+            }
+          >
+            {/* Waveform - always mounted to ensure ref is available for initialization */}
+            <StyledWaveformContainer
+              isRecording={controller.state === "recording"}
+            >
+              <StyledChatAudioWave ref={waveformContainerRef} />
+            </StyledWaveformContainer>
+
+            {acceptFile === AcceptFileValue.None ||
+            controller.state === "recording" ? null : (
               <ChatFileUploadButton
                 getRootProps={getRootProps}
                 getInputProps={getInputProps}
@@ -408,75 +583,134 @@ function ChatInput({
                 theme={theme}
               />
             )}
-            <UITextArea
-              inputRef={chatInputRef}
-              value={value}
-              placeholder={placeholder}
-              onChange={handleChange}
-              onKeyDown={handleKeyDown}
-              aria-label={placeholder}
-              disabled={disabled}
-              rows={1}
-              overrides={{
-                Root: {
-                  style: {
-                    minHeight: theme.sizes.minElementHeight,
-                    outline: "none",
-                    borderLeftWidth: "0",
-                    borderRightWidth: "0",
-                    borderTopWidth: "0",
-                    borderBottomWidth: "0",
-                    borderTopLeftRadius: "0",
-                    borderTopRightRadius: "0",
-                    borderBottomRightRadius: "0",
-                    borderBottomLeftRadius: "0",
-                  },
-                },
-                Input: {
-                  props: {
-                    "data-testid": "stChatInputTextArea",
-                  },
-                  style: {
-                    fontWeight: theme.fontWeights.normal,
-                    lineHeight: theme.lineHeights.inputWidget,
-                    "::placeholder": {
-                      color: theme.colors.fadedText60,
+
+            {/* Textarea - only shown when not recording */}
+            {controller.state !== "recording" && (
+              <UITextArea
+                inputRef={chatInputRef}
+                value={value}
+                placeholder={placeholder}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                aria-label={placeholder}
+                disabled={disabled}
+                rows={1}
+                overrides={{
+                  Root: {
+                    style: {
+                      minHeight: theme.sizes.minElementHeight,
+                      outline: "none",
+                      borderLeftWidth: "0",
+                      borderRightWidth: "0",
+                      borderTopWidth: "0",
+                      borderBottomWidth: "0",
+                      borderTopLeftRadius: "0",
+                      borderTopRightRadius: "0",
+                      borderBottomRightRadius: "0",
+                      borderBottomLeftRadius: "0",
                     },
-                    height: autoExpand.height,
-                    maxHeight: autoExpand.maxHeight,
-                    // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
-                    paddingLeft: theme.spacing.none,
-                    paddingBottom: theme.spacing.sm,
-                    paddingTop: theme.spacing.sm,
-                    // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
-                    // and some additional margin between the icon and the text (spacing.sm).
-                    paddingRight: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
                   },
-                },
-              }}
-            />
-            {/* Hide the character limit in small widget sizes */}
-            {width > theme.breakpoints.hideWidgetDetails && (
-              <StyledInputInstructionsContainer>
-                <InputInstructions
-                  dirty={dirty}
-                  value={value}
-                  maxLength={maxChars}
-                  type="chat"
-                  // Chat Input are not able to be used in forms
-                  inForm={false}
-                />
-              </StyledInputInstructionsContainer>
+                  Input: {
+                    props: {
+                      "data-testid": "stChatInputTextArea",
+                    },
+                    style: {
+                      fontWeight: theme.fontWeights.normal,
+                      lineHeight: theme.lineHeights.inputWidget,
+                      "::placeholder": {
+                        color: theme.colors.fadedText60,
+                      },
+                      height: autoExpand.height,
+                      maxHeight: autoExpand.maxHeight,
+                      // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                      paddingLeft: theme.spacing.none,
+                      paddingBottom: theme.spacing.sm,
+                      paddingTop: theme.spacing.sm,
+                      // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
+                      // and some additional margin between the icon and the text (spacing.sm).
+                      paddingRight: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
+                    },
+                  },
+                }}
+              />
             )}
-            <StyledSendIconButtonContainer>
-              <StyledSendIconButton
-                onClick={handleSubmit}
-                disabled={!dirty || disabled}
-                extended={autoExpand.isExtended}
-                data-testid="stChatInputSubmitButton"
-              >
-                <Icon content={Send} size="xl" color="inherit" />
-              </StyledSendIconButton>
+
+            {/* Input instructions - hidden during recording */}
+            {controller.state !== "recording" &&
+              width > theme.breakpoints.hideWidgetDetails && (
+                <StyledInputInstructionsContainer>
+                  <InputInstructions
+                    dirty={dirty}
+                    value={value}
+                    maxLength={maxChars}
+                    type="chat"
+                    // Chat Input are not able to be used in forms
+                    inForm={false}
+                  />
+                </StyledInputInstructionsContainer>
+              )}
+
+            {/* Right-side buttons */}
+            <StyledSendIconButtonContainer
+              isRecording={controller.state === "recording"}
+            >
+              {controller.state === "recording" ? (
+                <>
+                  {/* Cancel button (X icon) */}
+                  <StyledSendIconButton
+                    onClick={handleRecordingCancel}
+                    disabled={disabled}
+                    extended={autoExpand.isExtended}
+                    data-testid="stChatInputCancelButton"
+                  >
+                    <Icon content={Close} size="lg" color="inherit" />
+                  </StyledSendIconButton>
+                  {/* Approve button (✓ icon or spinner during upload) */}
+                  <StyledSendIconButton
+                    onClick={() => {
+                      handleRecordingApprove().catch(_error => {
+                        // Error handling is done via controller events
+                      })
+                    }}
+                    disabled={disabled || audioUploading}
+                    extended={autoExpand.isExtended}
+                    data-testid="stChatInputApproveButton"
+                  >
+                    {audioUploading ? (
+                      <StyledSpinnerIcon size="lg" margin="0" padding="0" />
+                    ) : (
+                      <Icon content={Check} size="lg" color="inherit" />
+                    )}
+                  </StyledSendIconButton>
+                </>
+              ) : (
+                <>
+                  {/* Mic button */}
+                  {acceptAudio && (
+                    <StyledSendIconButton
+                      onClick={(e: React.MouseEvent) => {
+                        handleMicClick(e).catch(_error => {
+                          // Error handling is done via controller events
+                        })
+                      }}
+                      disabled={disabled || audioUploading}
+                      extended={autoExpand.isExtended}
+                      data-testid="stChatInputMicButton"
+                    >
+                      <Icon content={Mic} size="xl" color="inherit" />
+                    </StyledSendIconButton>
+                  )}
+                  {/* Send button */}
+                  <StyledSendIconButton
+                    onClick={handleSubmit}
+                    disabled={!dirty || disabled || audioUploading}
+                    extended={autoExpand.isExtended}
+                    data-testid="stChatInputSubmitButton"
+                  >
+                    <Icon content={Send} size="xl" color="inherit" />
+                  </StyledSendIconButton>
+                </>
+              )}
             </StyledSendIconButtonContainer>
           </StyledChatInput>
         )}

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -627,10 +627,10 @@ function ChatInput({
                       paddingBottom: theme.spacing.sm,
                       paddingTop: theme.spacing.sm,
                       // Calculate the right padding to account for button(s) on the right
-                      // Each button is: iconSizes.xl + 2 * spacing.sm
-                      // When acceptAudio is true, there are 2 buttons (mic + send) with extra margin
+                      // Each button is: iconSizes.xl + 2 * spacing.sm (40px total)
+                      // When acceptAudio is true, there are 2 buttons (mic + send) = 80px
                       paddingRight: acceptAudio
-                        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + 2 * ${theme.spacing.sm})`
+                        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}))`
                         : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
                     },
                   },

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -40,7 +40,6 @@ import {
 
 import { useWaveformController } from "~lib/components/audio"
 import { LOG } from "~lib/components/ChatInput/logger"
-
 import Icon, { StyledSpinnerIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
 import {

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -113,7 +113,7 @@ export const StyledSendIconButtonContainer =
     bottom: isRecording ? undefined : 0,
     marginBottom: isRecording ? 0 : `-${theme.sizes.borderWidth}`,
     pointerEvents: "none",
-    gap: isRecording ? theme.spacing.sm : 0,
+    gap: 0,
     paddingRight: isRecording ? theme.spacing.sm : 0,
   }))
 
@@ -128,9 +128,9 @@ export const StyledInputInstructionsContainer =
       bottom: "0px",
       // Calculate the right padding to account for button(s) on the right
       // Each button is: iconSizes.xl + 2 * spacing.sm
-      // When acceptAudio is true, there are 2 buttons (mic + send) with gap between them
+      // When acceptAudio is true, there are 2 buttons (mic + send)
       right: acceptAudio
-        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + 2 * ${theme.spacing.sm})`
+        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + ${theme.spacing.sm})`
         : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
     })
   )

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -117,13 +117,23 @@ export const StyledSendIconButtonContainer =
     paddingRight: isRecording ? theme.spacing.sm : 0,
   }))
 
-export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
-  position: "absolute",
-  bottom: "0px",
-  // Calculate the right padding to account for the send icon (iconSizes.xl + 2 * spacing.sm)
-  // and some additional margin between the icon and the text (spacing.sm).
-  right: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
-}))
+interface StyledInputInstructionsContainerProps {
+  acceptAudio?: boolean
+}
+
+export const StyledInputInstructionsContainer =
+  styled.div<StyledInputInstructionsContainerProps>(
+    ({ theme, acceptAudio }) => ({
+      position: "absolute",
+      bottom: "0px",
+      // Calculate the right padding to account for button(s) on the right
+      // Each button is: iconSizes.xl + 2 * spacing.sm
+      // When acceptAudio is true, there are 2 buttons (mic + send), otherwise just 1 (send)
+      right: acceptAudio
+        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + ${theme.spacing.sm})`
+        : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
+    })
+  )
 
 interface StyledWaveformContainerProps {
   isRecording: boolean

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -36,6 +36,8 @@ export const StyledChatInput = styled.div<StyledChatInputProps>(
     position: "relative",
     flexGrow: 1,
     display: "flex",
+    flexDirection: "row",
+    flexWrap: "nowrap",
     alignItems: "center",
     paddingLeft: theme.spacing.lg,
     maxHeight: extended ? "none" : theme.sizes.minElementHeight,
@@ -97,16 +99,24 @@ export const StyledSendIconButton = styled.button<StyledSendIconButtonProps>(
   }
 )
 
-export const StyledSendIconButtonContainer = styled.div(({ theme }) => ({
-  display: "flex",
-  alignItems: "flex-end",
-  height: "100%",
-  position: "absolute",
-  right: 0,
-  // Negative margin to offset the parent border width when we align button to end
-  marginBottom: `-${theme.sizes.borderWidth}`,
-  pointerEvents: "none",
-}))
+interface StyledSendIconButtonContainerProps {
+  isRecording?: boolean
+}
+
+export const StyledSendIconButtonContainer =
+  styled.div<StyledSendIconButtonContainerProps>(({ theme, isRecording }) => ({
+    display: "flex",
+    alignItems: isRecording ? "center" : "flex-end",
+    height: "100%",
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+    // Negative margin to offset the parent border width when we align button to end
+    marginBottom: isRecording ? 0 : `-${theme.sizes.borderWidth}`,
+    pointerEvents: "none",
+    gap: isRecording ? theme.spacing.twoXS : 0,
+    paddingRight: isRecording ? theme.spacing.sm : 0,
+  }))
 
 export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
   position: "absolute",
@@ -115,3 +125,15 @@ export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({
   // and some additional margin between the icon and the text (spacing.sm).
   right: `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
 }))
+
+interface StyledWaveformContainerProps {
+  isRecording: boolean
+}
+
+export const StyledWaveformContainer =
+  styled.div<StyledWaveformContainerProps>(({ isRecording }) => ({
+    display: isRecording ? "flex" : "none",
+    flex: isRecording ? 1 : undefined,
+    alignItems: "center",
+    minWidth: 0, // Allow flex item to shrink below content size if needed
+  }))

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -137,3 +137,14 @@ export const StyledWaveformContainer =
     alignItems: "center",
     minWidth: 0, // Allow flex item to shrink below content size if needed
   }))
+
+export const StyledChatAudioWave = styled.div(({ theme }) => ({
+  position: "relative",
+  minHeight: theme.sizes.minElementHeight,
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
+  "& > div": {
+    position: "absolute",
+    inset: 0,
+  },
+}))

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -140,6 +140,7 @@ export const StyledWaveformContainer =
 
 export const StyledChatAudioWave = styled.div(({ theme }) => ({
   position: "relative",
+  width: "100%",
   minHeight: theme.sizes.minElementHeight,
   borderRadius: theme.radii.default,
   overflow: "hidden",

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -128,9 +128,9 @@ export const StyledInputInstructionsContainer =
       bottom: "0px",
       // Calculate the right padding to account for button(s) on the right
       // Each button is: iconSizes.xl + 2 * spacing.sm
-      // When acceptAudio is true, there are 2 buttons (mic + send), otherwise just 1 (send)
+      // When acceptAudio is true, there are 2 buttons (mic + send) with gap between them
       right: acceptAudio
-        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + ${theme.spacing.sm})`
+        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + 2 * ${theme.spacing.sm})`
         : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
     })
   )

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -108,14 +108,12 @@ export const StyledSendIconButtonContainer =
     display: "flex",
     alignItems: isRecording ? "center" : "flex-end",
     height: "100%",
-    position: "absolute",
-    right: 0,
-    bottom: 0,
-    // Negative margin to offset the parent border width when we align button to end
+    position: isRecording ? "static" : "absolute",
+    right: isRecording ? undefined : 0,
+    bottom: isRecording ? undefined : 0,
     marginBottom: isRecording ? 0 : `-${theme.sizes.borderWidth}`,
     pointerEvents: "none",
-    gap: isRecording ? theme.spacing.twoXS : 0,
-    paddingRight: isRecording ? theme.spacing.sm : 0,
+    gap: isRecording ? theme.spacing.sm : 0,
   }))
 
 export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -114,6 +114,7 @@ export const StyledSendIconButtonContainer =
     marginBottom: isRecording ? 0 : `-${theme.sizes.borderWidth}`,
     pointerEvents: "none",
     gap: isRecording ? theme.spacing.sm : 0,
+    paddingRight: isRecording ? theme.spacing.sm : 0,
   }))
 
 export const StyledInputInstructionsContainer = styled.div(({ theme }) => ({

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -128,9 +128,9 @@ export const StyledInputInstructionsContainer =
       bottom: "0px",
       // Calculate the right padding to account for button(s) on the right
       // Each button is: iconSizes.xl + 2 * spacing.sm
-      // When acceptAudio is true, there are 2 buttons (mic + send)
+      // When acceptAudio is true, there are 2 buttons (mic + send) with extra margin
       right: acceptAudio
-        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + ${theme.spacing.sm})`
+        ? `calc(2 * (${theme.iconSizes.xl} + 2 * ${theme.spacing.sm}) + 2 * ${theme.spacing.sm})`
         : `calc(${theme.iconSizes.xl} + 2 * ${theme.spacing.sm} + ${theme.spacing.sm})`,
     })
   )


### PR DESCRIPTION
## Describe your changes

This PR refactors the AudioInput component and adds audio recording capabilities to the ChatInput component:

1. In AudioInput:
   - Improved code organization by moving the transcodeAndUploadFile function before controller initialization
   - Removed the unnecessary ref for transcodeAndUploadFile and passed the function directly to onApprove
   - Added cleanup for blob URLs to prevent memory leaks
   - Added explanatory comments for error handling cases

2. In ChatInput:
   - Added audio recording functionality with mic button when acceptAudio is enabled
   - Implemented recording UI with waveform visualization and approve/cancel buttons
   - Added audio file upload and submission logic
   - Ensured proper cleanup of audio resources
   - Fixed setValue handling to prevent duplicate processing

## Testing Plan

- The AudioInput refactoring maintains the same functionality with improved code organization
- Manually tested audio recording in ChatInput with various browsers
- Verified that audio files are properly uploaded and submitted with chat messages
- Tested error handling for recording and upload failures
- Verified that UI state transitions correctly between text input and recording modes
- Confirmed that audio resources are properly cleaned up when component unmounts

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.