### PR TITLE
Enable better file uploading on Android

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3005,7 +3005,10 @@ describe("App", () => {
       )
     })
 
-    it("processes queued requests after session info is restored via handleNewSession", () => {
+    it("does not process queued requests when connected but session info is not set yet", () => {
+      // This tests the race condition where WebSocket connects before
+      // handleNewSession is received. The queue should NOT be processed
+      // until session info is available.
       renderApp(getProps())
 
       const fileUploadClient =
@@ -3022,8 +3025,6 @@ describe("App", () => {
       expect(connectionManager.sendMessage).not.toBeCalled()
 
       // Connection is re-established but session info is NOT set yet
-      // This simulates the race condition where connection comes up
-      // before handleNewSession is received
       getMockConnectionManager(true)
 
       act(() => {
@@ -3032,8 +3033,41 @@ describe("App", () => {
         )
       })
 
-      // File URL request should NOT be sent yet because session info is not set
-      // (though other messages like rerunScript may be sent)
+      // File URL request should NOT be sent because session info is missing.
+      // processPendingFileURLRequests should return early without processing.
+      expect(connectionManager.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileUrlsRequest: expect.anything(),
+        })
+      )
+    })
+
+    it("processes queued requests after session info is restored via handleNewSession", () => {
+      // This tests that requests queued while disconnected are eventually
+      // processed once both connection AND session info are available.
+      renderApp(getProps())
+
+      const fileUploadClient =
+        getStoredValue<FileUploadClient>(FileUploadClient)
+
+      // Queue a request while disconnected (no session info set)
+      // @ts-expect-error - requestFileURLs is private
+      fileUploadClient.requestFileURLs("myRequestId", [
+        new File([""], "file1.txt"),
+      ])
+
+      const connectionManager = getMockConnectionManager()
+
+      // Connection is re-established but session info is NOT set yet
+      getMockConnectionManager(true)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // Request not sent yet (session info missing)
       expect(connectionManager.sendMessage).not.toHaveBeenCalledWith(
         expect.objectContaining({
           fileUrlsRequest: expect.anything(),
@@ -3041,7 +3075,7 @@ describe("App", () => {
       )
 
       // Now simulate receiving handleNewSession which sets session info
-      // This should trigger processPendingFileURLRequests again
+      // This triggers processPendingFileURLRequests from handleInitialization
       sendForwardMessage("newSession", NEW_SESSION_JSON)
 
       // Now the queued request should be sent

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3004,6 +3004,56 @@ describe("App", () => {
         })
       )
     })
+
+    it("processes queued requests after session info is restored via handleNewSession", () => {
+      renderApp(getProps())
+
+      const fileUploadClient =
+        getStoredValue<FileUploadClient>(FileUploadClient)
+
+      // Queue a request while disconnected (no session info set)
+      // @ts-expect-error - requestFileURLs is private
+      fileUploadClient.requestFileURLs("myRequestId", [
+        new File([""], "file1.txt"),
+      ])
+
+      // No message sent yet
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.sendMessage).not.toBeCalled()
+
+      // Connection is re-established but session info is NOT set yet
+      // This simulates the race condition where connection comes up
+      // before handleNewSession is received
+      getMockConnectionManager(true)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // File URL request should NOT be sent yet because session info is not set
+      // (though other messages like rerunScript may be sent)
+      expect(connectionManager.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileUrlsRequest: expect.anything(),
+        })
+      )
+
+      // Now simulate receiving handleNewSession which sets session info
+      // This should trigger processPendingFileURLRequests again
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // Now the queued request should be sent
+      expect(connectionManager.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileUrlsRequest: expect.objectContaining({
+            requestId: "myRequestId",
+            fileNames: ["file1.txt"],
+          }),
+        })
+      )
+    })
   })
 
   describe("Test Main Menu shortcut functionality", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2945,7 +2945,7 @@ describe("App", () => {
       })
     })
 
