### PR TITLE
[fix] Do not print warning for placeholder CCv2 definitions

### DIFF
--- a/lib/streamlit/components/v2/component_registry.py
+++ b/lib/streamlit/components/v2/component_registry.py
@@ -165,6 +165,16 @@ class BidiComponentDefinition:
         return False, None
 
     @property
+    def is_placeholder(self) -> bool:
+        """Return True if this definition is a placeholder (no content).
+
+        Placeholders are typically created during the manifest scanning phase
+        when we discover a component's existence but haven't yet loaded its
+        content via the public API.
+        """
+        return self.html is None and self.css is None and self.js is None
+
+    @property
     def css_url(self) -> str | None:
         """Return the asset-dir-relative URL path for CSS when file-backed.
 
@@ -329,7 +339,14 @@ class BidiComponentRegistry:
             name = definition.name
             if name in self._components:
                 existing_definition = self._components[name]
-                if existing_definition != definition:
+                # Check if the existing definition is different and NOT a placeholder.
+                # We expect placeholders (from manifest scanning) to be overwritten
+                # by the actual definition from the script execution, so we silence
+                # the warning in that specific case.
+                if (
+                    existing_definition != definition
+                    and not existing_definition.is_placeholder
+                ):
                     _LOGGER.warning(
                         "Component %s is already registered. Overwriting "
                         "previous definition. This may lead to unexpected behavior "

--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -913,3 +913,64 @@ def test_runtime_override_removes_field(
     assert getattr(definition, target_field) is None
     # Provided non-target field should remain present
     assert getattr(definition, expect_present_field) is not None
+
+
+def test_register_overwrites_placeholder_without_warning() -> None:
+    """Verify that overwriting a placeholder definition does not log a warning.
+
+    This scenario happens when a component is first discovered via manifest scan
+    (creating a placeholder) and then registered via the public API at runtime.
+    """
+    reg = BidiComponentRegistry()
+    name = "test_component"
+
+    # 1. Register placeholder (mimics manifest scanning)
+    placeholder = BidiComponentDefinition(name=name, html=None, css=None, js=None)
+    reg.register(placeholder)
+    assert placeholder.is_placeholder
+
+    # 2. Register actual definition (mimics runtime API call)
+    real_def = BidiComponentDefinition(
+        name=name,
+        html="<div>Content</div>",
+        css=None,
+        js=None,
+    )
+
+    with patch("streamlit.components.v2.component_registry._LOGGER") as mock_logger:
+        reg.register(real_def)
+
+        # Verify registration succeeded
+        stored = reg.get(name)
+        assert stored == real_def
+        assert not stored.is_placeholder
+
+        # Verify NO warning was logged
+        mock_logger.warning.assert_not_called()
+
+
+def test_register_overwrites_real_definition_with_warning() -> None:
+    """Verify that overwriting a real definition LOGS a warning."""
+    reg = BidiComponentRegistry()
+    name = "test_component"
+
+    # 1. Register real definition
+    def1 = BidiComponentDefinition(
+        name=name, html="<div>Initial</div>", css=None, js=None
+    )
+    reg.register(def1)
+
+    # 2. Register different definition
+    def2 = BidiComponentDefinition(
+        name=name, html="<div>Updated</div>", css=None, js=None
+    )
+
+    with patch("streamlit.components.v2.component_registry._LOGGER") as mock_logger:
+        reg.register(def2)
+
+        # Verify registration succeeded
+        stored = reg.get(name)
+        assert stored == def2
+
+        # Verify warning WAS logged
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION
## Describe your changes

- Added a new `is_placeholder` property to `BidiComponentDefinition` to identify placeholder component definitions (those with no content).
- Modified the component registration logic to suppress warning messages when a placeholder definition is overwritten by a real definition.
- This change improves the user experience by eliminating unnecessary warning messages that occur during normal operation when components are first discovered via manifest scanning and then properly registered at runtime.

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/13042

## Testing Plan

- Unit Tests (Python): Added two new test cases:
  - `test_register_overwrites_placeholder_without_warning`: Verifies that overwriting a placeholder definition does not log a warning
  - `test_register_overwrites_real_definition_with_warning`: Verifies that overwriting a real definition still logs a warning as expected

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.