### PR TITLE
Improve metric sparkline hovering efficiency

### DIFF
--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -478,7 +478,7 @@ describe("Metric element", () => {
           encodings: ["x"],
           nearest: true,
           on: "mousemove",
-          clear: "mouseout",
+          clear: "mouseleave",
         }),
       })
     })

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -483,6 +483,26 @@ describe("Metric element", () => {
       })
     })
 
+    it("throttles hover selection for large datasets", () => {
+      const largeChartData = Array.from({ length: 1500 }, (_, index) =>
+        Number(index)
+      )
+      const spec = getMetricChartSpec(
+        largeChartData,
+        MetricProto.ChartType.LINE,
+        200,
+        mockTheme.emotion,
+        MetricProto.MetricColor.RED
+      ) as TopLevelSpec & { layer: unknown[] }
+
+      const pointsLayer = spec.layer?.[1] as { params?: unknown[] }
+      expect(pointsLayer?.params?.[0]).toMatchObject({
+        select: expect.objectContaining({
+          on: "mousemove{16}",
+        }),
+      })
+    })
+
     it("includes highlighted points layer", () => {
       const spec = getMetricChartSpec(
         [1, 2, 3],

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -169,7 +169,7 @@ export function getMetricChartSpec(
               encodings: ["x"],
               nearest: true,
               on: "mousemove",
-              clear: "mouseout",
+              clear: "mouseleave",
             },
           },
         ],
@@ -183,17 +183,6 @@ export function getMetricChartSpec(
               param: `${baseName}_hover_selection`,
               empty: false,
             },
-          },
-          {
-            window: [
-              {
-                op: "row_number",
-                as: "hover_selection_rank",
-              },
-            ],
-          },
-          {
-            filter: "datum.hover_selection_rank === 1",
           },
         ],
         mark: {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -172,7 +172,7 @@ export function getMetricChartSpec(
               nearest: true,
               on:
                 chartData.length > LARGE_DATASET_POINT_THRESHOLD
-                  ? "mousemove{16}" // Throttle hover events for large datasets to
+                  ? "mousemove{16}" // Throttle hover events for large datasets to 16ms
                   : "mousemove",
               clear: "mouseleave",
             },

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -49,6 +49,8 @@ import {
   StyledTruncateText,
 } from "./styled-components"
 
+const LARGE_DATASET_POINT_THRESHOLD = 1000
+
 /**
  * Returns a Vega-Lite spec for a metric chart.
  *
@@ -168,7 +170,10 @@ export function getMetricChartSpec(
               type: "point",
               encodings: ["x"],
               nearest: true,
-              on: "mousemove",
+              on:
+                chartData.length > LARGE_DATASET_POINT_THRESHOLD
+                  ? "mousemove{16}" // Throttle hover events for large datasets to
+                  : "mousemove",
               clear: "mouseleave",
             },
           },


### PR DESCRIPTION
## Describe your changes

Hovering over `st.metric` sparkline charts can become slow if there are many data points. This PR removes an unnecessary computation step and introduces optimizations for larger datasets to enhance hovering performance.

## Testing Plan

- Update unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
