### PR TITLE
Deprecate kwargs support for `st.vega_lite_chart`

### DIFF
--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -113,7 +113,7 @@ def test_use_column_width_parameter(app: Page, assert_snapshot: ImageCompareFunc
 
     expect(app.get_by_test_id("stMainBlockContainer")).to_contain_text(
         "The use_column_width parameter has been deprecated and will be removed in a "
-        "future release. Please utilize the use_container_width parameter instead."
+        "future release. Please utilize the width parameter instead."
     )
 
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -171,7 +171,7 @@ class ImageMixin:
 
             show_deprecation_warning(
                 "The `use_column_width` parameter has been deprecated and will be removed "
-                "in a future release. Please utilize the `use_container_width` parameter instead."
+                "in a future release. Please utilize the `width` parameter instead."
             )
             if use_column_width in {"auto", "never"} or use_column_width is False:
                 width = "content"

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -2133,6 +2133,14 @@ class VegaChartsMixin:
         translated to the syntax shown above.
 
         """
+        if kwargs:
+            show_deprecation_warning(
+                "Variable keyword arguments for `st.vega_lite_chart` have been "
+                "deprecated and will be removed in a future release. Use the "
+                "`spec` argument instead to specify Vega-Lite configuration "
+                "options."
+            )
+
         return self._vega_lite_chart(
             data=data,
             spec=spec,

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -1002,6 +1002,24 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
             },
         )
 
+    @patch("streamlit.elements.vega_charts.show_deprecation_warning")
+    def test_kwargs_deprecation_warning(self, mock_warning: Mock):
+        """Test that passing kwargs shows a deprecation warning."""
+        st.vega_lite_chart(df1, x="foo", boink_boop=100)
+
+        mock_warning.assert_called_once()
+        warning_message = mock_warning.call_args[0][0]
+        assert "Variable keyword arguments" in warning_message
+        assert "deprecated" in warning_message
+        assert "spec" in warning_message
+
+    @patch("streamlit.elements.vega_charts.show_deprecation_warning")
+    def test_no_kwargs_no_deprecation_warning(self, mock_warning: Mock):
+        """Test that not passing kwargs does not show a deprecation warning."""
+        st.vega_lite_chart(df1, {"mark": "rect"})
+
+        mock_warning.assert_not_called()
+
     def test_pyarrow_table_data(self):
         """Test that you can pass pyarrow.Table as data."""
         table = pa.Table.from_pandas(df1)


### PR DESCRIPTION
## Describe your changes

Deprecates the *kwargs support in `st.vega_lite_chart`. The `spec` parameter should be used instead for passing spec configuration.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
