### PR TITLE
[feat] Add flaky test verification workflow

### DIFF
--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Trigger changed-files workflow (iteration ${{ matrix.iteration }})
         run: |
           gh workflow run playwright-changed-files.yml \
+            --ref ${{ github.ref_name }} \
             -f ref=refs/pull/${{ needs.verify.outputs.pr-number }}/merge \
             --repo streamlit/streamlit
         env:

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   FLAKY_VERIFY_LABEL: flaky-verify
@@ -30,7 +31,7 @@ jobs:
     outputs:
       runs: ${{ steps.compute.outputs.runs }}
       pr-number: ${{ steps.compute.outputs.pr_number }}
-      base-ref: ${{ steps.compute.outputs.base_ref }}
+      base_ref: ${{ steps.compute.outputs.base_ref }}
       matrix: ${{ steps.compute.outputs.matrix }}
     steps:
       - name: Compute inputs and matrix
@@ -47,10 +48,18 @@ jobs:
           echo "runs=$runs_input" >> "$GITHUB_OUTPUT"
 
           # Resolve PR number from input or event
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr_number }}" ]]; then
-            pr_number="${{ inputs.pr_number }}"
-          else
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ -n "${{ inputs.pr_number }}" ]]; then
+              pr_number="${{ inputs.pr_number }}"
+            else
+              echo "::error::No PR number provided. When using workflow_dispatch, the pr_number input is required."
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             pr_number="${{ github.event.pull_request.number }}"
+          else
+            echo "::error::Unsupported event type: ${{ github.event_name }}"
+            exit 1
           fi
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
@@ -78,6 +87,6 @@ jobs:
     uses: ./.github/workflows/playwright-changed-files.yml
     with:
       ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
-      base_ref: ${{ needs.verify.outputs.base-ref }}
+      base_ref: ${{ needs.verify.outputs.base_ref }}
       iteration: ${{ matrix.iteration }}
     secrets: inherit

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -1,6 +1,8 @@
 name: Flaky Test Verification
 
 on:
+  pull_request:
+    types: [labeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -63,11 +63,16 @@ jobs:
   e2e-changed-files-matrix:
     needs: verify
     if: needs.verify.outputs.pr-number != ''
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         iteration: ${{ fromJson(needs.verify.outputs.matrix) }}
-    uses: ./.github/workflows/playwright-changed-files.yml
-    with:
-      ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
-    secrets: inherit
+    steps:
+      - name: Trigger changed-files workflow (iteration ${{ matrix.iteration }})
+        run: |
+          gh workflow run playwright-changed-files.yml \
+            -f ref=refs/pull/${{ needs.verify.outputs.pr-number }}/merge \
+            --repo streamlit/streamlit
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -63,14 +63,11 @@ jobs:
   e2e-changed-files-matrix:
     needs: verify
     if: needs.verify.outputs.pr-number != ''
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         iteration: ${{ fromJson(needs.verify.outputs.matrix) }}
-    steps:
-      - name: Call changed-files workflow (iteration ${{ matrix.iteration }})
-        uses: ./.github/workflows/playwright-changed-files.yml
-        with:
-          ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
-        secrets: inherit
+    uses: ./.github/workflows/playwright-changed-files.yml
+    with:
+      ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
+    secrets: inherit

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -31,11 +31,14 @@ jobs:
     outputs:
       runs: ${{ steps.compute.outputs.runs }}
       pr-number: ${{ steps.compute.outputs.pr_number }}
+      base-ref: ${{ steps.compute.outputs.base_ref }}
       matrix: ${{ steps.compute.outputs.matrix }}
     steps:
       - name: Compute inputs and matrix
         id: compute
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Resolve runs
           runs_input="${{ inputs.runs }}"
@@ -46,10 +49,15 @@ jobs:
 
           # Resolve PR number from input or event
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr_number }}" ]]; then
-            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            pr_number="${{ inputs.pr_number }}"
           else
-            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            pr_number="${{ github.event.pull_request.number }}"
           fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+          # Get base branch for the PR
