### PR TITLE
[fix] Simplify the semgrep CI conditions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,24 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  # Internal PRs (same-repo branches): run the full Semgrep reusable workflow
-  # with app token.
   run-semgrep-reusable-workflow:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     uses: snowflakedb/reusable-workflows/.github/workflows/semgrep-v2.yml@main
     secrets:
       token: ${{ secrets.SEMGREP_APP_TOKEN }}
-  # Forked PRs: skip the Semgrep reusable workflow and just print a message so
-  # it prints a status and does not block merges. This mirrors patterns in other
-  # workflows where secret-using steps are skipped for forks.
-  # Any code integrated into `develop` will be scanned by Semgrep in other PRs,
-  # notably the release branch -> `develop` PR that is created for every new
-  # release.
-  run-semgrep-fork-safe:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Skip Semgrep for forked PRs
-        run: |
-          echo "Semgrep App scan requires repo secrets and is skipped for forked PRs."
-          echo "This job exists to keep the workflow green for forks, matching other workflows' behavior."


### PR DESCRIPTION
## Describe your changes

- Seems like https://github.com/streamlit/streamlit/pull/12920 actually made things more complicated than necessary.
- Before some of these changes we just had semgrep running on code to `develop`, without filtering on repo name specifically: https://github.com/streamlit/streamlit/blob/8278041b0fc36660db4faa5a8534eba58edb600b/.github/workflows/semgrep.yml
  - This PR effectively brings us back to this pattern, but without filtering only on `develop`.

## GitHub Issue Link (if applicable)

## Testing Plan

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
