### PR TITLE
[fix] Fixup semgrep checks for forked PRs

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,8 +9,21 @@ permissions:
   contents: read
 
 jobs:
+  # Internal PRs (same-repo branches): run the full Semgrep reusable workflow
+  # with app token.
   run-semgrep-reusable-workflow:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     uses: snowflakedb/reusable-workflows/.github/workflows/semgrep-v2.yml@main
     secrets:
       token: ${{ secrets.SEMGREP_APP_TOKEN }}
+  # Forked PRs: skip the Semgrep reusable workflow and just print a message so
+  # it prints a status and does not block merges. This mirrors patterns in other
+  # workflows where secret-using steps are skipped for forks.
+  run-semgrep-fork-safe:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip Semgrep for forked PRs
+        run: |
+          echo "Semgrep App scan requires repo secrets and is skipped for forked PRs."
+          echo "This job exists to keep the workflow green for forks, matching other workflows' behavior."

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,6 +19,9 @@ jobs:
   # Forked PRs: skip the Semgrep reusable workflow and just print a message so
   # it prints a status and does not block merges. This mirrors patterns in other
   # workflows where secret-using steps are skipped for forks.
+  # Any code integrated into `develop` will be scanned by Semgrep in other PRs,
+  # notably the release branch -> `develop` PR that is created for every new
+  # release.
   run-semgrep-fork-safe:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Describe your changes

- Fixes an issue where semgrep check is required but not being run on PRs from forked repos.
  - This is due to a change made in https://github.com/streamlit/streamlit/pull/12855
- Functionally, this PR restores the previous behavior for forked PRs, but technically marks the Semgrep PR as "success" since it's a no-op.

## GitHub Issue Link (if applicable)

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
