### PR TITLE
Add unit tests coverage for Plotly frontend component

### DIFF
--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockTheme } from "~lib/mocks/mockTheme"
+
+import {
+  applyStreamlitTheme,
+  applyStreamlitThemeTemplateLayout,
+  layoutWithThemeDefaults,
+  replaceTemporaryColors,
+} from "./CustomTheme"
+
+const theme = mockTheme.emotion
+
+describe("PlotlyChart CustomTheme", () => {
+  describe("applyStreamlitThemeTemplateLayout", () => {
+    it("applies streamlit theme to layout", () => {
+      const layout = {}
+      applyStreamlitThemeTemplateLayout(layout, theme)
+
+      expect(layout).toEqual(
+        expect.objectContaining({
+          font: expect.objectContaining({
+            color: expect.any(String),
+            family: theme.genericFonts.bodyFont,
+          }),
+          paper_bgcolor: theme.colors.bgColor,
+          plot_bgcolor: theme.colors.bgColor,
+          xaxis: expect.objectContaining({
+            showgrid: false,
+            zeroline: false,
+            automargin: true,
+          }),
+          yaxis: expect.objectContaining({
+            automargin: true,
+            ticklabelposition: "outside",
+          }),
+        })
+      )
+    })
+  })
+
+  describe("replaceTemporaryColors", () => {
+    it("replaces categorical colors for streamlit theme", () => {
+      // #000001 is CATEGORY_0
+      const spec = JSON.stringify({ color: "#000001" })
+      const result = replaceTemporaryColors(spec, theme, "streamlit")
+
+      expect(result).toContain(theme.colors.chartCategoricalColors[0])
+      expect(result).not.toContain("#000001")
+    })
+
+    it("replaces categorical colors for default theme", () => {
+      const spec = JSON.stringify({ color: "#000001" })
+      const result = replaceTemporaryColors(spec, theme, "default")
+
+      // Default plotly color for CATEGORY_0 is #636efa
+      expect(result).toContain("#636efa")
+      expect(result).not.toContain("#000001")
+    })
+
+    it("replaces sequential colors", () => {
+      // #000011 is SEQUENTIAL_0
+      const spec = JSON.stringify({ color: "#000011" })
+      const result = replaceTemporaryColors(spec, theme, "streamlit")
+
+      expect(result).toContain(theme.colors.chartSequentialColors[0])
+      expect(result).not.toContain("#000011")
+    })
+
+    it("replaces diverging colors", () => {
+      // #000021 is DIVERGING_0
+      const spec = JSON.stringify({ color: "#000021" })
+      const result = replaceTemporaryColors(spec, theme, "streamlit")
+
+      // We check if it replaced it with *something* different than the placeholder
+      expect(result).not.toContain("#000021")
+    })
+
+    it("replaces GO specific colors", () => {
+      // #000032 is INCREASING
+      const spec = JSON.stringify({ color: "#000032" })
+      const result = replaceTemporaryColors(spec, theme, "streamlit")
+
+      // getIncreasingGreen(theme) -> usually equals theme.colors.green80 or similar logic
+      expect(result).not.toContain("#000032")
+    })
+  })
+
+  describe("applyStreamlitTheme", () => {
+    it("applies theme to layout template and bolds title", () => {
+      const spec = {
+        layout: {
+          title: {
+            text: "My Chart",
+          },
+          template: {
+            layout: {},
+          },
+        },
+      }
+
+      applyStreamlitTheme(spec, theme)
+
+      expect(spec.layout.title.text).toBe("<b>My Chart</b>")
+      // Check if applyStreamlitThemeTemplateLayout was called (side effect on template.layout)
+      expect(spec.layout.template.layout).toHaveProperty("paper_bgcolor")
+    })
+
+    it("handles missing template gracefully", () => {
+      const spec = {
+        layout: {
+          title: { text: "My Chart" },
+          // missing template
+        },
+      }
+
+      // Should not throw
+      expect(() => applyStreamlitTheme(spec, theme)).not.toThrow()
+    })
+  })
+
+  describe("layoutWithThemeDefaults", () => {
+    it("applies defaults when properties are missing", () => {
+      const layout = {}
+      const result = layoutWithThemeDefaults(layout, theme)
+
+      expect(result.font.family).toBe(theme.genericFonts.bodyFont)
+      expect(result.paper_bgcolor).toBe(theme.colors.bgColor)
+      expect(result.plot_bgcolor).toBe(theme.colors.secondaryBg)
+    })
+
+    it("preserves existing properties", () => {
+      const layout = {
+        font: { family: "Arial" },
+        paper_bgcolor: "red",
+      }
+      const result = layoutWithThemeDefaults(layout, theme)
+
+      expect(result.font.family).toBe("Arial")
+      expect(result.paper_bgcolor).toBe("red")
+      // Should still apply missing ones
+      expect(result.plot_bgcolor).toBe(theme.colors.secondaryBg)
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
@@ -116,7 +116,7 @@ describe("PlotlyChart CustomTheme", () => {
       applyStreamlitTheme(spec, theme)
 
       expect(spec.layout.title.text).toBe("<b>My Chart</b>")
-      // Check if applyStreamlitThemeTemplateLayout was called (side effect on template.layout)
+      // Verify that template.layout was modified with theme properties
       expect(spec.layout.template.layout).toHaveProperty("paper_bgcolor")
     })
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -78,19 +78,21 @@ function getLastPlotProps(): any {
   return MockPlot.mock.calls[MockPlot.mock.calls.length - 1][0]
 }
 
-describe("PlotlyChart Component", () => {
-  const defaultElement = new PlotlyChartProto({
-    spec: JSON.stringify({
-      data: [{ type: "scatter", x: [1, 2], y: [1, 2] }],
-      layout: { title: "Test Chart" },
-    }),
-    config: JSON.stringify({}),
-    selectionMode: [],
-    id: "test_chart_id",
-    theme: "streamlit",
-  })
+// Static test data - extracted to module level per coding guidelines
+const DEFAULT_ELEMENT = new PlotlyChartProto({
+  spec: JSON.stringify({
+    data: [{ type: "scatter", x: [1, 2], y: [1, 2] }],
+    layout: { title: "Test Chart" },
+  }),
+  config: JSON.stringify({}),
+  selectionMode: [],
+  id: "test_chart_id",
+  theme: "streamlit",
+})
 
-  const widgetMgr = createWidgetManager()
+describe("PlotlyChart Component", () => {
+  // Create fresh widgetMgr for each test to avoid shared state
+  let widgetMgr: WidgetStateManager
 
   const renderComponent = (
     props: Partial<React.ComponentProps<typeof PlotlyChart>> = {},
@@ -109,7 +111,7 @@ describe("PlotlyChart Component", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       <ElementFullscreenContext.Provider value={finalContext as any}>
         <PlotlyChart
-          element={defaultElement}
+          element={DEFAULT_ELEMENT}
           widgetMgr={widgetMgr}
           disabled={false}
           width={600}
@@ -121,6 +123,7 @@ describe("PlotlyChart Component", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    widgetMgr = createWidgetManager()
   })
 
   it("renders without crashing", () => {
@@ -170,7 +173,7 @@ describe("PlotlyChart Component", () => {
 
   it("configures selection modes correctly (Points)", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
     })
 
@@ -185,7 +188,7 @@ describe("PlotlyChart Component", () => {
 
   it("configures selection modes correctly (Box)", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.BOX],
     })
 
@@ -201,7 +204,7 @@ describe("PlotlyChart Component", () => {
 
   it("configures selection modes correctly (Lasso)", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.LASSO],
     })
 
@@ -217,7 +220,7 @@ describe("PlotlyChart Component", () => {
 
   it("disables interactions when disabled prop is true", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
     })
 
@@ -232,7 +235,7 @@ describe("PlotlyChart Component", () => {
 
   it("handles empty spec gracefully", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       spec: "",
     })
 
@@ -246,7 +249,7 @@ describe("PlotlyChart Component", () => {
 
   it("calls handleSelection on selection event", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
     })
 
@@ -263,14 +266,14 @@ describe("PlotlyChart Component", () => {
     expect(handleSelection).toHaveBeenCalledWith(
       mockEvent,
       widgetMgr,
-      expect.objectContaining({ id: defaultElement.id }),
+      expect.objectContaining({ id: DEFAULT_ELEMENT.id }),
       undefined
     )
   })
 
   it("calls sendEmptySelection on deselect event", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
     })
 
@@ -286,14 +289,14 @@ describe("PlotlyChart Component", () => {
     // And it also calls resetSelectionsCallback(false) inside component
     expect(sendEmptySelection).toHaveBeenCalledWith(
       widgetMgr,
-      expect.objectContaining({ id: defaultElement.id }),
+      expect.objectContaining({ id: DEFAULT_ELEMENT.id }),
       undefined
     )
   })
 
   it("resets selections on double-click when selection is activated", () => {
     const element = new PlotlyChartProto({
-      ...defaultElement,
+      ...DEFAULT_ELEMENT,
       selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
     })
 
@@ -311,7 +314,7 @@ describe("PlotlyChart Component", () => {
     // Double-click should reset selections by calling sendEmptySelection
     expect(sendEmptySelection).toHaveBeenCalledWith(
       widgetMgr,
-      expect.objectContaining({ id: defaultElement.id }),
+      expect.objectContaining({ id: DEFAULT_ELEMENT.id }),
       undefined
     )
   })
@@ -337,7 +340,7 @@ describe("PlotlyChart Component", () => {
     })
 
     expect(widgetMgr.setElementState).toHaveBeenCalledWith(
-      defaultElement.id,
+      DEFAULT_ELEMENT.id,
       "figure",
       newFigure
     )

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -1,0 +1,377 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { act, render, screen } from "@testing-library/react"
+
+import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"
+
+import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
+import { mockTheme } from "~lib/mocks/mockTheme"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import { PlotlyChart } from "./PlotlyChart"
+import { applyTheming, handleSelection, sendEmptySelection } from "./utils"
+
+// Mock Plotly component to capture props
+const MockPlot = vi.fn((_props: unknown) => (
+  <div data-testid="stPlotlyChartMock" />
+))
+
+vi.mock("react-plotly.js", () => ({
+  default: (props: unknown) => MockPlot(props),
+}))
+
+// Mock dependencies
+vi.mock("~lib/hooks/useCalculatedDimensions", () => ({
+  useCalculatedDimensions: () => ({
+    height: 450,
+    elementRef: { current: null },
+  }),
+}))
+
+vi.mock("~lib/hooks/useEmotionTheme", () => ({
+  useEmotionTheme: () => mockTheme.emotion,
+}))
+
+vi.mock("./utils", () => ({
+  applyTheming: vi.fn(spec => spec),
+  handleSelection: vi.fn(),
+  sendEmptySelection: vi.fn(),
+}))
+
+vi.mock("~lib/components/widgets/Form/FormClearHelper", () => {
+  return {
+    FormClearHelper: vi.fn().mockImplementation(() => ({
+      manageFormClearListener: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+  }
+})
+
+const createWidgetManager = (): WidgetStateManager => {
+  const mgr = new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+  mgr.getElementState = vi.fn()
+  mgr.setElementState = vi.fn()
+  return mgr
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getLastPlotProps(): any {
+  return MockPlot.mock.calls[MockPlot.mock.calls.length - 1][0]
+}
+
+describe("PlotlyChart Component", () => {
+  const defaultElement = new PlotlyChartProto({
+    spec: JSON.stringify({
+      data: [{ type: "scatter", x: [1, 2], y: [1, 2] }],
+      layout: { title: "Test Chart" },
+    }),
+    config: JSON.stringify({}),
+    selectionMode: [],
+    id: "test_chart_id",
+    theme: "streamlit",
+  })
+
+  const widgetMgr = createWidgetManager()
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof PlotlyChart>> = {},
+    contextValue: Record<string, unknown> = {}
+  ): ReturnType<typeof render> => {
+    const finalContext = {
+      expanded: false,
+      width: 600,
+      height: 500,
+      expand: vi.fn(),
+      collapse: vi.fn(),
+      ...contextValue,
+    }
+
+    return render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ElementFullscreenContext.Provider value={finalContext as any}>
+        <PlotlyChart
+          element={defaultElement}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+          {...props}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders without crashing", () => {
+    renderComponent()
+    expect(screen.getByTestId("stPlotlyChart")).toBeVisible()
+    expect(MockPlot).toHaveBeenCalled()
+  })
+
+  it("initializes figure state correctly", () => {
+    renderComponent()
+    expect(applyTheming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layout: expect.objectContaining({ title: "Test Chart" }),
+      }),
+      "streamlit",
+      expect.anything()
+    )
+  })
+
+  it("recovers state from widgetMgr if available", () => {
+    const savedFigure = { data: [], layout: { title: "Recovered" } }
+    vi.mocked(widgetMgr.getElementState).mockReturnValue(savedFigure)
+
+    renderComponent()
+
+    const lastCallProps = getLastPlotProps()
+    expect(lastCallProps.layout.title).toBe("Recovered")
+  })
+
+  it("updates dimensions based on context", () => {
+    renderComponent({}, { width: 800 })
+
+    const lastCallProps = getLastPlotProps()
+
+    expect(lastCallProps.layout.width).toBe(800)
+    expect(lastCallProps.layout.height).toBe(450)
+  })
+
+  it("handles fullscreen mode dimensions", () => {
+    renderComponent({}, { expanded: true, height: 900, width: 1000 })
+
+    const lastCallProps = getLastPlotProps()
+
+    expect(lastCallProps.layout.width).toBe(1000)
+    expect(lastCallProps.layout.height).toBe(900)
+  })
+
+  it("configures selection modes correctly (Points)", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    // Points selection -> clickmode: "event+select", dragmode: "pan"
+    expect(lastCallProps.layout.clickmode).toBe("event+select")
+    expect(lastCallProps.layout.dragmode).toBe("pan")
+  })
+
+  it("configures selection modes correctly (Box)", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.BOX],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    // Box selection -> dragmode: "select"
+    expect(lastCallProps.layout.dragmode).toBe("select")
+    // clickmode is set to "event" via effect when dragmode is select/lasso
+    expect(lastCallProps.layout.clickmode).toBe("event")
+  })
+
+  it("configures selection modes correctly (Lasso)", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.LASSO],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    // Lasso selection -> dragmode: "lasso"
+    expect(lastCallProps.layout.dragmode).toBe("lasso")
+    // clickmode is set to "event" via effect when dragmode is select/lasso
+    expect(lastCallProps.layout.clickmode).toBe("event")
+  })
+
+  it("disables interactions when disabled prop is true", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+
+    renderComponent({ element, disabled: true })
+
+    const lastCallProps = getLastPlotProps()
+
+    // When disabled, clickmode should be "none" and dragmode should be "pan"
+    expect(lastCallProps.layout.clickmode).toBe("none")
+    expect(lastCallProps.layout.dragmode).toBe("pan")
+  })
+
+  it("handles empty spec gracefully", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      spec: "",
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    expect(lastCallProps.data).toEqual([])
+    expect(lastCallProps.layout).toBeDefined()
+  })
+
+  it("calls handleSelection on selection event", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockEvent = {} as any
+
+    act(() => {
+      lastCallProps.onSelected(mockEvent)
+    })
+
+    expect(handleSelection).toHaveBeenCalledWith(
+      mockEvent,
+      widgetMgr,
+      expect.objectContaining({ id: defaultElement.id }),
+      undefined
+    )
+  })
+
+  it("calls sendEmptySelection on deselect event", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    act(() => {
+      lastCallProps.onDeselect()
+    })
+
+    // It should call sendEmptySelection
+    // And it also calls resetSelectionsCallback(false) inside component
+    expect(sendEmptySelection).toHaveBeenCalledWith(
+      widgetMgr,
+      expect.objectContaining({ id: defaultElement.id }),
+      undefined
+    )
+  })
+
+  it("resets selections on double-click when selection is activated", () => {
+    const element = new PlotlyChartProto({
+      ...defaultElement,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+
+    renderComponent({ element })
+
+    const lastCallProps = getLastPlotProps()
+
+    // onDoubleClick should be defined when selection is activated
+    expect(lastCallProps.onDoubleClick).toBeDefined()
+
+    act(() => {
+      lastCallProps.onDoubleClick()
+    })
+
+    // Double-click should reset selections by calling sendEmptySelection
+    expect(sendEmptySelection).toHaveBeenCalledWith(
+      widgetMgr,
+      expect.objectContaining({ id: defaultElement.id }),
+      undefined
+    )
+  })
+
+  it("does not have double-click handler when selection is not activated", () => {
+    // No selection mode means selection is not activated
+    renderComponent()
+
+    const lastCallProps = getLastPlotProps()
+
+    // onDoubleClick should be undefined when selection is not activated
+    expect(lastCallProps.onDoubleClick).toBeUndefined()
+  })
+
+  it("saves figure to widget state on update", () => {
+    renderComponent()
+
+    const lastCallProps = getLastPlotProps()
+    const newFigure = { data: [], layout: { title: "New Title" } }
+
+    act(() => {
+      lastCallProps.onUpdate(newFigure)
+    })
+
+    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
+      defaultElement.id,
+      "figure",
+      newFigure
+    )
+  })
+
+  it("adds fullscreen button to toolbar", () => {
+    renderComponent()
+
+    const lastCallProps = getLastPlotProps()
+    const config = lastCallProps.config
+
+    expect(config.modeBarButtonsToAdd).toBeDefined()
+    const fullscreenButton = config.modeBarButtonsToAdd.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (b: any) => b.name === "Fullscreen"
+    )
+    expect(fullscreenButton).toBeDefined()
+  })
+
+  it("handles fullscreen button click", () => {
+    const expandMock = vi.fn()
+    renderComponent({}, { expanded: false, expand: expandMock })
+
+    const lastCallProps = getLastPlotProps()
+    const config = lastCallProps.config
+    const fullscreenButton = config.modeBarButtonsToAdd.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (b: any) => b.name === "Fullscreen"
+    )
+
+    act(() => {
+      fullscreenButton.click()
+    })
+
+    expect(expandMock).toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -70,11 +70,6 @@ export interface PlotlyChartProps {
   width: number
 }
 
-/**
- * Note: we do not have any React-testing-library tests because Plotly doesn't support it
- * https://github.com/plotly/react-plotly.js/issues/176
- */
-
 export function PlotlyChart({
   element,
   widgetMgr,


### PR DESCRIPTION
## Describe your changes

The Plotly frontend component hasn't been covered by unit tests since it doesn't support react-testing-library well (see [here](https://github.com/plotly/react-plotly.js/issues/176)). However, we can still test a lot of aspects via mocking. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
