### PR TITLE
Fix query parameters not preserved on back navigation

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -439,6 +439,32 @@ def test_removes_non_embed_query_params_when_swapping_pages(app: Page, app_port:
     )
 
 
+def test_preserves_query_params_on_browser_back_navigation(app: Page, app_port: int):
+    """Test that query params are preserved on first script run after browser back button.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/9279
+    """
+    # Navigate to main page with query params
+    goto_app(app, f"http://localhost:{app_port}/?mykey=myvalue")
+    expect(app).to_have_url(f"http://localhost:{app_port}/?mykey=myvalue")
+
+    # Verify query params are displayed
+    expect_prefixed_markdown(app, "Query Params:", "{'mykey': 'myvalue'}")
+
+    # Navigate to another page via sidebar (this clears query params)
+    get_page_link(app, "page 4").click()
+    wait_for_app_loaded(app)
+    expect(app).to_have_url(f"http://localhost:{app_port}/page_4")
+
+    # Use browser back button to return to main page with query params
+    app.go_back()
+    wait_for_app_loaded(app)
+
+    # Verify query params are preserved on the first script run after back navigation
+    expect(app).to_have_url(f"http://localhost:{app_port}/?mykey=myvalue")
+    expect_prefixed_markdown(app, "Query Params:", "{'mykey': 'myvalue'}")
+
+
 def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that logos display properly in sidebar and main sections."""
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1580,6 +1580,52 @@ describe("App", () => {
           .pageScriptHash
       ).toBe("top_hash")
     })
+
+    it("preserves query params from URL on first script run after browser back button", async () => {
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", {
+        ...CURRENT_NEW_SESSION_JSON,
+        pageScriptHash: "top_hash",
+      })
+      sendForwardMessage("navigation", {
+        ...THIS_NAVIGATION_JSON,
+        pageScriptHash: "top_hash",
+      })
+
+      const connectionManager = getMockConnectionManager()
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      // Navigate to page2
+      sendForwardMessage("newSession", {
+        ...CURRENT_NEW_SESSION_JSON,
+        pageScriptHash: "sub_hash",
+      })
+      sendForwardMessage("navigation", {
+        ...THIS_NAVIGATION_JSON,
+        pageScriptHash: "sub_hash",
+      })
+
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      // Simulate user clicking browser back button to main page with query params.
+      // In a real browser, the URL would be restored to include query params.
+      // In JSDOM, we need to manually set the URL before triggering popstate.
+      window.history.pushState({}, "", "/?mykey=myvalue")
+      window.dispatchEvent(new PopStateEvent("popstate"))
+
+      await waitFor(() => {
+        expect(connectionManager.sendMessage).toBeCalledTimes(1)
+      })
+
+      // Verify the query params from the URL are preserved in the rerun message
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
+      ).toBe("mykey=myvalue")
+    })
   })
 
   describe("App.handlePageConfigChanged", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1316,7 +1316,11 @@ export class App extends PureComponent<Props, State> {
     if (isNullOrUndefined(targetAppPage) || (hasAnchor && isSamePage)) {
       return
     }
-    this.onPageChange(targetAppPage.pageScriptHash as string)
+    // Pass preserveQueryParams=true to preserve query params from the URL when
+    // navigating via browser history (back/forward buttons). This ensures that
+    // query params present in the URL after history navigation are sent to the
+    // server on the first script run.
+    this.onPageChange(targetAppPage.pageScriptHash as string, true)
   }
 
   /**
@@ -1670,7 +1674,10 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  onPageChange = (pageScriptHash: string): void => {
+  onPageChange = (
+    pageScriptHash: string,
+    preserveQueryParams?: boolean
+  ): void => {
     const { elements, mainScriptHash } = this.state
 
     // We are about to change the page, so clear all auto reruns
@@ -1694,7 +1701,9 @@ export class App extends PureComponent<Props, State> {
     this.sendRerunBackMsg(
       this.widgetMgr.getActiveWidgetStates(activeWidgetIds),
       undefined,
-      pageScriptHash
+      pageScriptHash,
+      undefined,
+      preserveQueryParams
     )
   }
 
@@ -1711,7 +1720,8 @@ export class App extends PureComponent<Props, State> {
     widgetStates?: WidgetStates,
     fragmentId?: string,
     pageScriptHash?: string,
-    isAutoRerun?: boolean
+    isAutoRerun?: boolean,
+    preserveQueryParams?: boolean
   ): void => {
     const baseUriParts = this.getBaseUriParts()
     if (!baseUriParts) {
@@ -1739,9 +1749,11 @@ export class App extends PureComponent<Props, State> {
     if (pageScriptHash) {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
-      if (pageScriptHash != currentPageScriptHash) {
+      if (pageScriptHash != currentPageScriptHash && !preserveQueryParams) {
         // Clear non-embed query parameters within a page change while we wait
         // for the server to send updated query params (if any).
+        // Skip clearing if preserveQueryParams is true (e.g., browser back/forward
+        // navigation where query params from the URL should be preserved).
         const preservedQueryParams = preserveEmbedQueryParams()
         queryString = preservedQueryParams
         this.setState({ queryParams: preservedQueryParams })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -363,7 +363,7 @@ export class App extends PureComponent<Props, State> {
         this.setState({ inputsDisabled })
       },
       themeChanged: this.handleThemeMessage,
-      pageChanged: this.onPageChange,
+      pageChanged: pageScriptHash => this.onPageChange(pageScriptHash),
       isOwnerChanged: isOwner => this.setState({ isOwner }),
       fileUploadClientConfigChanged: config => {
         if (this.endpoints.setFileUploadClientConfig !== undefined) {
@@ -1749,7 +1749,7 @@ export class App extends PureComponent<Props, State> {
     if (pageScriptHash) {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
-      if (pageScriptHash != currentPageScriptHash && !preserveQueryParams) {
+      if (pageScriptHash !== currentPageScriptHash && !preserveQueryParams) {
         // Clear non-embed query parameters within a page change while we wait
         // for the server to send updated query params (if any).
         // Skip clearing if preserveQueryParams is true (e.g., browser back/forward


### PR DESCRIPTION
## Describe your changes

Fixes an issue where query parameters don't get synced correctly on browser back navigation. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9279

## Testing Plan

- Added unit & e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
