### PR TITLE
Activate pytest timeouts for e2e tests

### DIFF
--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings =
     # Likely needs to be refactored to support pytest 9.
     ignore:Marks applied to fixtures have no effect.*:pytest.PytestWarning::
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short
+timeout = 300

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -36,3 +36,4 @@ pytest-rerunfailures>=15.0,!=16.0
 pytest-github-actions-annotate-failures
 pytest-benchmark>=5.1.0
 pytest-repeat>=0.9.3
+pytest-timeout>=2.3.1


### PR DESCRIPTION
## Describe your changes

It seems like that sometimes individual tests seem to take a very long time, causing the e2e workflow to hit its 30 min timeout. This is adding a timeout of 300s that is applied to all of the individual e2e tests to get better insights into which test cases are causing trouble.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
