### PR TITLE
Fix `MultiselectColumn` shape error when adding data

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -320,6 +320,20 @@ def _parse_added_row(
     return index_value, new_row
 
 
+def _assign_row_values(
+    df: pd.DataFrame,
+    row_label: Any,
+    row_values: list[Any],
+) -> None:
+    """Assign values to a dataframe row via a mapping.
+
+    This avoids numpy attempting to coerce nested sequences (e.g. lists) into
+    multi-dimensional arrays when a column legitimately stores list values.
+    """
+
+    df.loc[row_label] = dict(zip(df.columns, row_values, strict=True))
+
+
 def _apply_row_additions(
     df: pd.DataFrame,
     added_rows: list[dict[str, Any]],
@@ -376,13 +390,13 @@ def _apply_row_additions(
             # already exists. In the future, it would be better to
             # require users to provide unique non-None values for the index with
             # some kind of visual indications.
-            df.loc[index_value, :] = new_row
+            _assign_row_values(df, index_value, new_row)
             continue
 
         if index_stop is not None and index_step is not None:
             # Case 2: Range or integer index that can be auto incremented.
             # Add row using the next value in the sequence
-            df.loc[index_stop, :] = new_row
+            _assign_row_values(df, index_stop, new_row)
             # Increment to the next range index value
             index_stop += index_step
             continue

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -219,12 +219,25 @@ class DataEditorUtilTest(unittest.TestCase):
                     datetime.datetime.now(),
                     datetime.datetime.now(),
                 ],
+                "col5": [["x"], ["y"], ["z"]],
             }
         )
 
         added_rows: list[dict[str, Any]] = [
-            {"col1": 10, "col2": "foo", "col3": False, "col4": "2020-03-20T14:28:23"},
-            {"col1": 11, "col2": "bar", "col3": True, "col4": "2023-03-20T14:28:23"},
+            {
+                "col1": 10,
+                "col2": "foo",
+                "col3": False,
+                "col4": "2020-03-20T14:28:23",
+                "col5": ["x", "y"],
+            },
+            {
+                "col1": 11,
+                "col2": "bar",
+                "col3": True,
+                "col4": "2023-03-20T14:28:23",
+                "col5": ["z"],
+            },
         ]
 
         _apply_row_additions(
@@ -232,6 +245,9 @@ class DataEditorUtilTest(unittest.TestCase):
         )
 
         assert len(df) == 5
+        assert df.loc[3, "col5"] == ["x", "y"]
+        assert df.loc[4, "col5"] == ["z"]
+        assert pd.api.types.is_bool_dtype(df["col3"])
 
     def test_apply_row_deletions(self):
         """Test applying row deletions to a DataFrame."""


### PR DESCRIPTION
## Describe your changes

Fixes an issue when adding new data to `MultiselectColumn` resulting in a wrong shape error.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/12815

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use dict-based row assignment to preserve list values during row additions and add tests covering list columns.
> 
> - **Data Editor (backend)**:
>   - Introduce `_assign_row_values` to assign rows via `dict(zip(df.columns, row_values))`.
>   - Replace `df.loc[...]=new_row` in `_apply_row_additions` with `_assign_row_values` to prevent NumPy coercion of list values.
> - **Tests** (`lib/tests/streamlit/elements/data_editor_test.py`):
>   - Extend `test_apply_row_additions` with list column `col5` and verify list values persist and dtypes remain correct.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8abaf7617b27e8426c2d0486a163bcfea5e54068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->