### PR TITLE
Improve phrasing of st.plotly_chart **kwarg deprecation warning 

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -665,9 +665,9 @@ class PlotlyMixin:
 
         if kwargs:
             show_deprecation_warning(
-                "The keyword arguments have been deprecated and will be removed "
-                "in a future release. Use `config` instead to specify Plotly "
-                "configuration options."
+                "Keyword arguments for `st.plotly_chart` have been deprecated "
+                "and will be removed in a future release. Use the `config` "
+                "argument instead to specify Plotly configuration options."
             )
 
         if theme not in ["streamlit", None]:

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -665,9 +665,10 @@ class PlotlyMixin:
 
         if kwargs:
             show_deprecation_warning(
-                "Keyword arguments for `st.plotly_chart` have been deprecated "
-                "and will be removed in a future release. Use the `config` "
-                "argument instead to specify Plotly configuration options."
+                "Variable keyword arguments for `st.plotly_chart` have been "
+                "deprecated and will be removed in a future release. Use the "
+                "`config` argument instead to specify Plotly configuration "
+                "options."
             )
 
         if theme not in ["streamlit", None]:


### PR DESCRIPTION
## Describe your changes

Improve the phrasing of the deprecation warning that's shown when users use variable keyword arguments in `st.plotly_chart`.

## Screenshot or video (only for visual changes)

n/a

## GitHub Issue Link (if applicable)

n/a

## Testing Plan

- Explanation of why no additional tests are needed: this is just a simple copy change.
- ~~Unit Tests (JS and/or Python)~~
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
