### PR TITLE
[fix] Ensure key is reflective of data arg in CCv2 instances

### DIFF
--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -351,12 +351,12 @@ class BidiComponentMixin:
                         bidi_component_proto.arrow_data.CopyFrom(arrow_data_proto)
                     else:
                         # Fallback to JSON.
-                        bidi_component_proto.json = json.dumps(data)
+                        bidi_component_proto.json = json.dumps(data, sort_keys=True)
             except Exception:
                 # As a last resort attempt JSON serialization so that we don't
                 # silently drop developer data.
                 try:
-                    bidi_component_proto.json = json.dumps(data)
+                    bidi_component_proto.json = json.dumps(data, sort_keys=True)
                 except Exception:
                     raise BidiComponentUnserializableDataError()
         bidi_component_proto.form_id = current_form_id(self.dg)

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -158,6 +158,7 @@ class BidiComponentMixin:
         width: Width,
         height: Height,
         proto: BidiComponentProto,
+        data: BidiComponentData = None,
     ) -> dict[str, Any]:
         """Build deterministic identity kwargs for ID computation.
 
@@ -182,6 +183,9 @@ class BidiComponentMixin:
             The populated component protobuf. Its ``data`` oneof determines
             which serialized payload (JSON, Arrow, bytes, or Mixed) contributes
             to identity.
+        data : BidiComponentData
+            The raw data passed to the component. Used to optimize identity
+            calculation for JSON payloads by avoiding a parse/serialize cycle.
 
         Returns
         -------
@@ -208,9 +212,24 @@ class BidiComponentMixin:
 
         if data_field == "json":
             # Canonicalize only for identity so unkeyed widgets don't churn when
-            # dict insertion order changes, while the original ordering still
-            # reaches the frontend untouched.
-            identity["json"] = self._canonical_json_digest_for_identity(proto.json)
+            # dict insertion order changes.
+            #
+            # Optimization: Use raw `data` if available to avoid the overhead of
+            # parsing `proto.json` back into a dict.
+            canonical_digest = None
+
+            if data is not None:
+                try:
+                    canonical = json.dumps(data, sort_keys=True)
+                    canonical_digest = calc_md5(canonical)
+                except (TypeError, ValueError):
+                    # Fallback to existing logic if direct dump fails
+                    pass
+
+            if canonical_digest is None:
+                canonical_digest = self._canonical_json_digest_for_identity(proto.json)
+
+            identity["json"] = canonical_digest
         elif data_field == "arrow_data":
             # Hash large payloads instead of shoving raw bytes through the ID
             # hasher for performance.
@@ -417,6 +436,7 @@ class BidiComponentMixin:
             width=width,
             height=height,
             proto=bidi_component_proto,
+            data=data,
         )
         # Compute a unique ID for this component instance now that the proto is
         # populated.

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -59,6 +59,7 @@ from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import register_widget
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     from streamlit.components.v2.types import (
@@ -118,6 +119,26 @@ def _make_trigger_id(base: str, event: str) -> str:
 class BidiComponentMixin:
     """Mixin class for the bidi_component DeltaGenerator method."""
 
+    def _canonicalize_json_for_identity(self, payload: str) -> str:
+        """Return a deterministic JSON string for identity comparisons.
+
+        Payloads that cannot be parsed (or re-serialized) are returned as-is to
+        avoid mutating developer data.
+        """
+
+        if not payload:
+            return payload
+
+        try:
+            parsed = json.loads(payload)
+        except (TypeError, ValueError):
+            return payload
+
+        try:
+            return json.dumps(parsed, sort_keys=True)
+        except (TypeError, ValueError):
+            return payload
+
     def _build_bidi_identity_kwargs(
         self,
         *,
@@ -175,15 +196,23 @@ class BidiComponentMixin:
             return identity
 
         if data_field == "json":
-            identity["json"] = proto.json
+            # Canonicalize only for identity so unkeyed widgets don't churn when
+            # dict insertion order changes, while the original ordering still
+            # reaches the frontend untouched.
+            identity["json"] = self._canonicalize_json_for_identity(proto.json)
         elif data_field == "arrow_data":
-            identity["arrow_data"] = proto.arrow_data.data
+            # Hash large payloads instead of shoving raw bytes through the ID
+            # hasher for performance.
+            identity["arrow_data"] = calc_md5(proto.arrow_data.data)
         elif data_field == "bytes":
-            identity["bytes"] = proto.bytes
+            # Same story for arbitrary bytes payloads: content-address the data
+            # so identity changes track real mutations without re-hashing the
+            # whole blob every run.
+            identity["bytes"] = calc_md5(proto.bytes)
         elif data_field == "mixed":
             mixed: MixedDataProto = proto.mixed
             # Add the JSON content of the MixedData to the identity.
-            identity["mixed_json"] = mixed.json
+            identity["mixed_json"] = self._canonicalize_json_for_identity(mixed.json)
             # Add the sorted content-addressed ref IDs of the Arrow blobs to the identity.
             # Unlike other data types where we include actual bytes, here we only include
             # the blob keys. This is sufficient because keys are MD5 hashes of the blob
@@ -353,13 +382,16 @@ class BidiComponentMixin:
 
                         bidi_component_proto.arrow_data.CopyFrom(arrow_data_proto)
                     else:
-                        # Fallback to JSON.
-                        bidi_component_proto.json = json.dumps(data, sort_keys=True)
+                        # Fallback to JSON: leave insertion order intact so component
+                        # authors can rely on whatever ordering semantics they encoded.
+                        bidi_component_proto.json = json.dumps(data)
             except Exception:
                 # As a last resort attempt JSON serialization so that we don't
                 # silently drop developer data.
                 try:
-                    bidi_component_proto.json = json.dumps(data, sort_keys=True)
+                    # Same as above—never sort here; identity canonicalization handles
+                    # stability without mutating developer payloads.
+                    bidi_component_proto.json = json.dumps(data)
                 except Exception:
                     raise BidiComponentUnserializableDataError()
         bidi_component_proto.form_id = current_form_id(self.dg)

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -193,60 +193,6 @@ class BidiComponentMixin:
 
         return identity
 
-    def _compute_bidi_component_id(
-        self,
-        *,
-        key: str | None,
-        component_name: str,
-        isolate_styles: bool,
-        width: Width,
-        height: Height,
-        proto: BidiComponentProto,
-    ) -> str:
-        """Compute and register the CCv2 element ID.
-
-        Wraps ``compute_and_register_element_id`` with identity inputs built by
-        ``_build_bidi_identity_kwargs``. When a user key is provided,
-        ``key_as_main_identity=True`` causes payload-derived inputs to be
-        ignored; otherwise, serialized payload fingerprints are included so
-        unkeyed components change identity when their data changes.
-
-        Parameters
-        ----------
-        key : str or None
-            Optional user-provided key. When set, it dominates identity.
-        component_name : str
-            The registered component name.
-        isolate_styles : bool
-            Whether the component styles are rendered in a Shadow DOM.
-        width : Width
-            Desired width configuration passed to the component.
-        height : Height
-            Desired height configuration passed to the component.
-        proto : BidiComponentProto
-            The populated component protobuf used to derive payload identity.
-
-        Returns
-        -------
-        str
-            The registered, stable element ID.
-        """
-        identity_kwargs = self._build_bidi_identity_kwargs(
-            component_name=component_name,
-            isolate_styles=isolate_styles,
-            width=width,
-            height=height,
-            proto=proto,
-        )
-
-        return compute_and_register_element_id(
-            "bidi_component",
-            user_key=key,
-            key_as_main_identity=True,
-            dg=self.dg,
-            **identity_kwargs,
-        )
-
     @gather_metrics("_bidi_component")
     def _bidi_component(
         self,
@@ -415,14 +361,23 @@ class BidiComponentMixin:
                     raise BidiComponentUnserializableDataError()
         bidi_component_proto.form_id = current_form_id(self.dg)
 
-        # Compute a unique ID for this component instance now that the proto is populated.
-        computed_id = self._compute_bidi_component_id(
-            key=key,
+        # Build identity kwargs for the component instance now that the proto is
+        # populated.
+        identity_kwargs = self._build_bidi_identity_kwargs(
             component_name=component_name,
             isolate_styles=isolate_styles,
             width=width,
             height=height,
             proto=bidi_component_proto,
+        )
+        # Compute a unique ID for this component instance now that the proto is
+        # populated.
+        computed_id = compute_and_register_element_id(
+            "bidi_component",
+            user_key=key,
+            key_as_main_identity=True,
+            dg=self.dg,
+            **identity_kwargs,
         )
         bidi_component_proto.id = computed_id
 

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -55,6 +55,7 @@ from streamlit.errors import (
 )
 from streamlit.proto.ArrowData_pb2 import ArrowData as ArrowDataProto
 from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
+from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import register_widget
@@ -116,6 +117,135 @@ def _make_trigger_id(base: str, event: str) -> str:
 
 class BidiComponentMixin:
     """Mixin class for the bidi_component DeltaGenerator method."""
+
+    def _build_bidi_identity_kwargs(
+        self,
+        *,
+        component_name: str,
+        isolate_styles: bool,
+        width: Width,
+        height: Height,
+        proto: BidiComponentProto,
+    ) -> dict[str, Any]:
+        """Build deterministic identity kwargs for ID computation.
+
+        Construct a stable mapping of identity-relevant properties for
+        ``compute_and_register_element_id``. This includes structural
+        properties (name, style isolation, layout) and an explicit, typed
+        handling of the ``BidiComponent`` ``oneof data`` field to ensure
+        unkeyed components change identity when their serialized payload
+        changes.
+
+        Parameters
+        ----------
+        component_name : str
+            The registered component name.
+        isolate_styles : bool
+            Whether the component styles are rendered in a Shadow DOM.
+        width : Width
+            Desired width configuration passed to the component.
+        height : Height
+            Desired height configuration passed to the component.
+        proto : BidiComponentProto
+            The populated component protobuf. Its ``data`` oneof determines
+            which serialized payload (JSON, Arrow, bytes, or Mixed) contributes
+            to identity.
+
+        Returns
+        -------
+        dict[str, Any]
+            A mapping of deterministic values to be forwarded into
+            ``compute_and_register_element_id``.
+
+        Raises
+        ------
+        RuntimeError
+            If an unhandled ``oneof data`` variant is encountered (guards
+            against adding new fields without updating identity computation).
+        """
+        identity: dict[str, Any] = {
+            "component_name": component_name,
+            "isolate_styles": isolate_styles,
+            "width": width,
+            "height": height,
+        }
+
+        data_field = proto.WhichOneof("data")
+        if data_field is None:
+            return identity
+
+        if data_field == "json":
+            identity["json"] = proto.json
+        elif data_field == "arrow_data":
+            identity["arrow_data"] = proto.arrow_data.data
+        elif data_field == "bytes":
+            identity["bytes"] = proto.bytes
+        elif data_field == "mixed":
+            mixed: MixedDataProto = proto.mixed
+            # Add the JSON content of the MixedData to the identity.
+            identity["mixed_json"] = mixed.json
+            # Add the sorted content-addressed ref IDs of the Arrow blobs to the identity.
+            identity["mixed_arrow_blobs"] = ",".join(sorted(mixed.arrow_blobs.keys()))
+        else:
+            raise RuntimeError(
+                f"Unhandled BidiComponent.data oneof field: {data_field}"
+            )
+
+        return identity
+
+    def _compute_bidi_component_id(
+        self,
+        *,
+        key: str | None,
+        component_name: str,
+        isolate_styles: bool,
+        width: Width,
+        height: Height,
+        proto: BidiComponentProto,
+    ) -> str:
+        """Compute and register the CCv2 element ID.
+
+        Wraps ``compute_and_register_element_id`` with identity inputs built by
+        ``_build_bidi_identity_kwargs``. When a user key is provided,
+        ``key_as_main_identity=True`` causes payload-derived inputs to be
+        ignored; otherwise, serialized payload fingerprints are included so
+        unkeyed components change identity when their data changes.
+
+        Parameters
+        ----------
+        key : str or None
+            Optional user-provided key. When set, it dominates identity.
+        component_name : str
+            The registered component name.
+        isolate_styles : bool
+            Whether the component styles are rendered in a Shadow DOM.
+        width : Width
+            Desired width configuration passed to the component.
+        height : Height
+            Desired height configuration passed to the component.
+        proto : BidiComponentProto
+            The populated component protobuf used to derive payload identity.
+
+        Returns
+        -------
+        str
+            The registered, stable element ID.
+        """
+        identity_kwargs = self._build_bidi_identity_kwargs(
+            component_name=component_name,
+            isolate_styles=isolate_styles,
+            width=width,
+            height=height,
+            proto=proto,
+        )
+
+        return compute_and_register_element_id(
+            "bidi_component",
+            user_key=key,
+            key_as_main_identity=True,
+            dg=self.dg,
+            **identity_kwargs,
+        )
 
     @gather_metrics("_bidi_component")
     def _bidi_component(
@@ -206,18 +336,6 @@ class BidiComponentMixin:
         if not has_js and not has_html:
             raise BidiComponentMissingContentError(component_name)
 
-        # Compute a unique ID for this component instance
-        computed_id = compute_and_register_element_id(
-            "bidi_component",
-            user_key=key,
-            component_name=component_name,
-            isolate_styles=isolate_styles,
-            width=width,
-            height=height,
-            dg=self.dg,
-            key_as_main_identity=True,
-        )
-
         # ------------------------------------------------------------------
         # 1. Parse user-supplied callbacks
         # ------------------------------------------------------------------
@@ -253,7 +371,6 @@ class BidiComponentMixin:
 
         # Set up the component proto
         bidi_component_proto = BidiComponentProto()
-        bidi_component_proto.id = computed_id
         bidi_component_proto.component_name = component_name
         bidi_component_proto.isolate_styles = isolate_styles
         bidi_component_proto.js_content = component_def.js_content or ""
@@ -297,6 +414,17 @@ class BidiComponentMixin:
                 except Exception:
                     raise BidiComponentUnserializableDataError()
         bidi_component_proto.form_id = current_form_id(self.dg)
+
+        # Compute a unique ID for this component instance now that the proto is populated.
+        computed_id = self._compute_bidi_component_id(
+            key=key,
+            component_name=component_name,
+            isolate_styles=isolate_styles,
+            width=width,
+            height=height,
+            proto=bidi_component_proto,
+        )
+        bidi_component_proto.id = computed_id
 
         # Instantiate the Serde for this component instance
         serde = BidiComponentSerde(default=default)

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -185,6 +185,9 @@ class BidiComponentMixin:
             # Add the JSON content of the MixedData to the identity.
             identity["mixed_json"] = mixed.json
             # Add the sorted content-addressed ref IDs of the Arrow blobs to the identity.
+            # Unlike other data types where we include actual bytes, here we only include
+            # the blob keys. This is sufficient because keys are MD5 hashes of the blob
+            # content (content-addressed), so identical content produces identical keys.
             identity["mixed_arrow_blobs"] = ",".join(sorted(mixed.arrow_blobs.keys()))
         else:
             raise RuntimeError(

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -139,6 +139,17 @@ class BidiComponentMixin:
         except (TypeError, ValueError):
             return payload
 
+    def _canonical_json_digest_for_identity(self, payload: str) -> str:
+        """Return the hash of the canonicalized JSON payload for identity use.
+
+        Hashing keeps the kwargs passed to ``compute_and_register_element_id``
+        small even when the JSON payload is very large, while still changing the
+        identity whenever the canonical JSON content changes.
+        """
+
+        canonical = self._canonicalize_json_for_identity(payload)
+        return calc_md5(canonical)
+
     def _build_bidi_identity_kwargs(
         self,
         *,
@@ -199,7 +210,7 @@ class BidiComponentMixin:
             # Canonicalize only for identity so unkeyed widgets don't churn when
             # dict insertion order changes, while the original ordering still
             # reaches the frontend untouched.
-            identity["json"] = self._canonicalize_json_for_identity(proto.json)
+            identity["json"] = self._canonical_json_digest_for_identity(proto.json)
         elif data_field == "arrow_data":
             # Hash large payloads instead of shoving raw bytes through the ID
             # hasher for performance.
@@ -212,7 +223,9 @@ class BidiComponentMixin:
         elif data_field == "mixed":
             mixed: MixedDataProto = proto.mixed
             # Add the JSON content of the MixedData to the identity.
-            identity["mixed_json"] = self._canonicalize_json_for_identity(mixed.json)
+            identity["mixed_json"] = self._canonical_json_digest_for_identity(
+                mixed.json
+            )
             # Add the sorted content-addressed ref IDs of the Arrow blobs to the identity.
             # Unlike other data types where we include actual bytes, here we only include
             # the blob keys. This is sufficient because keys are MD5 hashes of the blob

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -414,15 +414,12 @@ class BidiComponentMixin:
 
                         bidi_component_proto.arrow_data.CopyFrom(arrow_data_proto)
                     else:
-                        # Fallback to JSON: leave insertion order intact so component
-                        # authors can rely on whatever ordering semantics they encoded.
+                        # Fallback to JSON.
                         bidi_component_proto.json = json.dumps(data)
             except Exception:
                 # As a last resort attempt JSON serialization so that we don't
                 # silently drop developer data.
                 try:
-                    # Same as above—never sort here; identity canonicalization handles
-                    # stability without mutating developer payloads.
                     bidi_component_proto.json = json.dumps(data)
                 except Exception:
                     raise BidiComponentUnserializableDataError()

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -111,7 +111,7 @@ def serialize_mixed_data(data: Any, bidi_component_proto: BidiComponentProto) ->
         # We have dataframes, use mixed data serialization
         mixed_proto = MixedDataProto()
         try:
-            mixed_proto.json = json.dumps(processed_data)
+            mixed_proto.json = json.dumps(processed_data, sort_keys=True)
         except TypeError:
             # If JSON serialization fails (e.g., due to undetected dataframes),
             # fall back to string representation
@@ -125,7 +125,7 @@ def serialize_mixed_data(data: Any, bidi_component_proto: BidiComponentProto) ->
     else:
         # No dataframes found, use regular JSON serialization
         try:
-            bidi_component_proto.json = json.dumps(processed_data)
+            bidi_component_proto.json = json.dumps(processed_data, sort_keys=True)
         except TypeError:
             # If JSON serialization fails (e.g., due to dataframes in lists/tuples),
             # fall back to string representation

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -67,12 +67,19 @@ def _extract_dataframes_from_dict(
             try:
                 arrow_bytes = convert_anything_to_arrow_bytes(value)
                 # Use deterministic, content-addressed ref IDs so placeholders
-                # are stable for identical content on each run.
+                # are stable for identical content on each run. This also provides
+                # natural deduplication - identical DataFrames share a single blob.
                 ref_id = calc_md5(arrow_bytes)
                 arrow_blobs[ref_id] = arrow_bytes
                 processed_data[key] = {ARROW_REF_KEY: ref_id}
-            except Exception:
-                # If Arrow serialization fails, keep the original value for JSON serialization
+            except Exception as e:
+                # If Arrow serialization fails, keep the original value for JSON
+                # serialization attempt downstream.
+                _LOGGER.debug(
+                    "Arrow serialization failed for key %r, keeping original value: %s",
+                    key,
+                    e,
+                )
                 processed_data[key] = value
         else:
             # Not dataframe-like, keep as-is

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -118,7 +118,7 @@ def serialize_mixed_data(data: Any, bidi_component_proto: BidiComponentProto) ->
         # We have dataframes, use mixed data serialization
         mixed_proto = MixedDataProto()
         try:
-            mixed_proto.json = json.dumps(processed_data, sort_keys=True)
+            mixed_proto.json = json.dumps(processed_data)
         except TypeError:
             # If JSON serialization fails (e.g., due to undetected dataframes),
             # fall back to string representation
@@ -132,7 +132,7 @@ def serialize_mixed_data(data: Any, bidi_component_proto: BidiComponentProto) ->
     else:
         # No dataframes found, use regular JSON serialization
         try:
-            bidi_component_proto.json = json.dumps(processed_data, sort_keys=True)
+            bidi_component_proto.json = json.dumps(processed_data)
         except TypeError:
             # If JSON serialization fails (e.g., due to dataframes in lists/tuples),
             # fall back to string representation

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -68,7 +68,7 @@ def _extract_dataframes_from_dict(
                 arrow_bytes = convert_anything_to_arrow_bytes(value)
                 # Use deterministic, content-addressed ref IDs so placeholders
                 # are stable for identical content on each run.
-                ref_id = calc_md5(str(arrow_bytes))
+                ref_id = calc_md5(arrow_bytes)
                 arrow_blobs[ref_id] = arrow_bytes
                 processed_data[key] = {ARROW_REF_KEY: ref_id}
             except Exception:

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -23,7 +23,7 @@ from streamlit.dataframe_util import convert_anything_to_arrow_bytes, is_datafra
 from streamlit.logger import get_logger
 from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
 from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
-from streamlit.util import AttributeDictionary
+from streamlit.util import AttributeDictionary, calc_md5
 
 if TYPE_CHECKING:
     from streamlit.components.v2.bidi_component.state import BidiComponentState
@@ -56,8 +56,6 @@ def _extract_dataframes_from_dict(
     dict[str, Any]
         A new dictionary with dataframe-like objects replaced by placeholders.
     """
