### PR TITLE
Fix `MultiselectColumn` issue when starting with empty rows

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -198,7 +198,7 @@ def _parse_value(
     import pandas as pd
 
     try:
-        if column_data_kind == ColumnDataKind.LIST:
+        if column_data_kind in (ColumnDataKind.LIST, ColumnDataKind.EMPTY):
             return list(value) if is_list_like(value) else [value]  # ty: ignore
 
         if column_data_kind == ColumnDataKind.STRING:
@@ -209,7 +209,7 @@ def _parse_value(
         # This isn't expected to happen.
         if isinstance(value, list):
             raise TypeError(  # noqa: TRY301
-                "List values are only supported by list and string columns."
+                "List values are only supported by list, string and empty columns."
             )
 
         if column_data_kind == ColumnDataKind.INTEGER:

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -153,6 +153,11 @@ class DataEditorUtilTest(unittest.TestCase):
                 ColumnDataKind.LIST,
                 ["foo"],
             ),
+            (
+                ["foo"],
+                ColumnDataKind.EMPTY,
+                ["foo"],
+            ),
         ]
     )
     def test_parse_value(


### PR DESCRIPTION
## Describe your changes

Fix an issue with `MultiselectColumn` when starting from empty rows.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/12842

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat `ColumnDataKind.EMPTY` like `LIST` in `_parse_value`, enabling list conversion for empty columns; add unit test coverage.
> 
> - **Data parsing**:
>   - Update `_parse_value` to handle `ColumnDataKind.EMPTY` like `LIST`, converting inputs to lists and adjusting the TypeError message accordingly.
> - **Tests**:
>   - Add test case asserting list parsing for `ColumnDataKind.EMPTY` in `data_editor_test.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a46cb2bc7358eef19710923abaf6d503a18578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->