### PR TITLE
[fix] Update semgrep workflow to run on more PRs

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,13 +3,14 @@ name: Run Semgrep Checks
 
 on:
   pull_request:
-    branches: [develop]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
 
 jobs:
   run-semgrep-reusable-workflow:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     uses: snowflakedb/reusable-workflows/.github/workflows/semgrep-v2.yml@main
     secrets:
       token: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
## Describe your changes

- Rather than only running on PRs to `develop`, we match the PR lifecycle of our other jobs.
- Additionally, we add a filter to ensure this ONLY runs on PRs in `streamlit/streamlit`.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