-    import uuid
-
     if arrow_blobs is None:
         arrow_blobs = {}
 
@@ -68,7 +66,9 @@ def _extract_dataframes_from_dict(
             # This is a dataframe-like object, serialize it to Arrow
             try:
                 arrow_bytes = convert_anything_to_arrow_bytes(value)
-                ref_id = str(uuid.uuid4())
+                # Use deterministic, content-addressed ref IDs so placeholders
+                # are stable for identical content on each run.
+                ref_id = calc_md5(str(arrow_bytes))
                 arrow_blobs[ref_id] = arrow_bytes
                 processed_data[key] = {ARROW_REF_KEY: ref_id}
             except Exception:

--- a/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
@@ -238,3 +238,24 @@ def test_serialization_fallback_to_string():
     assert not proto.HasField("mixed")
     assert proto.HasField("json")
     assert json.loads(proto.json) == str(data)
+
+
+def test_extract_dataframes_from_dict_fallback_on_arrow_failure(monkeypatch):
+    """If Arrow serialization fails for a dataframe-like value, the original value should be preserved."""
+    from streamlit.components.v2.bidi_component import serialization as ser
+
+    class Sentinel:
+        pass
+
+    obj = Sentinel()
+
+    # Force detection as dataframe-like but make conversion raise.
+    monkeypatch.setattr(ser, "is_dataframe_like", lambda v: v is obj)
+
+    def _boom(_: object) -> bytes:  # type: ignore[return-value]
+        raise Exception("boom")
+
+    monkeypatch.setattr(ser, "convert_anything_to_arrow_bytes", _boom)
+
+    result = ser._extract_dataframes_from_dict({"df": obj})
+    assert result["df"] is obj

--- a/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_serialization.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+from typing import NoReturn
 
 import pandas as pd
 
@@ -252,7 +253,7 @@ def test_extract_dataframes_from_dict_fallback_on_arrow_failure(monkeypatch):
     # Force detection as dataframe-like but make conversion raise.
     monkeypatch.setattr(ser, "is_dataframe_like", lambda v: v is obj)
 
-    def _boom(_: object) -> bytes:  # type: ignore[return-value]
+    def _boom(_: object) -> NoReturn:
         raise Exception("boom")
 
     monkeypatch.setattr(ser, "convert_anything_to_arrow_bytes", _boom)

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1269,6 +1269,25 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
         assert id1 == id2
 
+    def test_unkeyed_id_stable_with_duplicate_dataframe_content(self):
+        """Two different keys with identical DataFrame content should produce stable IDs.
+
+        This validates content-addressing deduplication: identical DataFrames under
+        different keys share the same blob ref ID, so the identity is stable.
+        """
+        data1 = {"df1": pd.DataFrame({"x": [1]}), "df2": pd.DataFrame({"x": [1]})}
+        st._bidi_component("ident", data=data1)
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        # Same structure, new DataFrame objects with identical content
+        data2 = {"df1": pd.DataFrame({"x": [1]}), "df2": pd.DataFrame({"x": [1]})}
+        st._bidi_component("ident", data=data2)
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
 
 class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):
     """Verify that per-state callbacks fire exclusively for their key."""

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1355,6 +1355,54 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
         assert id1 == id2
 
