### PR TITLE
[chore] unskip test_layouts_container_various_elements in chromium

### DIFF
--- a/e2e_playwright/st_layouts_container_various_elements_test.py
+++ b/e2e_playwright/st_layouts_container_various_elements_test.py
@@ -34,7 +34,6 @@ CONTAINER_KEYS = [
     "layout-horizontal-expander-dataframe-content-width-large",
     "layout-vertical-stretch-height",
     "layout-vertical-content-width-container-with-various-elements",
-    # Moved from st_layouts_container_min_width.py
     "layout-vertical-content-width-container-with-stretch-width-dataframes",
     "layout-vertical-content-width-container-with-content-width-dataframes",
     "layout-horizontal-content-width-container-with-metrics-dataframes-line-charts",
@@ -47,8 +46,6 @@ CONTAINER_KEYS_WITH_EXPANDERS = [
 ]
 
 
-# Flaky in CI on Chromium. See workflow: https://github.com/streamlit/streamlit/actions/runs/18964912763/job/54180100557
-@pytest.mark.skip_browser("chromium")
 def test_layouts_container_various_elements(
     app: Page, assert_snapshot: ImageCompareFunction
 ):


### PR DESCRIPTION
## Describe your changes

This test was skipped in chromium on Friday, but since then a fix for the flaky snapshot subtest has been merged https://github.com/streamlit/streamlit/pull/12906

The other flaky snapshot subtest that we see failing is failing in Webkit not Chromium so this skipping has no affect and we can unskip this independently of resolving that issue. 

<!-- If it's a visual change, please include a screenshot or video! -->

## GitHub Issue Link (if applicable)

## Testing Plan

Test only. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
