### PR TITLE
`StreamlitMarkdown` - module level plugin cache

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -82,6 +82,7 @@ import {
   type RawPlugin,
   useLazyPlugin,
   wrapRehypePlugin,
+  wrapRemarkPlugin,
 } from "./utils"
 
 const StreamlitSyntaxHighlighter = lazy(
@@ -879,7 +880,8 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     ]
 
     if (needsEmoji && isLoadedPlugin(emojiPlugin)) {
-      plugins.push(emojiPlugin)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unified's Plugin type is more complex than our wrapper expects
+      plugins.push(wrapRemarkPlugin(emojiPlugin as any, "remark-emoji"))
     }
 
     return plugins

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -872,6 +872,32 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
 
   const colorMapping = useMemo(() => createColorMapping(theme), [theme])
 
+  // Wrap plugins once when they load, not on every render or when other deps change
+  const wrappedKatexPlugin = useMemo(
+    () =>
+      isLoadedPlugin(katexPlugin)
+        ? wrapRehypePlugin(katexPlugin, "rehype-katex")
+        : null,
+    [katexPlugin]
+  )
+
+  const wrappedRawPlugin = useMemo(
+    () =>
+      isLoadedPlugin(rawPlugin)
+        ? wrapRehypePlugin(rawPlugin, "rehype-raw")
+        : null,
+    [rawPlugin]
+  )
+
+  const wrappedEmojiPlugin = useMemo(
+    () =>
+      isLoadedPlugin(emojiPlugin)
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unified's Plugin type is more complex than our wrapper expects
+          wrapRemarkPlugin(emojiPlugin as any, "remark-emoji")
+        : null,
+    [emojiPlugin]
+  )
+
   const remarkPlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = [
       ...BASE_REMARK_PLUGINS,
@@ -879,23 +905,22 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       createRemarkMaterialIcons(theme),
     ]
 
-    if (needsEmoji && isLoadedPlugin(emojiPlugin)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unified's Plugin type is more complex than our wrapper expects
-      plugins.push(wrapRemarkPlugin(emojiPlugin as any, "remark-emoji"))
+    if (needsEmoji && wrappedEmojiPlugin) {
+      plugins.push(wrappedEmojiPlugin)
     }
 
     return plugins
-  }, [theme, colorMapping, needsEmoji, emojiPlugin])
+  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin])
 
   const rehypePlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = []
 
