### PR TITLE
Ignore `eslint-plugin-streamlit-custom` for test coverage

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       include: ["*/src/**/*"],
       exclude: [
         "lib/src/vendor/**",
+        "eslint-plugin-streamlit-custom/**",
         "**/*.interface.ts",
         ...coverageConfigDefaults.exclude,
       ],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       include: ["*/src/**/*"],
       exclude: [
         "lib/src/vendor/**",
-        "eslint-plugin-streamlit-custom/**",
+        "eslint-plugin-streamlit-custom/src/**",
         "**/*.interface.ts",
         ...coverageConfigDefaults.exclude,
       ],


### PR DESCRIPTION
## Describe your changes

Ignore `eslint-plugin-streamlit-custom` for our test coverage calculation. We have tests for our custom rules via ruleTester, but they don't seem to work with our test coverage calculation. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
