### PR TITLE
[fix] Use PR head instead of merge ref in flaky test verification workflow

### DIFF
--- a/.github/workflows/flaky-test-verification.yml
+++ b/.github/workflows/flaky-test-verification.yml
@@ -96,7 +96,7 @@ jobs:
         iteration: ${{ fromJson(needs.verify.outputs.matrix) }}
     uses: ./.github/workflows/playwright-changed-files.yml
     with:
-      ref: refs/pull/${{ needs.verify.outputs.pr-number }}/merge
+      ref: refs/pull/${{ needs.verify.outputs.pr-number }}/head
       base_ref: ${{ needs.verify.outputs.base_ref }}
       iteration: ${{ matrix.iteration }}
     secrets: inherit


### PR DESCRIPTION
## Describe your changes



Problem

The flaky test verification workflow was detecting test files that weren't actually changed in the PR. For example, PR #12934 only modified websocket_reconnects_test.py, but the workflow detected and ran 5 test files:

- st_camera_input_test.py
- st_file_uploader_test.py
- st_html_test.py
- st_pills_test.py
- websocket_reconnects_test.py

Root Cause

The workflow was checking out refs/pull/{pr-number}/merge - GitHub's auto-generated merge commit that represents what the PR would look like merged into the current state of the base branch.

When a PR is created from an older base commit and the base branch has moved forward, the merge ref includes:

1. The PR's actual changes
2. All commits added to the base branch since the PR was created

The workflow then diffs old_base...merge_ref, which includes changes from both sources.

Example timeline:
PR created from develop @ c71294e5
↓
develop moves forward with commits that touch:
\- st_camera_input_test.py
\- st_file_uploader_test.py
\- st_html_test.py
\- st_pills_test.py
↓
refs/pull/12934/merge = PR changes + new develop commits
↓
Diff detects all 5 test files ❌

Solution

Changed the workflow to check out refs/pull/{pr-number}/head instead, which is just the PR's actual HEAD commit without any merge.

Now the diff only includes files actually changed in the PR:
diff old_base..pr_head = only PR changes ✅

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.