### PR TITLE
Add optional uvloop support for better event loop performance

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -112,7 +112,7 @@ EXTRA_REQUIRES = {
     ],
     # Install all optional dependencies:
     "all": [
-        "streamlit[auth,charts,snowflake,sql,pdf]",
+        "streamlit[auth,charts,snowflake,sql,pdf,performance]",
         # Improved exception traceback formatting:
         "rich>=11.0.0",
     ],

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -103,6 +103,13 @@ EXTRA_REQUIRES = {
     "sql": [
         "SQLAlchemy>=2.0.0",
     ],
+    # Optional dependency for better performance:
+    "performance": [
+        # orjson speeds up large plotly figure processing by 5-10x:
+        "orjson>=3.5.0",
+        # uvloop speeds up the event loop:
+        "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",  # noqa: E501
+    ],
     # Install all optional dependencies:
     "all": [
         "streamlit[auth,charts,snowflake,sql,pdf]",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -108,7 +108,7 @@ EXTRA_REQUIRES = {
         # orjson speeds up large plotly figure processing by 5-10x:
         "orjson>=3.5.0",
         # uvloop speeds up the event loop:
-        "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",  # noqa: E501
+        "uvloop>=0.15.2; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",  # noqa: E501
     ],
     # Install all optional dependencies:
     "all": [

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -155,6 +155,7 @@ _ATTRIBUTIONS_TO_CHECK: Final = [
     "authlib",
     "fastapi",
     "starlette",
+    "uvloop",
 ]
 
 _ETC_MACHINE_ID_PATH = "/etc/machine-id"

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -58,6 +58,29 @@ def _fix_sys_path(main_script_path: str) -> None:
     sys.path.insert(0, os.path.dirname(main_script_path))
 
 
+def _maybe_install_uvloop(running_in_event_loop: bool) -> None:
+    """Install uvloop as the default event loop policy if available."""
+
+    if running_in_event_loop:
+        return
+
+    if env_util.IS_WINDOWS:
+        return
+
+    try:
+        import uvloop
+    except ModuleNotFoundError:
+        return
+
+    try:
+        uvloop.install()
+        _LOGGER.debug("uvloop installed as default event loop policy.")
+    except Exception:
+        _LOGGER.warning(
+            "Failed to install uvloop. Falling back to default loop.", exc_info=True
+        )
+
+
 def _fix_tornado_crash() -> None:
     """Set default asyncio policy to be compatible with Tornado 6.
 
@@ -326,6 +349,7 @@ def run(
         # This prevents the task from being garbage collected
         server._bootstrap_task = task
     else:
+        _maybe_install_uvloop(running_in_event_loop)
         # No running event loop, so we can use asyncio.run
         # This is the normal case when running streamlit from the command line
         _LOGGER.debug("Starting new event loop for server")

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,7 +8,7 @@ watchdog>=2.1.5
 streamlit-pdf>=1.0.0
 
 # Optional dependency for better performance:
-uvloop>=0.15.1
+uvloop>=0.15.2
 
 # Optional dependency used for improved exception formatting
 # in Community Cloud:

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -7,6 +7,9 @@ seaborn>=0.11.2
 watchdog>=2.1.5
 streamlit-pdf>=1.0.0
 
+# Optional dependency for better performance:
+uvloop>=0.15.1
+
 # Optional dependency used for improved exception formatting
 # in Community Cloud:
 rich>=10.14.0

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import os.path
 import sys
+import types
 from io import StringIO
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import Mock, patch
 
 from streamlit import config
@@ -441,3 +442,49 @@ class BootstrapRunTest(IsolatedAsyncioTestCase):
 
         with testutil.patch_config_options({"server.headless": True}):
             bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)
+
+
+class BootstrapUvloopTest(TestCase):
+    def test_installs_uvloop_when_available(self):
+        """uvloop is installed as the default policy when present."""
+        fake_uvloop = types.ModuleType("uvloop")
+        fake_uvloop.install = Mock()
+
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+        ):
+            bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+
+        fake_uvloop.install.assert_called_once()
+
+    def test_skips_install_when_loop_running(self):
+        """uvloop installation is skipped if a loop is already running."""
+        fake_uvloop = types.ModuleType("uvloop")
+        fake_uvloop.install = Mock()
+
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+        ):
+            bootstrap._maybe_install_uvloop(running_in_event_loop=True)
+
+        fake_uvloop.install.assert_not_called()
+
+    def test_skips_install_on_windows(self):
+        """uvloop installation is skipped on Windows."""
+        fake_uvloop = types.ModuleType("uvloop")
+        fake_uvloop.install = Mock()
+
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", True),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+        ):
+            bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+
+        fake_uvloop.install.assert_not_called()
+
+    def test_handles_missing_uvloop(self):
+        """Missing uvloop does not raise."""
+        with patch.object(bootstrap.env_util, "IS_WINDOWS", False):
+            bootstrap._maybe_install_uvloop(running_in_event_loop=False)

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -487,4 +487,5 @@ class BootstrapUvloopTest(TestCase):
     def test_handles_missing_uvloop(self):
         """Missing uvloop does not raise."""
         with patch.object(bootstrap.env_util, "IS_WINDOWS", False):
-            bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+            with patch.dict("sys.modules", {"uvloop": None}):
+                bootstrap._maybe_install_uvloop(running_in_event_loop=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -85,3 +85,6 @@ ignore_missing_imports = true
 
 [mypy-authlib.*]
 ignore_missing_imports = true
+
+[mypy-uvloop.*]
+ignore_missing_imports = true


### PR DESCRIPTION
## Describe your changes

Adds optional support for using uvloop as event loop. uvloop is an ultra-fast, drop-in replacement of the built-in asyncio event loop. This feature will get activated by having uvloop installed.

This change is a preparation for #12772 

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
