### PR TITLE
Extract unsupported directive cleanup into separate plugin

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -630,9 +630,23 @@ function createRemarkColoringAndSmall(
         }
         return
       }
+    })
+    return tree
+  }
+}
 
-      // Handle unsupported directives
-      // We convert unsupported text directives to plain text to avoid them being
+/**
+ * Factory function to create the unsupported directives cleanup plugin.
+ * This plugin should run last to convert any unsupported text directives
+ * to plain text, ensuring they are rendered rather than ignored.
+ */
+function createRemarkUnsupportedDirectivesCleanup() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+  return () => (tree: any) => {
+    visit(tree, "textDirective", (node, _index, _parent) => {
+      const nodeName = String(node.name)
+
+      // Convert unsupported text directives to plain text to avoid them being
       // ignored / not rendered. See https://github.com/streamlit/streamlit/issues/8726,
       // https://github.com/streamlit/streamlit/issues/5968
       // Don't convert if the directive was already handled by another plugin
@@ -949,6 +963,9 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     if (emojiPlugin) {
       plugins.push(emojiPlugin)
     }
+
+    // This plugin must run last to clean up any unsupported directives
+    plugins.push(createRemarkUnsupportedDirectivesCleanup())
 
     return plugins
   }, [theme, colorMapping, emojiPlugin])

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -640,7 +640,8 @@ function createRemarkColoringAndSmall(
  * This plugin should run last to convert any unsupported text directives
  * to plain text, ensuring they are rendered rather than ignored.
  */
-function createRemarkUnsupportedDirectivesCleanup() {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+function createRemarkUnsupportedDirectivesCleanup(): () => (tree: any) => any {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   return () => (tree: any) => {
     visit(tree, "textDirective", (node, _index, _parent) => {


### PR DESCRIPTION
## Summary

Refactors markdown directive handling to improve code organization.

## Changes

- Extracted unsupported directive cleanup logic from `createRemarkColoringAndSmall()` into dedicated `createRemarkUnsupportedDirectivesCleanup()` function
- Plugin now runs last in the pipeline to ensure it only catches directives not handled by other plugins

## Rationale

The cleanup logic for unsupported directives is a general fallback mechanism, not specific to color/small directives. Separating it makes the code more maintainable and clarifies plugin execution order.

## Testing Plan

- **No additional tests needed** - Pure refactoring with no behavior change
- **Unit Tests (JS):** Covered by existing test `"does not remove unknown directive"` in `StreamlitMarkdown.test.tsx`
