### PR TITLE
Reduce entry bundle size - Part 5

### DIFF
--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -21,6 +21,15 @@ import { buildHttpUri } from "@streamlit/utils"
 
 import { DefaultStreamlitEndpoints } from "./DefaultStreamlitEndpoints"
 
+// Mock the dynamic import to return the same axios instance we're using for testing
+vi.mock("axios", async importOriginal => {
+  const actual = await importOriginal<typeof import("axios")>()
+  return {
+    ...actual,
+    default: actual.default,
+  }
+})
+
 const MOCK_SERVER_URI = {
   protocol: "http:",
   hostname: "streamlit.mock",
@@ -503,19 +512,23 @@ describe("DefaultStreamlitEndpoints", () => {
   // Test our private csrfRequest() API, which is responsible for setting
   // the "X-Xsrftoken" header.
   describe("csrfRequest()", () => {
-    const spyRequest = vi.spyOn(axios, "request")
     let prevDocumentCookie: string
+    let mockRequest: ReturnType<typeof vi.fn>
 
     beforeEach(() => {
       prevDocumentCookie = document.cookie
       document.cookie = "_streamlit_xsrf=mockXsrfCookie;"
+      // Create a mock for axios.request that will be used by the dynamic import
+      mockRequest = vi.fn().mockResolvedValue({ data: {} })
+      vi.spyOn(axios, "request").mockImplementation(mockRequest)
     })
 
     afterEach(() => {
       document.cookie = prevDocumentCookie
+      vi.restoreAllMocks()
     })
 
-    it("sets token when csrfEnabled: true", () => {
+    it("sets token when csrfEnabled: true", async () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: true,
@@ -524,16 +537,16 @@ describe("DefaultStreamlitEndpoints", () => {
 
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
       // @ts-expect-error
-      void endpoints.csrfRequest(url, {})
+      await endpoints.csrfRequest(url, {})
 
-      expect(spyRequest).toHaveBeenCalledWith({
+      expect(mockRequest).toHaveBeenCalledWith({
         headers: { "X-Xsrftoken": "mockXsrfCookie" },
         withCredentials: true,
         url,
       })
     })
 
-    it("omits token when csrfEnabled: false", () => {
+    it("omits token when csrfEnabled: false", async () => {
       const endpoints = new DefaultStreamlitEndpoints({
         getServerUri: () => MOCK_SERVER_URI,
         csrfEnabled: false,
@@ -542,9 +555,9 @@ describe("DefaultStreamlitEndpoints", () => {
 
       const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
       // @ts-expect-error
-      void endpoints.csrfRequest(url, {})
+      await endpoints.csrfRequest(url, {})
 
-      expect(spyRequest).toHaveBeenCalledWith({
+      expect(mockRequest).toHaveBeenCalledWith({
         url,
       })
     })

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
+import type { AxiosRequestConfig, AxiosResponse } from "axios"
 import { getLogger } from "loglevel"
 
 import { IAppPage } from "@streamlit/protobuf"
@@ -362,9 +362,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   /**
    * Wrapper around axios.request to update the request config with
    * CSRF headers if client has CSRF protection enabled.
+   * Uses dynamic import to load axios only when needed (file upload/delete operations).
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private csrfRequest<T = any, R = AxiosResponse<T>>(
+  private async csrfRequest<T = any, R = AxiosResponse<T>>(
     url: string,
     params: AxiosRequestConfig
   ): Promise<R> {
@@ -381,6 +382,8 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       }
     }
 
+    // Dynamic import to avoid loading axios in the entry bundle
+    const { default: axios } = await import("axios")
     return axios.request<T, R>(params)
   }
 }

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -20,7 +20,6 @@
  * Returns a promise with the index of the URI that worked.
  */
 
-import axios from "axios"
 import { getLogger } from "loglevel"
 
 // Note we expect the polyfill to load from this import
@@ -34,7 +33,12 @@ import {
   SERVER_PING_PATH,
 } from "./constants"
 import { ErrorDetails, IHostConfigResponse, OnRetry } from "./types"
-import { parseUriIntoBaseParts } from "./utils"
+import {
+  FetchError,
+  fetchWithTimeout,
+  parseUriIntoBaseParts,
+  serializeForDisplay,
+} from "./utils"
 
 const LOG = getLogger("DoInitPings")
 
@@ -176,22 +180,22 @@ If you are trying to access a Streamlit app running on another server, this coul
     // not to do so as it's semantically cleaner to not give the healthcheck
     // endpoint additional responsibilities.
     Promise.all([
-      axios.get(healthzUri, { timeout: PING_TIMEOUT_MS }),
-      axios.get(hostConfigUri, { timeout: PING_TIMEOUT_MS }),
+      fetchWithTimeout(healthzUri, PING_TIMEOUT_MS),
+      fetchWithTimeout(hostConfigUri, PING_TIMEOUT_MS),
     ])
       .then(([_, hostConfigResp]) => {
-        onHostConfigResp(hostConfigResp.data)
+        onHostConfigResp(hostConfigResp.data as IHostConfigResponse)
         resolve(uriNumber)
       })
-      .catch(error => {
+      .catch((error: FetchError) => {
         // If its our 6th try (retry count at which we show connection error dialog), send a client error
         // to inform the host of connection error
         const tooManyRetries = totalTries >= MAX_RETRIES_BEFORE_CLIENT_ERROR
 
-        if (error.code === "ECONNABORTED") {
+        if (error.isTimeout) {
           if (tooManyRetries) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
-            const source = determineUrlSource(error.config?.url)
+            const source = determineUrlSource(error.url)
             LOG.error("Client error: DoInitPings timed out")
             sendClientError(
               "DoInitPings timed out",
@@ -208,7 +212,7 @@ If you are trying to access a Streamlit app running on another server, this coul
 
           const { data, status, statusText } = error.response
           // Handle retrieving the source URL from the error (health or host-config endpoint)
-          const source = determineUrlSource(error.response.config?.url)
+          const source = determineUrlSource(error.url)
 
           if (status === /* NO RESPONSE */ 0) {
             if (tooManyRetries) {
@@ -241,32 +245,25 @@ If you are trying to access a Streamlit app running on another server, this coul
             sendClientError(status, statusText, source)
           }
 
-          const responseData =
-            data !== null && typeof data === "object"
-              ? JSON.stringify(data, null, 2)
-              : data
-          const messageEnding = responseData ? ", and response:" : "."
-
+          const responseDataStr = serializeForDisplay(data)
           return retry({
-            message: `Connection failed with status ${status}${messageEnding}`,
-            ...(responseData && { codeBlock: responseData }),
+            message: `Connection failed with status ${status}${responseDataStr ? ", and response:" : "."}`,
+            ...(responseDataStr && { codeBlock: responseDataStr }),
           })
         }
 
-        if (error.request) {
+        if (error.isNetworkError) {
           // The request was made but no response was received
-          // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-          // http.ClientRequest in node.js
 
           if (tooManyRetries) {
             // Handle retrieving the source URL from the error (health or host-config endpoint)
-            const source = determineUrlSource(error.request.path)
+            const source = determineUrlSource(error.url)
             LOG.error(
               `Client Error in reaching server endpoint - No response received when attempting to reach ${source}`
             )
             sendClientError(
               "No response received from server",
-              error.request.status,
+              "Network error",
               source
             )
           }
@@ -276,7 +273,7 @@ If you are trying to access a Streamlit app running on another server, this coul
         // Something happened in setting up the request that triggered an Error
         if (tooManyRetries) {
           // Handle retrieving the source URL from the error (health or host-config endpoint)
-          const source = determineUrlSource(error.config?.url)
+          const source = determineUrlSource(error.url)
           LOG.error(
             `Client Error in reaching server endpoint - error in setting up request when attempting to reach ${source}`
           )

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import axios from "axios"
 import { zip } from "lodash-es"
 import { default as WS } from "vitest-websocket-mock"
 
@@ -35,34 +34,87 @@ const MOCK_ALLOWED_ORIGINS_CONFIG = {
   useExternalAuthToken: false,
 }
 
-const MOCK_HOST_CONFIG_RESPONSE = {
-  data: MOCK_ALLOWED_ORIGINS_CONFIG,
-}
+const MOCK_HOST_CONFIG_RESPONSE = MOCK_ALLOWED_ORIGINS_CONFIG
 
 const MOCK_HEALTH_RESPONSE = { status: "ok" }
 
-// Sets up axios get mock to fail a specific number of times before succeeding
-function setupAxiosMockWithFailures(
+/**
+ * Helper to create a successful fetch Response
+ */
+function createSuccessResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    statusText: "OK",
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+/**
+ * Helper to create an error fetch Response (non-2xx status)
+ */
+function createErrorResponse(
+  status: number,
+  statusText: string,
+  data?: unknown
+): Response {
+  return new Response(data ? JSON.stringify(data) : "", {
+    status,
+    statusText,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+/**
+ * Helper to create an AbortError (simulates timeout)
+ */
+function createAbortError(): DOMException {
+  return new DOMException("The operation was aborted.", "AbortError")
+}
+
+/**
+ * Helper to create a network error (TypeError from fetch)
+ */
+function createNetworkError(message = "Failed to fetch"): TypeError {
+  return new TypeError(message)
+}
+
+// Sets up fetch mock to fail a specific number of times before succeeding
+function setupFetchMockWithFailures(
   retryCount: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  errorObj: any
+  errorType: "response" | "network" | "timeout",
+  responseOptions?: { status: number; statusText: string; data?: unknown }
 ): ReturnType<typeof vi.fn> {
   const mockImplementation = vi.fn()
-  axios.get = mockImplementation
 
   // Each "totalTries" increment involves cycling through all URIs
-  // Each URI requires 2 axios calls (health + config)
+  // Each URI requires 2 fetch calls (health + config)
   // So total failed calls needed = retryCount * numUris * 2
   const totalFailedCalls = retryCount * 2 * 2
 
-  // Setup all the rejected calls
+  // Setup all the rejected/error calls
   for (let i = 0; i < totalFailedCalls; i++) {
-    mockImplementation.mockRejectedValueOnce(errorObj)
+    if (errorType === "timeout") {
+      mockImplementation.mockRejectedValueOnce(createAbortError())
+    } else if (errorType === "network") {
+      mockImplementation.mockRejectedValueOnce(createNetworkError())
+    } else if (errorType === "response" && responseOptions) {
+      mockImplementation.mockResolvedValueOnce(
+        createErrorResponse(
+          responseOptions.status,
+          responseOptions.statusText,
+          responseOptions.data
+        )
+      )
+    }
   }
 
   // Add final successful calls to break the loop
-  mockImplementation.mockResolvedValueOnce("") // healthzUri success
-  mockImplementation.mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE) // hostConfigUri success
+  mockImplementation.mockResolvedValueOnce(
+    createSuccessResponse(MOCK_HEALTH_RESPONSE)
+  ) // healthzUri success
+  mockImplementation.mockResolvedValueOnce(
+    createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE)
+  ) // hostConfigUri success
 
   return mockImplementation
 }
@@ -91,14 +143,16 @@ function createMockArgs(overrides?: Partial<Args>): Args {
   }
 }
 
-/** Create a robust axios mock that handles any number of HTTP requests */
-function createAxiosMock(): ReturnType<typeof vi.fn> {
+/** Create a robust fetch mock that handles any number of HTTP requests */
+function createFetchMock(): ReturnType<typeof vi.fn> {
   let callCount = 0
   return vi.fn().mockImplementation(() => {
     callCount++
     // Alternate between health check (empty string) and host config responses
     return Promise.resolve(
-      callCount % 2 === 1 ? "" : MOCK_HOST_CONFIG_RESPONSE
+      callCount % 2 === 1
+        ? createSuccessResponse({})
+        : createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE)
     )
   })
 }
@@ -126,8 +180,7 @@ describe("doInitPings", () => {
     setAllowedOrigins: vi.fn(),
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let originalAxiosGet: any
+  let originalFetch: typeof global.fetch
 
   // Helper function to create retry callbacks that advance timers
   const createTimerAdvancingRetryCallback = (
@@ -143,7 +196,7 @@ describe("doInitPings", () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
-    originalAxiosGet = axios.get
+    originalFetch = global.fetch
     MOCK_PING_DATA.retryCallback = vi.fn()
     MOCK_PING_DATA.setAllowedOrigins = vi.fn()
   })
@@ -151,15 +204,15 @@ describe("doInitPings", () => {
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
-    axios.get = originalAxiosGet
+    global.fetch = originalFetch
     window.__streamlit = undefined
   })
 
   it("calls the /_stcore/health endpoint when pinging server", async () => {
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      .mockResolvedValueOnce(MOCK_HEALTH_RESPONSE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HEALTH_RESPONSE))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const { promise } = doInitPings(
       MOCK_PING_DATA.uri,
@@ -178,10 +231,10 @@ describe("doInitPings", () => {
 
   it("makes the host config call using window.__streamlit.HOST_CONFIG_BASE_URL if set", async () => {
     window.__streamlit = { HOST_CONFIG_BASE_URL: "https://example.com:1234" }
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      .mockResolvedValueOnce(MOCK_HEALTH_RESPONSE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HEALTH_RESPONSE))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const { promise } = doInitPings(
       MOCK_PING_DATA.uri,
@@ -196,18 +249,18 @@ describe("doInitPings", () => {
     expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_ORIGINS_CONFIG
     )
-    // @ts-expect-error
-    expect(axios.get.mock.calls[1]).toEqual([
+    // Verify the second call was to the custom host config URL
+    expect(global.fetch).toHaveBeenCalledWith(
       "https://example.com:1234/_stcore/host-config",
-      { timeout: 15000 },
-    ])
+      expect.any(Object)
+    )
   })
 
   it("returns the uri index and sets hostConfig for the first successful ping (0)", async () => {
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const { promise } = doInitPings(
       MOCK_PING_DATA.uri,
@@ -225,14 +278,14 @@ describe("doInitPings", () => {
   })
 
   it("returns the uri index and sets hostConfig for the first successful ping (1)", async () => {
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(new Error(""))
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - network error
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback()
 
@@ -258,14 +311,14 @@ describe("doInitPings", () => {
   it("calls retry with the corresponding error message if there was an error", async () => {
     const TEST_ERROR_MESSAGE = "ERROR_MESSAGE"
 
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(new Error(TEST_ERROR_MESSAGE))
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - network error with message
+      .mockRejectedValueOnce(createNetworkError(TEST_ERROR_MESSAGE))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -286,22 +339,22 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      { message: TEST_ERROR_MESSAGE },
+      expect.objectContaining({
+        message: expect.stringContaining("Streamlit server is not responding"),
+      }),
       expect.anything()
     )
   })
 
-  it("calls retry with 'Connection timed out.' when the error code is `ECONNABORTED`", async () => {
-    const TEST_ERROR = { code: "ECONNABORTED" }
-
-    axios.get = vi
+  it("calls retry with 'Connection timed out.' when fetch times out (AbortError)", async () => {
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - timeout
+      .mockRejectedValueOnce(createAbortError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -327,62 +380,15 @@ describe("doInitPings", () => {
     )
   })
 
-  it("calls retry with 'Streamlit server is not responding. Are you connected to the internet?' when there is no response", async () => {
-    const TEST_ERROR = {
-      response: {
-        status: 0,
-      },
-    }
-
-    axios.get = vi
+  it("calls retry with 'Streamlit server is not responding. Are you connected to the internet?' when there is a network error", async () => {
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-
-    const retryCallback = createTimerAdvancingRetryCallback(
-      MOCK_PING_DATA.retryCallback
-    )
-
-    const { promise } = doInitPings(
-      MOCK_PING_DATA.uri,
-      MOCK_PING_DATA.timeoutMs,
-      MOCK_PING_DATA.maxTimeoutMs,
-      retryCallback,
-      MOCK_PING_DATA.sendClientError,
-      MOCK_PING_DATA.setAllowedOrigins
-    )
-
-    // Run any remaining timers to complete the ping process
-    await vi.runAllTimersAsync()
-    await promise
-
-    expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
-      1,
-      {
-        message:
-          "Streamlit server is not responding. Are you connected to the internet?",
-      },
-      expect.anything()
-    )
-  })
-
-  it("calls retry with 'Streamlit server is not responding. Are you connected to the internet?' when the request was made but no response was received", async () => {
-    const TEST_ERROR = {
-      request: {},
-    }
-
-    axios.get = vi
-      .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - network error
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -430,20 +436,14 @@ describe("doInitPings", () => {
       ] as URL[],
     }
 
-    const TEST_ERROR = {
-      response: {
-        status: 0,
-      },
-    }
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - network error
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA_LOCALHOST.retryCallback
@@ -470,24 +470,18 @@ describe("doInitPings", () => {
   })
 
   it("calls retry with corresponding fragment when the status is 403 (forbidden)", async () => {
-    const TEST_ERROR = {
-      response: {
-        status: 403,
-      },
-    }
-
     const forbiddenMarkdown = `Cannot connect to Streamlit (HTTP status: 403).
 
 If you are trying to access a Streamlit app running on another server, this could be due to the app's [CORS](${CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}) settings.`
 
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - 403 error
+      .mockResolvedValueOnce(createErrorResponse(403, "Forbidden"))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -514,21 +508,16 @@ If you are trying to access a Streamlit app running on another server, this coul
   })
 
   it("calls retry with 'Connection failed with status ...' for any status code other than 0, 403, and 2xx", async () => {
-    const TEST_ERROR = {
-      response: {
-        status: 500,
-        data: "TEST_DATA",
-      },
-    }
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - 500 error
+      .mockResolvedValueOnce(
+        createErrorResponse(500, "Internal Server Error", "TEST_DATA")
+      )
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -550,31 +539,26 @@ If you are trying to access a Streamlit app running on another server, this coul
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
       {
-        message: `Connection failed with status ${TEST_ERROR.response.status}, and response:`,
-        codeBlock: TEST_ERROR.response.data,
+        message: "Connection failed with status 500, and response:",
+        codeBlock: "TEST_DATA",
       },
       expect.anything()
     )
   })
 
   it("calls retry with 'Connection failed with status ...' for any status code other than 0, 403, and 2xx with an object response", async () => {
-    const TEST_ERROR = {
-      response: {
-        status: 500,
-        data: {
-          message: "TEST_DATA",
-        },
-      },
-    }
+    const TEST_DATA = { message: "TEST_DATA" }
 
-    axios.get = vi
+    global.fetch = vi
       .fn()
-      // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
-      // Second Connection attempt
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      // First Connection attempt - 500 error with object data
+      .mockResolvedValueOnce(
+        createErrorResponse(500, "Internal Server Error", TEST_DATA)
+      )
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
+      // Second Connection attempt - success
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -596,36 +580,34 @@ If you are trying to access a Streamlit app running on another server, this coul
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
       {
-        message: `Connection failed with status ${TEST_ERROR.response.status}, and response:`,
-        codeBlock: JSON.stringify(TEST_ERROR.response.data, null, 2),
+        message: "Connection failed with status 500, and response:",
+        codeBlock: JSON.stringify(TEST_DATA, null, 2),
       },
       expect.anything()
     )
   })
 
   it("calls retry with correct total tries", async () => {
-    const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
       // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Second Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Third Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fourth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fifth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Final Attempt (to avoid infinite loop)
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const retryCallback = createTimerAdvancingRetryCallback(
       MOCK_PING_DATA.retryCallback
@@ -648,28 +630,26 @@ If you are trying to access a Streamlit app running on another server, this coul
   })
 
   it("has increasing but capped retry backoff", async () => {
-    const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
       // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Second Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Third Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fourth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fifth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Final Attempt (to avoid infinite loop)
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const timeouts: number[] = []
     const retryCallback = (
@@ -685,6 +665,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const { promise } = doInitPings(
       [
         {
+          protocol: "http:",
           hostname: "not.a.real.host",
           port: "3000",
           pathname: "/",
@@ -714,28 +695,26 @@ If you are trying to access a Streamlit app running on another server, this coul
   })
 
   it("backs off independently for each target url", async () => {
-    const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
       // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Second Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Third Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fourth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fifth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Final Attempt (to avoid infinite loop)
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const timeouts: number[] = []
     const retryCallback = (
@@ -769,28 +748,26 @@ If you are trying to access a Streamlit app running on another server, this coul
   })
 
   it("resets timeout each ping call", async () => {
-    const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
-
-    axios.get = vi
+    global.fetch = vi
       .fn()
       // First Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Second Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Third Connection attempt (successful)
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fourth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Fifth Connection attempt
-      .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockRejectedValueOnce(createNetworkError())
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
       // Final Attempt (to avoid infinite loop)
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce(MOCK_HOST_CONFIG_RESPONSE)
+      .mockResolvedValueOnce(createSuccessResponse({}))
+      .mockResolvedValueOnce(createSuccessResponse(MOCK_HOST_CONFIG_RESPONSE))
 
     const timeouts: number[] = []
     const retryCallback = (
@@ -806,6 +783,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const { promise: promise1 } = doInitPings(
       [
         {
+          protocol: "http:",
           hostname: "not.a.real.host",
           port: "3000",
           pathname: "/",
@@ -836,6 +814,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     const { promise: promise2 } = doInitPings(
       [
         {
+          protocol: "http:",
           hostname: "not.a.real.host",
           port: "3000",
           pathname: "/",
@@ -858,56 +837,15 @@ If you are trying to access a Streamlit app running on another server, this coul
   })
 
   describe("calls sendClientError when we've reached connection error threshold", () => {
-    it("with status = 0 response", async () => {
-      const sendClientErrorSpy = vi.fn()
-
-      // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
-        response: {
-          status: 0,
-          statusText: "No response",
-          config: {
-            url: "https://example.com/health",
-          },
-        },
-      })
-
-      const retryCallback = createTimerAdvancingRetryCallback()
-
-      const { promise } = doInitPings(
-        MOCK_PING_DATA.uri,
-        MOCK_PING_DATA.timeoutMs,
-        MOCK_PING_DATA.maxTimeoutMs,
-        retryCallback,
-        sendClientErrorSpy,
-        MOCK_PING_DATA.setAllowedOrigins
-      )
-
-      // Run any remaining timers to complete the ping process
-      await vi.runAllTimersAsync()
-      await promise
-
-      // Verify that sendClientError was called with the expected arguments
-      expect(sendClientErrorSpy).toHaveBeenCalledWith(
-        "Response received with status 0",
-        "No response",
-        "/health"
-      )
-    })
-
     it("with status = 403 response", async () => {
       const sendClientErrorSpy = vi.fn()
 
-      // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
-        response: {
-          status: 403,
-          statusText: "Forbidden",
-          config: {
-            url: "https://example.com/health",
-          },
-        },
-      })
+      // We need to mock fetch to simulate connection error threshold
+      global.fetch = setupFetchMockWithFailures(
+        MAX_RETRIES_BEFORE_CLIENT_ERROR,
+        "response",
+        { status: 403, statusText: "Forbidden" }
+      )
 
       const retryCallback = createTimerAdvancingRetryCallback()
 
@@ -927,23 +865,19 @@ If you are trying to access a Streamlit app running on another server, this coul
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         403,
         "Forbidden",
-        "/health"
+        expect.any(String)
       )
     })
 
     it("with status = 500 response", async () => {
       const sendClientErrorSpy = vi.fn()
 
-      // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
-        response: {
-          status: 500,
-          statusText: "Internal Server Error",
-          config: {
-            url: "https://example.com/health",
-          },
-        },
-      })
+      // We need to mock fetch to simulate connection error threshold
+      global.fetch = setupFetchMockWithFailures(
+        MAX_RETRIES_BEFORE_CLIENT_ERROR,
+        "response",
+        { status: 500, statusText: "Internal Server Error" }
+      )
 
       const retryCallback = createTimerAdvancingRetryCallback()
 
@@ -963,19 +897,19 @@ If you are trying to access a Streamlit app running on another server, this coul
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         500,
         "Internal Server Error",
-        "/health"
+        expect.any(String)
       )
     })
 
-    it("with request error", async () => {
+    it("with network error", async () => {
       const sendClientErrorSpy = vi.fn()
 
-      // We need to mock axios.get to simulate connection error threshold
-      axios.get = setupAxiosMockWithFailures(MAX_RETRIES_BEFORE_CLIENT_ERROR, {
-        request: {
-          path: "https://example.com/health",
-        },
-      })
+      // We need to mock fetch to simulate connection error threshold
+      global.fetch = setupFetchMockWithFailures(
+        MAX_RETRIES_BEFORE_CLIENT_ERROR,
+        "network",
+        undefined
+      )
 
       const retryCallback = createTimerAdvancingRetryCallback()
 
@@ -994,8 +928,8 @@ If you are trying to access a Streamlit app running on another server, this coul
 
       expect(sendClientErrorSpy).toHaveBeenCalledWith(
         "No response received from server",
-        undefined,
-        "/health"
+        "Network error",
+        expect.any(String)
       )
     })
   })
@@ -1004,21 +938,20 @@ If you are trying to access a Streamlit app running on another server, this coul
 describe("WebsocketConnection", () => {
   let client: WebsocketConnection
   let server: WS
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let originalAxiosGet: any
+  let originalFetch: typeof global.fetch
 
   beforeEach(() => {
     vi.useFakeTimers()
     server = new WS("ws://localhost:1234/_stcore/stream")
 
-    originalAxiosGet = axios.get
-    axios.get = createAxiosMock()
+    originalFetch = global.fetch
+    global.fetch = createFetchMock()
 
     client = new WebsocketConnection(createMockArgs())
   })
 
   afterEach(async () => {
-    axios.get = originalAxiosGet
+    global.fetch = originalFetch
 
     // @ts-expect-error
     if (client.websocket) {
@@ -1077,6 +1010,7 @@ describe("WebsocketConnection", () => {
     // Advance fake timers to allow connection process to complete
     await vi.runAllTimersAsync()
     await server.connected
+
     // @ts-expect-error
     const sendSpy = vi.spyOn(client.websocket, "send")
 
@@ -1106,8 +1040,7 @@ describe("WebsocketConnection", () => {
 })
 
 describe("WebsocketConnection auth token handling", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let originalAxiosGet: any
+  let originalFetch: typeof global.fetch
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   let websocketSpy: any
   let server: WS
@@ -1116,12 +1049,12 @@ describe("WebsocketConnection auth token handling", () => {
     server = new WS("ws://localhost:1234/_stcore/stream")
     websocketSpy = vi.spyOn(window, "WebSocket")
 
-    originalAxiosGet = axios.get
-    axios.get = createAxiosMock()
+    originalFetch = global.fetch
+    global.fetch = createFetchMock()
   })
 
   afterEach(() => {
-    axios.get = originalAxiosGet
+    global.fetch = originalFetch
 
     server.close()
   })

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -18,8 +18,11 @@ import { buildHttpUri } from "@streamlit/utils"
 
 import {
   buildWsUri,
+  FetchError,
+  fetchWithTimeout,
   getPossibleBaseUris,
   parseUriIntoBaseParts,
+  serializeForDisplay,
 } from "./utils"
 
 describe("parseUriIntoBaseParts", () => {
@@ -253,5 +256,303 @@ describe("getPossibleBaseUris", () => {
       hostname: "used_host",
       pathname: "/foo",
     })
+  })
+})
+
+describe("serializeForDisplay", () => {
+  it("returns undefined for null", () => {
+    expect(serializeForDisplay(null)).toBeUndefined()
+  })
+
+  it("returns undefined for undefined", () => {
+    expect(serializeForDisplay(undefined)).toBeUndefined()
+  })
+
+  it("returns string as-is", () => {
+    expect(serializeForDisplay("hello")).toBe("hello")
+  })
+
+  it("converts number to string", () => {
+    expect(serializeForDisplay(42)).toBe("42")
+  })
+
+  it("converts boolean to string", () => {
+    expect(serializeForDisplay(true)).toBe("true")
+    expect(serializeForDisplay(false)).toBe("false")
+  })
+
+  it("pretty-prints object as JSON", () => {
+    expect(serializeForDisplay({ foo: "bar" })).toBe('{\n  "foo": "bar"\n}')
+  })
+
+  it("pretty-prints array as JSON", () => {
+    expect(serializeForDisplay([1, 2, 3])).toBe("[\n  1,\n  2,\n  3\n]")
+  })
+
+  it("returns undefined for function", () => {
+    expect(serializeForDisplay(() => {})).toBeUndefined()
+  })
+
+  it("returns undefined for symbol", () => {
+    expect(serializeForDisplay(Symbol("test"))).toBeUndefined()
+  })
+})
+
+describe("FetchError", () => {
+  it("creates error with message and url", () => {
+    const error = new FetchError("Test error", "http://example.com")
+
+    expect(error.message).toBe("Test error")
+    expect(error.url).toBe("http://example.com")
+    expect(error.name).toBe("FetchError")
+    expect(error.isTimeout).toBe(false)
+    expect(error.isNetworkError).toBe(false)
+    expect(error.response).toBeUndefined()
+  })
+
+  it("creates timeout error", () => {
+    const error = new FetchError("Timeout", "http://example.com", {
+      isTimeout: true,
+    })
+
+    expect(error.isTimeout).toBe(true)
+    expect(error.isNetworkError).toBe(false)
+  })
+
+  it("creates network error", () => {
+    const error = new FetchError("Network failed", "http://example.com", {
+      isNetworkError: true,
+    })
+
+    expect(error.isNetworkError).toBe(true)
+    expect(error.isTimeout).toBe(false)
+  })
+
+  it("creates error with response", () => {
+    const error = new FetchError("Server error", "http://example.com", {
+      response: {
+        status: 500,
+        statusText: "Internal Server Error",
+        data: { error: "Something went wrong" },
+      },
+    })
+
+    expect(error.response).toEqual({
+      status: 500,
+      statusText: "Internal Server Error",
+      data: { error: "Something went wrong" },
+    })
+  })
+
+  it("is an instance of Error", () => {
+    const error = new FetchError("Test", "http://example.com")
+    expect(error instanceof Error).toBe(true)
+    expect(error instanceof FetchError).toBe(true)
+  })
+})
+
+describe("fetchWithTimeout", () => {
+  const mockUrl = "http://example.com/api"
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns data on successful JSON fetch", async () => {
+    const mockData = { success: true }
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockData)),
+    })
+
+    const result = await fetchWithTimeout(mockUrl, 5000)
+    expect(result).toEqual({ data: mockData, url: mockUrl })
+  })
+
+  it("returns plain text when response is not JSON (e.g., healthz returns 'ok')", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("ok"),
+    })
+
+    const result = await fetchWithTimeout(mockUrl, 5000)
+    expect(result).toEqual({ data: "ok", url: mockUrl })
+  })
+
+  it("throws FetchError with response on HTTP error", async () => {
+    const errorData = { error: "Not found" }
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve(errorData),
+    })
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      response: {
+        status: 404,
+        statusText: "Not Found",
+        data: errorData,
+      },
+    })
+  })
+
+  it("correctly passes status 403 for CORS/forbidden errors", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: () => Promise.resolve({ message: "Access denied" }),
+    })
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      response: {
+        status: 403,
+        statusText: "Forbidden",
+        data: { message: "Access denied" },
+      },
+    })
+  })
+
+  it("correctly passes status 0 for no-response scenarios", async () => {
+    // Status 0 typically indicates the request was blocked (CORS) or couldn't complete
+    // With native fetch this is rare (usually throws TypeError), but we handle it for completeness
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 0,
+      statusText: "",
+      json: () => Promise.reject(new Error("No body")),
+      text: () => Promise.reject(new Error("No body")),
+    })
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      response: {
+        status: 0,
+        statusText: "",
+        data: null,
+      },
+    })
+  })
+
+  it("falls back to text when JSON parsing fails on error response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("Invalid JSON")),
+      text: () => Promise.resolve("Plain text error"),
+    })
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      response: { data: "Plain text error" },
+    })
+  })
+
+  it("sets data to null when both JSON and text parsing fail", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("Invalid JSON")),
+      text: () => Promise.reject(new Error("Text failed")),
+    })
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      response: { data: null },
+    })
+  })
+
+  it("throws FetchError with isTimeout on abort", async () => {
+    // Mock fetch to never resolve, forcing the timeout to trigger
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_, reject) => {
+        // Listen to the abort signal and reject when aborted
+        options?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"))
+        })
+      })
+    })
+
+    // Use a very short timeout
+    await expect(fetchWithTimeout(mockUrl, 10)).rejects.toMatchObject({
+      name: "FetchError",
+      isTimeout: true,
+      message: "Connection timed out",
+    })
+  })
+
+  it("throws FetchError with isNetworkError on TypeError", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      isNetworkError: true,
+      message: "Failed to fetch",
+    })
+  })
+
+  it("throws FetchError with generic message on unknown error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Something went wrong"))
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      message: "Something went wrong",
+      isTimeout: false,
+      isNetworkError: false,
+    })
+  })
+
+  it("handles non-Error thrown values", async () => {
+    global.fetch = vi.fn().mockRejectedValue("string error")
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toMatchObject({
+      name: "FetchError",
+      message: "Unknown error",
+    })
+  })
+
+  it("preserves the original url in all error types", async () => {
+    const testUrl = "http://test-server.com/healthz"
+
+    // Test HTTP error
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.resolve({}),
+    })
+    await expect(fetchWithTimeout(testUrl, 5000)).rejects.toMatchObject({
+      url: testUrl,
+    })
+
+    // Test network error
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+    await expect(fetchWithTimeout(testUrl, 5000)).rejects.toMatchObject({
+      url: testUrl,
+    })
+  })
+
+  it("clears timeout on successful response", async () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout")
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ status: "ok" })),
+    })
+
+    await fetchWithTimeout(mockUrl, 5000)
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it("clears timeout on error response", async () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout")
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"))
+
+    await expect(fetchWithTimeout(mockUrl, 5000)).rejects.toThrow()
+    expect(clearTimeoutSpy).toHaveBeenCalled()
   })
 })

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -82,3 +82,137 @@ export function buildWsUri(
   const fullPath = makePath(pathname, path)
   return `${wsProtocol}://${hostname}:${port}/${fullPath}`
 }
+
+/**
+ * Serialize data for display in error messages.
+ * Objects are pretty-printed as JSON, primitives are converted to strings.
+ * Returns undefined for null, undefined, or non-serializable types.
+ */
+export function serializeForDisplay(data: unknown): string | undefined {
+  if (data === null || data === undefined) {
+    return undefined
+  }
+
+  switch (typeof data) {
+    case "object":
+      return JSON.stringify(data, null, 2)
+    case "string":
+    case "number":
+    case "boolean":
+      return String(data)
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Custom error class to normalize fetch errors into a consistent structure.
+ * This mimics axios error patterns for compatibility with previous error handling logic.
+ */
+export class FetchError extends Error {
+  url: string
+
+  isTimeout: boolean
+
+  response?: {
+    status: number
+    statusText: string
+    data: unknown
+  }
+
+  isNetworkError: boolean
+
+  constructor(
+    message: string,
+    url: string,
+    options: {
+      isTimeout?: boolean
+      isNetworkError?: boolean
+      response?: { status: number; statusText: string; data: unknown }
+    } = {}
+  ) {
+    super(message)
+    this.name = "FetchError"
+    this.url = url
+    this.isTimeout = options.isTimeout ?? false
+    this.isNetworkError = options.isNetworkError ?? false
+    this.response = options.response
+  }
+}
+
+/**
+ * Fetch with timeout support using AbortController.
+ * Normalizes different error types (timeout, network, HTTP errors) into FetchError.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number
+): Promise<{ data: unknown; url: string }> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      // Server responded with error status
+      let data: unknown
+      try {
+        data = await response.json()
+      } catch {
+        try {
+          data = await response.text()
+        } catch {
+          data = null
+        }
+      }
+
+      throw new FetchError(
+        `Request failed with status ${response.status}`,
+        url,
+        {
+          response: {
+            status: response.status,
+            statusText: response.statusText,
+            data,
+          },
+        }
+      )
+    }
+
+    // Try JSON first, fall back to text (healthz returns string, host-config returns JSON)
+    // We don't rely on Content-Type since proxies/CDNs may not preserve headers correctly
+    const text = await response.text()
+    try {
+      return { data: JSON.parse(text), url }
+    } catch {
+      return { data: text, url }
+    }
+  } catch (error) {
+    clearTimeout(timeoutId)
+
+    // Re-throw FetchError as-is
+    if (error instanceof FetchError) {
+      throw error
+    }
+
+    // Handle AbortController timeout
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new FetchError("Connection timed out", url, { isTimeout: true })
+    }
+
+    // Handle network errors (TypeError from fetch when network fails)
+    if (error instanceof TypeError) {
+      throw new FetchError(error.message || "Network error", url, {
+        isNetworkError: true,
+      })
+    }
+
+    // Generic error
+    throw new FetchError(
+      error instanceof Error ? error.message : "Unknown error",
+      url
+    )
+  }
+}

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -81,8 +81,6 @@ import { Skeleton } from "~lib/components/elements/Skeleton"
 import TextElement from "~lib/components/elements/TextElement"
 import ErrorBoundary from "~lib/components/shared/ErrorBoundary"
 import Heading from "~lib/components/shared/StreamlitMarkdown/Heading"
-import { ComponentInstance } from "~lib/components/widgets/CustomComponent"
-import { FormSubmitContent } from "~lib/components/widgets/Form"
 import { getElementId } from "~lib/util/utils"
 
 import { StyledSpace } from "./styled-components"
@@ -96,41 +94,44 @@ import {
 } from "./utils"
 
 // Lazy-load elements.
-const Audio = lazy(() => import("~lib/components/elements/Audio"))
-const Balloons = lazy(() => import("~lib/components/elements/Balloons"))
-const Json = lazy(() => import("~lib/components/elements/Json"))
-const Metric = lazy(() => import("~lib/components/elements/Metric"))
-const Snow = lazy(() => import("~lib/components/elements/Snow"))
 const ArrowTable = lazy(() => import("~lib/components/elements/ArrowTable"))
-const ArrowDataFrame = lazy(() => import("~lib/components/widgets/DataFrame"))
 const ArrowVegaLiteChart = lazy(
   () => import("~lib/components/elements/ArrowVegaLiteChart")
 )
-const Toast = lazy(() => import("~lib/components/elements/Toast"))
-
+const Audio = lazy(() => import("~lib/components/elements/Audio"))
+const Balloons = lazy(() => import("~lib/components/elements/Balloons"))
 const DeckGlJsonChart = lazy(
   () => import("~lib/components/elements/DeckGlJsonChart")
 )
 const GraphVizChart = lazy(
   () => import("~lib/components/elements/GraphVizChart")
 )
+const Html = lazy(() => import("~lib/components/elements/Html"))
 const IFrame = lazy(() => import("~lib/components/elements/IFrame"))
 const ImageList = lazy(() => import("~lib/components/elements/ImageList"))
-
+const Json = lazy(() => import("~lib/components/elements/Json"))
 const LinkButton = lazy(() => import("~lib/components/elements/LinkButton"))
-
+const Metric = lazy(() => import("~lib/components/elements/Metric"))
 const PageLink = lazy(() => import("~lib/components/elements/PageLink"))
-
 const PlotlyChart = lazy(() => import("~lib/components/elements/PlotlyChart"))
+const Progress = lazy(() => import("~lib/components/elements/Progress"))
+const Snow = lazy(() => import("~lib/components/elements/Snow"))
+const Spinner = lazy(() => import("~lib/components/elements/Spinner"))
+const StreamlitSyntaxHighlighter = lazy(
+  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+)
+const Toast = lazy(() => import("~lib/components/elements/Toast"))
 const Video = lazy(() => import("~lib/components/elements/Video"))
 
 // Lazy-load widgets.
 const AudioInput = lazy(() => import("~lib/components/widgets/AudioInput"))
-
+const ArrowDataFrame = lazy(() => import("~lib/components/widgets/DataFrame"))
 const Button = lazy(() => import("~lib/components/widgets/Button"))
 const ButtonGroup = lazy(() => import("~lib/components/widgets/ButtonGroup"))
-const DownloadButton = lazy(
-  () => import("~lib/components/widgets/DownloadButton")
+const ComponentInstance = lazy(() =>
+  import("~lib/components/widgets/CustomComponent").then(module => ({
+    default: module.ComponentInstance,
+  }))
 )
 const CameraInput = lazy(() => import("~lib/components/widgets/CameraInput"))
 const ChatInput = lazy(() => import("~lib/components/widgets/ChatInput"))
@@ -140,21 +141,23 @@ const DateInput = lazy(() => import("~lib/components/widgets/DateInput"))
 const DateTimeInput = lazy(
   () => import("~lib/components/widgets/DateTimeInput")
 )
-const Html = lazy(() => import("~lib/components/elements/Html"))
+const DownloadButton = lazy(
+  () => import("~lib/components/widgets/DownloadButton")
+)
+const FileUploader = lazy(() => import("~lib/components/widgets/FileUploader"))
+const FormSubmitContent = lazy(() =>
+  import("~lib/components/widgets/Form").then(module => ({
+    default: module.FormSubmitContent,
+  }))
+)
 const Multiselect = lazy(() => import("~lib/components/widgets/Multiselect"))
-const Progress = lazy(() => import("~lib/components/elements/Progress"))
-const Spinner = lazy(() => import("~lib/components/elements/Spinner"))
+const NumberInput = lazy(() => import("~lib/components/widgets/NumberInput"))
 const Radio = lazy(() => import("~lib/components/widgets/Radio"))
 const Selectbox = lazy(() => import("~lib/components/widgets/Selectbox"))
 const Slider = lazy(() => import("~lib/components/widgets/Slider"))
-const FileUploader = lazy(() => import("~lib/components/widgets/FileUploader"))
 const TextArea = lazy(() => import("~lib/components/widgets/TextArea"))
 const TextInput = lazy(() => import("~lib/components/widgets/TextInput"))
 const TimeInput = lazy(() => import("~lib/components/widgets/TimeInput"))
-const NumberInput = lazy(() => import("~lib/components/widgets/NumberInput"))
-const StreamlitSyntaxHighlighter = lazy(
-  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
-)
 
 const BidiComponent = lazy(
   () => import("~lib/components/widgets/BidiComponent")

--- a/frontend/protobuf/package.json
+++ b/frontend/protobuf/package.json
@@ -24,6 +24,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "protobufjs": "^7.5.4",
     "protobufjs-cli": "^1.2.0",
     "typesync": "^0.14.3"
   }

--- a/frontend/protobuf/package.json
+++ b/frontend/protobuf/package.json
@@ -24,7 +24,6 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "protobufjs": "^7.5.4",
     "protobufjs-cli": "^1.2.0",
     "typesync": "^0.14.3"
   }

--- a/frontend/protobuf/scripts/generate-proto.js
+++ b/frontend/protobuf/scripts/generate-proto.js
@@ -47,7 +47,7 @@ const pbjsCommand = [
 const pbtsCommand = ["yarn", "run", "--silent", "pbts", "proto.js"]
 const TEMPLATE = "/* eslint-disable */\n\n"
 
-const runCommand = (commandAndArgs, outputFile, postProcess = null) => {
+const runCommand = (commandAndArgs, outputFile) => {
   const [cmd, ...args] = commandAndArgs
   const result = spawnSync(cmd, args, {
     maxBuffer: 4096 * 1024,
@@ -68,22 +68,13 @@ const runCommand = (commandAndArgs, outputFile, postProcess = null) => {
     console.warn(`Warnings:\n${result.stderr}`)
   }
 
-  let output = result.stdout
-
-  // Apply post-processing if provided
-  if (postProcess) {
-    output = postProcess(output)
-  }
-
-  fs.writeFileSync(outputFile, `${TEMPLATE}${output}`, "utf8")
+  fs.writeFileSync(outputFile, `${TEMPLATE}${result.stdout}`, "utf8")
   console.log(`Generated: ${outputFile}`)
 }
 
 // Run the commands sequentially
 try {
   console.log("Generating proto.js with optimizations...")
-
-  // No post-processing needed - keeping protobufjs/minimal import
   runCommand(pbjsCommand, outputJsFile)
 
   console.log("Generating proto.d.ts...")

--- a/frontend/protobuf/scripts/generate-proto.js
+++ b/frontend/protobuf/scripts/generate-proto.js
@@ -28,7 +28,7 @@ console.log(`Proto files: ${protoGlob}`)
 const outputJsFile = "proto.js"
 const outputDtsFile = "proto.d.ts"
 
-// Commands to run
+// Commands to run with optimization flags
 const pbjsCommand = [
   "yarn",
   "run",
@@ -41,11 +41,13 @@ const pbjsCommand = [
   "static-module",
   "--wrap",
   "es6",
+  "--no-verify", // Remove verification methods (not used)
+  "--no-delimited", // Remove delimited encoding (not used)
 ]
 const pbtsCommand = ["yarn", "run", "--silent", "pbts", "proto.js"]
 const TEMPLATE = "/* eslint-disable */\n\n"
 
-const runCommand = (commandAndArgs, outputFile) => {
+const runCommand = (commandAndArgs, outputFile, postProcess = null) => {
   const [cmd, ...args] = commandAndArgs
   const result = spawnSync(cmd, args, {
     maxBuffer: 4096 * 1024,
@@ -66,20 +68,29 @@ const runCommand = (commandAndArgs, outputFile) => {
     console.warn(`Warnings:\n${result.stderr}`)
   }
 
-  fs.writeFileSync(outputFile, `${TEMPLATE}${result.stdout}`, "utf8")
+  let output = result.stdout
+
+  // Apply post-processing if provided
+  if (postProcess) {
+    output = postProcess(output)
+  }
+
+  fs.writeFileSync(outputFile, `${TEMPLATE}${output}`, "utf8")
   console.log(`Generated: ${outputFile}`)
 }
 
 // Run the commands sequentially
 try {
-  console.log("Generating proto.js...")
+  console.log("Generating proto.js with optimizations...")
+
+  // No post-processing needed - keeping protobufjs/minimal import
   runCommand(pbjsCommand, outputJsFile)
 
   console.log("Generating proto.d.ts...")
   runCommand(pbtsCommand, outputDtsFile)
 
-  console.log("Protobuf files generated successfully!")
+  console.log("✅ Protobuf files generated successfully!")
 } catch (err) {
-  console.error("Failed to generate protobuf files:", err)
+  console.error("❌ Failed to generate protobuf files:", err)
   process.exit(1)
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3669,7 +3669,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/protobuf@workspace:protobuf"
   dependencies:
-    protobufjs: "npm:^7.5.4"
     protobufjs-cli: "npm:^1.2.0"
     typesync: "npm:^0.14.3"
   languageName: unknown

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3669,6 +3669,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/protobuf@workspace:protobuf"
   dependencies:
+    protobufjs: "npm:^7.5.4"
     protobufjs-cli: "npm:^1.2.0"
     typesync: "npm:^0.14.3"
   languageName: unknown
@@ -4955,12 +4956,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0":
+"@types/node@npm:*":
   version: 20.17.8
   resolution: "@types/node@npm:20.17.8"
   dependencies:
     undici-types: "npm:~6.19.2"
   checksum: 10c0/d68bbd9f8946a56d3f405e2dbfcc98d1d7a3cdbaa45d0a8fea2865e63ecdf3a2c9a0e992d9ea1658651909273026d341047e593596e133e842374371e04031c3
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 24.10.1
+  resolution: "@types/node@npm:24.10.1"
+  dependencies:
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/d6bca7a78f550fbb376f236f92b405d676003a8a09a1b411f55920ef34286ee3ee51f566203920e835478784df52662b5b2af89159d9d319352e9ea21801c002
   languageName: node
   linkType: hard
 
@@ -13557,7 +13567,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0, long@npm:^5.2.1":
+"long@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.2.1":
   version: 5.2.3
   resolution: "long@npm:5.2.3"
   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
@@ -19366,6 +19383,13 @@ __metadata:
   version: 7.10.0
   resolution: "undici-types@npm:7.10.0"
   checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes
Attempt to improve initial load time by reducing dependencies included in entry bundle.

Changes made:
* **Reduce `protobuf/proto.js` size by optimizing flags passed to `pbjs`**
  * Added `--no-verify` & `--no-delimited` flags to remove unused verification and delimited encoding functions
  * Reduces entry `proto.js` from 723 KB to 550 KB (24%)
* **Remove `axios` from entry bundle**
  * Refactor `doInitPings` to use `fetch`, lazy load `axios` in `DefaultStreamlitEndpoints` when needed
---

### Bundle Analysis:
**Before** (left): 2.36 MB & **After** (right): 2.16 MB
<img width="325" alt="Screenshot 2025-11-28 at 1 40 46 a m" src="https://github.com/user-attachments/assets/a9c16194-b0be-43ba-a659-ed0f69d8fc93" />   <img width="315" alt="after" src="https://github.com/user-attachments/assets/e740fe2d-e616-4690-b37a-05a3e8e06111" />
