### PR TITLE
Fix flaky js heading unit test

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -168,9 +168,9 @@ describe("Heading", () => {
   it("does not render tables", async () => {
     const props = getHeadingProps({
       body: `| Syntax | Description |
-           | ----------- | ----------- |
-           | Header      | Title       |
-           | Paragraph   | Text        |`,
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |`,
     })
     render(<Heading {...props} />)
 
@@ -181,7 +181,7 @@ describe("Heading", () => {
     // Wait for lazy-loaded content to render
     await waitFor(() => {
       expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
-        "| Syntax | Description | | ----------- | ----------- | | Header | Title | | Paragraph | Text |"
+        "| Syntax | Description || ----------- | ----------- | | Header | Title | | Paragraph | Text |"
       )
     })
 


### PR DESCRIPTION
## Describe your changes

Same root cause as https://github.com/streamlit/streamlit/pull/13279. The space got interpreted as code block -> which triggered a skeleton because of lazy-loading -> which caused some flakiness.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
