### PR TITLE
[fix] Fixes visual regression with `st.audio_input` waveform

### DIFF
--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -239,7 +239,13 @@ export function useWaveformController({
     } finally {
       isInitializingRef.current = false
     }
-  }, [containerRef, theme, effectiveSampleRate, configurePlayerEvents])
+  }, [
+    containerRef,
+    theme,
+    effectiveSampleRate,
+    configurePlayerEvents,
+    waveformPadding,
+  ])
 
   useEffect(() => {
     void initializeWaveSurfer()

--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -56,6 +56,10 @@ interface UseWaveformControllerParams {
   containerRef: RefObject<HTMLDivElement>
   sampleRate?: number | null
   events: WaveformControllerEvents
+  /**
+   * Vertical padding in pixels to apply around the waveform.
+   * This reduces the waveform height to prevent it from touching container edges.
+   */
   waveformPadding?: number
 }
 

--- a/frontend/lib/src/components/audio/core/useWaveformController.ts
+++ b/frontend/lib/src/components/audio/core/useWaveformController.ts
@@ -39,7 +39,7 @@ import type {
   WaveformControllerEvents,
 } from "~lib/components/audio/core/types"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { blend } from "~lib/theme/utils"
+import { blend, convertRemToPx } from "~lib/theme/utils"
 
 const BAR_WIDTH = 4
 const BAR_GAP = 4
@@ -56,12 +56,14 @@ interface UseWaveformControllerParams {
   containerRef: RefObject<HTMLDivElement>
   sampleRate?: number | null
   events: WaveformControllerEvents
+  waveformPadding?: number
 }
 
 export function useWaveformController({
   containerRef,
   sampleRate,
   events,
+  waveformPadding = 0,
 }: UseWaveformControllerParams): WaveformController {
   const theme = useEmotionTheme()
 
@@ -190,7 +192,11 @@ export function useWaveformController({
         container: containerRef.current,
         waveColor: theme.colors.primary,
         progressColor: theme.colors.bodyText,
-        height: "auto",
+        height:
+          waveformPadding > 0
+            ? convertRemToPx(theme.sizes.largestElementHeight) -
+              2 * waveformPadding
+            : "auto",
         barWidth: BAR_WIDTH,
         barGap: BAR_GAP,
         barRadius: BAR_RADIUS,

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -232,7 +232,7 @@ const AudioInput: React.FC<Props> = ({
   const controller = useWaveformController({
     containerRef,
     sampleRate: element.sampleRate ?? undefined,
-    waveformPadding: 4,
+    waveformPadding: 4, // Pixels of vertical padding to prevent waveform from touching edges
     events: {
       onPermissionDenied: () => {
         setHasNoMicPermissions(true)

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -232,6 +232,7 @@ const AudioInput: React.FC<Props> = ({
   const controller = useWaveformController({
     containerRef,
     sampleRate: element.sampleRate ?? undefined,
+    waveformPadding: 4,
     events: {
       onPermissionDenied: () => {
         setHasNoMicPermissions(true)

--- a/frontend/lib/src/components/widgets/AudioInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/AudioInput/styled-components.ts
@@ -49,9 +49,6 @@ export const StyledWaveSurferDiv = styled.div<{ show: boolean }>(
     // as sibling divs. Stack them with relative positioning so they overlap.
     position: "relative",
     height: theme.sizes.largestElementHeight,
-    // Add vertical padding to prevent waveform from touching container edges.
-    paddingTop: theme.spacing.threeXS,
-    paddingBottom: theme.spacing.threeXS,
     // Each WaveSurfer child div should be absolutely positioned to stack
     "& > div": {
       position: "absolute",


### PR DESCRIPTION
## Describe your changes

I noticed yesterday during the demos that there was a slight visual regression on `st.audio_input`. The waveform would fill 100% of the height of the component. Luckily, we haven't released this yet, and it is resolved in this PR.

Why was it not caught by snapshot tests? Because getting a deterministic screenshot of a moving waveform (or even just a waveform) is a difficult challenge. 


## Before fix
<img width="772" height="158" alt="image" src="https://github.com/user-attachments/assets/e68a787a-15fe-4668-bc08-91b8be460944" />


## After fix
<img width="797" height="163" alt="image" src="https://github.com/user-attachments/assets/1b08570e-af9a-4599-9ee2-95864fce31b9" />


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
