### PR TITLE
[fix] improve width/height error message to say "positive integer"

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -587,9 +587,9 @@ class StreamlitInvalidWidthError(LocalizableStreamlitException):
     """Exception raised when an invalid width value is provided."""
 
     def __init__(self, width: Any, allow_content: bool = False) -> None:
-        valid_values = "an integer (pixels) or 'stretch'"
+        valid_values = "a positive integer (pixels) or 'stretch'"
         if allow_content:
-            valid_values = "an integer (pixels), 'stretch', or 'content'"
+            valid_values = "a positive integer (pixels), 'stretch', or 'content'"
 
         super().__init__(
             "Invalid width value: {width}. Width must be either {valid_values}.",
@@ -602,9 +602,9 @@ class StreamlitInvalidHeightError(LocalizableStreamlitException):
     """Exception raised when an invalid height value is provided."""
 
     def __init__(self, height: Any, allow_content: bool = False) -> None:
-        valid_values = "an integer (pixels) or 'stretch'"
+        valid_values = "a positive integer (pixels) or 'stretch'"
         if allow_content:
-            valid_values = "an integer (pixels), 'stretch', or 'content'"
+            valid_values = "a positive integer (pixels), 'stretch', or 'content'"
 
         super().__init__(
             "Invalid height value: {height}. Height must be either {valid_values}.",
@@ -618,7 +618,7 @@ class StreamlitInvalidSizeError(LocalizableStreamlitException):
 
     def __init__(self, size: Any) -> None:
         super().__init__(
-            "Invalid size value: {size}. Size must be either an integer (pixels), "
+            "Invalid size value: {size}. Size must be either a positive integer (pixels), "
             "'stretch', 'small', 'medium', or 'large'.",
             size=repr(size),
         )

--- a/lib/tests/streamlit/elements/alert_test.py
+++ b/lib/tests/streamlit/elements/alert_test.py
@@ -37,7 +37,9 @@ class AlertAPITest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidWidthError) as e:
             alert_func("some alert", width="invalid")
         assert "Invalid width value" in str(e.value)
-        assert "Width must be either an integer (pixels) or 'stretch'" in str(e.value)
+        assert "Width must be either a positive integer (pixels) or 'stretch'" in str(
+            e.value
+        )
 
     @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
     def test_st_alert_negative_width(self, alert_func):
@@ -45,7 +47,9 @@ class AlertAPITest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidWidthError) as e:
             alert_func("some alert", width=-100)
         assert "Invalid width value" in str(e.value)
-        assert "Width must be either an integer (pixels) or 'stretch'" in str(e.value)
+        assert "Width must be either a positive integer (pixels) or 'stretch'" in str(
+            e.value
+        )
 
 
 class StErrorAPITest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -929,19 +929,19 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -950,7 +950,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     command(["a", "b", "c"], width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     @parameterized.expand(get_command_matrix([]))
     def test_button_group_default_width(self, command: Callable[..., None]):

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -260,19 +260,19 @@ hello
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -283,7 +283,7 @@ hello
                         f"invalid checkbox width test {index}", width=width_value
                     )
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_checkbox_default_width(self):
         """Test that st.checkbox defaults to content width."""
