### PR TITLE
Fix flaky websocket reconnect e2e test

### DIFF
--- a/e2e_playwright/websocket_reconnects_test.py
+++ b/e2e_playwright/websocket_reconnects_test.py
@@ -22,6 +22,7 @@ from e2e_playwright.shared.app_utils import (
     click_button,
     expect_connection_status,
     expect_markdown,
+    expect_script_state,
     get_checkbox,
 )
 
@@ -64,8 +65,13 @@ def test_reruns_script_when_interrupted_by_websocket_disconnect(
     # Click on the checkbox, but don't wait for the app to finish running.
     get_checkbox(app, "do something slow").locator("label").click()
 
+    # Wait for the script rerun to start.
+    expect_script_state(app, "running")
+
+    # Disconnect the websocket and wait for status to jump to CONNECTING.
     expect_connection_status(app, "CONNECTING", DISCONNECT_WEBSOCKET_ACTION)
 
+    # Wait for the app to connect again and finish running.
     wait_for_app_run(app)
     expect_markdown(app, "slow operations attempted: 2")
 


### PR DESCRIPTION
## Describe your changes

Attempts to fix a flaky websocket reconnect e2e test by waiting for the script to actually start running before triggering the disconnect.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Waits for script to be "running" before disconnecting the websocket to stabilize the reconnect e2e test.
> 
> - **E2E Tests**:
>   - `e2e_playwright/websocket_reconnects_test.py`:
>     - Use `expect_script_state(app, "running")` before triggering websocket disconnect in `test_reruns_script_when_interrupted_by_websocket_disconnect`.
>     - Import `expect_script_state` from `e2e_playwright.shared.app_utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5533775cfd70f9d3becaf85c9f3110de5005a580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->