### PR TITLE
[Prototype] Add `st.datetime` input

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -35,6 +35,7 @@ import {
   ColorPicker as ColorPickerProto,
   ComponentInstance as ComponentInstanceProto,
   DateInput as DateInputProto,
+  DatetimeInput as DatetimeInputProto,
   DeckGlJsonChart as DeckGlJsonChartProto,
   DocString as DocStringProto,
   DownloadButton as DownloadButtonProto,
@@ -148,6 +149,9 @@ const ChatInput = lazy(() => import("~lib/components/widgets/ChatInput"))
 const Checkbox = lazy(() => import("~lib/components/widgets/Checkbox"))
 const ColorPicker = lazy(() => import("~lib/components/widgets/ColorPicker"))
 const DateInput = lazy(() => import("~lib/components/widgets/DateInput"))
+const DatetimeInput = lazy(
+  () => import("~lib/components/widgets/DatetimeInput")
+)
 const Html = lazy(() => import("~lib/components/elements/Html"))
 const Multiselect = lazy(() => import("~lib/components/widgets/Multiselect"))
 const Progress = lazy(() => import("~lib/components/elements/Progress"))
@@ -574,6 +578,20 @@ const RawElementNodeRenderer = (
         <DateInput
           key={dateInputProto.id}
           element={dateInputProto}
+          {...widgetProps}
+        />
+      )
+    }
+
+    case "datetimeInput": {
+      const datetimeInputProto = node.element
+        .datetimeInput as DatetimeInputProto
+      widgetProps.disabled =
+        widgetProps.disabled || datetimeInputProto.disabled
+      return (
+        <DatetimeInput
+          key={datetimeInputProto.id}
+          element={datetimeInputProto}
           {...widgetProps}
         />
       )

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -45,6 +45,7 @@ const LARGE_STRETCH_BEHAVIOR = [
 
 const MEDIUM_STRETCH_BEHAVIOR = [
   "dateInput",
+  "datetimeInput",
   "radio",
   "slider", // also includes st.select_slider
   "textArea",

--- a/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
@@ -1,0 +1,481 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  memo,
+  ReactElement,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react"
+
+import { ErrorOutline } from "@emotion-icons/material-outlined"
+import { DENSITY, Datepicker as UIDatePicker } from "baseui/datepicker"
+import { PLACEMENT } from "baseui/popover"
+import { format } from "date-fns"
+import moment from "moment"
+
+import { DatetimeInput as DatetimeInputProto } from "@streamlit/protobuf"
+
+import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import { LibConfigContext } from "~lib/components/core/LibConfigContext"
+import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import Icon from "~lib/components/shared/Icon"
+import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
+import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
+import TooltipIcon from "~lib/components/shared/TooltipIcon"
+import {
+  StyledWidgetLabelHelp,
+  WidgetLabel,
+} from "~lib/components/widgets/BaseWidget"
+import {
+  useBasicWidgetState,
+  ValueWithSource,
+} from "~lib/hooks/useBasicWidgetState"
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { hasLightBackgroundColor } from "~lib/theme"
+import {
+  isNullOrUndefined,
+  labelVisibilityProtoValueToEnum,
+} from "~lib/util/utils"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import { useIntlLocale } from "src/components/widgets/DateInput/useIntlLocale"
+
+export interface Props {
+  disabled: boolean
+  element: DatetimeInputProto
+  widgetMgr: WidgetStateManager
+  fragmentId?: string
+}
+
+const DATETIME_PROTO_FORMAT = "YYYY/MM/DD HH:mm:ss"
+
+function DatetimeInput({
+  disabled,
+  element,
+  widgetMgr,
+  fragmentId,
+}: Props): ReactElement {
+  const theme = useEmotionTheme()
+  const isInSidebar = useContext(IsSidebarContext)
+
+  const [value, setValueWithSource] = useBasicWidgetState<
+    string | null,
+    DatetimeInputProto
+  >({
+    getStateFromWidgetMgr,
+    getDefaultStateFromProto,
+    getCurrStateFromProto,
+    updateWidgetMgrState,
+    element,
+    widgetMgr,
+    fragmentId,
+  })
+
+  const [isEmpty, setIsEmpty] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { locale } = useContext(LibConfigContext)
+  const loadedLocale = useIntlLocale(locale)
+
+  const minDate = useMemo(
+    () => moment(element.min, DATETIME_PROTO_FORMAT).toDate(),
+    [element.min]
+  )
+  const maxDate = useMemo(
+    () => moment(element.max, DATETIME_PROTO_FORMAT).toDate(),
+    [element.max]
+  )
+
+  const clearable = !element.default && !disabled
+  const selectedDate = useMemo(() => stringToDate(value), [value])
+
+  const dateMask = useMemo(
+    () => `${element.format.replaceAll(/[a-zA-Z]/g, "9")} 99:99`,
+    [element.format]
+  )
+
+  const dateFormat = useMemo(
+    () => `${element.format.replaceAll("Y", "y").replaceAll("D", "d")} HH:mm`,
+    [element.format]
+  )
+
+  const placeholder = useMemo(
+    () => `${element.format} HH:MM`,
+    [element.format]
+  )
+
+  const minDateString = useMemo(
+    () => format(minDate, dateFormat, { locale: loadedLocale }),
+    [minDate, dateFormat, loadedLocale]
+  )
+  const maxDateString = useMemo(
+    () => format(maxDate, dateFormat, { locale: loadedLocale }),
+    [maxDate, dateFormat, loadedLocale]
+  )
+
+  const createErrorMessage = useCallback(
+    (errorType: "min" | "max" | null): string | null => {
+      if (!errorType) {
+        return null
+      }
+
+      const direction = errorType === "min" ? "after" : "before"
+      const boundary = errorType === "min" ? minDateString : maxDateString
+      return `**Error**: Datetime set outside allowed range. Please select a datetime ${direction} ${boundary}.`
+    },
+    [minDateString, maxDateString]
+  )
+
+  const stepSeconds = element.step || 900
+
+  const handleChange = useCallback(
+    ({
+      date,
+    }: {
+      date: Date | (Date | null | undefined)[] | null | undefined
+    }): void => {
+      setError(null)
+
+      if (isNullOrUndefined(date)) {
+        setValueWithSource({ value: null, fromUi: true })
+        setIsEmpty(true)
+        return
+      }
+
+      const nextDate = Array.isArray(date) ? date[0] : date
+      if (!nextDate) {
+        setValueWithSource({ value: null, fromUi: true })
+        setIsEmpty(true)
+        return
+      }
+
+      const normalizedDate = normalizeToMinute(nextDate)
+      const snappedDate = snapToStep(normalizedDate, stepSeconds)
+      const errorType = validateDatetime(snappedDate, minDate, maxDate)
+
+      if (errorType) {
+        setError(createErrorMessage(errorType))
+      }
+
+      setValueWithSource({
+        value: dateToString(snappedDate),
+        fromUi: true,
+      })
+      setIsEmpty(false)
+    },
+    [createErrorMessage, maxDate, minDate, setValueWithSource, stepSeconds]
+  )
+
+  const handleClose = useCallback((): void => {
+    if (!isEmpty) {
+      return
+    }
+
+    const nextValue = element.default || null
+    setValueWithSource({ value: nextValue, fromUi: true })
+    setIsEmpty(!nextValue)
+  }, [element.default, isEmpty, setValueWithSource])
+
+  return (
+    <div className="stDatetimeInput" data-testid="stDatetimeInput">
+      <WidgetLabel
+        label={element.label}
+        disabled={disabled}
+        labelVisibility={labelVisibilityProtoValueToEnum(
+          element.labelVisibility?.value
+        )}
+      >
+        {element.help && (
+          <StyledWidgetLabelHelp>
+            <TooltipIcon
+              content={element.help}
+              placement={Placement.TOP_RIGHT}
+            />
+          </StyledWidgetLabelHelp>
+        )}
+      </WidgetLabel>
+      <UIDatePicker
+        locale={loadedLocale}
+        density={DENSITY.high}
+        formatString={dateFormat}
+        mask={dateMask}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={handleChange}
+        onClose={handleClose}
+        clearable={clearable}
+        value={selectedDate}
+        minDate={minDate}
+        maxDate={maxDate}
+        timeSelectStart
+        aria-label={element.label}
+        overrides={{
+          Popover: {
+            props: {
+              ignoreBoundary: isInSidebar,
+              placement: PLACEMENT.bottomLeft,
+              overrides: {
+                Body: {
+                  style: {
+                    marginTop: theme.spacing.px,
+                  },
+                },
+              },
+            },
+          },
+          CalendarContainer: {
+            style: {
+              fontSize: theme.fontSizes.sm,
+              paddingRight: theme.spacing.sm,
+              paddingLeft: theme.spacing.sm,
+              paddingBottom: theme.spacing.sm,
+              paddingTop: theme.spacing.sm,
+            },
+          },
+          Week: {
+            style: {
+              fontSize: theme.fontSizes.sm,
+            },
+          },
+          Day: {
+            style: ({
+              $pseudoHighlighted,
+              $pseudoSelected,
+              $selected,
+              $isHovered,
+            }: Record<string, boolean>) => ({
+              fontSize: theme.fontSizes.sm,
+              lineHeight: theme.lineHeights.base,
+
+              "::before": {
+                backgroundColor:
+                  $selected ||
+                  $pseudoSelected ||
+                  $pseudoHighlighted ||
+                  $isHovered
+                    ? `${theme.colors.darkenedBgMix15} !important`
+                    : theme.colors.transparent,
+              },
+
+              "::after": {
+                borderColor: theme.colors.transparent,
+              },
+
+              ...(hasLightBackgroundColor(theme) &&
+              $isHovered &&
+              $pseudoSelected &&
+              !$selected
+                ? {
+                    color: theme.colors.secondaryBg,
+                  }
+                : {}),
+            }),
+          },
+          PrevButton: {
+            style: () => ({
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              ":active": {
+                backgroundColor: theme.colors.transparent,
+              },
+              ":focus": {
+                backgroundColor: theme.colors.transparent,
+                outline: 0,
+              },
+            }),
+          },
+          NextButton: {
+            style: {
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              ":active": {
+                backgroundColor: theme.colors.transparent,
+              },
+              ":focus": {
+                backgroundColor: theme.colors.transparent,
+                outline: 0,
+              },
+            },
+          },
+          Input: {
+            props: {
+              maskChar: null,
+              endEnhancer: error && (
+                <Tooltip
+                  content={
+                    <StreamlitMarkdown source={error} allowHTML={false} />
+                  }
+                  placement={Placement.TOP_RIGHT}
+                  error
+                >
+                  <Icon content={ErrorOutline} size="lg" />
+                </Tooltip>
+              ),
+              overrides: {
+                EndEnhancer: {
+                  style: {
+                    color: theme.colors.redTextColor,
+                    backgroundColor: theme.colors.transparent,
+                  },
+                },
+                Root: {
+                  style: ({ $isFocused }: { $isFocused: boolean }) => {
+                    const borderColor = getBorderColor(
+                      theme.colors,
+                      $isFocused
+                    )
+                    return {
+                      borderLeftWidth: theme.sizes.borderWidth,
+                      borderRightWidth: theme.sizes.borderWidth,
+                      borderTopWidth: theme.sizes.borderWidth,
+                      borderBottomWidth: theme.sizes.borderWidth,
+                      paddingRight: theme.spacing.twoXS,
+                      borderTopColor: borderColor,
+                      borderRightColor: borderColor,
+                      borderBottomColor: borderColor,
+                      borderLeftColor: borderColor,
+                      ...(error && {
+                        backgroundColor: theme.colors.redBackgroundColor,
+                      }),
+                    }
+                  },
+                },
+                InputContainer: {
+                  style: {
+                    backgroundColor: theme.colors.transparent,
+                  },
+                },
+                Input: {
+                  style: {
+                    fontWeight: theme.fontWeights.normal,
+                    paddingRight: theme.spacing.sm,
+                    paddingLeft: theme.spacing.md,
+                    paddingBottom: theme.spacing.sm,
+                    paddingTop: theme.spacing.sm,
+                    lineHeight: theme.lineHeights.inputWidget,
+                    "::placeholder": {
+                      color: theme.colors.fadedText60,
+                    },
+                    ...(error && {
+                      color: theme.colors.redTextColor,
+                    }),
+                  },
+                  props: {
+                    "data-testid": "stDatetimeInputField",
+                  },
+                },
+                ClearIcon: {
+                  props: {
+                    overrides: {
+                      Svg: {
+                        style: {
+                          color: theme.colors.grayTextColor,
+                          padding: theme.spacing.threeXS,
+                          height: theme.sizes.clearIconSize,
+                          width: theme.sizes.clearIconSize,
+                          ":hover": {
+                            fill: theme.colors.bodyText,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }}
+      />
+    </div>
+  )
+}
+
+function getStateFromWidgetMgr(
+  widgetMgr: WidgetStateManager,
+  element: DatetimeInputProto
+): string | null {
+  return widgetMgr.getStringValue(element) ?? (element.default || null)
+}
+
+function getDefaultStateFromProto(element: DatetimeInputProto): string | null {
+  return element.default || null
+}
+
+function getCurrStateFromProto(element: DatetimeInputProto): string | null {
+  return element.value || null
+}
+
+function updateWidgetMgrState(
+  element: DatetimeInputProto,
+  widgetMgr: WidgetStateManager,
+  vws: ValueWithSource<string | null>,
+  fragmentId?: string
+): void {
+  widgetMgr.setStringValue(
+    element,
+    vws.value,
+    { fromUi: vws.fromUi },
+    fragmentId
+  )
+}
+
+function dateToString(date: Date): string {
+  return moment(date).format(DATETIME_PROTO_FORMAT)
+}
+
+function stringToDate(value: string | null): Date | null {
+  if (!value) {
+    return null
+  }
+  return moment(value, DATETIME_PROTO_FORMAT).toDate()
+}
+
+function normalizeToMinute(date: Date): Date {
+  const normalized = new Date(date.getTime())
+  normalized.setSeconds(0, 0)
+  return normalized
+}
+
+function snapToStep(date: Date, stepSeconds: number): Date {
+  if (stepSeconds <= 0) {
+    return date
+  }
+
+  const snappedTimestamp =
+    Math.floor(date.getTime() / (stepSeconds * 1000)) * stepSeconds * 1000
+  return new Date(snappedTimestamp)
+}
+
+function validateDatetime(
+  date: Date,
+  minDate: Date,
+  maxDate: Date
+): "min" | "max" | null {
+  if (date < minDate) {
+    return "min"
+  }
+  if (date > maxDate) {
+    return "max"
+  }
+  return null
+}
+
+export default memo(DatetimeInput)

--- a/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
@@ -19,12 +19,15 @@ import React, {
   ReactElement,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
 import { ErrorOutline } from "@emotion-icons/material-outlined"
 import { DENSITY, Datepicker as UIDatePicker } from "baseui/datepicker"
+import type DatepickerClass from "baseui/datepicker/datepicker"
 import { ChevronDown } from "baseui/icon"
 import { PLACEMENT } from "baseui/popover"
 import { format } from "date-fns"
@@ -74,6 +77,7 @@ function DatetimeInput({
 }: Props): ReactElement {
   const theme = useEmotionTheme()
   const isInSidebar = useContext(IsSidebarContext)
+  const datepickerRef = useRef<DatepickerClass<Date> | null>(null)
 
   const [value, setValueWithSource] = useBasicWidgetState<
     string | null,
@@ -88,7 +92,6 @@ function DatetimeInput({
     fragmentId,
   })
 
-  const [isEmpty, setIsEmpty] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const { locale } = useContext(LibConfigContext)
@@ -104,7 +107,12 @@ function DatetimeInput({
   )
 
   const clearable = !element.default && !disabled
-  const selectedDate = useMemo(() => stringToDate(value), [value])
+  const committedDate = useMemo(() => stringToDate(value), [value])
+  const [pendingDate, setPendingDate] = useState<Date | null>(committedDate)
+
+  useEffect(() => {
+    setPendingDate(committedDate)
+  }, [committedDate])
 
   const dateMask = useMemo(() => {
     const datePartMask = element.format.replaceAll(/[a-zA-Z]/g, "9")
@@ -243,15 +251,13 @@ function DatetimeInput({
       setError(null)
 
       if (isNullOrUndefined(date)) {
-        setValueWithSource({ value: null, fromUi: true })
-        setIsEmpty(true)
+        setPendingDate(null)
         return
       }
 
       const nextDate = Array.isArray(date) ? date[0] : date
       if (!nextDate) {
-        setValueWithSource({ value: null, fromUi: true })
-        setIsEmpty(true)
+        setPendingDate(null)
         return
       }
 
@@ -263,24 +269,24 @@ function DatetimeInput({
         setError(createErrorMessage(errorType))
       }
 
-      setValueWithSource({
-        value: dateToString(snappedDate),
-        fromUi: true,
-      })
-      setIsEmpty(false)
+      setPendingDate(snappedDate)
+
+      datepickerRef.current?.open?.()
     },
-    [createErrorMessage, maxDate, minDate, setValueWithSource, stepSeconds]
+    [createErrorMessage, maxDate, minDate, stepSeconds]
   )
 
   const handleClose = useCallback((): void => {
-    if (!isEmpty) {
-      return
-    }
+    const nextValue = pendingDate ? dateToString(pendingDate) : null
+    const hasChanged = nextValue !== value
 
-    const nextValue = element.default || null
-    setValueWithSource({ value: nextValue, fromUi: true })
-    setIsEmpty(!nextValue)
-  }, [element.default, isEmpty, setValueWithSource])
+    if (hasChanged) {
+      setValueWithSource({
+        value: nextValue,
+        fromUi: true,
+      })
+    }
+  }, [pendingDate, setValueWithSource, value])
 
   return (
     <div className="stDatetimeInput" data-testid="stDatetimeInput">
@@ -301,6 +307,7 @@ function DatetimeInput({
         )}
       </WidgetLabel>
       <UIDatePicker
+        ref={datepickerRef}
         locale={loadedLocale}
         density={DENSITY.high}
         formatString={dateFormat}
@@ -310,7 +317,7 @@ function DatetimeInput({
         onChange={handleChange}
         onClose={handleClose}
         clearable={clearable}
-        value={selectedDate}
+        value={pendingDate}
         minDate={minDate}
         maxDate={maxDate}
         timeSelectStart

--- a/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
@@ -105,18 +105,18 @@ function DatetimeInput({
   const clearable = !element.default && !disabled
   const selectedDate = useMemo(() => stringToDate(value), [value])
 
-  const dateMask = useMemo(
-    () => `${element.format.replaceAll(/[a-zA-Z]/g, "9")} 99:99`,
-    [element.format]
-  )
+  const dateMask = useMemo(() => {
+    const datePartMask = element.format.replaceAll(/[a-zA-Z]/g, "9")
+    return `${datePartMask}, 99:99`
+  }, [element.format])
 
   const dateFormat = useMemo(
-    () => `${element.format.replaceAll("Y", "y").replaceAll("D", "d")} HH:mm`,
+    () => `${element.format.replaceAll("Y", "y").replaceAll("D", "d")}, HH:mm`,
     [element.format]
   )
 
   const placeholder = useMemo(
-    () => `${element.format} HH:MM`,
+    () => `${element.format}, HH:MM`,
     [element.format]
   )
 

--- a/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
@@ -25,6 +25,7 @@ import React, {
 
 import { ErrorOutline } from "@emotion-icons/material-outlined"
 import { DENSITY, Datepicker as UIDatePicker } from "baseui/datepicker"
+import { ChevronDown } from "baseui/icon"
 import { PLACEMENT } from "baseui/popover"
 import { format } from "date-fns"
 import moment from "moment"
@@ -42,6 +43,8 @@ import {
   StyledWidgetLabelHelp,
   WidgetLabel,
 } from "~lib/components/widgets/BaseWidget"
+import { useIntlLocale } from "~lib/components/widgets/DateInput/useIntlLocale"
+import { StyledTimeDropdownListItem } from "~lib/components/widgets/TimeInput/styled-components"
 import {
   useBasicWidgetState,
   ValueWithSource,
@@ -53,8 +56,6 @@ import {
   labelVisibilityProtoValueToEnum,
 } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
-
-import { useIntlLocale } from "src/components/widgets/DateInput/useIntlLocale"
 
 export interface Props {
   disabled: boolean
@@ -127,6 +128,95 @@ function DatetimeInput({
   const maxDateString = useMemo(
     () => format(maxDate, dateFormat, { locale: loadedLocale }),
     [maxDate, dateFormat, loadedLocale]
+  )
+
+  const timeSelectOverrides = useMemo(
+    () => ({
+      Select: {
+        props: {
+          disabled,
+          overrides: {
+            ControlContainer: {
+              style: ({ $isFocused }: { $isFocused: boolean }) => {
+                const borderColor = getBorderColor(theme.colors, $isFocused)
+                return {
+                  height: theme.sizes.minElementHeight,
+                  borderLeftWidth: theme.sizes.borderWidth,
+                  borderRightWidth: theme.sizes.borderWidth,
+                  borderTopWidth: theme.sizes.borderWidth,
+                  borderBottomWidth: theme.sizes.borderWidth,
+                  borderTopColor: borderColor,
+                  borderRightColor: borderColor,
+                  borderBottomColor: borderColor,
+                  borderLeftColor: borderColor,
+                }
+              },
+            },
+            IconsContainer: {
+              style: {
+                paddingRight: theme.spacing.sm,
+              },
+            },
+            ValueContainer: {
+              style: {
+                lineHeight: theme.lineHeights.inputWidget,
+                paddingRight: theme.spacing.sm,
+                paddingLeft: theme.spacing.md,
+                paddingBottom: theme.spacing.sm,
+                paddingTop: theme.spacing.sm,
+              },
+            },
+            SingleValue: {
+              style: {
+                fontWeight: theme.fontWeights.normal,
+              },
+            },
+            Dropdown: {
+              style: {
+                paddingTop: theme.spacing.none,
+                paddingBottom: theme.spacing.none,
+                boxShadow: "none",
+                maxHeight: theme.sizes.maxDropdownHeight,
+              },
+            },
+            DropdownListItem: {
+              component: StyledTimeDropdownListItem,
+            },
+            Popover: {
+              props: {
+                ignoreBoundary: isInSidebar,
+                overrides: {
+                  Body: {
+                    style: {
+                      marginTop: theme.spacing.px,
+                    },
+                  },
+                },
+              },
+            },
+            Placeholder: {
+              style: {
+                color: theme.colors.fadedText60,
+              },
+            },
+            SelectArrow: {
+              component: ChevronDown,
+              props: {
+                overrides: {
+                  Svg: {
+                    style: {
+                      width: theme.iconSizes.xl,
+                      height: theme.iconSizes.xl,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+    [disabled, isInSidebar, theme]
   )
 
   const createErrorMessage = useCallback(
@@ -242,6 +332,12 @@ function DatetimeInput({
           TimeSelectFormControl: {
             props: {
               label: "",
+            },
+          },
+          TimeSelect: {
+            props: {
+              format: "24",
+              overrides: timeSelectOverrides,
             },
           },
           CalendarContainer: {

--- a/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DatetimeInput/DatetimeInput.tsx
@@ -239,6 +239,11 @@ function DatetimeInput({
               },
             },
           },
+          TimeSelectFormControl: {
+            props: {
+              label: "",
+            },
+          },
           CalendarContainer: {
             style: {
               fontSize: theme.fontSizes.sm,

--- a/frontend/lib/src/components/widgets/DatetimeInput/index.ts
+++ b/frontend/lib/src/components/widgets/DatetimeInput/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./DatetimeInput"

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -180,6 +180,7 @@ container = _main.container
 dataframe = _main.dataframe
 data_editor = _main.data_editor
 date_input = _main.date_input
+datetime_input = _main.datetime_input
 divider = _main.divider
 download_button = _main.download_button
 expander = _main.expander

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -18,15 +18,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from textwrap import dedent
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Final,
-    Literal,
-    TypeAlias,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, cast, overload
 
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.layout_utils import (
@@ -47,6 +39,7 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
+from streamlit.proto.DatetimeInput_pb2 import DatetimeInput as DatetimeInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
@@ -68,6 +61,12 @@ TimeValue: TypeAlias = time | datetime | str | Literal["now"]
 # Type for things that point to a specific date (even if a default date, including None).
 NullableScalarDateValue: TypeAlias = date | datetime | str | Literal["today"] | None
 
+# Type for datetime widget values (date + time combined).
+DatetimeValue: TypeAlias = datetime | date | time | str | Literal["now"] | None
+
+# Type for datetime widget boundaries (min/max).
+DatetimeBoundaryValue: TypeAlias = datetime | date | time | str | None
+
 # The accepted input value for st.date_input. Can be a date scalar or a date range.
 DateValue: TypeAlias = NullableScalarDateValue | Sequence[NullableScalarDateValue]
 
@@ -75,11 +74,15 @@ DateValue: TypeAlias = NullableScalarDateValue | Sequence[NullableScalarDateValu
 DateWidgetRangeReturn: TypeAlias = tuple[()] | tuple[date] | tuple[date, date]
 DateWidgetReturn: TypeAlias = date | DateWidgetRangeReturn | None
 
+# The return value of st.datetime_input.
+DatetimeWidgetReturn: TypeAlias = datetime | None
+
 
 DEFAULT_STEP_MINUTES: Final = 15
 ALLOWED_DATE_FORMATS: Final = re.compile(
     r"^(YYYY[/.\-]MM[/.\-]DD|DD[/.\-]MM[/.\-]YYYY|MM[/.\-]DD[/.\-]YYYY)$"
 )
+DATETIME_PROTO_FORMAT: Final = "%Y/%m/%d %H:%M:%S"
 
 
 def _convert_timelike_to_time(value: TimeValue) -> time:
@@ -201,6 +204,108 @@ def _parse_max_date(
     return parsed_max_date
 
 
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is not None:
+        value = value.replace(tzinfo=None)
+    return value.replace(microsecond=0)
+
+
+def _convert_datetime_like_to_datetime(
+    value: DatetimeValue,
+    *,
+    fallback_date: date | None = None,
+) -> datetime:
+    if value == "now":
+        return _normalize_datetime(datetime.now())
+
+    if isinstance(value, datetime):
+        return _normalize_datetime(value)
+
+    if isinstance(value, date):
+        return datetime.combine(value, time.min)
+
+    if isinstance(value, time):
+        base_date = fallback_date or datetime.now().date()
+        normalized_time = value.replace(tzinfo=None)
+        return datetime.combine(base_date, normalized_time)
+
+    if isinstance(value, str):
+        trimmed_value = value.strip()
+        if trimmed_value.lower() == "now":
+            return _normalize_datetime(datetime.now())
+
+        try:
+            parsed_datetime = datetime.fromisoformat(trimmed_value)
+        except ValueError:
+            parsed_datetime = None
+        if parsed_datetime is not None:
+            return _normalize_datetime(parsed_datetime)
+
+        try:
+            parsed_date = date.fromisoformat(trimmed_value)
+        except ValueError:
+            parsed_date = None
+        if parsed_date is not None:
+            return datetime.combine(parsed_date, time.min)
+
+        try:
+            parsed_time = time.fromisoformat(trimmed_value)
+        except ValueError:
+            parsed_time = None
+        if parsed_time is not None:
+            base_date = fallback_date or datetime.now().date()
+            normalized_time = parsed_time.replace(tzinfo=None)
+            return datetime.combine(base_date, normalized_time)
+
+    raise StreamlitAPIException(
+        "DatetimeInput value should either be a datetime, date, time, ISO string, "
+        'the string "now", or None'
+    )
+
+
+def _adjust_datetime_years(value: datetime, years: int) -> datetime:
+    adjusted_date = adjust_years(value.date(), years=years)
+    return datetime.combine(adjusted_date, value.time())
+
+
+def _parse_min_datetime(
+    min_value: DatetimeBoundaryValue,
+    parsed_value: datetime | None,
+) -> datetime:
+    if isinstance(min_value, (datetime, date, time, str)):
+        fallback = parsed_value.date() if parsed_value is not None else None
+        parsed_min = _convert_datetime_like_to_datetime(
+            min_value, fallback_date=fallback
+        )
+    elif min_value is None:
+        base = parsed_value or _normalize_datetime(datetime.now())
+        parsed_min = _adjust_datetime_years(base, years=-10)
+    else:
+        raise StreamlitAPIException(
+            "DatetimeInput min_value should either be a datetime/date/time/ISO string or None"
+        )
+    return parsed_min
+
+
+def _parse_max_datetime(
+    max_value: DatetimeBoundaryValue,
+    parsed_value: datetime | None,
+) -> datetime:
+    if isinstance(max_value, (datetime, date, time, str)):
+        fallback = parsed_value.date() if parsed_value is not None else None
+        parsed_max = _convert_datetime_like_to_datetime(
+            max_value, fallback_date=fallback
+        )
+    elif max_value is None:
+        base = parsed_value or _normalize_datetime(datetime.now())
+        parsed_max = _adjust_datetime_years(base, years=10)
+    else:
+        raise StreamlitAPIException(
+            "DatetimeInput max_value should either be a datetime/date/time/ISO string or None"
+        )
+    return parsed_max
+
+
 @dataclass(frozen=True)
 class _DateInputValues:
     value: Sequence[date] | None
@@ -303,6 +408,97 @@ class DateInputSerde:
 
         to_serialize = list(v) if isinstance(v, Sequence) else [v]
         return [date.strftime(v, "%Y/%m/%d") for v in to_serialize]
+
+
+@dataclass(frozen=True)
+class _DatetimeInputValues:
+    value: datetime | None
+    min: datetime
+    max: datetime
+
+    @classmethod
+    def from_raw_values(
+        cls,
+        value: DatetimeValue,
+        min_value: DatetimeBoundaryValue,
+        max_value: DatetimeBoundaryValue,
+    ) -> _DatetimeInputValues:
+        parsed_value = (
+            None if value is None else _convert_datetime_like_to_datetime(value)
+        )
+        parsed_min = _parse_min_datetime(
+            min_value=min_value,
+            parsed_value=parsed_value,
+        )
+        parsed_max = _parse_max_datetime(
+            max_value=max_value,
+            parsed_value=parsed_value,
+        )
+
+        if parsed_value is not None:
+            if isinstance(value, str) and value.strip().lower() == "now":
+                parsed_value = max(min(parsed_value, parsed_max), parsed_min)
+
+            if parsed_value < parsed_min or parsed_value > parsed_max:
+                raise StreamlitAPIException(
+                    f"The default `value` of {parsed_value} must lie between the "
+                    f"`min_value` of {parsed_min} and the `max_value` of {parsed_max}, "
+                    "inclusively."
+                )
+
+        return cls(
+            value=parsed_value,
+            min=parsed_min,
+            max=parsed_max,
+        )
+
+    def __post_init__(self) -> None:
+        if self.min > self.max:
+            raise StreamlitAPIException(
+                f"The `min_value`, set to {self.min}, shouldn't be larger "
+                f"than the `max_value`, set to {self.max}."
+            )
+
+
+@dataclass
+class DatetimeInputSerde:
+    value: _DatetimeInputValues
+
+    def deserialize(self, ui_value: str | None) -> DatetimeWidgetReturn:
+        if ui_value is not None:
+            return datetime.strptime(ui_value, DATETIME_PROTO_FORMAT)
+        return self.value.value
+
+    def serialize(self, v: DatetimeWidgetReturn) -> str | None:
+        if v is None:
+            return None
+        return datetime.strftime(v, DATETIME_PROTO_FORMAT)
+
+
+def _datetime_value_to_id_component(
+    value: DatetimeValue | DatetimeBoundaryValue,
+) -> str | None:
+    if value is None:
+        return None
+
+    value_obj: object = value
+
+    if isinstance(value_obj, str):
+        trimmed = value_obj.strip()
+        return None if trimmed.lower() == "now" else trimmed
+
+    if isinstance(value_obj, datetime):
+        return datetime.strftime(_normalize_datetime(value_obj), DATETIME_PROTO_FORMAT)
+
+    if isinstance(value_obj, date):
+        combined = datetime.combine(value_obj, time.min)
+        return datetime.strftime(combined, DATETIME_PROTO_FORMAT)
+
+    if isinstance(value_obj, time):
+        normalized_time = value_obj.replace(tzinfo=None)
+        return time.strftime(normalized_time, "%H:%M:%S")
+
+    return None
 
 
 class TimeWidgetsMixin:
@@ -1000,6 +1196,304 @@ class TimeWidgetsMixin:
         layout_config = LayoutConfig(width=width)
 
         self.dg._enqueue("date_input", date_input_proto, layout_config=layout_config)
+        return widget_state.value
+
+    @overload
+    def datetime_input(
+        self,
+        label: str,
+        value: datetime | date | time | str | Literal["now"] = "now",
+        min_value: DatetimeBoundaryValue = None,
+        max_value: DatetimeBoundaryValue = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        *,  # keyword-only arguments:
+        format: str = "YYYY/MM/DD",
+        step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
+        disabled: bool = False,
+        label_visibility: LabelVisibility = "visible",
+        width: WidthWithoutContent = "stretch",
+    ) -> datetime: ...
+
+    @overload
+    def datetime_input(
+        self,
+        label: str,
+        value: None,
+        min_value: DatetimeBoundaryValue = None,
+        max_value: DatetimeBoundaryValue = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        *,  # keyword-only arguments:
+        format: str = "YYYY/MM/DD",
+        step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
+        disabled: bool = False,
+        label_visibility: LabelVisibility = "visible",
+        width: WidthWithoutContent = "stretch",
+    ) -> DatetimeWidgetReturn: ...
+
+    @gather_metrics("datetime_input")
+    def datetime_input(
+        self,
+        label: str,
+        value: DatetimeValue = "now",
+        min_value: DatetimeBoundaryValue = None,
+        max_value: DatetimeBoundaryValue = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        *,  # keyword-only arguments:
+        format: str = "YYYY/MM/DD",
+        step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
+        disabled: bool = False,
+        label_visibility: LabelVisibility = "visible",
+        width: WidthWithoutContent = "stretch",
+    ) -> DatetimeWidgetReturn:
+        r"""Display a datetime input widget.
+
+        Parameters
+        ----------
+        label : str
+            A short label explaining to the user what this datetime input is for.
+            The label can optionally contain GitHub-flavored Markdown of the
+            following types: Bold, Italics, Strikethroughs, Inline Code, Links,
+            and Images. Images display like icons, with a max height equal to
+            the font height. Unsupported Markdown elements are unwrapped so only
+            their children render.
+
+        value : "now", datetime.datetime, datetime.date, datetime.time, str, or None
+            The value of this widget when it first renders. This can be one of
+            the following:
+
+            - ``"now"`` (default): Initializes with the current datetime.
+            - ``datetime.datetime``: Initializes with the given datetime. Timezone
+              information, if present, is ignored.
+            - ``datetime.date``: Initializes with the given date and a time of 00:00.
+            - ``datetime.time``: Initializes with today's date and the given time.
+            - ISO-formatted datetime/date/time string: Parsed according to Python's
+              ``datetime.fromisoformat`` rules.
+            - ``None``: Initializes with no selection and returns ``None`` until the
+              user selects a datetime.
+
+        min_value : datetime.datetime, datetime.date, str, or None
+            The minimum selectable datetime. Accepts the same formats as ``value``
+            except for ``None``.
+
+            If this is ``None`` (default), the minimum selectable datetime is ten
+            years before the initial value. If no initial value is set, the minimum
+            defaults to ten years before the current moment.
+
+        max_value : datetime.datetime, datetime.date, str, or None
+            The maximum selectable datetime. Accepts the same formats as ``min_value``.
+
+            If this is ``None`` (default), the maximum selectable datetime is ten
+            years after the initial value. If no initial value is set, the maximum
+            defaults to ten years after the current moment.
+
+        key : str or int
+            An optional string or integer to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+        help : str or None
+            A tooltip that gets displayed next to the widget label. Streamlit
+            only displays the tooltip when ``label_visibility="visible"``.
+
+        on_change : callable
+            An optional callback invoked when this widget's value changes.
+
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
+
+        format : str
+            A format string controlling how the interface should display the date
+            portion. Supports "YYYY/MM/DD" (default), "DD/MM/YYYY", or "MM/DD/YYYY".
+            You may also use a period (.) or hyphen (-) as separators.
+
+        step : int or datetime.timedelta
+            The stepping interval in seconds for the time picker. Defaults to 900
+            (15 minutes). The minimum allowed step is 60 seconds and the maximum
+            is 23 hours.
+
+        disabled : bool
+            An optional boolean that disables the input if set to ``True``.
+
+        label_visibility : "visible", "hidden", or "collapsed"
+            Controls the visibility of the label. See ``st.date_input`` for details.
+
+        width : "stretch" or int
+            The width of the widget. ``"stretch"`` matches the parent container.
+            An integer specifies the width in pixels.
+
+        Returns
+        -------
+        datetime.datetime or None
+            The current value of the datetime input widget or ``None`` if no value
+            has been selected.
+        """
+        ctx = get_script_run_ctx()
+        return self._datetime_input(
+            label=label,
+            value=value,
+            min_value=min_value,
+            max_value=max_value,
+            key=key,
+            help=help,
+            on_change=on_change,
+            args=args,
+            kwargs=kwargs,
+            format=format,
+            step=step,
+            disabled=disabled,
+            label_visibility=label_visibility,
+            width=width,
+            ctx=ctx,
+        )
+
+    def _datetime_input(
+        self,
+        label: str,
+        value: DatetimeValue = "now",
+        min_value: DatetimeBoundaryValue = None,
+        max_value: DatetimeBoundaryValue = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        *,  # keyword-only arguments:
+        format: str = "YYYY/MM/DD",
+        step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
+        disabled: bool = False,
+        label_visibility: LabelVisibility = "visible",
+        width: WidthWithoutContent = "stretch",
+        ctx: ScriptRunContext | None = None,
+    ) -> DatetimeWidgetReturn:
+        key = to_key(key)
+
+        check_widget_policies(
+            self.dg,
+            key,
+            on_change,
+            default_value=value if value != "now" else None,
+        )
+        maybe_raise_label_warnings(label, label_visibility)
+
+        parsed_value_id = _datetime_value_to_id_component(value)
+        parsed_min_id = _datetime_value_to_id_component(min_value)
+        parsed_max_id = _datetime_value_to_id_component(max_value)
+
+        element_id = compute_and_register_element_id(
+            "datetime_input",
+            user_key=key,
+            key_as_main_identity={"min_value", "max_value", "format", "step"},
+            dg=self.dg,
+            label=label,
+            value=parsed_value_id,
+            min_value=parsed_min_id,
+            max_value=parsed_max_id,
+            help=help,
+            format=format,
+            step=step,
+            width=width,
+        )
+
+        if not bool(ALLOWED_DATE_FORMATS.match(format)):
+            raise StreamlitAPIException(
+                f"The provided format (`{format}`) is not valid. DatetimeInput format "
+                "should be one of `YYYY/MM/DD`, `DD/MM/YYYY`, or `MM/DD/YYYY` "
+                "and can also use a period (.) or hyphen (-) as separators."
+            )
+
+        parsed_values = _DatetimeInputValues.from_raw_values(
+            value=value,
+            min_value=min_value,
+            max_value=max_value,
+        )
+
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state and session_state[key] is None:
+            parsed_values = _DatetimeInputValues(
+                value=None,
+                min=parsed_values.min,
+                max=parsed_values.max,
+            )
+
+        if not isinstance(step, (int, timedelta)):
+            raise StreamlitAPIException(
+                f"`step` can only be `int` or `timedelta` but {type(step)} is provided."
+            )
+        if isinstance(step, timedelta):
+            step_seconds = int(step.total_seconds())
+        else:
+            step_seconds = step
+        if step_seconds < 60 or step_seconds > timedelta(hours=23).seconds:
+            raise StreamlitAPIException(
+                f"`step` must be between 60 seconds and 23 hours but is currently set to {step_seconds} seconds."
+            )
+
+        datetime_input_proto = DatetimeInputProto()
+        datetime_input_proto.id = element_id
+        datetime_input_proto.label = label
+        datetime_input_proto.form_id = current_form_id(self.dg)
+        datetime_input_proto.disabled = disabled
+        datetime_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+        datetime_input_proto.format = format
+        datetime_input_proto.step = step_seconds
+        datetime_input_proto.min = datetime.strftime(
+            parsed_values.min, DATETIME_PROTO_FORMAT
+        )
+        datetime_input_proto.max = datetime.strftime(
+            parsed_values.max, DATETIME_PROTO_FORMAT
+        )
+
+        if parsed_values.value is not None:
+            datetime_input_proto.default = datetime.strftime(
+                parsed_values.value, DATETIME_PROTO_FORMAT
+            )
+
+        if help is not None:
+            datetime_input_proto.help = dedent(help)
+
+        serde = DatetimeInputSerde(parsed_values)
+        widget_state = register_widget(
+            datetime_input_proto.id,
+            on_change_handler=on_change,
+            args=args,
+            kwargs=kwargs,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
+            ctx=ctx,
+            value_type="string_value",
+        )
+
+        if widget_state.value_changed:
+            serialized_value = serde.serialize(widget_state.value)
+            if serialized_value is not None:
+                datetime_input_proto.value = serialized_value
+            datetime_input_proto.set_value = True
+
+        validate_width(width)
+        layout_config = LayoutConfig(width=width)
+
+        self.dg._enqueue(
+            "datetime_input",
+            datetime_input_proto,
+            layout_config=layout_config,
+        )
         return widget_state.value
 
     @property

--- a/proto/streamlit/proto/DatetimeInput.proto
+++ b/proto/streamlit/proto/DatetimeInput.proto
@@ -1,0 +1,38 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DatetimeInputProto";
+
+import "streamlit/proto/LabelVisibilityMessage.proto";
+
+message DatetimeInput {
+  string id = 1;
+  string label = 2;
+  string default = 3;
+  string min = 4;
+  string max = 5;
+  string help = 6;
+  string form_id = 7;
+  string value = 8;
+  bool set_value = 9;
+  bool disabled = 10;
+  LabelVisibilityMessage label_visibility = 11;
+  string format = 12;
+  uint32 step = 13;
+}

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -36,6 +36,7 @@ import "streamlit/proto/Code.proto";
 import "streamlit/proto/ColorPicker.proto";
 import "streamlit/proto/DataFrame.proto";
 import "streamlit/proto/DateInput.proto";
+import "streamlit/proto/DatetimeInput.proto";
 import "streamlit/proto/DeckGlJsonChart.proto";
 import "streamlit/proto/DocString.proto";
 import "streamlit/proto/Empty.proto";
@@ -136,13 +137,14 @@ message Element {
     TextArea text_area = 22;
     TextInput text_input = 24;
     TimeInput time_input = 26;
+    DatetimeInput datetime_input = 61;
     Toast toast = 50;
     // DEPRECATED: This element is deprecated and unused:
     VegaLiteChart vega_lite_chart = 10;
     Video video = 14;
     Heading heading = 47;
     Code code = 48;
-    // Next ID: 61
+    // Next ID: 62
   }
 
   reserved 9;


### PR DESCRIPTION
## Describe your changes

Adds an `st.datetime_input` command that lets the user select a date and time in one input, and returns a `datetime` object. Vibe-coded with Codex. 

<!-- If it's a visual change, please include a screenshot or video! -->


https://github.com/user-attachments/assets/6388303a-4410-4999-bd46-0d3252ee1b00


## GitHub Issue Link (if applicable)

Closes #6089

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
