### PR TITLE
[test] Add e2e tests for JS in st.html

### DIFF
--- a/e2e_playwright/st_html.py
+++ b/e2e_playwright/st_html.py
@@ -101,3 +101,15 @@ st.html(
     """,
     width=300,
 )
+
+# Test that JavaScript executes when explicitly allowed
+st.html(
+    """
+    <div id="x">initial</div>
+    <script>
+      document.getElementById('x').textContent = 'OK'
+      window.__st_html_flag__ = 'ran'
+    </script>
+    """,
+    unsafe_allow_javascript=True,
+)

--- a/e2e_playwright/st_html_test.py
+++ b/e2e_playwright/st_html_test.py
@@ -21,7 +21,7 @@ from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
 # If the html content is only style tags, it will generate the stHtml element
 # in the event container. If the html content is a mix of style tags and other tags,
 # it will generate the stHtml element with both style/other tags in the main container.
-ST_HTML_ELEMENTS = 10
+ST_HTML_ELEMENTS = 11
 
 
 def test_html_in_line_styles(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -111,13 +111,13 @@ def test_html_in_main_container(app: Page):
     # in the main container and are visible
     main_container = app.get_by_test_id("stMain")
     other_html_elements = main_container.get_by_test_id("stHtml")
-    expect(other_html_elements).to_have_count(8)
+    expect(other_html_elements).to_have_count(9)
 
     # Check that the remaining stHtml elements are in the main container
     # and are visible
     main_container = app.get_by_test_id("stMain")
     other_html_elements = main_container.get_by_test_id("stHtml")
-    expect(other_html_elements).to_have_count(8)
+    expect(other_html_elements).to_have_count(9)
     expect(other_html_elements.nth(0)).to_be_visible()
     expect(other_html_elements.nth(1)).to_be_visible()
     expect(other_html_elements.nth(2)).to_be_visible()
@@ -192,3 +192,18 @@ def test_html_width_examples(app: Page, assert_snapshot: ImageCompareFunction):
     assert_snapshot(main_html_elements.nth(5), name="st_html-width_content")
     assert_snapshot(main_html_elements.nth(6), name="st_html-width_stretch")
     assert_snapshot(main_html_elements.nth(7), name="st_html-width_300px")
+
+
+def test_html_executes_javascript_when_allowed(app: Page) -> None:
+    """Test that JavaScript executes in st.html when
+    `unsafe_allow_javascript=True` is set.
+
+    This test verifies that when the `unsafe_allow_javascript` option is
+    enabled, JavaScript code within st.html is executed, and that the expected
+    side effects occur.
+    """
+    el = app.locator("#x")
+    expect(el).to_have_text("OK")
+
+    ran = app.evaluate("() => window.__st_html_flag__")
+    assert ran == "ran"


### PR DESCRIPTION
## Describe your changes

Adds e2e tests for `st.html` with `unsafe_allow_javascript`.

## GitHub Issue Link (if applicable)

## Testing Plan

- E2E Tests: Added a test case in `st_html.py` that includes JavaScript code with the new parameter, and updated `st_html_test.py` to verify that:
  1. The JavaScript code executes correctly when allowed
  2. The DOM is updated as expected by the script
  3. The global variable set by the script is accessible

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.