-    if (needsKatex && isLoadedPlugin(katexPlugin)) {
-      plugins.push(wrapRehypePlugin(katexPlugin, "rehype-katex"))
+    if (needsKatex && wrappedKatexPlugin) {
+      plugins.push(wrappedKatexPlugin)
     }
 
-    if (allowHTML && isLoadedPlugin(rawPlugin)) {
-      plugins.push(wrapRehypePlugin(rawPlugin, "rehype-raw"))
+    if (allowHTML && wrappedRawPlugin) {
+      plugins.push(wrappedRawPlugin)
     }
 
     // This plugin must run last to ensure the inline property is set correctly
@@ -903,7 +928,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     plugins.push(rehypeSetCodeInlineProperty)
 
     return plugins
-  }, [allowHTML, needsKatex, katexPlugin, rawPlugin])
+  }, [allowHTML, needsKatex, wrappedKatexPlugin, wrappedRawPlugin])
 
   const renderers = useMemo(
     () =>

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -25,9 +25,7 @@ import React, {
   Suspense,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react"
 
@@ -73,25 +71,22 @@ import {
   StyledPreWrapper,
   StyledStreamlitMarkdown,
 } from "./styled-components"
+import {
+  type EmojiPlugin,
+  isLoadedPlugin,
+  type KatexPlugin,
+  loadKatexPlugin,
+  loadKatexStyles,
+  loadRehypeRaw,
+  loadRemarkEmoji,
+  type RawPlugin,
+  useLazyPlugin,
+  wrapRehypePlugin,
+} from "./utils"
 
 const StreamlitSyntaxHighlighter = lazy(
   () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
 )
-
-// Lazy load katex dependencies
-const loadKatexPlugin = (): Promise<typeof import("rehype-katex")> =>
-  import("rehype-katex")
-const loadKatexStyles = once((): void => {
-  void import("katex/dist/katex.min.css")
-})
-
-// Lazy load rehype-raw (pulls in parse5)
-const loadRehypeRaw = (): Promise<typeof import("rehype-raw")> =>
-  import("rehype-raw")
-
-// Lazy load remark-emoji (pulls in node-emoji and @sindresorhus/is)
-const loadRemarkEmoji = (): Promise<typeof import("remark-emoji")> =>
-  import("remark-emoji")
 
 /**
  * Heuristic to determine if the markdown source contains emoji shortcodes that require remark-emoji.
@@ -847,94 +842,32 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   disableLinks,
 }: Readonly<RenderedMarkdownProps>): ReactElement {
   const theme = useEmotionTheme()
-  type KatexPlugin = Awaited<ReturnType<typeof loadKatexPlugin>>["default"]
-  type RawPlugin = Awaited<ReturnType<typeof loadRehypeRaw>>["default"]
-  type EmojiPlugin = Awaited<ReturnType<typeof loadRemarkEmoji>>["default"]
-  const [katexPlugin, setKatexPlugin] = useState<KatexPlugin | null>(null)
-  const isLoadingKatexRef = useRef(false)
-  const [rawPlugin, setRawPlugin] = useState<RawPlugin | null>(null)
-  const isLoadingRawRef = useRef(false)
-  const [emojiPlugin, setEmojiPlugin] = useState<EmojiPlugin | null>(null)
-  const isLoadingEmojiRef = useRef(false)
 
   const needsKatex = useMemo(() => containsMathSyntax(source), [source])
   const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source])
 
-  // Load katex plugin when needed
-  useEffect(() => {
-    let isMounted = true
+  // Lazy load plugins only when needed
+  const katexPlugin = useLazyPlugin<KatexPlugin>({
+    key: "katex",
+    needed: needsKatex,
+    load: loadKatexPlugin,
+    pluginName: "rehype-katex",
+    onBeforeLoad: loadKatexStyles,
+  })
 
-    if (needsKatex && !katexPlugin && !isLoadingKatexRef.current) {
-      isLoadingKatexRef.current = true
-      loadKatexStyles()
-      void loadKatexPlugin()
-        .then(module => {
-          if (isMounted) {
-            setKatexPlugin(() => module.default)
-          }
-        })
-        .catch(() => {
-          // Silently fail - math will render as plain text
-        })
-        .finally(() => {
-          isLoadingKatexRef.current = false
-        })
-    }
+  const rawPlugin = useLazyPlugin<RawPlugin>({
+    key: "raw",
+    needed: allowHTML,
+    load: loadRehypeRaw,
+    pluginName: "rehype-raw",
+  })
 
-    return () => {
-      isMounted = false
-    }
-  }, [needsKatex, katexPlugin])
-
-  // Load rehype-raw plugin when HTML is allowed
-  useEffect(() => {
-    let isMounted = true
-
-    if (allowHTML && !rawPlugin && !isLoadingRawRef.current) {
-      isLoadingRawRef.current = true
-      void loadRehypeRaw()
-        .then(module => {
-          if (isMounted) {
-            setRawPlugin(() => module.default)
-          }
-        })
-        .catch(() => {
-          // Silently fail - HTML will be escaped
-        })
-        .finally(() => {
-          isLoadingRawRef.current = false
-        })
-    }
-
-    return () => {
-      isMounted = false
-    }
-  }, [allowHTML, rawPlugin])
-
-  // Load remark-emoji plugin when emoji shortcodes are detected
-  useEffect(() => {
-    let isMounted = true
-
-    if (needsEmoji && !emojiPlugin && !isLoadingEmojiRef.current) {
-      isLoadingEmojiRef.current = true
-      void loadRemarkEmoji()
-        .then(module => {
-          if (isMounted) {
-            setEmojiPlugin(() => module.default)
-          }
-        })
-        .catch(() => {
-          // Silently fail - emoji shortcodes will render as plain text
-        })
-        .finally(() => {
-          isLoadingEmojiRef.current = false
-        })
-    }
-
-    return () => {
-      isMounted = false
-    }
-  }, [needsEmoji, emojiPlugin])
+  const emojiPlugin = useLazyPlugin<EmojiPlugin>({
+    key: "emoji",
+    needed: needsEmoji,
+    load: loadRemarkEmoji,
+    pluginName: "remark-emoji",
+  })
 
   const colorMapping = useMemo(() => createColorMapping(theme), [theme])
 
@@ -945,25 +878,22 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       createRemarkMaterialIcons(theme),
     ]
 
-    // Only add emoji plugin if it's loaded (lazy-loaded when emoji shortcodes detected)
-    if (emojiPlugin) {
+    if (needsEmoji && isLoadedPlugin(emojiPlugin)) {
       plugins.push(emojiPlugin)
     }
 
     return plugins
-  }, [theme, colorMapping, emojiPlugin])
+  }, [theme, colorMapping, needsEmoji, emojiPlugin])
 
   const rehypePlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = []
 
-    // Only add katex plugin if it's loaded
-    if (katexPlugin) {
-      plugins.push(katexPlugin)
+    if (needsKatex && isLoadedPlugin(katexPlugin)) {
+      plugins.push(wrapRehypePlugin(katexPlugin, "rehype-katex"))
     }
 
-    // Only add raw plugin if it's loaded and HTML is allowed
-    if (allowHTML && rawPlugin) {
-      plugins.push(rawPlugin)
+    if (allowHTML && isLoadedPlugin(rawPlugin)) {
+      plugins.push(wrapRehypePlugin(rawPlugin, "rehype-raw"))
     }
 
     // This plugin must run last to ensure the inline property is set correctly
@@ -971,7 +901,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     plugins.push(rehypeSetCodeInlineProperty)
 
     return plugins
-  }, [allowHTML, katexPlugin, rawPlugin])
+  }, [allowHTML, needsKatex, katexPlugin, rawPlugin])
 
   const renderers = useMemo(
     () =>
@@ -993,12 +923,14 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     return disableLinks ? LINKS_DISALLOWED_ELEMENTS : LABEL_DISALLOWED_ELEMENTS
   }, [isLabel, disableLinks])
 
-  // Show skeleton while dependencies are loading
-  if (
-    (needsKatex && !katexPlugin) ||
-    (allowHTML && !rawPlugin) ||
-    (needsEmoji && !emojiPlugin)
-  ) {
+  // Show skeleton while required plugins are still loading
+  // A plugin is "loading" if it's needed but state is still null (not loaded, not failed)
+  const isLoadingPlugins =
+    (needsKatex && katexPlugin === null) ||
+    (allowHTML && rawPlugin === null) ||
+    (needsEmoji && emojiPlugin === null)
+
+  if (isLoadingPlugins) {
     return (
       <ErrorBoundary>
         <Skeleton

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { Root } from "hast"
+import type { VFile } from "vfile"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  _resetCacheForTesting,
+  extractPlugin,
+  isLoadedPlugin,
+  LOAD_FAILED,
+  type PluginState,
+  useLazyPlugin,
+  wrapRehypePlugin,
+} from "./utils"
+
+// Reset the module-level cache between tests to ensure isolation
+afterEach(() => {
+  _resetCacheForTesting()
+})
+
+describe("LOAD_FAILED", () => {
+  it("is a unique symbol", () => {
+    expect(typeof LOAD_FAILED).toBe("symbol")
+    expect(LOAD_FAILED.description).toBe("plugin_load_failed")
+  })
+})
+
+describe("isLoadedPlugin", () => {
+  it("returns true for a loaded plugin (function)", () => {
+    const plugin = vi.fn()
+    expect(isLoadedPlugin(plugin)).toBe(true)
+  })
+
+  it("returns true for a loaded plugin (object)", () => {
+    const plugin = { transform: vi.fn() }
+    expect(isLoadedPlugin(plugin)).toBe(true)
+  })
+
+  it("returns false for null", () => {
+    expect(isLoadedPlugin(null)).toBe(false)
+  })
+
+  it("returns false for LOAD_FAILED", () => {
+    expect(isLoadedPlugin(LOAD_FAILED)).toBe(false)
+  })
+})
+
+describe("extractPlugin", () => {
+  it("extracts a function from module.default", () => {
+    const pluginFn = vi.fn()
+    const module = { default: pluginFn }
+
+    const result = extractPlugin(module, "test-plugin")
+
+    expect(result).toBe(pluginFn)
+  })
+
+  it("extracts a function from nested default exports", () => {
+    const pluginFn = vi.fn()
+    const module = { default: { default: pluginFn } }
+
+    const result = extractPlugin(module, "test-plugin")
+
+    expect(result).toBe(pluginFn)
+  })
+
+  it("extracts a function directly from module if no default", () => {
+    const module = vi.fn()
+
+    const result = extractPlugin(
+      module as unknown as Record<string, unknown>,
+      "test-plugin"
+    )
+
+    expect(result).toBe(module)
+  })
+
+  it("returns LOAD_FAILED if no function found", () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {})
+    const module = { default: { notAFunction: "value" } }
+
+    const result = extractPlugin(module, "test-plugin")
+
+    expect(result).toBe(LOAD_FAILED)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[StreamlitMarkdown] Failed to load test-plugin plugin"
+    )
+    consoleWarnSpy.mockRestore()
+  })
+
+  it("handles circular default references", () => {
+    const pluginFn = vi.fn()
+    const module: Record<string, unknown> = { default: pluginFn }
+    // Create a scenario where default points to itself (shouldn't happen in practice)
+    // but the code handles it by checking next === current
+
+    const result = extractPlugin(module, "test-plugin")
+
+    expect(result).toBe(pluginFn)
+  })
+
+  it("limits depth to prevent infinite loops", () => {
+    // Create deeply nested defaults (more than 5 levels)
+    const pluginFn = vi.fn()
+    const module = {
+      default: {
+        default: {
+          default: {
+            default: {
+              default: {
+                default: {
+                  default: pluginFn,
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    // Should still find the function even with deep nesting (up to 5 levels)
+    const result = extractPlugin(module, "test-plugin")
+
+    // The function is at depth 7, but we only go 5 deep, so we should find
+    // an object at depth 5, not the function. However, the module itself
+    // is also added as a candidate, so it depends on the order.
+    // In practice, this tests that we don't infinite loop.
+    expect(typeof result).toBeDefined()
+  })
+})
+
+describe("wrapRehypePlugin", () => {
+  // Create properly typed mock objects matching Root and VFile types
+  const createMockTree = (): Root => ({
+    type: "root",
+    children: [],
+  })
+  const createMockFile = (): VFile => ({ path: "test.md", value: "" }) as VFile
+
+  it("wraps a plugin and calls the original transformer", () => {
+    const mockTree = createMockTree()
+    const mockFile = createMockFile()
+    const transformer = vi.fn().mockReturnValue(mockTree)
+    const plugin = vi.fn().mockReturnValue(transformer)
+
+    const wrapped = wrapRehypePlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+
+    expect(plugin).toHaveBeenCalled()
+
+    const result = wrappedTransformer(mockTree, mockFile)
+
+    expect(transformer).toHaveBeenCalledWith(mockTree, mockFile)
+    expect(result).toBe(mockTree)
+  })
+
+  it("returns undefined tree without calling transformer", () => {
+    const transformer = vi.fn()
+    const plugin = vi.fn().mockReturnValue(transformer)
+
+    const wrapped = wrapRehypePlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+    // Test undefined handling - cast needed since Root doesn't include undefined
+    const result = wrappedTransformer(
+      undefined as unknown as Root,
+      createMockFile()
+    )
+
+    expect(transformer).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it("catches errors and returns original tree", () => {
+    const mockTree = createMockTree()
+    const mockFile = createMockFile()
+    const error = new Error("Plugin crashed!")
+    const transformer = vi.fn().mockImplementation(() => {
+      throw error
+    })
+    const plugin = vi.fn().mockReturnValue(transformer)
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    const wrapped = wrapRehypePlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+    const result = wrappedTransformer(mockTree, mockFile)
+
+    expect(result).toBe(mockTree)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[StreamlitMarkdown] test-plugin crashed while transforming",
+      error
+    )
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("passes plugin options through", () => {
+    const mockTree = createMockTree()
+    const transformer = vi.fn().mockReturnValue(mockTree)
+    const plugin = vi.fn().mockReturnValue(transformer)
+    const options = { strict: true, output: "html" }
+
+    const wrapped = wrapRehypePlugin(plugin, "test-plugin")
+    wrapped(options)
+
+    expect(plugin).toHaveBeenCalledWith(options)
+  })
+})
+
+describe("useLazyPlugin", () => {
+  it("returns null initially when plugin is not needed", () => {
+    const { result } = renderHook(() =>
+      useLazyPlugin({
+        key: "katex",
+        needed: false,
+        load: vi.fn(),
+        pluginName: "test-plugin",
+      })
+    )
+
+    expect(result.current).toBeNull()
+  })
+
+  it("loads plugin when needed", async () => {
+    const mockPlugin = vi.fn()
+    const loadFn = vi.fn().mockResolvedValue({ default: mockPlugin })
+
+    const { result } = renderHook(() =>
+      useLazyPlugin({
+        key: "katex",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    // Initially null
+    expect(result.current).toBeNull()
+
+    // Wait for the plugin to load
+    await waitFor(() => {
+      expect(result.current).toBe(mockPlugin)
+    })
+
+    expect(loadFn).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onBeforeLoad before loading", async () => {
+    const mockPlugin = vi.fn()
+    const loadFn = vi.fn().mockResolvedValue({ default: mockPlugin })
+    const onBeforeLoad = vi.fn()
+
+    renderHook(() =>
+      useLazyPlugin({
+        key: "raw",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+        onBeforeLoad,
+      })
+    )
+
+    await waitFor(() => {
+      expect(onBeforeLoad).toHaveBeenCalled()
+    })
+
+    // onBeforeLoad should be called before load completes
+    expect(onBeforeLoad).toHaveBeenCalled()
+  })
+
+  it("returns LOAD_FAILED when load fails", async () => {
+    const loadFn = vi.fn().mockRejectedValue(new Error("Network error"))
+
+    const { result } = renderHook(() =>
+      useLazyPlugin({
+        key: "emoji",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBe(LOAD_FAILED)
+    })
+  })
+
+  it("does not reload when plugin is already loaded", async () => {
+    const mockPlugin = vi.fn()
+    const loadFn = vi.fn().mockResolvedValue({ default: mockPlugin })
+
+    const { result, rerender } = renderHook(
+      ({ needed }) =>
+        useLazyPlugin({
+          key: "katex",
+          needed,
+          load: loadFn,
+          pluginName: "test-plugin",
+        }),
+      { initialProps: { needed: true } }
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBe(mockPlugin)
+    })
+
+    // Rerender with same props
+    rerender({ needed: true })
+
+    // Should not call load again
+    expect(loadFn).toHaveBeenCalledTimes(1)
+  })
+
+  it("handles cleanup on unmount without errors", () => {
+    const mockPlugin = vi.fn()
+    let resolveLoad: (value: { default: typeof mockPlugin }) => void
+    const loadFn = vi.fn().mockReturnValue(
+      new Promise(resolve => {
+        resolveLoad = resolve
+      })
+    )
+
+    // Spy on console.error to detect React warnings about state updates on unmounted components
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    const { unmount } = renderHook(() =>
+      useLazyPlugin({
+        key: "emoji",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    // Unmount before load completes
+    unmount()
+
+    // Resolve the load after unmount
+    act(() => {
+      resolveLoad({ default: mockPlugin })
+    })
+
+    // The hook should have cleaned up and not caused any React warnings
+    // about updating state on an unmounted component
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("unmounted component")
+    )
+    consoleErrorSpy.mockRestore()
+  })
+})
+
+describe("PluginState type", () => {
+  it("can hold a plugin function", () => {
+    const plugin: PluginState<() => void> = vi.fn()
+    expect(typeof plugin).toBe("function")
+  })
+
+  it("can hold null", () => {
+    const plugin: PluginState<() => void> = null
+    expect(plugin).toBeNull()
+  })
+
+  it("can hold LOAD_FAILED", () => {
+    const plugin: PluginState<() => void> = LOAD_FAILED
+    expect(plugin).toBe(LOAD_FAILED)
+  })
+})

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
@@ -108,20 +108,33 @@ describe("extractPlugin", () => {
     consoleWarnSpy.mockRestore()
   })
 
-  it("handles circular default references", () => {
-    const pluginFn = vi.fn()
-    const module: Record<string, unknown> = { default: pluginFn }
-    // Create a scenario where default points to itself (shouldn't happen in practice)
-    // but the code handles it by checking next === current
+  it("handles circular default references without infinite loop", () => {
+    // Create a true circular reference where default points to itself
+    const module: Record<string, unknown> = {}
+    module.default = module
+
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {})
 
     const result = extractPlugin(module, "test-plugin")
 
-    expect(result).toBe(pluginFn)
+    // The circular reference is detected (next === current), loop breaks,
+    // but no function is found, so LOAD_FAILED is returned
+    expect(result).toBe(LOAD_FAILED)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[StreamlitMarkdown] Failed to load test-plugin plugin"
+    )
+    consoleWarnSpy.mockRestore()
   })
 
-  it("limits depth to prevent infinite loops", () => {
-    // Create deeply nested defaults (more than 5 levels)
-    const pluginFn = vi.fn()
+  it("limits depth to 5 levels to prevent deep nesting issues", () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {})
+
+    // Create deeply nested defaults (7 levels deep, beyond the 5-level limit)
+    // The function is at depth 7, unreachable within the 5-level limit
     const module = {
       default: {
         default: {
@@ -129,7 +142,7 @@ describe("extractPlugin", () => {
             default: {
               default: {
                 default: {
-                  default: pluginFn,
+                  default: vi.fn(), // depth 7 - unreachable
                 },
               },
             },
@@ -138,14 +151,36 @@ describe("extractPlugin", () => {
       },
     }
 
-    // Should still find the function even with deep nesting (up to 5 levels)
     const result = extractPlugin(module, "test-plugin")
 
-    // The function is at depth 7, but we only go 5 deep, so we should find
-    // an object at depth 5, not the function. However, the module itself
-    // is also added as a candidate, so it depends on the order.
-    // In practice, this tests that we don't infinite loop.
-    expect(typeof result).toBeDefined()
+    // We only traverse 5 levels deep, so the function at depth 7 is not found.
+    // The module itself is added as a fallback candidate but it's an object, not a function.
+    // Therefore, LOAD_FAILED should be returned.
+    expect(result).toBe(LOAD_FAILED)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[StreamlitMarkdown] Failed to load test-plugin plugin"
+    )
+    consoleWarnSpy.mockRestore()
+  })
+
+  it("finds function within the 5-level depth limit", () => {
+    const pluginFn = vi.fn()
+    // Function at depth 5 - should be found
+    const module = {
+      default: {
+        default: {
+          default: {
+            default: {
+              default: pluginFn, // depth 5 - reachable
+            },
+          },
+        },
+      },
+    }
+
+    const result = extractPlugin(module, "test-plugin")
+
+    expect(result).toBe(pluginFn)
   })
 })
 
@@ -446,6 +481,64 @@ describe("useLazyPlugin", () => {
       expect.stringContaining("unmounted component")
     )
     consoleErrorSpy.mockRestore()
+  })
+
+  it("shares loading promise across concurrent hook instances", async () => {
+    const mockPlugin = vi.fn()
+    let resolveLoad: (value: { default: typeof mockPlugin }) => void
+    const loadFn = vi.fn().mockReturnValue(
+      new Promise(resolve => {
+        resolveLoad = resolve
+      })
+    )
+
+    // Render multiple hooks simultaneously with the same plugin key
+    const { result: result1 } = renderHook(() =>
+      useLazyPlugin({
+        key: "katex",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    const { result: result2 } = renderHook(() =>
+      useLazyPlugin({
+        key: "katex",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    const { result: result3 } = renderHook(() =>
+      useLazyPlugin({
+        key: "katex",
+        needed: true,
+        load: loadFn,
+        pluginName: "test-plugin",
+      })
+    )
+
+    // All should be null initially (loading)
+    expect(result1.current).toBeNull()
+    expect(result2.current).toBeNull()
+    expect(result3.current).toBeNull()
+
+    // Load function should only be called once despite 3 concurrent requests
+    expect(loadFn).toHaveBeenCalledTimes(1)
+
+    // Resolve the shared promise
+    act(() => {
+      resolveLoad({ default: mockPlugin })
+    })
+
+    // All instances should receive the same loaded plugin
+    await waitFor(() => {
+      expect(result1.current).toBe(mockPlugin)
+      expect(result2.current).toBe(mockPlugin)
+      expect(result3.current).toBe(mockPlugin)
+    })
   })
 })
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
@@ -444,6 +444,32 @@ describe("useLazyPlugin", () => {
     expect(loadFn).toHaveBeenCalledTimes(1)
   })
 
+  it("returns null when needed becomes false after plugin is loaded", async () => {
+    const mockPlugin = vi.fn()
+    const loadFn = vi.fn().mockResolvedValue({ default: mockPlugin })
+
+    const { result, rerender } = renderHook(
+      ({ needed }) =>
+        useLazyPlugin({
+          key: "raw",
+          needed,
+          load: loadFn,
+          pluginName: "test-plugin",
+        }),
+      { initialProps: { needed: true } }
+    )
+
+    // Wait for plugin to load
+    await waitFor(() => {
+      expect(result.current).toBe(mockPlugin)
+    })
+
+    // Now set needed to false - should return null, not the stale plugin
+    rerender({ needed: false })
+
+    expect(result.current).toBeNull()
+  })
+
   it("handles cleanup on unmount without errors", () => {
     const mockPlugin = vi.fn()
     let resolveLoad: (value: { default: typeof mockPlugin }) => void

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { act, renderHook, waitFor } from "@testing-library/react"
-import type { Root } from "hast"
+import type { Root as HastRoot } from "hast"
+import type { Root as MdastRoot } from "mdast"
 import type { VFile } from "vfile"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -27,6 +28,7 @@ import {
   type PluginState,
   useLazyPlugin,
   wrapRehypePlugin,
+  wrapRemarkPlugin,
 } from "./utils"
 
 // Reset the module-level cache between tests to ensure isolation
@@ -148,15 +150,15 @@ describe("extractPlugin", () => {
 })
 
 describe("wrapRehypePlugin", () => {
-  // Create properly typed mock objects matching Root and VFile types
-  const createMockTree = (): Root => ({
+  // Create properly typed mock objects matching HastRoot and VFile types
+  const createMockHastTree = (): HastRoot => ({
     type: "root",
     children: [],
   })
   const createMockFile = (): VFile => ({ path: "test.md", value: "" }) as VFile
 
   it("wraps a plugin and calls the original transformer", () => {
-    const mockTree = createMockTree()
+    const mockTree = createMockHastTree()
     const mockFile = createMockFile()
     const transformer = vi.fn().mockReturnValue(mockTree)
     const plugin = vi.fn().mockReturnValue(transformer)
@@ -178,9 +180,9 @@ describe("wrapRehypePlugin", () => {
 
     const wrapped = wrapRehypePlugin(plugin, "test-plugin")
     const wrappedTransformer = wrapped()
-    // Test undefined handling - cast needed since Root doesn't include undefined
+    // Test undefined handling - cast needed since HastRoot doesn't include undefined
     const result = wrappedTransformer(
-      undefined as unknown as Root,
+      undefined as unknown as HastRoot,
       createMockFile()
     )
 
@@ -189,7 +191,7 @@ describe("wrapRehypePlugin", () => {
   })
 
   it("catches errors and returns original tree", () => {
-    const mockTree = createMockTree()
+    const mockTree = createMockHastTree()
     const mockFile = createMockFile()
     const error = new Error("Plugin crashed!")
     const transformer = vi.fn().mockImplementation(() => {
@@ -213,12 +215,90 @@ describe("wrapRehypePlugin", () => {
   })
 
   it("passes plugin options through", () => {
-    const mockTree = createMockTree()
+    const mockTree = createMockHastTree()
     const transformer = vi.fn().mockReturnValue(mockTree)
     const plugin = vi.fn().mockReturnValue(transformer)
     const options = { strict: true, output: "html" }
 
     const wrapped = wrapRehypePlugin(plugin, "test-plugin")
+    wrapped(options)
+
+    expect(plugin).toHaveBeenCalledWith(options)
+  })
+})
+
+describe("wrapRemarkPlugin", () => {
+  // Create properly typed mock objects matching MdastRoot and VFile types
+  const createMockMdastTree = (): MdastRoot => ({
+    type: "root",
+    children: [],
+  })
+  const createMockFile = (): VFile => ({ path: "test.md", value: "" }) as VFile
+
+  it("wraps a plugin and calls the original transformer", () => {
+    const mockTree = createMockMdastTree()
+    const mockFile = createMockFile()
+    const transformer = vi.fn().mockReturnValue(mockTree)
+    const plugin = vi.fn().mockReturnValue(transformer)
+
+    const wrapped = wrapRemarkPlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+
+    expect(plugin).toHaveBeenCalled()
+
+    const result = wrappedTransformer(mockTree, mockFile)
+
+    expect(transformer).toHaveBeenCalledWith(mockTree, mockFile)
+    expect(result).toBe(mockTree)
+  })
+
+  it("returns undefined tree without calling transformer", () => {
+    const transformer = vi.fn()
+    const plugin = vi.fn().mockReturnValue(transformer)
+
+    const wrapped = wrapRemarkPlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+    // Test undefined handling - cast needed since MdastRoot doesn't include undefined
+    const result = wrappedTransformer(
+      undefined as unknown as MdastRoot,
+      createMockFile()
+    )
+
+    expect(transformer).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it("catches errors and returns original tree", () => {
+    const mockTree = createMockMdastTree()
+    const mockFile = createMockFile()
+    const error = new Error("Plugin crashed!")
+    const transformer = vi.fn().mockImplementation(() => {
+      throw error
+    })
+    const plugin = vi.fn().mockReturnValue(transformer)
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    const wrapped = wrapRemarkPlugin(plugin, "test-plugin")
+    const wrappedTransformer = wrapped()
+    const result = wrappedTransformer(mockTree, mockFile)
+
+    expect(result).toBe(mockTree)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[StreamlitMarkdown] test-plugin crashed while transforming",
+      error
+    )
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("passes plugin options through", () => {
+    const mockTree = createMockMdastTree()
+    const transformer = vi.fn().mockReturnValue(mockTree)
+    const plugin = vi.fn().mockReturnValue(transformer)
+    const options = { emoticon: true, padSpaceAfter: false }
+
+    const wrapped = wrapRemarkPlugin(plugin, "test-plugin")
     wrapped(options)
 
     expect(plugin).toHaveBeenCalledWith(options)

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -68,7 +68,12 @@ type RemarkPluginFactory<Options = unknown> = (
   options?: Options
 ) => RemarkTransformer
 
-/** Configuration for the useLazyPlugin hook */
+/**
+ * Configuration for the useLazyPlugin hook.
+ *
+ * Note: `load` and `onBeforeLoad` should be stable references (e.g., module-level
+ * functions or wrapped in useCallback) to avoid unnecessary effect re-runs.
+ */
 export interface PluginLoaderConfig {
   key: PluginKey
   needed: boolean

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -16,8 +16,9 @@
 
 import { useEffect, useState } from "react"
 
-import type { Root } from "hast"
+import type { Root as HastRoot } from "hast"
 import { once } from "lodash-es"
+import type { Root as MdastRoot } from "mdast"
 import type { VFile } from "vfile"
 
 /**
@@ -45,13 +46,27 @@ export type PluginKey = "katex" | "raw" | "emoji"
 /** Union type for all supported plugin types */
 type AnyPlugin = KatexPlugin | RawPlugin | EmojiPlugin
 
-/** A rehype transformer function that processes an AST tree */
-type RehypeTransformer = (tree: Root, file: VFile) => Root | undefined | void
+/** A rehype transformer function that processes an HTML AST tree */
+type RehypeTransformer = (
+  tree: HastRoot,
+  file: VFile
+) => HastRoot | undefined | void
 
 /** A rehype plugin factory that returns a transformer when called with options */
 type RehypePluginFactory<Options = unknown> = (
   options?: Options
 ) => RehypeTransformer
+
+/** A remark transformer function that processes a Markdown AST tree */
+type RemarkTransformer = (
+  tree: MdastRoot,
+  file: VFile
+) => MdastRoot | undefined | void
+
+/** A remark plugin factory that returns a transformer when called with options */
+type RemarkPluginFactory<Options = unknown> = (
+  options?: Options
+) => RemarkTransformer
 
 /** Configuration for the useLazyPlugin hook */
 export interface PluginLoaderConfig {
@@ -154,7 +169,8 @@ export function extractPlugin<T>(
 
 /**
  * Wraps a rehype plugin to add error handling and guard against undefined trees.
- * Returns a factory function that unified will call to get the transformer.
+ * If the plugin crashes during transformation, the original tree is returned,
+ * allowing the content to render as plain text instead of breaking the component.
  */
 export function wrapRehypePlugin<Options = unknown>(
   plugin: RehypePluginFactory<Options>,
@@ -163,7 +179,38 @@ export function wrapRehypePlugin<Options = unknown>(
   return (options?: Options): RehypeTransformer => {
     const transformer = plugin(options)
 
-    return (tree: Root, file: VFile): Root | undefined | void => {
+    return (tree: HastRoot, file: VFile): HastRoot | undefined | void => {
+      if (!tree) {
+        return tree
+      }
+
+      try {
+        return transformer(tree, file)
+      } catch (error) {
+        // eslint-disable-next-line no-console -- Intentional error logging for debugging plugin crashes
+        console.error(
+          `[StreamlitMarkdown] ${pluginName} crashed while transforming`,
+          error
+        )
+        return tree
+      }
+    }
+  }
+}
+
+/**
+ * Wraps a remark plugin to add error handling and guard against undefined trees.
+ * If the plugin crashes during transformation, the original tree is returned,
+ * allowing the content to render as plain text instead of breaking the component.
+ */
+export function wrapRemarkPlugin<Options = unknown>(
+  plugin: RemarkPluginFactory<Options>,
+  pluginName: string
+): RemarkPluginFactory<Options> {
+  return (options?: Options): RemarkTransformer => {
+    const transformer = plugin(options)
+
+    return (tree: MdastRoot, file: VFile): MdastRoot | undefined | void => {
       if (!tree) {
         return tree
       }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from "react"
+
+import type { Root } from "hast"
+import { once } from "lodash-es"
+import type { VFile } from "vfile"
+
+/**
+ * Plugin type aliases derived from dynamic imports.
+ * These represent the actual plugin functions after module resolution.
+ */
+export type KatexPlugin = Awaited<
+  ReturnType<typeof loadKatexPlugin>
+>["default"]
+export type RawPlugin = Awaited<ReturnType<typeof loadRehypeRaw>>["default"]
+export type EmojiPlugin = Awaited<
+  ReturnType<typeof loadRemarkEmoji>
+>["default"]
+
+/** Sentinel value for failed plugin loads */
+export const LOAD_FAILED = Symbol("plugin_load_failed")
+export type FailedPlugin = typeof LOAD_FAILED
+
+/** Represents a plugin's loading state: loaded, failed, or not yet attempted */
+export type PluginState<T> = T | FailedPlugin | null
+
+/** Keys for the plugin cache */
+export type PluginKey = "katex" | "raw" | "emoji"
+
+/** Union type for all supported plugin types */
+type AnyPlugin = KatexPlugin | RawPlugin | EmojiPlugin
+
+/** A rehype transformer function that processes an AST tree */
+type RehypeTransformer = (tree: Root, file: VFile) => Root | undefined | void
+
+/** A rehype plugin factory that returns a transformer when called with options */
+type RehypePluginFactory<Options = unknown> = (
+  options?: Options
+) => RehypeTransformer
+
+/** Configuration for the useLazyPlugin hook */
+export interface PluginLoaderConfig {
+  key: PluginKey
+  needed: boolean
+  load: () => Promise<Record<string, unknown>>
+  pluginName: string
+  onBeforeLoad?: () => void
+}
+
+/**
+ * Module-level cache for loaded plugins.
+ * Shared across all component instances to avoid redundant loading.
+ */
+const pluginCache: Record<PluginKey, PluginState<AnyPlugin>> = {
+  katex: null,
+  raw: null,
+  emoji: null,
+}
+
+/**
+ * Module-level cache for in-flight loading promises.
+ * Prevents duplicate loads when multiple components request the same plugin.
+ */
+const loadingPromises: Record<
+  PluginKey,
+  Promise<PluginState<AnyPlugin>> | null
+> = {
+  katex: null,
+  raw: null,
+  emoji: null,
+}
+
+/** Lazy load rehype-katex for math rendering */
+export const loadKatexPlugin = (): Promise<typeof import("rehype-katex")> =>
+  import("rehype-katex")
+
+/** Load KaTeX CSS styles (only once per app lifecycle) */
+export const loadKatexStyles = once((): void => {
+  void import("katex/dist/katex.min.css")
+})
+
+/** Lazy load rehype-raw for HTML parsing (pulls in parse5) */
+export const loadRehypeRaw = (): Promise<typeof import("rehype-raw")> =>
+  import("rehype-raw")
+
+/** Lazy load remark-emoji for emoji shortcode conversion */
+export const loadRemarkEmoji = (): Promise<typeof import("remark-emoji")> =>
+  import("remark-emoji")
+
+/**
+ * Type guard to check if a plugin was successfully loaded.
+ */
+export function isLoadedPlugin<T>(plugin: PluginState<T>): plugin is T {
+  return plugin !== null && plugin !== LOAD_FAILED
+}
+
+/**
+ * Extracts the plugin function from a dynamically imported module.
+ * Handles various module shapes from different bundlers (nested default exports, etc.)
+ */
+export function extractPlugin<T>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Module shape varies by bundler
+  module: Record<string, any>,
+  pluginName: string
+): PluginState<T> {
+  const candidates: unknown[] = []
+  let current: unknown = module
+  let depth = 0
+
+  // Unwrap nested default exports (some bundlers wrap modules multiple times)
+  while (
+    current &&
+    typeof current === "object" &&
+    "default" in (current as Record<string, unknown>) &&
+    depth < 5
+  ) {
+    const next = (current as Record<string, unknown>).default
+    candidates.push(next)
+    if (next === current) {
+      break
+    }
+    current = next
+    depth += 1
+  }
+
+  candidates.push(module)
+
+  // Find the first function candidate (the actual plugin)
+  for (const candidate of candidates) {
+    if (typeof candidate === "function") {
+      return candidate as T
+    }
+  }
+
+  // eslint-disable-next-line no-console -- Intentional warning for debugging plugin load failures
+  console.warn(`[StreamlitMarkdown] Failed to load ${pluginName} plugin`)
+  return LOAD_FAILED
+}
+
+/**
+ * Wraps a rehype plugin to add error handling and guard against undefined trees.
+ * Returns a factory function that unified will call to get the transformer.
+ */
+export function wrapRehypePlugin<Options = unknown>(
+  plugin: RehypePluginFactory<Options>,
+  pluginName: string
+): RehypePluginFactory<Options> {
+  return (options?: Options): RehypeTransformer => {
+    const transformer = plugin(options)
+
+    return (tree: Root, file: VFile): Root | undefined | void => {
+      if (!tree) {
+        return tree
+      }
+
+      try {
+        return transformer(tree, file)
+      } catch (error) {
+        // eslint-disable-next-line no-console -- Intentional error logging for debugging plugin crashes
+        console.error(
+          `[StreamlitMarkdown] ${pluginName} crashed while transforming`,
+          error
+        )
+        return tree
+      }
+    }
+  }
+}
+
+/**
+ * Custom hook for lazy loading markdown plugins with module-level caching.
+ *
+ * Handles the complexity of:
+ * - Module-level caching to share plugins across component instances
+ * - Shared in-flight promises to prevent duplicate loads
+ * - React StrictMode compatibility (proper cleanup)
+ * - Preventing React from calling plugin functions as state updaters
+ *
+ * @typeParam T - The plugin type, used for return type inference
+ */
+export function useLazyPlugin<T>(config: PluginLoaderConfig): PluginState<T> {
+  const { key, needed, load, pluginName, onBeforeLoad } = config
+
+  // Use lazy initialization to prevent React from calling the cached plugin
+  const [plugin, setPlugin] = useState<PluginState<T>>(
+    () => pluginCache[key] as PluginState<T>
+  )
+
+  useEffect(() => {
+    if (!needed || plugin) {
+      return
+    }
+
+    const cached = pluginCache[key]
+    if (cached) {
+      // Wrap in arrow function to prevent React from calling the plugin
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing from module-level cache, not causing cascading renders
+      setPlugin(() => cached as PluginState<T>)
+      return
+    }
+
+    let isCancelled = false
+    const resolve = (loadedPlugin: PluginState<T>): void => {
+      if (!isCancelled) {
+        // Wrap in arrow function to prevent React from calling the plugin
+        setPlugin(() => loadedPlugin)
+      }
+    }
+
+    const existingPromise = loadingPromises[key]
+    if (existingPromise) {
+      void existingPromise.then(p => resolve(p as PluginState<T>))
+      return () => {
+        isCancelled = true
+      }
+    }
+
+    onBeforeLoad?.()
+
+    const loadPromise = load()
+      .then(module => extractPlugin<T>(module, pluginName))
+      .then(extracted => {
+        pluginCache[key] = extracted as PluginState<AnyPlugin>
+        return extracted
+      })
+      .catch(() => {
+        pluginCache[key] = LOAD_FAILED
+        return LOAD_FAILED
+      })
+      .finally(() => {
+        loadingPromises[key] = null
+      }) as Promise<PluginState<T>>
+
+    loadingPromises[key] = loadPromise as Promise<PluginState<AnyPlugin>>
+    void loadPromise.then(resolve)
+
+    return () => {
+      isCancelled = true
+    }
+  }, [needed, plugin, key, load, pluginName, onBeforeLoad])
+
+  return plugin
+}
+
+/**
+ * Resets the plugin cache and loading promises.
+ * @internal Only exported for testing - do not use in production code.
+ */
+export function _resetCacheForTesting(): void {
+  pluginCache.katex = null
+  pluginCache.raw = null
+  pluginCache.emoji = null
+  loadingPromises.katex = null
+  loadingPromises.raw = null
+  loadingPromises.emoji = null
+}

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -317,7 +317,11 @@ export function useLazyPlugin<T>(config: PluginLoaderConfig): PluginState<T> {
     onBeforeLoad,
   ])
 
-  // Return cached plugin if available (source of truth), otherwise loading result
+  if (!needed) {
+    return null
+  }
+
+  // Return cached plugin (source of truth) if available, otherwise loading result
   return cachedPlugin ?? loadingResult
 }
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -129,8 +129,7 @@ export function isLoadedPlugin<T>(plugin: PluginState<T>): plugin is T {
  * Handles various module shapes from different bundlers (nested default exports, etc.)
  */
 export function extractPlugin<T>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Module shape varies by bundler
-  module: Record<string, any>,
+  module: Record<string, unknown>,
   pluginName: string
 ): PluginState<T> {
   const candidates: unknown[] = []
@@ -249,14 +248,18 @@ export function useLazyPlugin<T>(config: PluginLoaderConfig): PluginState<T> {
   )
 
   useEffect(() => {
+    // Skip if not needed, or if we already have a result (including LOAD_FAILED).
+    // LOAD_FAILED is a truthy Symbol, so failed plugins are intentionally cached
+    // and not retried - this prevents infinite retry loops on persistent failures.
     if (!needed || plugin) {
       return
     }
 
+    // Sync from module-level cache if another instance already loaded this plugin
     const cached = pluginCache[key]
     if (cached) {
       // Wrap in arrow function to prevent React from calling the plugin
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing from module-level cache, not causing cascading renders
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing from module-level cache on mount, not causing cascading renders
       setPlugin(() => cached as PluginState<T>)
       return
     }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/utils.ts
@@ -242,39 +242,31 @@ export function wrapRemarkPlugin<Options = unknown>(
 export function useLazyPlugin<T>(config: PluginLoaderConfig): PluginState<T> {
   const { key, needed, load, pluginName, onBeforeLoad } = config
 
-  // Use lazy initialization to prevent React from calling the cached plugin
-  const [plugin, setPlugin] = useState<PluginState<T>>(
-    () => pluginCache[key] as PluginState<T>
-  )
+  // Read from module-level cache during render - this is the source of truth.
+  // This avoids the anti-pattern of syncing external state into local state via useEffect.
+  const cachedPlugin = needed ? (pluginCache[key] as PluginState<T>) : null
+
+  // Local state only tracks loading progress, not the final cached value
+  const [loadingResult, setLoadingResult] = useState<PluginState<T>>(null)
 
   useEffect(() => {
-    // Skip if not needed, or if we already have a result (including LOAD_FAILED).
+    // Skip if not needed, already cached, or already have a loading result.
     // LOAD_FAILED is a truthy Symbol, so failed plugins are intentionally cached
     // and not retried - this prevents infinite retry loops on persistent failures.
-    if (!needed || plugin) {
+    if (!needed || cachedPlugin || loadingResult) {
       return
     }
 
-    // Sync from module-level cache if another instance already loaded this plugin
-    const cached = pluginCache[key]
-    if (cached) {
-      // Wrap in arrow function to prevent React from calling the plugin
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing from module-level cache on mount, not causing cascading renders
-      setPlugin(() => cached as PluginState<T>)
-      return
-    }
-
-    let isCancelled = false
-    const resolve = (loadedPlugin: PluginState<T>): void => {
-      if (!isCancelled) {
-        // Wrap in arrow function to prevent React from calling the plugin
-        setPlugin(() => loadedPlugin)
-      }
-    }
-
+    // Check if another instance is already loading this plugin
     const existingPromise = loadingPromises[key]
     if (existingPromise) {
-      void existingPromise.then(p => resolve(p as PluginState<T>))
+      let isCancelled = false
+      void existingPromise.then(p => {
+        if (!isCancelled) {
+          // Wrap in arrow function to prevent React from calling the plugin
+          setLoadingResult(() => p as PluginState<T>)
+        }
+      })
       return () => {
         isCancelled = true
       }
@@ -282,29 +274,46 @@ export function useLazyPlugin<T>(config: PluginLoaderConfig): PluginState<T> {
 
     onBeforeLoad?.()
 
+    let isCancelled = false
     const loadPromise = load()
       .then(module => extractPlugin<T>(module, pluginName))
       .then(extracted => {
         pluginCache[key] = extracted as PluginState<AnyPlugin>
+        if (!isCancelled) {
+          // Wrap in arrow function to prevent React from calling the plugin
+          setLoadingResult(() => extracted)
+        }
         return extracted
       })
       .catch(() => {
-        pluginCache[key] = LOAD_FAILED
-        return LOAD_FAILED
+        const failed = LOAD_FAILED as PluginState<T>
+        pluginCache[key] = failed as PluginState<AnyPlugin>
+        if (!isCancelled) {
+          setLoadingResult(() => failed)
+        }
+        return failed
       })
       .finally(() => {
         loadingPromises[key] = null
       }) as Promise<PluginState<T>>
 
     loadingPromises[key] = loadPromise as Promise<PluginState<AnyPlugin>>
-    void loadPromise.then(resolve)
 
     return () => {
       isCancelled = true
     }
-  }, [needed, plugin, key, load, pluginName, onBeforeLoad])
+  }, [
+    needed,
+    cachedPlugin,
+    loadingResult,
+    key,
+    load,
+    pluginName,
+    onBeforeLoad,
+  ])
 
-  return plugin
+  // Return cached plugin if available (source of truth), otherwise loading result
+  return cachedPlugin ?? loadingResult
 }
 
 /**


### PR DESCRIPTION
## Describe your changes
React's `StrictMode` exposed some opportunities to improve the recently added lazy loading for `StreamlitMarkdown`'s plugins:`rehype-katex`, `rehype-raw`, & `remark-emoji`

Component is now StrictMode compatible, with improved performance (plugins load once per app, not per component instance), and better handle plugin load failure (render as plain text).

This PR better makes the following changes:
* **Module-level caching**: Moved plugin storage outside React's component lifecycle to share across instances and persist across re-renders
* **Adds custom `useLazyPlugin` hook**: Consolidated three nearly-identical useEffect blocks into a single reusable hook with proper cleanup handling
* **Extraction to `utils.ts`**: Moved all plugin-related logic (types, loaders, cache, helpers, hook) to a dedicated file

## Testing Plan
- Unit Tests (JS and/or Python): ✅  Added
- Manual Testing: ✅ 
