### PR TITLE
Implementation of pixel-level ``gap`` for ``st.container`` and ``st.columns``

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -239,6 +239,7 @@ describe("FlexBoxContainer layout props", () => {
       { gapConfig: { gapSize: streamlit.GapSize.NONE } },
       "gap: 0;",
     ],
+    ["gap: pixel", { gapConfig: { pixelGap: 6 } }, "gap: 6px;"],
   ])("should apply %s", (_desc, flexContainer, expectedStyle) => {
     const block: BlockNode = makeVerticalBlock([], {
       flexContainer,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -53,7 +53,7 @@ import {
 } from "./styled-components"
 import {
   assignDividerColor,
-  backwardsCompatibleColumnGapSize,
+  backwardsCompatibleColumnGapConfig,
   BaseBlockProps,
   checkFlexContainerBackwardsCompatibile,
   convertKeyToClassName,
@@ -126,7 +126,7 @@ export const ContainerContentsWrapper = (
   const defaultStyles: StyledFlexContainerBlockProps = {
     direction: Direction.VERTICAL,
     flex: 1,
-    gap: streamlit.GapSize.SMALL,
+    gapConfig: { gapSize: streamlit.GapSize.SMALL },
     height: props.height,
     // eslint-disable-next-line streamlit-custom/no-hardcoded-theme-values
     border: false,
@@ -173,12 +173,20 @@ export const FlexBoxContainer = (
     subElement: getLayoutSubElement(props.node.deltaBlock),
   })
 
+  const flexGapConfig = props.node.deltaBlock.flexContainer?.gapConfig
+  const hasPixelGap =
+    flexGapConfig?.pixelGap !== undefined && flexGapConfig?.pixelGap !== null
+  const hasGapSize =
+    flexGapConfig?.gapSize !== undefined &&
+    flexGapConfig?.gapSize !== null &&
+    flexGapConfig?.gapSize !== streamlit.GapSize.GAP_UNDEFINED
+  const resolvedGapConfig: streamlit.IGapConfig =
+    hasPixelGap || hasGapSize
+      ? flexGapConfig
+      : { gapSize: streamlit.GapSize.SMALL }
+
   const styles = {
-    gap:
-      // This is backwards compatible with old proto messages since previously
-      // the gap size was defaulted to small.
-      props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
-      streamlit.GapSize.SMALL,
+    gapConfig: resolvedGapConfig,
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
@@ -375,7 +383,7 @@ export const BlockNodeRenderer = (
     return (
       <StyledColumn
         weight={node.deltaBlock.column.weight ?? 0}
-        gap={backwardsCompatibleColumnGapSize(node.deltaBlock.column)}
+        gapConfig={backwardsCompatibleColumnGapConfig(node.deltaBlock.column)}
         verticalAlignment={
           node.deltaBlock.column.verticalAlignment ?? undefined
         }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext } from "react"
+import React, { ReactElement, useContext, useMemo } from "react"
 
 import classNames from "classnames"
 
@@ -62,6 +62,7 @@ import {
   getClassnamePrefix,
   getKeyFromId,
   isComponentStale,
+  resolveGapConfigWithDefault,
   shouldComponentBeEnabled,
 } from "./utils"
 
@@ -174,16 +175,10 @@ export const FlexBoxContainer = (
   })
 
   const flexGapConfig = props.node.deltaBlock.flexContainer?.gapConfig
-  const hasPixelGap =
-    flexGapConfig?.pixelGap !== undefined && flexGapConfig?.pixelGap !== null
-  const hasGapSize =
-    flexGapConfig?.gapSize !== undefined &&
-    flexGapConfig?.gapSize !== null &&
-    flexGapConfig?.gapSize !== streamlit.GapSize.GAP_UNDEFINED
-  const resolvedGapConfig: streamlit.IGapConfig =
-    hasPixelGap || hasGapSize
-      ? flexGapConfig
-      : { gapSize: streamlit.GapSize.SMALL }
+  const resolvedGapConfig = useMemo(
+    () => resolveGapConfigWithDefault(flexGapConfig),
+    [flexGapConfig]
+  )
 
   const styles = {
     gapConfig: resolvedGapConfig,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -62,7 +62,7 @@ import {
   getClassnamePrefix,
   getKeyFromId,
   isComponentStale,
-  resolveGapConfigWithDefault,
+  resolveGapConfig,
   shouldComponentBeEnabled,
 } from "./utils"
 
@@ -175,10 +175,11 @@ export const FlexBoxContainer = (
   })
 
   const flexGapConfig = props.node.deltaBlock.flexContainer?.gapConfig
-  const resolvedGapConfig = useMemo(
-    () => resolveGapConfigWithDefault(flexGapConfig),
-    [flexGapConfig]
-  )
+  const resolvedGapConfig = useMemo(() => {
+    return (
+      resolveGapConfig(flexGapConfig) ?? { gapSize: streamlit.GapSize.SMALL }
+    )
+  }, [flexGapConfig])
 
   const styles = {
     gapConfig: resolvedGapConfig,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -50,15 +50,15 @@ function translateGapWidth(
 }
 
 function resolveGapWidth(
-  gapConfig: streamlit.IGapConfig | undefined | null,
+  gapSizeValue: streamlit.GapSize | undefined | null,
+  pixelGap: number | undefined | null,
   theme: EmotionTheme
 ): string {
-  const pixelGap = gapConfig?.pixelGap
   if (pixelGap !== undefined && pixelGap !== null) {
     return `${pixelGap}px`
   }
 
-  return translateGapWidth(gapConfig?.gapSize, theme)
+  return translateGapWidth(gapSizeValue, theme)
 }
 
 export interface StyledElementContainerProps {
@@ -159,7 +159,11 @@ export const StyledColumn = styled.div<StyledColumnProps>(
   ({ theme, weight, gapConfig, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = resolveGapWidth(gapConfig, theme)
+    const gapWidth = resolveGapWidth(
+      gapConfig?.gapSize,
+      gapConfig?.pixelGap,
+      theme
+    )
     const width =
       gapWidth === theme.spacing.none
         ? `${percentage}%`
@@ -273,7 +277,11 @@ export const StyledFlexContainerBlock =
       justify,
       overflow,
     }) => {
-      const gapWidth = resolveGapWidth(gapConfig, theme)
+      const gapWidth = resolveGapWidth(
+        gapConfig?.gapSize,
+        gapConfig?.pixelGap,
+        theme
+      )
 
       return {
         display: "flex",

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -26,15 +26,9 @@ import { EmotionTheme, STALE_STYLES } from "~lib/theme"
 import { assertNever } from "~lib/util/assertNever"
 
 function translateGapWidth(
-  gapConfig: streamlit.IGapConfig | undefined | null,
+  gapSizeValue: streamlit.GapSize | undefined | null,
   theme: EmotionTheme
 ): string {
-  const pixelGap = gapConfig?.pixelGap
-  if (pixelGap !== undefined && pixelGap !== null) {
-    return `${pixelGap}px`
-  }
-  const gapSizeValue = gapConfig?.gapSize
-
   const gapSize =
     isNullOrUndefined(gapSizeValue) ||
     gapSizeValue === streamlit.GapSize.GAP_UNDEFINED
@@ -48,9 +42,23 @@ function translateGapWidth(
       return theme.spacing.fourXL
     case streamlit.GapSize.NONE:
       return theme.spacing.none
+    case streamlit.GapSize.SMALL:
+      return theme.spacing.lg
     default:
       return theme.spacing.lg
   }
+}
+
+function resolveGapWidth(
+  gapConfig: streamlit.IGapConfig | undefined | null,
+  theme: EmotionTheme
+): string {
+  const pixelGap = gapConfig?.pixelGap
+  if (pixelGap !== undefined && pixelGap !== null) {
+    return `${pixelGap}px`
+  }
+
+  return translateGapWidth(gapConfig?.gapSize, theme)
 }
 
 export interface StyledElementContainerProps {
@@ -151,7 +159,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
   ({ theme, weight, gapConfig, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = translateGapWidth(gapConfig, theme)
+    const gapWidth = resolveGapWidth(gapConfig, theme)
     const width =
       gapWidth === theme.spacing.none
         ? `${percentage}%`
@@ -265,7 +273,7 @@ export const StyledFlexContainerBlock =
       justify,
       overflow,
     }) => {
-      const gapWidth = translateGapWidth(gapConfig, theme)
+      const gapWidth = resolveGapWidth(gapConfig, theme)
 
       return {
         display: "flex",

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -19,24 +19,38 @@ import React, { CSSProperties } from "react"
 import styled from "@emotion/styled"
 
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
+import { isNullOrUndefined } from "@streamlit/utils"
 
 import { StyledCheckbox } from "~lib/components/widgets/Checkbox/styled-components"
 import { EmotionTheme, STALE_STYLES } from "~lib/theme"
 import { assertNever } from "~lib/util/assertNever"
 
 function translateGapWidth(
-  gap: streamlit.GapSize | undefined,
+  gapConfig: streamlit.IGapConfig | undefined | null,
   theme: EmotionTheme
 ): string {
-  let gapWidth = theme.spacing.lg
-  if (gap === streamlit.GapSize.MEDIUM) {
-    gapWidth = theme.spacing.threeXL
-  } else if (gap === streamlit.GapSize.LARGE) {
-    gapWidth = theme.spacing.fourXL
-  } else if (gap === streamlit.GapSize.NONE) {
-    gapWidth = theme.spacing.none
+  const pixelGap = gapConfig?.pixelGap
+  if (pixelGap !== undefined && pixelGap !== null) {
+    return `${pixelGap}px`
   }
-  return gapWidth
+  const gapSizeValue = gapConfig?.gapSize
+
+  const gapSize =
+    isNullOrUndefined(gapSizeValue) ||
+    gapSizeValue === streamlit.GapSize.GAP_UNDEFINED
+      ? streamlit.GapSize.SMALL
+      : gapSizeValue
+
+  switch (gapSize) {
+    case streamlit.GapSize.MEDIUM:
+      return theme.spacing.threeXL
+    case streamlit.GapSize.LARGE:
+      return theme.spacing.fourXL
+    case streamlit.GapSize.NONE:
+      return theme.spacing.none
+    default:
+      return theme.spacing.lg
+  }
 }
 
 export interface StyledElementContainerProps {
@@ -128,16 +142,16 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
 
 interface StyledColumnProps {
   weight: number
-  gap: streamlit.GapSize | undefined
+  gapConfig?: streamlit.IGapConfig | null
   showBorder: boolean
   verticalAlignment?: BlockProto.Column.VerticalAlignment
 }
 
 export const StyledColumn = styled.div<StyledColumnProps>(
-  ({ theme, weight, gap, showBorder, verticalAlignment }) => {
+  ({ theme, weight, gapConfig, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = translateGapWidth(gap, theme)
+    const gapWidth = translateGapWidth(gapConfig, theme)
     const width =
       gapWidth === theme.spacing.none
         ? `${percentage}%`
@@ -224,7 +238,7 @@ const getJustifyContent = (
 
 export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
-  gap?: streamlit.GapSize | undefined
+  gapConfig?: streamlit.IGapConfig | null
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
   // not passed to the DOM. It overlaps with a valid attribute
@@ -242,7 +256,7 @@ export const StyledFlexContainerBlock =
     ({
       theme,
       direction,
-      gap,
+      gapConfig,
       flex,
       $wrap,
       height,
@@ -251,10 +265,7 @@ export const StyledFlexContainerBlock =
       justify,
       overflow,
     }) => {
-      let gapWidth
-      if (gap !== undefined) {
-        gapWidth = translateGapWidth(gap, theme)
-      }
+      const gapWidth = translateGapWidth(gapConfig, theme)
 
       return {
         display: "flex",

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -27,7 +27,7 @@ import {
   getBorderBackwardsCompatible,
   getKeyFromId,
   isElementStale,
-  resolveGapConfigWithDefault,
+  resolveGapConfig,
 } from "./utils"
 
 describe("isElementStale", () => {
@@ -251,10 +251,10 @@ describe("backwardsCompatibleColumnGapConfig", () => {
   })
 })
 
-describe("resolveGapConfigWithDefault", () => {
+describe("resolveGapConfig", () => {
   it("uses the pixel gap when provided", () => {
     expect(
-      resolveGapConfigWithDefault({
+      resolveGapConfig({
         pixelGap: 10,
         gapSize: streamlit.GapSize.MEDIUM,
       })
@@ -262,21 +262,16 @@ describe("resolveGapConfigWithDefault", () => {
   })
 
   it("falls back to provided gap size when defined", () => {
-    expect(
-      resolveGapConfigWithDefault({ gapSize: streamlit.GapSize.LARGE })
-    ).toEqual({ gapSize: streamlit.GapSize.LARGE })
+    expect(resolveGapConfig({ gapSize: streamlit.GapSize.LARGE })).toEqual({
+      gapSize: streamlit.GapSize.LARGE,
+    })
   })
 
-  it("returns fallback when gap size undefined", () => {
-    expect(resolveGapConfigWithDefault()).toEqual({
-      gapSize: streamlit.GapSize.SMALL,
-    })
+  it("returns undefined when gap config not set", () => {
+    expect(resolveGapConfig()).toBeUndefined()
     expect(
-      resolveGapConfigWithDefault(
-        { gapSize: streamlit.GapSize.GAP_UNDEFINED },
-        streamlit.GapSize.MEDIUM
-      )
-    ).toEqual({ gapSize: streamlit.GapSize.MEDIUM })
+      resolveGapConfig({ gapSize: streamlit.GapSize.GAP_UNDEFINED })
+    ).toBeUndefined()
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -27,6 +27,7 @@ import {
   getBorderBackwardsCompatible,
   getKeyFromId,
   isElementStale,
+  resolveGapConfigWithDefault,
 } from "./utils"
 
 describe("isElementStale", () => {
@@ -247,6 +248,35 @@ describe("backwardsCompatibleColumnGapConfig", () => {
     expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
       gapSize: streamlit.GapSize.LARGE,
     })
+  })
+})
+
+describe("resolveGapConfigWithDefault", () => {
+  it("uses the pixel gap when provided", () => {
+    expect(
+      resolveGapConfigWithDefault({
+        pixelGap: 10,
+        gapSize: streamlit.GapSize.MEDIUM,
+      })
+    ).toEqual({ pixelGap: 10 })
+  })
+
+  it("falls back to provided gap size when defined", () => {
+    expect(
+      resolveGapConfigWithDefault({ gapSize: streamlit.GapSize.LARGE })
+    ).toEqual({ gapSize: streamlit.GapSize.LARGE })
+  })
+
+  it("returns fallback when gap size undefined", () => {
+    expect(resolveGapConfigWithDefault()).toEqual({
+      gapSize: streamlit.GapSize.SMALL,
+    })
+    expect(
+      resolveGapConfigWithDefault(
+        { gapSize: streamlit.GapSize.GAP_UNDEFINED },
+        streamlit.GapSize.MEDIUM
+      )
+    ).toEqual({ gapSize: streamlit.GapSize.MEDIUM })
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -20,7 +20,7 @@ import { BlockNode, ElementNode } from "~lib/AppNode"
 import { ScriptRunState } from "~lib/ScriptRunState"
 
 import {
-  backwardsCompatibleColumnGapSize,
+  backwardsCompatibleColumnGapConfig,
   checkFlexContainerBackwardsCompatibile,
   convertKeyToClassName,
   getActivateScrollToBottomBackwardsCompatible,
@@ -167,16 +167,16 @@ describe("getKeyFromId", () => {
   )
 })
 
-describe("backwardsCompatibleColumnGapSize", () => {
+describe("backwardsCompatibleColumnGapConfig", () => {
   it("returns gapSize when it exists", () => {
     const columnProto = {
       gapConfig: {
         gapSize: streamlit.GapSize.MEDIUM,
       },
     }
-    expect(backwardsCompatibleColumnGapSize(columnProto)).toBe(
-      streamlit.GapSize.MEDIUM
-    )
+    expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.MEDIUM,
+    })
   })
 
   it("returns default gapSize when gapSize is undefined", () => {
@@ -185,9 +185,20 @@ describe("backwardsCompatibleColumnGapSize", () => {
         gapSize: streamlit.GapSize.GAP_UNDEFINED,
       },
     }
-    expect(backwardsCompatibleColumnGapSize(columnProto)).toBe(
-      streamlit.GapSize.SMALL
-    )
+    expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.SMALL,
+    })
+  })
+
+  it("returns pixel gap when pixelGap exists", () => {
+    const columnProto = {
+      gapConfig: {
+        pixelGap: 16,
+      },
+    }
+    expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
+      pixelGap: 16,
+    })
   })
 
   const gapStringCases = [
@@ -200,7 +211,9 @@ describe("backwardsCompatibleColumnGapSize", () => {
     "converts '$gap' gap to corresponding GapSize",
     ({ gap, expected }) => {
       const columnProto = { gap }
-      expect(backwardsCompatibleColumnGapSize(columnProto)).toBe(expected)
+      expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
+        gapSize: expected,
+      })
     }
   )
 
@@ -208,19 +221,19 @@ describe("backwardsCompatibleColumnGapSize", () => {
     {
       description: "when neither gapSize nor gap exists",
       proto: {},
-      expected: streamlit.GapSize.SMALL,
+      expected: { gapSize: streamlit.GapSize.SMALL },
     },
     {
       description: "with unrecognized gap string",
       proto: { gap: "unrecognized" },
-      expected: streamlit.GapSize.SMALL,
+      expected: { gapSize: streamlit.GapSize.SMALL },
     },
   ]
 
   test.each(fallbackCases)(
     "returns GapSize.SMALL $description",
     ({ proto, expected }) => {
-      expect(backwardsCompatibleColumnGapSize(proto)).toBe(expected)
+      expect(backwardsCompatibleColumnGapConfig(proto)).toEqual(expected)
     }
   )
 
@@ -231,9 +244,9 @@ describe("backwardsCompatibleColumnGapSize", () => {
       },
       gap: "small",
     }
-    expect(backwardsCompatibleColumnGapSize(columnProto)).toBe(
-      streamlit.GapSize.LARGE
-    )
+    expect(backwardsCompatibleColumnGapConfig(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.LARGE,
+    })
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -183,21 +183,37 @@ export function getKeyFromId(
   return userKey === "None" ? undefined : userKey
 }
 
-export function backwardsCompatibleColumnGapSize(
+export function backwardsCompatibleColumnGapConfig(
   columnProto: BlockProto.IColumn
-): streamlit.GapSize {
-  if (columnProto.gapConfig?.gapSize) {
-    return columnProto.gapConfig.gapSize
-  } else if (columnProto.gap) {
-    if (columnProto.gap === "small") {
-      return streamlit.GapSize.SMALL
-    } else if (columnProto.gap === "medium") {
-      return streamlit.GapSize.MEDIUM
-    } else if (columnProto.gap === "large") {
-      return streamlit.GapSize.LARGE
+): streamlit.IGapConfig {
+  const gapConfig = columnProto.gapConfig
+
+  if (gapConfig) {
+    if (gapConfig.pixelGap !== undefined && gapConfig.pixelGap !== null) {
+      return { pixelGap: gapConfig.pixelGap }
+    }
+
+    if (
+      gapConfig.gapSize !== undefined &&
+      gapConfig.gapSize !== null &&
+      gapConfig.gapSize !== streamlit.GapSize.GAP_UNDEFINED
+    ) {
+      return { gapSize: gapConfig.gapSize }
     }
   }
-  return streamlit.GapSize.SMALL
+
+  const gap = columnProto.gap?.toLowerCase()
+  if (gap === "small") {
+    return { gapSize: streamlit.GapSize.SMALL }
+  }
+  if (gap === "medium") {
+    return { gapSize: streamlit.GapSize.MEDIUM }
+  }
+  if (gap === "large") {
+    return { gapSize: streamlit.GapSize.LARGE }
+  }
+
+  return { gapSize: streamlit.GapSize.SMALL }
 }
 
 export function checkFlexContainerBackwardsCompatibile(

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -216,6 +216,26 @@ export function backwardsCompatibleColumnGapConfig(
   return { gapSize: streamlit.GapSize.SMALL }
 }
 
+export function resolveGapConfigWithDefault(
+  gapConfig?: streamlit.IGapConfig | null,
+  fallbackSize: streamlit.GapSize = streamlit.GapSize.SMALL
+): streamlit.IGapConfig {
+  if (gapConfig?.pixelGap !== undefined && gapConfig?.pixelGap !== null) {
+    return { pixelGap: gapConfig.pixelGap }
+  }
+
+  const gapSize = gapConfig?.gapSize
+  if (
+    gapSize !== undefined &&
+    gapSize !== null &&
+    gapSize !== streamlit.GapSize.GAP_UNDEFINED
+  ) {
+    return { gapSize }
+  }
+
+  return { gapSize: fallbackSize }
+}
+
 export function checkFlexContainerBackwardsCompatibile(
   blockProto: BlockProto
 ): boolean {

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -216,10 +216,9 @@ export function backwardsCompatibleColumnGapConfig(
   return { gapSize: streamlit.GapSize.SMALL }
 }
 
-export function resolveGapConfigWithDefault(
-  gapConfig?: streamlit.IGapConfig | null,
-  fallbackSize: streamlit.GapSize = streamlit.GapSize.SMALL
-): streamlit.IGapConfig {
+export function resolveGapConfig(
+  gapConfig?: streamlit.IGapConfig | null
+): streamlit.IGapConfig | undefined {
   if (gapConfig?.pixelGap !== undefined && gapConfig?.pixelGap !== null) {
     return { pixelGap: gapConfig.pixelGap }
   }
@@ -233,7 +232,7 @@ export function resolveGapConfigWithDefault(
     return { gapSize }
   }
 
-  return { gapSize: fallbackSize }
+  return undefined
 }
 
 export function checkFlexContainerBackwardsCompatibile(

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -173,12 +173,11 @@ class LayoutsMixin:
             - ``"small"`` (default): 1rem gap between the elements.
             - ``"medium"``: 2rem gap between the elements.
             - ``"large"``: 4rem gap between the elements.
-            - An integer specifying the gap between the elements in pixels.
+            - An integer between 0 and 1000 (the ``MAX_PIXEL_GAP`` limit) specifying the gap in pixels.
             - ``None``: No gap between the elements.
 
-            The integer value must be positive. Use ``None`` to remove the gap
-            entirely. The rem unit is relative to the ``theme.baseFontSize``
-            configuration option.
+            Use ``0`` or ``None`` to remove the gap entirely. Named sizes use
+            rem units relative to the ``theme.baseFontSize`` configuration option.
 
             The minimum gap applies to both the vertical and horizontal gaps
             between the elements. Elements may have larger gaps in one
@@ -372,12 +371,11 @@ class LayoutsMixin:
             - ``"small"`` (default): 1rem gap between the columns.
             - ``"medium"``: 2rem gap between the columns.
             - ``"large"``: 4rem gap between the columns.
-            - An integer specifying the gap between the columns in pixels.
+            - An integer between 0 and 1000 (the ``MAX_PIXEL_GAP`` limit) specifying the gap in pixels.
             - ``None``: No gap between the columns.
 
-            The integer value must be positive. Use ``None`` to remove the gap
-            entirely. The rem unit is relative to the ``theme.baseFontSize``
-            configuration option.
+            Use ``0`` or ``None`` to remove the gap entirely.
+            Named sizes use rem units relative to the ``theme.baseFontSize`` configuration option.
 
         vertical_alignment : "top", "center", or "bottom"
             The vertical alignment of the content inside the columns. The

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -26,7 +26,7 @@ from streamlit.elements.lib.layout_utils import (
     Width,
     WidthWithoutContent,
     get_align,
-    get_gap_size,
+    get_gap_config,
     get_height_config,
     get_justify,
     get_width_config,
@@ -42,7 +42,6 @@ from streamlit.errors import (
     StreamlitInvalidVerticalAlignmentError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.proto.GapSize_pb2 import GapConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import validate_icon_or_emoji
 
@@ -167,16 +166,18 @@ class LayoutsMixin:
               When ``horizontal`` is ``True``, ``"distribute"`` aligns the
               elements the same as ``"top"``.
 
-        gap : "small", "medium", "large", or None
+        gap : "small", "medium", "large", int, or None
             The minimum gap size between the elements inside the container.
             This can be one of the following:
 
             - ``"small"`` (default): 1rem gap between the elements.
             - ``"medium"``: 2rem gap between the elements.
             - ``"large"``: 4rem gap between the elements.
+            - An integer specifying the gap between the elements in pixels.
             - ``None``: No gap between the elements.
 
-            The rem unit is relative to the ``theme.baseFontSize``
+            The integer value must be positive. Use ``None`` to remove the gap
+            entirely. The rem unit is relative to the ``theme.baseFontSize``
             configuration option.
 
             The minimum gap applies to both the vertical and horizontal gaps
@@ -279,8 +280,8 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.gap_size = get_gap_size(
-            gap, "st.container"
+        block_proto.flex_container.gap_config.CopyFrom(
+            get_gap_config(gap, "st.container")
         )
 
         validate_horizontal_alignment(horizontal_alignment)
@@ -364,16 +365,18 @@ class LayoutsMixin:
               Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
-        gap : "small", "medium", "large", or None
+        gap : "small", "medium", "large", int, or None
             The size of the gap between the columns. This can be one of the
             following:
 
             - ``"small"`` (default): 1rem gap between the columns.
             - ``"medium"``: 2rem gap between the columns.
             - ``"large"``: 4rem gap between the columns.
+            - An integer specifying the gap between the columns in pixels.
             - ``None``: No gap between the columns.
 
-            The rem unit is relative to the ``theme.baseFontSize``
+            The integer value must be positive. Use ``None`` to remove the gap
+            entirely. The rem unit is relative to the ``theme.baseFontSize``
             configuration option.
 
         vertical_alignment : "top", "center", or "bottom"
@@ -524,9 +527,7 @@ class LayoutsMixin:
                 element_type="st.columns",
             )
 
-        gap_size = get_gap_size(gap, "st.columns")
-        gap_config = GapConfig()
-        gap_config.gap_size = gap_size
+        gap_config = get_gap_config(gap, "st.columns")
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -222,16 +222,12 @@ def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
         gap_config.gap_size = GapSize.NONE
         return gap_config
     elif isinstance(gap, int) and not isinstance(gap, bool):
-        if gap < 0 or gap > MAX_PIXEL_GAP:
-            raise StreamlitInvalidColumnGapError(
-                gap=gap, element_type=element_type, max_pixel_gap=MAX_PIXEL_GAP
-            )
-
-        if gap == 0:
-            gap_config.gap_size = GapSize.NONE
-        else:
-            gap_config.pixel_gap = int(gap)
-        return gap_config
+        if 0 <= gap <= MAX_PIXEL_GAP:
+            if gap == 0:
+                gap_config.gap_size = GapSize.NONE
+            else:
+                gap_config.pixel_gap = int(gap)
+            return gap_config
 
     raise StreamlitInvalidColumnGapError(
         gap=gap, element_type=element_type, max_pixel_gap=MAX_PIXEL_GAP

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -25,7 +25,7 @@ from streamlit.errors import (
     StreamlitInvalidWidthError,
 )
 from streamlit.proto.Block_pb2 import Block
-from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.GapSize_pb2 import GapConfig, GapSize
 from streamlit.proto.HeightConfig_pb2 import HeightConfig
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
 
@@ -34,7 +34,7 @@ Width: TypeAlias = int | Literal["stretch", "content"]
 HeightWithoutContent: TypeAlias = int | Literal["stretch"]
 Height: TypeAlias = int | Literal["stretch", "content"]
 SpaceSize: TypeAlias = int | Literal["stretch", "small", "medium", "large"]
-Gap: TypeAlias = Literal["small", "medium", "large"]
+Gap: TypeAlias = int | Literal["small", "medium", "large"]
 HorizontalAlignment: TypeAlias = Literal["left", "center", "right", "distribute"]
 VerticalAlignment: TypeAlias = Literal["top", "center", "bottom", "distribute"]
 
@@ -176,22 +176,31 @@ def get_height_config(height: Height | SpaceSize) -> HeightConfig:
     return height_config
 
 
-def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
-    """Convert a gap string or None to a GapSize proto value."""
+def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
+    """Convert a gap spec into a GapConfig proto."""
     gap_mapping = {
         "small": GapSize.SMALL,
         "medium": GapSize.MEDIUM,
         "large": GapSize.LARGE,
     }
 
+    gap_config = GapConfig()
+
     if isinstance(gap, str):
         gap_size = gap.lower()
         valid_sizes = gap_mapping.keys()
 
         if gap_size in valid_sizes:
-            return gap_mapping[gap_size]
+            gap_config.gap_size = gap_mapping[gap_size]
+            return gap_config
     elif gap is None:
-        return GapSize.NONE
+        gap_config.gap_size = GapSize.NONE
+        return gap_config
+    elif isinstance(gap, int) and not isinstance(gap, bool):
+        if gap <= 0:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        gap_config.pixel_gap = gap
+        return gap_config
 
     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
 

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -47,6 +47,9 @@ SIZE_TO_REM_MAPPING = {
     "large": 4.25,  # Height of large widget without label
 }
 
+# Integer gap values are clamped to this maximum
+MAX_PIXEL_GAP = 1000
+
 
 @dataclass
 class LayoutConfig:
@@ -177,7 +180,29 @@ def get_height_config(height: Height | SpaceSize) -> HeightConfig:
 
 
 def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
-    """Convert a gap spec into a GapConfig proto."""
+    """
+    Convert a gap specification into a GapConfig proto message.
+
+    Parameters
+    ----------
+    gap : {"small", "medium", "large", int} or None
+        Named gaps map to the matching :class:`GapSize` enum value.
+        Integer inputs specify the gap in pixels and must be between 0 and
+        ``MAX_PIXEL_GAP`` (inclusive). ``0`` or ``None`` remove the gap entirely.
+    element_type : str
+        The element requesting the gap. Used for contextualizing error messages.
+
+    Returns
+    -------
+    GapConfig
+        A proto with either ``gap_size`` or ``pixel_gap`` populated.
+
+    Raises
+    ------
+    StreamlitInvalidColumnGapError
+        If ``gap`` is not a supported string, is a boolean, or falls outside the
+        allowed integer range.
+    """
     gap_mapping = {
         "small": GapSize.SMALL,
         "medium": GapSize.MEDIUM,
@@ -197,12 +222,20 @@ def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
         gap_config.gap_size = GapSize.NONE
         return gap_config
     elif isinstance(gap, int) and not isinstance(gap, bool):
-        if gap <= 0:
-            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
-        gap_config.pixel_gap = gap
+        if gap < 0 or gap > MAX_PIXEL_GAP:
+            raise StreamlitInvalidColumnGapError(
+                gap=gap, element_type=element_type, max_pixel_gap=MAX_PIXEL_GAP
+            )
+
+        if gap == 0:
+            gap_config.gap_size = GapSize.NONE
+        else:
+            gap_config.pixel_gap = int(gap)
         return gap_config
 
-    raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+    raise StreamlitInvalidColumnGapError(
+        gap=gap, element_type=element_type, max_pixel_gap=MAX_PIXEL_GAP
+    )
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -263,9 +263,10 @@ class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
 class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     """Exception raised when an invalid value is specified for gap."""
 
-    def __init__(self, gap: str, element_type: str) -> None:
+    def __init__(self, gap: object, element_type: str) -> None:
         super().__init__(
-            'The `gap` argument to `{element_type}` must be `"small"`, `"medium"`, `"large"`, or `"none"`. \n'
+            'The `gap` argument to `{element_type}` must be `"small"`, `"medium"`, `"large"`, '
+            '`"none"`, or a positive integer number of pixels. \n'
             "The argument passed was {gap}.",
             gap=gap,
             element_type=element_type,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -266,7 +266,7 @@ class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     def __init__(self, gap: object, element_type: str) -> None:
         super().__init__(
             'The `gap` argument to `{element_type}` must be `"small"`, `"medium"`, `"large"`, '
-            '`"none"`, or a positive integer number of pixels. \n'
+            "`None`, or a positive integer number of pixels. \n"
             "The argument passed was {gap}.",
             gap=gap,
             element_type=element_type,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -263,10 +263,17 @@ class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
 class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     """Exception raised when an invalid value is specified for gap."""
 
-    def __init__(self, gap: object, element_type: str) -> None:
+    def __init__(
+        self, gap: object, element_type: str, max_pixel_gap: int | None = None
+    ) -> None:
+        pixel_clause = (
+            "or a non-negative integer number of pixels"
+            if max_pixel_gap is None
+            else f"or an integer number of pixels between 0 and {max_pixel_gap}"
+        )
         super().__init__(
             'The `gap` argument to `{element_type}` must be `"small"`, `"medium"`, `"large"`, '
-            "`None`, or a positive integer number of pixels. \n"
+            f"`None`, {pixel_clause}. \n"
             "The argument passed was {gap}.",
             gap=gap,
             element_type=element_type,

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -262,12 +262,40 @@ class ColumnsTest(DeltaGeneratorTestCase):
             )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.NONE
 
+    def test_columns_with_pixel_gap(self):
+        """Test that it works correctly with an integer gap argument"""
+
+        st.columns(3, gap=12)
+
+        all_deltas = self.get_all_deltas_from_queue()
+
+        horizontal_container = all_deltas[0]
+        columns_blocks = all_deltas[1:4]
+
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
+                "gap_spec"
+            )
+            == "pixel_gap"
+        )
+        assert horizontal_container.add_block.flex_container.gap_config.pixel_gap == 12
+
+        for col_block in columns_blocks:
+            assert (
+                col_block.add_block.column.gap_config.WhichOneof("gap_spec")
+                == "pixel_gap"
+            )
+            assert col_block.add_block.column.gap_config.pixel_gap == 12
+
     @parameterized.expand(
         [
             "invalid",
-            5,
+            5.5,
             "5rem",
             "10px",
+            -3,
+            0,
+            True,
         ]
     )
     def test_columns_with_invalid_gap(self, invalid_gap):
@@ -611,6 +639,30 @@ class ContainerTest(DeltaGeneratorTestCase):
         assert (
             container_block.add_block.flex_container.gap_config.gap_size == expected_gap
         )
+
+    def test_container_pixel_gap(self) -> None:
+        """Test that st.container supports integer pixel gaps."""
+
+        st.container(gap=8)
+        container_block = self.get_delta_from_queue()
+        assert (
+            container_block.add_block.flex_container.gap_config.WhichOneof("gap_spec")
+            == "pixel_gap"
+        )
+        assert container_block.add_block.flex_container.gap_config.pixel_gap == 8
+
+    @parameterized.expand(
+        [
+            (-1,),
+            (0,),
+            (True,),
+        ],
+    )
+    def test_container_invalid_gap(self, invalid_gap) -> None:
+        """Test that st.container raises on invalid gap values."""
+
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            st.container(gap=invalid_gap)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.dialog_decorator import dialog_decorator
+from streamlit.elements.lib.layout_utils import MAX_PIXEL_GAP
 from streamlit.errors import (
     FragmentHandledException,
     StreamlitAPIException,
@@ -287,6 +288,23 @@ class ColumnsTest(DeltaGeneratorTestCase):
             )
             assert col_block.add_block.column.gap_config.pixel_gap == 12
 
+    def test_columns_with_zero_gap(self):
+        """Test that passing 0 removes the gap."""
+
+        st.columns(3, gap=0)
+
+        all_deltas = self.get_all_deltas_from_queue()
+
+        horizontal_container = all_deltas[0]
+        columns_blocks = all_deltas[1:4]
+
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.gap_size
+            == GapSize.NONE
+        )
+        for col_block in columns_blocks:
+            assert col_block.add_block.column.gap_config.gap_size == GapSize.NONE
+
     @parameterized.expand(
         [
             "invalid",
@@ -294,7 +312,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
             "5rem",
             "10px",
             -3,
-            0,
+            MAX_PIXEL_GAP + 1,
             True,
         ]
     )
@@ -651,10 +669,19 @@ class ContainerTest(DeltaGeneratorTestCase):
         )
         assert container_block.add_block.flex_container.gap_config.pixel_gap == 8
 
+    def test_container_zero_gap(self) -> None:
+        """Test that st.container treats a 0px gap as no gap."""
+
+        st.container(gap=0)
+        container_block = self.get_delta_from_queue()
+        assert (
+            container_block.add_block.flex_container.gap_config.gap_size == GapSize.NONE
+        )
+
     @parameterized.expand(
         [
             (-1,),
-            (0,),
+            (MAX_PIXEL_GAP + 1,),
             (True,),
         ],
     )

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from streamlit.elements.lib.layout_utils import (
     SpaceSize,
     get_align,
-    get_gap_size,
+    get_gap_config,
     get_height_config,
     get_justify,
     get_width_config,
@@ -207,19 +207,43 @@ class LayoutUtilsTest(unittest.TestCase):
             ("small", GapSize.SMALL),
             ("medium", GapSize.MEDIUM),
             ("large", GapSize.LARGE),
-            (None, GapSize.NONE),
         ]
     )
-    def test_get_gap_size_valid(self, gap: str | None, expected: GapSize.ValueType):
-        """get_gap_size maps valid inputs to GapSize values, None to GapSize.NONE."""
+    def test_get_gap_config_valid_named(self, gap: str, expected: GapSize.ValueType):
+        """get_gap_config maps valid inputs to GapSize values."""
 
-        assert get_gap_size(gap, "st.columns") == expected
+        config = get_gap_config(gap, "st.columns")
+        assert config.WhichOneof("gap_spec") == "gap_size"
+        assert config.gap_size == expected
 
-    def test_get_gap_size_invalid(self):
-        """get_gap_size raises for invalid gap strings."""
+    def test_get_gap_config_none(self):
+        """get_gap_config maps None to GapSize.NONE."""
+
+        config = get_gap_config(None, "st.columns")
+        assert config.WhichOneof("gap_spec") == "gap_size"
+        assert config.gap_size == GapSize.NONE
+
+    def test_get_gap_config_pixel(self):
+        """get_gap_config stores integer gaps as pixel values."""
+
+        config = get_gap_config(12, "st.columns")
+        assert config.WhichOneof("gap_spec") == "pixel_gap"
+        assert config.pixel_gap == 12
+
+    @parameterized.expand(
+        [
+            ("tiny",),
+            (-5,),
+            (0,),
+            (5.5,),
+            (True,),
+        ]
+    )
+    def test_get_gap_config_invalid(self, gap):
+        """get_gap_config raises for invalid gap values."""
 
         with pytest.raises(StreamlitInvalidColumnGapError):
-            get_gap_size("tiny", "st.columns")
+            get_gap_config(gap, "st.columns")  # type: ignore[arg-type]
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -20,6 +20,7 @@ import pytest
 from parameterized import parameterized
 
 from streamlit.elements.lib.layout_utils import (
+    MAX_PIXEL_GAP,
     SpaceSize,
     get_align,
     get_gap_config,
@@ -223,6 +224,13 @@ class LayoutUtilsTest(unittest.TestCase):
         assert config.WhichOneof("gap_spec") == "gap_size"
         assert config.gap_size == GapSize.NONE
 
+    def test_get_gap_config_zero(self):
+        """get_gap_config treats 0px the same as None."""
+
+        config = get_gap_config(0, "st.columns")
+        assert config.WhichOneof("gap_spec") == "gap_size"
+        assert config.gap_size == GapSize.NONE
+
     def test_get_gap_config_pixel(self):
         """get_gap_config stores integer gaps as pixel values."""
 
@@ -234,7 +242,7 @@ class LayoutUtilsTest(unittest.TestCase):
         [
             ("tiny",),
             (-5,),
-            (0,),
+            (MAX_PIXEL_GAP + 1,),
             (5.5,),
             (True,),
         ]

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -32,5 +32,6 @@ enum GapSize {
 message GapConfig {
   oneof gap_spec {
     GapSize gap_size = 1;
+    uint32 pixel_gap = 2;
   }
 }


### PR DESCRIPTION
## Describe your changes
solves streamlit/streamlit#13005

Adds support for pixel-based gap-control in ``st.container`` and ``st.columns``.
``gap`` can now be specified as an integer (e.g., ``gap=8`` → 8px) in addition to the existing named gaps ("small", "medium", "large") or None. 

### Key Changes:

_Backend:_
- Added support for integer pixel gaps via ``GapConfig.pixel_gap``.
- Updated layout utils and layout elements (container, columns) to handle both named and numeric gaps.

_Frontend:_
- Added support for rendering pixel gaps in ``FlexBoxContainer`` and layout styling.
- Updated gap resolution logic to prefer ``pixelGap`` when present.

Implementation restores backwards compatibility for existing apps.

## Screenshot or video (only for visual changes)
<img width="1842" height="839" alt="Bildschirmfoto 2025-11-19 um 20 00 11" src="https://github.com/user-attachments/assets/97b64aef-68fe-4d25-99ca-4545733a2a20" />

## GitHub Issue Link (if applicable)
This PR solves [issue 13005](https://github.com/streamlit/streamlit/issues/13005)

## Testing Plan
- Added and updated Python unit tests for gap config parsing and validation.
- Added and updated frontend tests for:
   - pixelGap rendering,
   - gapSize fallbacks,
   - column gap compatibility logic.
- Manual testing with a local app using various gap configurations.
- No E2E changes required, since spacing behavior is fully validated in unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
