### PR TITLE
Send all Python runtime exceptions to parent iframe

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1106,6 +1106,16 @@ export class App extends PureComponent<Props, State> {
         newDialog,
         sessionEvent.scriptCompilationException?.message ?? "No message"
       )
+    } else if (sessionEvent.type === "scriptRuntimeException") {
+      // Send runtime exception to parent iframe via CLIENT_ERROR
+      const exception = sessionEvent.scriptRuntimeException
+      this.hostCommunicationMgr.sendMessageToHost({
+        type: "CLIENT_ERROR",
+        component: "Script Runtime",
+        error: exception?.type ?? "RuntimeError",
+        message: exception?.message ?? "An uncaught exception occurred",
+        source: "runtime",
+      })
     } else if (sessionEvent.type === "scriptChangedOnDisk") {
       this.setState({ scriptChangedOnDisk: true })
     }

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -570,8 +570,10 @@ class AppSession:
             ENQUEUE_FORWARD_MSG event.
 
         exception : BaseException | None
-            An exception thrown during compilation. Set only for the
-            SCRIPT_STOPPED_WITH_COMPILE_ERROR event.
+            An exception thrown during compilation or runtime. Set for the
+            SCRIPT_STOPPED_WITH_COMPILE_ERROR event (compilation error),
+            and optionally for SCRIPT_STOPPED_WITH_SUCCESS and
+            FRAGMENT_STOPPED_WITH_SUCCESS events (runtime exception).
 
         client_state : streamlit.proto.ClientState_pb2.ClientState | None
             The ScriptRunner's final ClientState. Set only for the
@@ -659,6 +661,15 @@ class AppSession:
                 if self._local_sources_watcher:
                     self._local_sources_watcher.update_watched_modules()
                     self._local_sources_watcher.update_watched_pages()
+
+                # If the script had an uncaught runtime exception, send it to the frontend
+                # so it can be forwarded to the parent iframe.
+                if exception is not None:
+                    msg = ForwardMsg()
+                    exception_utils.marshall(
+                        msg.session_event.script_runtime_exception, exception
+                    )
+                    self._enqueue_forward_msg(msg)
             else:
                 # The script didn't complete successfully: send the exception
                 # to the frontend.

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -715,7 +715,9 @@ class ScriptRunner:
                     # Always capture all exceptions since we want to make sure that
                     # the telemetry never causes any issues.
                     _LOGGER.debug("Failed to create page profile", exc_info=ex)
-            self._on_script_finished(ctx, finished_event, premature_stop)
+            self._on_script_finished(
+                ctx, finished_event, premature_stop, uncaught_exception
+            )
 
             # # Use _log_if_error() to make sure we never ever ever stop running the
             # # script without meaning to.
@@ -727,7 +729,11 @@ class ScriptRunner:
                 break
 
     def _on_script_finished(
-        self, ctx: ScriptRunContext, event: ScriptRunnerEvent, premature_stop: bool
+        self,
+        ctx: ScriptRunContext,
+        event: ScriptRunnerEvent,
+        premature_stop: bool,
+        uncaught_exception: Exception | None,
     ) -> None:
         """Called when our script finishes executing, even if it finished
         early with an exception. We perform post-run cleanup here.
@@ -738,7 +744,7 @@ class ScriptRunner:
 
         # Signal that the script has finished. (We use SCRIPT_STOPPED_WITH_SUCCESS
         # even if we were stopped with an exception.)
-        self.on_event.send(self, event=event)
+        self.on_event.send(self, event=event, exception=uncaught_exception)
 
         # Remove orphaned files now that the script has run and files in use
         # are marked as active.

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -133,14 +133,18 @@ class LocalScriptRunner(ScriptRunner):
         return any(e == ScriptRunnerEvent.SHUTDOWN for e in self.events)
 
     def _on_script_finished(
-        self, ctx: ScriptRunContext, event: ScriptRunnerEvent, premature_stop: bool
+        self,
+        ctx: ScriptRunContext,
+        event: ScriptRunnerEvent,
+        premature_stop: bool,
+        uncaught_exception: Exception | None,
     ) -> None:
         if not premature_stop:
             self._session_state.on_script_finished(ctx.widget_ids_this_run)
 
         # Signal that the script has finished. (We use SCRIPT_STOPPED_WITH_SUCCESS
         # even if we were stopped with an exception.)
-        self.on_event.send(self, event=event)
+        self.on_event.send(self, event=event, exception=uncaught_exception)
 
         # Remove orphaned files now that the script has run and files in use
         # are marked as active.

--- a/proto/streamlit/proto/SessionEvent.proto
+++ b/proto/streamlit/proto/SessionEvent.proto
@@ -35,5 +35,9 @@ message SessionEvent {
     // Script compilation failed with an exception.
     // We can't start running the script.
     Exception script_compilation_exception = 3;
+
+    // Script runtime failed with an uncaught exception.
+    // The script was running but encountered an error during execution.
+    Exception script_runtime_exception = 4;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where runtime exceptions (like `AttributeError`, `KeyError`, etc.) were not being sent to the parent iframe. Previously, only compilation errors (like `SyntaxError`) were forwarded via `CLIENT_ERROR`.

This change ensures that all uncaught Python exceptions during script execution are sent to the parent iframe via `CLIENT_ERROR` message, providing better visibility and error handling for embedded Streamlit apps.

## Changes

- **Protobuf**: Added `script_runtime_exception` field to `SessionEvent` message
- **Backend**: Modified `ScriptRunner` to pass uncaught exceptions through the event system
- **Backend**: Updated `AppSession` to send runtime exceptions to the frontend
- **Frontend**: Added handler in `App.tsx` to forward runtime exceptions to parent iframe via `CLIENT_ERROR`

## Examples of Exceptions Now Caught

Runtime exceptions that will now be sent to the parent iframe:
- `AttributeError` - Accessing non-existent attributes
- `KeyError` - Accessing missing dictionary keys  
- `ValueError` - Invalid values passed to functions
- `TypeError` - Type mismatches
- `ZeroDivisionError` - Division by zero
- `NameError` - Using undefined variables
- And all other uncaught exceptions during script execution

## Testing

- ✅ All 31 ScriptRunner tests pass
- ✅ All 68 AppSession tests pass  
- ✅ All pre-commit hooks pass

## Related

Follow-up to PR #10856 which added `CLIENT_ERROR` for compilation exceptions and other client-side errors.