### PR TITLE
[fix] Conditionally expose files/audio attributes in ChatInputValue based on accept parameters

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, MutableMapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -99,43 +99,93 @@ class ChatInputValue(MutableMapping[str, Any]):
     text : str
         The text input provided by the user.
     files : list[UploadedFile]
-        A list of files uploaded by the user.
+        A list of files uploaded by the user. Only present when accept_file=True.
     audio : UploadedFile or None, optional
-        An audio recording uploaded by the user, if any.
+        An audio recording uploaded by the user, if any. Only present when accept_audio=True.
 
     Notes
     -----
     - Supports dict-like access via `__getitem__`, `__setitem__`, and `__delitem__`.
     - Use `to_dict()` to convert the value to a standard dictionary.
+    - The 'files' key is only present when accept_file=True.
+    - The 'audio' key is only present when accept_audio=True.
     """
 
     text: str
-    files: list[UploadedFile]
+    files: list[UploadedFile] = field(default_factory=list)
     audio: UploadedFile | None = None
+    _include_files: bool = field(default=False, repr=False, compare=False)
+    _include_audio: bool = field(default=False, repr=False, compare=False)
+    _included_keys: tuple[str, ...] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Compute and cache the included keys after initialization."""
+        keys: list[str] = ["text"]
+        if self._include_files:
+            keys.append("files")
+        if self._include_audio:
+            keys.append("audio")
+        object.__setattr__(self, "_included_keys", tuple(keys))
+
+    def _get_included_keys(self) -> tuple[str, ...]:
+        """Return tuple of keys that should be exposed based on inclusion flags."""
+        return self._included_keys
 
     def __len__(self) -> int:
-        return len(vars(self))
+        return len(self._get_included_keys())
 
     def __iter__(self) -> Iterator[str]:
-        return iter(vars(self))
+        return iter(self._get_included_keys())
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return key in self._get_included_keys()
 
     def __getitem__(self, item: str) -> str | list[UploadedFile] | UploadedFile | None:
+        if item not in self._get_included_keys():
+            raise KeyError(f"Invalid key: {item}")
         try:
             return getattr(self, item)  # type: ignore[no-any-return]
         except AttributeError:
             raise KeyError(f"Invalid key: {item}") from None
 
+    def __getattribute__(self, name: str) -> Any:
+        # Intercept access to files/audio when they're excluded
+        # Use object.__getattribute__ to avoid infinite recursion
+        if name == "files" and not object.__getattribute__(self, "_include_files"):
+            raise AttributeError(
+                "'ChatInputValue' object has no attribute 'files' (accept_file=False)"
+            )
+        if name == "audio" and not object.__getattribute__(self, "_include_audio"):
+            raise AttributeError(
+                "'ChatInputValue' object has no attribute 'audio' (accept_audio=False)"
+            )
+        # For all other attributes, use normal lookup
+        return object.__getattribute__(self, name)
+
     def __setitem__(self, key: str, value: Any) -> None:
+        if key not in self._get_included_keys():
+            raise KeyError(f"Invalid key: {key}")
         setattr(self, key, value)
 
     def __delitem__(self, key: str) -> None:
+        if key not in self._get_included_keys():
+            raise KeyError(f"Invalid key: {key}")
         try:
             delattr(self, key)
         except AttributeError:
             raise KeyError(f"Invalid key: {key}") from None
 
     def to_dict(self) -> dict[str, str | list[UploadedFile] | UploadedFile | None]:
-        return vars(self)
+        result: dict[str, str | list[UploadedFile] | UploadedFile | None] = {
+            "text": self.text
+        }
+        if self._include_files:
+            result["files"] = self.files
+        if self._include_audio:
+            result["audio"] = self.audio
+        return result
 
 
 class PresetNames(str, Enum):
@@ -335,6 +385,8 @@ class ChatInputSerde:
             text=ui_value.data,
             files=uploaded_files,
             audio=audio_file,
+            _include_files=self.accept_files,
+            _include_audio=self.accept_audio,
         )
 
     def serialize(self, v: str | None) -> ChatInputValueProto:
@@ -619,8 +671,9 @@ class ChatMixin:
             When enabled, users can record and submit audio messages.
             Recorded audio is uploaded as a WAV file and can be accessed
             through the ``audio`` attribute of the returned dict-like object.
-            The ``audio`` attribute will be ``None`` when ``accept_audio=False``
-            or when no audio is recorded.
+            The ``audio`` attribute is only present when ``accept_audio=True``.
+            When present, it contains an ``UploadedFile`` object or ``None``
+            if no audio was recorded.
             This defaults to ``False``.
 
         audio_sample_rate : int or None
@@ -673,7 +726,9 @@ class ChatMixin:
             - A dict-like object: When the widget is configured to accept files
               and/or audio and the user submitted a message and/or file(s)
               and/or audio in the last rerun, the widget returns a dict-like
-              object with three attributes: ``text``, ``files``, and ``audio``.
+              object. The object always includes the ``text`` attribute, and
+              optionally includes ``files`` and/or ``audio`` attributes depending
+              on the ``accept_file`` and ``accept_audio`` parameters.
 
             When the widget is configured to accept files or audio and the user
             submits something in the last rerun, you can access the user's
@@ -684,14 +739,15 @@ class ChatMixin:
             This is an empty string if the user only submitted one or more
             files or audio.
 
-            The ``files`` attribute holds a list of UploadedFile objects.
+            The ``files`` attribute is only present when ``accept_file`` is not
+            ``False``. When present, it holds a list of ``UploadedFile`` objects.
             The list is empty if the user only submitted a message or audio.
             Unlike ``st.file_uploader``, this attribute always returns a list,
             even when the widget is configured to accept only one file at a time.
 
