### PR TITLE
Fix #12954: Dropdowns not visible in dark mode

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -25,6 +25,7 @@ import { FixedSizeList } from "react-window"
 
 import { OverflowTooltip, Placement } from "~lib/components/shared/Tooltip"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { hasLightBackgroundColor } from "~lib/theme"
 import { convertRemToPx } from "~lib/theme/utils"
 
 import { ThemedStyledDropdownListItem } from "./styled-components"
@@ -84,6 +85,12 @@ const VirtualDropdown = forwardRef<any, any>((props, ref) => {
           // Somehow this adds an additional shadow, even though we already have
           // one on the popover, so we need to remove it here.
           boxShadow: "none",
+          ...(!hasLightBackgroundColor(theme) && {
+            borderTop: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+            borderBottom: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+            borderLeft: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+            borderRight: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+          }),
         }}
         ref={ref}
         data-testid="stSelectboxVirtualDropdownEmpty"
@@ -116,6 +123,12 @@ const VirtualDropdown = forwardRef<any, any>((props, ref) => {
         // Somehow this adds an additional shadow, even though we already have
         // one on the popover, so we need to remove it here.
         boxShadow: "none",
+        ...(!hasLightBackgroundColor(theme) && {
+          borderTop: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+          borderBottom: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+          borderLeft: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+          borderRight: `${theme.sizes.borderWidth} solid ${theme.colors.gray70}`,
+        }),
       }}
       data-testid="stSelectboxVirtualDropdown"
     >


### PR DESCRIPTION
## Describe your changes

This PR improves the visibility of dropdown menus in dark mode by adding a distinct border around the dropdown list (popover) for both `st.selectbox` and `st.multiselect` widgets.

The fix involves:

*   Modifying `VirtualDropdown.tsx` (the shared component for dropdown lists) to conditionally apply a `gray70` border when the theme is in dark mode.
*   This border is applied to the `StyledList` container for both the empty state and the populated list state.
*   This ensures that the dropdown menu is clearly distinguishable from the background in dark themes, where the contrast was previously insufficient.

## Screenshot or video (only for visual changes)

<img width="1512" height="903" alt="Screenshot 2025-11-23 at 7 49 12 PM" src="https://github.com/user-attachments/assets/2b921c4f-c921-4256-9175-50549b474fcc" />

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed
  - This is a purely visual CSS fix to improve accessibility in dark mode. No logic changes were made to the component's functionality.

- Unit Tests (JS and/or Python)
  - None required.

- E2E Tests
  - None required.

- Any manual testing needed?
  - Yes, manual verification to ensure:
      - The border appears around the dropdown list in dark mode for both `st.selectbox` and `st.multiselect`.
      - The border matches the `gray70` color as intended.
      - The border does NOT appear when the app is in light mode.
      - The styling works correctly for both empty lists ("No options") and lists with items.