### PR TITLE
Activate tracing for components e2e tests

### DIFF
--- a/.github/workflows/playwright-custom-components.yml
+++ b/.github/workflows/playwright-custom-components.yml
@@ -66,7 +66,7 @@ jobs:
           echo "Installing custom components"
           uv pip install -r ./custom_components/components-e2e-requirements.txt
           rm -rf ./test-results
-          pytest ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1
+          pytest ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1 --tracing retain-on-failure
       - name: Upload failed test results
         uses: actions/upload-artifact@v5
         if: always()


### PR DESCRIPTION
## Describe your changes

Having traces in our custom components e2e tests has been quite useful for debugging some aspects for the starlette migration. I think we can just have this always activated for the components e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