@@ -326,19 +326,19 @@ hello
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -347,7 +347,7 @@ hello
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.toggle(f"invalid toggle test {index}", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_toggle_default_width(self):
         """Test that st.toggle defaults to content width."""

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -148,11 +148,11 @@ class ColorPickerTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -161,7 +161,7 @@ class ColorPickerTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.color_picker("test label", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_color_picker_default_width(self):
         """Test that st.color_picker defaults to content width."""

--- a/lib/tests/streamlit/elements/heading_test.py
+++ b/lib/tests/streamlit/elements/heading_test.py
@@ -119,19 +119,19 @@ class StHeaderTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -140,7 +140,7 @@ class StHeaderTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.header("some header", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_header_default_width(self):
         """Test that st.header defaults to stretch width."""
@@ -254,19 +254,19 @@ class StSubheaderTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -275,7 +275,7 @@ class StSubheaderTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.subheader("some subheader", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_subheader_default_width(self):
         """Test that st.subheader defaults to stretch width."""
@@ -378,19 +378,19 @@ class StTitleTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -399,7 +399,7 @@ class StTitleTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.title("some title", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_title_default_width(self):
         """Test that st.title defaults to stretch width."""

--- a/lib/tests/streamlit/elements/html_test.py
+++ b/lib/tests/streamlit/elements/html_test.py
@@ -217,19 +217,19 @@ class StHtmlAPITest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -238,7 +238,7 @@ class StHtmlAPITest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.html("<p>test html</p>", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_html_default_width(self):
         """Test that st.html defaults to stretch width."""

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -558,23 +558,23 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 "",
-                "Invalid width value: ''. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -1,
-                "Invalid width value: -1. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 None,
-                "Invalid width value: None. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
     )
@@ -585,4 +585,4 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc_info:
             st.image(img, width=invalid_width)
 
-        assert str(exc_info.value) == expected_error_message
+        assert expected_error_message in str(exc_info.value)

--- a/lib/tests/streamlit/elements/markdown_test.py
+++ b/lib/tests/streamlit/elements/markdown_test.py
@@ -70,19 +70,19 @@ class StMarkdownAPITest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -91,7 +91,7 @@ class StMarkdownAPITest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.markdown("some markdown", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_markdown_default_width(self):
         """Test that st.markdown defaults to stretch width."""
@@ -167,19 +167,19 @@ class StCaptionAPITest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -50,
-                "Invalid width value: -50. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 75.5,
-                "Invalid width value: 75.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -188,7 +188,7 @@ class StCaptionAPITest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.caption("some caption", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_caption_default_width(self):
         """Test that st.caption defaults to stretch width."""
@@ -266,19 +266,19 @@ class StBadgeAPITest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -25,
-                "Invalid width value: -25. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 50.7,
-                "Invalid width value: 50.7. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -287,7 +287,7 @@ class StBadgeAPITest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.badge("test badge", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_st_badge_default_width(self):
         """Test that st.badge defaults to content width."""

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -358,19 +358,19 @@ class MetricTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid height value: 'invalid'. Height must be either an integer (pixels), 'stretch', or 'content'.",
+                "Height must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid height value: -100. Height must be either an integer (pixels), 'stretch', or 'content'.",
+                "Height must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid height value: 0. Height must be either an integer (pixels), 'stretch', or 'content'.",
+                "Height must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid height value: 100.5. Height must be either an integer (pixels), 'stretch', or 'content'.",
+                "Height must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -379,7 +379,7 @@ class MetricTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.metric("label_test", "123", height=height_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_width_types(self):
         """Test that metric can be called with different width types."""
@@ -408,19 +408,19 @@ class MetricTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -429,7 +429,7 @@ class MetricTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.metric("label_test", "123", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_chart_data_none(self):
         """Test that metric works with default chart_data=None."""

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -164,23 +164,23 @@ class PyplotTest(DeltaGeneratorTestCase):
         [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 "",
-                "Invalid width value: ''. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -1,
-                "Invalid width value: -1. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 None,
-                "Invalid width value: None. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
     )
@@ -193,7 +193,7 @@ class PyplotTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc_info:
             st.pyplot(fig, width=invalid_width)
 
-        assert str(exc_info.value) == expected_error_message
+        assert expected_error_message in str(exc_info.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -285,19 +285,19 @@ class RadioTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -306,7 +306,7 @@ class RadioTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.radio("test label", ["option 1", "option 2"], width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_radio_default_width(self):
         """Test that st.radio defaults to content width."""

--- a/lib/tests/streamlit/elements/text_test.py
+++ b/lib/tests/streamlit/elements/text_test.py
@@ -64,19 +64,19 @@ class StTextAPITest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -85,7 +85,7 @@ class StTextAPITest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     st.text("some text", width=width_value)
 
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
 
 class StTextTextAlignmentTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -111,19 +111,19 @@ class SpinnerTest(DeltaGeneratorTestCase):
         test_cases = [
             (
                 "invalid",
-                "Invalid width value: 'invalid'. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 -100,
-                "Invalid width value: -100. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 0,
-                "Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
             (
                 100.5,
-                "Invalid width value: 100.5. Width must be either an integer (pixels), 'stretch', or 'content'.",
+                "Width must be either a positive integer (pixels), 'stretch', or 'content'.",
             ),
         ]
 
@@ -132,7 +132,7 @@ class SpinnerTest(DeltaGeneratorTestCase):
                 with pytest.raises(StreamlitAPIException) as exc:
                     with st.spinner("test text", width=width_value):
                         time.sleep(0.1)
-                assert str(exc.value) == expected_error_message
+                assert expected_error_message in str(exc.value)
 
     def test_spinner_default_width(self):
         """Test that st.spinner defaults to content width."""


### PR DESCRIPTION
## Describe your changes

Fixes #12868

Updates the error message for invalid `width` and `height` values to say **"a positive integer"** instead of **"an integer"**. This makes the error message more accurate since 0 and negative values are not valid.

**Before:**

> Invalid width value: 0. Width must be either an integer (pixels), 'stretch', or 'content'.

**After:**

> Invalid width value: 0. Width must be either a positive integer (pixels), 'stretch', or 'content'.

### Changes

- Updated `StreamlitInvalidWidthError` in `errors.py` to say "a positive integer (pixels)"
- Updated `StreamlitInvalidHeightError` in `errors.py` to say "a positive integer (pixels)"
- Updated `StreamlitInvalidSizeError` in `errors.py` to say "a positive integer (pixels)"
- Updated all corresponding unit tests to use substring matching for error messages

## GitHub Issue Link (if applicable)

Closes #12868

## Testing Plan

- Unit Tests (Python): Updated existing tests in 14 test files to verify the new error message wording. Tests use substring matching (`in`) to check for the key part of the error message.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
