### PR TITLE
nit: fix Makefile's clean rule to delete the generated proto.js and proto.d.ts correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ clean:
 	rm -rf frontend/lib/node_modules
 	rm -rf frontend/connection/node_modules
 	rm -rf frontend/test_results
-	rm -f frontend/protobuf/src/proto.js
-	rm -f frontend/protobuf/src/proto.d.ts
+	rm -f frontend/protobuf/proto.js
+	rm -f frontend/protobuf/proto.d.ts
 	rm -rf frontend/public/reports
 	rm -rf frontend/lib/dist
 	rm -rf frontend/connection/dist


### PR DESCRIPTION
## Describe your changes
The paths of `proto.js` and `proto.d.ts` in the `clean` rule in Makefile are wrong.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
