### PR TITLE
[fix] Pin specific streamlit-pdf version

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.3.4
 plotly>=5.3.1
 seaborn>=0.11.2
 watchdog>=2.1.5
-streamlit-pdf>=1.0.0
+streamlit-pdf>=1.0.0,<2.0.0
 
 # Optional dependency used for improved exception formatting
 # in Community Cloud:


### PR DESCRIPTION
## Describe your changes

- Temporarily pin the `streamlit-pdf` version until we fix the unit tests to keep CI green.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
