### PR TITLE
[Fix] Theme hashing

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -956,18 +956,22 @@ describe("App", () => {
       expect(props.theme.setTheme).not.toHaveBeenCalled()
     })
 
-    it("does nothing if no custom theme is received and themeHash is 'hash_for_undefined_custom_theme'", () => {
+    it("processes null theme on first newSession to clear any cached custom themes", () => {
       const props = getProps()
       renderApp(props)
 
-      // Send Forward message with custom theme
+      // Send first newSession with null custom theme
+      // This should process the theme (themeHash changes from "" to "hash_for_undefined_custom_theme")
+      // and call addThemes([]) to clear any cached custom themes from localStorage
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
         customTheme: null,
       })
 
-      expect(props.theme.addThemes).not.toHaveBeenCalled()
-      expect(props.theme.setTheme).not.toHaveBeenCalled()
+      // Should call addThemes to clear custom themes
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+      // @ts-expect-error
+      expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
     })
 
     it("does not update theme when receiving theme with nested objects in different key orders", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -836,31 +836,23 @@ describe("App", () => {
       expect(props.theme.addThemes.mock.calls[1][0]).toEqual([])
     })
 
-    it("removes the cached custom theme from theme options", () => {
-      window.localStorage.setItem(
-        LocalStore.ACTIVE_THEME,
-        JSON.stringify({ name: CUSTOM_THEME_NAME, themeInput: {} })
-      )
-      const props = getProps({
-        theme: {
-          activeTheme: {
-            ...lightTheme,
-            name: CUSTOM_THEME_NAME,
-          },
-          availableThemes: [],
-          setTheme: vi.fn(),
-          addThemes: vi.fn(),
-          setFonts: vi.fn(),
-          setImportedTheme: vi.fn(),
-        },
-      })
+    it("removes custom theme when server sends null for customTheme", () => {
+      const props = getProps()
       renderApp(props)
 
+      // First, send a custom theme to establish it
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+
+      // @ts-expect-error
+      props.theme.addThemes.mockClear()
+
+      // Then send null to remove the custom theme
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
         customTheme: null,
       })
 
+      // Should call addThemes with empty array to remove custom themes
       expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
 
       // @ts-expect-error
@@ -976,6 +968,93 @@ describe("App", () => {
 
       expect(props.theme.addThemes).not.toHaveBeenCalled()
       expect(props.theme.setTheme).not.toHaveBeenCalled()
+    })
+
+    it("does not update theme when receiving theme with nested objects in different key orders", () => {
+      const props = getProps()
+      renderApp(props)
+
+      // Create theme config with nested objects in a specific key order
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        backgroundColor: "white",
+        sidebar: {
+          backgroundColor: "gray",
+          textColor: "black",
+        },
+        light: {
+          primaryColor: "lightblue",
+          textColor: "darkgray",
+        },
+      })
+
+      // Send first theme
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      // Reset mocks to check subsequent calls
+      vi.mocked(props.theme.addThemes).mockClear()
+      vi.mocked(props.theme.setTheme).mockClear()
+
+      // Send same theme with keys in different order (including nested objects)
+      const theme2 = new CustomThemeConfig({
+        sidebar: {
+          textColor: "black",
+          backgroundColor: "gray",
+        },
+        primaryColor: "blue",
+        light: {
+          textColor: "darkgray",
+          primaryColor: "lightblue",
+        },
+        backgroundColor: "white",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should not update theme since the content is identical
+      expect(props.theme.addThemes).not.toHaveBeenCalled()
+      expect(props.theme.setTheme).not.toHaveBeenCalled()
+    })
+
+    it("updates theme when receiving theme with different values", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        backgroundColor: "white",
+      })
+
+      // Send first theme
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      // Reset mocks to check subsequent calls
+      vi.mocked(props.theme.addThemes).mockClear()
+      vi.mocked(props.theme.setTheme).mockClear()
+
+      // Send different theme
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "red",
+        backgroundColor: "white",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should update theme since the content is different
+      expect(props.theme.addThemes).toHaveBeenCalled()
+      expect(props.theme.setTheme).toHaveBeenCalled()
     })
 
     it("performs one-time initialization", () => {
@@ -2225,6 +2304,251 @@ describe("App", () => {
           }),
         })
       )