+          base_ref=$(gh api repos/streamlit/streamlit/pulls/$pr_number --jq '.base.ref')
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
 
           # Build JSON array for matrix
           json="["
@@ -74,6 +82,7 @@ jobs:
           gh workflow run playwright-changed-files.yml \
             --ref ${{ github.ref_name }} \
             -f ref=refs/pull/${{ needs.verify.outputs.pr-number }}/merge \
+            -f base_ref=${{ needs.verify.outputs.base-ref }} \
             --repo streamlit/streamlit
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -19,9 +19,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  FLAKY_VERIFY_LABEL: flaky-verify
-
 jobs:
   verify:
     if: |

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -24,6 +24,9 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'flaky-verify')
+    # ubuntu-latest (4 cores) is sufficient for this lightweight coordination job.
+    # The actual E2E test execution happens in the called workflow (playwright-changed-files.yml)
+    # which uses ubuntu-latest-8-cores.
     runs-on: ubuntu-latest
     outputs:
       runs: ${{ steps.compute.outputs.runs }}

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -55,9 +55,10 @@ jobs:
           fi
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
-          # Get base branch for the PR
-          base_ref=$(gh api repos/streamlit/streamlit/pulls/$pr_number --jq '.base.ref')
-          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+          # Get base ref/SHA for the PR
+          # Use base SHA for comparison since Graphite uses special base refs like "graphite-base/12922"
+          base_sha=$(gh api repos/streamlit/streamlit/pulls/$pr_number --jq '.base.sha')
+          echo "base_ref=$base_sha" >> "$GITHUB_OUTPUT"
 
           # Build JSON array for matrix
           json="["

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
 
 env:
   FLAKY_VERIFY_LABEL: flaky-verify

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -1,0 +1,76 @@
+name: Flaky Test Verification
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to verify
+        required: false
+        type: string
+      runs:
+        description: Number of times to run changed-files E2E
+        required: false
+        default: "50"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  FLAKY_VERIFY_LABEL: flaky-verify
+
+jobs:
+  verify:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == env.FLAKY_VERIFY_LABEL)
+    runs-on: ubuntu-latest
+    outputs:
+      runs: ${{ steps.compute.outputs.runs }}
+      pr-number: ${{ steps.compute.outputs.pr_number }}
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Compute inputs and matrix
+        id: compute
+        shell: bash
+        run: |
+          # Resolve runs
+          runs_input="${{ inputs.runs }}"
+          if [[ -z "$runs_input" ]]; then
+            runs_input="50"
+          fi
+          echo "runs=$runs_input" >> "$GITHUB_OUTPUT"
+
+          # Resolve PR number from input or event
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr_number }}" ]]; then
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Build JSON array for matrix
+          json="["
+          for i in $(seq 1 "$runs_input"); do
+            if [[ $i -gt 1 ]]; then json+=", "; fi
+            json+="$i"
+          done
+          json+="]"
+          echo "matrix=$json" >> "$GITHUB_OUTPUT"
+
+  e2e-changed-files-matrix:
+    needs: verify
+    if: needs.verify.outputs.pr-number != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        iteration: ${{ fromJson(needs.verify.outputs.matrix) }}
+    steps:
+      - name: Call changed-files workflow (iteration ${{ matrix.iteration }})
+        uses: ./.github/workflows/playwright-changed-files.yml
+        with:
+          ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
+        secrets: inherit

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 env:
   FLAKY_VERIFY_LABEL: flaky-verify
