### PR TITLE
[chore] Skip Firefox browser for multi_row_column_and_cell_select test

### DIFF
--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -671,6 +671,7 @@ def test_multi_row_and_single_cell_select(app: Page):
     )
 
 
+@pytest.mark.skip_browser("firefox")
 def test_multi_row_column_and_cell_select(
     app: Page, assert_snapshot: ImageCompareFunction
 ):


### PR DESCRIPTION
## Describe your changes

Skip Firefox browser for the `test_multi_row_column_and_cell_select` test in the dataframe selections test suite.

## GitHub Issue Link (if applicable)

Seeing this test fail on nightly here: https://github.com/streamlit/streamlit/actions/runs/19060155595

## Testing Plan

- No additional tests needed as this change is specifically modifying an existing test
- The change adds a pytest marker to skip a specific test on Firefox browsers

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.