### PR TITLE
Reduce entry bundle size - Part 1

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -20,7 +20,6 @@ import classNames from "classnames"
 import { enableMapSet, enablePatches } from "immer"
 import without from "lodash/without"
 import { getLogger } from "loglevel"
-import moment from "moment"
 import { flushSync } from "react-dom"
 import Hotkeys from "react-hot-keys"
 
@@ -78,6 +77,7 @@ import {
   getHostSpecifiedTheme,
   getIFrameEnclosingApp,
   getLocaleLanguage,
+  getScreencastTimestamp,
   getTimezone,
   getTimezoneOffset,
   getUrl,
@@ -1964,7 +1964,7 @@ export class App extends PureComponent<Props, State> {
   screencastCallback = (): void => {
     const { scriptName } = this.state
     const { startRecording } = this.props.screenCast
-    const date = moment().format("YYYY-MM-DD-HH-MM-SS")
+    const date = getScreencastTimestamp()
 
     startRecording(`streamlit-${scriptName}-${date}`)
   }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -74,7 +74,6 @@ import { ViewStateContext } from "~lib/components/core/ViewStateContext"
 import AlertElement, {
   getAlertElementKind,
 } from "~lib/components/elements/AlertElement"
-import ArrowTable from "~lib/components/elements/ArrowTable"
 import DocString from "~lib/components/elements/DocString"
 import ExceptionElement from "~lib/components/elements/ExceptionElement"
 import Json from "~lib/components/elements/Json"
@@ -102,6 +101,7 @@ import {
 const Audio = lazy(() => import("~lib/components/elements/Audio"))
 const Balloons = lazy(() => import("~lib/components/elements/Balloons"))
 const Snow = lazy(() => import("~lib/components/elements/Snow"))
+const ArrowTable = lazy(() => import("~lib/components/elements/ArrowTable"))
 const ArrowDataFrame = lazy(() => import("~lib/components/widgets/DataFrame"))
 const ArrowVegaLiteChart = lazy(
   () => import("~lib/components/elements/ArrowVegaLiteChart")

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -76,7 +76,6 @@ import AlertElement, {
 } from "~lib/components/elements/AlertElement"
 import DocString from "~lib/components/elements/DocString"
 import ExceptionElement from "~lib/components/elements/ExceptionElement"
-import Json from "~lib/components/elements/Json"
 import Markdown from "~lib/components/elements/Markdown"
 import { Skeleton } from "~lib/components/elements/Skeleton"
 import TextElement from "~lib/components/elements/TextElement"
@@ -99,6 +98,7 @@ import {
 // Lazy-load elements.
 const Audio = lazy(() => import("~lib/components/elements/Audio"))
 const Balloons = lazy(() => import("~lib/components/elements/Balloons"))
+const Json = lazy(() => import("~lib/components/elements/Json"))
 const Metric = lazy(() => import("~lib/components/elements/Metric"))
 const Snow = lazy(() => import("~lib/components/elements/Snow"))
 const ArrowTable = lazy(() => import("~lib/components/elements/ArrowTable"))

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -78,7 +78,6 @@ import DocString from "~lib/components/elements/DocString"
 import ExceptionElement from "~lib/components/elements/ExceptionElement"
 import Json from "~lib/components/elements/Json"
 import Markdown from "~lib/components/elements/Markdown"
-import Metric from "~lib/components/elements/Metric"
 import { Skeleton } from "~lib/components/elements/Skeleton"
 import TextElement from "~lib/components/elements/TextElement"
 import ErrorBoundary from "~lib/components/shared/ErrorBoundary"
@@ -100,6 +99,7 @@ import {
 // Lazy-load elements.
 const Audio = lazy(() => import("~lib/components/elements/Audio"))
 const Balloons = lazy(() => import("~lib/components/elements/Balloons"))
+const Metric = lazy(() => import("~lib/components/elements/Metric"))
 const Snow = lazy(() => import("~lib/components/elements/Snow"))
 const ArrowTable = lazy(() => import("~lib/components/elements/ArrowTable"))
 const ArrowDataFrame = lazy(() => import("~lib/components/widgets/DataFrame"))

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -158,6 +158,7 @@ export {
   getEmbeddingIdClassName,
   getIFrameEnclosingApp,
   getLocaleLanguage,
+  getScreencastTimestamp,
   getTimezone,
   getTimezoneOffset,
   getUrl,

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -734,11 +734,14 @@ describe("getSelectPlaceholder", () => {
 
 describe("getScreencastTimestamp", () => {
   beforeEach(() => {
+    // Set timezone to UTC for consistent test results across all environments
+    process.env.TZ = "UTC"
     vi.useFakeTimers()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    delete process.env.TZ
   })
 
   it("should return a timestamp in the correct format", () => {

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -29,6 +29,7 @@ import {
   EMBED_QUERY_PARAM_VALUES,
   getEmbedUrlParams,
   getLoadingScreenType,
+  getScreencastTimestamp,
   getSelectPlaceholder,
   getUrl,
   isDarkThemeInQueryParams,
@@ -728,5 +729,60 @@ describe("getSelectPlaceholder", () => {
       expect(result.placeholder).toBe(" ")
       expect(result.shouldDisable).toBe(false)
     })
+  })
+})
+
+describe("getScreencastTimestamp", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("should return a timestamp in the correct format", () => {
+    vi.setSystemTime(new Date("2025-11-18T12:00:00.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-11-18-12-00-00")
+  })
+
+  it("should handle single-digit months with proper padding", () => {
+    vi.setSystemTime(new Date("2025-01-05T08:03:07.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-01-05-08-03-07")
+  })
+
+  it("should handle single-digit days with proper padding", () => {
+    vi.setSystemTime(new Date("2025-12-09T14:30:45.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-12-09-14-30-45")
+  })
+
+  it("should handle single-digit hours with proper padding", () => {
+    vi.setSystemTime(new Date("2025-06-15T03:25:50.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-06-15-03-25-50")
+  })
+
+  it("should handle single-digit minutes with proper padding", () => {
+    vi.setSystemTime(new Date("2025-07-20T18:05:30.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-07-20-18-05-30")
+  })
+
+  it("should handle single-digit seconds with proper padding", () => {
+    vi.setSystemTime(new Date("2025-08-25T23:45:09.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-08-25-23-45-09")
+  })
+
+  it("should handle midnight correctly", () => {
+    vi.setSystemTime(new Date("2025-03-10T00:00:00.000Z"))
+    expect(getScreencastTimestamp()).toBe("2025-03-10-00-00-00")
+  })
+
+  it("should handle end of year correctly", () => {
+    vi.setSystemTime(new Date("2024-12-31T23:59:59.000Z"))
+    expect(getScreencastTimestamp()).toBe("2024-12-31-23-59-59")
+  })
+
+  it("should ignore milliseconds", () => {
+    vi.setSystemTime(new Date("2025-05-15T10:20:30.999Z"))
+    expect(getScreencastTimestamp()).toBe("2025-05-15-10-20-30")
   })
 })

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -229,14 +229,17 @@ export function getUrl(): string {
 
 /**
  * Returns date in "YYYY-MM-DD-HH-MM-SS" format to be used for screencast recording file name.
- * Example: ISO format "2025-11-18T12:00:00.000Z" will be converted to "2025-11-18-12-00-00"
  */
 export function getScreencastTimestamp(): string {
-  return new Date()
-    .toISOString()
-    .slice(0, 19)
-    .replace("T", "-")
-    .replaceAll(":", "-")
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  const hours = String(date.getHours()).padStart(2, "0")
+  const minutes = String(date.getMinutes()).padStart(2, "0")
+  const seconds = String(date.getSeconds()).padStart(2, "0")
+
+  return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`
 }
 
 /**

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -228,6 +228,18 @@ export function getUrl(): string {
 }
 
 /**
+ * Returns date in "YYYY-MM-DD-HH-MM-SS" format to be used for screencast recording file name.
+ * Example: ISO format "2025-11-18T12:00:00.000Z" will be converted to "2025-11-18-12-00-00"
+ */
+export function getScreencastTimestamp(): string {
+  return new Date()
+    .toISOString()
+    .slice(0, 19)
+    .replace("T", "-")
+    .replace(/:/g, "-")
+}
+
+/**
  * Returns the timezone from the browser's Intl API.
  */
 export function getTimezone(): string {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -236,7 +236,7 @@ export function getScreencastTimestamp(): string {
     .toISOString()
     .slice(0, 19)
     .replace("T", "-")
-    .replace(/:/g, "-")
+    .replaceAll(":", "-")
 }
 
 /**


### PR DESCRIPTION
## Describe your changes
Attempt to improve initial load time by reducing dependencies included in entry bundle.

Dependencies removed from entry:
* **`moment-timezone`**: Removed moment usage from `App` & lazy loaded `ArrowTable`

* **`vega-lite`**: Lazy load `Metric` component (already lazy-loaded `ArrowVegaLiteChart`)

 * **`react-json-view`**: Lazy load `Json` component 
---

### Bundle Analysis:
**Before** (left): 7.64 MB & **After** (right): 5.11 MB
<img width="260" alt="Entry bundle - start" src="https://github.com/user-attachments/assets/82d3f7de-f9d6-49f2-84ac-21192b8bcab0" />   <img width="250" alt="Entry bundle - after part 1" src="https://github.com/user-attachments/assets/f6928445-4606-4973-bf58-4785170014ff" />