### PR TITLE
[fix] Ensure cleanup function is only called when instance removed

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
@@ -625,6 +625,74 @@ describe("BidiComponent", () => {
       )
     })
 
+    it("should re-run JS when element data changes without early cleanup", async () => {
+      const jsContent = `
+        export default function({ data, parentElement }) {
+          const count = Number(parentElement.dataset.runCount || "0") + 1;
+          parentElement.dataset.runCount = String(count);
+
+          return () => {
+            const inv = JSON.parse(parentElement.dataset.cleanupInvocations || "[]");
+            inv.push("cleanup");
+            parentElement.dataset.cleanupInvocations = JSON.stringify(inv);
+          };
+        }
+      `
+
+      const element1 = createMockElement({
+        jsContent,
+        componentName: "DataChangeComponent",
+        id: "data-change",
+        json: JSON.stringify({ value: 1 }),
+      })
+
+      const { rerender, unmount } = renderWithContexts(
+        <BidiComponent
+          element={element1}
+          widgetMgr={mockWidgetMgr}
+          fragmentId={mockFragmentId}
+        />,
+        {}
+      )
+
+      const container = screen.getByTestId("stBidiComponentRegular")
+      await waitFor(() => {
+        expect(container.dataset.runCount).toBe("1")
+      })
+
+      const element2 = createMockElement({
+        isolateStyles: false,
+        jsContent,
+        componentName: "DataChangeComponent",
+        id: "data-change",
+        json: JSON.stringify({ value: 2 }),
+      })
+
+      rerender(
+        <BidiComponent
+          element={element2}
+          widgetMgr={mockWidgetMgr}
+          fragmentId={mockFragmentId}
+        />
+      )
+
+      await waitFor(() => {
+        expect(container.dataset.runCount).toBe("2")
+      })
+
+      // Verify cleanup not called before unmount
+      expect(container.dataset.cleanupInvocations).toBeUndefined()
+
+      unmount()
+
+      await waitFor(() => {
+        const inv = JSON.parse(
+          (container.dataset.cleanupInvocations as string) || "[]"
+        )
+        expect(inv).toEqual(["cleanup"])
+      })
+    })
+
     it("should handle inline JavaScript content with valid module execution", async () => {
       // Create a valid JavaScript module that will execute
       const jsContent = `

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useContext, useEffect, useMemo } from "react"
+import React, { useContext, useEffect, useMemo, useRef } from "react"
 
 import { v4 as uuidv4 } from "uuid"
 
@@ -209,9 +209,15 @@ export const useHandleJsContent = ({
     return getBidiComponentURL(componentName, jsSourcePath)
   }, [componentName, jsSourcePath, getBidiComponentURL])
 
+  // Lifecycle refs to ensure we only run the user-written JS cleanup function
+  // when the component is unmounted by Streamlit.
+  const cleanupRef = useRef<OptionalComponentCleanupFunction>()
+  const scriptElementRef = useRef<HTMLScriptElement>()
+  const unmountedRef = useRef(false)
+
+  // Initialization/update effect: runs when inputs change
   useEffect(() => {
     const { current: containerRefCurrent } = containerRef
-
     if (
       skip ||
       (!inlineJsContent && !externalJsSourcePathUrl) ||
@@ -219,10 +225,6 @@ export const useHandleJsContent = ({
     ) {
       return
     }
-
-    let isMounted = true
-    let cleanup: OptionalComponentCleanupFunction
-    let scriptElement: HTMLScriptElement | undefined
 
     const run = async (): Promise<void> => {
       try {
@@ -232,7 +234,7 @@ export const useHandleJsContent = ({
             `st-bidi-${componentName}`
           )
 
-          cleanup = await loadAndRunModule({
+          cleanupRef.current = await loadAndRunModule({
             componentId,
             componentIdForWidgetMgr: id,
             componentName,
@@ -250,7 +252,7 @@ export const useHandleJsContent = ({
           try {
             // Load the script
             await new Promise<void>((resolve, reject) => {
-              scriptElement = document.createElement("script")
+              const scriptElement = document.createElement("script")
               scriptElement.type = "module"
               scriptElement.src = scriptUrl
               scriptElement.async = true
@@ -262,10 +264,11 @@ export const useHandleJsContent = ({
                   )
                 )
               document.head.appendChild(scriptElement)
+              scriptElementRef.current = scriptElement
             })
 
-            // Run the module
-            cleanup = await loadAndRunModule({
+            // Run the module and store the cleanup function
+            cleanupRef.current = await loadAndRunModule({
               componentId,
               componentIdForWidgetMgr: id,
               componentName,
@@ -285,32 +288,13 @@ export const useHandleJsContent = ({
           }
         }
       } catch (error) {
-        if (isMounted) {
+        if (!unmountedRef.current) {
           handleError(error, setError)
         }
       }
     }
 
     void run()
-
-    // Cleanup function
-    return () => {
-      isMounted = false
-
-      if (cleanup) {
-        void Promise.resolve(cleanup)
-          .then(result => {
-            result?.()
-          })
-          .catch(error => {
-            LOG.error(`Failed to run cleanup for element ${id}`, error)
-          })
-      }
-
-      if (scriptElement?.parentNode) {
-        scriptElement.parentNode.removeChild(scriptElement)
-      }
-    }
   }, [
     componentId,
     componentName,
@@ -329,4 +313,27 @@ export const useHandleJsContent = ({
     // theme-dependent JS logic can be applied at the proper lifecycle time.
     theme,
   ])
+
+  // Unmount-only cleanup effect
+  useEffect(() => {
+    return () => {
+      unmountedRef.current = true
+
+      const maybeCleanup = cleanupRef.current
+      if (maybeCleanup) {
+        void Promise.resolve(maybeCleanup)
+          .then(result => {
+            result?.()
+          })
+          .catch(error => {
+            LOG.error("Failed to run custom component cleanup", error)
+          })
+      }
+
+      const scriptElement = scriptElementRef.current
+      if (scriptElement?.parentNode) {
+        scriptElement.parentNode.removeChild(scriptElement)
+      }
+    }
+  }, [])
 }


### PR DESCRIPTION
## Describe your changes

**Problem:**
- Before this fix, we were calling `cleanup` far too often, leading to unnecessary full component re-renders.
- This is especially egregious in larger custom components, especially ones that leverage a framework like React.

**Solution:**
- Updates the lifecycle of cleanup to match what we do for all other elements in Streamlit.


## GitHub Issue Link (if applicable)

## Testing Plan

- Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
