### PR TITLE
[chore] Add automation for deploying @streamlit/component-v2-lib to npm

### DIFF
--- a/.github/workflows/bump-component-v2-lib.yml
+++ b/.github/workflows/bump-component-v2-lib.yml
@@ -53,7 +53,7 @@ jobs:
           NEXT="${{ inputs.new_version }}"
           if ! echo "$NEXT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then echo "invalid semver: $NEXT"; exit 1; fi
           if [ "$NEXT" = "$CURR" ]; then echo "new_version equals current"; exit 1; fi
-          node -e "const fs=require('fs');const f='package.json';const p=JSON.parse(fs.readFileSync(f));p.version='${{ inputs.new_version }}';fs.writeFileSync(f, JSON.stringify(p, null, 2)+'\\n');"
+          npm version "${{ inputs.new_version }}" --no-git-tag-version
           echo "next=$NEXT" >> $GITHUB_OUTPUT
 
       - name: Create branch and commit (@streamlit/component-v2-lib)

--- a/.github/workflows/bump-component-v2-lib.yml
+++ b/.github/workflows/bump-component-v2-lib.yml
@@ -1,0 +1,111 @@
+name: Bump @streamlit/component-v2-lib version and open PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: New semver to set (x.y.z)
+        type: string
+        required: true
+      dry_run:
+        description: Run without pushing branch or creating PR
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-component-v2-lib
+  cancel-in-progress: true
+
+jobs:
+  bump-component-v2-lib-and-pr:
+    if: github.repository == 'streamlit/streamlit'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Compute next version (@streamlit/component-v2-lib)
+        id: compute
+        working-directory: frontend/component-v2-lib
+        run: |
+          set -euo pipefail
+          CURR=$(node -p "require('./package.json').version")
+          echo "current=$CURR" >> $GITHUB_OUTPUT
+          NEXT="${{ inputs.new_version }}"
+          if ! echo "$NEXT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then echo "invalid semver: $NEXT"; exit 1; fi
+          if [ "$NEXT" = "$CURR" ]; then echo "new_version equals current"; exit 1; fi
+          node -e "const fs=require('fs');const f='package.json';const p=JSON.parse(fs.readFileSync(f));p.version='${{ inputs.new_version }}';fs.writeFileSync(f, JSON.stringify(p, null, 2)+'\\n');"
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+
+      - name: Create branch and commit (@streamlit/component-v2-lib)
+        if: inputs.dry_run != true
+        env:
+          NEXT: ${{ steps.compute.outputs.next }}
+        run: |
+          git config user.name "Streamlit Bot"
+          git config user.email "core+streamlitbot-github@streamlit.io"
+          git checkout -b "chore/bump-component-v2-lib-to-v${NEXT}"
+          git add frontend/component-v2-lib/package.json
+          git commit -m "[chore] Bump @streamlit/component-v2-lib to v${NEXT}"
+          git push origin "chore/bump-component-v2-lib-to-v${NEXT}"
+
+      - name: Create PR to develop (@streamlit/component-v2-lib)
+        if: inputs.dry_run != true
+        id: create_pr
+        uses: actions/github-script@v8
+        env:
+          NEXT: ${{ steps.compute.outputs.next }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = `[chore] Bump @streamlit/component-v2-lib to v${process.env.NEXT}`;
+            const body = `Automated PR to bump @streamlit/component-v2-lib to v${process.env.NEXT}.`;
+            const created = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              head: `chore/bump-component-v2-lib-to-v${process.env.NEXT}`,
+              base: 'develop',
+              body,
+              draft: false,
+            });
+            const pr = created.data;
+            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, labels: ['change:chore','impact:internal'] });
+            core.setOutput('pr_url', pr.html_url);
+
+      - name: Summary (@streamlit/component-v2-lib)
+        env:
+          CURR: ${{ steps.compute.outputs.current }}
+          NEXT: ${{ steps.compute.outputs.next }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## @streamlit/component-v2-lib version bump";
+            echo "- current: ${CURR}";
+            echo "- next: ${NEXT}";
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "- Dry run: true (no branch/PR created)";
+            else
+              echo "- PR: ${PR_URL:-n/a}";
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-component-v2-lib.yml
+++ b/.github/workflows/publish-component-v2-lib.yml
@@ -99,8 +99,21 @@ jobs:
         if: inputs.dry_run == false
         working-directory: frontend/component-v2-lib
         run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
-          echo "Published version:" $(npm view @streamlit/component-v2-lib@"$VERSION" version)
+          echo "Verifying published version: $VERSION"
+          ATTEMPTS=6
+          DELAY=10
+          for i in $(seq 1 $ATTEMPTS); do
+            if npm view @streamlit/component-v2-lib@"$VERSION" version >/dev/null 2>&1; then
+              echo "Published version:" $(npm view @streamlit/component-v2-lib@"$VERSION" version)
+              exit 0
+            fi
+            echo "Waiting for npm registry propagation... attempt $i/$ATTEMPTS"
+            sleep $DELAY
+          done
+          echo "Failed to verify version $VERSION on npm after $ATTEMPTS attempts."
+          exit 1
 
       - name: Set up Python for Slack notifications
         if: always() && inputs.dry_run == false

--- a/.github/workflows/publish-component-v2-lib.yml
+++ b/.github/workflows/publish-component-v2-lib.yml
@@ -1,0 +1,93 @@
+name: Publish @streamlit/component-v2-lib to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, sha, or tag) to publish from
+        type: string
+        required: false
+      dry_run:
+        description: Run npm publish in dry-run mode
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: npm-publish-component-v2-lib
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-component-v2-lib:
+    if: ${{ github.repository == 'streamlit/streamlit' && github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+          submodules: recursive
+          fetch-depth: 2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node and npm registry
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install dependencies (@streamlit/component-v2-lib)
+        working-directory: frontend/component-v2-lib
+        run: yarn install --immutable
+
+      - name: Guard version does not already exist on npm (@streamlit/component-v2-lib)
+        working-directory: frontend/component-v2-lib
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Version to publish: $VERSION"
+          if npm view @streamlit/component-v2-lib@"$VERSION" version >/dev/null 2>&1; then
+            echo "Version $VERSION already exists on npm"; exit 1; fi
+
+      - name: Build, lint, and test (@streamlit/component-v2-lib)
+        working-directory: frontend/component-v2-lib
+        run: |
+          yarn build
+          yarn lint
+          yarn test
+
+      - name: Validate publish contents (@streamlit/component-v2-lib)
+        working-directory: frontend/component-v2-lib
+        run: |
+          npm pack --dry-run
+          test -d dist || (echo "Missing dist folder" && exit 1)
+
+      - name: Publish (dry-run) @streamlit/component-v2-lib
+        if: inputs.dry_run == true
+        working-directory: frontend/component-v2-lib
+        run: npm publish --dry-run --provenance --access public
+
+      - name: Publish (live) @streamlit/component-v2-lib
+        if: inputs.dry_run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: frontend/component-v2-lib
+        run: npm publish --provenance --access public
+
+      - name: Verify published version (@streamlit/component-v2-lib)
+        if: inputs.dry_run == false
+        working-directory: frontend/component-v2-lib
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Published version:" $(npm view @streamlit/component-v2-lib@"$VERSION" version)

--- a/.github/workflows/publish-component-v2-lib.yml
+++ b/.github/workflows/publish-component-v2-lib.yml
@@ -76,6 +76,13 @@ jobs:
           npm pack --dry-run
           test -d dist || (echo "Missing dist folder" && exit 1)
 
+      - name: Export package info
+        id: pkg
+        working-directory: frontend/component-v2-lib
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Publish (dry-run) @streamlit/component-v2-lib
         if: inputs.dry_run == true
         working-directory: frontend/component-v2-lib
@@ -92,3 +99,37 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "Published version:" $(npm view @streamlit/component-v2-lib@"$VERSION" version)
+
+      - name: Set up Python for Slack notifications
+        if: always() && inputs.dry_run == false
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps for Slack notifications
+        if: always() && inputs.dry_run == false
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Slack notification - success
+        if: success() && inputs.dry_run == false
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          PACKAGE_NAME: ${{ steps.pkg.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          python scripts/slack_notifications.py npm_publish success
+
+      - name: Slack notification - failure
+        if: failure() && inputs.dry_run == false
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          PACKAGE_NAME: ${{ steps.pkg.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          python scripts/slack_notifications.py npm_publish failure

--- a/.github/workflows/publish-component-v2-lib.yml
+++ b/.github/workflows/publish-component-v2-lib.yml
@@ -47,6 +47,9 @@ jobs:
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 
+      - name: Ensure latest npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies (@streamlit/component-v2-lib)
         working-directory: frontend/component-v2-lib
         run: yarn install --immutable
@@ -76,14 +79,12 @@ jobs:
       - name: Publish (dry-run) @streamlit/component-v2-lib
         if: inputs.dry_run == true
         working-directory: frontend/component-v2-lib
-        run: npm publish --dry-run --provenance --access public
+        run: npm publish --dry-run
 
       - name: Publish (live) @streamlit/component-v2-lib
         if: inputs.dry_run == false
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: frontend/component-v2-lib
-        run: npm publish --provenance --access public
+        run: npm publish
 
       - name: Verify published version (@streamlit/component-v2-lib)
         if: inputs.dry_run == false

--- a/.github/workflows/publish-component-v2-lib.yml
+++ b/.github/workflows/publish-component-v2-lib.yml
@@ -61,7 +61,9 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "Version to publish: $VERSION"
           if npm view @streamlit/component-v2-lib@"$VERSION" version >/dev/null 2>&1; then
-            echo "Version $VERSION already exists on npm"; exit 1; fi
+            echo "Version $VERSION already exists on npm"
+            exit 1
+          fi
 
       - name: Build, lint, and test (@streamlit/component-v2-lib)
         working-directory: frontend/component-v2-lib

--- a/frontend/component-v2-lib/package.json
+++ b/frontend/component-v2-lib/package.json
@@ -19,6 +19,10 @@
     "LICENSE"
   ],
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "vite build",
     "buildWatch": "env DEV_WATCH=1 vite build --watch",

--- a/scripts/slack_notifications.py
+++ b/scripts/slack_notifications.py
@@ -205,6 +205,49 @@ def send_notification() -> None:
             )
             payload = {"text": text}
 
+    if workflow == "npm_publish":
+        repo = os.getenv("REPO", os.getenv("GITHUB_REPOSITORY", ""))
+        run_id = os.getenv("RUN_ID")
+        package_name = os.getenv("PACKAGE_NAME", "")
+        package_version = os.getenv("PACKAGE_VERSION", "")
+        npm_link = (
+            f"https://www.npmjs.com/package/{package_name}/v/{package_version}"
+            if package_name and package_version
+            else None
+        )
+
+        if message_key == "success":
+            lines = [
+                ":package: npm publish succeeded",
+                f"- Package: {package_name}@{package_version}"
+                if package_name and package_version
+                else None,
+                (
+                    f"- Run: https://github.com/{repo}/actions/runs/{run_id}"
+                    if repo and run_id
+                    else None
+                ),
+                (f"- npm: {npm_link}" if npm_link else None),
+            ]
+            text = "\n".join([ln for ln in lines if ln])
+            payload = {"text": text}
+        else:
+            error_reason = os.getenv("ERROR_REASON", "")
+            lines = [
+                ":x: npm publish failed",
+                f"- Package: {package_name}@{package_version}"
+                if package_name and package_version
+                else None,
+                (
+                    f"- Run: https://github.com/{repo}/actions/runs/{run_id}"
+                    if repo and run_id
+                    else None
+                ),
+                (f"- Note: {error_reason}" if error_reason else None),
+            ]
+            text = "\n".join([ln for ln in lines if ln])
+            payload = {"text": text}
+
     if payload:
         response = requests.post(webhook, json=payload)
 


### PR DESCRIPTION
## Describe your changes

- Add two GitHub Actions workflows to support publishing the `@streamlit/component-v2-lib` package:
  - `.github/workflows/bump-component-v2-lib.yml`:
    - Bumps the version in `frontend/component-v2-lib/package.json`, creates a branch, and opens a PR to `develop` with appropriate labels.
    - Includes a `dry_run` mode, concurrency control, and is restricted to the `streamlit/streamlit` repository.
  - `.github/workflows/publish-component-v2-lib.yml`:
    - Publishes `@streamlit/component-v2-lib` to npm (or runs a dry-run).
    - Uses npm Trusted Publishing (OIDC) via `id-token: write`, builds/lints/tests the package, validates publish contents, and verifies the published version.
    - Adds Slack notifications for publish success/failure
- Update `frontend/component-v2-lib/package.json` to enable npm Trusted Publishing and public access by adding:
  - `publishConfig.access: "public"`
  - `publishConfig.provenance: true`

These are internal release/publishing workflows and configuration; no runtime code paths in Streamlit apps are changed.

## GitHub Issue Link (if applicable)

## Testing Plan

- Any manual testing needed?
  - Bump workflow:
    - Trigger via `workflow_dispatch` with `new_version` (e.g., `0.1.1`) and `dry_run: true` to validate version computation and summary output without creating a branch/PR.
    - Then run with `dry_run: false` to verify branch creation and PR opened to `develop` with labels `change:chore` and `impact:internal`.
  - Publish workflow:
    - Trigger via `workflow_dispatch` with `dry_run: true` (optionally set `ref` to a specific commit/tag). Confirms build/lint/test pass and `npm pack --dry-run` validates contents (including presence of `dist/`).
    - Run with `dry_run: false` in the `release` environment to publish, then verify the version via the final step output.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