+    def test_identity_kwargs_uses_optimization_when_data_provided(self):
+        """When data is provided, identity calculation should skip unnecessary deserialization."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        data = {"a": 1, "b": 2}
+        # Pre-populate proto.json to simulate what happens in main
+        proto.json = json.dumps(data)
+
+        # Mock _canonical_json_digest_for_identity to ensure it's NOT called
+        # when the optimization path is taken.
+        with patch.object(mixin, "_canonical_json_digest_for_identity") as mock_digest:
+            identity = mixin._build_bidi_identity_kwargs(
+                component_name="cmp",
+                isolate_styles=True,
+                width="stretch",
+                height="content",
+                proto=proto,
+                data=data,
+            )
+
+            # Verify the result is correct (sorted keys)
+            expected_canonical = json.dumps(data, sort_keys=True)
+            assert identity["json"] == calc_md5(expected_canonical)
+
+            # Verify the slow path was skipped
+            mock_digest.assert_not_called()
+
+        # Verify behavior WITHOUT data (slow path fallback)
+        with patch.object(
+            mixin,
+            "_canonical_json_digest_for_identity",
+            wraps=mixin._canonical_json_digest_for_identity,
+        ) as mock_digest:
+            identity = mixin._build_bidi_identity_kwargs(
+                component_name="cmp",
+                isolate_styles=True,
+                width="stretch",
+                height="content",
+                proto=proto,
+                data=None,
+            )
+
+            # Verify result is still correct
+            assert identity["json"] == calc_md5(expected_canonical)
+
+            # Verify the slow path WAS called
+            mock_digest.assert_called_once()
+
 
 class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):
     """Verify that per-state callbacks fire exclusively for their key."""

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1212,28 +1212,6 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
         assert identity["mixed_json"] == "{}"
         assert identity["mixed_arrow_blobs"] == "a,b"
 
-    def test_extract_dataframes_from_dict_fallback_on_arrow_failure(self):
-        """If Arrow serialization fails for a dataframe-like value, the original value should be preserved."""
-        from streamlit.components.v2.bidi_component import serialization as ser
-
-        class Sentinel:
-            pass
-
-        obj = Sentinel()
-
-        with (
-            patch(
-                "streamlit.components.v2.bidi_component.serialization.is_dataframe_like",
-                side_effect=lambda v: v is obj,
-            ),
-            patch(
-                "streamlit.components.v2.bidi_component.serialization.convert_anything_to_arrow_bytes",
-                side_effect=Exception("boom"),
-            ),
-        ):
-            result = ser._extract_dataframes_from_dict({"df": obj})
-            assert result["df"] is obj
-
 
 class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):
     """Verify that per-state callbacks fire exclusively for their key."""

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1232,7 +1232,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["mixed_json"] == "{}"
+        assert identity["mixed_json"] == calc_md5("{}")
         assert identity["mixed_arrow_blobs"] == "a,b"
 
     def test_identity_kwargs_json_canonicalizes_order(self):
@@ -1249,7 +1249,8 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["json"] == json.dumps({"a": 1, "b": 2}, sort_keys=True)
+        expected = json.dumps({"a": 1, "b": 2}, sort_keys=True)
+        assert identity["json"] == calc_md5(expected)
 
     def test_identity_kwargs_mixed_json_canonicalizes_order(self):
         """MixedData identity must canonicalize JSON portion independently of storage order."""
@@ -1265,7 +1266,8 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["mixed_json"] == json.dumps({"a": 1, "b": 2}, sort_keys=True)
+        expected = json.dumps({"a": 1, "b": 2}, sort_keys=True)
+        assert identity["mixed_json"] == calc_md5(expected)
 
     def test_identity_kwargs_bytes_use_digest(self):
         """Raw byte payloads should contribute content digests, not the full payload."""

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1178,7 +1178,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
         mixin = BidiComponentMixin()
 
         class DummyProto:
-            def WhichOneof(self, name: str) -> str:
+            def WhichOneof(self, _name: str) -> str:
                 return "new_unhandled_field"
 
         with pytest.raises(

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -25,7 +25,10 @@ import pytest
 import streamlit as st
 from streamlit import _main as st_main
 from streamlit.components.v2.bidi_component.constants import EVENT_DELIM
-from streamlit.components.v2.bidi_component.main import _make_trigger_id
+from streamlit.components.v2.bidi_component.main import (
+    BidiComponentMixin,
+    _make_trigger_id,
+)
 from streamlit.components.v2.bidi_component.state import BidiComponentResult
 from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_registry import BidiComponentDefinition
@@ -33,6 +36,7 @@ from streamlit.errors import (
     BidiComponentInvalidCallbackNameError,
     StreamlitAPIException,
 )
+from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -1024,6 +1028,211 @@ class BidiComponentTest(DeltaGeneratorTestCase):
         # Verify complex values are properly set
         assert result["list_state"] == complex_list
         assert result["dict_state"] == complex_dict
+
+
+class BidiComponentIdentityTest(DeltaGeneratorTestCase):
+    """Validate CCv2 identity rules for keyed and unkeyed instances."""
+
+    def setUp(self):
+        super().setUp()
+        self.manager = BidiComponentManager()
+        runtime = Runtime.instance()
+        if runtime is None:
+            raise RuntimeError("Runtime.instance() returned None in test setup.")
+        runtime.bidi_component_registry = self.manager
+        self.manager.register(
+            BidiComponentDefinition(name="ident", js="console.log('hi');")
+        )
+
+    def _clear_widget_registrations_for_current_run(self) -> None:
+        """Allow re-registering the same id within the same run for testing keyed stability."""
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        ctx.widget_user_keys_this_run.clear()
+        ctx.widget_ids_this_run.clear()
+
+    def _render_and_get_id(self) -> str:
+        delta = self.get_delta_from_queue()
+        return delta.new_element.bidi_component.id
+
+    def test_unkeyed_id_changes_when_json_data_changes(self):
+        """Without a user key, changing JSON data must change the backend id."""
+        st._bidi_component("ident", data={"x": 1})
+        id1 = self._render_and_get_id()
+
+        st._bidi_component("ident", data={"x": 2})
+        id2 = self._render_and_get_id()
+
+        assert id1 != id2
+
+    def test_unkeyed_id_changes_when_bytes_change(self):
+        """Without a user key, changing bytes must change the backend id."""
+        st._bidi_component("ident", data=b"abc")
+        id1 = self._render_and_get_id()
+
+        st._bidi_component("ident", data=b"abcd")
+        id2 = self._render_and_get_id()
+
+        assert id1 != id2
+
+    def test_unkeyed_id_changes_when_arrow_data_changes(self):
+        """Without a user key, changing dataframe content must change the backend id."""
+
+        st._bidi_component("ident", data=pd.DataFrame({"a": [1, 2]}))
+        id1 = self._render_and_get_id()
+
+        st._bidi_component("ident", data=pd.DataFrame({"a": [1, 3]}))
+        id2 = self._render_and_get_id()
+
+        assert id1 != id2
+
+    def test_unkeyed_id_changes_when_mixed_blobs_change(self):
+        """Without a user key, MixedData blob fingerprint differences must change id."""
+
+        st._bidi_component("ident", data={"df": pd.DataFrame({"x": [1]})})
+        id1 = self._render_and_get_id()
+
+        st._bidi_component("ident", data={"df": pd.DataFrame({"x": [2]})})
+        id2 = self._render_and_get_id()
+
+        assert id1 != id2
+
+    def test_keyed_id_stable_when_data_changes_json(self):
+        """With a user key, changing JSON data must NOT change the backend id (same run)."""
+        st._bidi_component("ident", key="K", data={"v": 1})
+        id1 = self._render_and_get_id()
+
+        # Allow re-registering the same id in the same run for test purposes
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component("ident", key="K", data={"v": 2})
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_keyed_id_stable_when_mixed_data_changes(self):
+        """With a user key, changing MixedData (JSON + blobs) must NOT change the backend id (same run)."""
+
+        st._bidi_component(
+            "ident", key="MIX", data={"df": pd.DataFrame({"a": [1]}), "m": {"x": 1}}
+        )
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component(
+            "ident", key="MIX", data={"df": pd.DataFrame({"a": [2]}), "m": {"x": 2}}
+        )
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_unkeyed_id_stable_when_arrow_data_unchanged(self):
+        """Without a user key, unchanged dataframe content must keep the same backend id (no needless churn)."""
+
+        df1 = pd.DataFrame({"a": [1, 2, 3]})
+        st._bidi_component("ident", data=df1)
+        id1 = self._render_and_get_id()
+
+        # Allow re-registering the same id in this run for stability assertion
+        self._clear_widget_registrations_for_current_run()
+
+        # New DataFrame object with identical content
+        df2 = pd.DataFrame({"a": [1, 2, 3]})
+        st._bidi_component("ident", data=df2)
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_unkeyed_id_stable_when_mixed_data_unchanged(self):
+        """Without a user key, unchanged MixedData must keep the same backend id (no needless churn)."""
+
+        mixed1 = {"df": pd.DataFrame({"x": [1, 2]}), "meta": {"k": "v"}}
+        st._bidi_component("ident", data=mixed1)
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        # New objects but same serialized content and key order
+        mixed2 = {"df": pd.DataFrame({"x": [1, 2]}), "meta": {"k": "v"}}
+        st._bidi_component("ident", data=mixed2)
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_keyed_id_stable_when_data_changes_arrow(self):
+        """With a user key, changing Arrow/mixed data must NOT change the backend id (same run)."""
+
+        st._bidi_component("ident", key="ARW", data=pd.DataFrame({"a": [1]}))
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component("ident", key="ARW", data=pd.DataFrame({"a": [2]}))
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_identity_kwargs_raises_on_unhandled_oneof(self):
+        """_build_bidi_identity_kwargs should raise if an unknown oneof is encountered."""
+        mixin = BidiComponentMixin()
+
+        class DummyProto:
+            def WhichOneof(self, name: str) -> str:
+                return "new_unhandled_field"
+
+        with pytest.raises(
+            RuntimeError, match=r"Unhandled BidiComponent\.data oneof field"
+        ):
+            mixin._build_bidi_identity_kwargs(
+                component_name="cmp",
+                isolate_styles=True,
+                width="stretch",
+                height="content",
+                proto=DummyProto(),  # type: ignore[arg-type]
+            )
+
+    def test_identity_kwargs_mixed_blob_keys_are_sorted(self):
+        """When computing identity, mixed arrow blob ref IDs must be sorted for stability."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        proto.mixed.json = "{}"
+        # Insert keys in descending order to verify sorting in identity.
+        proto.mixed.arrow_blobs["b"].data = b"b"
+        proto.mixed.arrow_blobs["a"].data = b"a"
+
+        identity = mixin._build_bidi_identity_kwargs(
+            component_name="cmp",
+            isolate_styles=True,
+            width="stretch",
+            height="content",
+            proto=proto,
+        )
+
+        assert identity["mixed_json"] == "{}"
+        assert identity["mixed_arrow_blobs"] == "a,b"
+
+    def test_extract_dataframes_from_dict_fallback_on_arrow_failure(self):
+        """If Arrow serialization fails for a dataframe-like value, the original value should be preserved."""
+        from streamlit.components.v2.bidi_component import serialization as ser
+
+        class Sentinel:
+            pass
+
+        obj = Sentinel()
+
+        with (
+            patch(
+                "streamlit.components.v2.bidi_component.serialization.is_dataframe_like",
+                side_effect=lambda v: v is obj,
+            ),
+            patch(
+                "streamlit.components.v2.bidi_component.serialization.convert_anything_to_arrow_bytes",
+                side_effect=Exception("boom"),
+            ),
+        ):
+            result = ser._extract_dataframes_from_dict({"df": obj})
+            assert result["df"] is obj
 
 
 class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -44,6 +44,7 @@ from streamlit.runtime.state.session_state import (
     STREAMLIT_INTERNAL_KEY_PREFIX,
     _is_internal_key,
 )
