### PR TITLE
Fix flaky dataframe list overlay e2e test

### DIFF
--- a/e2e_playwright/st_dataframe_config_test.py
+++ b/e2e_playwright/st_dataframe_config_test.py
@@ -158,6 +158,8 @@ def test_list_cell_overlay(themed_app: Page, assert_snapshot: ImageCompareFuncti
     click_on_cell(dataframe_element, 1, 1, double_click=True, column_width="medium")
 
     cell_overlay = get_open_cell_overlay(themed_app)
+    # Reset the hovering to ensure that there aren't unexpected UI elements visible
+    reset_hovering(themed_app)
     assert_snapshot(cell_overlay, name="st_dataframe-list_column_overlay")
 
 


### PR DESCRIPTION
## Describe your changes

Fix the flaky list overlay dataframe e2e test caused by the scrollbar sometimes shown or hidden.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
