### PR TITLE
[fix] Include default in key for CCv2 instances

### DIFF
--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -159,15 +159,16 @@ class BidiComponentMixin:
         height: Height,
         proto: BidiComponentProto,
         data: BidiComponentData = None,
+        default: BidiComponentDefaults = None,
     ) -> dict[str, Any]:
         """Build deterministic identity kwargs for ID computation.
 
         Construct a stable mapping of identity-relevant properties for
         ``compute_and_register_element_id``. This includes structural
-        properties (name, style isolation, layout) and an explicit, typed
-        handling of the ``BidiComponent`` ``oneof data`` field to ensure
-        unkeyed components change identity when their serialized payload
-        changes.
+        properties (name, style isolation, layout), default state values, and
+        an explicit, typed handling of the ``BidiComponent`` ``oneof data``
+        field to ensure unkeyed components change identity when their
+        serialized payload or defaults change.
 
         Parameters
         ----------
@@ -183,9 +184,17 @@ class BidiComponentMixin:
             The populated component protobuf. Its ``data`` oneof determines
             which serialized payload (JSON, Arrow, bytes, or Mixed) contributes
             to identity.
-        data : BidiComponentData
+        data : BidiComponentData, optional
             The raw data passed to the component. Used to optimize identity
             calculation for JSON payloads by avoiding a parse/serialize cycle.
+            When omitted, the helper falls back to canonicalizing the JSON
+            content stored on the protobuf.
+        default : BidiComponentDefaults, optional
+            The default state mapping for the component instance. Defaults are
+            included in the identity for unkeyed components so that changing
+            default values produces a new backend identity. When a user key is
+            provided with ``key_as_main_identity=True``, these defaults are
+            ignored by :func:`compute_and_register_element_id`.
 
         Returns
         -------
@@ -204,6 +213,7 @@ class BidiComponentMixin:
             "isolate_styles": isolate_styles,
             "width": width,
             "height": height,
+            "default": default,
         }
 
         data_field = proto.WhichOneof("data")
@@ -434,6 +444,7 @@ class BidiComponentMixin:
             height=height,
             proto=bidi_component_proto,
             data=data,
+            default=default,
         )
         # Compute a unique ID for this component instance now that the proto is
         # populated.

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -1190,6 +1190,66 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
         assert id1 == id2
 
+    def test_unkeyed_id_stable_when_default_unchanged(self):
+        """Without a user key, unchanged defaults must keep the same backend id."""
+        st._bidi_component(
+            "ident",
+            default={"foo": 1},
+            on_foo_change=MagicMock(),
+        )
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component(
+            "ident",
+            default={"foo": 1},
+            on_foo_change=MagicMock(),
+        )
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
+    def test_unkeyed_id_changes_when_default_changes(self):
+        """Without a user key, changing defaults must change the backend id."""
+        st._bidi_component(
+            "ident",
+            default={"foo": 1},
+            on_foo_change=MagicMock(),
+        )
+        id1 = self._render_and_get_id()
+
+        st._bidi_component(
+            "ident",
+            default={"foo": 2},
+            on_foo_change=MagicMock(),
+        )
+        id2 = self._render_and_get_id()
+
+        assert id1 != id2
+
+    def test_keyed_id_stable_when_default_changes(self):
+        """With a user key, changing defaults must NOT change the backend id (same run)."""
+        st._bidi_component(
+            "ident",
+            key="DEF",
+            default={"foo": 1},
+            on_foo_change=MagicMock(),
+        )
+        id1 = self._render_and_get_id()
+
+        self._clear_widget_registrations_for_current_run()
+
+        st._bidi_component(
+            "ident",
+            key="DEF",
+            default={"foo": 2},
+            on_foo_change=MagicMock(),
+        )
+        id2 = self._render_and_get_id()
+
+        assert id1 == id2
+
     def test_identity_kwargs_raises_on_unhandled_oneof(self):
         """_build_bidi_identity_kwargs should raise if an unknown oneof is encountered."""
         mixin = BidiComponentMixin()


### PR DESCRIPTION
## Describe your changes

Include default state values in the identity calculation for unkeyed CCv2s. This ensures that when default values change for unkeyed components, they receive a new backend identity. For keyed components, the defaults are ignored in the identity calculation, maintaining stable identity across default value changes.

## Testing Plan

- Adds Python unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.