+from streamlit.util import calc_md5
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -1233,6 +1234,70 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
         assert identity["mixed_json"] == "{}"
         assert identity["mixed_arrow_blobs"] == "a,b"
+
+    def test_identity_kwargs_json_canonicalizes_order(self):
+        """Identity canonicalization should ignore key insertion order for JSON data."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        proto.json = json.dumps({"b": 2, "a": 1})
+
+        identity = mixin._build_bidi_identity_kwargs(
+            component_name="cmp",
+            isolate_styles=True,
+            width="stretch",
+            height="content",
+            proto=proto,
+        )
+
+        assert identity["json"] == json.dumps({"a": 1, "b": 2}, sort_keys=True)
+
+    def test_identity_kwargs_mixed_json_canonicalizes_order(self):
+        """MixedData identity must canonicalize JSON portion independently of storage order."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        proto.mixed.json = json.dumps({"b": 2, "a": 1})
+
+        identity = mixin._build_bidi_identity_kwargs(
+            component_name="cmp",
+            isolate_styles=True,
+            width="stretch",
+            height="content",
+            proto=proto,
+        )
+
+        assert identity["mixed_json"] == json.dumps({"a": 1, "b": 2}, sort_keys=True)
+
+    def test_identity_kwargs_bytes_use_digest(self):
+        """Raw byte payloads should contribute content digests, not the full payload."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        proto.bytes = b"bytes payload"
+
+        identity = mixin._build_bidi_identity_kwargs(
+            component_name="cmp",
+            isolate_styles=True,
+            width="stretch",
+            height="content",
+            proto=proto,
+        )
+
+        assert identity["bytes"] == calc_md5(b"bytes payload")
+
+    def test_identity_kwargs_arrow_data_use_digest(self):
+        """Arrow payloads should contribute digests to avoid hashing large blobs repeatedly."""
+        mixin = BidiComponentMixin()
+        proto = BidiComponentProto()
+        proto.arrow_data.data = b"\x00\x01"
+
+        identity = mixin._build_bidi_identity_kwargs(
+            component_name="cmp",
+            isolate_styles=True,
+            width="stretch",
+            height="content",
+            proto=proto,
+        )
+
+        assert identity["arrow_data"] == calc_md5(b"\x00\x01")
 
     def test_unkeyed_id_stable_when_json_key_order_changes(self):
         """Without a user key, changing the insertion order of keys in a JSON dict should NOT change the backend id."""

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1055,6 +1055,28 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
         delta = self.get_delta_from_queue()
         return delta.new_element.bidi_component.id
 
+    def test_unkeyed_id_stable_when_data_is_none(self):
+        """Without data, unkeyed components should have stable IDs based on other params."""
+        st._bidi_component("ident")
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component("ident")
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_unkeyed_id_differs_between_none_and_empty_data(self):
+        """data=None must produce a different ID than data={} (empty dict is still data)."""
+        st._bidi_component("ident", data=None)
+        id_none = self._render_and_get_id()
+
+        st._bidi_component("ident", data={})
+        id_empty = self._render_and_get_id()
+
+        assert id_none != id_empty
+
     def test_unkeyed_id_changes_when_json_data_changes(self):
         """Without a user key, changing JSON data must change the backend id."""
         st._bidi_component("ident", data={"x": 1})
@@ -1211,6 +1233,41 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
         assert identity["mixed_json"] == "{}"
         assert identity["mixed_arrow_blobs"] == "a,b"
+
+    def test_unkeyed_id_stable_when_json_key_order_changes(self):
+        """Without a user key, changing the insertion order of keys in a JSON dict should NOT change the backend id."""
+        data1 = {"a": 1, "b": 2}
+        data2 = {"b": 2, "a": 1}
+
+        st._bidi_component("ident", data=data1)
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component("ident", data=data2)
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_unkeyed_id_stable_when_mixed_data_json_key_order_changes(self):
+        """Without a user key, changing the insertion order of keys in the JSON
+        part of MixedData should NOT change the backend id."""
+        # We use different dataframes (same content) to trigger mixed processing but keep blobs same
+        df1 = pd.DataFrame({"c": [3]})
+        df2 = pd.DataFrame({"c": [3]})
+
+        data1 = {"df": df1, "meta": {"a": 1, "b": 2}}
+        data2 = {"df": df2, "meta": {"b": 2, "a": 1}}
+
+        st._bidi_component("ident", data=data1)
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component("ident", data=data2)
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
 
 
 class BidiComponentStateCallbackTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

- This fixes a few issues with how CCv2 handles the `data` arg, especially as it relates to creating a `key`.
  - Specifically, we weren't passing in the `data` arg to `compute_and_register_element_id` before this change. Now we do so, but in order to support the many different data shapes, we calculate a stable identifier for the content first before passing it in.
  - As a side-effect of ensuring the `data` param is stable, we move from a UUID-based placeholder to an MD5-based placeholder for serialized arrow data to ensure it is deterministic. Previously, it would be a new UUID on each run, which is inefficient.
- Writes a bunch of unit tests that exercise the various `data` shapes.

## GitHub Issue Link (if applicable)

## Testing Plan

- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
