### PR TITLE
Navigate to home page on logo click

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics.py
@@ -24,7 +24,7 @@ SMALL_LOGO = Image.open(str(PARENT_DIR / "small-streamlit.png"))
 
 LOGO = Image.open(str(PARENT_DIR / "full-streamlit.png"))
 
-st.logo(LOGO, link="https://www.example.com", icon_image=SMALL_LOGO)
+st.logo(LOGO, icon_image=SMALL_LOGO)
 
 st.header("Main Page")
 x = st.slider("x")

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -472,11 +472,29 @@ def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     get_page_link(app, "page 8").click()
     wait_for_app_loaded(app)
 
-    # Sidebar logo
-    expect(app.get_by_test_id("stSidebarHeader").locator("a")).to_have_attribute(
-        "href", "https://www.example.com"
-    )
     assert_snapshot(app.get_by_test_id("stSidebar"), name="sidebar-logo")
+
+
+def test_logo_navigates_to_home_page(app: Page):
+    """Test that clicking the logo navigates to the home page in multi-page apps."""
+
+    # Navigate to a different page first
+    get_page_link(app, "page 8").click()
+    wait_for_app_loaded(app)
+    expect(page_heading(app)).to_contain_text("Page 8")
+
+    # The logo should be a clickable button (not an external link) when no link is provided
+    logo_button = app.get_by_test_id("stSidebarHeader").get_by_test_id("stLogoLink")
+    expect(logo_button).to_be_visible()
+    # Verify it's a button, not an anchor tag
+    expect(logo_button).to_have_attribute("aria-label", "Navigate to home page")
+
+    # Click the logo to navigate to the home page
+    logo_button.click()
+    wait_for_app_loaded(app)
+
+    # Verify we're on the main page (home)
+    expect(main_heading(app)).to_contain_text("Main Page")
 
 
 def test_page_link_with_path(app: Page):

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -226,6 +226,32 @@ describe("LogoComponent", () => {
       expect(mockOnPageChange).toHaveBeenCalledWith("home_hash")
     })
 
