### PR TITLE
Reduce entry bundle size - Part 2

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -34,6 +34,7 @@ import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import {
   ConnectionManager,
   ConnectionState,
+  ErrorDetails,
   mockEndpoints,
 } from "@streamlit/connection"
 import {
@@ -4213,9 +4214,9 @@ describe("App", () => {
 
         // Trigger a connection error dialog
         act(() => {
-          getMockConnectionManagerProp("onConnectionError")(
-            "Connection error message."
-          )
+          getMockConnectionManagerProp("onConnectionError")({
+            message: "Connection error message.",
+          })
         })
 
         expect(hostCommunicationMgr.sendMessageToHost).toBeCalledWith({
@@ -4833,11 +4834,11 @@ describe("App.hasReceivedNewSession flag behavior", () => {
   describe("Connection Error Handling", () => {
     const triggerConnectionError = (
       connectionManager: ConnectionManager,
-      errorMessage: string
+      errorDetails: ErrorDetails
     ): void => {
       act(() => {
         // @ts-expect-error - connectionManager.props is private
-        connectionManager.props.onConnectionError(errorMessage)
+        connectionManager.props.onConnectionError(errorDetails)
       })
     }
 
@@ -4846,10 +4847,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         renderApp(getProps())
         const connectionManager = getMockConnectionManager(false)
 
-        triggerConnectionError(
-          connectionManager,
-          "Network error: Unable to connect"
-        )
+        triggerConnectionError(connectionManager, {
+          message: "Network error: Unable to connect",
+        })
 
         // Verify error dialog and message are displayed
         expect(screen.getByText("Connection error")).toBeVisible()
@@ -4863,7 +4863,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         const connectionManager = getMockConnectionManager(false)
 
         // First error
-        triggerConnectionError(connectionManager, "Connection lost")
+        triggerConnectionError(connectionManager, {
+          message: "Connection lost",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
 
@@ -4877,7 +4879,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         expect(screen.queryByText("Connection error")).toBeNull()
 
         // Second error should not display
-        triggerConnectionError(connectionManager, "Another connection error")
+        triggerConnectionError(connectionManager, {
+          message: "Another connection error",
+        })
 
         expect(screen.queryByText("Connection error")).toBeNull()
       })
@@ -4900,7 +4904,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
 
         // Trigger error
-        triggerConnectionError(connectionManager, "Connection lost")
+        triggerConnectionError(connectionManager, {
+          message: "Connection lost",
+        })
 
         // Dialog should not be displayed
         expect(screen.queryByText("Connection error")).toBeNull()
@@ -4915,16 +4921,15 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         )
       })
 
-      it("displays error with StreamlitMarkdown formatting", () => {
+      it("displays error with DialogErrorMessage formatting", () => {
         renderApp(getProps())
         const connectionManager = getMockConnectionManager(false)
 
-        triggerConnectionError(
-          connectionManager,
-          "**Network Error**: Unable to connect to server"
-        )
+        triggerConnectionError(connectionManager, {
+          message: "Network Error: Unable to connect to server",
+        })
 
-        // Verify both error dialog and markdown content are displayed
+        // Verify both error dialog and error message are displayed
         expect(screen.getByText("Connection error")).toBeVisible()
         expect(screen.getByText(/Network Error/)).toBeVisible()
       })
@@ -4936,7 +4941,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         const connectionManager = getMockConnectionManager(false)
 
         // Trigger connection error
-        triggerConnectionError(connectionManager, "Connection lost")
+        triggerConnectionError(connectionManager, {
+          message: "Connection lost",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
 
@@ -4957,7 +4964,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
 
         // New error should be displayed after reconnection
-        triggerConnectionError(connectionManager, "New connection error")
+        triggerConnectionError(connectionManager, {
+          message: "New connection error",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
         expect(screen.getByText(/New connection error/)).toBeVisible()
@@ -4984,7 +4993,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
 
         // Trigger connection error
-        triggerConnectionError(connectionManager, "Connection lost")
+        triggerConnectionError(connectionManager, {
+          message: "Connection lost",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
 
@@ -5004,7 +5015,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         const connectionManager = getMockConnectionManager(false)
 
         // First, show a connection error dialog
-        triggerConnectionError(connectionManager, "Connection lost")
+        triggerConnectionError(connectionManager, {
+          message: "Connection lost",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
 
@@ -5073,11 +5086,11 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         const connectionManager = getMockConnectionManager(false)
 
         // Trigger multiple errors
-        triggerConnectionError(connectionManager, "Error 1")
+        triggerConnectionError(connectionManager, { message: "Error 1" })
 
-        triggerConnectionError(connectionManager, "Error 2")
+        triggerConnectionError(connectionManager, { message: "Error 2" })
 
-        triggerConnectionError(connectionManager, "Error 3")
+        triggerConnectionError(connectionManager, { message: "Error 3" })
 
         // Should only show the latest error
         expect(screen.getByText("Connection error")).toBeVisible()
@@ -5091,7 +5104,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         const connectionManager = getMockConnectionManager(false)
 
         // First error
-        triggerConnectionError(connectionManager, "First error")
+        triggerConnectionError(connectionManager, { message: "First error" })
 
         expect(screen.getByText("Connection error")).toBeVisible()
 
@@ -5118,7 +5131,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
 
         // Error should still not display (dismissal persists)
-        triggerConnectionError(connectionManager, "Another error")
+        triggerConnectionError(connectionManager, { message: "Another error" })
 
         expect(screen.queryByText("Connection error")).toBeNull()
 
@@ -5129,7 +5142,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
           )
         })
 
-        triggerConnectionError(connectionManager, "Error after reconnect")
+        triggerConnectionError(connectionManager, {
+          message: "Error after reconnect",
+        })
 
         expect(screen.getByText("Connection error")).toBeVisible()
       })
@@ -5206,7 +5221,9 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
 
         // Try to trigger connection error
-        triggerConnectionError(connectionManager, "Error while disconnected")
+        triggerConnectionError(connectionManager, {
+          message: "Error while disconnected",
+        })
 
         // Should still show error dialog even when disconnected
         expect(screen.getByText("Connection error")).toBeVisible()

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -36,6 +36,7 @@ import {
   WarningProps,
 } from "@streamlit/app/src/components/StreamlitDialog"
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
+import DialogErrorMessage from "@streamlit/app/src/components/StreamlitDialog/DialogErrorMessage"
 import { UserSettings } from "@streamlit/app/src/components/StreamlitDialog/UserSettings"
 import ToolbarActions from "@streamlit/app/src/components/ToolbarActions"
 import withScreencast, {
@@ -51,6 +52,7 @@ import {
   ConnectionManager,
   ConnectionState,
   DefaultStreamlitEndpoints,
+  ErrorDetails,
   IHostConfigResponse,
   LibConfig,
   parseUriIntoBaseParts,
@@ -100,7 +102,6 @@ import {
   PresetThemeName,
   ScriptRunState,
   SessionInfo,
-  StreamlitMarkdown,
   ThemeConfig,
   toExportedTheme,
   toThemeInput,
@@ -654,19 +655,25 @@ export class App extends PureComponent<Props, State> {
 
   showError(
     title: string,
-    errorMarkdown: string,
+    errorDetails: ErrorDetails,
     dialogType:
       | DialogType.WARNING
       | DialogType.CONNECTION_ERROR = DialogType.WARNING
   ): void {
-    LOG.error(errorMarkdown)
+    LOG.error(errorDetails.message)
+
     const newDialog: WarningProps | ConnectionErrorProps = {
       type: dialogType,
       title,
-      msg: <StreamlitMarkdown source={errorMarkdown} allowHTML={false} />,
+      msg: (
+        <DialogErrorMessage
+          message={errorDetails.message}
+          codeBlock={errorDetails.codeBlock}
+        />
+      ),
       onClose: () => {},
     }
-    this.maybeShowErrorDialog(newDialog, errorMarkdown)
+    this.maybeShowErrorDialog(newDialog, errorDetails.message)
   }
 
   showDeployError = (
@@ -901,7 +908,7 @@ export class App extends PureComponent<Props, State> {
     } catch (e) {
       const err = ensureError(e)
       LOG.error(err)
-      this.showError("Bad message format", err.message)
+      this.showError("Bad message format", { message: err.message })
     }
   }
 
@@ -993,7 +1000,9 @@ export class App extends PureComponent<Props, State> {
     const errMsg = pageName
       ? `You have requested page /${pageName}, but no corresponding file was found in the app's pages/ directory`
       : "The page that you have requested does not seem to exist"
-    this.showError("Page not found", `${errMsg}. Running the app's main page.`)
+    this.showError("Page not found", {
+      message: `${errMsg}. Running the app's main page.`,
+    })
   }
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
@@ -1883,7 +1892,7 @@ export class App extends PureComponent<Props, State> {
   /**
    * Updates the app body when there's a connection error.
    */
-  handleConnectionError = (errMarkdown: string): void => {
+  handleConnectionError = (errDetails: ErrorDetails): void => {
     // Don't show the error dialog if it has been dismissed for this session
     if (this.state.connectionErrorDismissed) {
       return
@@ -1891,11 +1900,7 @@ export class App extends PureComponent<Props, State> {
 
     // This is just a regular error dialog, but with type CONNECTION_ERROR
     // instead of WARNING, so we can rescind the dialog later when reconnected.
-    this.showError(
-      "Connection error",
-      errMarkdown,
-      DialogType.CONNECTION_ERROR
-    )
+    this.showError("Connection error", errDetails, DialogType.CONNECTION_ERROR)
   }
 
   /**

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
@@ -19,7 +19,7 @@ import React from "react"
 import { screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import { render } from "@streamlit/lib"
+import { render } from "@streamlit/lib/testing"
 
 import DialogErrorMessage, {
   DialogErrorMessageProps,
@@ -116,32 +116,27 @@ Line 3`
     expect(screen.getByText("streamlit run yourscript.py")).toBeVisible()
   })
 
-  it("renders plain URLs as clickable links", () => {
+  it("renders multiple markdown links in message", () => {
     renderDialogErrorMessage({
       message:
-        "Cannot connect to Streamlit (HTTP status: 403).\n\nIf you are trying to access a Streamlit app running on another server, this could be due to the app's CORS settings. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS",
+        "Error occurred. See [docs](https://example.com/docs) or [support](https://example.com/support) for help.",
     })
 
-    // Check for key parts of the message
-    expect(
-      screen.getByText("Cannot connect to Streamlit (HTTP status: 403).", {
-        exact: false,
-      })
-    ).toBeVisible()
-    expect(screen.getByText(/CORS settings/)).toBeVisible()
+    // Verify both links are clickable
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(2)
 
-    // Verify plain URL is clickable
-    const link = screen.getByRole("link")
-    expect(link).toBeVisible()
-    expect(link).toHaveAttribute(
-      "href",
-      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
-    )
-    expect(link).toHaveAttribute("target", "_blank")
-    expect(link).toHaveAttribute("rel", "noopener noreferrer")
-    expect(link).toHaveTextContent(
-      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
-    )
+    expect(links[0]).toBeVisible()
+    expect(links[0]).toHaveAttribute("href", "https://example.com/docs")
+    expect(links[0]).toHaveAttribute("target", "_blank")
+    expect(links[0]).toHaveAttribute("rel", "noopener noreferrer")
+    expect(links[0]).toHaveTextContent("docs")
+
+    expect(links[1]).toBeVisible()
+    expect(links[1]).toHaveAttribute("href", "https://example.com/support")
+    expect(links[1]).toHaveAttribute("target", "_blank")
+    expect(links[1]).toHaveAttribute("rel", "noopener noreferrer")
+    expect(links[1]).toHaveTextContent("support")
   })
 
   it("renders markdown links but not other markdown syntax", () => {

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { render } from "@streamlit/lib"
+
+import DialogErrorMessage, {
+  DialogErrorMessageProps,
+} from "./DialogErrorMessage"
+
+function renderDialogErrorMessage(
+  props: DialogErrorMessageProps
+): ReturnType<typeof render> {
+  return render(<DialogErrorMessage {...props} />)
+}
+
+describe("DialogErrorMessage", () => {
+  it("renders plain text message", () => {
+    renderDialogErrorMessage({
+      message: "Simple error message",
+    })
+
+    expect(screen.getByText("Simple error message")).toBeVisible()
+  })
+
+  it("renders multiline message", () => {
+    const multilineMessage = `Line 1
+Line 2
+Line 3`
+
+    renderDialogErrorMessage({
+      message: multilineMessage,
+    })
+
+    // Check for individual lines
+    expect(screen.getByText("Line 1", { exact: false })).toBeVisible()
+    expect(screen.getByText("Line 2", { exact: false })).toBeVisible()
+    expect(screen.getByText("Line 3", { exact: false })).toBeVisible()
+  })
+
+  it("renders message without code block when codeBlock is not passed", () => {
+    renderDialogErrorMessage({
+      message: "Error occurred",
+      codeBlock: undefined,
+    })
+
+    expect(screen.getByText("Error occurred")).toBeVisible()
+    expect(screen.queryByTestId("stErrorCodeBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders message with code block when codeBlock is provided", () => {
+    renderDialogErrorMessage({
+      message: "Connection failed with status 500, and response:",
+      codeBlock: '{"error": "Internal Server Error"}',
+    })
+
+    expect(
+      screen.getByText("Connection failed with status 500, and response:")
+    ).toBeVisible()
+    expect(screen.getByTestId("stErrorCodeBlock")).toBeVisible()
+    expect(
+      screen.getByText('{"error": "Internal Server Error"}')
+    ).toBeVisible()
+  })
+
+  it("renders formatted JSON in code block", () => {
+    const jsonCode = JSON.stringify(
+      {
+        error: "Internal Server Error",
+        message: "Something went wrong",
+        code: 500,
+      },
+      null,
+      2
+    )
+
+    renderDialogErrorMessage({
+      message: "Server error:",
+      codeBlock: jsonCode,
+    })
+
+    expect(screen.getByText("Server error:")).toBeVisible()
+    expect(screen.getByTestId("stErrorCodeBlock")).toBeVisible()
+    // Check for parts of the JSON
+    expect(
+      screen.getByText(/"error": "Internal Server Error"/, { exact: false })
+    ).toBeVisible()
+  })
+
+  it("renders command in code block for localhost connection error", () => {
+    renderDialogErrorMessage({
+      message:
+        "Is Streamlit still running? If you accidentally stopped Streamlit, just restart it in your terminal:",
+      codeBlock: "streamlit run yourscript.py",
+    })
+
+    expect(screen.getByText(/Is Streamlit still running/)).toBeVisible()
+    expect(screen.getByTestId("stErrorCodeBlock")).toBeVisible()
+    expect(screen.getByText("streamlit run yourscript.py")).toBeVisible()
+  })
+
+  it("renders plain URLs as clickable links", () => {
+    renderDialogErrorMessage({
+      message:
+        "Cannot connect to Streamlit (HTTP status: 403).\n\nIf you are trying to access a Streamlit app running on another server, this could be due to the app's CORS settings. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS",
+    })
+
+    // Check for key parts of the message
+    expect(
+      screen.getByText("Cannot connect to Streamlit (HTTP status: 403).", {
+        exact: false,
+      })
+    ).toBeVisible()
+    expect(screen.getByText(/CORS settings/)).toBeVisible()
+
+    // Verify plain URL is clickable
+    const link = screen.getByRole("link")
+    expect(link).toBeVisible()
+    expect(link).toHaveAttribute(
+      "href",
+      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+    )
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", "noopener noreferrer")
+    expect(link).toHaveTextContent(
+      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+    )
+  })
+
+  it("renders markdown links but not other markdown syntax", () => {
+    renderDialogErrorMessage({
+      message:
+        "**Bold text** and *italic text* and [link](https://example.com)",
+    })
+
+    // Bold and italic are shown as literal text (not parsed)
+    expect(screen.getByText(/\*\*Bold text\*\*/)).toBeVisible()
+    expect(screen.getByText(/\*italic text\*/)).toBeVisible()
+
+    // But markdown links ARE parsed and clickable
+    const link = screen.getByRole("link", { name: "link" })
+    expect(link).toBeVisible()
+    expect(link).toHaveAttribute("href", "https://example.com")
+  })
+
+  it("renders CORS error with clickable markdown link", () => {
+    renderDialogErrorMessage({
+      message:
+        "Cannot connect to Streamlit (HTTP status: 403).\n\nIf you are trying to access a Streamlit app running on another server, this could be due to the app's [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings.",
+    })
+
+    // Verify the CORS link is clickable
+    const link = screen.getByRole("link", { name: "CORS" })
+    expect(link).toBeVisible()
+    expect(link).toHaveAttribute(
+      "href",
+      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+    )
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", "noopener noreferrer")
+  })
+
+  it("renders message with special characters", () => {
+    renderDialogErrorMessage({
+      message:
+        'Error: <script>alert("XSS")</script> & "quotes" \'and\' symbols',
+    })
+
+    expect(
+      screen.getByText(
+        'Error: <script>alert("XSS")</script> & "quotes" \'and\' symbols'
+      )
+    ).toBeVisible()
+  })
+
+  it("renders connection timeout error", () => {
+    renderDialogErrorMessage({
+      message: "Connection timed out.",
+    })
+
+    expect(screen.getByText("Connection timed out.")).toBeVisible()
+    expect(screen.queryByTestId("stErrorCodeBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders server not responding error", () => {
+    renderDialogErrorMessage({
+      message:
+        "Streamlit server is not responding. Are you connected to the internet?",
+    })
+
+    expect(
+      screen.getByText(
+        "Streamlit server is not responding. Are you connected to the internet?"
+      )
+    ).toBeVisible()
+    expect(screen.queryByTestId("stErrorCodeBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders page not found error", () => {
+    renderDialogErrorMessage({
+      message:
+        "You have requested page /nonexistent, but no corresponding file was found in the app's pages/ directory. Running the app's main page.",
+    })
+
+    expect(
+      screen.getByText(
+        "You have requested page /nonexistent, but no corresponding file was found in the app's pages/ directory. Running the app's main page."
+      )
+    ).toBeVisible()
+    expect(screen.queryByTestId("stErrorCodeBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders bad message format error", () => {
+    renderDialogErrorMessage({
+      message: "Invalid JSON format in message",
+    })
+
+    expect(screen.getByText("Invalid JSON format in message")).toBeVisible()
+    expect(screen.queryByTestId("stErrorCodeBlock")).not.toBeInTheDocument()
+  })
+
+  it("code block component has copy functionality", () => {
+    renderDialogErrorMessage({
+      message: "Error:",
+      codeBlock: "some code to copy",
+    })
+
+    const codeBlock = screen.getByTestId("stErrorCodeBlock")
+    expect(codeBlock).toBeVisible()
+
+    // The StreamlitErrorCodeBlock should contain the text
+    expect(codeBlock).toHaveTextContent("some code to copy")
+  })
+
+  it("renders very long message text", () => {
+    renderDialogErrorMessage({
+      message:
+        "This is a very long error message that might wrap across multiple lines in the dialog. ".repeat(
+          10
+        ),
+    })
+
+    // Check that the message appears (checking for a substring)
+    expect(
+      screen.getByText(
+        "This is a very long error message that might wrap across multiple lines in the dialog.",
+        { exact: false }
+      )
+    ).toBeVisible()
+  })
+
+  it("renders very long code block", () => {
+    const longCode = JSON.stringify(
+      {
+        error: "Long error",
+        stack: "Line 1\n".repeat(50),
+        data: Array(100)
+          .fill(0)
+          .map((_, i) => i),
+      },
+      null,
+      2
+    )
+
+    renderDialogErrorMessage({
+      message: "Stack trace:",
+      codeBlock: longCode,
+    })
+
+    expect(screen.getByText("Stack trace:")).toBeVisible()
+    expect(screen.getByTestId("stErrorCodeBlock")).toBeVisible()
+    // Check for part of the code
+    expect(
+      screen.getByText(/"error": "Long error"/, { exact: false })
+    ).toBeVisible()
+  })
+})

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
@@ -116,29 +116,6 @@ Line 3`
     expect(screen.getByText("streamlit run yourscript.py")).toBeVisible()
   })
 
-  it("renders multiple markdown links in message", () => {
-    renderDialogErrorMessage({
-      message:
-        "Error occurred. See [docs](https://example.com/docs) or [support](https://example.com/support) for help.",
-    })
-
-    // Verify both links are clickable
-    const links = screen.getAllByRole("link")
-    expect(links).toHaveLength(2)
-
-    expect(links[0]).toBeVisible()
-    expect(links[0]).toHaveAttribute("href", "https://example.com/docs")
-    expect(links[0]).toHaveAttribute("target", "_blank")
-    expect(links[0]).toHaveAttribute("rel", "noopener noreferrer")
-    expect(links[0]).toHaveTextContent("docs")
-
-    expect(links[1]).toBeVisible()
-    expect(links[1]).toHaveAttribute("href", "https://example.com/support")
-    expect(links[1]).toHaveAttribute("target", "_blank")
-    expect(links[1]).toHaveAttribute("rel", "noopener noreferrer")
-    expect(links[1]).toHaveTextContent("support")
-  })
-
   it("renders markdown links but not other markdown syntax", () => {
     renderDialogErrorMessage({
       message:
@@ -285,5 +262,116 @@ Line 3`
     expect(
       screen.getByText(/"error": "Long error"/, { exact: false })
     ).toBeVisible()
+  })
+
+  describe("parseLinks function", () => {
+    it.each([
+      {
+        description: "GitHub issue link",
+        message:
+          "This is not expected to happen. Please [report this bug](https://github.com/streamlit/streamlit/issues).",
+        expectedLinks: [
+          {
+            text: "report this bug",
+            href: "https://github.com/streamlit/streamlit/issues",
+          },
+        ],
+      },
+      {
+        description: "MDN CORS documentation link",
+        message:
+          "This could be due to the app's [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings.",
+        expectedLinks: [
+          {
+            text: "CORS",
+            href: "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS",
+          },
+        ],
+      },
+      {
+        description: "multiple links in one message",
+        message:
+          "Error occurred. See [documentation](https://docs.streamlit.io) or [contact support](https://support.streamlit.io) for help.",
+        expectedLinks: [
+          {
+            text: "documentation",
+            href: "https://docs.streamlit.io",
+          },
+          {
+            text: "contact support",
+            href: "https://support.streamlit.io",
+          },
+        ],
+      },
+      {
+        description: "link with text before and after",
+        message:
+          "Connection failed. Check your [network settings](https://example.com/network) and try again.",
+        expectedLinks: [
+          {
+            text: "network settings",
+            href: "https://example.com/network",
+          },
+        ],
+      },
+      {
+        description: "link at the start of message",
+        message:
+          "[Click here](https://example.com) to learn more about this error.",
+        expectedLinks: [
+          {
+            text: "Click here",
+            href: "https://example.com",
+          },
+        ],
+      },
+      {
+        description: "link at the end of message",
+        message:
+          "For more information, see [this guide](https://example.com/guide)",
+        expectedLinks: [
+          {
+            text: "this guide",
+            href: "https://example.com/guide",
+          },
+        ],
+      },
+      {
+        description: "link with special characters in URL",
+        message:
+          "Reference: [API docs](https://api.example.com/v1/docs?section=auth&format=json)",
+        expectedLinks: [
+          {
+            text: "API docs",
+            href: "https://api.example.com/v1/docs?section=auth&format=json",
+          },
+        ],
+      },
+      {
+        description: "link with parentheses in text",
+        message:
+          "See [Python docs (3.9+)](https://docs.python.org/3/) for details.",
+        expectedLinks: [
+          {
+            text: "Python docs (3.9+)",
+            href: "https://docs.python.org/3/",
+          },
+        ],
+      },
+    ])("renders $description correctly", ({ message, expectedLinks }) => {
+      renderDialogErrorMessage({ message })
+
+      // Verify all expected links are rendered correctly
+      const links = screen.getAllByRole("link")
+      expect(links).toHaveLength(expectedLinks.length)
+
+      expectedLinks.forEach((expectedLink, index) => {
+        expect(links[index]).toBeVisible()
+        expect(links[index]).toHaveTextContent(expectedLink.text)
+        expect(links[index]).toHaveAttribute("href", expectedLink.href)
+        expect(links[index]).toHaveAttribute("target", "_blank")
+        expect(links[index]).toHaveAttribute("rel", "noopener noreferrer")
+      })
+    })
   })
 })

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
@@ -18,6 +18,8 @@ import React, { Fragment, ReactElement, ReactNode } from "react"
 
 import { StreamlitErrorCodeBlock } from "@streamlit/lib"
 
+import { StyledErrorText } from "./styled-components"
+
 export interface DialogErrorMessageProps {
   message: string
   codeBlock?: string
@@ -94,7 +96,9 @@ function DialogErrorMessage({
 }: Readonly<DialogErrorMessageProps>): ReactElement {
   return (
     <>
-      <div>{parseLinks(message)}</div>
+      <StyledErrorText hasCodeBelow={!!codeBlock}>
+        {parseLinks(message)}
+      </StyledErrorText>
       {codeBlock && (
         <StreamlitErrorCodeBlock>{codeBlock}</StreamlitErrorCodeBlock>
       )}

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Fragment, ReactElement, ReactNode } from "react"
+
+import { StreamlitErrorCodeBlock } from "@streamlit/lib"
+
+export interface DialogErrorMessageProps {
+  message: string
+  codeBlock?: string
+}
+
+/**
+ * Parse message text and convert markdown links [text](url) and plain URLs
+ * into clickable anchor tags.
+ */
+function parseLinks(text: string): ReactNode[] {
+  const parts: ReactNode[] = []
+  let currentIndex = 0
+  let key = 0
+
+  // Match: 1) Markdown links [text](url)  2) Plain URLs http(s)://...
+  const pattern = /(\[([^\]]+)\]\(([^)]+)\))|(https?:\/\/[^\s]+)/g
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    // Add text before the match
+    if (match.index > currentIndex) {
+      parts.push(
+        <Fragment key={key++}>
+          {text.substring(currentIndex, match.index)}
+        </Fragment>
+      )
+    }
+
+    if (match[1]) {
+      // Markdown link: [text](url)
+      parts.push(
+        <a
+          key={key++}
+          href={match[3]}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {match[2]}
+        </a>
+      )
+    } else if (match[4]) {
+      // Plain URL
+      parts.push(
+        <a
+          key={key++}
+          href={match[4]}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {match[4]}
+        </a>
+      )
+    }
+
+    currentIndex = match.index + match[0].length
+  }
+
+  // Add remaining text
+  if (currentIndex < text.length) {
+    parts.push(<Fragment key={key++}>{text.substring(currentIndex)}</Fragment>)
+  }
+
+  return parts
+}
+
+/**
+ * Component for displaying error messages with optional code blocks.
+ * Used in error dialogs to display text messages with links and formatted code.
+ * Supports markdown-style links [text](url) and plain URLs.
+ */
+function DialogErrorMessage({
+  message,
+  codeBlock,
+}: Readonly<DialogErrorMessageProps>): ReactElement {
+  return (
+    <>
+      <div>{parseLinks(message)}</div>
+      {codeBlock && (
+        <StreamlitErrorCodeBlock>{codeBlock}</StreamlitErrorCodeBlock>
+      )}
+    </>
+  )
+}
+
+export default DialogErrorMessage

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, ReactElement, ReactNode } from "react"
+import React, { Fragment, memo, ReactElement, ReactNode } from "react"
 
 import { StreamlitErrorCodeBlock } from "@streamlit/lib"
 
@@ -26,16 +26,15 @@ export interface DialogErrorMessageProps {
 }
 
 /**
- * Parse message text and convert markdown links [text](url) and plain URLs
- * into clickable anchor tags.
+ * Parse message text and convert markdown links [text](url) into clickable anchor tags.
  */
 function parseLinks(text: string): ReactNode[] {
   const parts: ReactNode[] = []
   let currentIndex = 0
   let key = 0
 
-  // Match: 1) Markdown links [text](url)  2) Plain URLs http(s)://...
-  const pattern = /(\[([^\]]+)\]\(([^)]+)\))|(https?:\/\/[^\s]+)/g
+  // Match markdown links: [text](url)
+  const pattern = /\[([^\]]+)\]\(([^)]+)\)/g
   let match: RegExpExecArray | null
 
   while ((match = pattern.exec(text)) !== null) {
@@ -48,31 +47,12 @@ function parseLinks(text: string): ReactNode[] {
       )
     }
 
-    if (match[1]) {
-      // Markdown link: [text](url)
-      parts.push(
-        <a
-          key={key++}
-          href={match[3]}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {match[2]}
-        </a>
-      )
-    } else if (match[4]) {
-      // Plain URL
-      parts.push(
-        <a
-          key={key++}
-          href={match[4]}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {match[4]}
-        </a>
-      )
-    }
+    // Add markdown link: [text](url)
+    parts.push(
+      <a key={key++} href={match[2]} target="_blank" rel="noopener noreferrer">
+        {match[1]}
+      </a>
+    )
 
     currentIndex = match.index + match[0].length
   }
@@ -88,7 +68,7 @@ function parseLinks(text: string): ReactNode[] {
 /**
  * Component for displaying error messages with optional code blocks.
  * Used in error dialogs to display text messages with links and formatted code.
- * Supports markdown-style links [text](url) and plain URLs.
+ * Supports markdown-style links [text](url).
  */
 function DialogErrorMessage({
   message,
@@ -106,4 +86,4 @@ function DialogErrorMessage({
   )
 }
 
-export default DialogErrorMessage
+export default memo(DialogErrorMessage)

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -25,8 +25,8 @@ import {
   ModalFooter,
   ModalHeader,
   SessionInfo,
+  StreamlitErrorCodeBlock,
   StreamlitMarkdown,
-  StreamlitSyntaxHighlighter,
 } from "@streamlit/lib"
 import { IException } from "@streamlit/protobuf"
 
@@ -162,9 +162,9 @@ function ScriptCompileErrorDialog(
     <Modal isOpen onClose={props.onClose} size="auto" autoFocus={false}>
       <ModalHeader>Script execution error</ModalHeader>
       <ModalBody>
-        <StreamlitSyntaxHighlighter showLineNumbers={false} wrapLines={false}>
+        <StreamlitErrorCodeBlock>
           {props.exception?.message ? props.exception.message : "No message"}
-        </StreamlitSyntaxHighlighter>
+        </StreamlitErrorCodeBlock>
       </ModalBody>
       <ModalFooter>
         <ModalButton kind={BaseButtonKind.SECONDARY} onClick={props.onClose}>

--- a/frontend/app/src/components/StreamlitDialog/styled-components.ts
+++ b/frontend/app/src/components/StreamlitDialog/styled-components.ts
@@ -111,3 +111,15 @@ export const StyledDeployErrorContent = styled.div(({ theme }) => ({
     paddingLeft: theme.spacing.twoXL,
   },
 }))
+
+interface StyledErrorTextProps {
+  hasCodeBelow: boolean
+}
+
+export const StyledErrorText = styled.div<StyledErrorTextProps>(
+  ({ theme, hasCodeBelow }) => ({
+    ...(hasCodeBelow && {
+      marginBottom: theme.spacing.lg,
+    }),
+  })
+)

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -21,7 +21,7 @@ import { BackMsg, ForwardMsg } from "@streamlit/protobuf"
 import { ConnectionState } from "./ConnectionState"
 import { MAX_RETRIES_BEFORE_CLIENT_ERROR } from "./constants"
 import { establishStaticConnection } from "./StaticConnection"
-import { IHostConfigResponse, StreamlitEndpoints } from "./types"
+import { ErrorDetails, IHostConfigResponse, StreamlitEndpoints } from "./types"
 import { getPossibleBaseUris } from "./utils"
 import { WebsocketConnection } from "./WebsocketConnection"
 
@@ -42,7 +42,7 @@ interface Props {
   /**
    * Function to be called when the connection errors out.
    */
-  onConnectionError: (errNode: string) => void
+  onConnectionError: (errNode: ErrorDetails) => void
 
   /**
    * Called when our ConnectionState is changed.
@@ -195,10 +195,9 @@ export class ConnectionManager {
           err.message,
           "Connection Manager"
         )
-        this.setConnectionState(
-          ConnectionState.DISCONNECTED_FOREVER,
-          err.message
-        )
+        this.setConnectionState(ConnectionState.DISCONNECTED_FOREVER, {
+          message: err.message,
+        })
       }
     }
   }
@@ -209,7 +208,7 @@ export class ConnectionManager {
 
   private setConnectionState = (
     connectionState: ConnectionState,
-    errMsg?: string
+    errMsg?: ErrorDetails
   ): void => {
     if (this.connectionState !== connectionState) {
       this.connectionState = connectionState
@@ -223,7 +222,7 @@ export class ConnectionManager {
 
   private showRetryError = (
     totalRetries: number,
-    latestError: string,
+    latestError: ErrorDetails,
     // The last argument of this function is unused and exists because the
     // WebsocketConnection.OnRetry type allows a third argument to be set to be
     // used in tests.

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -33,7 +33,7 @@ import {
   PING_TIMEOUT_MS,
   SERVER_PING_PATH,
 } from "./constants"
-import { IHostConfigResponse, OnRetry } from "./types"
+import { ErrorDetails, IHostConfigResponse, OnRetry } from "./types"
 import { parseUriIntoBaseParts } from "./utils"
 
 const LOG = getLogger("DoInitPings")
@@ -78,7 +78,7 @@ export function doInitPings(
     connect()
   }
 
-  const retry = (errorMarkdown: string): void => {
+  const retry = (errorDetails: ErrorDetails): void => {
     // Adjust retry time by +- 20% to spread out load
     const jitter = Math.random() * 0.4 - 0.2
     // Exponential backoff to reduce load from health pings when experiencing
@@ -89,7 +89,7 @@ export function doInitPings(
         : minimumTimeoutMs * 2 ** (totalTries - 1) * (1 + jitter)
     const retryTimeout = Math.min(maximumTimeoutMs, timeoutMs)
 
-    retryCallback(totalTries, errorMarkdown, retryTimeout)
+    retryCallback(totalTries, errorDetails, retryTimeout)
 
     if (typeof window === "undefined") {
       // There seems to be a race condition when tearing down test env
@@ -107,28 +107,25 @@ export function doInitPings(
     const uri = new URL(buildHttpUri(uriParts, ""))
 
     if (uri.hostname === "localhost") {
-      const markdownMessage = `
-Is Streamlit still running? If you accidentally stopped Streamlit, just restart it in your terminal:
-
-\`\`\`bash
-streamlit run yourscript.py
-\`\`\`
-      `
-      retry(markdownMessage)
+      retry({
+        message:
+          "Is Streamlit still running? If you accidentally stopped Streamlit, just restart it in your terminal:",
+        codeBlock: "streamlit run yourscript.py",
+      })
     } else {
-      retry(
-        "Streamlit server is not responding. " +
-          "Are you connected to the internet?"
-      )
+      retry({
+        message:
+          "Streamlit server is not responding. Are you connected to the internet?",
+      })
     }
   }
 
   const retryWhenIsForbidden = (): void => {
-    const forbiddenMessage = `Cannot connect to Streamlit (HTTP status: 403).
+    retry({
+      message: `Cannot connect to Streamlit (HTTP status: 403).
 
-If you are trying to access a Streamlit app running on another server, this could be due to the app's [CORS](${CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}) settings.`
-
-    retry(forbiddenMessage)
+If you are trying to access a Streamlit app running on another server, this could be due to the app's [CORS](${CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}) settings.`,
+    })
   }
 
   // Handle retrieving the source URL, otherwise fallback to "DoInitPings"
@@ -202,7 +199,7 @@ If you are trying to access a Streamlit app running on another server, this coul
               source
             )
           }
-          return retry("Connection timed out.")
+          return retry({ message: "Connection timed out." })
         }
 
         if (error.response) {
@@ -244,14 +241,16 @@ If you are trying to access a Streamlit app running on another server, this coul
             sendClientError(status, statusText, source)
           }
 
-          return retry(
-            `Connection failed with status ${status}, ` +
-              "and response:\n```\n" +
-              (data !== null && typeof data === "object"
-                ? JSON.stringify(data, null, 2)
-                : data) +
-              "\n```"
-          )
+          const responseData =
+            data !== null && typeof data === "object"
+              ? JSON.stringify(data, null, 2)
+              : data
+          const messageEnding = responseData ? ", and response:" : "."
+
+          return retry({
+            message: `Connection failed with status ${status}${messageEnding}`,
+            ...(responseData && { codeBlock: responseData }),
+          })
         }
 
         if (error.request) {
@@ -287,7 +286,7 @@ If you are trying to access a Streamlit app running on another server, this coul
             source
           )
         }
-        return retry(error.message)
+        return retry({ message: error.message })
       })
   }
 

--- a/frontend/connection/src/StaticConnection.tsx
+++ b/frontend/connection/src/StaticConnection.tsx
@@ -20,7 +20,7 @@ import { ForwardMsgList } from "@streamlit/protobuf"
 import { localStorageAvailable } from "@streamlit/utils"
 
 import { ConnectionState } from "./ConnectionState"
-import { StreamlitEndpoints } from "./types"
+import { ErrorDetails, StreamlitEndpoints } from "./types"
 
 // TODO: Change this to a stable location and eventually make it configurable
 // Holds url for static asset location
@@ -31,7 +31,7 @@ export const LOG = getLogger("StaticConnection")
 type OnMessage = (ForwardMsg: any) => void
 type OnConnectionStateChange = (
   connectionState: ConnectionState,
-  errMsg?: string
+  errMsg?: ErrorDetails
 ) => void
 
 // Fetches the static asset url from the config file
@@ -103,15 +103,15 @@ export async function dispatchAppForwardMessages(
   staticAppId: string,
   staticConfigUrl: string,
   onMessage: OnMessage,
-  onConnectionError: (message: string) => void
+  onConnectionError: (message: ErrorDetails) => void
 ): Promise<void> {
   const arrayBuffer = await getProtoResponse(staticAppId, staticConfigUrl)
 
   if (!arrayBuffer) {
     LOG.error("Failed to retrieve static app protos")
-    onConnectionError(
-      `Failed to retrieve static app protos. Please confirm the id is correct and try again. Given static app id: ${staticAppId}`
-    )
+    onConnectionError({
+      message: `Failed to retrieve static app protos. Please confirm the id is correct and try again. Given static app id: ${staticAppId}`,
+    })
     return
   }
 
@@ -128,7 +128,7 @@ export async function establishStaticConnection(
   staticAppId: string,
   onConnectionStateChange: OnConnectionStateChange,
   onMessage: OnMessage,
-  onConnectionError: (message: string) => void,
+  onConnectionError: (message: ErrorDetails) => void,
   endpoints: StreamlitEndpoints
 ): Promise<void> {
   // Static notebooks are not connected to a server - put into connecting

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -27,6 +27,7 @@ import {
 } from "./constants"
 import { doInitPings } from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
+import { ErrorDetails } from "./types"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
 
 const MOCK_ALLOWED_ORIGINS_CONFIG = {
@@ -285,7 +286,7 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      TEST_ERROR_MESSAGE,
+      { message: TEST_ERROR_MESSAGE },
       expect.anything()
     )
   })
@@ -321,7 +322,7 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      "Connection timed out.",
+      { message: "Connection timed out." },
       expect.anything()
     )
   })
@@ -361,7 +362,10 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      "Streamlit server is not responding. Are you connected to the internet?",
+      {
+        message:
+          "Streamlit server is not responding. Are you connected to the internet?",
+      },
       expect.anything()
     )
   })
@@ -399,7 +403,10 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      "Streamlit server is not responding. Are you connected to the internet?",
+      {
+        message:
+          "Streamlit server is not responding. Are you connected to the internet?",
+      },
       expect.anything()
     )
   })
@@ -501,7 +508,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      forbiddenMarkdown,
+      { message: forbiddenMarkdown },
       expect.anything()
     )
   })
@@ -542,10 +549,10 @@ If you are trying to access a Streamlit app running on another server, this coul
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      `Connection failed with status ${TEST_ERROR.response.status}, ` +
-        "and response:\n```\n" +
-        TEST_ERROR.response.data +
-        "\n```",
+      {
+        message: `Connection failed with status ${TEST_ERROR.response.status}, and response:`,
+        codeBlock: TEST_ERROR.response.data,
+      },
       expect.anything()
     )
   })
@@ -588,10 +595,10 @@ If you are trying to access a Streamlit app running on another server, this coul
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      `Connection failed with status ${TEST_ERROR.response.status}, ` +
-        "and response:\n```\n" +
-        JSON.stringify(TEST_ERROR.response.data, null, 2) +
-        "\n```",
+      {
+        message: `Connection failed with status ${TEST_ERROR.response.status}, and response:`,
+        codeBlock: JSON.stringify(TEST_ERROR.response.data, null, 2),
+      },
       expect.anything()
     )
   })
@@ -667,7 +674,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const timeouts: number[] = []
     const retryCallback = (
       _times: number,
-      _errorNode: React.ReactNode,
+      _errorDetails: ErrorDetails,
       timeout: number
     ): void => {
       timeouts.push(timeout)
@@ -733,7 +740,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const timeouts: number[] = []
     const retryCallback = (
       _times: number,
-      _errorNode: React.ReactNode,
+      _errorDetails: ErrorDetails,
       timeout: number
     ): void => {
       timeouts.push(timeout)
@@ -788,7 +795,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const timeouts: number[] = []
     const retryCallback = (
       _times: number,
-      _errorNode: React.ReactNode,
+      _errorDetails: ErrorDetails,
       timeout: number
     ): void => {
       timeouts.push(timeout)
@@ -818,7 +825,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const timeouts2: number[] = []
     const retryCallback2 = (
       _times: number,
-      _errorNode: React.ReactNode,
+      _errorDetails: ErrorDetails,
       timeout: number
     ): void => {
       timeouts2.push(timeout)

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -37,6 +37,7 @@ import {
 } from "./DoInitPings"
 import { ForwardMsgCache } from "./ForwardMessageCache"
 import {
+  ErrorDetails,
   Event,
   IHostConfigResponse,
   OnConnectionStateChange,
@@ -214,7 +215,10 @@ export class WebsocketConnection {
   }
 
   // This should only be called inside stepFsm().
-  private setFsmState(state: ConnectionState, errMsg?: string): void {
+  private setFsmState(
+    state: ConnectionState,
+    errDetails?: ErrorDetails
+  ): void {
     LOG.info(`New state: ${state}`)
     this.state = state
 
@@ -229,7 +233,7 @@ export class WebsocketConnection {
         break
     }
 
-    this.args.onConnectionStateChange(state, errMsg)
+    this.args.onConnectionStateChange(state, errDetails)
 
     // Perform post-callback actions when entering certain states.
     switch (this.state) {
@@ -273,7 +277,9 @@ export class WebsocketConnection {
       )
       // If we get a fatal error, we transition to DISCONNECTED_FOREVER
       // regardless of our current state.
-      this.setFsmState(ConnectionState.DISCONNECTED_FOREVER, errMsg)
+      this.setFsmState(ConnectionState.DISCONNECTED_FOREVER, {
+        message: errMsg || "Unknown error",
+      })
       return
     }
 

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -34,14 +34,19 @@ declare global {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
 export type OnMessage = (ForwardMsg: any) => void
 
+export interface ErrorDetails {
+  message: string
+  codeBlock?: string
+}
+
 export type OnConnectionStateChange = (
   connectionState: ConnectionState,
-  errMsg?: string
+  errMsg?: ErrorDetails
 ) => void
 
 export type OnRetry = (
   totalTries: number,
-  errorMarkdown: string,
+  errorDetails: ErrorDetails,
   retryTimeout: number
 ) => void
 

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { screen } from "@testing-library/react"
+
+import { render } from "~lib/test_util"
+
+import StreamlitErrorCodeBlock, {
+  StreamlitCodeBlockProps,
+} from "./StreamlitErrorCodeBlock"
+
+// Realistic Python exception traceback example
+const EXCEPTION_TRACEBACK = `Traceback (most recent call last):
+  File "/app/streamlit_app.py", line 45, in <module>
+    result = divide_numbers(10, 0)
+  File "/app/streamlit_app.py", line 12, in divide_numbers
+    return a / b
+ZeroDivisionError: division by zero`
+
+const getStreamlitCodeBlockProps = (
+  props: Partial<StreamlitCodeBlockProps> = {}
+): StreamlitCodeBlockProps => ({
+  children: EXCEPTION_TRACEBACK,
+  ...props,
+})
+
+describe("StreamlitErrorCodeBlock", () => {
+  it("should render without crashing", () => {
+    const props = getStreamlitCodeBlockProps()
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    const codeBlock = screen.getByTestId("stErrorCodeBlock")
+    expect(codeBlock).toBeVisible()
+  })
+
+  it("should render the error code block with correct class", () => {
+    const props = getStreamlitCodeBlockProps()
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    const codeBlock = screen.getByTestId("stErrorCodeBlock")
+    expect(codeBlock).toHaveClass("stErrorCodeBlock")
+  })
+
+  it("should render copy button when children is a non-empty string", () => {
+    const props = getStreamlitCodeBlockProps()
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    // Copy button exists in DOM but is hidden by default (scale(0))
+    // and only becomes visible on hover
+    const copyButton = screen.getByTestId("stCodeCopyButton")
+    expect(copyButton).toBeInTheDocument()
+  })
+
+  it("should not render copy button when children is an empty string", () => {
+    const props = getStreamlitCodeBlockProps({ children: "" })
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    const copyButton = screen.queryByTestId("stCodeCopyButton")
+    expect(copyButton).not.toBeInTheDocument()
+  })
+
+  it("should not render copy button when children is only whitespace", () => {
+    const props = getStreamlitCodeBlockProps({ children: "   \n\t  " })
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    const copyButton = screen.queryByTestId("stCodeCopyButton")
+    expect(copyButton).not.toBeInTheDocument()
+  })
+
+  it("should not render copy button when children is an array", () => {
+    const props = getStreamlitCodeBlockProps({
+      children: ["Line 1\n", "Line 2\n"],
+    })
+    render(<StreamlitErrorCodeBlock {...props} />)
+
+    const copyButton = screen.queryByTestId("stCodeCopyButton")
+    expect(copyButton).not.toBeInTheDocument()
+  })
+
+  it("should render exception text content correctly", () => {
+    const props = getStreamlitCodeBlockProps()
+    const { baseElement } = render(<StreamlitErrorCodeBlock {...props} />)
+
+    const pre = baseElement.querySelector("pre")
+    expect(pre?.textContent).toContain("ZeroDivisionError: division by zero")
+    expect(pre?.textContent).toContain("Traceback (most recent call last)")
+  })
+
+  it("should render array children correctly", () => {
+    const arrayChildren = [
+      "Traceback (most recent call last):\n",
+      '  File "app.py", line 10, in <module>\n',
+      "    raise ValueError('Invalid input')\n",
+      "ValueError: Invalid input",
+    ]
+    const props = getStreamlitCodeBlockProps({ children: arrayChildren })
+    const { baseElement } = render(<StreamlitErrorCodeBlock {...props} />)
+
+    const pre = baseElement.querySelector("pre")
+    arrayChildren.forEach(line => {
+      expect(pre?.textContent).toContain(line.trim())
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
@@ -21,7 +21,7 @@ import { screen } from "@testing-library/react"
 import { render } from "~lib/test_util"
 
 import StreamlitErrorCodeBlock, {
-  StreamlitCodeBlockProps,
+  StreamlitErrorCodeBlockProps,
 } from "./StreamlitErrorCodeBlock"
 
 // Realistic Python exception traceback example
@@ -33,8 +33,8 @@ const EXCEPTION_TRACEBACK = `Traceback (most recent call last):
 ZeroDivisionError: division by zero`
 
 const getStreamlitCodeBlockProps = (
-  props: Partial<StreamlitCodeBlockProps> = {}
-): StreamlitCodeBlockProps => ({
+  props: Partial<StreamlitErrorCodeBlockProps> = {}
+): StreamlitErrorCodeBlockProps => ({
   children: EXCEPTION_TRACEBACK,
   ...props,
 })
@@ -66,26 +66,12 @@ describe("StreamlitErrorCodeBlock", () => {
     expect(copyButton).toBeInTheDocument()
   })
 
-  it("should not render copy button when children is an empty string", () => {
-    const props = getStreamlitCodeBlockProps({ children: "" })
-    render(<StreamlitErrorCodeBlock {...props} />)
-
-    const copyButton = screen.queryByTestId("stCodeCopyButton")
-    expect(copyButton).not.toBeInTheDocument()
-  })
-
-  it("should not render copy button when children is only whitespace", () => {
-    const props = getStreamlitCodeBlockProps({ children: "   \n\t  " })
-    render(<StreamlitErrorCodeBlock {...props} />)
-
-    const copyButton = screen.queryByTestId("stCodeCopyButton")
-    expect(copyButton).not.toBeInTheDocument()
-  })
-
-  it("should not render copy button when children is an array", () => {
-    const props = getStreamlitCodeBlockProps({
-      children: ["Line 1\n", "Line 2\n"],
-    })
+  it.each([
+    { label: "empty string", value: "" },
+    { label: "only whitespace", value: "   \n\t  " },
+    { label: "array", value: ["Line 1\n", "Line 2\n"] },
+  ])("should not render copy button when children is $label", ({ value }) => {
+    const props = getStreamlitCodeBlockProps({ children: value })
     render(<StreamlitErrorCodeBlock {...props} />)
 
     const copyButton = screen.queryByTestId("stCodeCopyButton")

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
@@ -18,6 +18,7 @@ import React, { memo, ReactElement } from "react"
 
 import CopyButton from "./CopyButton"
 import {
+  StyledCode,
   StyledCodeBlock,
   StyledCopyButtonContainer,
   StyledPre,
@@ -38,7 +39,9 @@ function StreamlitErrorCodeBlock({
       className="stErrorCodeBlock"
       data-testid="stErrorCodeBlock"
     >
-      <StyledPre wrapLines={false}>{children}</StyledPre>
+      <StyledPre wrapLines={false}>
+        <StyledCode wrapLines={false}>{children}</StyledCode>
+      </StyledPre>
       {shouldShowCopyButton && (
         <StyledCopyButtonContainer>
           <CopyButton text={children} />

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { memo, ReactElement } from "react"
+
+import CopyButton from "./CopyButton"
+import {
+  StyledCodeBlock,
+  StyledCopyButtonContainer,
+  StyledPre,
+} from "./styled-components"
+
+export interface StreamlitCodeBlockProps {
+  children: string | string[]
+  height?: number
+}
+
+function StreamlitErrorCodeBlock({
+  children,
+}: Readonly<StreamlitCodeBlockProps>): ReactElement {
+  return (
+    <StyledCodeBlock
+      className="stErrorCodeBlock"
+      data-testid="stErrorCodeBlock"
+    >
+      <StyledPre wrapLines={false}>{children}</StyledPre>
+      {typeof children === "string" && children.trim() !== "" && (
+        <StyledCopyButtonContainer>
+          <CopyButton text={children} />
+        </StyledCopyButtonContainer>
+      )}
+    </StyledCodeBlock>
+  )
+}
+
+export default memo(StreamlitErrorCodeBlock)

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
@@ -23,21 +23,23 @@ import {
   StyledPre,
 } from "./styled-components"
 
-export interface StreamlitCodeBlockProps {
+export interface StreamlitErrorCodeBlockProps {
   children: string | string[]
-  height?: number
 }
 
 function StreamlitErrorCodeBlock({
   children,
-}: Readonly<StreamlitCodeBlockProps>): ReactElement {
+}: Readonly<StreamlitErrorCodeBlockProps>): ReactElement {
+  const shouldShowCopyButton =
+    typeof children === "string" && children.trim().length > 0
+
   return (
     <StyledCodeBlock
       className="stErrorCodeBlock"
       data-testid="stErrorCodeBlock"
     >
       <StyledPre wrapLines={false}>{children}</StyledPre>
-      {typeof children === "string" && children.trim() !== "" && (
+      {shouldShowCopyButton && (
         <StyledCopyButtonContainer>
           <CopyButton text={children} />
         </StyledCopyButtonContainer>

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 
 import { Heading as HeadingProto } from "@streamlit/protobuf"
 
@@ -39,13 +39,16 @@ const getHeadingProps = (
 })
 
 describe("Heading", () => {
-  it("renders properly after a new line", () => {
+  it("renders properly after a new line", async () => {
     const props = getHeadingProps()
     render(<Heading {...props} />)
 
     const heading = screen.getByRole("heading")
     expect(heading).toHaveTextContent("hello world")
     expect(heading).not.toHaveTextContent("this is a new line")
+
+    // Wait for the lazy-loaded code block to render
+    await screen.findByText("this is a new line")
     expect(screen.getByText("this is a new line")).toBeInTheDocument()
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
 
@@ -162,7 +165,7 @@ describe("Heading", () => {
     expect(screen.queryByRole("blockquote")).not.toBeInTheDocument()
   })
 
-  it("does not render tables", () => {
+  it("does not render tables", async () => {
     const props = getHeadingProps({
       body: `| Syntax | Description |
            | ----------- | ----------- |
@@ -171,12 +174,17 @@ describe("Heading", () => {
     })
     render(<Heading {...props} />)
 
-    expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
-      "| Syntax | Description | | ----------- | ----------- | | Header | Title | | Paragraph | Text |"
-    )
     expect(screen.getByRole("heading")).toHaveTextContent(
       `| Syntax | Description |`
     )
+
+    // Wait for lazy-loaded content to render
+    await waitFor(() => {
+      expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
+        "| Syntax | Description | | ----------- | ----------- | | Header | Title | | Paragraph | Text |"
+      )
+    })
+
     expect(screen.queryByRole("table")).not.toBeInTheDocument()
     expect(screen.getAllByTestId("stMarkdownContainer")).toHaveLength(1)
   })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -527,37 +527,41 @@ st.write("Hello")
 })
 
 describe("CustomCodeTag Element", () => {
-  it("should render without crashing", () => {
+  it("should render without crashing", async () => {
     const props = getCustomCodeTagProps()
     render(<CustomCodeTag {...props} />)
 
-    const stCode = screen.getByTestId("stCode")
+    const stCode = await screen.findByTestId("stCode")
     expect(stCode).toBeInTheDocument()
   })
 
-  it("should render as plaintext", () => {
+  it("should render as plaintext", async () => {
     const props = getCustomCodeTagProps({ className: "language-plaintext" })
     render(<CustomCodeTag {...props} />)
 
-    const stCode = screen.getByTestId("stCode")
+    const stCode = await screen.findByTestId("stCode")
     expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(-1)
   })
 
-  it("should render copy button when code block has content", () => {
+  it("should render copy button when code block has content", async () => {
     const props = getCustomCodeTagProps({
       children: "i am not empty",
     })
     render(<CustomCodeTag {...props} />)
-    const copyButton = screen.getByTitle("Copy to clipboard")
+    const copyButton = await screen.findByTitle("Copy to clipboard")
 
     expect(copyButton).not.toBeNull()
   })
 
-  it("should not render copy button when code block is empty", () => {
+  it("should not render copy button when code block is empty", async () => {
     const props = getCustomCodeTagProps({
       children: "",
     })
     render(<CustomCodeTag {...props} />)
+
+    // Wait for the component to load
+    await screen.findByTestId("stCode")
+
     // queryBy returns null vs. error
     const copyButton = screen.queryByRole("button")
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -18,9 +18,11 @@ import React, {
   CSSProperties,
   type FC,
   type HTMLProps,
+  lazy,
   memo,
   type ReactElement,
   type ReactNode,
+  Suspense,
   useCallback,
   useContext,
   useMemo,
@@ -47,11 +49,13 @@ import { PluggableList } from "unified"
 import { visit } from "unist-util-visit"
 import xxhash from "xxhashjs"
 
+import { Skeleton as SkeletonProto } from "@streamlit/protobuf"
+
 import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg"
 import IsDialogContext from "~lib/components/core/IsDialogContext"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import StreamlitSyntaxHighlighter from "~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter"
 import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
+import { Skeleton } from "~lib/components/elements/Skeleton"
 import ErrorBoundary from "~lib/components/shared/ErrorBoundary"
 import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon"
 import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
@@ -72,6 +76,10 @@ import {
 } from "./styled-components"
 
 import "katex/dist/katex.min.css"
+
+const StreamlitSyntaxHighlighter = lazy(
+  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+)
 
 export enum Tags {
   H1 = "h1",
@@ -357,9 +365,24 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
 
   const language = match?.[1] || ""
   return !inline ? (
-    <StreamlitSyntaxHighlighter language={language} showLineNumbers={false}>
-      {codeText}
-    </StreamlitSyntaxHighlighter>
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <Skeleton
+            element={SkeletonProto.create({
+              style: SkeletonProto.SkeletonStyle.ELEMENT,
+            })}
+          />
+        }
+      >
+        <StreamlitSyntaxHighlighter
+          language={language}
+          showLineNumbers={false}
+        >
+          {codeText}
+        </StreamlitSyntaxHighlighter>
+      </Suspense>
+    </ErrorBoundary>
   ) : (
     <StyledInlineCode className={className} {...omit(props, "node")}>
       {children}

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -47,7 +47,7 @@ export { default as ThemeProvider } from "./components/core/ThemeProvider"
 export { ViewStateContext } from "./components/core/ViewStateContext"
 export type { ViewStateContextProps } from "./components/core/ViewStateContext"
 export { default as AlertElement } from "./components/elements/AlertElement"
-export { default as StreamlitSyntaxHighlighter } from "./components/elements/CodeBlock/StreamlitSyntaxHighlighter"
+export { default as StreamlitErrorCodeBlock } from "./components/elements/CodeBlock/StreamlitErrorCodeBlock"
 export { handleFavicon } from "./components/elements/Favicon"
 export { default as TextElement } from "./components/elements/TextElement"
 export {


### PR DESCRIPTION
## Describe your changes
Attempt to improve initial load time by reducing dependencies included in entry bundle.

* Lazy load `StreamlitSyntaxHighlighter` in `StreamlitMarkdown` 
* Replaced usage of `StreamlitSyntaxHighlighter` with more minimal `StreamlitErrorCodeBlock` in `ScriptCompileErrorDialog`
* Replaced `StreamlitMarkdown` in Warning/Connection error dialogs with new `DialogErrorMessage`

**Before**: 
<img width="300" alt="Page Not Found - before" src="https://github.com/user-attachments/assets/5ac86f80-cdf4-4fd8-a5f0-9b20aad967f5" />
<img width="300" alt="Bad message format - before" src="https://github.com/user-attachments/assets/75e134ba-b013-4760-8a32-01038dc64dd6" />
<img width="300" alt="expected_websocket_connection-disconnected_dialog firefox" src="https://github.com/user-attachments/assets/c79e8bab-fd6f-4a37-9450-0f5bbb52bcd1" />

**After**:
<img width="300" alt="Page not found - after" src="https://github.com/user-attachments/assets/a41937dd-f0f3-498e-9084-7743258430db" />
<img width="300" alt="Bad message format - after" src="https://github.com/user-attachments/assets/04c7bf87-6ea5-41c4-867e-a941acfeae76" />
<img width="300" alt="connection error after" src="https://github.com/user-attachments/assets/1e3da4d8-1067-48ec-b9fa-9c5a2b02f23e" />


Dependencies removed from entry:
* **`highlight.js/lib`**
* **`refractor`**
 * **`react-syntax-highlighter`**

_`react-syntax-highlighter` is a syntax highlighting lib which uses `refractor` & `highlight.js`._

---

### Bundle Analysis:
**Before** (left): 5.11 MB & **After** (right): 3.51 MB
<img width="255" alt="Entry bundle - after part 1" src="https://github.com/user-attachments/assets/f6928445-4606-4973-bf58-4785170014ff" />   <img width="260" alt="Entry bundle - after part 2" src="https://github.com/user-attachments/assets/46555530-39e5-4d45-9418-2fb4e758216b" />