### PR TITLE
[chore] Fix typos in function and variable names

### DIFF
--- a/lib/streamlit/net_util.py
+++ b/lib/streamlit/net_util.py
@@ -50,7 +50,7 @@ def get_external_ip() -> str | None:
     if response is None:
         response = _make_blocking_http_get(_AWS_CHECK_IP_HTTPS, timeout=5)
 
-    if _looks_like_an_ip_adress(response):
+    if _looks_like_an_ip_address(response):
         _external_ip = response
     else:
         _LOGGER.warning(
@@ -103,7 +103,7 @@ def _make_blocking_http_get(url: str, timeout: float = 5) -> str | None:
         return None
 
 
-def _looks_like_an_ip_adress(address: str | None) -> bool:
+def _looks_like_an_ip_address(address: str | None) -> bool:
     if address is None:
         return False
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -106,7 +106,7 @@ class DataframeUtilTest(unittest.TestCase):
         """Test that `convert_anything_to_pandas_df` creates a copy of the original
         dataframe if `ensure_copy` is True.
         """
-        orginal_df = pd.DataFrame(
+        original_df = pd.DataFrame(
             {
                 "integer": [1, 2, 3],
                 "float": [1.0, 2.1, 3.2],
@@ -116,20 +116,20 @@ class DataframeUtilTest(unittest.TestCase):
         )
 
         converted_df = dataframe_util.convert_anything_to_pandas_df(
-            orginal_df, ensure_copy=True
+            original_df, ensure_copy=True
         )
         # Apply a change
         converted_df["integer"] = [4, 5, 6]
         # Ensure that the original dataframe is not changed
-        assert orginal_df["integer"].to_list() == [1, 2, 3]
+        assert original_df["integer"].to_list() == [1, 2, 3]
 
         converted_df = dataframe_util.convert_anything_to_pandas_df(
-            orginal_df, ensure_copy=False
+            original_df, ensure_copy=False
         )
         # Apply a change
         converted_df["integer"] = [4, 5, 6]
         # The original dataframe should be changed here since ensure_copy is False
-        assert orginal_df["integer"].to_list() == [4, 5, 6]
+        assert original_df["integer"].to_list() == [4, 5, 6]
 
     @pytest.mark.usefixtures("benchmark")
     def test_convert_anything_to_pandas_df_ensure_copy_performance(self):


### PR DESCRIPTION
## Summary
- Renamed `_looks_like_an_ip_adress` to `_looks_like_an_ip_address` in `lib/streamlit/net_util.py`
- Renamed `orginal_df` to `original_df` in `lib/tests/streamlit/dataframe_util_test.py`

## Test Plan
- [x] Ran `test_convert_anything_to_pandas_df_ensure_copy` - PASSED
- [x] Ran all `net_util_test.py` tests (4 tests) - ALL PASSED