### PR TITLE
[fix] st.dataframe date picker icon visibility in dark mode

### DIFF
--- a/frontend/lib/src/styled-components.ts
+++ b/frontend/lib/src/styled-components.ts
@@ -16,6 +16,8 @@
 
 import styled from "@emotion/styled"
 
+import { hasLightBackgroundColor } from "@streamlit/lib"
+
 export const StyledApp = styled.div(({ theme }) => ({
   position: "absolute",
   background: theme.colors.bgColor,
@@ -44,4 +46,13 @@ export const StyledDataFrameOverlay = styled.div(({ theme }) => ({
   left: 0,
   zIndex: theme.zIndices.tablePortal,
   lineHeight: "100%",
+  ...(!hasLightBackgroundColor(theme) && {
+    "& input[type='date'], & input[type='time'], & input[type='datetime-local']":
+      {
+        "&::-webkit-calendar-picker-indicator": {
+          filter: "brightness(0) invert(1)",
+          opacity: 1,
+        },
+      },
+  }),
 }))


### PR DESCRIPTION
Fixes the calendar icon in `st.dataframe`'s date picker not being visible properly in dark mode. Applies theme-based filter correction to the WebKit calendar indicator.

- Closes #12852

- Verified on light and dark themes.
- Checked date/time/datetime-local inputs for better visibility in light and dark mode.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

## Describe your changes

## Screenshot or video (only for visual changes)

https://github.com/user-attachments/assets/58c2abd7-017b-4063-ac0f-40ca4144938f



https://github.com/user-attachments/assets/64b34fd7-0b31-4a94-aaa0-5b16b383c467



## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies dark-theme conditional styling to WebKit calendar picker indicators in `StyledDataFrameOverlay` to make date/time icons visible.
> 
> - **Frontend/Styling**:
>   - **`frontend/lib/src/styled-components.ts`**:
>     - Add conditional dark-theme styles in `StyledDataFrameOverlay` for `input[type='date'| 'time'| 'datetime-local']` WebKit calendar picker indicator (`filter: brightness(0) invert(1)`, `opacity: 1`).
>     - Import and use `hasLightBackgroundColor` to gate the styling by theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9cf58bd10f8f49a4201457bdf46402c517ae2a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->