### PR TITLE
Lower the asset size threshold

### DIFF
--- a/e2e_playwright/basic_app_test.py
+++ b/e2e_playwright/basic_app_test.py
@@ -42,7 +42,7 @@ def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
     # frontend (in MB) for a basic app run. While its important to keep the total
     # size of web assets low, you can modify this threshold if it's really needed
     # to add some new features. But make sure that its justified and intended.
-    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 7.9  # noqa: N806
+    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 5  # noqa: N806
 
     total_size_bytes = 0
 

--- a/e2e_playwright/basic_app_test.py
+++ b/e2e_playwright/basic_app_test.py
@@ -42,7 +42,7 @@ def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
     # frontend (in MB) for a basic app run. While its important to keep the total
     # size of web assets low, you can modify this threshold if it's really needed
     # to add some new features. But make sure that its justified and intended.
-    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 2  # noqa: N806
+    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 3.8  # noqa: N806
 
     total_size_bytes = 0
 

--- a/e2e_playwright/basic_app_test.py
+++ b/e2e_playwright/basic_app_test.py
@@ -42,7 +42,7 @@ def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
     # frontend (in MB) for a basic app run. While its important to keep the total
     # size of web assets low, you can modify this threshold if it's really needed
     # to add some new features. But make sure that its justified and intended.
-    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 5  # noqa: N806
+    TOTAL_ASSET_SIZE_THRESHOLD_MB: Final = 2  # noqa: N806
 
     total_size_bytes = 0
 


### PR DESCRIPTION
## Describe your changes

With the recent improvements to asset and bundle size, we can lower the loaded asset size threshold in our tests to 3.8MB. Currently, the actual value is ~3.5 MB, but I think it's ok to have a bit of space to grow.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
