### PR TITLE
Add ability to clear transient nodes when the script is run

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1366,9 +1366,11 @@ export class App extends PureComponent<Props, State> {
       appHash === newSessionHash &&
       prevPageScriptHash === newPageScriptHash
     ) {
-      this.setState({
+      this.setState(prevState => ({
+        // Clear the transient nodes before executing everything else.
+        elements: prevState.elements.clearTransientNodes(fragmentIdsThisRun),
         scriptRunId,
-      })
+      }))
     } else {
       this.clearAppState(
         newSessionHash,

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -986,6 +986,80 @@ describe("AppRoot", () => {
     })
   })
 
+  describe("AppRoot.clearTransientNodes", () => {
+    it("clears transient nodes by replacing them with their anchor", () => {
+      // Since we can't easily construct a TransientNode with an anchor via applyDelta
+      // (as applyDelta uses newTransient which sets anchor to undefined),
+      // we'll test that the visitor is called.
+      //
+      // Note: The actual clearing logic (TransientNode -> Anchor) is tested in ClearTransientNodesVisitor.test.ts.
+      // Here we verify that AppRoot delegates to the visitor.
+
+      const delta = makeProto(DeltaProto, {
+        newTransient: {
+          elements: [{ text: { body: "transientElement!" } }],
+        },
+      })
+      // This applies delta at [0, 0], which corresponds to text("1") in ROOT.
+      // SetNodeByDeltaPathVisitor will set text("1") as the anchor for the new TransientNode.
+      const rootWithTransient = ROOT.applyDelta(
+        "session_id",
+        delta,
+        forwardMsgMetadata([0, 0])
+      )
+
+      // Verify we have a transient node
+      const transientNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rootWithTransient.main,
+        [0]
+      )
+      expect(transientNode).toBeInstanceOf(TransientNode)
+
+      // Clear it. Since it has an anchor (text("1")), it should revert to that anchor.
+      const clearedRoot = rootWithTransient.clearTransientNodes()
+
+      const clearedNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        clearedRoot.main,
+        [0]
+      )
+      expect(clearedNode).toBeTextNode("1")
+    })
+
+    it("respects fragmentIdsThisRun when clearing", () => {
+      // Create a block with a fragmentId
+      const delta = makeProto(DeltaProto, {
+        addBlock: { vertical: {}, allowEmpty: true },
+        fragmentId: "my_fragment",
+      })
+      const transientDelta = makeProto(DeltaProto, {
+        newTransient: {
+          elements: [{ text: { body: "transient!" } }],
+        },
+      })
+
+      // Use path [0, 2] which corresponds to an empty BlockNode in ROOT.
+      // This ensures no anchor is created.
+      const root = ROOT.applyDelta(
+        "session_id",
+        delta,
+        forwardMsgMetadata([0, 2])
+      ).applyDelta("session_id", transientDelta, forwardMsgMetadata([0, 2, 0]))
+
+      // 1. Clear with UNRELATED fragment ID -> Should NOT clear
+      let clearedRoot = root.clearTransientNodes(["other_fragment"])
+      let node = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        clearedRoot.main,
+        [2, 0]
+      )
+      expect(node).toBeInstanceOf(TransientNode)
+
+      // 2. Clear with MATCHING fragment ID -> Should clear
+      clearedRoot = root.clearTransientNodes(["my_fragment"])
+      node = GetNodeByDeltaPathVisitor.getNodeAtPath(clearedRoot.main, [2, 0])
+      expect(node).toBeUndefined()
+    })
+  })
+
   describe("AppRoot.getElements", () => {
     it("returns all elements using ElementsSetVisitor", () => {
       // We have elements at main.[0] and main.[1, 0]

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -39,6 +39,7 @@ import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
 import { TransientNode } from "./TransientNode"
 import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
+import { ClearTransientNodesVisitor } from "./visitors/ClearTransientNodesVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
 import { ElementsSetVisitor } from "./visitors/ElementsSetVisitor"
 import { FilterMainScriptElementsVisitor } from "./visitors/FilterMainScriptElementsVisitor"
@@ -353,6 +354,24 @@ export class AppRoot {
         currentScriptRunId
       ),
       appLogo
+    )
+  }
+
+  public clearTransientNodes(fragmentIdsThisRun?: Array<string>): AppRoot {
+    const visitor = new ClearTransientNodesVisitor(fragmentIdsThisRun)
+    const newChildren = this.root.children.map(node =>
+      this.ensureBlockNode(node.accept(visitor))
+    )
+
+    return new AppRoot(
+      this.mainScriptHash,
+      new BlockNode(
+        this.mainScriptHash,
+        newChildren,
+        new BlockProto({ allowEmpty: true }),
+        this.main.scriptRunId
+      ),
+      this.appLogo
     )
   }
 

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -15,7 +15,8 @@
  */
 
 import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
-import { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
+
+import { AppNodeVisitor } from "./AppNodeVisitor.interface"
 
 /**
  * Visitor that clears stale nodes from the render tree. It does this by:

--- a/frontend/lib/src/render-tree/visitors/ClearTransientNodesVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearTransientNodesVisitor.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Block as BlockProto, Delta as DeltaProto } from "@streamlit/protobuf"
+
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import {
+  block,
+  FAKE_SCRIPT_HASH,
+  makeProto,
+  text,
+} from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
+
+import { ClearTransientNodesVisitor } from "./ClearTransientNodesVisitor"
+
+describe("ClearTransientNodesVisitor", () => {
+  const TEXT_NODE = text("Hello")
+  const TRANSIENT_NODE = new TransientNode(
+    "script_run_id",
+    TEXT_NODE,
+    [text("Transient")],
+    Date.now()
+  )
+
+  it("returns element nodes unchanged", () => {
+    const visitor = new ClearTransientNodesVisitor([])
+    expect(visitor.visitElementNode(TEXT_NODE)).toBe(TEXT_NODE)
+  })
+
+  it("returns the anchor of transient nodes", () => {
+    const visitor = new ClearTransientNodesVisitor([])
+    expect(visitor.visitTransientNode(TRANSIENT_NODE)).toBe(TEXT_NODE)
+  })
+
+  it("recurses into block nodes", () => {
+    const blockNode = block([TRANSIENT_NODE])
+    const visitor = new ClearTransientNodesVisitor([])
+    const result = visitor.visitBlockNode(blockNode) as BlockNode
+
+    expect(result).toBeInstanceOf(BlockNode)
+    expect(result.children).toHaveLength(1)
+    expect(result.children[0]).toBe(TEXT_NODE)
+  })
+
+  it("returns the same block node if no children changed", () => {
+    const blockNode = block([TEXT_NODE])
+    const visitor = new ClearTransientNodesVisitor([])
+    const result = visitor.visitBlockNode(blockNode)
+
+    expect(result).toBe(blockNode)
+  })
+
+  it("respects fragmentIdsThisRun", () => {
+    // If fragmentIdsThisRun is set, and the block has a fragmentId NOT in the list,
+    // it should not be traversed/cleared.
+
+    // 1. Create a block with a fragmentId that IS in the list
+    const fragmentBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [TRANSIENT_NODE],
+      makeProto(DeltaProto, {}).addBlock as BlockProto,
+      "script_run_id",
+      "my_fragment"
+    )
+
+    const visitor1 = new ClearTransientNodesVisitor(["my_fragment"])
+    const result1 = visitor1.visitBlockNode(fragmentBlock) as BlockNode
+    // Should be cleared (TransientNode -> TextNode)
+    expect(result1.children[0]).toBe(TEXT_NODE)
+
+    // 2. Create a block with a fragmentId that IS NOT in the list
+    const otherFragmentBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [TRANSIENT_NODE],
+      makeProto(DeltaProto, {}).addBlock as BlockProto,
+      "script_run_id",
+      "other_fragment"
+    )
+
+    const visitor2 = new ClearTransientNodesVisitor(["my_fragment"])
+    const result2 = visitor2.visitBlockNode(otherFragmentBlock)
+    // Should NOT be cleared (should remain same block with TransientNode)
+    expect(result2).toBe(otherFragmentBlock)
+    expect((result2 as BlockNode).children[0]).toBe(TRANSIENT_NODE)
+  })
+
+  it("returns undefined when transient node has no anchor", () => {
+    const transientWithNoAnchor = new TransientNode(
+      "script_run_id",
+      undefined,
+      [text("Transient")],
+      Date.now()
+    )
+    const visitor = new ClearTransientNodesVisitor([])
+    expect(visitor.visitTransientNode(transientWithNoAnchor)).toBeUndefined()
+  })
+
+  it("traverses blocks without fragmentId even if fragmentIdsThisRun is set", () => {
+    // If the block has NO fragmentId, it should be traversed regardless of fragmentIdsThisRun
+    // (This is the default behavior for main root blocks usually, though depends on how the visitor is called)
+    // The code says:
+    // if (fragmentIdsThisRun.length > 0 && node.fragmentId && !fragmentIdsThisRun.includes(node.fragmentId)) return node
+
+    // So if node.fragmentId is undefined, we proceed.
+
+    const blockNode = block([TRANSIENT_NODE])
+    const visitor = new ClearTransientNodesVisitor(["some_fragment"])
+    const result = visitor.visitBlockNode(blockNode) as BlockNode
+
+    expect(result).not.toBe(blockNode)
+    expect(result.children[0]).toBe(TEXT_NODE)
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/ClearTransientNodesVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearTransientNodesVisitor.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
+
+import { AppNodeVisitor } from "./AppNodeVisitor.interface"
+
+/**
+ * Visitor that clears transient nodes from the render tree. It does this by:
+ *
+ * 1. If there are fragment IDs this run, and this block is not one of them,
+ *    then it should not be traversed/cleared.
+ * 2. It recurses into block nodes.
+ * 3. It returns the same block node if no children changed.
+ */
+export class ClearTransientNodesVisitor implements AppNodeVisitor<
+  AppNode | undefined
+> {
+  private readonly fragmentIdsThisRun: string[]
+
+  constructor(fragmentIdsThisRun: string[] | undefined) {
+    this.fragmentIdsThisRun = fragmentIdsThisRun ?? []
+  }
+
+  visitBlockNode(node: BlockNode): AppNode | undefined {
+    if (
+      // There are fragment IDs this run, and this block is not one of them
+      this.fragmentIdsThisRun.length > 0 &&
+      node.fragmentId &&
+      !this.fragmentIdsThisRun.includes(node.fragmentId)
+    ) {
+      return node
+    }
+
+    const newChildren: AppNode[] = []
+    let childrenChanged = false
+    node.children.forEach(child => {
+      const filteredChild = child.accept(this)
+      if (filteredChild !== child) {
+        childrenChanged = true
+      }
+      if (filteredChild !== undefined) {
+        newChildren.push(filteredChild)
+      }
+    })
+
+    // Performance optimization: If the children haven't changed, return the same node.
+    if (!childrenChanged) {
+      return node
+    }
+
+    return new BlockNode(
+      node.activeScriptHash,
+      newChildren,
+      node.deltaBlock,
+      node.scriptRunId,
+      node.fragmentId,
+      node.deltaMsgReceivedAt
+    )
+  }
+
+  visitElementNode(node: ElementNode): AppNode | undefined {
+    // There are no transient nodes to clear.
+    return node
+  }
+
+  visitTransientNode(node: TransientNode): AppNode | undefined {
+    // Clear the transient nodes and just show the anchor node
+    return node.anchor
+  }
+}


### PR DESCRIPTION
## Describe your changes

Added a mechanism to clear transient nodes from the render tree when rerunning a script. This ensures that transient elements don't persist inappropriately between runs.

The implementation:
1. Added a `clearTransientNodes` method to `AppRoot` that replaces transient nodes with their anchors
2. Created a new `ClearTransientNodesVisitor` class that handles the traversal and replacement logic
3. Added logic to respect fragment IDs when clearing, so only relevant fragments are processed
4. Updated the App component to call this method before executing a script run

## Testing Plan

- Unit Tests: Added comprehensive tests for the new functionality:
  - Tests for `AppRoot.clearTransientNodes` to verify it correctly delegates to the visitor
  - Tests for `ClearTransientNodesVisitor` to verify it correctly handles different node types
  - Tests to verify fragment ID filtering works as expected

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.