### PR TITLE
[fix] Ensure correct telemetry values for CCv2 names

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -333,8 +333,10 @@ def _get_command_telemetry(
     ):
         name = f"component:{self_arg.name}"
 
-    if name == "_bidi_component" and len(args) > 0 and isinstance(args[0], str):
-        component_name = args[0]
+    if name == "_bidi_component" and len(args) > 1 and isinstance(args[1], str):
+        # Bound DeltaGenerator methods always receive `self` as args[0], so args[1]
+        # is the user-supplied component name.
+        component_name = args[1]
         name = f"component_v2:{component_name}"
 
     return Command(name=name, args=arguments)

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -221,18 +221,30 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
 
     def test_get_command_telemetry_custom_component_v2(self):
         """Test getting command telemetry for Custom Components v2 via _get_command_telemetry."""
-        # Create a mock bidi_component function that appears to be from streamlit
-        mock_bidi_component = MagicMock()
-        mock_bidi_component.__module__ = "streamlit.components.v2.bidi_component"
+
+        def fake_bidi_component(
+            self, component_name: str, **_kwargs: Any
+        ) -> None:  # pragma: no cover - never executed
+            del self, component_name, _kwargs
+
+        fake_bidi_component.__module__ = "streamlit.components.v2.bidi_component"
 
         # Test with a Custom Components v2 call
         command_metadata = metrics_util._get_command_telemetry(
-            mock_bidi_component, "_bidi_component", "my_custom_component", key="test"
+            fake_bidi_component,
+            "_bidi_component",
+            MagicMock(name="delta_generator_instance"),
+            "my_custom_component",
+            key="test",
         )
 
         assert command_metadata.name == "component_v2:my_custom_component"
-        assert len(command_metadata.args) == 1
-        assert str(command_metadata.args[0]).strip() == 'k: "key"\nt: "str"\nm: "len:4"'
+        assert len(command_metadata.args) == 2
+        assert (
+            str(command_metadata.args[0]).strip()
+            == 'k: "component_name"\nt: "str"\nm: "len:19"\np: 1'
+        )
+        assert str(command_metadata.args[1]).strip() == 'k: "key"\nt: "str"\nm: "len:4"'
 
     def test_create_page_profile_message(self):
         """Test creating the page profile message via create_page_profile_message."""


### PR DESCRIPTION
## Describe your changes

- Fixed a bug in the telemetry collection for Custom Components v2.
  - The component name was being incorrectly extracted from `args[0]` instead of `args[1]`. This is because bound DeltaGenerator methods always receive `self` as `args[0]`, making the user-supplied component name available at `args[1]`.
  - The impact is that before this change we're only getting `_bidi_component` telemetry results, but not the actual custom component registered names.

## Testing Plan

- Updated the existing test for Custom Components v2 telemetry to properly simulate the function call structure with a DeltaGenerator instance as the first argument
- Modified assertions to verify the correct argument extraction and parameter ordering

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.