### PR TITLE
[feat] Add frontend for executing JS in st.html

### DIFF
--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -14,100 +14,90 @@
  * limitations under the License.
  */
 
-import React from "react"
-
-import { screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
 
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
-import { render } from "~lib/test_util"
+import Html from "./Html"
 
-import Html, { HtmlProps } from "./Html"
+function makeProto(partial: Partial<HtmlProto>): HtmlProto {
+  return {
+    body: "",
+    unsafeAllowJavascript: false,
+    toJSON: () => ({}),
+    ...partial,
+  }
+}
 
-const getProps = (elementProps: Partial<HtmlProto> = {}): HtmlProps => ({
-  element: HtmlProto.create({
-    body: "<div>Test Html</div>",
-    ...elementProps,
-  }),
-})
+describe("Html element", () => {
+  describe("when unsafeAllowJavascript=false", () => {
+    const unsafeAllowJavascript = false
 
-describe("HTML element", () => {
-  it("renders the element as expected", () => {
-    const props = getProps()
-    render(<Html {...props} />)
-    const html = screen.getByTestId("stHtml")
-    expect(html).toBeInTheDocument()
-    expect(html).toHaveTextContent("Test Html")
-    expect(html).toHaveStyle("width: 100%")
-    expect(html).toHaveClass("stHtml")
-  })
-
-  it("handles <style> tags - applies style", () => {
-    const props = getProps({
-      body: `
-        <style>
-            #random { color: rgb(255, 165, 0); }
-        </style>
-        <div id="random">Test Html</div>
-    `,
-    })
-    render(<Html {...props} />)
-    const html = screen.getByTestId("stHtml")
-    expect(html).toHaveTextContent("Test Html")
-    // Check that the style tag is applied to the div
-    expect(screen.getByText("Test Html")).toHaveStyle(
-      "color: rgb(255, 165, 0)"
-    )
-  })
-
-  it("sanitizes <script> tags", () => {
-    const props = getProps({
-      body: `<script> alert('BEWARE - the script tag is scripting'); </script>`,
-    })
-    render(<Html {...props} />)
-    expect(screen.queryByTestId("stHtml")).not.toBeInTheDocument()
-  })
-
-  it("sanitizes <svg> tags", () => {
-    const props = getProps({
-      body: `
-        <svg width="100" height="100">
-            <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
-        </svg>
-    `,
-    })
-    render(<Html {...props} />)
-    expect(screen.getByTestId("stHtml")).toHaveTextContent("")
-  })
-
-  describe("sanitizes anchor tags", () => {
-    it("does not add target when not present", () => {
-      const props = getProps({
-        body: '<a href="https://streamlit.io">Click Me</a>',
+    it("sanitizes and does not include script", () => {
+      const element = makeProto({
+        body: "<div id=\"x\">A</div><script>document.body.dataset.x='ran'</script>",
+        unsafeAllowJavascript,
       })
-      render(<Html {...props} />)
-      const anchorElement = screen.getByRole("link", { name: "Click Me" })
-      expect(anchorElement).not.toHaveAttribute("target")
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      expect(root.innerHTML).toContain('<div id="x">A</div>')
+      // script tags are removed by sanitize
+      expect(root.innerHTML).not.toContain("<script")
     })
 
-    it("preserves target='_blank' and adds rel attributes", () => {
-      const props = getProps({
-        body: '<a href="https://streamlit.io" target="_blank">Click Me</a>',
+    it("preserves target=_blank and sets rel attributes", () => {
+      const element = makeProto({
+        body: '<a href="https://example.com" target="_blank">Go</a>',
+        unsafeAllowJavascript,
       })
-      render(<Html {...props} />)
-      const anchorElement = screen.getByRole("link", { name: "Click Me" })
-      expect(anchorElement).toHaveAttribute("target", "_blank")
-      expect(anchorElement).toHaveAttribute("rel", "noopener noreferrer")
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      const link = root.querySelector<HTMLAnchorElement>("a")
+      expect(link).not.toBeNull()
+      expect(link?.getAttribute("target")).toBe("_blank")
+      expect(link?.getAttribute("rel")).toBe("noopener noreferrer")
     })
 
-    it("removes non-_blank target attributes", () => {
-      const props = getProps({
-        body: '<a href="https://streamlit.io" target="_self">Click Me</a>',
+    it("removes dangerous attributes and style/script tags", () => {
+      const element = makeProto({
+        body: '<div id="x" onclick="alert(1)">A</div><style>.a{color:red}</style><script>window.x=1</script>',
+        unsafeAllowJavascript,
       })
-      render(<Html {...props} />)
-      const anchorElement = screen.getByRole("link", { name: "Click Me" })
-      expect(anchorElement).not.toHaveAttribute("target")
-      expect(anchorElement).not.toHaveAttribute("rel")
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      const x = root.querySelector("#x") as HTMLElement
+      expect(x).not.toBeNull()
+      expect(x.hasAttribute("onclick")).toBe(false)
+      // style tags are allowed in sanitized HTML
+      expect(root.innerHTML).toContain("<style")
+      expect(root.innerHTML).not.toContain("<script")
+    })
+  })
+
+  describe("when unsafeAllowJavascript=true", () => {
+    const unsafeAllowJavascript = true
+
+    it("injects raw HTML and contains script tag", () => {
+      const element = makeProto({
+        body: '<div id="x">A</div><script>window.__x=1</script>',
+        unsafeAllowJavascript,
+      })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      // raw HTML injected
+      expect(root.querySelector("#x")).not.toBeNull()
+      // our logic replaces scripts with new script elements; they remain present
+      const scripts = root.querySelectorAll("script")
+      expect(scripts.length).toBeGreaterThan(0)
     })
   })
 })

--- a/frontend/lib/src/components/elements/Html/Html.test.tsx
+++ b/frontend/lib/src/components/elements/Html/Html.test.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
 
 import { Html as HtmlProto } from "@streamlit/protobuf"
 
 import Html from "./Html"
+
+declare global {
+  // Augment Window for test globals used by injected scripts
+  interface Window {
+    __counter?: number
+    __runs?: number
+  }
+}
 
 function makeProto(partial: Partial<HtmlProto>): HtmlProto {
   return {
@@ -31,6 +39,57 @@ function makeProto(partial: Partial<HtmlProto>): HtmlProto {
 }
 
 describe("Html element", () => {
+  describe.each([
+    {
+      unsafeAllowJavascript: false,
+      title: "when unsafeAllowJavascript=false",
+    },
+    {
+      unsafeAllowJavascript: true,
+      title: "when unsafeAllowJavascript=true",
+    },
+  ])("common behaviors $title", ({ unsafeAllowJavascript }) => {
+    it("renders the container with the expected test id and class", () => {
+      const element = makeProto({
+        body: "<div>hello</div>",
+        unsafeAllowJavascript,
+      })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      expect(root).not.toBeNull()
+      expect(root.classList.contains("stHtml")).toBe(true)
+    })
+
+    it("preserves target=_blank links and applies rel attributes", () => {
+      const element = makeProto({
+        body: '<a href="https://example.com" target="_blank">Go</a>',
+        unsafeAllowJavascript,
+      })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      const link = root.querySelector<HTMLAnchorElement>("a")
+      expect(link).not.toBeNull()
+      expect(link?.getAttribute("target")).toBe("_blank")
+      expect(link?.getAttribute("rel")).toBe("noopener noreferrer")
+    })
+
+    it("retains style tags", () => {
+      const element = makeProto({
+        body: '<style>.a{color:red}</style><div class="a">A</div>',
+        unsafeAllowJavascript,
+      })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      expect(root.innerHTML).toContain("<style")
+    })
+  })
+
   describe("when unsafeAllowJavascript=false", () => {
     const unsafeAllowJavascript = false
 
@@ -46,21 +105,6 @@ describe("Html element", () => {
       expect(root.innerHTML).toContain('<div id="x">A</div>')
       // script tags are removed by sanitize
       expect(root.innerHTML).not.toContain("<script")
-    })
-
-    it("preserves target=_blank and sets rel attributes", () => {
-      const element = makeProto({
-        body: '<a href="https://example.com" target="_blank">Go</a>',
-        unsafeAllowJavascript,
-      })
-
-      render(<Html element={element} />)
-
-      const root = screen.getByTestId("stHtml")
-      const link = root.querySelector<HTMLAnchorElement>("a")
-      expect(link).not.toBeNull()
-      expect(link?.getAttribute("target")).toBe("_blank")
-      expect(link?.getAttribute("rel")).toBe("noopener noreferrer")
     })
 
     it("removes dangerous attributes and style/script tags", () => {
@@ -98,6 +142,126 @@ describe("Html element", () => {
       // our logic replaces scripts with new script elements; they remain present
       const scripts = root.querySelectorAll("script")
       expect(scripts.length).toBeGreaterThan(0)
+    })
+
+    it("clones and replaces inline scripts (this proves scripts will be executed)", async () => {
+      const body = "<script>/* inline */</script>"
+      const element = makeProto({ body, unsafeAllowJavascript })
+
+      const createSpy = vi.spyOn(document, "createElement")
+      const replaceSpy = vi.spyOn(Node.prototype, "replaceChild")
+
+      render(<Html element={element} />)
+
+      await waitFor(() => {
+        const root = screen.getByTestId("stHtml")
+        const scripts = root.querySelectorAll("script")
+        expect(scripts.length).toBe(1)
+      })
+
+      // At least one new script element was created and old replaced
+      expect(createSpy.mock.calls.some(([tag]) => tag === "script")).toBe(true)
+      expect(replaceSpy).toHaveBeenCalled()
+
+      const script = screen.getByTestId("stHtml").querySelector("script")
+      expect(script?.textContent).toContain("inline")
+
+      createSpy.mockRestore()
+      replaceSpy.mockRestore()
+    })
+
+    it("preserves script attributes when recreating external and inline scripts", () => {
+      const body = [
+        '<script src="https://example.com/a.js" async defer crossorigin="anonymous" referrerpolicy="no-referrer" integrity="sha256-abc"></script>',
+        '<script type="module" nonce="xyz">/* noop */</script>',
+      ].join("")
+
+      const element = makeProto({ body, unsafeAllowJavascript })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      const scripts = root.querySelectorAll("script")
+      expect(scripts.length).toBe(2)
+
+      const [ext, mod] = Array.from(scripts)
+      expect(
+        ext.getAttribute("src")?.includes("https://example.com/a.js")
+      ).toBe(true)
+      expect(ext.hasAttribute("async")).toBe(true)
+      expect(ext.hasAttribute("defer")).toBe(true)
+      expect(ext.getAttribute("crossorigin")).toBe("anonymous")
+      expect(ext.getAttribute("referrerpolicy")).toBe("no-referrer")
+      expect(ext.getAttribute("integrity")).toBe("sha256-abc")
+
+      expect(mod.getAttribute("type")).toBe("module")
+      expect(mod.getAttribute("nonce")).toBe("xyz")
+    })
+
+    it("cleans previous content on dependency change and only runs cloning when body changes", async () => {
+      const first = makeProto({
+        body: '<div id="first"></div><script>/* a */</script>',
+        unsafeAllowJavascript,
+      })
+
+      const replaceSpy = vi.spyOn(Node.prototype, "replaceChild")
+
+      const { rerender } = render(<Html element={first} />)
+
+      let root = screen.getByTestId("stHtml")
+      await waitFor(() => expect(root.querySelector("#first")).not.toBeNull())
+
+      const initialReplaceCalls = replaceSpy.mock.calls.length
+
+      // Re-render with SAME body: should not perform additional replacements
+      rerender(<Html element={first} />)
+      await waitFor(() => {
+        expect(replaceSpy.mock.calls.length).toBe(initialReplaceCalls)
+      })
+
+      // Re-render with different body: cleanup and more replacements
+      const second = makeProto({
+        body: '<div id="second"></div><script>/* b */</script>',
+        unsafeAllowJavascript,
+      })
+      rerender(<Html element={second} />)
+
+      root = screen.getByTestId("stHtml")
+      expect(root.querySelector("#first")).toBeNull()
+      await waitFor(() => expect(root.querySelector("#second")).not.toBeNull())
+      expect(replaceSpy.mock.calls.length).toBeGreaterThan(initialReplaceCalls)
+
+      replaceSpy.mockRestore()
+    })
+
+    it("handles attribute copy failures gracefully (catch path)", () => {
+      const original = Element.prototype.setAttribute
+      const spy = vi
+        .spyOn(Element.prototype, "setAttribute")
+        .mockImplementation(function (
+          this: Element,
+          name: string,
+          value: string
+        ) {
+          if (name === "nonce") {
+            throw new Error("boom")
+          }
+          return original.call(this, name, value)
+        })
+
+      const element = makeProto({
+        body: '<script type="module" nonce="throw-me">/* noop */</script>',
+        unsafeAllowJavascript,
+      })
+
+      render(<Html element={element} />)
+
+      const root = screen.getByTestId("stHtml")
+      // Script should still be present despite attribute copy error
+      const script = root.querySelector("script")
+      expect(script).not.toBeNull()
+
+      spy.mockRestore()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Html/HtmlContainer.tsx
+++ b/frontend/lib/src/components/elements/Html/HtmlContainer.tsx
@@ -14,28 +14,23 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement } from "react"
+import { forwardRef } from "react"
 
-import { Html as HtmlProto } from "@streamlit/protobuf"
+import { StyledHtml } from "./styled-components"
 
-import HtmlWithJs from "./HtmlWithJs"
-import SanitizedHtml from "./SanitizedHtml"
+type StyledHtmlProps = React.ComponentProps<typeof StyledHtml>
 
-export interface HtmlProps {
-  element: HtmlProto
-}
+const HtmlContainer = forwardRef<HTMLDivElement, StyledHtmlProps>(
+  function HtmlContainer(props, ref) {
+    return (
+      <StyledHtml
+        className="stHtml"
+        data-testid="stHtml"
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
 
-/**
- * HTML code to insert into the page.
- */
-function Html({ element }: Readonly<HtmlProps>): ReactElement {
-  const { body, unsafeAllowJavascript } = element
-
-  return unsafeAllowJavascript ? (
-    <HtmlWithJs body={body} />
-  ) : (
-    <SanitizedHtml body={body} />
-  )
-}
-
-export default memo(Html)
+export default HtmlContainer

--- a/frontend/lib/src/components/elements/Html/HtmlWithJs.tsx
+++ b/frontend/lib/src/components/elements/Html/HtmlWithJs.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC, memo, useEffect, useRef } from "react"
+
+import HtmlContainer from "./HtmlContainer"
+
+export interface HtmlWithJsProps {
+  body: string
+}
+
+const HtmlWithJs: FC<HtmlWithJsProps> = ({ body }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    // Reset and inject raw HTML
+    container.innerHTML = ""
+    container.innerHTML = body
+
+    // Post-process links opened in new tabs for security
+    const anchors = container.querySelectorAll<HTMLAnchorElement>(
+      'a[target="_blank"]'
+    )
+    anchors.forEach(a => {
+      a.setAttribute("rel", "noopener noreferrer")
+    })
+
+    // Execute scripts by cloning them so the browser runs them
+    const scripts = Array.from(
+      container.querySelectorAll<HTMLScriptElement>("script")
+    )
+
+    scripts.forEach(oldScript => {
+      const newScript = document.createElement("script")
+
+      // Copy attributes (type, src, async, defer, nonce, etc.)
+      for (const { name, value } of Array.from(oldScript.attributes)) {
+        try {
+          newScript.setAttribute(name, value)
+        } catch {
+          // Best-effort; ignore invalid attributes
+        }
+      }
+
+      if (oldScript.src) {
+        newScript.src = oldScript.src
+      } else {
+        newScript.textContent = oldScript.textContent
+      }
+
+      // Replace to trigger execution
+      oldScript.parentNode?.replaceChild(newScript, oldScript)
+    })
+
+    // Cleanup on dependency change
+    return () => {
+      container.innerHTML = ""
+    }
+  }, [body])
+
+  return <HtmlContainer ref={containerRef} />
+}
+
+export default memo(HtmlWithJs)

--- a/frontend/lib/src/components/elements/Html/HtmlWithJs.tsx
+++ b/frontend/lib/src/components/elements/Html/HtmlWithJs.tsx
@@ -14,16 +14,53 @@
  * limitations under the License.
  */
 
-import { FC, memo, useEffect, useRef } from "react"
+import { FC, memo, useEffect, useMemo, useRef } from "react"
 
+import dompurify, { SANITIZE_HTML_BASE_OPTIONS } from "./dompurifyHooks"
 import HtmlContainer from "./HtmlContainer"
 
 export interface HtmlWithJsProps {
   body: string
 }
 
+/**
+ * Local sanitizer for the "unsafe allow JavaScript" path.
+ *
+ * - Based on the shared HTML profile `SANITIZE_HTML_BASE_OPTIONS`.
+ * - Extends allow-lists to keep <script>/<style> and common script attributes
+ *   (ADD_TAGS/ADD_ATTR).
+ */
+const SANITIZE_HTML_ALLOW_SCRIPTS_OPTIONS = {
+  ...SANITIZE_HTML_BASE_OPTIONS,
+  ADD_TAGS: ["script", "style"],
+  ADD_ATTR: [
+    "src",
+    "type",
+    "async",
+    "defer",
+    "nonce",
+    "crossorigin",
+    "referrerpolicy",
+    "integrity",
+  ],
+}
+
+/**
+ * Sanitizes an HTML string while retaining <script> and related attributes.
+ * Intended only for the unsafeAllowJavascript path where scripts are executed
+ * programmatically after insertion.
+ */
+function sanitizeHtmlStringAllowingScripts(html: string): string {
+  return dompurify.sanitize(html, SANITIZE_HTML_ALLOW_SCRIPTS_OPTIONS)
+}
+
 const HtmlWithJs: FC<HtmlWithJsProps> = ({ body }) => {
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const sanitizedBody = useMemo(
+    () => sanitizeHtmlStringAllowingScripts(body),
+    [body]
+  )
 
   useEffect(() => {
     const container = containerRef.current
@@ -31,19 +68,11 @@ const HtmlWithJs: FC<HtmlWithJsProps> = ({ body }) => {
       return
     }
 
-    // Reset and inject raw HTML
-    container.innerHTML = ""
-    container.innerHTML = body
+    // Inject sanitized HTML. Our DOMPurify hooks will add rel="noopener noreferrer"
+    // to links with target="_blank" for security.
+    container.innerHTML = sanitizedBody
 
-    // Post-process links opened in new tabs for security
-    const anchors = container.querySelectorAll<HTMLAnchorElement>(
-      'a[target="_blank"]'
-    )
-    anchors.forEach(a => {
-      a.setAttribute("rel", "noopener noreferrer")
-    })
-
-    // Execute scripts by cloning them so the browser runs them
+    // Execute scripts: Cloning <script> elements causes the browser to run them.
     const scripts = Array.from(
       container.querySelectorAll<HTMLScriptElement>("script")
     )
@@ -51,30 +80,28 @@ const HtmlWithJs: FC<HtmlWithJsProps> = ({ body }) => {
     scripts.forEach(oldScript => {
       const newScript = document.createElement("script")
 
-      // Copy attributes (type, src, async, defer, nonce, etc.)
+      // Copy attributes (type, src, async, defer, nonce, etc.).
       for (const { name, value } of Array.from(oldScript.attributes)) {
         try {
           newScript.setAttribute(name, value)
         } catch {
-          // Best-effort; ignore invalid attributes
+          // Best-effort - ignore invalid attributes.
         }
       }
 
-      if (oldScript.src) {
-        newScript.src = oldScript.src
-      } else {
+      if (!oldScript.src) {
         newScript.textContent = oldScript.textContent
       }
 
-      // Replace to trigger execution
+      // Replace to trigger JS execution.
       oldScript.parentNode?.replaceChild(newScript, oldScript)
     })
 
-    // Cleanup on dependency change
+    // Cleanup on dependency change.
     return () => {
       container.innerHTML = ""
     }
-  }, [body])
+  }, [sanitizedBody])
 
   return <HtmlContainer ref={containerRef} />
 }

--- a/frontend/lib/src/components/elements/Html/SanitizedHtml.tsx
+++ b/frontend/lib/src/components/elements/Html/SanitizedHtml.tsx
@@ -16,50 +16,23 @@
 
 import { memo, ReactElement, useMemo } from "react"
 
-import dompurify from "dompurify"
-
+import dompurify, { SANITIZE_HTML_BASE_OPTIONS } from "./dompurifyHooks"
 import HtmlContainer from "./HtmlContainer"
+
+/**
+ * Sanitizes an HTML string for safe rendering (no script execution).
+ */
+function sanitizeHtmlString(html: string): string {
+  return dompurify.sanitize(html, SANITIZE_HTML_BASE_OPTIONS)
+}
 
 export interface SanitizedHtmlProps {
   body: string
 }
-
-// preserve target=_blank and set security attributes (see https://github.com/cure53/DOMPurify/issues/317)
-const TEMPORARY_ATTRIBUTE = "data-temp-href-target"
-dompurify.addHook("beforeSanitizeAttributes", function (node) {
-  if (
-    node instanceof HTMLElement &&
-    node.hasAttribute("target") &&
-    node.getAttribute("target") === "_blank"
-  ) {
-    node.setAttribute(TEMPORARY_ATTRIBUTE, "_blank")
-  }
-})
-dompurify.addHook("afterSanitizeAttributes", function (node) {
-  if (node instanceof HTMLElement && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
-    node.setAttribute("target", "_blank")
-    // according to https://html.spec.whatwg.org/multipage/links.html#link-type-noopener,
-    // noreferrer implies noopener, but we set it just to be sure in case some browsers
-    // do not implement the spec accordingly.
-    node.setAttribute("rel", "noopener noreferrer")
-    node.removeAttribute(TEMPORARY_ATTRIBUTE)
-  }
-})
-
-const sanitizeString = (html: string): string => {
-  const sanitizationOptions = {
-    // Default to permit HTML, SVG and MathML, this limits to HTML only
-    USE_PROFILES: { html: true },
-    // glue elements like style, script or others to document.body and prevent unintuitive browser behavior in several edge-cases
-    FORCE_BODY: true,
-  }
-  return dompurify.sanitize(html, sanitizationOptions)
-}
-
 function SanitizedHtml({
   body,
 }: Readonly<SanitizedHtmlProps>): ReactElement | null {
-  const sanitizedHtml = useMemo(() => sanitizeString(body), [body])
+  const sanitizedHtml = useMemo(() => sanitizeHtmlString(body), [body])
 
   if (!sanitizedHtml) {
     return null

--- a/frontend/lib/src/components/elements/Html/SanitizedHtml.tsx
+++ b/frontend/lib/src/components/elements/Html/SanitizedHtml.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo, ReactElement, useMemo } from "react"
+
+import dompurify from "dompurify"
+
+import HtmlContainer from "./HtmlContainer"
+
+export interface SanitizedHtmlProps {
+  body: string
+}
+
+// preserve target=_blank and set security attributes (see https://github.com/cure53/DOMPurify/issues/317)
+const TEMPORARY_ATTRIBUTE = "data-temp-href-target"
+dompurify.addHook("beforeSanitizeAttributes", function (node) {
+  if (
+    node instanceof HTMLElement &&
+    node.hasAttribute("target") &&
+    node.getAttribute("target") === "_blank"
+  ) {
+    node.setAttribute(TEMPORARY_ATTRIBUTE, "_blank")
+  }
+})
+dompurify.addHook("afterSanitizeAttributes", function (node) {
+  if (node instanceof HTMLElement && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
+    node.setAttribute("target", "_blank")
+    // according to https://html.spec.whatwg.org/multipage/links.html#link-type-noopener,
+    // noreferrer implies noopener, but we set it just to be sure in case some browsers
+    // do not implement the spec accordingly.
+    node.setAttribute("rel", "noopener noreferrer")
+    node.removeAttribute(TEMPORARY_ATTRIBUTE)
+  }
+})
+
+const sanitizeString = (html: string): string => {
+  const sanitizationOptions = {
+    // Default to permit HTML, SVG and MathML, this limits to HTML only
+    USE_PROFILES: { html: true },
+    // glue elements like style, script or others to document.body and prevent unintuitive browser behavior in several edge-cases
+    FORCE_BODY: true,
+  }
+  return dompurify.sanitize(html, sanitizationOptions)
+}
+
+function SanitizedHtml({
+  body,
+}: Readonly<SanitizedHtmlProps>): ReactElement | null {
+  const sanitizedHtml = useMemo(() => sanitizeString(body), [body])
+
+  if (!sanitizedHtml) {
+    return null
+  }
+
+  return (
+    <HtmlContainer
+      // Note: This is an expected usage of dangerouslySetInnerHTML.
+      // eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  )
+}
+
+export default memo(SanitizedHtml)

--- a/frontend/lib/src/components/elements/Html/dompurifyHooks.ts
+++ b/frontend/lib/src/components/elements/Html/dompurifyHooks.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Centralized DOMPurify instance and hooks used across HTML-rendering components.
+ */
+import dompurify from "dompurify"
+
+/**
+ * We temporarily store target="_blank" on links before attribute sanitization
+ * and re-apply it afterwards together with a safe rel value.
+ *
+ * Why: Opening links in a new tab (target="_blank") can enable
+ * reverse-tabnabbing unless rel includes "noopener" (and usually "noreferrer").
+ * DOMPurify does not add such attributes by default. Using hooks, we can
+ * preserve the author's intent while enforcing safe defaults.
+ *
+ * Implementation detail: We stash the intent in a temporary data- attribute.
+ * DOMPurify allows data-* attributes by default (ALLOW_DATA_ATTR: true), so the
+ * marker survives the attribute pass and can be observed in the after-hook.
+ *
+ * @see https://github.com/cure53/DOMPurify/issues/317
+ */
+const TEMPORARY_ATTRIBUTE = "data-temp-href-target"
+
+/**
+ * Preserve links with target="_blank" across sanitization and enforce
+ * rel="noopener noreferrer" afterwards for security.
+ */
+dompurify.addHook("beforeSanitizeAttributes", function (node): void {
+  if (
+    node instanceof HTMLElement &&
+    node.hasAttribute("target") &&
+    node.getAttribute("target") === "_blank"
+  ) {
+    node.setAttribute(TEMPORARY_ATTRIBUTE, "_blank")
+  }
+})
+
+dompurify.addHook("afterSanitizeAttributes", function (node): void {
+  if (node instanceof HTMLElement && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
+    node.setAttribute("target", "_blank")
+    // according to https://html.spec.whatwg.org/multipage/links.html#link-type-noopener,
+    // noreferrer implies noopener, but we set it just to be sure in case some browsers
+    // do not implement the spec accordingly.
+    node.setAttribute("rel", "noopener noreferrer")
+    node.removeAttribute(TEMPORARY_ATTRIBUTE)
+  }
+})
+
+/**
+ * Shared DOMPurify sanitization options used for safe rendering.
+ *
+ * @see https://github.com/cure53/DOMPurify
+ */
+export const SANITIZE_HTML_BASE_OPTIONS = {
+  // Restrict sanitization to the HTML profile (no SVG/MathML)
+  USE_PROFILES: { html: true },
+  // Parse inside a <body> context to avoid cross-browser reparenting/hoisting quirks
+  FORCE_BODY: true,
+}
+
+export default dompurify


### PR DESCRIPTION
## Describe your changes

Refactored the HTML component to properly handle JavaScript execution when `unsafeAllowJavascript` is enabled. The implementation now:

- Splits HTML rendering into two components: `SanitizedHtml` and `HtmlWithJs`
- Properly executes scripts by cloning and replacing them in the DOM
- Preserves script attributes (src, type, async, defer, nonce, etc.)
- Centralizes DOMPurify hooks in a shared module
- Improves cleanup when HTML content changes

## Testing Plan

- Unit Tests: Completely rewrote the test suite to thoroughly test both safe and unsafe modes
  - Added tests for script execution, attribute preservation, and cleanup behavior
  - Added tests for error handling during attribute copying
  - Added tests to verify proper sanitization in safe mode
  - Added tests to verify script execution in unsafe mode

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.