### PR TITLE
Add hints about e2e test results to agent rules

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -16,8 +16,11 @@ We use playwright with pytest to e2e test Streamlit library. E2E tests verify th
   - `*_test.py`: Playwright pytest file that runs the app and tests it
 - If the test is specific to a Streamlit element, prefix the filename with `st_<element_name>`
 - Tests can use screenshot comparisons for visual verification
-- Screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
-- Other test results are stored in `e2e_playwright/test_results/`
+- All screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
+- Other e2e test results are stored in `e2e_playwright/test_results/` which includes:
+  - `e2e_playwright/test_results/<test_name>/`: Video and traces related to the failed test.
+  - `e2e_playwright/test_results/snapshot-tests-failures/<os>/<test_script>/<test_name>/`: Expected, actual, and diff screenshots of the failed snapshot test.
+  - `e2e_playwright/test_results/snapshot-updates/<os>/<test_script>/<test_name>/`: All updated screenshots of the failed test.
 
 ## Key Fixtures and Utilities
 

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -74,6 +74,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
+- The hot-reload dev server for the frontend will be available at <http://localhost:3000>.
 
 ## Testing Strategy
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
+- The hot-reload dev server for the frontend will be available at <http://localhost:3000>.
 
 ## Testing Strategy
 

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -14,8 +14,11 @@ We use playwright with pytest to e2e test Streamlit library. E2E tests verify th
   - `*_test.py`: Playwright pytest file that runs the app and tests it
 - If the test is specific to a Streamlit element, prefix the filename with `st_<element_name>`
 - Tests can use screenshot comparisons for visual verification
-- Screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
-- Other test results are stored in `e2e_playwright/test_results/`
+- All screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
+- Other e2e test results are stored in `e2e_playwright/test_results/` which includes:
+  - `e2e_playwright/test_results/<test_name>/`: Video and traces related to the failed test.
+  - `e2e_playwright/test_results/snapshot-tests-failures/<os>/<test_script>/<test_name>/`: Expected, actual, and diff screenshots of the failed snapshot test.
+  - `e2e_playwright/test_results/snapshot-updates/<os>/<test_script>/<test_name>/`: All updated screenshots of the failed test.
 
 ## Key Fixtures and Utilities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
+- The hot-reload dev server for the frontend will be available at <http://localhost:3000>.
 
 ## Testing Strategy
 

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -10,8 +10,11 @@ We use playwright with pytest to e2e test Streamlit library. E2E tests verify th
   - `*_test.py`: Playwright pytest file that runs the app and tests it
 - If the test is specific to a Streamlit element, prefix the filename with `st_<element_name>`
 - Tests can use screenshot comparisons for visual verification
-- Screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
-- Other test results are stored in `e2e_playwright/test_results/`
+- All screenshots are stored in `e2e_playwright/__snapshots__/<os>/`
+- Other e2e test results are stored in `e2e_playwright/test_results/` which includes:
+  - `e2e_playwright/test_results/<test_name>/`: Video and traces related to the failed test.
+  - `e2e_playwright/test_results/snapshot-tests-failures/<os>/<test_script>/<test_name>/`: Expected, actual, and diff screenshots of the failed snapshot test.
+  - `e2e_playwright/test_results/snapshot-updates/<os>/<test_script>/<test_name>/`: All updated screenshots of the failed test.
 
 ## Key Fixtures and Utilities
 

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -826,7 +826,7 @@ def assert_snapshot(
 
             error_msg = (
                 f"Snapshot mismatch for {snapshot_file_name} ({mismatch} pixels difference;"
-                f" {mismatch / total_pixels * 100:.2f}%). "
+                f" {mismatch / total_pixels * 100:.2f}%)"
             )
 
             # Create new failures folder for this test:
@@ -860,7 +860,7 @@ def assert_snapshot(
                 f"Wrong size: expected={img_b.size}, actual={img_a.size} "
                 f"({pixel_diff} pixels difference; "
                 f"{pixel_diff / expected_pixels * 100:.2f}%). "
-                f"Error: {ex}. "
+                f"Error: {ex}"
             )
 
         if is_last_rerun:

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -826,7 +826,8 @@ def assert_snapshot(
 
             error_msg = (
                 f"Snapshot mismatch for {snapshot_file_name} ({mismatch} pixels difference;"
-                f" {mismatch / total_pixels * 100:.2f}%)"
+                f" {mismatch / total_pixels * 100:.2f}%). "
+                f"Find the diff, actual, and expected screenshots in {test_failures_dir}."
             )
 
             # Create new failures folder for this test:
@@ -860,7 +861,8 @@ def assert_snapshot(
                 f"Wrong size: expected={img_b.size}, actual={img_a.size} "
                 f"({pixel_diff} pixels difference; "
                 f"{pixel_diff / expected_pixels * 100:.2f}%). "
-                f"Error: {ex}"
+                f"Find the actual and expected screenshots in {test_failures_dir}. "
+                f"Error: {ex}. "
             )
 
         if is_last_rerun:

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -827,7 +827,6 @@ def assert_snapshot(
             error_msg = (
                 f"Snapshot mismatch for {snapshot_file_name} ({mismatch} pixels difference;"
                 f" {mismatch / total_pixels * 100:.2f}%). "
-                f"Find the diff, actual, and expected screenshots in {test_failures_dir}."
             )
 
             # Create new failures folder for this test:
@@ -861,7 +860,6 @@ def assert_snapshot(
                 f"Wrong size: expected={img_b.size}, actual={img_a.size} "
                 f"({pixel_diff} pixels difference; "
                 f"{pixel_diff / expected_pixels * 100:.2f}%). "
-                f"Find the actual and expected screenshots in {test_failures_dir}. "
                 f"Error: {ex}. "
             )
 


### PR DESCRIPTION
## Describe your changes

Cursor support agents have been looking at images in the file system recently: https://cursor.com/changelog#image-file-support-for-agent. Adding some hints to our rules to make it easier for the agent to find those screenshots.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs for E2E Playwright artifact locations and mentions the frontend hot-reload dev server URL in repo overviews/instructions.
> 
> - **Docs — E2E Playwright**:
>   - Clarify storage of screenshots in `e2e_playwright/__snapshots__/<os>/`.
>   - Add locations for test artifacts under `e2e_playwright/test_results/`:
>     - `test_results/<test_name>/` (videos, traces)
>     - `test_results/snapshot-tests-failures/<os>/<test_script>/<test_name>/` (expected/actual/diff screenshots)
>     - `test_results/snapshot-updates/<os>/<test_script>/<test_name>/` (updated screenshots)
> - **Docs — Repo Overview/Agent Instructions**:
>   - Note frontend hot-reload dev server at `http://localhost:3000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eea33e0c6ac956ec29a0bb14e5de0f28e05de89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->