### PR TITLE
Show warning when hiding index in dynamic data editor

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -1006,6 +1006,13 @@ class DataEditorMixin:
             update_column_config(
                 column_config_mapping, INDEX_IDENTIFIER, {"required": True}
             )
+            if num_rows == "dynamic" and hide_index is True:
+                _LOGGER.warning(
+                    "Setting `hide_index=True` in data editor with a non-range index will not have any effect "
+                    "when `num_rows='dynamic'`. It is required for the user to fill in index values for "
+                    "adding new rows. To hide the index, make sure to set the DataFrame "
+                    "index to a range index."
+                )
 
         if hide_index is None and has_range_index and num_rows == "dynamic":
             # Temporary workaround:

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -730,6 +730,20 @@ class DataEditorTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         assert proto.columns == json.dumps({INDEX_IDENTIFIER: {"hidden": False}})
 
+    @patch("streamlit.elements.widgets.data_editor._LOGGER")
+    def test_hide_index_true_dynamic_non_range_index_logs_warning(
+        self, mock_logger: MagicMock
+    ):
+        """Test that hide_index=True with dynamic rows and non-range index logs a warning."""
+        df = pd.DataFrame({"a": [1, 2]}, index=["row_0", "row_1"])
+
+        st.data_editor(df, hide_index=True, num_rows="dynamic")
+
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        assert "hide_index=True" in warning_message
+        assert "num_rows='dynamic'" in warning_message
+
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""


### PR DESCRIPTION
## Describe your changes

Logs a warning when the user tries to hide and index for a dataframe with a non-range index in data editor that is configured with `num_rows="dynamic"`

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/8263

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