@@ -72,18 +71,12 @@ jobs:
   e2e-changed-files-matrix:
     needs: verify
     if: needs.verify.outputs.pr-number != ''
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         iteration: ${{ fromJson(needs.verify.outputs.matrix) }}
-    steps:
-      - name: Trigger changed-files workflow (iteration ${{ matrix.iteration }})
-        run: |
-          gh workflow run playwright-changed-files.yml \
-            --ref ${{ github.ref_name }} \
-            -f ref=refs/pull/${{ needs.verify.outputs.pr-number }}/merge \
-            -f base_ref=${{ needs.verify.outputs.base-ref }} \
-            --repo streamlit/streamlit
-        env:
-          GH_TOKEN: ${{ github.token }}
+    uses: ./.github/workflows/playwright-changed-files.yml
+    with:
+      ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
+      base_ref: ${{ needs.verify.outputs.base-ref }}
+    secrets: inherit

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -1,7 +1,7 @@
 name: Flaky Test Verification
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -23,7 +23,7 @@ jobs:
   verify:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'flaky-verify')
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'flaky-verify')
     # ubuntu-latest (4 cores) is sufficient for this lightweight coordination job.
     # The actual E2E test execution happens in the called workflow (playwright-changed-files.yml)
     # which uses ubuntu-latest-8-cores.
@@ -55,7 +55,7 @@ jobs:
               echo "::error::No PR number provided. When using workflow_dispatch, the pr_number input is required."
               exit 1
             fi
-          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             pr_number="${{ github.event.pull_request.number }}"
           else
             echo "::error::Unsupported event type: ${{ github.event_name }}"

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -79,4 +79,5 @@ jobs:
     with:
       ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
       base_ref: ${{ needs.verify.outputs.base-ref }}
+      iteration: ${{ matrix.iteration }}
     secrets: inherit

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -61,11 +61,21 @@ jobs:
             echo "::error::Unsupported event type: ${{ github.event_name }}"
             exit 1
           fi
+
+          # Validate pr_number is a positive integer
+          if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::PR number must be a positive integer, got: $pr_number"
+            exit 1
+          fi
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
           # Get base ref/SHA for the PR
           # Use base SHA for comparison since Graphite uses special base refs like "graphite-base/12922"
           base_sha=$(gh api repos/streamlit/streamlit/pulls/$pr_number --jq '.base.sha')
+          if [[ -z "$base_sha" ]]; then
+            echo "::error::Failed to retrieve base SHA for PR #$pr_number"
+            exit 1
+          fi
           echo "base_ref=$base_sha" >> "$GITHUB_OUTPUT"
 
           # Build JSON array for matrix

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -1,8 +1,6 @@
 name: Flaky Test Verification
 
 on:
-  pull_request:
-    types: [labeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -26,7 +26,7 @@ jobs:
   verify:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == env.FLAKY_VERIFY_LABEL)
+      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'flaky-verify')
     runs-on: ubuntu-latest
     outputs:
       runs: ${{ steps.compute.outputs.runs }}

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -197,11 +197,11 @@ jobs:
         uses: actions/upload-artifact@v5
         if: always()
         with:
-          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
+          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}${{ inputs.iteration != '' && format('_iter{0}', inputs.iteration) || '' }}
           path: e2e_playwright/test-results
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v5
         with:
-          name: coverage_report_e2e
+          name: coverage_report_e2e${{ inputs.iteration != '' && format('_iter{0}', inputs.iteration) || '' }}
           path: e2e_playwright/htmlcov
           retention-days: 14

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -161,6 +161,9 @@ jobs:
           else
             echo "run_tests=true" >> $GITHUB_OUTPUT
           fi
+      - name: Use output
+        run: |
+          echo "The output value is: ${{ steps.check_changed_files.outputs.run_tests }}"
       - name: Set Python version vars
         uses: ./.github/actions/build_info
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -41,7 +41,7 @@ on:
 # Concurrency control: cancel duplicate runs on same branch
 # When called via workflow_call with iteration input, include it to allow parallel matrix runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.iteration }}-playwright-changed-files
+  group: ${{ github.workflow }}-${{ github.ref }}${{ inputs.iteration && format('-{0}', inputs.iteration) || '' }}-playwright-changed-files
   cancel-in-progress: true
 
 jobs:
@@ -81,8 +81,8 @@ jobs:
           BASE_REF: ${{ inputs.base_ref || 'develop' }}
         run: |
           # Fetch base branch/SHA for comparison
