### PR TITLE
Fix #6147: Wrap file paths in backticks to prevent markdown escape is…

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -60,7 +60,7 @@ class SecretErrorMessages:
             f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
         )
         self.error_parsing_file_at_path: Callable[[str, Exception], str] = (
-            lambda path, ex: f"Error parsing secrets file at {path}: {ex}"
+            lambda path, ex: f"Error parsing secrets file at `{path}`: {ex}"
         )
         self.subfolder_path_is_not_a_folder: Callable[[str], str] = (
             lambda sub_folder_path: (

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -56,8 +56,8 @@ class SecretErrorMessages:
             "on Streamlit Cloud? More info: "
             "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
         )
-        self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
-            f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(file_paths)}"
+	self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
+	f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
         )
         self.error_parsing_file_at_path: Callable[[str, Exception], str] = (
             lambda path, ex: f"Error parsing secrets file at {path}: {ex}"

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -57,7 +57,7 @@ class SecretErrorMessages:
             "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
         )
         self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
-        f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
+            f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
         )
         self.error_parsing_file_at_path: Callable[[str, Exception], str] = (
             lambda path, ex: f"Error parsing secrets file at {path}: {ex}"

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -56,8 +56,8 @@ class SecretErrorMessages:
             "on Streamlit Cloud? More info: "
             "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
         )
-	self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
-	f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
+        self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
+        f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(f'`{path}`' for path in file_paths)}"
         )
         self.error_parsing_file_at_path: Callable[[str, Exception], str] = (
             lambda path, ex: f"Error parsing secrets file at {path}: {ex}"

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -602,3 +602,32 @@ class SecretsFallbackTest(DeltaGeneratorTestCase):
                     markdown_text = element.markdown.body
                     assert "Error" not in markdown_text
                     assert "error" not in markdown_text
+
+
+
+def test_secrets_file_not_found_error_message():
+    """Test that the secrets file not found error message properly formats paths."""
+    with patch("streamlit.runtime.secrets.file_util.os.path.isfile") as isfile_mock:
+        isfile_mock.return_value = False
+        
+        # Test Windows path formatting
+        with patch("streamlit.runtime.secrets.file_util.secrets_file_locations") as locations_mock:
+            locations_mock.return_value = ["C:\\Users\\user\\.streamlit\\secrets.toml"]
+            
+            with pytest.raises(FileNotFoundError) as exc_info:
+                secrets = Secrets("fake_path/.streamlit/secrets.toml")
+            
+            error_message = str(exc_info.value)
+            # Verify backticks are present around the path
+            assert "`C:\\Users\\user\\.streamlit\\secrets.toml`" in error_message
+        
+        # Test POSIX path formatting
+        with patch("streamlit.runtime.secrets.file_util.secrets_file_locations") as locations_mock:
+            locations_mock.return_value = ["/home/user/.streamlit/secrets.toml"]
+            
+            with pytest.raises(FileNotFoundError) as exc_info:
+                secrets = Secrets("fake_path/.streamlit/secrets.toml")
+            
+            error_message = str(exc_info.value)
+            # Verify backticks are present around the path
+            assert "`/home/user/.streamlit/secrets.toml`" in error_message


### PR DESCRIPTION
…sues on Windows

- Changed error message to wrap each path in backticks
- This prevents backslashes from being interpreted as markdown escapes
- Fixes display of Windows paths like C:\path\.streamlit\secrets.toml

## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