-    it("does nothing if server is disconnected", () => {
+    it("queues requests when server is disconnected", () => {
       renderApp(getProps())
 
       const fileUploadClient =
@@ -2960,7 +2960,49 @@ describe("App", () => {
 
       const connectionManager = getMockConnectionManager()
 
+      // No message sent when disconnected
       expect(connectionManager.sendMessage).not.toBeCalled()
+    })
+
+    it("processes queued requests when connection is re-established", () => {
+      renderApp(getProps())
+
+      const fileUploadClient =
+        getStoredValue<FileUploadClient>(FileUploadClient)
+
+      // Queue a request while disconnected
+      // @ts-expect-error - requestFileURLs is private
+      fileUploadClient.requestFileURLs("myRequestId", [
+        new File([""], "file1.txt"),
+        new File([""], "file2.txt"),
+      ])
+
+      // No message sent yet
+      const connectionManager = getMockConnectionManager()
+      expect(connectionManager.sendMessage).not.toBeCalled()
+
+      // Set up session info
+      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+      sessionInfo.setCurrent(mockSessionInfoProps())
+
+      // Mock connection as connected and simulate connection state change
+      getMockConnectionManager(true)
+
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // The queued request should now be sent
+      expect(connectionManager.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileUrlsRequest: expect.objectContaining({
+            requestId: "myRequestId",
+            fileNames: ["file1.txt", "file2.txt"],
+          }),
+        })
+      )
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2945,11 +2945,20 @@ describe("App", () => {
       })
     })
 
-    it("queues requests when server is disconnected", () => {
+    it("rejects with error when server is disconnected", () => {
+      // When disconnected, file upload requests should be rejected immediately
+      // with an error. We can't queue and retry because reconnection triggers
+      // a script rerun, which remounts the FileUploader component and
+      // invalidates the promise callback.
       renderApp(getProps())
 
       const fileUploadClient =
         getStoredValue<FileUploadClient>(FileUploadClient)
+
+      const onFileURLsResponseSpy = vi.spyOn(
+        fileUploadClient,
+        "onFileURLsResponse"
+      )
 
       // @ts-expect-error - requestFileURLs is private
       fileUploadClient.requestFileURLs("myRequestId", [
@@ -2962,131 +2971,13 @@ describe("App", () => {
 
       // No message sent when disconnected
       expect(connectionManager.sendMessage).not.toBeCalled()
-    })
 
-    it("processes queued requests when connection is re-established", () => {
-      renderApp(getProps())
-
-      const fileUploadClient =
-        getStoredValue<FileUploadClient>(FileUploadClient)
-
-      // Queue a request while disconnected
-      // @ts-expect-error - requestFileURLs is private
-      fileUploadClient.requestFileURLs("myRequestId", [
-        new File([""], "file1.txt"),
-        new File([""], "file2.txt"),
-      ])
-
-      // No message sent yet
-      const connectionManager = getMockConnectionManager()
-      expect(connectionManager.sendMessage).not.toBeCalled()
-
-      // Set up session info
-      const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
-      sessionInfo.setCurrent(mockSessionInfoProps())
-
-      // Mock connection as connected and simulate connection state change
-      getMockConnectionManager(true)
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
+      // Error response should be sent to reject the pending promise
+      expect(onFileURLsResponseSpy).toHaveBeenCalledWith({
+        responseId: "myRequestId",
+        errorMsg:
+          "Connection lost. Please wait for the app to reconnect, then try again.",
       })
-
-      // The queued request should now be sent
-      expect(connectionManager.sendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileUrlsRequest: expect.objectContaining({
-            requestId: "myRequestId",
-            fileNames: ["file1.txt", "file2.txt"],
-          }),
-        })
-      )
-    })
-
-    it("does not process queued requests when connected but session info is not set yet", () => {
-      // This tests the race condition where WebSocket connects before
-      // handleNewSession is received. The queue should NOT be processed
-      // until session info is available.
-      renderApp(getProps())
-
-      const fileUploadClient =
-        getStoredValue<FileUploadClient>(FileUploadClient)
-
-      // Queue a request while disconnected (no session info set)
-      // @ts-expect-error - requestFileURLs is private
-      fileUploadClient.requestFileURLs("myRequestId", [
-        new File([""], "file1.txt"),
-      ])
-
-      // No message sent yet
-      const connectionManager = getMockConnectionManager()
-      expect(connectionManager.sendMessage).not.toBeCalled()
-
-      // Connection is re-established but session info is NOT set yet
-      getMockConnectionManager(true)
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-
-      // File URL request should NOT be sent because session info is missing.
-      // processPendingFileURLRequests should return early without processing.
-      expect(connectionManager.sendMessage).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileUrlsRequest: expect.anything(),
-        })
-      )
-    })
-
-    it("processes queued requests after session info is restored via handleNewSession", () => {
-      // This tests that requests queued while disconnected are eventually
-      // processed once both connection AND session info are available.
-      renderApp(getProps())
-
-      const fileUploadClient =
-        getStoredValue<FileUploadClient>(FileUploadClient)
-
-      // Queue a request while disconnected (no session info set)
-      // @ts-expect-error - requestFileURLs is private
-      fileUploadClient.requestFileURLs("myRequestId", [
-        new File([""], "file1.txt"),
-      ])
-
-      const connectionManager = getMockConnectionManager()
-
-      // Connection is re-established but session info is NOT set yet
-      getMockConnectionManager(true)
-
-      act(() => {
-        getMockConnectionManagerProp("connectionStateChanged")(
-          ConnectionState.CONNECTED
-        )
-      })
-
-      // Request not sent yet (session info missing)
-      expect(connectionManager.sendMessage).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileUrlsRequest: expect.anything(),
-        })
-      )
-
-      // Now simulate receiving handleNewSession which sets session info
-      // This triggers processPendingFileURLRequests from handleInitialization
-      sendForwardMessage("newSession", NEW_SESSION_JSON)
-
-      // Now the queued request should be sent
-      expect(connectionManager.sendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileUrlsRequest: expect.objectContaining({
-            requestId: "myRequestId",
-            fileNames: ["file1.txt"],
-          }),
-        })
-      )
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -264,14 +264,6 @@ export class App extends PureComponent<Props, State> {
 
   private isInitializingConnectionManager: boolean = true
 
-  // Queue for pending file URL requests when disconnected.
-  // This handles the case where users select files on mobile browsers while
-  // the WebSocket connection has timed out (e.g., file picker was open too long).
-  private pendingFileURLRequests: Array<{
-    requestId: string
-    files: File[]
-  }> = []
-
   // Whether we have received a NewSession message after the latest rerun request.
   // This is used to ensure that we only increment the message cache run count after
   // we have received a NewSession message after the latest rerun request.
@@ -795,11 +787,6 @@ export class App extends PureComponent<Props, State> {
       this.hostCommunicationMgr.sendMessageToHost({
         type: "WEBSOCKET_CONNECTED",
       })
-
-      // Process any queued file URL requests that were made while disconnected.
-      // This handles the case where users select files on mobile browsers while
-      // the WebSocket connection had timed out.
-      this.processPendingFileURLRequests()
     } else {
       // If we're starting from the CONNECTED state and going to any other
       // state, we must be disconnecting.
@@ -1301,12 +1288,6 @@ export class App extends PureComponent<Props, State> {
     this.sessionInfo.setCurrent(
       SessionInfo.propsFromNewSessionMessage(newSessionProto)
     )
-
-    // Process any queued file URL requests now that session info is available.
-    // This handles the case where the connection was re-established but
-    // session info wasn't yet set when processPendingFileURLRequests was
-    // first called from handleConnectionStateChanged.
-    this.processPendingFileURLRequests()
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Fix this
     this.metricsMgr.initialize({
@@ -2095,44 +2076,21 @@ export class App extends PureComponent<Props, State> {
       backMsg.type = "fileUrlsRequest"
       this.sendBackMsg(backMsg)
     } else {
-      // Queue the request to be sent when the connection is re-established.
-      // This handles the case where users select files on mobile browsers while
-      // the WebSocket connection has timed out (e.g., file picker was open too long).
-      LOG.info(
-        `Queueing file URL request (isServerConnected: ${isConnected}, isSessionInfoSet: ${isSessionInfoSet})`
+      // Reject the request immediately with an error. This can happen on mobile
+      // browsers when the file picker is open for an extended period causing
+      // the WebSocket connection to time out.
+      //
+      // We can't queue and retry because reconnection triggers a script rerun,
+      // which remounts the FileUploader component and invalidates the promise
+      // callback. The user needs to re-select the file after reconnection.
+      LOG.warn(
+        `Cannot request file URLs (isServerConnected: ${isConnected}, isSessionInfoSet: ${isSessionInfoSet})`
       )
-      this.pendingFileURLRequests.push({ requestId, files })
-    }
-  }
-
-  /**
-   * Process any queued file URL requests that were made while disconnected.
-   * Called when the WebSocket connection is re-established and session info
-   * is available.
-   */
-  processPendingFileURLRequests = (): void => {
-    if (this.pendingFileURLRequests.length === 0) {
-      return
-    }
-
-    // Don't process if connection or session info isn't ready yet.
-    // This method will be called again from handleInitialization once
-    // session info is available.
-    if (!this.isServerConnected() || !this.sessionInfo.isSet) {
-      return
-    }
-
-    LOG.info(
-      `Processing ${this.pendingFileURLRequests.length} pending file URL request(s)`
-    )
-
-    // Process all pending requests
-    const pendingRequests = [...this.pendingFileURLRequests]
-    this.pendingFileURLRequests = []
-
-    for (const { requestId, files } of pendingRequests) {
-      // Re-invoke requestFileURLs now that we're connected
-      this.requestFileURLs(requestId, files)
+      this.uploadClient.onFileURLsResponse({
+        responseId: requestId,
+        errorMsg:
+          "Connection lost. Please wait for the app to reconnect, then try again.",
+      })
     }
   }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1302,6 +1302,12 @@ export class App extends PureComponent<Props, State> {
       SessionInfo.propsFromNewSessionMessage(newSessionProto)
     )
 
+    // Process any queued file URL requests now that session info is available.
+    // This handles the case where the connection was re-established but
+    // session info wasn't yet set when processPendingFileURLRequests was
+    // first called from handleConnectionStateChanged.
+    this.processPendingFileURLRequests()
+
     // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Fix this
     this.metricsMgr.initialize({
       gatherUsageStats: config.gatherUsageStats,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -264,6 +264,14 @@ export class App extends PureComponent<Props, State> {
 
   private isInitializingConnectionManager: boolean = true
 
+  // Queue for pending file URL requests when disconnected.
+  // This handles the case where users select files on mobile browsers while
+  // the WebSocket connection has timed out (e.g., file picker was open too long).
+  private pendingFileURLRequests: Array<{
+    requestId: string
+    files: File[]
+  }> = []
+
   // Whether we have received a NewSession message after the latest rerun request.
   // This is used to ensure that we only increment the message cache run count after
   // we have received a NewSession message after the latest rerun request.
@@ -787,6 +795,11 @@ export class App extends PureComponent<Props, State> {
       this.hostCommunicationMgr.sendMessageToHost({
         type: "WEBSOCKET_CONNECTED",
       })
+
+      // Process any queued file URL requests that were made while disconnected.
+      // This handles the case where users select files on mobile browsers while
+      // the WebSocket connection had timed out.
+      this.processPendingFileURLRequests()
     } else {
       // If we're starting from the CONNECTED state and going to any other
       // state, we must be disconnecting.
@@ -2076,9 +2089,36 @@ export class App extends PureComponent<Props, State> {
       backMsg.type = "fileUrlsRequest"
       this.sendBackMsg(backMsg)
     } else {
-      LOG.warn(
-        `Cannot request file URLs (isServerConnected: ${isConnected}, isSessionInfoSet: ${isSessionInfoSet})`
+      // Queue the request to be sent when the connection is re-established.
+      // This handles the case where users select files on mobile browsers while
+      // the WebSocket connection has timed out (e.g., file picker was open too long).
+      LOG.info(
+        `Queueing file URL request (isServerConnected: ${isConnected}, isSessionInfoSet: ${isSessionInfoSet})`
       )
+      this.pendingFileURLRequests.push({ requestId, files })
+    }
+  }
+
+  /**
+   * Process any queued file URL requests that were made while disconnected.
+   * Called when the WebSocket connection is re-established.
+   */
+  processPendingFileURLRequests = (): void => {
+    if (this.pendingFileURLRequests.length === 0) {
+      return
+    }
+
+    LOG.info(
+      `Processing ${this.pendingFileURLRequests.length} pending file URL request(s)`
+    )
+
+    // Process all pending requests
+    const pendingRequests = [...this.pendingFileURLRequests]
+    this.pendingFileURLRequests = []
+
+    for (const { requestId, files } of pendingRequests) {
+      // Re-invoke requestFileURLs now that we're connected
+      this.requestFileURLs(requestId, files)
     }
   }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2107,10 +2107,18 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Process any queued file URL requests that were made while disconnected.
-   * Called when the WebSocket connection is re-established.
+   * Called when the WebSocket connection is re-established and session info
+   * is available.
    */
   processPendingFileURLRequests = (): void => {
     if (this.pendingFileURLRequests.length === 0) {
+      return
+    }
+
+    // Don't process if connection or session info isn't ready yet.
+    // This method will be called again from handleInitialization once
+    // session info is available.
+    if (!this.isServerConnected() || !this.sessionInfo.isSet) {
       return
     }
 

--- a/frontend/connection/src/constants.ts
+++ b/frontend/connection/src/constants.ts
@@ -48,9 +48,25 @@ export const PING_MAXIMUM_RETRY_PERIOD_MS = 2000
 export const MAX_RETRIES_BEFORE_CLIENT_ERROR = 6
 
 /**
- * Timeout when attempting to connect to a websocket, in millis.
+ * Detect if we're on an Android device. This is used to adjust timeouts
+ * for Android Chrome where file pickers can keep the app backgrounded
+ * for extended periods.
  */
-export const WEBSOCKET_TIMEOUT_MS = 15 * 1000
+const isAndroidDevice = (): boolean => {
+  if (typeof navigator === "undefined") {
+    return false
+  }
+  return /Android/i.test(navigator.userAgent)
+}
+
+/**
+ * Timeout when attempting to connect to a websocket, in millis.
+ * Android devices get a longer timeout (60s vs 15s) because file pickers
+ * background the browser tab for extended periods, causing premature
+ * connection timeouts.
+ * See: https://github.com/streamlit/streamlit/issues/11419
+ */
+export const WEBSOCKET_TIMEOUT_MS = isAndroidDevice() ? 60 * 1000 : 15 * 1000
 
 /**
  * Ping timeout in millis.


### PR DESCRIPTION
## Describe your changes

Use a higher websocket timeout on Android and better error message to improve file uploading on Android. Currently, this doesn't work if the user needs more than 15 seconds to choose a file since the websocket connection disconnects.

From my research, a proper fix for this would be quite complicate.

I manually verified on Android that this change works and makes it a lot more convenient to choose files.

## GitHub Issue Link (if applicable)

- Improves https://github.com/streamlit/streamlit/issues/11419 (allows us to move this from P2 -> P3)

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