-            The ``audio`` attribute holds an UploadedFile object representing
-            the recorded audio, or ``None`` if no audio was recorded or when
-            ``accept_audio=False``.
+            The ``audio`` attribute is only present when ``accept_audio=True``.
+            When present, it holds an ``UploadedFile`` object representing
+            the recorded audio, or ``None`` if no audio was recorded.
 
             The UploadedFile class is a subclass of BytesIO, and therefore is
             "file-like". This means you can pass an instance of it anywhere a

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -250,7 +250,7 @@ class ChatTest(DeltaGeneratorTestCase):
         ]
 
         deserialize_patch.return_value = ChatInputValue(
-            text="placeholder", files=uploaded_files
+            text="placeholder", files=uploaded_files, _include_files=True
         )
 
         return_val = st.chat_input(accept_file="multiple")
@@ -281,7 +281,7 @@ class ChatTest(DeltaGeneratorTestCase):
         ]
 
         deserialize_patch.return_value = ChatInputValue(
-            text="placeholder", files=uploaded_files
+            text="placeholder", files=uploaded_files, _include_files=True
         )
 
         # These file_uploaders have different labels so that we don't cause
@@ -643,10 +643,14 @@ class ChatTest(DeltaGeneratorTestCase):
         )
 
         deserialize_patch.return_value = ChatInputValue(
-            text="", files=[], audio=audio_file
+            text="",
+            files=[],
+            audio=audio_file,
+            _include_files=True,
+            _include_audio=True,
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_file="multiple", accept_audio=True)
 
         assert return_val.audio == audio_file
         assert return_val.audio.name == "recording.wav"
@@ -657,10 +661,10 @@ class ChatTest(DeltaGeneratorTestCase):
     def test_audio_file_none(self, deserialize_patch):
         """Test that ChatInputValue handles None audio file correctly."""
         deserialize_patch.return_value = ChatInputValue(
-            text="hello", files=[], audio=None
+            text="hello", files=[], audio=None, _include_files=True, _include_audio=True
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_file="multiple", accept_audio=True)
 
         assert return_val.audio is None
         assert return_val.text == "hello"
@@ -674,10 +678,14 @@ class ChatTest(DeltaGeneratorTestCase):
         )
 
         deserialize_patch.return_value = ChatInputValue(
-            text="test", files=[], audio=audio_file
+            text="test",
+            files=[],
+            audio=audio_file,
+            _include_files=True,
+            _include_audio=True,
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_file="multiple", accept_audio=True)
 
         # Test dict-like access
         assert return_val["audio"] == audio_file
@@ -733,3 +741,68 @@ class ChatTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.chat_input(accept_audio=True, audio_sample_rate=12345)
         assert "Invalid audio_sample_rate" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            (False, False, False, False, {"text"}),
+            ("multiple", False, True, False, {"text", "files"}),
+            (False, True, False, True, {"text", "audio"}),
+            ("multiple", True, True, True, {"text", "files", "audio"}),
+        ]
+    )
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_conditional_keys(
+        self,
+        accept_file,
+        accept_audio,
+        include_files,
+        include_audio,
+        expected_keys,
+        deserialize_patch,
+    ):
+        """Test that ChatInputValue only includes keys based on accept_file/accept_audio."""
+        deserialize_patch.return_value = ChatInputValue(
+            text="test",
+            files=[],
+            audio=None,
+            _include_files=include_files,
+            _include_audio=include_audio,
+        )
+
+        return_val = st.chat_input(accept_file=accept_file, accept_audio=accept_audio)
+
+        # Verify expected keys are present
+        assert set(return_val.keys()) == expected_keys
+
+        # Verify text is always accessible
+        assert "text" in return_val
+        assert return_val["text"] == "test"
+        assert return_val.text == "test"
+
+        # Verify files key behavior
+        if "files" in expected_keys:
+            assert "files" in return_val
+            assert return_val["files"] == []
+            assert return_val.files == []
+        else:
+            assert "files" not in return_val
+            with pytest.raises(KeyError):
+                _ = return_val["files"]
+            with pytest.raises(AttributeError):
+                _ = return_val.files
+
+        # Verify audio key behavior
+        if "audio" in expected_keys:
+            assert "audio" in return_val
+            assert return_val["audio"] is None
+            assert return_val.audio is None
+        else:
+            assert "audio" not in return_val
+            with pytest.raises(KeyError):
+                _ = return_val["audio"]
+            with pytest.raises(AttributeError):
+                _ = return_val.audio
+
+        # Verify to_dict matches expected keys
+        as_dict = return_val.to_dict()
+        assert set(as_dict.keys()) == expected_keys


### PR DESCRIPTION
## Describe your changes

Improved the `ChatInputValue` class to conditionally expose `files` and `audio` attributes based on the `accept_file` and `accept_audio` parameters. This change ensures that:

- The `files` attribute is only accessible when `accept_file=True`
- The `audio` attribute is only accessible when `accept_audio=True`
- Attempting to access these attributes when not enabled raises appropriate errors
- The `to_dict()` method and dictionary-like access only include the enabled attributes
- Updated docstrings to clarify this conditional behavior

## Testing Plan

- Unit Tests: Added comprehensive tests to verify the conditional behavior of `ChatInputValue` attributes based on different combinations of `accept_file` and `accept_audio` parameters
- Existing tests were updated to properly initialize `ChatInputValue` objects with the new required parameters

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.