### PR TITLE
Remove agent-knowledge and specs from CI workflow paths-ignore

### DIFF
--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
 # Avoid duplicate workflows on same branch
 concurrency:

--- a/.github/workflows/enforce-pre-commit.yml
+++ b/.github/workflows/enforce-pre-commit.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/ensure-relative-imports.yml
+++ b/.github/workflows/ensure-relative-imports.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/python-bare-executions.yml
+++ b/.github/workflows/python-bare-executions.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,11 +6,6 @@ on:
       - "develop"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
   # Allows workflow to be called from other workflows
   workflow_call:

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -3,11 +3,6 @@ name: Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
 jobs:
   check-required-labels:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,11 +4,6 @@ name: Run Semgrep Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in the specs folder:
-      - "specs/**"
-      # Don't run CI if changes are only in the agent-knowledge folder:
-      - "agent-knowledge/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Describe your changes

Removes `agent-knowledge/**` and `specs/**` from `paths-ignore` in CI workflows to allow required status checks to complete.

- Reverts the paths-ignore approach that blocks PR merges when workflows are configured as required checks
- Removes specs/ exclusion that was accidentally re-added by the agent-knowledge PR
- Updates 9 workflow files to remove both exclusions
- Workflows will now run for these directory changes, allowing required status checks to report completion

## Testing

- CI workflows will run on this PR to verify the changes work correctly