+    })
+  })
+
+  describe("App theme hash change detection", () => {
+    it("detects changes when sidebar config is modified", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        sidebar: { backgroundColor: "white" },
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        sidebar: { backgroundColor: "gray" }, // Different sidebar color
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
+    })
+
+    it("detects changes when light section config is modified", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        light: { backgroundColor: "white" },
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        light: { backgroundColor: "lightgray" }, // Different light background
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
+    })
+
+    it("detects changes when dark section config is modified", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        dark: { backgroundColor: "black" },
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        dark: { backgroundColor: "darkgray" }, // Different dark background
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
+    })
+
+    it("detects changes when nested sidebar in light section is modified", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        light: {
+          sidebar: { backgroundColor: "white" },
+        },
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        light: {
+          sidebar: { backgroundColor: "lightgray" }, // Different nested sidebar
+        },
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
+    })
+
+    it("does not re-process theme when hash is unchanged", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme = new CustomThemeConfig({
+        primaryColor: "blue",
+        backgroundColor: "white",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      // Send the same theme again
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme,
+      })
+
+      // Should still only be called once (theme not re-processed)
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not re-process when theme with same content but different key order is sent", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        backgroundColor: "white",
+        textColor: "black",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      // Create theme with same values but potentially different internal key order
+      const theme2 = new CustomThemeConfig({
+        textColor: "black",
+        backgroundColor: "white",
+        primaryColor: "blue",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should still only be called once (hashes should match)
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+    })
+
+    it("detects changes in font configuration", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        bodyFont: "Arial",
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        bodyFont: "Helvetica", // Different font
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
+    })
+
+    it("detects changes in array properties", () => {
+      const props = getProps()
+      renderApp(props)
+
+      const theme1 = new CustomThemeConfig({
+        primaryColor: "blue",
+        headingFontSizes: ["2rem", "1.5rem", "1.25rem"],
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme1,
+      })
+
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(1)
+
+      const theme2 = new CustomThemeConfig({
+        primaryColor: "blue",
+        headingFontSizes: ["2rem", "1.5rem", "1rem"], // Different array value
+      })
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        customTheme: theme2,
+      })
+
+      // Should be called again because the hash changed
+      expect(props.theme.addThemes).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -282,11 +282,6 @@ export class App extends PureComponent<Props, State> {
     enablePatches()
     enableMapSet()
 
-    // Theme hash is initially set to default (undefined custom theme).
-    // When a custom theme is received from the server via handleNewSession,
-    // processThemeInput will update the hash based on the server's theme config.
-    const themeHash = this.createThemeHash()
-
     this.state = {
       connectionState: ConnectionState.INITIAL,
       elements: AppRoot.empty("", true), // Blank Main Script Hash for initial render
@@ -306,7 +301,11 @@ export class App extends PureComponent<Props, State> {
       menuItems: undefined,
       allowRunOnSave: true,
       scriptFinishedHandlers: [],
-      themeHash,
+      // Initialize themeHash to empty string to ensure the first processThemeInput
+      // call always processes the theme (whether null or custom theme from server).
+      // This prevents the bug where a cached custom theme isn't cleared when the
+      // server sends null, because null and undefined both hash to the same value.
+      themeHash: "",
       gitInfo: null,
       formsData: createFormsData(),
       appPages: [],

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -102,9 +102,9 @@ import {
   PresetThemeName,
   ScriptRunState,
   SessionInfo,
+  sortThemeInputKeys,
   ThemeConfig,
   toExportedTheme,
-  toThemeInput,
   WidgetStateManager,
 } from "@streamlit/lib"
 import {
@@ -282,15 +282,10 @@ export class App extends PureComponent<Props, State> {
     enablePatches()
     enableMapSet()
 
-    // Theme hashes are only created for custom theme, and the custom theme
-    // may come from localStorage. We need to create the hash here to ensure
-    // that the theme is correctly represented.
-    let themeHash = this.createThemeHash()
-    if (!isPresetTheme(props.theme.activeTheme)) {
-      themeHash = this.createThemeHash(
-        toThemeInput(props.theme.activeTheme.emotion) as CustomThemeConfig
-      )
-    }
+    // Theme hash is initially set to default (undefined custom theme).
+    // When a custom theme is received from the server via handleNewSession,
+    // processThemeInput will update the hash based on the server's theme config.
+    const themeHash = this.createThemeHash()
 
     this.state = {
       connectionState: ConnectionState.INITIAL,
@@ -1366,10 +1361,17 @@ export class App extends PureComponent<Props, State> {
       return "hash_for_undefined_custom_theme"
     }
 
-    // Hash the sorted representation of the theme input:
-    return hashString(
-      JSON.stringify(themeInput, Object.keys(themeInput).sort())
-    )
+    // Convert to JSON and back to get a plain JS object without protobuf methods/metadata.
+    // JSON.stringify automatically filters out functions and non-enumerable properties.
+    // This ensures we hash only the actual theme data, not the protobuf object structure.
+    const plainObject = JSON.parse(JSON.stringify(themeInput))
+
+    // Recursively sort all keys (including nested objects like sidebar, light, dark)
+    // to ensure consistent hashing regardless of key order
+    const sorted = sortThemeInputKeys(plainObject)
+
+    // Hash the sorted representation
+    return hashString(JSON.stringify(sorted))
   }
 
   processThemeInput(themeInput: CustomThemeConfig): void {

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -133,6 +133,7 @@ export {
   lightTheme,
   removeCachedTheme,
   setCachedTheme,
+  sortThemeInputKeys,
   toExportedTheme,
   toThemeInput,
 } from "./theme"

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -53,6 +53,7 @@ import {
   parseFont,
   removeCachedTheme,
   setCachedTheme,
+  sortThemeInputKeys,
   toThemeInput,
 } from "./utils"
 
@@ -3211,6 +3212,186 @@ describe("Font weight configuration coverage", () => {
         defaultFontWeights[typedKey]
       )
     })
+  })
+})
+
+describe("sortThemeInputKeys", () => {
+  it("sorts basic theme input keys", () => {
+    const themeInput = new CustomThemeConfig({
+      primaryColor: "blue",
+      light: {
+        primaryColor: "red",
+      },
+    })
+    const sorted = sortThemeInputKeys(themeInput)
+
+    // sortThemeInputKeys should produce consistent JSON regardless of key order
+    const sorted2 = sortThemeInputKeys(themeInput)
+    expect(JSON.stringify(sorted)).toBe(JSON.stringify(sorted2))
+
+    // Verify the primary keys we care about are sorted
+    const keys = Object.keys(sorted as Record<string, unknown>)
+    const lightIndex = keys.indexOf("light")
+    const primaryColorIndex = keys.indexOf("primaryColor")
+
+    // 'light' should come before 'primaryColor' alphabetically
+    expect(lightIndex).toBeLessThan(primaryColorIndex)
+  })
+
+  it("handles deeply nested objects", () => {
+    const input = {
+      z: "last",
+      a: "first",
+      nested: {
+        z: "nested-last",
+        a: "nested-first",
+        deep: {
+          z: "deep-last",
+          a: "deep-first",
+        },
+      },
+    }
+    const sorted = sortThemeInputKeys(input) as Record<string, unknown>
+    const keys = Object.keys(sorted)
+    expect(keys[0]).toBe("a")
+    expect(keys[1]).toBe("nested")
+    expect(keys[2]).toBe("z")
+
+    const nested = sorted.nested as Record<string, unknown>
+    const nestedKeys = Object.keys(nested)
+    expect(nestedKeys[0]).toBe("a")
+    expect(nestedKeys[1]).toBe("deep")
+    expect(nestedKeys[2]).toBe("z")
+
+    const deep = nested.deep as Record<string, unknown>
+    const deepKeys = Object.keys(deep)
+    expect(deepKeys[0]).toBe("a")
+    expect(deepKeys[1]).toBe("z")
+  })
+
+  it("handles arrays of objects", () => {
+    const input = {
+      colors: [
+        { z: 1, a: 2 },
+        { z: 3, a: 4 },
+      ],
+    }
+    const sorted = sortThemeInputKeys(input) as {
+      colors: Array<Record<string, number>>
+    }
+    expect(Object.keys(sorted.colors[0])).toEqual(["a", "z"])
+    expect(Object.keys(sorted.colors[1])).toEqual(["a", "z"])
+    expect(sorted.colors[0]).toEqual({ a: 2, z: 1 })
+    expect(sorted.colors[1]).toEqual({ a: 4, z: 3 })
+  })
+
+  it("handles null and undefined values", () => {
+    const input = { b: null, a: undefined, c: "value" }
+    const sorted = sortThemeInputKeys(input)
+    expect(sorted).toEqual({ a: undefined, b: null, c: "value" })
+    // Verify order
+    const keys = Object.keys(sorted as Record<string, unknown>)
+    expect(keys).toEqual(["a", "b", "c"])
+  })
+
+  it("handles mixed types", () => {
+    const input = {
+      string: "text",
+      number: 42,
+      boolean: true,
+      array: [1, 2, 3],
+      object: { b: 2, a: 1 },
+      nullValue: null,
+    }
+    const sorted = sortThemeInputKeys(input) as Record<string, unknown>
+    const keys = Object.keys(sorted)
+    expect(keys).toEqual([
+      "array",
+      "boolean",
+      "nullValue",
+      "number",
+      "object",
+      "string",
+    ])
+    // Verify nested object is also sorted
+    const nestedObj = sorted.object as Record<string, number>
+    expect(Object.keys(nestedObj)).toEqual(["a", "b"])
+  })
+
+  it("produces consistent hashes for same content with different key orders", () => {
+    const input1 = { z: 1, y: 2, x: { c: 3, b: 4, a: 5 } }
+    const input2 = { x: { a: 5, b: 4, c: 3 }, y: 2, z: 1 }
+
+    const sorted1 = JSON.stringify(sortThemeInputKeys(input1))
+    const sorted2 = JSON.stringify(sortThemeInputKeys(input2))
+
+    expect(sorted1).toBe(sorted2)
+  })
+
+  it("handles empty objects and arrays", () => {
+    const input = {
+      emptyObject: {},
+      emptyArray: [],
+      nested: {
+        alsoEmpty: {},
+      },
+    }
+    const sorted = sortThemeInputKeys(input)
+    expect(sorted).toEqual({
+      emptyArray: [],
+      emptyObject: {},
+      nested: {
+        alsoEmpty: {},
+      },
+    })
+  })
+
+  it("handles arrays of primitives", () => {
+    const input = {
+      numbers: [3, 1, 2],
+      strings: ["c", "a", "b"],
+      mixed: [3, "a", null, true],
+    }
+    const sorted = sortThemeInputKeys(input) as typeof input
+    // Arrays should maintain their order (only objects within arrays get sorted)
+    expect(sorted.numbers).toEqual([3, 1, 2])
+    expect(sorted.strings).toEqual(["c", "a", "b"])
+    expect(sorted.mixed).toEqual([3, "a", null, true])
+  })
+
+  it("handles complex nested theme config structure", () => {
+    const input = new CustomThemeConfig({
+      primaryColor: "blue",
+      backgroundColor: "white",
+      sidebar: {
+        backgroundColor: "gray",
+        primaryColor: "red",
+      },
+      light: {
+        primaryColor: "lightblue",
+        sidebar: {
+          backgroundColor: "lightgray",
+        },
+      },
+      dark: {
+        primaryColor: "darkblue",
+        backgroundColor: "black",
+      },
+    })
+
+    const sorted = sortThemeInputKeys(input)
+    const sortedStr = JSON.stringify(sorted)
+
+    // Verify the JSON representation contains all properties
+    expect(sortedStr).toContain("backgroundColor")
+    expect(sortedStr).toContain("primaryColor")
+    expect(sortedStr).toContain("sidebar")
+    expect(sortedStr).toContain("light")
+    expect(sortedStr).toContain("dark")
+
+    // Verify consistent serialization
+    const sorted2 = sortThemeInputKeys(input)
+    expect(JSON.stringify(sorted)).toBe(JSON.stringify(sorted2))
   })
 })
 

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -74,6 +74,38 @@ declare global {
 }
 const LOG = getLogger("theme:utils")
 
+/**
+ * Recursively sorts the theme input keys to ensure consistent theme hashing.
+ * Used in App.tsx createThemeHash method.
+ *
+ * @param obj - The theme input object (or any nested value within it)
+ * @returns The same structure with all object keys sorted alphabetically
+ */
+export function sortThemeInputKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined) {
+    return obj
+  }
+
+  // Handle arrays by recursively sorting their elements
+  if (Array.isArray(obj)) {
+    return obj.map(item => sortThemeInputKeys(item))
+  }
+
+  // Handle objects (including nested theme sections)
+  if (typeof obj === "object") {
+    const sorted: Record<string, unknown> = {}
+    Object.keys(obj)
+      .sort()
+      .forEach(key => {
+        sorted[key] = sortThemeInputKeys((obj as Record<string, unknown>)[key])
+      })
+    return sorted
+  }
+
+  // Return primitives as-is
+  return obj
+}
+
 function mergeTheme(
   theme: ThemeConfig,
   injectedTheme: ICustomThemeConfig | undefined


### PR DESCRIPTION
## Describe your changes
Our current theme hashing only handles top level `[theme]` properties in calculating the theme hash to determine whether theme has been updated. This was sufficient prior to custom theming, but now section theme changes are silently ignored and a re-run does not trigger the expected update.

**Issue Repro:**
* In `[theme.sidebar]` section of your `config.toml` - set `primaryColor = "blue"`
* See blue primary color applied in app
* Update `primaryColor = "green"`
* A file change is detected, select **Rerun** in the app header
* The primary color in sidebar is still blue

This PR implements comprehensive theme hashing that includes all theme properties - including new subsections (`light`, `dark`, etc.) so changes now properly trigger theme reprocessing.

## Testing Plan
- Unit Tests (JS and/or Python): ✅ Added
- Manual Testing: ✅ 