### PR TITLE
Add layer of abstraction to generalize the CacheStat type

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -25,6 +25,7 @@ from typing import (
     Literal,
     TypeAlias,
     TypeVar,
+    cast,
     overload,
 )
 
@@ -61,11 +62,11 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from datetime import timedelta
 
     from streamlit.runtime.caching.hashing import HashFuncsDict
@@ -148,7 +149,7 @@ class CachedDataFuncInfo(CachedFuncInfo[P, R]):
         )
 
 
-class DataCaches(CacheStatsProvider):
+class DataCaches(StatsProvider):
     """Manages all DataCache instances."""
 
     def __init__(self) -> None:
@@ -249,7 +250,7 @@ class DataCaches(CacheStatsProvider):
         stats: list[CacheStat] = []
         for cache in function_caches.values():
             stats.extend(cache.get_stats())
-        return group_stats(stats)
+        return group_cache_stats(stats)
 
     def validate_cache_params(
         self,
@@ -315,7 +316,7 @@ class DataCaches(CacheStatsProvider):
 _data_caches = DataCaches()
 
 
-def get_data_cache_stats_provider() -> CacheStatsProvider:
+def get_data_cache_stats_provider() -> StatsProvider:
     """Return the StatsProvider for all @st.cache_data functions."""
     return _data_caches
 
@@ -630,9 +631,9 @@ class DataCache(Cache[R]):
         self.max_entries = max_entries
         self.persist = persist
 
-    def get_stats(self) -> list[CacheStat]:
-        if isinstance(self.storage, CacheStatsProvider):
-            return self.storage.get_stats()
+    def get_stats(self) -> Sequence[CacheStat]:
+        if isinstance(self.storage, StatsProvider):
+            return cast("Sequence[CacheStat]", self.storage.get_stats())
         return []
 
     def read_result(self, key: str) -> CachedResult[R]:

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -49,7 +49,7 @@ from streamlit.runtime.caching.cached_message_replay import (
     MsgData,
 )
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ def _equal_validate_funcs(a: ValidateFunc | None, b: ValidateFunc | None) -> boo
     return (a is None and b is None) or (a is not None and b is not None)
 
 
-class ResourceCaches(CacheStatsProvider):
+class ResourceCaches(StatsProvider):
     """Manages all ResourceCache instances."""
 
     def __init__(self) -> None:
@@ -136,14 +136,14 @@ class ResourceCaches(CacheStatsProvider):
         stats: list[CacheStat] = []
         for cache in function_caches.values():
             stats.extend(cache.get_stats())
-        return group_stats(stats)
+        return group_cache_stats(stats)
 
 
 # Singleton ResourceCaches instance
 _resource_caches = ResourceCaches()
 
 
-def get_resource_cache_stats_provider() -> CacheStatsProvider:
+def get_resource_cache_stats_provider() -> StatsProvider:
     """Return the StatsProvider for all @st.cache_resource functions."""
     return _resource_caches
 

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -28,7 +28,7 @@ from streamlit.runtime.media_file_storage import (
     MediaFileStorage,
     MediaFileStorageError,
 )
-from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -88,7 +88,7 @@ class MemoryFile(NamedTuple):
         return len(self.content)
 
 
-class MemoryMediaFileStorage(MediaFileStorage, CacheStatsProvider):
+class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
     def __init__(self, media_endpoint: str) -> None:
         """Create a new MemoryMediaFileStorage instance.
 
@@ -179,4 +179,4 @@ class MemoryMediaFileStorage(MediaFileStorage, CacheStatsProvider):
             )
             for _, file in files_by_id.items()
         ]
-        return group_stats(stats)
+        return group_cache_stats(stats)

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from streamlit import util
-from streamlit.runtime.stats import CacheStat, group_stats
+from streamlit.runtime.stats import CacheStat, group_cache_stats
 from streamlit.runtime.uploaded_file_manager import (
     UploadedFileManager,
     UploadedFileRec,
@@ -135,4 +135,4 @@ class MemoryUploadedFileManager(UploadedFileManager):
             )
             for file in all_files
         ]
-        return group_stats(stats)
+        return group_cache_stats(stats)

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -224,10 +224,16 @@ class Runtime:
         )
 
         self._stats_mgr = StatsManager()
-        self._stats_mgr.register_provider(get_data_cache_stats_provider())
-        self._stats_mgr.register_provider(get_resource_cache_stats_provider())
-        self._stats_mgr.register_provider(self._uploaded_file_mgr)
-        self._stats_mgr.register_provider(SessionStateStatProvider(self._session_mgr))
+        self._stats_mgr.register_provider(
+            "cache_memory_bytes", get_data_cache_stats_provider()
+        )
+        self._stats_mgr.register_provider(
+            "cache_memory_bytes", get_resource_cache_stats_provider()
+        )
+        self._stats_mgr.register_provider("cache_memory_bytes", self._uploaded_file_mgr)
+        self._stats_mgr.register_provider(
+            "cache_memory_bytes", SessionStateStatProvider(self._session_mgr)
+        )
 
     @property
     def state(self) -> RuntimeState:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -46,7 +46,7 @@ from streamlit.runtime.state.common import (
 )
 from streamlit.runtime.state.presentation import apply_presenter
 from streamlit.runtime.state.query_params import QueryParams
-from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
 
 if TYPE_CHECKING:
     from streamlit.runtime.session_manager import SessionManager
@@ -992,7 +992,7 @@ def _is_stale_widget(
 
 
 @dataclass
-class SessionStateStatProvider(CacheStatsProvider):
+class SessionStateStatProvider(StatsProvider):
     _session_mgr: SessionManager
 
     def get_stats(self) -> list[CacheStat]:
@@ -1000,4 +1000,4 @@ class SessionStateStatProvider(CacheStatsProvider):
         for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state
             stats.extend(session_state.get_stats())
-        return group_stats(stats)
+        return group_cache_stats(stats)

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import itertools
-from abc import abstractmethod
-from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -170,7 +169,6 @@ def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
 
 @runtime_checkable
 class StatsProvider(Protocol):
-    @abstractmethod
     def get_stats(self) -> Sequence[Stat]:
         raise NotImplementedError
 
@@ -200,11 +198,19 @@ class StatsManager:
         self._stats_providers[family_name].append(provider)
 
     def get_stats(self) -> dict[str, Sequence[Stat]]:
-        """Return a dict mapping family names to sequences of stats from each registered provider."""
+        """Return all registered stats grouped by metric family name.
+
+        Returns
+        -------
+        dict[str, Sequence[Stat]]
+            A dictionary mapping metric family names (as registered with
+            register_provider) to sequences of Stat objects from all providers
+            registered under that family name.
+        """
         result: dict[str, Sequence[Stat]] = {}
         for family_name, providers in self._stats_providers.items():
             all_stats: list[Stat] = []
             for provider in providers:
                 all_stats.extend(provider.get_stats())
-            result[family_name] = cast("Sequence[Stat]", all_stats)
+            result[family_name] = all_stats
         return result

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -16,10 +16,54 @@ from __future__ import annotations
 
 import itertools
 from abc import abstractmethod
-from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
-    from streamlit.proto.openmetrics_data_model_pb2 import Metric as MetricProto
+    from collections.abc import Sequence
+
+    from streamlit.proto.openmetrics_data_model_pb2 import (
+        Metric as MetricProto,
+    )
+    from streamlit.proto.openmetrics_data_model_pb2 import (
+        MetricType,
+    )
+
+
+@runtime_checkable
+class Stat(Protocol):
+    """Protocol for a stat that can be serialized to OpenMetrics format.
+
+    All stats must have these fields to identify the metric family they belong to
+    and provide metadata for OpenMetrics serialization.
+    """
+
+    @property
+    def family_name(self) -> str:
+        """The name of the metric family (e.g. 'cache_memory_bytes')."""
+        pass
+
+    @property
+    def type(self) -> str:
+        """The OpenMetrics type (e.g. 'gauge', 'counter')."""
+        pass
+
+    @property
+    def unit(self) -> str:
+        """The unit of the metric (e.g. 'bytes')."""
+        pass
+
+    @property
+    def help(self) -> str:
+        """A description of the metric."""
+        pass
+
+    def to_metric_str(self) -> str:
+        """Convert this stat to an OpenMetrics-formatted string."""
+        pass
+
+    def marshall_metric_proto(self, metric: MetricProto) -> None:
+        """Fill an OpenMetrics `Metric` protobuf object."""
+        pass
 
 
 class CacheStat(NamedTuple):
@@ -43,8 +87,25 @@ class CacheStat(NamedTuple):
     cache_name: str
     byte_length: int
 
+    # Stat Protocol fields with default values for cache metrics
+    @property
+    def family_name(self) -> str:
+        return "cache_memory_bytes"
+
+    @property
+    def type(self) -> str:
+        return "gauge"
+
+    @property
+    def unit(self) -> str:
+        return "bytes"
+
+    @property
+    def help(self) -> str:
+        return "Total memory consumed by a cache."
+
     def to_metric_str(self) -> str:
-        return f'cache_memory_bytes{{cache_type="{self.category_name}",cache="{self.cache_name}"}} {self.byte_length}'
+        return f'{self.family_name}{{cache_type="{self.category_name}",cache="{self.cache_name}"}} {self.byte_length}'
 
     def marshall_metric_proto(self, metric: MetricProto) -> None:
         """Fill an OpenMetrics `Metric` protobuf object."""
@@ -60,7 +121,7 @@ class CacheStat(NamedTuple):
         metric_point.gauge_value.int_value = self.byte_length
 
 
-def group_stats(stats: list[CacheStat]) -> list[CacheStat]:
+def group_cache_stats(stats: list[CacheStat]) -> list[CacheStat]:
     """Group a list of CacheStats by category_name and cache_name and sum byte_length."""
 
     def key_function(individual_stat: CacheStat) -> tuple[str, str]:
@@ -82,28 +143,68 @@ def group_stats(stats: list[CacheStat]) -> list[CacheStat]:
     return result
 
 
+def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
+    """Convert a metric type string to its corresponding proto enum value."""
+    from streamlit.proto.openmetrics_data_model_pb2 import (
+        COUNTER,
+        GAUGE,
+        GAUGE_HISTOGRAM,
+        HISTOGRAM,
+        INFO,
+        STATE_SET,
+        SUMMARY,
+        UNKNOWN,
+    )
+
+    type_map = {
+        "gauge": GAUGE,
+        "counter": COUNTER,
+        "state_set": STATE_SET,
+        "info": INFO,
+        "histogram": HISTOGRAM,
+        "gauge_histogram": GAUGE_HISTOGRAM,
+        "summary": SUMMARY,
+    }
+    return type_map.get(type_string, UNKNOWN)
+
+
 @runtime_checkable
-class CacheStatsProvider(Protocol):
+class StatsProvider(Protocol):
     @abstractmethod
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(self) -> Sequence[Stat]:
         raise NotImplementedError
 
 
 class StatsManager:
     def __init__(self) -> None:
-        self._cache_stats_providers: list[CacheStatsProvider] = []
+        self._stats_providers: dict[str, list[StatsProvider]] = {}
 
-    def register_provider(self, provider: CacheStatsProvider) -> None:
-        """Register a CacheStatsProvider with the manager.
+    def register_provider(self, family_name: str, provider: StatsProvider) -> None:
+        """Register a StatsProvider with the manager for a given metric family.
+
+        Multiple providers can be registered for the same family name, and their
+        stats will be combined when get_stats() is called.
+
         This function is not thread-safe. Call it immediately after
         creation.
+
+        Parameters
+        ----------
+        family_name : str
+            The name of the metric family that this provider produces stats for.
+        provider : StatsProvider
+            The stats provider to register.
         """
-        self._cache_stats_providers.append(provider)
+        if family_name not in self._stats_providers:
+            self._stats_providers[family_name] = []
+        self._stats_providers[family_name].append(provider)
 
-    def get_stats(self) -> list[CacheStat]:
-        """Return a list containing all stats from each registered provider."""
-        all_stats: list[CacheStat] = []
-        for provider in self._cache_stats_providers:
-            all_stats.extend(provider.get_stats())
-
-        return all_stats
+    def get_stats(self) -> dict[str, Sequence[Stat]]:
+        """Return a dict mapping family names to sequences of stats from each registered provider."""
+        result: dict[str, Sequence[Stat]] = {}
+        for family_name, providers in self._stats_providers.items():
+            all_stats: list[Stat] = []
+            for provider in providers:
+                all_stats.extend(provider.get_stats())
+            result[family_name] = cast("Sequence[Stat]", all_stats)
+        return result

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -19,7 +19,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from streamlit import util
-from streamlit.runtime.stats import CacheStatsProvider
+from streamlit.runtime.stats import StatsProvider
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -89,7 +89,7 @@ class UploadedFile(io.BytesIO):
         return util.repr_(self)
 
 
-class UploadedFileManager(CacheStatsProvider, Protocol):
+class UploadedFileManager(StatsProvider, Protocol):
     """UploadedFileManager protocol, that should be implemented by the concrete
     uploaded file managers.
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -315,7 +315,9 @@ class Server:
             ),
         )
 
-        self._runtime.stats_mgr.register_provider(media_file_storage)
+        self._runtime.stats_mgr.register_provider(
+            "cache_memory_bytes", media_file_storage
+        )
 
     @classmethod
     def initialize_mimetypes(cls) -> None:

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -18,12 +18,15 @@ from typing import TYPE_CHECKING, cast
 
 import tornado.web
 
+from streamlit.runtime.stats import metric_type_string_to_proto
 from streamlit.web.server import allow_all_cross_origin_requests, is_allowed_origin
 from streamlit.web.server.server_util import emit_endpoint_deprecation_notice
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
-    from streamlit.runtime.stats import CacheStat, StatsManager
+    from streamlit.runtime.stats import Stat, StatsManager
 
 
 class StatsRequestHandler(tornado.web.RequestHandler):
@@ -41,6 +44,9 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         self.set_status(204)
         self.finish()
 
+    # TODO(vdonato): Allow a caller to request specific metric families since we
+    # know cache stats are slow to compute so would like to avoid paying the
+    # cost of doing so frequently.
     def get(self) -> None:
         if self.request.uri and "_stcore/" not in self.request.uri:
             emit_endpoint_deprecation_notice(self, new_path="/_stcore/metrics")
@@ -54,44 +60,55 @@ class StatsRequestHandler(tornado.web.RequestHandler):
             self.set_header("Content-Type", "application/x-protobuf")
             self.set_status(200)
         else:
-            self.write(self._stats_to_text(self._manager.get_stats()))
+            self.write(self._stats_to_text(stats))
             self.set_header("Content-Type", "application/openmetrics-text")
             self.set_status(200)
 
     @staticmethod
-    def _stats_to_text(stats: list[CacheStat]) -> str:
-        metric_type = "# TYPE cache_memory_bytes gauge"
-        metric_unit = "# UNIT cache_memory_bytes bytes"
-        metric_help = "# HELP Total memory consumed by a cache."
-        openmetrics_eof = "# EOF\n"
+    def _stats_to_text(stats_by_family: dict[str, Sequence[Stat]]) -> str:
+        result: list[str] = []
 
-        # Format: header, stats, EOF
-        result = [metric_type, metric_unit, metric_help]
-        result.extend(stat.to_metric_str() for stat in stats)
-        result.append(openmetrics_eof)
+        for stats in stats_by_family.values():
+            if not stats:
+                continue
 
+            # All of the stats in a family will have the same family_name, type,
+            # unit, and help text, so we can just use the first one to construct
+            # our OpenMetrics comments.
+            first_stat = stats[0]
+            result.append(f"# TYPE {first_stat.family_name} {first_stat.type}")
+            result.append(f"# UNIT {first_stat.family_name} {first_stat.unit}")
+            result.append(f"# HELP {first_stat.help}")
+            result.extend(stat.to_metric_str() for stat in stats)
+
+        result.append("# EOF\n")
         return "\n".join(result)
 
     @staticmethod
-    def _stats_to_proto(stats: list[CacheStat]) -> MetricSetProto:
+    def _stats_to_proto(stats_by_family: dict[str, Sequence[Stat]]) -> MetricSetProto:
         # Lazy load the import of this proto message for better performance:
-        from streamlit.proto.openmetrics_data_model_pb2 import GAUGE
         from streamlit.proto.openmetrics_data_model_pb2 import (
             MetricSet as MetricSetProto,
         )
 
         metric_set = MetricSetProto()
 
-        metric_family = metric_set.metric_families.add()
-        metric_family.name = "cache_memory_bytes"
-        metric_family.type = GAUGE
-        metric_family.unit = "bytes"
-        metric_family.help = "Total memory consumed by a cache."
+        for stats in stats_by_family.values():
+            if not stats:
+                continue
 
-        for stat in stats:
-            metric_proto = metric_family.metrics.add()
-            stat.marshall_metric_proto(metric_proto)
+            # All of the stats in a family will have the same family_name, type,
+            # unit, and help text, so we can just use the first one to fill in
+            # these metric_family fields.
+            first_stat = stats[0]
+            metric_family = metric_set.metric_families.add()
+            metric_family.name = first_stat.family_name
+            metric_family.type = metric_type_string_to_proto(first_stat.type)
+            metric_family.unit = first_stat.unit
+            metric_family.help = first_stat.help
 
-        metric_set = MetricSetProto()
-        metric_set.metric_families.append(metric_family)
+            for stat in stats:
+                metric_proto = metric_family.metrics.add()
+                stat.marshall_metric_proto(metric_proto)
+
         return metric_set

--- a/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
@@ -178,7 +178,7 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
         self.storage.delete_file("mock_file_id")
 
     def test_cache_stats(self):
-        """Test our CacheStatsProvider implementation."""
+        """Test our StatsProvider implementation."""
         assert len(self.storage.get_stats()) == 0
 
         # Add several files to storage. We'll unique-ify them by filename.

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -16,11 +16,24 @@ from __future__ import annotations
 
 import unittest
 
+from parameterized import parameterized
+
+from streamlit.proto.openmetrics_data_model_pb2 import (
+    COUNTER,
+    GAUGE,
+    GAUGE_HISTOGRAM,
+    HISTOGRAM,
+    INFO,
+    STATE_SET,
+    SUMMARY,
+    UNKNOWN,
+)
 from streamlit.runtime.stats import (
     CacheStat,
     StatsManager,
     StatsProvider,
     group_cache_stats,
+    metric_type_string_to_proto,
 )
 
 
@@ -67,8 +80,8 @@ class StatsManagerTest(unittest.TestCase):
         manager.register_provider("family_a", provider1)
         manager.register_provider("family_b", provider2)
 
-        provider1.stats = [CacheStat("category1", "cache1", 100)]
-        provider2.stats = [CacheStat("category2", "cache2", 200)]
+        provider1.stats = [CacheStat("family_a", "cache1", 100)]
+        provider2.stats = [CacheStat("family_b", "cache2", 200)]
 
         result = manager.get_stats()
         assert "family_a" in result
@@ -134,3 +147,25 @@ class CacheStatProtocolTest(unittest.TestCase):
         stat = CacheStat("st.cache_data", "my_func", 512)
         expected = 'cache_memory_bytes{cache_type="st.cache_data",cache="my_func"} 512'
         assert stat.to_metric_str() == expected
+
+
+class MetricTypeStringToProtoTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("gauge", GAUGE),
+            ("counter", COUNTER),
+            ("state_set", STATE_SET),
+            ("info", INFO),
+            ("histogram", HISTOGRAM),
+            ("gauge_histogram", GAUGE_HISTOGRAM),
+            ("summary", SUMMARY),
+        ]
+    )
+    def test_known_types(self, type_string: str, expected: int) -> None:
+        """Test that known metric type strings map to correct proto enum values."""
+        assert metric_type_string_to_proto(type_string) == expected
+
+    def test_unknown_type_returns_unknown(self) -> None:
+        """Test that unknown type strings return the UNKNOWN enum value."""
+        assert metric_type_string_to_proto("not_a_real_type") == UNKNOWN
+        assert metric_type_string_to_proto("") == UNKNOWN

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -18,14 +18,14 @@ import unittest
 
 from streamlit.runtime.stats import (
     CacheStat,
-    CacheStatsProvider,
     StatsManager,
-    group_stats,
+    StatsProvider,
+    group_cache_stats,
 )
 
 
-class MockStatsProvider(CacheStatsProvider):
-    def __init__(self):
+class MockStatsProvider(StatsProvider):
+    def __init__(self) -> None:
         self.stats: list[CacheStat] = []
 
     def get_stats(self) -> list[CacheStat]:
@@ -33,16 +33,16 @@ class MockStatsProvider(CacheStatsProvider):
 
 
 class StatsManagerTest(unittest.TestCase):
-    def test_get_stats(self):
-        """StatsManager.get_stats should return all providers' stats."""
+    def test_get_stats(self) -> None:
+        """StatsManager.get_stats should return all providers' stats grouped by family."""
         manager = StatsManager()
         provider1 = MockStatsProvider()
         provider2 = MockStatsProvider()
-        manager.register_provider(provider1)
-        manager.register_provider(provider2)
+        manager.register_provider("cache_memory_bytes", provider1)
+        manager.register_provider("cache_memory_bytes", provider2)
 
         # No stats
-        assert manager.get_stats() == []
+        assert manager.get_stats() == {"cache_memory_bytes": []}
 
         # Some stats
         provider1.stats = [
@@ -55,12 +55,32 @@ class StatsManagerTest(unittest.TestCase):
             CacheStat("provider2", "qux", 4),
         ]
 
-        assert provider1.stats + provider2.stats == manager.get_stats()
+        result = manager.get_stats()
+        assert "cache_memory_bytes" in result
+        assert provider1.stats + provider2.stats == result["cache_memory_bytes"]
 
-    def test_group_stats(self):
+    def test_get_stats_multiple_families(self) -> None:
+        """StatsManager should support multiple metric families."""
+        manager = StatsManager()
+        provider1 = MockStatsProvider()
+        provider2 = MockStatsProvider()
+        manager.register_provider("family_a", provider1)
+        manager.register_provider("family_b", provider2)
+
+        provider1.stats = [CacheStat("category1", "cache1", 100)]
+        provider2.stats = [CacheStat("category2", "cache2", 200)]
+
+        result = manager.get_stats()
+        assert "family_a" in result
+        assert "family_b" in result
+        assert result["family_a"] == provider1.stats
+        assert result["family_b"] == provider2.stats
+
+    def test_group_cache_stats(self) -> None:
         """Should return stats grouped by category_name and cache_name.
-        byte_length should be summed."""
 
+        byte_length should be summed.
+        """
         # Similar stats sequential
         stats1 = [
             CacheStat("provider1", "foo", 1),
@@ -86,14 +106,31 @@ class StatsManagerTest(unittest.TestCase):
             CacheStat("provider3", "boo", 1),
         ]
 
-        assert set(group_stats(stats1)) == {
+        assert set(group_cache_stats(stats1)) == {
             CacheStat("provider1", "foo", 1),
             CacheStat("provider1", "bar", 7),
         }
 
-        assert set(group_stats(stats2)) == {
+        assert set(group_cache_stats(stats2)) == {
             CacheStat("provider2", "baz", 31),
             CacheStat("provider2", "qux", 4),
         }
 
-        assert set(group_stats(stats3)) == {CacheStat("provider3", "boo", 7)}
+        assert set(group_cache_stats(stats3)) == {CacheStat("provider3", "boo", 7)}
+
+
+class CacheStatProtocolTest(unittest.TestCase):
+    def test_cache_stat_implements_stat_protocol(self) -> None:
+        """CacheStat should have all the properties required by the Stat protocol."""
+        stat = CacheStat("test_category", "test_cache", 1024)
+
+        assert stat.family_name == "cache_memory_bytes"
+        assert stat.type == "gauge"
+        assert stat.unit == "bytes"
+        assert stat.help == "Total memory consumed by a cache."
+
+    def test_cache_stat_to_metric_str(self) -> None:
+        """CacheStat.to_metric_str should use family_name."""
+        stat = CacheStat("st.cache_data", "my_func", 512)
+        expected = 'cache_memory_bytes{cache_type="st.cache_data",cache="my_func"} 512'
+        assert stat.to_metric_str() == expected

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -90,7 +90,7 @@ class UploadedFileManagerTest(unittest.TestCase):
         assert self.mgr.get_files("session2", [FILE_1.file_id]) == [FILE_1]
 
     def test_cache_stats_provider(self):
-        """Test CacheStatsProvider implementation."""
+        """Test StatsProvider implementation."""
 
         # Test empty manager
         assert self.mgr.get_stats() == []

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -29,7 +29,7 @@ from streamlit.web.server.stats_request_handler import StatsRequestHandler
 
 class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):
-        self.mock_stats = []
+        self.mock_stats: dict[str, list[CacheStat]] = {"cache_memory_bytes": []}
         mock_stats_manager = MagicMock()
         mock_stats_manager.get_stats = MagicMock(side_effect=lambda: self.mock_stats)
         return tornado.web.Application(
@@ -43,16 +43,11 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
 
     def test_no_stats(self):
-        """If we have no stats, we expect to see just the header and footer."""
+        """If we have no stats, we expect to see just the EOF comment."""
         response = self.fetch("/_stcore/metrics")
         assert response.code == 200
 
-        expected_body = (
-            b"# TYPE cache_memory_bytes gauge\n"
-            b"# UNIT cache_memory_bytes bytes\n"
-            b"# HELP Total memory consumed by a cache.\n"
-            b"# EOF\n"
-        )
+        expected_body = b"# EOF\n"
 
         assert expected_body == response.body
 
@@ -67,18 +62,20 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.headers["deprecation"] == "True"
 
     def test_has_stats(self):
-        self.mock_stats = [
-            CacheStat(
-                category_name="st.singleton",
-                cache_name="foo",
-                byte_length=128,
-            ),
-            CacheStat(
-                category_name="st.memo",
-                cache_name="bar",
-                byte_length=256,
-            ),
-        ]
+        self.mock_stats = {
+            "cache_memory_bytes": [
+                CacheStat(
+                    category_name="st.singleton",
+                    cache_name="foo",
+                    byte_length=128,
+                ),
+                CacheStat(
+                    category_name="st.memo",
+                    cache_name="bar",
+                    byte_length=256,
+                ),
+            ]
+        }
 
         response = self.fetch("/_stcore/metrics")
         assert response.code == 200
@@ -104,18 +101,20 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         """Stats requests are returned in OpenMetrics protobuf format
         if the request's Content-Type header is protobuf.
         """
-        self.mock_stats = [
-            CacheStat(
-                category_name="st.singleton",
-                cache_name="foo",
-                byte_length=128,
-            ),
-            CacheStat(
-                category_name="st.memo",
-                cache_name="bar",
-                byte_length=256,
-            ),
-        ]
+        self.mock_stats = {
+            "cache_memory_bytes": [
+                CacheStat(
+                    category_name="st.singleton",
+                    cache_name="foo",
+                    byte_length=128,
+                ),
+                CacheStat(
+                    category_name="st.memo",
+                    cache_name="bar",
+                    byte_length=256,
+                ),
+            ]
+        }
 
         # Requests can have multiple Accept headers. Only one of them needs
         # to specify protobuf in order to get back protobuf.


### PR DESCRIPTION
## Describe your changes

Currently, the `_stcore/metrics` endpoint only returns data related to caches, including `st.session_state`, 
`@st.cache_data`, and `@st.cache_resource`. In the SiS vNext world, there are various use cases that where
it would be useful to be able to expose more metrics from this endpoint.

We'll be both adding additional metrics and making some changes to the endpoint itself in subsequent
PRs, but as a first step, we'll just add another layer of abstraction to generalize the existing `CacheStatsProvider`
class.

In this PR, we
  * add a new `Stat` protocol with required properties that give us enough information to describe an
OpenMetrics metric family
  * have the existing `CacheStat` class implement the new protocol
  * change the name of `CacheStatsProvider` to `StatsProvider`, and edit the signatures of `StatsManager`
     methods to now return a dictionary mapping from metric family name to lists of metrics rather than only
     returning lists of `CacheStat`s.
  * make corresponding downstream changes throughout the codebase so that things play nicely with our
     new `StatsManager.register_provider()` and `StatsManager.get_stats()` signatures.

We make one relatively small behavioral change to not include metrics comments if we don't have any
metrics to report, but aside from this, we don't make any behavioral changes in this PR.

## Testing Plan

- Unit Tests
   Updated Python unit tests
- Any manual testing needed?
   `curl`ed the metrics endpoint locally to verify that the output looks the same as it did previously.