### PR TITLE
Prevent `st.dialog` from showing elements from previous dialog

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -268,3 +268,24 @@ if st.button("Open on_dismiss callback Dialog"):
 
 if st.session_state.get("callback_executed"):
     st.write("Callback executions:", st.session_state.get("dismiss_count", 0))
+
+
+# Test case for issue #10907:
+# Prevent dialogs from showing stale elements from previous dialog
+@st.dialog("Fast Dialog")
+def fast_dialog() -> None:
+    st.write("Fast dialog content")
+    st.text_input("Fast dialog input")
+
+
+@st.dialog("Slow Dialog")
+def slow_dialog() -> None:
+    time.sleep(1)
+    st.write("Slow dialog content")
+
+
+if st.button("Open Fast Dialog"):
+    fast_dialog()
+
+if st.button("Open Slow Dialog"):
+    slow_dialog()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -651,3 +651,40 @@ def test_dialog_on_dismiss_callback(app: Page):
     expect(dialog).not_to_be_attached()
     # Callback should have been executed
     expect_prefixed_markdown(app, "Callback executions:", "3")
+
+
+def test_switching_dialogs_does_not_show_stale_content(app: Page):
+    """Test that switching between different dialogs does not show stale content from previous dialog.
+
+    Reproduces issue #10907: When opening dialog 1, closing it, then opening dialog 2,
+    the second dialog should NOT show any content from the first dialog while loading.
+    """
+    # Open the fast dialog first
+    click_button(app, "Open Fast Dialog")
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+    expect(dialog).to_contain_text("Fast dialog content")
+    # Verify the text input from fast dialog is present
+    expect(dialog.get_by_test_id("stTextInput")).to_be_visible()
+
+    # Dismiss the fast dialog
+    app.keyboard.press("Escape")
+    expect(dialog).not_to_be_attached()
+
+    # Now open the slow dialog, without waiting for the app to run to complete:
+    get_button(app, "Open Slow Dialog").click()
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    # The dialog should NOT contain any elements from the fast dialog
+    # Specifically: no "Fast dialog content" text, no text input
+    expect(dialog.get_by_text("Fast dialog content")).not_to_be_attached()
+    expect(dialog.get_by_test_id("stTextInput")).not_to_be_attached()
+
+    # Wait for the slow dialog to load its content
+    expect(dialog.get_by_text("Slow dialog content")).to_be_visible()
+
+    # Verify the slow dialog has its correct content and nothing from fast dialog
+    expect(dialog).to_contain_text("Slow dialog content")
+    expect(dialog.get_by_text("Fast dialog content")).not_to_be_attached()
+    expect(dialog.get_by_test_id("stTextInput")).not_to_be_attached()

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -425,6 +425,122 @@ describe("AppRoot", () => {
       expect(replacedBlock.children.length).toBe(1)
     })
 
