### PR TITLE
Add tracking of frontend bundle size stats to CI

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -102,6 +102,39 @@ jobs:
               console.log('Created new comment with ID:', newComment.id);
             }
 
+  analyze-frontend-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: 2
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+      - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: "${{ env.PYTHON_MAX_VERSION }}"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+      - name: Build Frontend & Analyze
+        env:
+          ANALYZE_BUNDLE: "true"
+        run: |
+          make frontend
+      - name: Upload Bundle Stats JSON
+        uses: actions/upload-artifact@v5
+        with:
+          name: bundle_analysis_json
+          path: frontend/app/bundle-analysis.json
+      - name: Upload Bundle Stats HTML
+        uses: actions/upload-artifact@v5
+        with:
+          name: bundle_analysis_html
+          path: frontend/app/bundle-analysis.html
+
   upload-whl:
     runs-on: ubuntu-latest
 

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -117,6 +117,7 @@
     "typesync": "^0.14.3",
     "util": "^0.12.5",
     "vite": "^7.1.11",
+    "vite-bundle-analyzer": "^1.2.3",
     "vite-plugin-svgr": "^4.5.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4",

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -69,10 +69,14 @@ export default defineConfig({
       ? [
           analyzer({
             analyzerMode: "json",
+            // NOTE: fileName is relative to the build output directory (outDir: "build").
+            // "../bundle-analysis.json" will be created in the project root (frontend/app/bundle-analysis.json).
             fileName: "../bundle-analysis.json",
           }),
           analyzer({
             analyzerMode: "static",
+            // NOTE: fileName is relative to the build output directory (outDir: "build").
+            // "../bundle-analysis.html" will be created in the project root (frontend/app/bundle-analysis.html).
             fileName: "../bundle-analysis.html",
           }),
         ]

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { defineConfig } from "vite"
+import { analyzer } from "vite-bundle-analyzer"
 import { version } from "./package.json"
 
 import react from "@vitejs/plugin-react-swc"
@@ -25,6 +26,7 @@ const HASH = process.env.OMIT_HASH_FROM_MAIN_FILES ? "" : ".[hash]"
 // This is a convenience for developers for debugging purposes
 const DEV_BUILD = Boolean(process.env.DEV_BUILD)
 const IS_PROFILER_BUILD = Boolean(process.env.IS_PROFILER_BUILD)
+const ANALYZE_BUNDLE = Boolean(process.env.ANALYZE_BUNDLE)
 // The URL of the backend server to proxy to:
 // Can be changed to run against a remote server or different port:
 const DEV_SERVER_BACKEND_URL =
@@ -63,6 +65,18 @@ export default defineConfig({
       plugins: [["@swc/plugin-emotion", {}]],
     }),
     viteTsconfigPaths(),
+    ...(ANALYZE_BUNDLE
+      ? [
+          analyzer({
+            analyzerMode: "json",
+            fileName: "../bundle-analysis.json",
+          }),
+          analyzer({
+            analyzerMode: "static",
+            fileName: "../bundle-analysis.html",
+          }),
+        ]
+      : []),
   ],
   resolve: {
     alias: [
@@ -113,7 +127,7 @@ export default defineConfig({
   build: {
     outDir: "build",
     assetsDir: "static",
-    sourcemap: DEV_BUILD,
+    sourcemap: DEV_BUILD || ANALYZE_BUNDLE,
     manifest: true,
     rollupOptions: {
       output: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3479,6 +3479,7 @@ __metadata:
     util: "npm:^0.12.5"
     uuid: "npm:^13.0.0"
     vite: "npm:^7.1.11"
+    vite-bundle-analyzer: "npm:^1.2.3"
     vite-plugin-svgr: "npm:^4.5.0"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^3.2.4"
@@ -20253,6 +20254,15 @@ __metadata:
   dependencies:
     "@math.gl/web-mercator": "npm:^3.5.5"
   checksum: 10c0/9a8a12f4bd68355a8162a23d4b161133b45aee71b2453fd8d57f54c55466007428cf502d0c02f58620d4c92ba934c29608613bc3176dd8c1d348f8a9deb34e32
+  languageName: node
+  linkType: hard
+
+"vite-bundle-analyzer@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "vite-bundle-analyzer@npm:1.2.3"
+  bin:
+    analyze: dist/bin.js
+  checksum: 10c0/e99c49cde7ec57ca6f70f02faa4bd96f0ed43da7a98b86b9e129b99e65c29eba7fec9fefa2bb3d8fd24db5bd0988258ae213cd70978cf3894905118b9eedb495
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Adds an optional bundle analysis to our vite config. Runs the analysis and uploads the html and raw data to our CI artefacts. As a follow up task, we will also add a dashboard to https://issues.streamlit.app to track the changes in bundle size + PR comments to warn from significant changes similar to how its done with the wheel size. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
