### PR TITLE
Remove `gitInfo` from context

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1816,6 +1816,7 @@ export class App extends PureComponent<Props, State> {
       isDeployErrorModalOpen:
         this.state.dialog?.type === DialogType.DEPLOY_ERROR,
       metricsMgr: this.metricsMgr,
+      gitInfo: this.state.gitInfo,
     }
     this.openDialog(deployDialogProps)
   }
@@ -2190,7 +2191,6 @@ export class App extends PureComponent<Props, State> {
         widgetsDisabled={
           inputsDisabled || connectionState !== ConnectionState.CONNECTED
         }
-        gitInfo={this.state.gitInfo}
         isFullScreen={isFullScreen}
         setFullScreen={this.handleFullScreen}
         activeTheme={this.props.theme.activeTheme}

--- a/frontend/app/src/components/AppContext.tsx
+++ b/frontend/app/src/components/AppContext.tsx
@@ -16,8 +16,6 @@
 
 import { createContext } from "react"
 
-import { IGitInfo } from "@streamlit/protobuf"
-
 export interface AppContextProps {
   /**
    * Whether to disable widgets and sidebar page navigation links, based on connection
@@ -30,13 +28,6 @@ export interface AppContextProps {
   widgetsDisabled: boolean
 
   /**
-   * The latest state of the git information related to the app.
-   * Pulled from appContext in DeployDialog
-   * @see DeployDialog
-   */
-  gitInfo: IGitInfo | null
-
-  /**
    * Whether to show the toolbar in the app header.
    * Can be configured via host message.
    * Pulled from appContext in Header
@@ -47,7 +38,6 @@ export interface AppContextProps {
 
 export const AppContext = createContext<AppContextProps | null>({
   widgetsDisabled: false,
-  gitInfo: null,
   showToolbar: true,
 })
 AppContext.displayName = "AppContext"

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -54,7 +54,6 @@ function getAppContextOutput(
 ): AppContextProps {
   return {
     widgetsDisabled: false,
-    gitInfo: null,
     showToolbar: true,
     ...context,
   }

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -147,15 +147,10 @@ function renderAppView(
     overrides?.navigationContext || {}
   )
 
-  return renderWithContexts(
-    <AppView {...getProps(props)} />,
-    {}, // libContextProps
-    sidebarConfigContextValues, // sidebarConfigContextProps
-    {}, // themeContextProps
-    navigationContextValues, // navigationContextProps
-    {}, // formsContextProps
-    {} // scriptRunContextProps
-  )
+  return renderWithContexts(<AppView {...getProps(props)} />, {
+    sidebarConfigContext: sidebarConfigContextValues,
+    navigationContext: navigationContextValues,
+  })
 }
 
 describe("AppView element", () => {
@@ -1282,9 +1277,16 @@ describe("AppView element", () => {
       // Use renderWithContexts to get the rerender with ability to update context values
       const { rerenderWithContexts } = renderWithContexts(
         <AppView {...props} />,
-        {}, // LibContext
-        { initialSidebarState: PageConfig.SidebarState.AUTO }, // SidebarConfigContext
-        { activeTheme: mockTheme, setTheme: vi.fn(), availableThemes: [] } // ThemeContext
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.AUTO,
+          },
+          themeContext: {
+            activeTheme: mockTheme,
+            setTheme: vi.fn(),
+            availableThemes: [],
+          },
+        }
       )
 
       // Sidebar should be rendered and expanded when initialSidebarState is AUTO
@@ -1293,11 +1295,11 @@ describe("AppView element", () => {
       expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
 
       // Now simulate receiving page config with collapsed state
-      rerenderWithContexts(
-        <AppView {...props} />,
-        {},
-        { initialSidebarState: PageConfig.SidebarState.COLLAPSED }
-      )
+      rerenderWithContexts(<AppView {...props} />, {
+        sidebarConfigContext: {
+          initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+        },
+      })
 
       // Now sidebar should be rendered but collapsed
       const sidebarAfterConfig = screen.getByTestId("stSidebar")

--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -38,7 +38,6 @@ const getMockAppContext = (
 ): ReturnType<typeof StreamlitContextProviderModule.useAppContext> => ({
   showToolbar: true,
   widgetsDisabled: false,
-  gitInfo: null,
   ...overrides,
 })
 

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -246,7 +246,9 @@ describe("LogoComponent", () => {
             })}
           />,
           {
-            libConfig: { resourceCrossOriginMode: "anonymous" },
+            libContext: {
+              libConfig: { resourceCrossOriginMode: "anonymous" },
+            },
           }
         )
 
@@ -280,7 +282,7 @@ describe("LogoComponent", () => {
           })}
         />,
         {
-          libConfig: { resourceCrossOriginMode: "anonymous" },
+          libContext: { libConfig: { resourceCrossOriginMode: "anonymous" } },
         }
       )
 
@@ -323,7 +325,7 @@ describe("LogoComponent", () => {
           })}
         />,
         {
-          libConfig: { resourceCrossOriginMode: "anonymous" },
+          libContext: { libConfig: { resourceCrossOriginMode: "anonymous" } },
         }
       )
 
@@ -355,7 +357,7 @@ describe("LogoComponent", () => {
             })}
           />,
           {
-            libConfig: { resourceCrossOriginMode: undefined },
+            libContext: { libConfig: { resourceCrossOriginMode: undefined } },
           }
         )
 
@@ -381,7 +383,9 @@ describe("LogoComponent", () => {
           })}
         />,
         {
-          libConfig: { resourceCrossOriginMode: "use-credentials" },
+          libContext: {
+            libConfig: { resourceCrossOriginMode: "use-credentials" },
+          },
         }
       )
 

--- a/frontend/app/src/components/Navigation/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.test.tsx
@@ -189,15 +189,10 @@ function renderSidebarNav(
     overrides?.navigationContext || {}
   )
 
-  return renderWithContexts(
-    <SidebarNav {...getProps(props)} />,
-    {}, // libContextProps
-    sidebarConfigContextValues, // sidebarConfigContextProps
-    {}, // themeContextProps
-    navigationContextValues, // navigationContextProps
-    {}, // formsContextProps
-    {} // scriptRunContextProps
-  )
+  return renderWithContexts(<SidebarNav {...getProps(props)} />, {
+    sidebarConfigContext: sidebarConfigContextValues,
+    navigationContext: navigationContextValues,
+  })
 }
 
 describe("SidebarNav", () => {

--- a/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
@@ -41,7 +41,6 @@ function getAppContextOutput(
 ): AppContextProps {
   return {
     widgetsDisabled: false,
-    gitInfo: null,
     showToolbar: true,
     ...context,
   }

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -74,15 +74,10 @@ function renderSidebar(
   const sidebarConfigContextValues = getSidebarConfigContextOutput(
     options?.sidebarConfigContext || {}
   )
-  return renderWithContexts(
-    <SidebarWrapper {...props} />,
-    {}, // LibContext
-    sidebarConfigContextValues, // SidebarConfigContext
-    {}, // ThemeContext
-    navigationContextValues, // NavigationContext
-    {}, // FormsContext
-    {} // ScriptRunContext
-  )
+  return renderWithContexts(<SidebarWrapper {...props} />, {
+    sidebarConfigContext: sidebarConfigContextValues,
+    navigationContext: navigationContextValues,
+  })
 }
 
 function getSidebarConfigContextOutput(

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -44,14 +44,7 @@ function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
 function renderThemedSidebar(
   props: Partial<SidebarProps> = {}
 ): ReturnType<typeof renderWithContexts> {
-  return renderWithContexts(
-    <ThemedSidebar {...getProps(props)} />,
-    {}, // LibContextProps
-    {}, // ThemeContextProps
-    {}, // NavigationContextProps
-    {}, // FormsContextProps
-    {} // ScriptRunContextProps
-  )
+  return renderWithContexts(<ThemedSidebar {...getProps(props)} />)
 }
 
 describe("ThemedSidebar Component", () => {

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -40,12 +40,11 @@ import {
   ThemeContextProps,
   useRequiredContext,
 } from "@streamlit/lib"
-import { IAppPage, IGitInfo, Logo, PageConfig } from "@streamlit/protobuf"
+import { IAppPage, Logo, PageConfig } from "@streamlit/protobuf"
 
 // Type for AppContext props
 type AppContextValues = {
   widgetsDisabled: boolean
-  gitInfo: IGitInfo | null
   showToolbar: boolean
 }
 
@@ -111,7 +110,6 @@ export type StreamlitContextProviderProps = PropsWithChildren<
 const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   // AppContext
   widgetsDisabled,
-  gitInfo,
   showToolbar,
   // LibContext
   isFullScreen,
@@ -148,10 +146,9 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   const appContextProps = useMemo<AppContextProps>(
     () => ({
       widgetsDisabled,
-      gitInfo,
       showToolbar,
     }),
-    [widgetsDisabled, gitInfo, showToolbar]
+    [widgetsDisabled, showToolbar]
   )
 
   // Memoized object for LibContext values

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -21,7 +21,6 @@ import { StyledAction, StyledBody } from "baseui/card"
 import StreamlitLogo from "@streamlit/app/src/assets/svg/logo.svg"
 import Rocket from "@streamlit/app/src/assets/svg/rocket.svg"
 import Snowflake from "@streamlit/app/src/assets/svg/snowflake.svg"
-import { useAppContext } from "@streamlit/app/src/components/StreamlitContextProvider"
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {
   DetachedHead,
@@ -73,6 +72,7 @@ const getDeployAppUrl = (gitInfo: IGitInfo | null): string => {
 }
 
 export interface DeployDialogProps {
+  gitInfo: IGitInfo | null
   // eslint-disable-next-line @eslint-react/no-unused-props
   type: DialogType.DEPLOY_DIALOG
   onClose: PlainEventHandler
@@ -88,10 +88,13 @@ export interface DeployDialogProps {
 export function DeployDialog(
   props: Readonly<DeployDialogProps>
 ): ReactElement {
-  // Get latest git info from AppContext:
-  const { gitInfo } = useAppContext()
-  const { onClose, metricsMgr, showDeployError, isDeployErrorModalOpen } =
-    props
+  const {
+    gitInfo,
+    onClose,
+    metricsMgr,
+    showDeployError,
+    isDeployErrorModalOpen,
+  } = props
   const onClickDeployApp = useCallback((): void => {
     metricsMgr.enqueue("menuClick", {
       label: "deployButtonInDialog",

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
@@ -88,15 +88,9 @@ describe("SettingsDialog", () => {
     const props = getProps()
     const themeContext = getThemeContext({ availableThemes })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     expect(screen.getByText("Settings")).toBeVisible()
   })
@@ -107,15 +101,9 @@ describe("SettingsDialog", () => {
       allowRunOnSave: true,
     })
     const themeContext = getThemeContext()
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     await user.click(screen.getByText("Run on save"))
 
@@ -129,15 +117,9 @@ describe("SettingsDialog", () => {
     const user = userEvent.setup()
     const props = getProps()
     const themeContext = getThemeContext()
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
     expect(screen.getByText("Wide mode")).toBeVisible()
 
     await user.click(screen.getByText("Wide mode"))
@@ -153,15 +135,9 @@ describe("SettingsDialog", () => {
     const props = getProps()
     const themeContext = getThemeContext({ availableThemes })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     expect(screen.getByText("Choose app theme")).toBeVisible()
 
@@ -178,15 +154,9 @@ describe("SettingsDialog", () => {
       activeTheme: customTheme,
     })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     const selectbox = screen.getByRole("combobox")
     expect(selectbox).toBeVisible()
@@ -210,15 +180,9 @@ describe("SettingsDialog", () => {
       activeTheme: customThemeLight,
     })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     // Correct selected theme is shown
     expect(screen.getByText(CUSTOM_THEME_LIGHT_NAME)).toBeVisible()
@@ -247,15 +211,9 @@ describe("SettingsDialog", () => {
       activeTheme: customThemeDark,
     })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     // Correct selected theme is shown
     expect(screen.getByText(CUSTOM_THEME_DARK_NAME)).toBeVisible()
@@ -278,15 +236,9 @@ describe("SettingsDialog", () => {
     const props = getProps()
     const themeContext = getThemeContext({ availableThemes })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     expect(screen.getByText("Light")).toBeVisible()
 
@@ -305,15 +257,9 @@ describe("SettingsDialog", () => {
       availableThemes,
     })
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     expect(screen.getByText("Dark")).toBeVisible()
 
@@ -327,15 +273,9 @@ describe("SettingsDialog", () => {
     })
     const themeContext = getThemeContext()
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     const versionRegex = /Made with Streamlit\s*42\.42\.42/
     const versionText = screen.getByText(versionRegex)
@@ -349,15 +289,9 @@ describe("SettingsDialog", () => {
     const props = getProps({ sessionInfo })
     const themeContext = getThemeContext()
 
-    renderWithContexts(
-      <SettingsDialog {...props} />,
-      // LibContext
-      {},
-      // SidebarConfigContext
-      {},
-      // ThemeContext
-      themeContext
-    )
+    renderWithContexts(<SettingsDialog {...props} />, {
+      themeContext: themeContext,
+    })
 
     const versionRegex = /^Made with Streamlit.*/
     const nonExistentText = screen.queryByText(versionRegex)

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -93,24 +93,12 @@ describe("ElementNodeRenderer Block Component", () => {
       const props = getProps({
         node: createBalloonNode(scriptRunId),
       })
-      renderWithContexts(
-        <ElementNodeRenderer {...props} />,
-        // LibContext overrides
-        {},
-        // SidebarConfigContext overrides
-        {},
-        // ThemeContext overrides
-        {},
-        // NavigationContext overrides
-        {},
-        // FormsContext overrides
-        {},
-        // ScriptRunContext overrides
-        {
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: {
           scriptRunState: ScriptRunState.RUNNING,
           scriptRunId: "NEW_SCRIPT_ID",
-        }
-      )
+        },
+      })
 
       await waitFor(() =>
         expect(screen.queryByTestId("stSkeleton")).toBeNull()
@@ -126,23 +114,9 @@ describe("ElementNodeRenderer Block Component", () => {
       const props = getProps({
         node: createBalloonNode(scriptRunId),
       })
-      renderWithContexts(
-        <ElementNodeRenderer {...props} />,
-        // LibContext overrides
-        {},
-        // SidebarConfigContext overrides
-        {},
-        // ThemeContext overrides
-        {},
-        // NavigationContext overrides
-        {},
-        // FormsContext overrides
-        {},
-        // ScriptRunContext overrides
-        {
-          scriptRunId,
-        }
-      )
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: { scriptRunId },
+      })
 
       await waitFor(() =>
         expect(screen.queryByTestId("stSkeleton")).toBeNull()
@@ -161,24 +135,12 @@ describe("ElementNodeRenderer Block Component", () => {
       const props = getProps({
         node: createSnowNode(scriptRunId),
       })
-      renderWithContexts(
-        <ElementNodeRenderer {...props} />,
-        // LibContext overrides
-        {},
-        // SidebarConfigContext overrides
-        {},
-        // ThemeContext overrides
-        {},
-        // NavigationContext overrides
-        {},
-        // FormsContext overrides
-        {},
-        // ScriptRunContext overrides
-        {
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: {
           scriptRunState: ScriptRunState.RUNNING,
           scriptRunId: "NEW_SCRIPT_ID",
-        }
-      )
+        },
+      })
 
       await waitFor(() =>
         expect(screen.queryByTestId("stSkeleton")).toBeNull()
@@ -193,23 +155,9 @@ describe("ElementNodeRenderer Block Component", () => {
       const props = getProps({
         node: createSnowNode(scriptRunId),
       })
-      renderWithContexts(
-        <ElementNodeRenderer {...props} />,
-        // LibContext overrides
-        {},
-        // SidebarConfigContext overrides
-        {},
-        // ThemeContext overrides
-        {},
-        // NavigationContext overrides
-        {},
-        // FormsContext overrides
-        {},
-        // ScriptRunContext overrides
-        {
-          scriptRunId,
-        }
-      )
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: { scriptRunId },
+      })
 
       await waitFor(() =>
         expect(screen.queryByTestId("stSkeleton")).toBeNull()

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -156,7 +156,9 @@ describe("Audio Element", () => {
       ({ resourceCrossOriginMode }) => {
         const props = getProps()
         renderWithContexts(<Audio {...props} />, {
-          libConfig: { resourceCrossOriginMode },
+          libContext: {
+            libConfig: { resourceCrossOriginMode },
+          },
         })
         const audioElement = screen.getByTestId("stAudio")
         expect(audioElement).not.toHaveAttribute("crossOrigin")
@@ -237,7 +239,9 @@ describe("Audio Element", () => {
         ({ expected, resourceCrossOriginMode, url }) => {
           const props = getProps({ url })
           renderWithContexts(<Audio {...props} />, {
-            libConfig: { resourceCrossOriginMode },
+            libContext: {
+              libConfig: { resourceCrossOriginMode },
+            },
           })
           const audioElement = screen.getByTestId("stAudio")
           if (expected) {

--- a/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
@@ -81,7 +81,9 @@ describe("Balloons element", () => {
         }
 
         renderWithContexts(<Balloons scriptRunId="51522269" />, {
-          libConfig: { resourceCrossOriginMode: "anonymous" },
+          libContext: {
+            libConfig: { resourceCrossOriginMode: "anonymous" },
+          },
         })
 
         const balloonImages = screen.getAllByRole("img")
@@ -107,7 +109,9 @@ describe("Balloons element", () => {
         }
 
         renderWithContexts(<Balloons scriptRunId="51522269" />, {
-          libConfig: { resourceCrossOriginMode: undefined },
+          libContext: {
+            libConfig: { resourceCrossOriginMode: undefined },
+          },
         })
 
         const balloonImages = screen.getAllByRole("img")

--- a/frontend/lib/src/components/elements/ChatMessage/ChatMessage.test.tsx
+++ b/frontend/lib/src/components/elements/ChatMessage/ChatMessage.test.tsx
@@ -113,7 +113,9 @@ describe("ChatMessage", () => {
             avatarType: BlockProto.ChatMessage.AvatarType.IMAGE,
           })
           renderWithContexts(<ChatMessage {...props} />, {
-            libConfig: { resourceCrossOriginMode: "anonymous" },
+            libContext: {
+              libConfig: { resourceCrossOriginMode: "anonymous" },
+            },
           })
 
           const chatAvatar = screen.getByAltText("user avatar")
@@ -141,7 +143,9 @@ describe("ChatMessage", () => {
             avatarType: BlockProto.ChatMessage.AvatarType.IMAGE,
           })
           renderWithContexts(<ChatMessage {...props} />, {
-            libConfig: { resourceCrossOriginMode: undefined },
+            libContext: {
+              libConfig: { resourceCrossOriginMode: undefined },
+            },
           })
 
           const chatAvatar = screen.getByAltText("user avatar")

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -266,7 +266,9 @@ describe("ImageList Element", () => {
       ({ resourceCrossOriginMode }) => {
         const props = getProps()
         renderWithContexts(<ImageList {...props} />, {
-          libConfig: { resourceCrossOriginMode },
+          libContext: {
+            libConfig: { resourceCrossOriginMode },
+          },
         })
         const images = screen.getAllByRole("img")
         expect(images).toHaveLength(2)
@@ -414,7 +416,9 @@ describe("ImageList Element", () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const props = getProps({ imgs: imgs as any })
           renderWithContexts(<ImageList {...props} />, {
-            libConfig: { resourceCrossOriginMode },
+            libContext: {
+              libConfig: { resourceCrossOriginMode },
+            },
           })
           const images = screen.getAllByRole("img")
           expect(images).toHaveLength(2)

--- a/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
@@ -88,19 +88,11 @@ describe("PageLink", () => {
     const user = userEvent.setup()
     const props = getProps()
 
-    renderWithContexts(
-      <PageLink {...props} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {
+    renderWithContexts(<PageLink {...props} />, {
+      navigationContext: {
         onPageChange: mockOnPageChange,
-      }
-    )
+      },
+    })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
     await user.click(pageNavLink)
@@ -111,19 +103,11 @@ describe("PageLink", () => {
     const user = userEvent.setup()
     const props = getProps({}, { disabled: true })
 
-    renderWithContexts(
-      <PageLink {...props} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {
+    renderWithContexts(<PageLink {...props} />, {
+      navigationContext: {
         onPageChange: mockOnPageChange,
-      }
-    )
+      },
+    })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
     await user.click(pageNavLink)
@@ -134,19 +118,11 @@ describe("PageLink", () => {
     const user = userEvent.setup()
     const props = getProps({ page: "http://example.com", external: true })
 
-    renderWithContexts(
-      <PageLink {...props} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {
+    renderWithContexts(<PageLink {...props} />, {
+      navigationContext: {
         onPageChange: mockOnPageChange,
-      }
-    )
+      },
+    })
 
     const pageNavLink = screen.getByTestId("stPageLink-NavLink")
     await user.click(pageNavLink)
@@ -197,19 +173,11 @@ describe("PageLink", () => {
 
   it("renders a current page link properly", () => {
     const props = getProps({ pageScriptHash: "main_page_hash" })
-    renderWithContexts(
-      <PageLink {...props} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {
+    renderWithContexts(<PageLink {...props} />, {
+      navigationContext: {
         currentPageScriptHash: "main_page_hash",
-      }
-    )
+      },
+    })
 
     const currentPageBgColor = lightTheme.emotion.colors.darkenedBgMix15
 

--- a/frontend/lib/src/components/elements/Snow/Snow.test.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.test.tsx
@@ -88,7 +88,9 @@ describe("Snow element", () => {
         }
 
         renderWithContexts(<Snow scriptRunId="51522269" />, {
-          libConfig: { resourceCrossOriginMode: "anonymous" },
+          libContext: {
+            libConfig: { resourceCrossOriginMode: "anonymous" },
+          },
         })
 
         const snowImages = screen.getAllByRole("img")
@@ -114,7 +116,9 @@ describe("Snow element", () => {
         }
 
         renderWithContexts(<Snow scriptRunId="51522269" />, {
-          libConfig: { resourceCrossOriginMode: undefined },
+          libContext: {
+            libConfig: { resourceCrossOriginMode: undefined },
+          },
         })
 
         const snowImages = screen.getAllByRole("img")

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -262,7 +262,9 @@ describe("Video Element", () => {
       async ({ resourceCrossOriginMode }) => {
         const props = getProps({ url: "/media/mockVideoFile.mp4" })
         renderWithContexts(<Video {...props} />, {
-          libConfig: { resourceCrossOriginMode },
+          libContext: {
+            libConfig: { resourceCrossOriginMode },
+          },
         })
         const videoElement = await screen.findByTestId("stVideo")
         expect(videoElement).not.toHaveAttribute("crossOrigin")
@@ -278,7 +280,9 @@ describe("Video Element", () => {
         subtitles: [{ url: "https://mock.subtitle.url" }],
       })
       renderWithContexts(<Video {...props} />, {
-        libConfig: { resourceCrossOriginMode: undefined },
+        libContext: {
+          libConfig: { resourceCrossOriginMode: undefined },
+        },
       })
       const videoElement = await screen.findByTestId("stVideo")
       expect(videoElement).toHaveAttribute("crossOrigin", "anonymous")
@@ -361,7 +365,9 @@ describe("Video Element", () => {
         async ({ expected, resourceCrossOriginMode, url }) => {
           const props = getProps({ url })
           renderWithContexts(<Video {...props} />, {
-            libConfig: { resourceCrossOriginMode },
+            libContext: {
+              libConfig: { resourceCrossOriginMode },
+            },
           })
           const videoElement = await screen.findByTestId("stVideo")
           if (expected) {

--- a/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
@@ -338,11 +338,13 @@ describe("BidiComponent", () => {
           fragmentId={mockFragmentId}
         />,
         {
-          componentRegistry: {
-            getBidiComponentURL: vi.fn(
-              (componentName, path) => `/components/${componentName}/${path}`
-            ),
-          } as unknown as ComponentRegistry,
+          libContext: {
+            componentRegistry: {
+              getBidiComponentURL: vi.fn(
+                (componentName, path) => `/components/${componentName}/${path}`
+              ),
+            } as unknown as ComponentRegistry,
+          },
         }
       )
 
@@ -1049,9 +1051,11 @@ describe("BidiComponent", () => {
           fragmentId={mockFragmentId}
         />,
         {
-          componentRegistry: {
-            getBidiComponentURL: mockGetBidiComponentURL,
-          } as unknown as ComponentRegistry,
+          libContext: {
+            componentRegistry: {
+              getBidiComponentURL: mockGetBidiComponentURL,
+            } as unknown as ComponentRegistry,
+          },
         }
       )
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -109,7 +109,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry,
+        libContext: { componentRegistry },
       }
     )
     expect(registerListener).toHaveBeenCalledTimes(1)
@@ -133,7 +133,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry,
+        libContext: { componentRegistry },
       }
     )
     unmount()
@@ -141,6 +141,7 @@ describe("ComponentInstance", () => {
   })
 
   it("renders its iframe correctly", () => {
+    const componentRegistry = getComponentRegistry()
     renderWithContexts(
       <ComponentInstance
         element={createElementProp()}
@@ -153,7 +154,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry: getComponentRegistry(),
+        libContext: { componentRegistry },
       }
     )
     const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -185,7 +186,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry,
+        libContext: { componentRegistry },
       }
     )
     const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -197,6 +198,7 @@ describe("ComponentInstance", () => {
 
   it("includes window.__streamlit?.CUSTOM_COMPONENT_CLIENT_ID in queryString if set", () => {
     window.__streamlit = { CUSTOM_COMPONENT_CLIENT_ID: "foobar" }
+    const componentRegistry = getComponentRegistry()
     renderWithContexts(
       <ComponentInstance
         element={createElementProp()}
@@ -209,7 +211,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry: getComponentRegistry(),
+        libContext: { componentRegistry },
       }
     )
     const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -220,6 +222,7 @@ describe("ComponentInstance", () => {
   })
 
   it("displays a skeleton initially with a certain height", () => {
+    const componentRegistry = getComponentRegistry()
     renderWithContexts(
       <ComponentInstance
         element={createElementProp()}
@@ -232,7 +235,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry: getComponentRegistry(),
+        libContext: { componentRegistry },
       }
     )
     const skeleton = screen.getByTestId("stSkeleton")
@@ -244,6 +247,7 @@ describe("ComponentInstance", () => {
   })
 
   it("will not displays a skeleton when height is explicitly set to 0", () => {
+    const componentRegistry = getComponentRegistry()
     renderWithContexts(
       <ComponentInstance
         element={createElementProp({ height: 0 })}
@@ -256,7 +260,7 @@ describe("ComponentInstance", () => {
         }
       />,
       {
-        componentRegistry: getComponentRegistry(),
+        libContext: { componentRegistry },
       }
     )
     expect(screen.queryByTestId("stSkeleton")).not.toBeInTheDocument()
@@ -268,6 +272,7 @@ describe("ComponentInstance", () => {
   describe("COMPONENT_READY handler", () => {
     it("posts a RENDER message to the iframe", () => {
       const jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -280,7 +285,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -303,6 +308,7 @@ describe("ComponentInstance", () => {
     })
 
     it("hides the skeleton and maintains iframe height of 0", () => {
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp()}
@@ -315,7 +321,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
 
@@ -340,6 +346,7 @@ describe("ComponentInstance", () => {
 
     it("prevents RENDER message until component is ready", () => {
       const jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -352,7 +359,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -366,6 +373,7 @@ describe("ComponentInstance", () => {
       // (This can happen during development, when the component's devserver
       // reloads.)
       const jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -378,7 +386,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -415,6 +423,7 @@ describe("ComponentInstance", () => {
 
     it("send render message whenever the args change and the component is ready", () => {
       let jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       const { rerender } = renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -427,7 +436,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -471,6 +480,7 @@ describe("ComponentInstance", () => {
       })
 
       const jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       const { rerender } = renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -483,7 +493,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -529,6 +539,7 @@ describe("ComponentInstance", () => {
     it("errors on unrecognized API version", () => {
       const badAPIVersion = CUSTOM_COMPONENT_API_VERSION + 1
       const jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp(jsonArgs)}
@@ -541,7 +552,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -566,6 +577,7 @@ describe("ComponentInstance", () => {
       const element = createElementProp(jsonArgs, [
         new SpecialArg({ key: "foo" }),
       ])
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={element}
@@ -578,7 +590,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       expect(
@@ -587,6 +599,7 @@ describe("ComponentInstance", () => {
     })
 
     it("warns if COMPONENT_READY hasn't been received after a timeout", async () => {
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={createElementProp()}
@@ -599,7 +612,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       // Advance past our warning timeout, and force a re-render.
@@ -630,7 +643,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry,
+          libContext: { componentRegistry },
         }
       )
 
@@ -660,7 +673,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry,
+          libContext: { componentRegistry },
         }
       )
       // Advance past our warning timeout, and force a re-render.
@@ -675,6 +688,7 @@ describe("ComponentInstance", () => {
 
   describe("SET_COMPONENT_VALUE handler", () => {
     it("handles JSON values", () => {
+      const componentRegistry = getComponentRegistry()
       const jsonValue = {
         foo: "string",
         bar: 123,
@@ -694,7 +708,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
 
@@ -743,6 +757,7 @@ describe("ComponentInstance", () => {
       const jsonValue = {}
 
       const element = createElementProp(jsonValue)
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={element}
@@ -757,7 +772,7 @@ describe("ComponentInstance", () => {
           fragmentId="myFragmentId"
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
 
@@ -812,6 +827,7 @@ describe("ComponentInstance", () => {
       }
 
       const element = createElementProp(jsonValue)
+      const componentRegistry = getComponentRegistry()
       renderWithContexts(
         <ComponentInstance
           element={element}
@@ -824,7 +840,7 @@ describe("ComponentInstance", () => {
           }
         />,
         {
-          componentRegistry: getComponentRegistry(),
+          libContext: { componentRegistry },
         }
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -856,6 +872,7 @@ describe("ComponentInstance", () => {
       it("updates the frameHeight without re-rendering", () => {
         const jsonValue = {}
         const element = createElementProp(jsonValue)
+        const componentRegistry = getComponentRegistry()
         renderWithContexts(
           <ComponentInstance
             element={element}
@@ -868,7 +885,7 @@ describe("ComponentInstance", () => {
             }
           />,
           {
-            componentRegistry: getComponentRegistry(),
+            libContext: { componentRegistry },
           }
         )
         const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
@@ -914,6 +931,7 @@ describe("ComponentInstance", () => {
         }
 
         const element = createElementProp(jsonValue)
+        const componentRegistry = getComponentRegistry()
         renderWithContexts(
           <ComponentInstance
             element={element}
@@ -926,7 +944,7 @@ describe("ComponentInstance", () => {
             }
           />,
           {
-            componentRegistry: getComponentRegistry(),
+            libContext: { componentRegistry },
           }
         )
         const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -424,7 +424,9 @@ describe("DateInput widget", () => {
       it("renders expected week day ordering", async () => {
         const user = userEvent.setup()
         const props = getProps()
-        renderWithContexts(<DateInput {...props} />, { locale })
+        renderWithContexts(<DateInput {...props} />, {
+          libContext: { locale },
+        })
 
         await user.click(await screen.findByLabelText("Select a date."))
 
@@ -438,7 +440,9 @@ describe("DateInput widget", () => {
       it("renders expected week day ordering", async () => {
         const user = userEvent.setup()
         const props = getProps()
-        renderWithContexts(<DateInput {...props} />, { locale })
+        renderWithContexts(<DateInput {...props} />, {
+          libContext: { locale },
+        })
 
         await user.click(await screen.findByLabelText("Select a date."))
 
@@ -452,7 +456,9 @@ describe("DateInput widget", () => {
       it("renders expected week day ordering", async () => {
         const user = userEvent.setup()
         const props = getProps()
-        renderWithContexts(<DateInput {...props} />, { locale })
+        renderWithContexts(<DateInput {...props} />, {
+          libContext: { locale },
+        })
 
         await user.click(await screen.findByLabelText("Select a date."))
 
@@ -466,7 +472,9 @@ describe("DateInput widget", () => {
       it("falls back to en-US locale", async () => {
         const user = userEvent.setup()
         const props = getProps()
-        renderWithContexts(<DateInput {...props} />, { locale })
+        renderWithContexts(<DateInput {...props} />, {
+          libContext: { locale },
+        })
 
         await user.click(await screen.findByLabelText("Select a date."))
 

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -53,21 +53,11 @@ describe("Form", () => {
   }
 
   it("renders without crashing", () => {
-    renderWithContexts(
-      <Form {...getProps()} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {},
-      // FormsContext overrides
-      {
+    renderWithContexts(<Form {...getProps()} />, {
+      formsContext: {
         formsData: defaultFormsData(),
-      }
-    )
+      },
+    })
     const formElement = screen.getByTestId("stForm")
     expect(formElement).toBeInTheDocument()
     expect(formElement).toHaveClass("stForm")
@@ -78,55 +68,34 @@ describe("Form", () => {
     const props = getProps({ formId })
 
     // Start with script RUNNING, no submit button
-    const { rerenderWithContexts } = renderWithContexts(
-      <Form {...props} />,
-      {},
-      {},
-      {},
-      {},
-      // FormsContext overrides
-      {
+    const { rerenderWithContexts } = renderWithContexts(<Form {...props} />, {
+      formsContext: {
         // default formsData has no submit buttons
         formsData: defaultFormsData(),
       },
-      // ScriptRunContext overrides
-      {
+      scriptRunContext: {
         scriptRunState: ScriptRunState.RUNNING,
-      }
-    )
+      },
+    })
 
     // We have no Submit Button, but the app is still running
     expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
 
     // When the app stops running, we show an error if the submit button
     // is still missing.
-    rerenderWithContexts(
-      <Form {...props} />,
-      {},
-      {},
-      {},
-      {},
-      {},
-      // ScriptRunContext overrides
-      {
+    rerenderWithContexts(<Form {...props} />, {
+      scriptRunContext: {
         scriptRunState: ScriptRunState.NOT_RUNNING,
-      }
-    )
+      },
+    })
     expect(screen.getByText("Missing Submit Button")).toBeInTheDocument()
 
     // If the app restarts, we continue to show the error...
-    rerenderWithContexts(
-      <Form {...props} />,
-      {},
-      {},
-      {},
-      {},
-      {},
-      // ScriptRunContext overrides
-      {
+    rerenderWithContexts(<Form {...props} />, {
+      scriptRunContext: {
         scriptRunState: ScriptRunState.RUNNING,
-      }
-    )
+      },
+    })
     expect(screen.getByText("Missing Submit Button")).toBeInTheDocument()
 
     // Until we get a submit button, and the error is removed immediately,
@@ -136,17 +105,11 @@ describe("Form", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test mock
       { formId } as any,
     ])
-    rerenderWithContexts(
-      <Form {...props} />,
-      {},
-      {},
-      {},
-      {},
-      // FormsContext overrides
-      {
+    rerenderWithContexts(<Form {...props} />, {
+      formsContext: {
         formsData: formsDataWithButton,
-      }
-    )
+      },
+    })
     expect(screen.getByTestId("stForm")).toBeInTheDocument()
     expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
   })

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -153,21 +153,11 @@ describe("FormSubmitButton", () => {
       formsWithUploads: new Set(["mockFormId"]),
     }
 
-    renderWithContexts(
-      <FormSubmitButton {...getProps()} />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {},
-      // FormsContext overrides
-      {
+    renderWithContexts(<FormSubmitButton {...getProps()} />, {
+      formsContext: {
         formsData: formsDataOverride,
-      }
-    )
+      },
+    })
 
     const formSubmitButton = screen.getByRole("button")
     expect(formSubmitButton).toBeDisabled()

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -120,21 +120,9 @@ describe("useWidgetManagerElementState hook", () => {
       )
     }
 
-    renderWithContexts(
-      <TestComponent />,
-      // LibContext overrides
-      {},
-      // SidebarConfigContext overrides
-      {},
-      // ThemeContext overrides
-      {},
-      // NavigationContext overrides
-      {},
-      // FormsContext overrides
-      {
-        formsData: createFormsData(),
-      }
-    )
+    renderWithContexts(<TestComponent />, {
+      formsContext: { formsData: createFormsData() },
+    })
 
     // verify default value
     const inputElement: HTMLInputElement =

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -145,118 +145,104 @@ export function mockWindowLocation(hostname: string): void {
 }
 
 /**
+ * Options for overriding context values in renderWithContexts.
+ * All properties are optional - only provide the contexts you need to override.
+ */
+export interface RenderWithContextsOptions {
+  libContext?: Partial<LibContextProps>
+  sidebarConfigContext?: Partial<SidebarConfigContextProps>
+  themeContext?: Partial<ThemeContextProps>
+  navigationContext?: Partial<NavigationContextProps>
+  formsContext?: Partial<FormsContextProps>
+  scriptRunContext?: Partial<ScriptRunContextProps>
+}
+
+/**
  * Extended RenderResult that includes a rerender function supporting context updates
  */
 export interface RenderWithContextsResult extends RenderResult {
   /**
    * Re-render the component with updated context values.
-   *
-   * Parameter order matches the provider nesting order (outer → inner):
-   * LibContext → SidebarConfigContext → ThemeContext → NavigationContext → FormsContext → ScriptRunContext
+   * Merges new context props with existing ones (shallow merge).
    *
    * @param component The component to render (usually the same component with updated props)
-   * @param newLibContextProps New LibContext overrides to merge with existing values
-   * @param newSidebarConfigContextProps New SidebarConfigContext overrides to merge with existing values
-   * @param newThemeContextProps New ThemeContext overrides to merge with existing values
-   * @param newNavigationContextProps New NavigationContext overrides to merge with existing values
-   * @param newFormsContextProps New FormsContext overrides to merge with existing values
-   * @param newScriptRunContextProps New ScriptRunContext overrides to merge with existing values
+   * @param options Context overrides to merge with existing values
    */
   rerenderWithContexts: (
     component: ReactElement,
-    newLibContextProps?: Partial<LibContextProps>,
-    newSidebarConfigContextProps?: Partial<SidebarConfigContextProps>,
-    newThemeContextProps?: Partial<ThemeContextProps>,
-    newNavigationContextProps?: Partial<NavigationContextProps>,
-    newFormsContextProps?: Partial<FormsContextProps>,
-    newScriptRunContextProps?: Partial<ScriptRunContextProps>
+    options?: RenderWithContextsOptions
   ) => void
 }
 
 /**
  * Use react-testing-library to render a ReactElement. The element will be
- * wrapped in our LibContext.Provider, SidebarConfigContext.Provider, ThemeContext.Provider, NavigationContext.Provider, FormsContext.Provider, and ScriptRunContext.Provider.
- *
- * Parameter order matches the provider nesting order (outer → inner):
- * LibContext → SidebarConfigContext → ThemeContext → NavigationContext → FormsContext → ScriptRunContext
+ * wrapped in Providers for LibContext, SidebarConfigContext, ThemeContext,
+ * NavigationContext, FormsContext, and ScriptRunContext.
  *
  * Returns an extended RenderResult with a `rerenderWithContexts` method that
  * allows updating context values during re-renders.
+ *
+ * @param component The React component to render
+ * @param options Context overrides (all optional)
+ * @returns Extended render result with rerenderWithContexts method
+ *
+ * @example
+ * renderWithContexts(<MyComponent />, {
+ *   navigationContext: { appPages: [...] },
+ *   themeContext: { activeTheme: customTheme }
+ * })
  */
 export const renderWithContexts = (
   component: ReactElement,
-  overrideLibContextProps: Partial<LibContextProps> = {},
-  overrideSidebarConfigContextProps: Partial<SidebarConfigContextProps> = {},
-  overrideThemeContextProps: Partial<ThemeContextProps> = {},
-  overrideNavigationContextProps: Partial<NavigationContextProps> = {},
-  overrideFormsContextProps: Partial<FormsContextProps> = {},
-  overrideScriptRunContextProps: Partial<ScriptRunContextProps> = {}
+  options: RenderWithContextsOptions = {}
 ): RenderWithContextsResult => {
-  const defaultLibContextProps = {
+  // Track current context values across rerenders.
+  // The Wrapper component below reads these on each render,
+  // so updating them in rerenderWithContexts will affect subsequent renders.
+  let currentLibContextProps: LibContextProps = {
     isFullScreen: false,
     setFullScreen: vi.fn(),
     libConfig: {},
     locale: "en-US",
     componentRegistry: new ComponentRegistry(mockEndpoints()),
+    ...options.libContext,
   }
 
-  const defaultSidebarConfigContextProps = {
+  let currentSidebarConfigContextProps: SidebarConfigContextProps = {
     initialSidebarState: PageConfig.SidebarState.AUTO,
     appLogo: null,
     sidebarChevronDownshift: 0,
     expandSidebarNav: false,
     hideSidebarNav: false,
+    ...options.sidebarConfigContext,
   }
 
-  const defaultThemeContextProps = {
+  let currentThemeContextProps: ThemeContextProps = {
     activeTheme: mockTheme,
     setTheme: vi.fn(),
     availableThemes: [],
+    ...options.themeContext,
   }
 
-  const defaultNavigationContextProps = {
+  let currentNavigationContextProps: NavigationContextProps = {
     pageLinkBaseUrl: "",
     currentPageScriptHash: "",
     onPageChange: vi.fn(),
     navSections: [],
     appPages: [],
+    ...options.navigationContext,
   }
 
-  const defaultFormsContextProps = {
+  let currentFormsContextProps: FormsContextProps = {
     formsData: createFormsData(),
+    ...options.formsContext,
   }
 
-  const defaultScriptRunContextProps = {
+  let currentScriptRunContextProps: ScriptRunContextProps = {
     scriptRunState: ScriptRunState.NOT_RUNNING,
     scriptRunId: "script run 123",
     fragmentIdsThisRun: [],
-  }
-
-  // Track current context values across rerenders
-  // Order matches provider nesting: LibContext → SidebarConfigContext → ThemeContext → NavigationContext → FormsContext → ScriptRunContext
-  let currentLibContextProps = {
-    ...defaultLibContextProps,
-    ...overrideLibContextProps,
-  }
-  let currentSidebarConfigContextProps = {
-    ...defaultSidebarConfigContextProps,
-    ...overrideSidebarConfigContextProps,
-  }
-  let currentThemeContextProps = {
-    ...defaultThemeContextProps,
-    ...overrideThemeContextProps,
-  }
-  let currentNavigationContextProps = {
-    ...defaultNavigationContextProps,
-    ...overrideNavigationContextProps,
-  }
-  let currentFormsContextProps = {
-    ...defaultFormsContextProps,
-    ...overrideFormsContextProps,
-  }
-  let currentScriptRunContextProps = {
-    ...defaultScriptRunContextProps,
-    ...overrideScriptRunContextProps,
+    ...options.scriptRunContext,
   }
 
   const Wrapper: FC<PropsWithChildren> = ({ children }) => (
@@ -295,49 +281,43 @@ export const renderWithContexts = (
     ...result,
     rerenderWithContexts: (
       newComponent: ReactElement,
-      newLibContextProps?: Partial<LibContextProps>,
-      newSidebarConfigContextProps?: Partial<SidebarConfigContextProps>,
-      newThemeContextProps?: Partial<ThemeContextProps>,
-      newNavigationContextProps?: Partial<NavigationContextProps>,
-      newFormsContextProps?: Partial<FormsContextProps>,
-      newScriptRunContextProps?: Partial<ScriptRunContextProps>
+      newOptions?: RenderWithContextsOptions
     ): void => {
       // Update context values if provided
-      // Order matches provider nesting: LibContext → SidebarConfigContext → ThemeContext → NavigationContext → FormsContext → ScriptRunContext
-      if (newLibContextProps) {
+      if (newOptions?.libContext) {
         currentLibContextProps = {
           ...currentLibContextProps,
-          ...newLibContextProps,
+          ...newOptions.libContext,
         }
       }
-      if (newSidebarConfigContextProps) {
+      if (newOptions?.sidebarConfigContext) {
         currentSidebarConfigContextProps = {
           ...currentSidebarConfigContextProps,
-          ...newSidebarConfigContextProps,
+          ...newOptions.sidebarConfigContext,
         }
       }
-      if (newThemeContextProps) {
+      if (newOptions?.themeContext) {
         currentThemeContextProps = {
           ...currentThemeContextProps,
-          ...newThemeContextProps,
+          ...newOptions.themeContext,
         }
       }
-      if (newNavigationContextProps) {
+      if (newOptions?.navigationContext) {
         currentNavigationContextProps = {
           ...currentNavigationContextProps,
-          ...newNavigationContextProps,
+          ...newOptions.navigationContext,
         }
       }
-      if (newFormsContextProps) {
+      if (newOptions?.formsContext) {
         currentFormsContextProps = {
           ...currentFormsContextProps,
-          ...newFormsContextProps,
+          ...newOptions.formsContext,
         }
       }
-      if (newScriptRunContextProps) {
+      if (newOptions?.scriptRunContext) {
         currentScriptRunContextProps = {
           ...currentScriptRunContextProps,
-          ...newScriptRunContextProps,
+          ...newOptions.scriptRunContext,
         }
       }
       // Use the original rerender with the wrapper


### PR DESCRIPTION
## Describe your changes
**Part 5 of `StreamlitContextProvider` updates**

This PR removes `gitInfo` from `AppContext` - it is only used in `DeployDialog` so it doesn't make much sense inside context
Also cleans up test utility function `renderWithContexts` to better manage passing various context overrides. 

## Testing Plan
- JS Unit Tests: ✅ Updated