### PR TITLE
[WIP] Allow disabling data export in `st.dataframe`

### DIFF
--- a/e2e_playwright/st_dataframe_config.py
+++ b/e2e_playwright/st_dataframe_config.py
@@ -915,3 +915,16 @@ st.dataframe(
     placeholder="-",
     width="content",
 )
+
+st.header("Disable export:")
+st.dataframe(
+    pd.DataFrame(
+        {
+            "col_0": [1, 2, 3],
+            "col_1": ["a", "b", "c"],
+        }
+    ),
+    disable_export=True,
+    width="content",
+    key="disable_export_df",
+)

--- a/e2e_playwright/st_dataframe_config_test.py
+++ b/e2e_playwright/st_dataframe_config_test.py
@@ -158,6 +158,8 @@ def test_list_cell_overlay(themed_app: Page, assert_snapshot: ImageCompareFuncti
     click_on_cell(dataframe_element, 1, 1, double_click=True, column_width="medium")
 
     cell_overlay = get_open_cell_overlay(themed_app)
+    # Reset the hovering to ensure that there aren't unexpected UI elements visible
+    reset_hovering(themed_app)
     assert_snapshot(cell_overlay, name="st_dataframe-list_column_overlay")
 
 

--- a/e2e_playwright/st_dataframe_config_test.py
+++ b/e2e_playwright/st_dataframe_config_test.py
@@ -327,3 +327,23 @@ def test_localized_date_and_number_formatting(
     assert_snapshot(
         dataframe_element, name="st_dataframe-localized_date_and_number_formatting"
     )
+
+
+def test_disable_export_hides_download_button(app: Page):
+    """Test that disable_export hides the download button."""
+    dataframe_element = app.get_by_test_id("stDataFrame").nth(33)
+    expect_canvas_to_be_visible(dataframe_element)
+    dataframe_element.scroll_into_view_if_needed()
+
+    # Hover over the dataframe to make the toolbar visible
+    dataframe_element.hover()
+    toolbar = dataframe_element.get_by_test_id("stElementToolbar")
+    expect(toolbar).to_be_visible()
+
+    # Verify that the download button is not attached
+    download_button = toolbar.get_by_label("Download as CSV")
+    expect(download_button).not_to_be_attached()
+
+    # Verify search button is still present (other toolbar items should still work)
+    search_button = toolbar.get_by_label("Search")
+    expect(search_button).to_be_visible()

--- a/e2e_playwright/st_dataframe_config_test.py
+++ b/e2e_playwright/st_dataframe_config_test.py
@@ -30,7 +30,7 @@ from e2e_playwright.shared.dataframe_utils import (
     open_column_menu,
 )
 
-NUM_DATAFRAME_ELEMENTS = 33
+NUM_DATAFRAME_ELEMENTS = 34
 
 
 def test_dataframe_supports_various_configurations(

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -136,4 +136,26 @@ describe("DataFrame widget", () => {
       {}
     )
   })
+
+  it("disableExport disables copy and getCellsForSelection", () => {
+    const propsWithDisableExport = {
+      ...getProps(new Quiver({ data: TEN_BY_TEN })),
+      element: ArrowProto.create({
+        data: new Uint8Array(),
+        disableExport: true,
+      }),
+    }
+
+    render(<DataFrame {...propsWithDisableExport} />)
+
+    expect(glideDataGridModule.DataEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        getCellsForSelection: undefined,
+        keybindings: expect.objectContaining({
+          copy: false,
+        }),
+      }),
+      {}
+    )
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -189,7 +189,7 @@ function DataFrame({
 
   // Determine if the device is primary using touch as input:
   const isTouchDevice = useMemo<boolean>(
-    () => window.matchMedia && window.matchMedia("(pointer: coarse)").matches,
+    () => window.matchMedia?.("(pointer: coarse)")?.matches ?? false,
     []
   )
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -688,7 +688,7 @@ function DataFrame({
             />
           </ColumnVisibilityMenu>
         )}
-        {!isLargeTable && !isEmptyTable && (
+        {!isLargeTable && !isEmptyTable && !element.disableExport && (
           <ToolbarAction
             label="Download as CSV"
             icon={FileDownload}
@@ -778,8 +778,8 @@ function DataFrame({
           smoothScrollY={true}
           // Show borders between cells:
           verticalBorder={true}
-          // Activate copy to clipboard functionality:
-          getCellsForSelection={true}
+          // Activate copy to clipboard functionality (disabled when export is disabled):
+          getCellsForSelection={element.disableExport ? undefined : true}
           // Deactivate row markers and numbers:
           rowMarkers={"none"}
           // Deactivate selections:
@@ -799,6 +799,8 @@ function DataFrame({
           // Activate keybindings:
           keybindings={{
             downFill: true,
+            // Disable copy keybinding when export is disabled:
+            copy: !element.disableExport,
             ...(isCellSelectionActivated || isLargeTable
               ? {
                   // Deactivate select all to prevent potential performance issues

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -530,9 +530,9 @@ class ArrowMixin:
             clipboard. If this is ``False`` (default), exporting is enabled.
 
             .. note::
-                While this makes it more difficult and inconvenient for users to export
-                large chunks of data, it is still technically possible to extract data
-                from the frontend with advanced skills.
+                This is a convenience feature, not a security control. Technically skilled users
+                can still extract data from the frontend.
+
 
         Returns
         -------

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -298,6 +298,7 @@ class ArrowMixin:
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
         row_height: int | None = None,
         placeholder: str | None = None,
+        disable_export: bool = False,
     ) -> DeltaGenerator: ...
 
     @overload
@@ -316,6 +317,7 @@ class ArrowMixin:
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
         row_height: int | None = None,
         placeholder: str | None = None,
+        disable_export: bool = False,
     ) -> DataframeState: ...
 
     @gather_metrics("dataframe")
@@ -334,6 +336,7 @@ class ArrowMixin:
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
         row_height: int | None = None,
         placeholder: str | None = None,
+        disable_export: bool = False,
     ) -> DeltaGenerator | DataframeState:
         """Display a dataframe as an interactive table.
 
@@ -521,6 +524,16 @@ class ArrowMixin:
             ``"NaN"``, ``"-"``, or ``""``). If this is ``None`` (default),
             missing values are displayed as ``"None"``.
 
+        disable_export : bool
+            Whether to disable exporting the data. If this is ``True``, users
+            cannot download the data as a CSV file or copy cells to the
+            clipboard. If this is ``False`` (default), exporting is enabled.
+
+            .. note::
+                While this makes it more difficult and inconvenient for users to export
+                large chunks of data, it is still technically possible to extract data
+                from the frontend with advanced skills.
+
         Returns
         -------
         element or dict
@@ -704,7 +717,7 @@ class ArrowMixin:
 
         if placeholder is not None:
             proto.placeholder = placeholder
-
+        proto.disable_export = disable_export
         proto.editing_mode = ArrowProto.EditingMode.READ_ONLY
 
         has_range_index: bool = False
@@ -782,6 +795,7 @@ class ArrowMixin:
                 is_selection_activated=is_selection_activated,
                 row_height=row_height,
                 placeholder=placeholder,
+                disable_export=disable_export,
             )
 
             serde = DataframeSelectionSerde()

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -158,6 +158,20 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         assert proto.placeholder == "-"
 
+    def test_disable_export_parameter(self):
+        """Test that disable_export parameter sets the proto field correctly."""
+        st.dataframe(pd.DataFrame(), disable_export=True)
+
+        proto = self.get_delta_from_queue().new_element.arrow_data_frame
+        assert proto.disable_export is True
+
+    def test_disable_export_default_is_false(self):
+        """Test that disable_export defaults to False."""
+        st.dataframe(pd.DataFrame())
+
+        proto = self.get_delta_from_queue().new_element.arrow_data_frame
+        assert proto.disable_export is False
+
     def test_uuid(self):
         df = mock_data_frame()
         styler = df.style

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -75,6 +75,7 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         assert proto.columns == "{}"
         # ID should not be set:
         assert proto.id == ""
+        assert proto.disable_export is False
         # Row height is marked optional should not be set if not specified
         assert not proto.HasField("row_height")
         assert proto.row_height == 0
@@ -164,13 +165,6 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         assert proto.disable_export is True
-
-    def test_disable_export_default_is_false(self):
-        """Test that disable_export defaults to False."""
-        st.dataframe(pd.DataFrame())
-
-        proto = self.get_delta_from_queue().new_element.arrow_data_frame
-        assert proto.disable_export is False
 
     def test_uuid(self):
         df = mock_data_frame()

--- a/proto/streamlit/proto/Arrow.proto
+++ b/proto/streamlit/proto/Arrow.proto
@@ -51,6 +51,8 @@ message Arrow {
   BorderMode border_mode = 14;
   // Placeholder string used when rendering missing values (e.g. nulls, NaNs).
   optional string placeholder = 15;
+  // If true, disables exporting (CSV download) and copying cells.
+  bool disable_export = 16;
 
   // Available editing modes:
   enum EditingMode {


### PR DESCRIPTION
## Describe your changes

Adds a `disable_export: bool` parameter to `st.dataframe` that allows to disable the CSV download & range copy-to-clipboard of cell data. While its no technical guarantee against unwanted data extraction from the frontend, it makes it less convenient and obvious on how to export large chunks of data. .

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/8402
- Closes https://github.com/streamlit/streamlit/issues/11358

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