+    it("removes a dialog block's children when replacing with a different dialog identity", () => {
+      // Create a dialog with some children. The id field represents the dialog's
+      // identity computed from its attributes.
+      const rootWithDialog1 = ROOT.applyDelta(
+        "script_run_id",
+        makeProto(DeltaProto, {
+          addBlock: {
+            id: "dialog-identity-1",
+            dialog: {
+              title: "Dialog 1",
+              dismissible: true,
+            },
+          },
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      ).applyDelta(
+        "script_run_id",
+        makeProto(DeltaProto, {
+          newElement: { text: { body: "Dialog 1 content" } },
+        }),
+        forwardMsgMetadata([0, 1, 1, 0])
+      )
+
+      // Verify Dialog 1 has children
+      const dialog1Node = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rootWithDialog1.main,
+        [1, 1]
+      ) as BlockNode
+      expect(dialog1Node).toBeDefined()
+      expect(dialog1Node.deltaBlock.type).toBe("dialog")
+      expect(dialog1Node.deltaBlock.id).toBe("dialog-identity-1")
+      expect(dialog1Node.children.length).toBe(1)
+
+      // Replace with a dialog with a different identity
+      const rootWithDialog2 = rootWithDialog1.applyDelta(
+        "new_script_run_id",
+        makeProto(DeltaProto, {
+          addBlock: {
+            id: "dialog-identity-2",
+            dialog: {
+              title: "Dialog 2",
+              dismissible: true,
+            },
+          },
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      // Verify Dialog 2 does NOT inherit Dialog 1's children (issue #10907)
+      const dialog2Node = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rootWithDialog2.main,
+        [1, 1]
+      ) as BlockNode
+      expect(dialog2Node).toBeDefined()
+      expect(dialog2Node.deltaBlock.type).toBe("dialog")
+      expect(dialog2Node.deltaBlock.id).toBe("dialog-identity-2")
+      expect(dialog2Node.children.length).toBe(0)
+    })
+
+    it("preserves a dialog block's children when replacing with the same dialog identity", () => {
+      // Create a dialog with some children
+      const rootWithDialog1 = ROOT.applyDelta(
+        "script_run_id",
+        makeProto(DeltaProto, {
+          addBlock: {
+            id: "same-dialog-identity",
+            dialog: {
+              title: "Same Dialog",
+              dismissible: true,
+            },
+          },
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      ).applyDelta(
+        "script_run_id",
+        makeProto(DeltaProto, {
+          newElement: { text: { body: "Dialog content" } },
+        }),
+        forwardMsgMetadata([0, 1, 1, 0])
+      )
+
+      // Verify the dialog has children
+      const dialogNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rootWithDialog1.main,
+        [1, 1]
+      ) as BlockNode
+      expect(dialogNode).toBeDefined()
+      expect(dialogNode.deltaBlock.type).toBe("dialog")
+      expect(dialogNode.children.length).toBe(1)
+
+      // Replace with a dialog with the same identity
+      const rootWithSameDialog = rootWithDialog1.applyDelta(
+        "new_script_run_id",
+        makeProto(DeltaProto, {
+          addBlock: {
+            id: "same-dialog-identity",
+            dialog: {
+              title: "Same Dialog",
+              dismissible: true,
+            },
+          },
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      // Verify the dialog preserves its children
+      const sameDialogNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rootWithSameDialog.main,
+        [1, 1]
+      ) as BlockNode
+      expect(sameDialogNode).toBeDefined()
+      expect(sameDialogNode.deltaBlock.type).toBe("dialog")
+      expect(sameDialogNode.deltaBlock.id).toBe("same-dialog-identity")
+      expect(sameDialogNode.children.length).toBe(1)
+    })
+
     it("specifies active script hash on 'newElement' deltas", () => {
       const delta = makeProto(DeltaProto, {
         newElement: { text: { body: "newElement!" } },

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -418,7 +418,18 @@ export class AppRoot {
       existingNode instanceof BlockNode &&
       existingNode.deltaBlock.type === block.type
     ) {
-      children = existingNode.children
+      // For dialog blocks, don't inherit children if the dialog identity is different.
+      // The identity is computed from the dialog's attributes.
+      // This prevents showing stale elements from a previous
+      // dialog when switching between different dialogs (see issue #10907).
+      const isDialogWithDifferentIdentity =
+        block.dialog &&
+        existingNode.deltaBlock.dialog &&
+        block.id !== existingNode.deltaBlock.id
+
+      if (!isDialogWithDifferentIdentity) {
+        children = existingNode.children
+      }
     }
 
     const blockNode = new BlockNode(

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -103,7 +103,9 @@ class Dialog(DeltaGenerator):
         # Compute a stable identity for the dialog based on its attributes.
         # This ID is used in the frontend to distinguish between different dialogs
         # and prevent showing stale content from a previous dialog (issue #10907).
-        # It's also used for widget registration when on_dismiss is activated.
+        # It's also used for widget registration when on_dismiss is activated
+        # but we don't want this to be a widget in its default case since it
+        # would change the behavior (especially with fragments).
         element_id = compute_and_register_element_id(
             "dialog",
             user_key=None,
@@ -114,6 +116,10 @@ class Dialog(DeltaGenerator):
             width=width,
             on_dismiss=str(on_dismiss) if not callable(on_dismiss) else "callback",
         )
+        # The block.id is used to identify the dialog in the frontend to
+        # prevent showing stale content from a previous dialog.
+        # For actual widget registration, we set the dialog.id also
+        # below. This will activate the widget behavior on dismiss.
         block_proto.id = element_id
 
         # Handle on_dismiss functionality
@@ -123,6 +129,8 @@ class Dialog(DeltaGenerator):
             # Register the dialog as a widget when on_dismiss is activated.
             # The same element_id is used for widget registration.
             ctx = get_script_run_ctx()
+            # Setting the dialog.id will activate the rerun on dismiss functionality
+            # in the frontend (we might add a dedicated flag later)
             block_proto.dialog.id = element_id
 
             register_widget(

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -100,25 +100,29 @@ class Dialog(DeltaGenerator):
         block_proto.dialog.dismissible = dismissible
         block_proto.dialog.width = _process_dialog_width_input(width)
 
+        # Compute a stable identity for the dialog based on its attributes.
+        # This ID is used in the frontend to distinguish between different dialogs
+        # and prevent showing stale content from a previous dialog (issue #10907).
+        # It's also used for widget registration when on_dismiss is activated.
+        element_id = compute_and_register_element_id(
+            "dialog",
+            user_key=None,
+            key_as_main_identity=False,
+            dg=parent,
+            title=title,
+            dismissible=dismissible,
+            width=width,
+            on_dismiss=str(on_dismiss) if not callable(on_dismiss) else "callback",
+        )
+        block_proto.id = element_id
+
         # Handle on_dismiss functionality
         is_dismiss_activated = on_dismiss != "ignore"
-        element_id = None
 
         if is_dismiss_activated:
-            # Register as widget when on_dismiss is activated
-
+            # Register the dialog as a widget when on_dismiss is activated.
+            # The same element_id is used for widget registration.
             ctx = get_script_run_ctx()
-
-            element_id = compute_and_register_element_id(
-                "dialog",
-                user_key=None,
-                key_as_main_identity=False,
-                dg=parent,
-                title=title,
-                dismissible=dismissible,
-                width=width,
-                on_dismiss=str(on_dismiss) if not callable(on_dismiss) else "callback",
-            )
             block_proto.dialog.id = element_id
 
             register_widget(


### PR DESCRIPTION
## Describe your changes

Fixes and issues where elements from previous dialogs were still showing up in a different dialog as stale elements. This was fixed by always calculating the dialog ID and only keeping the existing children in case it's the same dialog -> which expects the same type of children.

Before:

https://github.com/user-attachments/assets/c441b892-d531-4ebe-9178-4bc884b4eeb9

After:

https://github.com/user-attachments/assets/5d8facf9-2592-46e0-b012-b1b5cf3d9ac1


## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10907

## Testing Plan

- Added e2e and unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
