### PR TITLE
Fix: Show active values when disabled for st.pills and st.segmented control

### DIFF
--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -302,7 +302,7 @@ export const StyledPillsButtonActive = styled(
       color: theme.colors.primary,
     },
     "&:disabled, &:disabled:hover, &:disabled:active": {
-      borderColor: theme.colors.borderColor,
+      borderColor: theme.colors.fadedText40,
       backgroundColor: theme.colors.fadedText05,
       color: theme.colors.fadedText40,
       cursor: "not-allowed",
@@ -349,10 +349,11 @@ export const StyledSegmentedControlButtonActive = styled(
       backgroundColor: transparentize(theme.colors.primary, 0.8),
     },
     "&:disabled, &:disabled:hover, &:disabled:active": {
-      borderColor: theme.colors.borderColor,
+      borderColor: theme.colors.fadedText40,
       backgroundColor: theme.colors.fadedText05,
       color: theme.colors.fadedText40,
       cursor: "not-allowed",
+      zIndex: theme.zIndices.priority,
     },
   }
 })


### PR DESCRIPTION
## Describe your changes

This PR fixes issue #12912 by updating the CSS for `st.pills` and `st.segmented_control` so that the active selection remains visually distinct when the widget is disabled. The border color for disabled active buttons is now set to a more visible muted color, making selected options stand out even when disabled.

<!-- If it's a visual change, please include a screenshot or video! -->
**Visual Change:**  
Selected disabled pills and segmented controls now show a darker border, clearly indicating the active value.

## GitHub Issue Link (if applicable)

Closes #12912

## Testing Plan

- No additional tests needed: The change is purely CSS and leverages existing logic that already applies the correct button kind for selected/disabled states.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.