### PR TITLE
[chore] Enable Cursor's "Worktree" Agents

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "cd \"$(git rev-parse --show-toplevel)\"; [ -d .venv ] || uv venv; VIRTUAL_ENV=.venv PATH=\".venv/bin:.venv/Scripts:$PATH\" make all-dev frontend"
+  ]
+}


### PR DESCRIPTION
## Describe your changes

This PR aims to enable the Cursor Worktree Agents feature.
<img width="214" height="148" alt="image" src="https://github.com/user-attachments/assets/10e84a0a-5157-461f-b31c-fa6721505d8d" />


I started with:
```bash
[ -d .venv ] || uv venv; (. .venv/bin/activate 2>/dev/null || . .venv/Scripts/activate); make all-dev; make frontend
```

And this didn't work. ❌ 

I then created an extremely verbose test script:
```bash
#!/usr/bin/env bash
# Setup script for new Git worktrees (Streamlit project)
# - creates .venv with uv (required)
# - activates the venv
# - installs dev deps via `make all-dev`
# - builds frontend/types via `make frontend`

set -Eeuo pipefail

log() { printf '[setup] %s\n' "$*"; }

# Ensure we're at repo root (worktree root)
ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
cd "$ROOT_DIR"

# Pre-flight checks
if ! command -v uv >/dev/null 2>&1; then
  echo "ERROR: 'uv' not found. Install uv (https://astral.sh/uv) and re-run." >&2
  exit 1
fi

if ! command -v make >/dev/null 2>&1; then
  echo "ERROR: 'make' not found. Install make and re-run." >&2
  exit 1
fi

if [ ! -f "Makefile" ] && [ ! -f "makefile" ]; then
  echo "ERROR: No Makefile found in repo root ($ROOT_DIR)." >&2
  exit 1
fi

# 1) Create venv (idempotent)
if [ -d ".venv" ]; then
  log ".venv already exists; skipping creation."
else
  log "Creating virtual environment with uv → .venv"
  uv venv
fi

# 2) Activate venv (cross‑platform) – temporarily relax 'nounset' for activate script
log "Activating virtual environment"
set +u
if [ -f ".venv/bin/activate" ]; then
  # shellcheck disable=SC1091
  . ".venv/bin/activate"
elif [ -f ".venv/Scripts/activate" ]; then
  # shellcheck disable=SC1091
  . ".venv/Scripts/activate"
else
  echo "ERROR: Could not find venv activation script under .venv." >&2
  exit 1
fi
set -u

# 3) Install dev dependencies
log "Installing dev dependencies (make all-dev)"
# Verify target exists (make -nq: 0/1 ok, 2 = no rule)
if make -nq all-dev >/dev/null 2>&1; then :; else
  status=$?
  if [ "$status" -eq 2 ]; then
    echo "ERROR: Make target 'all-dev' not found." >&2
    exit 1
  fi
fi
make all-dev

# 4) Build frontend/types
log "Building frontend/types (make frontend)"
if make -nq frontend >/dev/null 2>&1; then :; else
  status=$?
  if [ "$status" -eq 2 ]; then
    echo "ERROR: Make target 'frontend' not found." >&2
    exit 1
  fi
fi
make frontend

log "Setup complete ✅"
```

and... it worked perfectly. 😓 

I then hypothesized it must be something related to the virtual env sourcing not persisting with it being inline. I asked ChatGPT to workaround this issue and it ended up coming up with:

```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"; [ -d .venv ] || uv venv; VIRTUAL_ENV=.venv PATH=".venv/bin:.venv/Scripts:$PATH" make all-dev frontend
```

and that seems to work, so going to check it in for others to use. ✅ 


## Why run the Streamlit make targets when creating a new Git worktree?

A worktree is a separate working directory with its own .git state. It intentionally does not share build artifacts, virtual environments, node modules, or Git hooks with other worktrees. Because of this, each fresh worktree needs its own bootstrap. By running all-dev and frontend we can ensure we have our dev env setup in a state after the worktree is created that should support most development flows.

<!-- If it's a visual change, please include a screenshot or video! -->

## Testing Plan

I tested this by having cursor create its worktree, then i `cd`'ed into that directory, sourced the virtual env, and ran `streamlit run e2e_playwright/st_chat_input.py` successfully.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