-          # If BASE_REF looks like a branch name (no slashes or is develop/main), fetch it
-          if [[ "$BASE_REF" == "develop" ]] || [[ "$BASE_REF" == "main" ]] || [[ "$BASE_REF" != */* ]]; then
+          # If BASE_REF is not a SHA (not 40 hex chars), fetch it as a branch name
+          if [[ ! "$BASE_REF" =~ ^[0-9a-f]{40}$ ]]; then
             git fetch origin "${BASE_REF}:${BASE_REF}" 2>/dev/null || true
           fi
           # If it's a SHA, git already has it (we used fetch-depth: 0)

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -145,109 +145,6 @@ jobs:
           else
             echo "run_tests=true" >> $GITHUB_OUTPUT
           fi
-      - name: Get changed test nodeids
-        id: changed-nodeids
-        env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-          BASE_REF: ${{ inputs.base_ref || 'develop' }}
-        run: |
-          python3 - << 'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-          changed = os.environ.get('CHANGED_FILES', '').strip()
-          if not changed:
-            print('no changed files')
-            print('all_changed_nodeids=')
-            print('all_changed_nodeids_count=0')
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write('all_changed_nodeids=\n')
-              f.write('all_changed_nodeids_count=0\n')
-            sys.exit(0)
-
-          files = [p for p in changed.split(' ') if p]
-
-          def get_added_line_ranges(repo_path: str, file_rel: str):
-            # Returns list of (start, end) inclusive line ranges for additions in new file
-            base_ref = os.environ.get('BASE_REF', 'develop')
-            cmd = ['git', 'diff', '--unified=0', '--no-color', f'{base_ref}...HEAD', '--', os.path.join('e2e_playwright', file_rel)]
-            proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
-            ranges = []
-            for line in proc.stdout.splitlines():
-              if line.startswith('@@'):
-                # Example: @@ -12,0 +13,5 @@
-                m = re.search(r'\+([0-9]+)(?:,([0-9]+))?', line)
-                if not m:
-                  continue
-                start = int(m.group(1))
-                count = int(m.group(2) or '1')
-                if count == 0:
-                  continue
-                ranges.append((start, start + count - 1))
-            return ranges
-
-          import ast
-
-          def collect_test_nodes(abs_path: str, rel_path: str):
-            # Returns list of tuples: (nodeid, start, end)
-            with open(abs_path, 'r', encoding='utf-8') as fh:
-              source = fh.read()
-            tree = ast.parse(source)
-            nodes = []
-            # module-level tests
-            for n in tree.body:
-              if isinstance(n, ast.FunctionDef) and n.name.startswith('test_'):
-                start = getattr(n, 'lineno', None)
-                end = getattr(n, 'end_lineno', None)
-                if start and end:
-                  nodes.append((f"{rel_path}::" + n.name, start, end))
-              elif isinstance(n, ast.ClassDef) and n.name.startswith('Test'):
-                for m in n.body:
-                  if isinstance(m, ast.FunctionDef) and m.name.startswith('test_'):
-                    start = getattr(m, 'lineno', None)
-                    end = getattr(m, 'end_lineno', None)
-                    if start and end:
-                      nodes.append((f"{rel_path}::" + n.name + '::' + m.name, start, end))
-            return nodes
-
-          nodeids = []
-          for rel in files:
-            abs_path = os.path.join('e2e_playwright', rel)
-            if not os.path.isfile(abs_path):
-              continue
-            if not abs_path.endswith('_test.py'):
-              # Only derive nodeids for test files
-              continue
-            ranges = get_added_line_ranges('.', rel)
-            if not ranges:
-              # If we cannot detect specific changed lines, skip; we'll fallback to file-level
-              continue
-            tests = collect_test_nodes(abs_path, rel)
-            for nodeid, start, end in tests:
-              for rstart, rend in ranges:
-                if not (end < rstart or start > rend):
-                  nodeids.append(nodeid)
-                  break
-
-          # Deduplicate while preserving order
-          seen = set()
-          nodeids_unique = []
-          for nid in nodeids:
-            if nid not in seen:
-              seen.add(nid)
-              nodeids_unique.append(nid)
-
-          joined = ' '.join(nodeids_unique)
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            f.write(f'all_changed_nodeids={joined}\n')
-            f.write(f'all_changed_nodeids_count={len(nodeids_unique)}\n')
-          PY
-      - name: Use output
-        run: |
-          echo "The output value is: ${{ steps.check_changed_files.outputs.run_tests }}"
       - name: Set Python version vars
         uses: ./.github/actions/build_info
       - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
@@ -272,21 +169,14 @@ jobs:
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
           fi
       - name: Run changed playwright tests
-        if: steps.changed-nodeids.outputs.all_changed_nodeids_count != '0' || steps.check_changed_files.outputs.run_tests == 'true'
+        if: steps.check_changed_files.outputs.run_tests == 'true'
         env:
-          NODEIDS: ${{ steps.changed-nodeids.outputs.all_changed_nodeids }}
-          NODEIDS_COUNT: ${{ steps.changed-nodeids.outputs.all_changed_nodeids_count }}
           FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           cd e2e_playwright
           rm -rf ./test-results
-          if [[ -n "$NODEIDS" && "$NODEIDS_COUNT" != "0" ]]; then
-            echo "Running specific changed tests: $NODEIDS"
-            pytest $NODEIDS --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
-          else
-            echo "Running changed files: $FILES"
-            pytest $FILES --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
-          fi
+          echo "Running changed test files: $FILES"
+          pytest $FILES --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
       - name: Upload failed test results
         uses: actions/upload-artifact@v5
         if: always()

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -194,13 +194,11 @@ jobs:
           fi
       - name: Run changed playwright tests
         if: steps.check_changed_files.outputs.run_tests == 'true'
-        env:
-          FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           cd e2e_playwright
           rm -rf ./test-results
-          echo "Running changed test files: $FILES"
-          pytest $FILES --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
+          echo "Running changed test files: ${{ steps.changed-files.outputs.all_changed_files }}"
+          pytest ${{ steps.changed-files.outputs.all_changed_files }} --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
       - name: Upload failed test results
         uses: actions/upload-artifact@v5
         if: always()

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
         default: ""
+      base_ref:
+        description: Base branch/SHA to compare against (e.g., develop, commit SHA, or parent in stack)
+        required: false
+        type: string
+        default: "develop"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -28,10 +28,8 @@ on:
         type: string
         default: "develop"
 
-# Avoid duplicate workflows on same branch (but allow parallel runs when called via workflow_call)
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}-playwright-changed-files
-  cancel-in-progress: true
+# Note: No workflow-level concurrency control to allow parallel matrix runs when called via workflow_call.
+# For pull_request triggers, GitHub automatically handles duplicate runs via PR-level concurrency.
 
 jobs:
   playwright-e2e-tests-changed-files:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: string
         default: "develop"
+      iteration:
+        description: Iteration number for matrix runs (used for unique concurrency groups)
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       ref:
@@ -27,9 +32,17 @@ on:
         required: false
         type: string
         default: "develop"
+      iteration:
+        description: Iteration number for matrix runs (used for unique concurrency groups)
+        required: false
+        type: string
+        default: ""
 
-# Note: No workflow-level concurrency control to allow parallel matrix runs when called via workflow_call.
-# For pull_request triggers, GitHub automatically handles duplicate runs via PR-level concurrency.
+# Concurrency control: cancel duplicate runs on same branch
+# When called via workflow_call with iteration input, include it to allow parallel matrix runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.iteration }}-playwright-changed-files
+  cancel-in-progress: true
 
 jobs:
   playwright-e2e-tests-changed-files:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: ""
       base_ref:
-        description: Base branch to compare against (e.g., develop, or parent branch in a stack)
+        description: Base branch/SHA to compare against (e.g., develop, commit SHA, or parent in stack)
         required: false
         type: string
         default: "develop"
@@ -59,10 +59,14 @@ jobs:
         env:
           BASE_REF: ${{ inputs.base_ref || 'develop' }}
         run: |
-          # Fetch base branch for comparison
-          git fetch origin "${BASE_REF}:${BASE_REF}" 2>/dev/null || true
+          # Fetch base branch/SHA for comparison
+          # If BASE_REF looks like a branch name (no slashes or is develop/main), fetch it
+          if [[ "$BASE_REF" == "develop" ]] || [[ "$BASE_REF" == "main" ]] || [[ "$BASE_REF" != */* ]]; then
+            git fetch origin "${BASE_REF}:${BASE_REF}" 2>/dev/null || true
+          fi
+          # If it's a SHA, git already has it (we used fetch-depth: 0)
 
