### PR TITLE
Makes fuzzy search case insensitive

### DIFF
--- a/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
+++ b/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import shuffle from "lodash/shuffle"
+
 import { fuzzyFilterSelectOptions } from "~lib/util/fuzzyFilterSelectOptions"
 
 describe("fuzzyFilterSelectOptions", () => {
@@ -62,6 +64,17 @@ describe("fuzzyFilterSelectOptions", () => {
 
     const results1 = fuzzyFilterSelectOptions(options, "stre")
     expect(results1.map(it => it.label)).toEqual([
+      "Streamlit",
+      "Another streamlit",
+      "Yet another streamlit",
+      "mistreamlit",
+      "Some estreamlit",
+    ])
+
+    // Randomize options to ensure order is not hiding an issue
+    const randomizedOptions = shuffle(options)
+    const results2 = fuzzyFilterSelectOptions(randomizedOptions, "stre")
+    expect(results2.map(it => it.label)).toEqual([
       "Streamlit",
       "Another streamlit",
       "Yet another streamlit",

--- a/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
+++ b/frontend/lib/src/util/fuzzyFilterSelectOptions.test.ts
@@ -50,4 +50,23 @@ describe("fuzzyFilterSelectOptions", () => {
       "e2e/scripts/st_experimental_get_query_params.py",
     ])
   })
+
+  it("prioritizes matches well with case insensitivity", () => {
+    const options = [
+      { label: "Streamlit", value: "" },
+      { label: "Another streamlit", value: "" },
+      { label: "Yet another streamlit", value: "" },
+      { label: "Some estreamlit", value: "" },
+      { label: "mistreamlit", value: "" },
+    ]
+
+    const results1 = fuzzyFilterSelectOptions(options, "stre")
+    expect(results1.map(it => it.label)).toEqual([
+      "Streamlit",
+      "Another streamlit",
+      "Yet another streamlit",
+      "mistreamlit",
+      "Some estreamlit",
+    ])
+  })
 })

--- a/frontend/lib/src/util/fuzzyFilterSelectOptions.ts
+++ b/frontend/lib/src/util/fuzzyFilterSelectOptions.ts
@@ -42,6 +42,6 @@ export function fuzzyFilterSelectOptions<T extends LabeledOption>(
     filteredOptions,
     // Use the negative score to sort the list in a stable manner
     // This ensures highest score is first
-    (opt: T) => -score(pattern, opt.label, true)
+    (opt: T) => -score(pattern, opt.label)
   )
 }


### PR DESCRIPTION
## Describe your changes

When working on #11309, I was working to provide more predictable case sensitive search. It works in some cases (where the case sensitive should come before a case insensitive), but it made fuzzy searching across other instances worse (See #11724) In the end, we will go for case insensitive search, because that's a little more intuitive as users type and will be less great from a case sensitivity.

I think the scoring could be better in that case insensitive can be slightly behind a case sensitive match, but that's a much tougher problem to solve. This will alleviate user's concerns

## GitHub Issue Link (if applicable)

closes #11724

## Testing Plan

- Added a unit test based on the issue's use case

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
