### PR TITLE
[feat] Enhance snapshot hygiene workflow with detailed orphaned snapshot reporting

### DIFF
--- a/.github/workflows/snapshot-hygiene.yml
+++ b/.github/workflows/snapshot-hygiene.yml
@@ -57,12 +57,18 @@ jobs:
         id: check-snapshots
         run: |
           source venv/bin/activate
-          python scripts/snapshot_cleanup.py --ci > snapshot_output.txt 2>&1 || echo "orphaned=true" >> $GITHUB_OUTPUT
+          set +e  # Don't exit immediately on error
+          python scripts/snapshot_cleanup.py --ci > snapshot_output.txt 2>&1
+          EXIT_CODE=$?
           if [ -f snapshot_output.txt ]; then
             cat snapshot_output.txt
             echo "snapshot_list<<EOF" >> $GITHUB_OUTPUT
             cat snapshot_output.txt >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+          fi
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "orphaned=true" >> $GITHUB_OUTPUT
+            exit 1
           fi
       - name: Delete comment on success
         if: success() && github.event_name == 'pull_request'

--- a/.github/workflows/snapshot-hygiene.yml
+++ b/.github/workflows/snapshot-hygiene.yml
@@ -125,7 +125,7 @@ jobs:
                 captureSummary = false;
                 captureCopyPaste = true;
                 summarySection += '```\n';
-                copyPasteSection += '\n**Copy-pastable list for DISALLOWED_SNAPSHOTS:**\n```python\n';
+                copyPasteSection += '\n**These are the snapshots I found that appear to be orphaned:**\n```python\n';
                 continue;
               }
               if (line.includes('--- COPY_PASTE_END ---')) {

--- a/.github/workflows/snapshot-hygiene.yml
+++ b/.github/workflows/snapshot-hygiene.yml
@@ -54,9 +54,16 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Check for orphaned snapshots
+        id: check-snapshots
         run: |
           source venv/bin/activate
-          python scripts/snapshot_cleanup.py --ci
+          python scripts/snapshot_cleanup.py --ci > snapshot_output.txt 2>&1 || echo "orphaned=true" >> $GITHUB_OUTPUT
+          if [ -f snapshot_output.txt ]; then
+            cat snapshot_output.txt
+            echo "snapshot_list<<EOF" >> $GITHUB_OUTPUT
+            cat snapshot_output.txt >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
       - name: Delete comment on success
         if: success() && github.event_name == 'pull_request'
         uses: actions/github-script@v8
@@ -93,18 +100,52 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const snapshotOutput = `${{ steps.check-snapshots.outputs.snapshot_list }}`;
+
+            // Extract the orphaned snapshots summary
+            const lines = snapshotOutput.split('\n');
+            let summarySection = '';
+            let copyPasteSection = '';
+            let captureSummary = false;
+            let captureCopyPaste = false;
+
+            for (const line of lines) {
+              if (line.includes('Orphaned snapshots by test:')) {
+                captureSummary = true;
+                summarySection += '\n**Orphaned snapshots by test:**\n```\n';
+                continue;
+              }
+              if (line.includes('--- COPY_PASTE_START ---')) {
+                captureSummary = false;
+                captureCopyPaste = true;
+                summarySection += '```\n';
+                copyPasteSection += '\n**Copy-pastable list for DISALLOWED_SNAPSHOTS:**\n```python\n';
+                continue;
+              }
+              if (line.includes('--- COPY_PASTE_END ---')) {
+                captureCopyPaste = false;
+                copyPasteSection += '```\n';
+                break;
+              }
+              if (captureSummary && !line.includes('--- COPY_PASTE_START ---')) {
+                summarySection += line + '\n';
+              }
+              if (captureCopyPaste && !line.includes('--- COPY_PASTE_END ---')) {
+                copyPasteSection += line + '\n';
+              }
+            }
+
             const body = `❌ **Orphaned Snapshots Detected**
 
             This PR contains orphaned e2e snapshots that are no longer used by tests.
-
+            ${summarySection}${copyPasteSection}
             **To fix this:**
             1. Run \`python scripts/snapshot_cleanup.py\` locally to clean them up
             2. Or review the snapshots manually to ensure they're actually orphaned
-            3. Commit and push the changes
+            3. If they're incorrectly flagged, copy the filenames above and add them to \`DISALLOWED_SNAPSHOTS\` in \`scripts/snapshot_cleanup.py\`
+            4. Commit and push the changes
 
-            This helps keep our snapshot directory clean and our tests maintainable.
-
-            If you believe the script incorrectly flagged valid snapshots, add them to the \`DISALLOWED_SNAPSHOTS\` set in the cleanup script.`;
+            This helps keep our snapshot directory clean and our tests maintainable.`;
 
             // Find existing orphaned snapshots comment
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/snapshot-hygiene.yml
+++ b/.github/workflows/snapshot-hygiene.yml
@@ -104,9 +104,11 @@ jobs:
       - name: Comment on PR if snapshots found
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v8
+        env:
+          SNAPSHOT_OUTPUT: ${{ steps.check-snapshots.outputs.snapshot_list }}
         with:
           script: |
-            const snapshotOutput = `${{ steps.check-snapshots.outputs.snapshot_list }}`;
+            const snapshotOutput = process.env.SNAPSHOT_OUTPUT || '';
 
             // Extract the orphaned snapshots summary
             const lines = snapshotOutput.split('\n');

--- a/scripts/snapshot_cleanup.py
+++ b/scripts/snapshot_cleanup.py
@@ -407,6 +407,11 @@ def main() -> None:
             count = len(orphaned_by_test[test_name])
             print(f"  {test_name}: {count} orphaned files")
 
+        print("\n--- COPY_PASTE_START ---")
+        for filename in sorted([os.path.basename(f) for f in orphaned_files]):
+            print(f'    "{filename}",')
+        print("--- COPY_PASTE_END ---")
+
         print("\nTo fix this, run: python scripts/snapshot_cleanup.py")
         print("Or review the snapshots manually to ensure they're actually orphaned.")
         sys.exit(1)


### PR DESCRIPTION
## Describe your changes

Enhanced the snapshot hygiene workflow to provide more detailed and actionable feedback when orphaned snapshots are detected:

1. Modified the snapshot-hygiene GitHub workflow to:
   - Capture and parse the output from the snapshot cleanup script
   - Format the orphaned snapshots list in a structured way in PR comments
   - Include a copy-pastable list of orphaned snapshots for easy addition to DISALLOWED_SNAPSHOTS

2. Updated the snapshot_cleanup.py script to:
   - Generate a copy-pastable format of orphaned snapshot filenames
   - Clearly mark the copy-pastable section with START/END markers

These changes make it easier for developers to identify and address orphaned snapshots by providing a ready-to-use list that can be directly copied into the DISALLOWED_SNAPSHOTS set if needed.

## Testing Plan

- The changes have been tested by running the snapshot cleanup script locally and verifying the output format
- The GitHub workflow changes have been reviewed to ensure they correctly parse and display the script output
- No additional tests are needed as this is an improvement to the developer workflow tooling

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.