-          # Get all changed files comparing against base branch
+          # Get all changed files comparing against base
           git_output=$(git diff --name-only "${BASE_REF}...HEAD")
 
           # Filter files in e2e_playwright directory and find relevant test files

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -28,9 +28,9 @@ on:
         type: string
         default: "develop"
 
-# Avoid duplicate workflows on same branch
+# Avoid duplicate workflows on same branch (but allow parallel runs when called via workflow_call)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-playwright-changed-files
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}-playwright-changed-files
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -3,6 +3,13 @@ name: Playwright E2E Tests - Changed Files
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch, SHA) or PR merge ref to checkout
+        required: false
+        type: string
+        default: ""
 
 # Avoid duplicate workflows on same branch
 concurrency:
@@ -19,10 +26,19 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout Streamlit code
+      - name: Checkout Streamlit code (ref input)
+        if: inputs.ref != ''
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: 2
+      - name: Checkout Streamlit code (PR head)
+        if: inputs.ref == ''
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
           persist-credentials: false
           submodules: "recursive"
           fetch-depth: 2
@@ -108,6 +124,104 @@ jobs:
           else
             echo "run_tests=true" >> $GITHUB_OUTPUT
           fi
+      - name: Get changed test nodeids
+        id: changed-nodeids
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          python3 - << 'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          changed = os.environ.get('CHANGED_FILES', '').strip()
+          if not changed:
+            print('no changed files')
+            print('all_changed_nodeids=')
+            print('all_changed_nodeids_count=0')
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write('all_changed_nodeids=\n')
+              f.write('all_changed_nodeids_count=0\n')
+            sys.exit(0)
+
+          files = [p for p in changed.split(' ') if p]
+
+          def get_added_line_ranges(repo_path: str, file_rel: str):
+            # Returns list of (start, end) inclusive line ranges for additions in new file
+            cmd = ['git', 'diff', '--unified=0', '--no-color', 'HEAD^', 'HEAD', '--', os.path.join('e2e_playwright', file_rel)]
+            proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+            ranges = []
+            for line in proc.stdout.splitlines():
+              if line.startswith('@@'):
+                # Example: @@ -12,0 +13,5 @@
+                m = re.search(r'\+([0-9]+)(?:,([0-9]+))?', line)
+                if not m:
+                  continue
+                start = int(m.group(1))
+                count = int(m.group(2) or '1')
+                if count == 0:
+                  continue
+                ranges.append((start, start + count - 1))
+            return ranges
+
+          import ast
+
+          def collect_test_nodes(abs_path: str, rel_path: str):
+            # Returns list of tuples: (nodeid, start, end)
+            with open(abs_path, 'r', encoding='utf-8') as fh:
+              source = fh.read()
+            tree = ast.parse(source)
+            nodes = []
+            # module-level tests
+            for n in tree.body:
+              if isinstance(n, ast.FunctionDef) and n.name.startswith('test_'):
+                start = getattr(n, 'lineno', None)
+                end = getattr(n, 'end_lineno', None)
+                if start and end:
+                  nodes.append((f"{rel_path}::" + n.name, start, end))
+              elif isinstance(n, ast.ClassDef) and n.name.startswith('Test'):
+                for m in n.body:
+                  if isinstance(m, ast.FunctionDef) and m.name.startswith('test_'):
+                    start = getattr(m, 'lineno', None)
+                    end = getattr(m, 'end_lineno', None)
+                    if start and end:
+                      nodes.append((f"{rel_path}::" + n.name + '::' + m.name, start, end))
+            return nodes
+
+          nodeids = []
+          for rel in files:
+            abs_path = os.path.join('e2e_playwright', rel)
+            if not os.path.isfile(abs_path):
+              continue
+            if not abs_path.endswith('_test.py'):
+              # Only derive nodeids for test files
+              continue
+            ranges = get_added_line_ranges('.', rel)
+            if not ranges:
+              # If we cannot detect specific changed lines, skip; we'll fallback to file-level
+              continue
+            tests = collect_test_nodes(abs_path, rel)
+            for nodeid, start, end in tests:
+              for rstart, rend in ranges:
+                if not (end < rstart or start > rend):
+                  nodeids.append(nodeid)
+                  break
+
+          # Deduplicate while preserving order
+          seen = set()
+          nodeids_unique = []
+          for nid in nodeids:
+            if nid not in seen:
+              seen.add(nid)
+              nodeids_unique.append(nid)
+
+          joined = ' '.join(nodeids_unique)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f'all_changed_nodeids={joined}\n')
+            f.write(f'all_changed_nodeids_count={len(nodeids_unique)}\n')
+          PY
       - name: Use output
         run: |
           echo "The output value is: ${{ steps.check_changed_files.outputs.run_tests }}"
