### PR TITLE
Add fastapi and starlette to attributions

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -153,6 +153,8 @@ _ATTRIBUTIONS_TO_CHECK: Final = [
     "pydantic",
     "plost",
     "authlib",
+    "fastapi",
+    "starlette",
 ]
 
 _ETC_MACHINE_ID_PATH = "/etc/machine-id"


### PR DESCRIPTION
## Describe your changes

Add FastAPI and Starlette to our metrics attribution as preparation for the Starlette migration.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
