### PR TITLE
feat: update internationalization of date pickers

### DIFF
--- a/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
@@ -18,6 +18,7 @@ import { useMemo } from "react"
 
 import type { Locale } from "date-fns"
 import { enUS } from "date-fns/locale/en-US"
+import * as dateFnsLocales from "date-fns/locale"
 
 /**
  * 1 = Monday, 7 = Sunday
@@ -83,10 +84,15 @@ export const useIntlLocale = (locale: string): Locale => {
    */
   const firstDay = weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay
 
+  const loadedLocale =
+    locale in dateFnsLocales
+      ? (dateFnsLocales[locale as keyof typeof dateFnsLocales] as Locale)
+      : enUS
+
   return {
-    ...enUS,
+    ...loadedLocale,
     options: {
-      ...enUS.options,
+      ...loadedLocale.options,
       weekStartsOn: firstDay,
     },
   }


### PR DESCRIPTION
## Describe your changes


This update improves the internationalization behavior of Streamlit’s date pickers.

Previously, the **useIntlLocale** hook always returned the fallback **enUS** locale, regardless of the browser’s actual locale settings. This caused **st.date_input** to ignore user locale preferences.

This change updates the logic so that date pickers correctly detect and use the locale from:

- **_window.navigator.language_**

When available, the appropriate locale data is loaded and applied instead of defaulting to **enUS**.

## Screenshot or video (only for visual changes)

<img width="1066" height="1126" alt="CleanShot 2025-11-22 at 07 51 26@2x" src="https://github.com/user-attachments/assets/1fe3d34e-d38b-4e31-99a5-c33080e8466f" />

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
