### PR TITLE
[feat] Add Python API for st.html unsafe_allow_javascript

### DIFF
--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -42,6 +42,7 @@ class HtmlMixin:
         body: str | Path | SupportsStr | SupportsReprHtml,
         *,  # keyword-only arguments:
         width: Width = "stretch",
+        unsafe_allow_javascript: bool = False,
     ) -> DeltaGenerator:
         """Insert HTML into your app.
 
@@ -52,8 +53,10 @@ class HtmlMixin:
         loading external code can increase the risk of vulnerabilities in your
         app.
 
-        ``st.html`` content is **not** iframed. Executing JavaScript is not
-        supported at this time.
+        ``st.html`` content is **not** iframed. By default, JavaScript is
+        ignored. To execute JavaScript contained in the HTML, set
+        ``unsafe_allow_javascript=True``. Use with caution and never pass
+        untrusted input.
 
         Parameters
         ----------
@@ -136,6 +139,8 @@ class HtmlMixin:
             html_proto.body = html_content
             return self._event_dg._enqueue("html", html_proto)
         # Otherwise, send the html to the main container as normal
+        # Only set the unsafe JS flag for non-style-only HTML content
+        html_proto.unsafe_allow_javascript = unsafe_allow_javascript
         html_proto.body = html_content
         return self.dg._enqueue("html", html_proto, layout_config=layout_config)
 

--- a/lib/tests/streamlit/elements/html_test.py
+++ b/lib/tests/streamlit/elements/html_test.py
@@ -25,6 +25,31 @@ from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 class StHtmlAPITest(DeltaGeneratorTestCase):
     """Test st.html API."""
 
+    def test_unsafe_allow_javascript_default_false(self):
+        """By default JS execution is disabled (flag False)."""
+        st.html("<div>Hi</div>")
+        el = self.get_delta_from_queue().new_element
+        assert el.html.body == "<div>Hi</div>"
+        assert el.html.unsafe_allow_javascript is False
+
+    def test_unsafe_allow_javascript_true(self):
+        """When enabled, the flag is serialized as True."""
+        st.html("<div>Hi</div>", unsafe_allow_javascript=True)
+        el = self.get_delta_from_queue().new_element
+        assert el.html.body == "<div>Hi</div>"
+        assert el.html.unsafe_allow_javascript is True
+
+    def test_unsafe_allow_javascript_style_only_ignores_flag(self):
+        """Style-only HTML ignores the JS flag since no scripts can execute."""
+        css = "<style>body{background:red}</style>"
+        st.html(css, unsafe_allow_javascript=True)
+        # First message routes the style-only tag to the event container; then
+        # the element
+        _ = self.get_message_from_queue()
+        style_el = self.get_delta_from_queue().new_element
+        assert style_el.html.body == css
+        assert style_el.html.unsafe_allow_javascript is False
+
     def test_st_html(self):
         """Test st.html."""
         st.html("<i> This is a i tag </i>")


### PR DESCRIPTION
## Describe your changes

Added a new `unsafe_allow_javascript` parameter to `st.html()` that allows JavaScript execution when set to `True`. By default, this parameter is `False`, maintaining the current behavior where JavaScript is ignored.

Updated the docstring to clarify that JavaScript execution is now possible but disabled by default, with appropriate warnings about using this feature with caution.

## GitHub Issue Link (if applicable)

## Testing Plan

- Added unit tests to verify:
  - Default behavior (JavaScript disabled)
  - Behavior when `unsafe_allow_javascript=True`
  - Proper flag propagation for style-only HTML content

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.