### PR TITLE
Update `ty` type checker to alpha25

### DIFF
--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -1,6 +1,6 @@
 pre-commit
 # We fix ty to a version since its still in preview and likely breaks our CI on updates:
-ty==0.0.1a23
+ty==0.0.1a25
 # We fix ruff to a version to be in sync with the pre-commit hook:
 ruff==0.14.2
 # We are pinning the upper version to not break our CI on updates,

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -145,28 +145,22 @@ class ContextVarWithLazyDefault(Generic[_T]):
         self._default = default
         self._context_var: ContextVar[_T] | None = None
 
-    def _init_context_var(self) -> None:
-        self._context_var = ContextVar(self._name, default=self._default())  # noqa: B039
+    def _ensure_context_var(self) -> ContextVar[_T]:
+        if self._context_var is None:
+            self._context_var = ContextVar(self._name, default=self._default())  # noqa: B039
+        return self._context_var
 
     def get(self) -> _T:
-        if self._context_var is None:
-            self._init_context_var()
-        return self._context_var.get()  # type: ignore[union-attr]
+        return self._ensure_context_var().get()
 
     def set(self, value: _T) -> Token[_T]:
-        if self._context_var is None:
-            self._init_context_var()
-        return self._context_var.set(value)  # type: ignore[union-attr]
+        return self._ensure_context_var().set(value)
 
     def reset(self, token: Token[_T]) -> None:
-        if self._context_var is None:
-            self._init_context_var()
-        self._context_var.reset(token)  # type: ignore[union-attr]
+        self._ensure_context_var().reset(token)
 
     def __hash__(self) -> int:
-        if self._context_var is None:
-            self._init_context_var()
-        return self._context_var.__hash__()
+        return self._ensure_context_var().__hash__()
 
 
 # we don't use the default factory here because `main_dg` is not initialized when this

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -79,7 +79,7 @@ class GitRepo:
 
             if self.git_version is not None and self.git_version >= _MIN_GIT_VERSION:
                 git_root = self.repo.git.rev_parse("--show-toplevel")
-                self.module = os.path.relpath(path, git_root)
+                self.module = str(os.path.relpath(path, git_root))
         except Exception:
             _LOGGER.debug(
                 "Did not find a git repo at %s. This is expected if this isn't a git repo, but could "

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -372,7 +372,7 @@ class CacheDataAPI:
         hash_funcs: HashFuncsDict | None = None,
     ) -> CachedFunc[P, R] | Callable[[Callable[P, R]], CachedFunc[P, R]]:
         return self._decorator(
-            func,
+            func,  # ty: ignore[invalid-argument-type]
             ttl=ttl,
             max_entries=max_entries,
             persist=persist,

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -247,8 +247,8 @@ class CacheResourceAPI:
         validate: ValidateFunc | None = None,
         hash_funcs: HashFuncsDict | None = None,
     ) -> CachedFunc[P, R] | Callable[[Callable[P, R]], CachedFunc[P, R]]:
-        return self._decorator(
-            func,
+        return self._decorator(  # ty: ignore
+            func,  # ty: ignore[invalid-argument-type]
             ttl=ttl,
             max_entries=max_entries,
             show_spinner=show_spinner,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import pickle
-from collections.abc import Iterator, KeysView, MutableMapping
+from collections.abc import Iterator, KeysView, Mapping, MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import (
@@ -726,7 +726,7 @@ class SessionState:
 
             for payload in payloads:
                 if isinstance(payload, dict):
-                    event_name = payload.get("event")
+                    event_name = cast("Mapping[str, object]", payload).get("event")
                     if isinstance(event_name, str) and metadata.callbacks:
                         cb = metadata.callbacks.get(event_name)
                         if cb is not None:

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -94,7 +94,11 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         files: dict[str, list[Any]] = {}
 
         if not self.path_kwargs:
-            self.send_error(404, reason="No path kwargs provided.")
+            # This is not expected to happen with normal Streamlit usage.
+            self.send_error(
+                400,
+                reason="No path arguments provided. Please provide a session_id and file_id in the URL.",
+            )
             return
 
         session_id = self.path_kwargs["session_id"]

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -145,7 +145,10 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         """Delete file request handler."""
 
         if not self.path_kwargs:
-            self.send_error(404, reason="No path kwargs provided.")
+            self.send_error(
+                400,
+                reason="No path arguments provided. Please provide a session_id and file_id in the URL.",
+            )
             return
 
         session_id = self.path_kwargs["session_id"]

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -93,6 +93,10 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         args: dict[str, list[bytes]] = {}
         files: dict[str, list[Any]] = {}
 
+        if not self.path_kwargs:
+            self.send_error(404, reason="No path kwargs provided.")
+            return
+
         session_id = self.path_kwargs["session_id"]
         file_id = self.path_kwargs["file_id"]
 
@@ -135,6 +139,11 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
 
     def delete(self, **kwargs: Any) -> None:
         """Delete file request handler."""
+
+        if not self.path_kwargs:
+            self.send_error(404, reason="No path kwargs provided.")
+            return
+
         session_id = self.path_kwargs["session_id"]
         file_id = self.path_kwargs["file_id"]
 

--- a/ty.toml
+++ b/ty.toml
@@ -17,7 +17,10 @@ root = ["./lib/streamlit"]
 
 [src]
 include = ["lib/streamlit", "e2e_playwright", "scripts"]
-exclude = ["e2e_playwright/compilation_error_dialog.py"]
+exclude = [
+  "e2e_playwright/compilation_error_dialog.py",
+  "lib/streamlit/vendor/**",
+]
 
 
 [rules]


### PR DESCRIPTION
## Describe your changes

Updates the `ty` type checker to alpha25 and fixes some typing issues. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `ty` to alpha25, updates its config, fixes/clarifies typing across modules, and adds path-argument validation to the upload-file handler.
> 
> - **Type checker**:
>   - Upgrade `ty` to `0.0.1a25` in `lib/dev-requirements.txt` and expand `ty.toml` excludes to `lib/streamlit/vendor/**`.
> - **Typing fixes/adjustments**:
>   - `delta_generator_singletons.py`: replace lazy ContextVar init with `_ensure_context_var()` and simplify `get/set/reset/__hash__` calls.
>   - `git_util.py`: ensure `module` is `str` via `str(os.path.relpath(...))`.
>   - `cache_data_api.py` / `cache_resource_api.py`: add `ty` ignore hints when forwarding optional `func` to decorators.
>   - `session_state.py`: import `Mapping` and use `cast` for JSON event payload access in trigger dispatch.
> - **Server**:
>   - `upload_file_request_handler.py`: validate presence of `path_kwargs` and return `400` for missing `session_id`/`file_id` in `PUT` and `DELETE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec3662058b1600aba9dc605051d253ab0f6598b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->