### PR TITLE
[chore] Update dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,9 @@ updates:
       - dependency-name: "sass"
         # Breaks our build process, needs more investigation
         versions: [">=1.80.0"]
+      - dependency-name: "react-window"
+        # This requires us to update baseui, since that has a dependency on react-window v1.
+        versions: [">=2.0.0"]
 
     groups:
       deck-gl:


### PR DESCRIPTION
## Describe your changes

- We can not properly* update `react-window` until we also update `baseui`
  - To be specific, we could update our 1 direct usage of `react-window` in our codebase to v2. However, baseui still has a dependency on `react-window`, therefore we'd be shipping 2 versions of `react-window` until we also update baseui. That seems like a strictly worse state than just being on v1, which works fine.

## GitHub Issue Link (if applicable)

Closes #12621

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
