### PR TITLE
[feat] Add headingFontSize1-6 and headingFontWeight1-6 CSS Custom Properties

### DIFF
--- a/frontend/component-v2-lib/src/theme.ts
+++ b/frontend/component-v2-lib/src/theme.ts
@@ -52,7 +52,23 @@ export interface StreamlitTheme {
   codeFontWeight: number
   codeFontSize: string
   headingFontSizes: string[]
+  // Individual heading font sizes and weights for levels 1–6. These provide
+  // direct access to specific heading levels and are derived from the same
+  // source as the headingFontSizes / headingFontWeights arrays. Both forms are
+  // maintained for backward compatibility and convenience.
+  headingFontSize1: string
+  headingFontSize2: string
+  headingFontSize3: string
+  headingFontSize4: string
+  headingFontSize5: string
+  headingFontSize6: string
   headingFontWeights: number[]
+  headingFontWeight1: number
+  headingFontWeight2: number
+  headingFontWeight3: number
+  headingFontWeight4: number
+  headingFontWeight5: number
+  headingFontWeight6: number
   borderColor: string
   dataframeBorderColor: string
   dataframeHeaderBackgroundColor: string

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
@@ -16,7 +16,10 @@
 
 import { describe, expect, expectTypeOf, it } from "vitest"
 
-import { StreamlitTheme } from "@streamlit/component-v2-lib"
+import {
+  StreamlitTheme,
+  StreamlitThemeCssProperties,
+} from "@streamlit/component-v2-lib"
 import { ICustomThemeConfig } from "@streamlit/protobuf"
 
 import {
@@ -53,7 +56,19 @@ describe("BidiComponent/utils/theme", () => {
         "1.25rem",
         "1rem",
       ],
+      headingFontSize1: "2.75rem",
+      headingFontSize2: "2.25rem",
+      headingFontSize3: "1.75rem",
+      headingFontSize4: "1.5rem",
+      headingFontSize5: "1.25rem",
+      headingFontSize6: "1rem",
       headingFontWeights: [700, 600, 600, 600, 600, 600],
+      headingFontWeight1: 700,
+      headingFontWeight2: 600,
+      headingFontWeight3: 600,
+      headingFontWeight4: 600,
+      headingFontWeight5: 600,
+      headingFontWeight6: 600,
       borderColor: "#eeeeee",
       borderColorLight: "#f5f5f5",
       dataframeBorderColor: "#f0f0f0",
@@ -119,6 +134,35 @@ describe("BidiComponent/utils/theme", () => {
       const dict = result as unknown as Record<string, string>
       expect(dict[expectedKey]).toBe(String(value))
     })
+
+    it.each<
+      [
+        key: keyof StreamlitTheme,
+        value: string | number,
+        expectedKey: keyof StreamlitThemeCssProperties,
+      ]
+    >([
+      ["headingFontSize1", "2.75rem", "--st-heading-font-size-1"],
+      ["headingFontSize2", "2.25rem", "--st-heading-font-size-2"],
+      ["headingFontSize3", "1.75rem", "--st-heading-font-size-3"],
+      ["headingFontSize4", "1.5rem", "--st-heading-font-size-4"],
+      ["headingFontSize5", "1.25rem", "--st-heading-font-size-5"],
+      ["headingFontSize6", "1rem", "--st-heading-font-size-6"],
+      ["headingFontWeight1", 700, "--st-heading-font-weight-1"],
+      ["headingFontWeight2", 600, "--st-heading-font-weight-2"],
+      ["headingFontWeight3", 600, "--st-heading-font-weight-3"],
+      ["headingFontWeight4", 600, "--st-heading-font-weight-4"],
+      ["headingFontWeight5", 600, "--st-heading-font-weight-5"],
+      ["headingFontWeight6", 600, "--st-heading-font-weight-6"],
+    ])(
+      "converts individual heading property %s to CSS custom property",
+      (propName, value, expectedKey) => {
+        const overrides: Partial<StreamlitTheme> = { [propName]: value }
+        const result = objectToCssCustomProperties(createTheme(overrides))
+
+        expect(result[expectedKey]).toBe(String(value))
+      }
+    )
 
     it("serializes baseFontSize with px unit", () => {
       const result = objectToCssCustomProperties(

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
@@ -58,6 +58,24 @@ export const objectToCssCustomProperties = (
 export const extractComponentsV2Theme = (
   theme: EmotionTheme
 ): StreamlitTheme => {
+  const headingFontSizes = [
+    theme.fontSizes.h1FontSize,
+    theme.fontSizes.h2FontSize,
+    theme.fontSizes.h3FontSize,
+    theme.fontSizes.h4FontSize,
+    theme.fontSizes.h5FontSize,
+    theme.fontSizes.h6FontSize,
+  ]
+
+  const headingFontWeights = [
+    theme.fontWeights.h1FontWeight,
+    theme.fontWeights.h2FontWeight,
+    theme.fontWeights.h3FontWeight,
+    theme.fontWeights.h4FontWeight,
+    theme.fontWeights.h5FontWeight,
+    theme.fontWeights.h6FontWeight,
+  ]
+
   return {
     primaryColor: theme.colors.primary,
     backgroundColor: theme.colors.bgColor,
@@ -76,22 +94,20 @@ export const extractComponentsV2Theme = (
     baseFontWeight: theme.fontWeights.normal,
     codeFontWeight: theme.fontWeights.code,
     codeFontSize: theme.fontSizes.codeFontSize,
-    headingFontSizes: [
-      theme.fontSizes.h1FontSize,
-      theme.fontSizes.h2FontSize,
-      theme.fontSizes.h3FontSize,
-      theme.fontSizes.h4FontSize,
-      theme.fontSizes.h5FontSize,
-      theme.fontSizes.h6FontSize,
-    ],
-    headingFontWeights: [
-      theme.fontWeights.h1FontWeight,
-      theme.fontWeights.h2FontWeight,
-      theme.fontWeights.h3FontWeight,
-      theme.fontWeights.h4FontWeight,
-      theme.fontWeights.h5FontWeight,
-      theme.fontWeights.h6FontWeight,
-    ],
+    headingFontSizes,
+    headingFontSize1: headingFontSizes[0],
+    headingFontSize2: headingFontSizes[1],
+    headingFontSize3: headingFontSizes[2],
+    headingFontSize4: headingFontSizes[3],
+    headingFontSize5: headingFontSizes[4],
+    headingFontSize6: headingFontSizes[5],
+    headingFontWeights,
+    headingFontWeight1: headingFontWeights[0],
+    headingFontWeight2: headingFontWeights[1],
+    headingFontWeight3: headingFontWeights[2],
+    headingFontWeight4: headingFontWeights[3],
+    headingFontWeight5: headingFontWeights[4],
+    headingFontWeight6: headingFontWeights[5],
     borderColor: theme.colors.borderColor,
     dataframeBorderColor: theme.colors.dataframeBorderColor,
     dataframeHeaderBackgroundColor:


### PR DESCRIPTION
## Describe your changes

Added individual heading font size and weight properties to the StreamlitTheme interface. This enhances the theme by providing direct access to specific heading levels (1-6) rather than only through array indices.

The changes include:
- Added individual properties for each heading font size (headingFontSize1 through headingFontSize6)
- Added individual properties for each heading font weight (headingFontWeight1 through headingFontWeight6)
- Updated the theme extraction function to populate these new properties
- Updated tests to verify the new properties

## Testing Plan

- No additional tests needed as the existing test was updated to verify the new properties
- The changes are backward compatible as the original array properties are maintained

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.