@@ -134,12 +248,22 @@ jobs:
           else
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
           fi
-      - if: steps.check_changed_files.outputs.run_tests == 'true'
-        name: Run changed playwright tests
+      - name: Run changed playwright tests
+        if: steps.changed-nodeids.outputs.all_changed_nodeids_count != '0' || steps.check_changed_files.outputs.run_tests == 'true'
+        env:
+          NODEIDS: ${{ steps.changed-nodeids.outputs.all_changed_nodeids }}
+          NODEIDS_COUNT: ${{ steps.changed-nodeids.outputs.all_changed_nodeids_count }}
+          FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           cd e2e_playwright
           rm -rf ./test-results
-          pytest ${{ steps.changed-files.outputs.all_changed_files }} --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
+          if [[ -n "$NODEIDS" && "$NODEIDS_COUNT" != "0" ]]; then
+            echo "Running specific changed tests: $NODEIDS"
+            pytest $NODEIDS --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
+          else
+            echo "Running changed files: $FILES"
+            pytest $FILES --browser webkit --browser chromium --browser firefox --tracing retain-on-failure -n auto --reruns 0 --cov=streamlit --cov-config=.coveragerc --cov-report=html
+          fi
       - name: Upload failed test results
         uses: actions/upload-artifact@v5
         if: always()

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -69,7 +69,7 @@ jobs:
           ref: ${{ github.head_ref }}
           persist-credentials: false
           submodules: "recursive"
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Get changed files
         id: changed-files
         env:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -10,6 +10,13 @@ on:
         required: false
         type: string
         default: ""
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, SHA) or PR merge ref to checkout
+        required: false
+        type: string
+        default: ""
 
 # Avoid duplicate workflows on same branch
 concurrency:

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ""
+      base_ref:
+        description: Base branch to compare against (e.g., develop, or parent branch in a stack)
+        required: false
+        type: string
+        default: "develop"
 
 # Avoid duplicate workflows on same branch
 concurrency:
