### PR TITLE
Fix animation_demo.py not to use deprecated `use_container_width` option on `st.image`

### DIFF
--- a/lib/streamlit/hello/animation_demo.py
+++ b/lib/streamlit/hello/animation_demo.py
@@ -57,7 +57,7 @@ def animation_demo() -> None:
             n_matrix[m_matrix] = i
 
         # Update the image placeholder by calling the image() function on it.
-        image.image(1.0 - (n_matrix / n_matrix.max()), use_container_width=True)
+        image.image(1.0 - (n_matrix / n_matrix.max()), width="content")
 
     # We clear elements by calling empty on them.
     progress_bar.empty()

--- a/lib/streamlit/hello/animation_demo.py
+++ b/lib/streamlit/hello/animation_demo.py
@@ -57,7 +57,7 @@ def animation_demo() -> None:
             n_matrix[m_matrix] = i
 
         # Update the image placeholder by calling the image() function on it.
-        image.image(1.0 - (n_matrix / n_matrix.max()), width="content")
+        image.image(1.0 - (n_matrix / n_matrix.max()), width="stretch")
 
     # We clear elements by calling empty on them.
     progress_bar.empty()


### PR DESCRIPTION
## Describe your changes
`use_column_width` is deprecated: https://docs.streamlit.io/develop/api-reference/media/st.image

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
