### PR TITLE
nit: set `private: true` on `eslint-plugin-streamlit-custom`

### DIFF
--- a/frontend/eslint-plugin-streamlit-custom/package.json
+++ b/frontend/eslint-plugin-streamlit-custom/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-plugin-streamlit-custom",
   "license": "Apache-2.0",
   "version": "1.0.0",
+  "private": true,
   "type": "module",
   "main": "./src/index.ts",
   "files": [


### PR DESCRIPTION
## Describe your changes

Other `frontend/*` packages have `private: true` config like below but `eslint-plugin-streamlit-custom`.
https://github.com/streamlit/streamlit/blob/8ae8a69dcd738149f6669f952e97ba95c412518b/frontend/typescript-config/package.json#L5

This PR sets it on `eslint-plugin-streamlit-custom` as well.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