@@ -40,7 +45,7 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: "recursive"
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Checkout Streamlit code (PR head)
         if: inputs.ref == ''
         uses: actions/checkout@v5
@@ -51,9 +56,14 @@ jobs:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
+        env:
+          BASE_REF: ${{ inputs.base_ref || 'develop' }}
         run: |
-          # Get all changed files using git diff-tree
-          git_output=$(git diff-tree --no-commit-id --name-only -r HEAD^ HEAD)
+          # Fetch base branch for comparison
+          git fetch origin "${BASE_REF}:${BASE_REF}" 2>/dev/null || true
+
+          # Get all changed files comparing against base branch
+          git_output=$(git diff --name-only "${BASE_REF}...HEAD")
 
           # Filter files in e2e_playwright directory and find relevant test files
           # Includes both changed test files and test files for changed app scripts
@@ -135,6 +145,7 @@ jobs:
         id: changed-nodeids
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          BASE_REF: ${{ inputs.base_ref || 'develop' }}
         run: |
           python3 - << 'PY'
           import json
@@ -157,7 +168,8 @@ jobs:
 
           def get_added_line_ranges(repo_path: str, file_rel: str):
             # Returns list of (start, end) inclusive line ranges for additions in new file
-            cmd = ['git', 'diff', '--unified=0', '--no-color', 'HEAD^', 'HEAD', '--', os.path.join('e2e_playwright', file_rel)]
+            base_ref = os.environ.get('BASE_REF', 'develop')
+            cmd = ['git', 'diff', '--unified=0', '--no-color', f'{base_ref}...HEAD', '--', os.path.join('e2e_playwright', file_rel)]
             proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
             ranges = []
             for line in proc.stdout.splitlines():

