### PR TITLE
[fix] Reclassify Auth Callback Error -> Warning

### DIFF
--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -162,8 +162,11 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             return
 
         if provider is None:
-            _LOGGER.error(
-                "Error, missing provider for oauth callback.",
+            # See https://github.com/streamlit/streamlit/issues/13101
+            _LOGGER.warning(
+                "Missing provider for OAuth callback; this often indicates a stale "
+                "or replayed callback (for example, from browser back/forward "
+                "navigation).",
             )
             self.redirect_to_base()
             return


### PR DESCRIPTION
## Describe your changes

Improved the error message when a provider is missing for an OAuth callback. Changed the log level from `error` to `warning` and added more context to the message, explaining that this often indicates a stale or replayed callback (e.g., from browser back/forward navigation).

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/13101

## Testing Plan

- No additional added as this is just a log message improvement

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.