### PR TITLE
Remove upper bound for the `packaging` package

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -39,7 +39,9 @@ INSTALL_REQUIRES = [
     "cachetools>=4.0, <7",
     "click>=7.0, <9",
     "numpy>=1.23, <3",
-    "packaging>=20, <26",
+    # The "packaging" package isn't version-capped because they use calendar-based
+    # versioning, i.e. "major" version increase != breaking changes
+    "packaging>=20",
     # Pandas <1.4 has a bug related to deleting columns in a DataFrame changing
     # the index dtype.
     "pandas>=1.4.0, <3",


### PR DESCRIPTION
## Describe your changes

https://packaging.pypa.io/en/stable/index.html
> The `packaging` library uses calendar-based versioning (`YY.N`).

So major version increase doesn't mean breaking changes. There's no reason to cap this, and it only makes it more likely to cause dependency conflicts.

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
