### PR TITLE
[chore] Skip flaky Chromium snapshot in layouts container test

### DIFF
--- a/e2e_playwright/st_layouts_container_various_elements_test.py
+++ b/e2e_playwright/st_layouts_container_various_elements_test.py
@@ -47,6 +47,8 @@ CONTAINER_KEYS_WITH_EXPANDERS = [
 ]
 
 
+# Flaky in CI on Chromium. See workflow: https://github.com/streamlit/streamlit/actions/runs/18964912763/job/54180100557
+@pytest.mark.skip_browser("chromium")
 def test_layouts_container_various_elements(
     app: Page, assert_snapshot: ImageCompareFunction
 ):


### PR DESCRIPTION
This pull request introduces a small change to the `e2e_playwright/st_layouts_container_various_elements_test.py` file. The test for container layouts is now skipped on Chromium due to flakiness observed in CI runs. 

CI failure: https://github.com/streamlit/streamlit/actions/runs/18964912763/job/54180100557