--- a/.github/workflows/playwright-changed-files.yml
+++ b/.github/workflows/playwright-changed-files.yml
@@ -54,6 +54,11 @@ jobs:
         shell: bash
 
     steps:
+      - name: Validate ref for workflow_call
+        if: github.event_name == 'workflow_call' && inputs.ref == ''
+        run: |
+          echo "::error::ref input is required when calling this workflow via workflow_call"
+          exit 1
       - name: Checkout Streamlit code (ref input)
         if: inputs.ref != ''
         uses: actions/checkout@v5
@@ -63,7 +68,7 @@ jobs:
           submodules: "recursive"
           fetch-depth: 0
       - name: Checkout Streamlit code (PR head)
-        if: inputs.ref == ''
+        if: inputs.ref == '' && github.event_name == 'pull_request'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
## Describe your changes

Added a new GitHub workflow for flaky test verification that allows running E2E tests multiple times to identify intermittent failures. The workflow can be triggered in two ways:

1. By adding the `flaky-verify` label to a PR (This one I have not been able to test because as far as I can tell, it only works when the workflow already exists in develop? If someone knows better, please correct me here.)
2. By manually triggering the workflow with a PR number and optional run count (This one is working: https://github.com/streamlit/streamlit/actions/workflows/flaky-test-verification.yml)

Also enhanced the existing `playwright-changed-files.yml` workflow to:
- Support being called from other workflows via `workflow_call`
- Accept custom git refs and base refs for comparison
- Support matrix runs with unique concurrency groups
- Improve changed file detection by comparing against a specified base ref
- Add better artifact naming for matrix runs

## Testing Plan

The flaky test verification workflow has been thoroughly tested using manual triggers:

  #### Test with 2 runs
 `gh workflow run flaky-test-verification.yml --ref 11-04-flaky_test_detector -f pr_number=12922 -f runs=2`

  #### Test with 5 runs
  `gh workflow run flaky-test-verification.yml --ref 11-04-flaky_test_detector -f pr_number=12922 -f runs=5`

  Verified functionality:
  - ✅ Workflow successfully detects PR base branch/SHA (supports Graphite stacks)
  - ✅ Triggers multiple concurrent runs of E2E tests
  - ✅ Correctly identifies changed test files
  - ✅ Runs changed tests against the PR merge ref
  - ✅ Works with stacked PRs (uses base SHA instead of branch name)

>[!NOTE]
> This originally used `pull_request_target`, but we switched it to use `pull_request` for security reasons and to closer align with our other workflows
>

  🧪 How to Test After Merge

  Once this PR is merged to develop:

  1. Go to any PR with E2E test changes (e.g., PR #12922, #12923, or #12927)
  2. Add the flaky-verify label
  3. The workflow should automatically trigger and run the tests N times (default: 50)
  4. Check the "Actions" tab to see the workflow run

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.