### PR TITLE
[feat] Add proto for st.html JS support

### DIFF
--- a/proto/streamlit/proto/Html.proto
+++ b/proto/streamlit/proto/Html.proto
@@ -22,4 +22,5 @@ option java_outer_classname = "HtmlProto";
 // st.html
 message Html {
   string body = 1;
+  bool unsafe_allow_javascript = 2;
 }


### PR DESCRIPTION
## Describe your changes

Added a new field `unsafe_allow_javascript` to the Html proto message. This boolean flag will allow controlling whether JavaScript execution is permitted in HTML content.

## GitHub Issue Link (if applicable)

## Testing Plan

- Proto-only change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.