+    it("does not call onPageChange when already on home page", async () => {
+      const user = userEvent.setup()
+      const mockOnPageChange = vi.fn()
+
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithoutLink,
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: multiPageAppPages,
+            onPageChange: mockOnPageChange,
+            currentPageScriptHash: "home_hash", // Already on home page
+          },
+        }
+      )
+
+      const logoButton = screen.getByTestId("stLogoLink")
+      await user.click(logoButton)
+
+      expect(mockOnPageChange).not.toHaveBeenCalled()
+    })
+
     it("uses external link when link is provided, even in multi-page app", () => {
       renderWithContexts(
         <LogoComponent

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -226,10 +226,7 @@ describe("LogoComponent", () => {
       expect(mockOnPageChange).toHaveBeenCalledWith("home_hash")
     })
 
-    it("does not call onPageChange when already on home page", async () => {
-      const user = userEvent.setup()
-      const mockOnPageChange = vi.fn()
-
+    it("renders non-clickable logo when already on home page", () => {
       renderWithContexts(
         <LogoComponent
           {...getProps({
@@ -240,16 +237,15 @@ describe("LogoComponent", () => {
         {
           navigationContext: {
             appPages: multiPageAppPages,
-            onPageChange: mockOnPageChange,
             currentPageScriptHash: "home_hash", // Already on home page
           },
         }
       )
 
-      const logoButton = screen.getByTestId("stLogoLink")
-      await user.click(logoButton)
-
-      expect(mockOnPageChange).not.toHaveBeenCalled()
+      // Should not render a clickable button when already on home page
+      expect(screen.queryByTestId("stLogoLink")).not.toBeInTheDocument()
+      // Logo should still be rendered
+      screen.getByTestId("stHeaderLogo")
     })
 
     it("uses external link when link is provided, even in multi-page app", () => {

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 
 import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { render, renderWithContexts } from "@streamlit/lib/testing"
 import { Logo as LogoProto } from "@streamlit/protobuf"
@@ -150,7 +151,7 @@ describe("LogoComponent", () => {
     expect(logoLink).toHaveAttribute("href", "https://example.com")
   })
 
-  it("renders logo without link when no link provided", () => {
+  it("renders logo without link when no link provided and single-page app", () => {
     const logoWithoutLink = LogoProto.create({
       image: "https://example.com/logo.png",
       size: "medium",
@@ -167,6 +168,126 @@ describe("LogoComponent", () => {
 
     expect(screen.queryByTestId("stLogoLink")).not.toBeInTheDocument()
     screen.getByTestId("stHeaderLogo")
+  })
+
+  describe("multi-page app home navigation", () => {
+    const logoWithoutLink = LogoProto.create({
+      image: "https://example.com/logo.png",
+      size: "medium",
+    })
+
+    const multiPageAppPages = [
+      { pageName: "Home", pageScriptHash: "home_hash", isDefault: true },
+      { pageName: "Page 2", pageScriptHash: "page2_hash", isDefault: false },
+    ]
+
+    it("renders clickable button when no link provided in multi-page app", () => {
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithoutLink,
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: multiPageAppPages,
+          },
+        }
+      )
+
+      const logoButton = screen.getByTestId("stLogoLink")
+      expect(logoButton.tagName).toBe("BUTTON")
+      expect(logoButton).toHaveAttribute("aria-label", "Navigate to home page")
+    })
+
+    it("calls onPageChange with home page hash when clicked", async () => {
+      const user = userEvent.setup()
+      const mockOnPageChange = vi.fn()
+
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithoutLink,
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: multiPageAppPages,
+            onPageChange: mockOnPageChange,
+          },
+        }
+      )
+
+      const logoButton = screen.getByTestId("stLogoLink")
+      await user.click(logoButton)
+
+      expect(mockOnPageChange).toHaveBeenCalledWith("home_hash")
+    })
+
+    it("uses external link when link is provided, even in multi-page app", () => {
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: sampleLogo, // Has link: "https://example.com"
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: multiPageAppPages,
+          },
+        }
+      )
+
+      const logoLink = screen.getByTestId("stLogoLink")
+      expect(logoLink.tagName).toBe("A")
+      expect(logoLink).toHaveAttribute("href", "https://example.com")
+      expect(logoLink).toHaveAttribute("target", "_blank")
+    })
+
+    it("renders non-clickable logo when single-page app with no link", () => {
+      const singlePageAppPages = [
+        { pageName: "Home", pageScriptHash: "home_hash", isDefault: true },
+      ]
+
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithoutLink,
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: singlePageAppPages,
+          },
+        }
+      )
+
+      expect(screen.queryByTestId("stLogoLink")).not.toBeInTheDocument()
+      screen.getByTestId("stHeaderLogo")
+    })
+
+    it("renders non-clickable logo when no pages are available", () => {
+      renderWithContexts(
+        <LogoComponent
+          {...getProps({
+            appLogo: logoWithoutLink,
+            dataTestId: "stHeaderLogo",
+          })}
+        />,
+        {
+          navigationContext: {
+            appPages: [],
+          },
+        }
+      )
+
+      expect(screen.queryByTestId("stLogoLink")).not.toBeInTheDocument()
+      screen.getByTestId("stHeaderLogo")
+    })
   })
 
   it("applies correct size classes", () => {

--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -52,7 +52,8 @@ const LogoComponent = ({
   dataTestId = "stLogo",
 }: LogoComponentProps): ReactElement | null => {
   const { resourceCrossOriginMode } = useContext(LibConfigContext)
-  const { appPages, onPageChange } = useContext(NavigationContext)
+  const { appPages, onPageChange, currentPageScriptHash } =
+    useContext(NavigationContext)
 
   // Find the home page (the default page) and check if this is a multi-page app
   const homePage = useMemo(
@@ -62,10 +63,14 @@ const LogoComponent = ({
   const isMultiPageApp = appPages.length > 1
 
   const handleLogoClick = useCallback(() => {
-    if (homePage?.pageScriptHash) {
+    // Only navigate if we're not already on the home page
+    if (
+      homePage?.pageScriptHash &&
+      currentPageScriptHash !== homePage.pageScriptHash
+    ) {
       onPageChange(homePage.pageScriptHash)
     }
-  }, [homePage, onPageChange])
+  }, [homePage, onPageChange, currentPageScriptHash])
 
   if (!appLogo) {
     return null

--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -61,16 +61,14 @@ const LogoComponent = ({
     [appPages]
   )
   const isMultiPageApp = appPages.length > 1
+  const isOnHomePage = homePage?.pageScriptHash === currentPageScriptHash
 
   const handleLogoClick = useCallback(() => {
     // Only navigate if we're not already on the home page
-    if (
-      homePage?.pageScriptHash &&
-      currentPageScriptHash !== homePage.pageScriptHash
-    ) {
+    if (homePage?.pageScriptHash && !isOnHomePage) {
       onPageChange(homePage.pageScriptHash)
     }
-  }, [homePage, onPageChange, currentPageScriptHash])
+  }, [homePage, onPageChange, isOnHomePage])
 
   if (!appLogo) {
     return null
@@ -126,7 +124,8 @@ const LogoComponent = ({
   }
 
   // In multi-page apps without an explicit link, clicking the logo navigates to home page
-  if (isMultiPageApp && homePage) {
+  // Only use the clickable button when not already on the home page
+  if (isMultiPageApp && homePage && !isOnHomePage) {
     return (
       <StyledLogoButton
         onClick={handleLogoClick}

--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext } from "react"
+import React, { ReactElement, useCallback, useContext, useMemo } from "react"
 
 import { getLogger } from "loglevel"
 
 import {
   StyledLogo,
+  StyledLogoButton,
   StyledLogoLink,
 } from "@streamlit/app/src/components/Sidebar/styled-components"
 import { StreamlitEndpoints } from "@streamlit/connection"
-import { getCrossOriginAttribute, LibConfigContext } from "@streamlit/lib"
+import {
+  getCrossOriginAttribute,
+  LibConfigContext,
+  NavigationContext,
+} from "@streamlit/lib"
 import { Logo } from "@streamlit/protobuf"
 
 const LOG = getLogger("LogoComponent")
@@ -47,6 +52,20 @@ const LogoComponent = ({
   dataTestId = "stLogo",
 }: LogoComponentProps): ReactElement | null => {
   const { resourceCrossOriginMode } = useContext(LibConfigContext)
+  const { appPages, onPageChange } = useContext(NavigationContext)
+
+  // Find the home page (the default page) and check if this is a multi-page app
+  const homePage = useMemo(
+    () => appPages.find(page => page.isDefault),
+    [appPages]
+  )
+  const isMultiPageApp = appPages.length > 1
+
+  const handleLogoClick = useCallback(() => {
+    if (homePage?.pageScriptHash) {
+      onPageChange(homePage.pageScriptHash)
+    }
+  }, [homePage, onPageChange])
 
   if (!appLogo) {
     return null
@@ -87,6 +106,7 @@ const LogoComponent = ({
     />
   )
 
+  // If an explicit link is provided, use it (opens in new tab)
   if (appLogo.link) {
     return (
       <StyledLogoLink
@@ -97,6 +117,19 @@ const LogoComponent = ({
       >
         {logo}
       </StyledLogoLink>
+    )
+  }
+
+  // In multi-page apps without an explicit link, clicking the logo navigates to home page
+  if (isMultiPageApp && homePage) {
+    return (
+      <StyledLogoButton
+        onClick={handleLogoClick}
+        data-testid="stLogoLink"
+        aria-label="Navigate to home page"
+      >
+        {logo}
+      </StyledLogoButton>
     )
   }
 

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -152,21 +152,21 @@ export const StyledSidebarHeaderContainer = styled.div(({ theme }) => ({
   height: theme.sizes.headerHeight,
 }))
 
-const logoLinkStyles = {
+export const StyledLogoLink = styled.a({
   "&:hover": {
     opacity: "0.7",
   },
-}
-
-export const StyledLogoLink = styled.a(logoLinkStyles)
+})
 
 export const StyledLogoButton = styled.button({
-  ...logoLinkStyles,
   // Reset button styles
   background: "none",
   border: "none",
   padding: 0,
   cursor: "pointer",
+  "&:hover": {
+    opacity: "0.7",
+  },
 })
 
 export interface StyledLogoProps {

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -152,10 +152,21 @@ export const StyledSidebarHeaderContainer = styled.div(({ theme }) => ({
   height: theme.sizes.headerHeight,
 }))
 
-export const StyledLogoLink = styled.a({
+const logoLinkStyles = {
   "&:hover": {
     opacity: "0.7",
   },
+}
+
+export const StyledLogoLink = styled.a(logoLinkStyles)
+
+export const StyledLogoButton = styled.button({
+  ...logoLinkStyles,
+  // Reset button styles
+  background: "none",
+  border: "none",
+  padding: 0,
+  cursor: "pointer",
 })
 
 export interface StyledLogoProps {


### PR DESCRIPTION
## Describe your changes

If `st.logo` is used in an MPA app without specifying a `link`, it will do an internal redirect to the default/home page on click.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/13155

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
