### PR TITLE
Add static data structures rule to TypeScript guide

### DIFF
--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -39,6 +39,39 @@ alwaysApply: false
 - Use the following pattern for naming custom CSS classes and test IDs: `stComponentSubcomponent`, for example: `stTextInputIcon`.
 - Avoid using pixel sizes for styling, always use rem, em, percentage, or other relative units.
 
+## Static Data Structures
+
+- Extract static lookup maps and constants to module-level scope outside functions/components
+- Static data recreated on every call/render wastes memory and CPU
+- Exception: Keep inside function only if data depends on parameters, props, or state
+
+<good-example>
+```tsx
+// ✅ Module-level - created once
+const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
+  [Alignment.LEFT]: "left",
+  [Alignment.CENTER]: "center",
+  // ...
+} as const
+
+function getAlignment(config: AlignmentConfig) {
+return ALIGNMENT_MAP[config.alignment]
+}
+
+````
+</good-example>
+
+<bad-example>
+```tsx
+// ❌ Recreated every call
+function getAlignment(config: AlignmentConfig) {
+  const alignmentMap = { /* same data */ }
+  return alignmentMap[config.alignment]
+}
+````
+
+</bad-example>
+
 ## Yarn Workspaces
 
 - Project Structure: Monorepo managed with Yarn Workspaces.

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -55,10 +55,10 @@ const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
 } as const
 
 function getAlignment(config: AlignmentConfig) {
-return ALIGNMENT_MAP[config.alignment]
+  return ALIGNMENT_MAP[config.alignment]
 }
 
-````
+```
 </good-example>
 
 <bad-example>
@@ -68,7 +68,7 @@ function getAlignment(config: AlignmentConfig) {
   const alignmentMap = { /* same data */ }
   return alignmentMap[config.alignment]
 }
-````
+```
 
 </bad-example>
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -53,10 +53,10 @@ const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
 } as const
 
 function getAlignment(config: AlignmentConfig) {
-return ALIGNMENT_MAP[config.alignment]
+  return ALIGNMENT_MAP[config.alignment]
 }
 
-````
+```
 </good-example>
 
 <bad-example>
@@ -66,7 +66,7 @@ function getAlignment(config: AlignmentConfig) {
   const alignmentMap = { /* same data */ }
   return alignmentMap[config.alignment]
 }
-````
+```
 
 </bad-example>
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -37,6 +37,39 @@ applyTo: "**/*.ts, **/*.tsx"
 - Use the following pattern for naming custom CSS classes and test IDs: `stComponentSubcomponent`, for example: `stTextInputIcon`.
 - Avoid using pixel sizes for styling, always use rem, em, percentage, or other relative units.
 
+## Static Data Structures
+
+- Extract static lookup maps and constants to module-level scope outside functions/components
+- Static data recreated on every call/render wastes memory and CPU
+- Exception: Keep inside function only if data depends on parameters, props, or state
+
+<good-example>
+```tsx
+// ✅ Module-level - created once
+const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
+  [Alignment.LEFT]: "left",
+  [Alignment.CENTER]: "center",
+  // ...
+} as const
+
+function getAlignment(config: AlignmentConfig) {
+return ALIGNMENT_MAP[config.alignment]
+}
+
+````
+</good-example>
+
+<bad-example>
+```tsx
+// ❌ Recreated every call
+function getAlignment(config: AlignmentConfig) {
+  const alignmentMap = { /* same data */ }
+  return alignmentMap[config.alignment]
+}
+````
+
+</bad-example>
+
 ## Yarn Workspaces
 
 - Project Structure: Monorepo managed with Yarn Workspaces.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -49,10 +49,10 @@ const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
 } as const
 
 function getAlignment(config: AlignmentConfig) {
-return ALIGNMENT_MAP[config.alignment]
+  return ALIGNMENT_MAP[config.alignment]
 }
 
-````
+```
 </good-example>
 
 <bad-example>
@@ -62,7 +62,7 @@ function getAlignment(config: AlignmentConfig) {
   const alignmentMap = { /* same data */ }
   return alignmentMap[config.alignment]
 }
-````
+```
 
 </bad-example>
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -33,6 +33,39 @@
 - Use the following pattern for naming custom CSS classes and test IDs: `stComponentSubcomponent`, for example: `stTextInputIcon`.
 - Avoid using pixel sizes for styling, always use rem, em, percentage, or other relative units.
 
+## Static Data Structures
+
+- Extract static lookup maps and constants to module-level scope outside functions/components
+- Static data recreated on every call/render wastes memory and CPU
+- Exception: Keep inside function only if data depends on parameters, props, or state
+
+<good-example>
+```tsx
+// ✅ Module-level - created once
+const ALIGNMENT_MAP: Record<Alignment, CSSProperties["textAlign"]> = {
+  [Alignment.LEFT]: "left",
+  [Alignment.CENTER]: "center",
+  // ...
+} as const
+
+function getAlignment(config: AlignmentConfig) {
+return ALIGNMENT_MAP[config.alignment]
+}
+
+````
+</good-example>
+
+<bad-example>
+```tsx
+// ❌ Recreated every call
+function getAlignment(config: AlignmentConfig) {
+  const alignmentMap = { /* same data */ }
+  return alignmentMap[config.alignment]
+}
+````
+
+</bad-example>
+
 ## Yarn Workspaces
 
 - Project Structure: Monorepo managed with Yarn Workspaces.


### PR DESCRIPTION
## What

Adds a rule to extract static lookup maps and constants to module-level scope to improve performance and reduce memory waste.

## Why

Based on PR feedback that static data structures recreated on every function call/render waste resources. This rule helps AI agents recognize this pattern proactively.

## Changes

- Added "Static Data Structures" section to `frontend/AGENTS.md` with examples
- Updated generated rule files (`.cursor/rules/typescript.mdc`, `.github/instructions/typescript.instructions.md`)
