### PR TITLE
Icons Display Images for St.Button

### DIFF
--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
@@ -33,7 +33,19 @@ interface IconPackEntry {
 
 export function parseIconPackEntry(iconName: string): IconPackEntry {
   // This is a regex to match icon pack and icon name from the strings of format
-  // :pack/icon: like :material/settings_suggest:
+
+  if (!iconName) {
+    return { pack: "emoji", icon: "" }
+  }
+
+  // This is a regex to match icon pack and icon name from the strings of format
+  const imageLike = /^(image:|https?:\/\/|data:|\/)/i
+  const hasImageExt = /\.(png|jpe?g|svg|gif|webp|ico)(\?.*)?$/i
+  if (imageLike.test(iconName) || hasImageExt.test(iconName)) {
+    const url = iconName.replace(/^image:/i, "")
+    return { pack: "image", icon: url }
+  }
+
   const matchResult = iconName.match(/^:(.+)\/(.+):$/)
   if (matchResult === null) {
     return { pack: "emoji", icon: iconName }
@@ -86,6 +98,16 @@ const DynamicIconDispatcher = ({
 
   const { pack, icon } = parseIconPackEntry(iconValue)
   switch (pack) {
+    case "image":
+      return (
+        <StyledDynamicIcon {...props}>
+          <StyledImageIcon
+            src={icon}
+            alt="icon"
+            data-testid={props.testid || "stImageIcon"}
+          />
+        </StyledDynamicIcon>
+      )
     case "material":
       switch (icon) {
         case "star_filled":

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -34,7 +34,6 @@ from streamlit import runtime
 from streamlit.elements.lib.form_utils import current_form_id, is_in_form
 from streamlit.elements.lib.layout_utils import LayoutConfig, Width, validate_width
 from streamlit.elements.lib.policies import check_widget_policies
-from streamlit.elements.lib.shortcut_utils import normalize_shortcut
 from streamlit.elements.lib.utils import (
     Key,
     compute_and_register_element_id,
@@ -49,9 +48,6 @@ from streamlit.errors import (
 from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.navigation.page import StreamlitPage
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.proto.ButtonLikeIconPosition_pb2 import (
-    ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
-)
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
 from streamlit.proto.LinkButton_pb2 import LinkButton as LinkButtonProto
 from streamlit.proto.PageLink_pb2 import PageLink as PageLinkProto
@@ -65,14 +61,12 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.runtime.state.query_params import process_query_params
 from streamlit.string_util import validate_icon_or_emoji
 from streamlit.url_util import is_url
 from streamlit.util import in_sidebar
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.runtime.state.query_params import QueryParamsInput
 
 FORM_DOCS_INFO: Final = """
 
@@ -88,36 +82,6 @@ DownloadButtonDataType: TypeAlias = (
     | io.RawIOBase
     | Callable[[], str | bytes | TextIO | BinaryIO | io.RawIOBase]
 )
-
-IconPosition: TypeAlias = Literal["left", "right"]
-
-_DEFAULT_ICON_POSITION: Final[IconPosition] = "left"
-_VALID_ICON_POSITIONS: Final[tuple[IconPosition, ...]] = ("left", "right")
-
-
-def _normalize_icon_position(
-    icon_position: IconPosition | str | None, command: str
-) -> IconPosition:
-    if icon_position is None:
-        return _DEFAULT_ICON_POSITION
-
-    if icon_position not in _VALID_ICON_POSITIONS:
-        raise StreamlitAPIException(
-            f'The icon_position argument to {command} must be "left" or "right". \n'
-            f'The argument passed was "{icon_position}".'
-        )
-
-    return cast("IconPosition", icon_position)
-
-
-def _icon_position_to_proto(
-    icon_position: IconPosition,
-) -> ProtoButtonLikeIconPosition.ValueType:
-    return (
-        ProtoButtonLikeIconPosition.RIGHT
-        if icon_position == "right"
-        else ProtoButtonLikeIconPosition.LEFT
-    )
 
 
 @dataclass
@@ -142,11 +106,9 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         use_container_width: bool | None = None,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> bool:
         r"""Display a button widget.
 
@@ -220,12 +182,6 @@ class ButtonMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
-            - ``"spinner"``: Displays a spinner as an icon.
-
-        icon_position : "left" or "right"
-            The position of the icon relative to the button label. Defaults to
-            ``"left"``.
-
         disabled : bool
             An optional boolean that disables the button if set to ``True``.
             The default is ``False``.
@@ -257,33 +213,6 @@ class ButtonMixin:
               fixed width. If the specified width is greater than the width of
               the parent container, the width of the button matches the width
               of the parent container.
-
-        shortcut : str or None
-            An optional keyboard shortcut that triggers the button. This can be
-            one of the following strings:
-
-            - A single alphanumeric key like ``"K"`` or ``"4"``.
-            - A function key like ``"F11"``.
-            - A special key like ``"Enter"``, ``"Esc"``, or ``"Tab"``.
-            - Any of the above combined with modifiers. For example, you can use
-              ``"Ctrl+K"`` or ``"Cmd+Shift+O"``.
-
-            .. important::
-                The keys ``"C"`` and ``"R"`` are reserved and can't be used,
-                even with modifiers. Punctuation keys like ``"."`` and ``","``
-                aren't currently supported.
-
-            The following special keys are supported: Backspace, Delete, Down,
-            End, Enter, Esc, Home, Left, PageDown, PageUp, Right, Space, Tab,
-            and Up.
-
-            The following modifiers are supported: Alt, Ctrl, Cmd, Meta, Mod,
-            Option, Shift.
-
-            - Ctrl, Cmd, Meta, and Mod are interchangeable and will display to
-              the user to match their platform.
-            - Option and Alt are interchangeable and will display to the user
-              to match their platform.
 
         Returns
         -------
@@ -329,25 +258,6 @@ class ButtonMixin:
            https://doc-button-icons.streamlit.app/
            height: 220px
 
-        **Example 3: Use keyboard shortcuts**
-
-        The following example shows how to use keyboard shortcuts to trigger a
-        button. If you use any of the platform-dependent modifiers (Ctrl, Cmd,
-        or Mod), they are interpreted interchangeably and always displayed to
-        the user to match their platform.
-
-        >>> import streamlit as st
-        >>>
-        >>> with st.container(horizontal=True, horizontal_alignment="distribute"):
-        >>>     "`A`" if st.button("A", shortcut="A") else "` `"
-        >>>     "`S`" if st.button("S", shortcut="Ctrl+S") else "` `"
-        >>>     "`D`" if st.button("D", shortcut="Cmd+Shift+D") else "` `"
-        >>>     "`F`" if st.button("F", shortcut="Mod+Alt+Shift+F") else "` `"
-
-        .. output::
-           https://doc-button-shortcuts.streamlit.app/
-           height: 220px
-
         """
         key = to_key(key)
         ctx = get_script_run_ctx()
@@ -362,8 +272,6 @@ class ButtonMixin:
                 f'\nThe argument passed was "{type}".'
             )
 
-        normalized_icon_position = _normalize_icon_position(icon_position, "st.button")
-
         return self.dg._button(
             label,
             key,
@@ -375,10 +283,8 @@ class ButtonMixin:
             disabled=disabled,
             type=type,
             icon=icon,
-            icon_position=normalized_icon_position,
             ctx=ctx,
             width=width,
-            shortcut=shortcut,
         )
 
     @gather_metrics("download_button")
@@ -396,22 +302,18 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         use_container_width: bool | None = None,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> bool:
         r"""Display a download button widget.
 
         This is useful when you would like to provide a way for your users
         to download a file directly from your app.
 
-        If you pass the data directly to the ``data`` parameter, then the data
-        is stored in-memory while the user is connected. It's a good idea to
-        keep file sizes under a couple hundred megabytes to conserve memory or
-        use deferred data generation by passing a callable to the ``data``
-        parameter.
+        Note that the data to be downloaded is stored in-memory while the
+        user is connected, so it's a good idea to keep file sizes under a
+        couple hundred megabytes to conserve memory.
 
         If you want to prevent your app from rerunning when a user clicks the
         download button, wrap the download button in a `fragment
@@ -437,20 +339,15 @@ class ButtonMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        data : str, bytes, file-like, or callable
-            The contents of the file to be downloaded or a callable that
-            returns the contents of the file.
+        data : str, bytes, file, or callable
+            The contents of the file to be downloaded.
 
-            File contents can be a string, bytes, or file-like object.
-            File-like objects include ``io.BytesIO``, ``io.StringIO``, or any
-            class that implements the abstract base class ``io.RawIOBase``.
-
-            If a callable is passed, it is executed when the user clicks
-            the download button and runs on a separate thread from the
-            resulting script rerun. This deferred generation is helpful for
-            large files to avoid blocking the page script. The callable can't
-            accept any arguments. If any Streamlit commands are executed inside
-            the callable, they will be ignored.
+            You can also pass a ``callable`` (no-arg function) that returns
+            ``str``, ``bytes``, or a file-like object. The callable is executed
+            when the user clicks the download button (deferred generation).
+            Streamlit commands inside the callable (for example,
+            ``st.write("Deferred data prepared")``) are ignored and will not
+            render.
 
             To prevent unnecessary recomputation, use caching when converting
             your data for download. For more information, see the Example 1
@@ -536,12 +433,6 @@ class ButtonMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
-            - ``"spinner"``: Displays a spinner as an icon.
-
-        icon_position : "left" or "right"
-            The position of the icon relative to the button label. Defaults to
-            ``"left"``.
-
         disabled : bool
             An optional boolean that disables the download button if set to
             ``True``. The default is ``False``.
@@ -573,27 +464,6 @@ class ButtonMixin:
               fixed width. If the specified width is greater than the width of
               the parent container, the width of the button matches the width
               of the parent container.
-
-        shortcut : str or None
-            An optional keyboard shortcut that triggers the button. This can be
-            one of the following strings:
-
-            - A single alphanumeric key like ``"K"`` or ``"4"``.
-            - A function key like ``"F11"``.
-            - A special key like ``"Enter"``, ``"Esc"``, or ``"Tab"``.
-            - Any of the above combined with modifiers. For example, you can use
-              ``"Ctrl+K"`` or ``"Cmd+Shift+O"``.
-
-            .. important::
-                The keys ``"C"`` and ``"R"`` are reserved and can't be used,
-                even with modifiers. Punctuation keys like ``"."`` and ``","``
-                aren't currently supported.
-
-            For a list of supported keys and modifiers, see the documentation
-            for |st.button|_.
-
-            .. |st.button| replace:: ``st.button``
-            .. _st.button: https://docs.streamlit.io/develop/api-reference/widgets/st.button
 
         Returns
         -------
@@ -705,30 +575,26 @@ class ButtonMixin:
            https://doc-download-button-file.streamlit.app/
            height: 200px
 
-        **Example 4: Generate the data on-click with a callable**
+        **Example 4: Generate the data on click with a callable**
 
-        Pass a callable to ``data`` to generate the bytes lazily when the user
-        clicks the button. Streamlit commands inside this callable are ignored.
-        The callable can't accept any arguments and must return a file-like
-        object.
+        Pass a function to ``data`` to generate the bytes lazily when the user
+        clicks the button. Streamlit commands inside this function are ignored.
 
         >>> import streamlit as st
         >>> import time
         >>>
         >>> def make_report():
+        >>>     # Runs on click; Streamlit commands here won't render
         >>>     time.sleep(1)
+        >>>     # st.write("Deferred data prepared")  # Ignored
         >>>     return "col1,col2\n1,2\n3,4".encode("utf-8")
         >>>
         >>> st.download_button(
         ...     label="Download report",
-        ...     data=make_report,
+        ...     data=make_report,  # pass the function, don't call it
         ...     file_name="report.csv",
         ...     mime="text/csv",
         ... )
-
-        .. output::
-           https://doc-download-button-deferred.streamlit.app/
-           height: 200px
 
         """
         ctx = get_script_run_ctx()
@@ -742,10 +608,6 @@ class ButtonMixin:
                 f'The argument passed was "{type}".'
             )
 
-        normalized_icon_position = _normalize_icon_position(
-            icon_position, "st.download_button"
-        )
-
         return self._download_button(
             label=label,
             data=data,
@@ -758,11 +620,9 @@ class ButtonMixin:
             kwargs=kwargs,
             type=type,
             icon=icon,
-            icon_position=normalized_icon_position,
             disabled=disabled,
             ctx=ctx,
             width=width,
-            shortcut=shortcut,
         )
 
     @gather_metrics("link_button")
@@ -774,11 +634,9 @@ class ButtonMixin:
         help: str | None = None,
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         use_container_width: bool | None = None,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> DeltaGenerator:
         r"""Display a link button element.
 
@@ -844,12 +702,6 @@ class ButtonMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
-            - ``"spinner"``: Displays a spinner as an icon.
-
-        icon_position : "left" or "right"
-            The position of the icon relative to the button label. Defaults to
-            ``"left"``.
-
         disabled : bool
             An optional boolean that disables the link button if set to
             ``True``. The default is ``False``.
@@ -882,27 +734,6 @@ class ButtonMixin:
               the parent container, the width of the button matches the width
               of the parent container.
 
-        shortcut : str or None
-            An optional keyboard shortcut that triggers the button. This can be
-            one of the following strings:
-
-            - A single alphanumeric key like ``"K"`` or ``"4"``.
-            - A function key like ``"F11"``.
-            - A special key like ``"Enter"``, ``"Esc"``, or ``"Tab"``.
-            - Any of the above combined with modifiers. For example, you can use
-              ``"Ctrl+K"`` or ``"Cmd+Shift+O"``.
-
-            .. important::
-                The keys ``"C"`` and ``"R"`` are reserved and can't be used,
-                even with modifiers. Punctuation keys like ``"."`` and ``","``
-                aren't currently supported.
-
-            For a list of supported keys and modifiers, see the documentation
-            for |st.button|_.
-
-            .. |st.button| replace:: ``st.button``
-            .. _st.button: https://docs.streamlit.io/develop/api-reference/widgets/st.button
-
         Example
         -------
         >>> import streamlit as st
@@ -921,10 +752,6 @@ class ButtonMixin:
                 f'\nThe argument passed was "{type}".'
             )
 
-        normalized_icon_position = _normalize_icon_position(
-            icon_position, "st.link_button"
-        )
-
         if use_container_width is not None:
             width = "stretch" if use_container_width else "content"
 
@@ -935,9 +762,7 @@ class ButtonMixin:
             disabled=disabled,
             type=type,
             icon=icon,
-            icon_position=normalized_icon_position,
             width=width,
-            shortcut=shortcut,
         )
 
     @gather_metrics("page_link")
@@ -947,12 +772,10 @@ class ButtonMixin:
         *,
         label: str | None = None,
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         help: str | None = None,
         disabled: bool = False,
         use_container_width: bool | None = None,
         width: Width = "content",
-        query_params: QueryParamsInput | None = None,
     ) -> DeltaGenerator:
         r"""Display a link to another page in a multipage app or to an external page.
 
@@ -1007,12 +830,6 @@ class ButtonMixin:
               <https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Rounded>`_
               font library.
 
-            - ``"spinner"``: Displays a spinner as an icon.
-
-        icon_position : "left" or "right"
-            The position of the icon relative to the page link label. Defaults
-            to ``"left"``.
-
         help : str or None
             A tooltip that gets displayed when the link is hovered over. If
             this is ``None`` (default), no tooltip is displayed.
@@ -1049,27 +866,15 @@ class ButtonMixin:
               the parent container, the width of the button matches the width
               of the parent container.
 
-        query_params : dict, list of tuples, or None
-            Query parameters to apply when navigating to the target page.
-            This can be a dictionary or an iterable of key-value tuples. Values can
-            be strings or iterables of strings (for repeated keys). When this is
-            ``None`` (default), all non-embed query parameters are cleared during
-            navigation.
-
         Example
         -------
-        **Example 1: Basic usage**
+        Consider the following example given this file structure:
 
-        The following example shows how to create page links in a multipage app
-        that uses the ``pages/`` directory:
-
-        .. code-block:: text
-
-            your-repository/
-            ├── pages/
-            │   ├── page_1.py
-            │   └── page_2.py
-            └── your_app.py
+        >>> your-repository/
+        >>> ├── pages/
+        >>> │   ├── page_1.py
+        >>> │   └── page_2.py
+        >>> └── your_app.py
 
         >>> import streamlit as st
         >>>
@@ -1086,32 +891,8 @@ class ButtonMixin:
         .. |client.showSidebarNavigation| replace:: ``client.showSidebarNavigation``
         .. _client.showSidebarNavigation: https://docs.streamlit.io/develop/api-reference/configuration/config.toml#client
 
-        .. output::
+        .. output ::
             https://doc-page-link.streamlit.app/
-            height: 350px
-
-        **Example 2: Passing query parameters**
-
-        The following example shows how to pass query parameters when creating a
-        page link in a multipage app:
-
-        .. code-block:: text
-
-            your-repository/
-            ├── page_2.py
-            └── your_app.py
-
-        >>> import streamlit as st
-        >>>
-        >>> def page_1():
-        >>>     st.title("Page 1")
-        >>>     st.page_link("page_2.py", query_params={"utm_source": "page_1"})
-        >>>
-        >>> pg = st.navigation([page_1, "page_2.py"])
-        >>> pg.run()
-
-        .. output::
-            https://doc-page-link-query-params.streamlit.app/
             height: 350px
 
         """
@@ -1122,19 +903,13 @@ class ButtonMixin:
             # Sidebar page links should always be stretch width.
             width = "stretch"
 
-        normalized_icon_position = _normalize_icon_position(
-            icon_position, "st.page_link"
-        )
-
         return self._page_link(
             page=page,
             label=label,
             icon=icon,
-            icon_position=normalized_icon_position,
             help=help,
             disabled=disabled,
             width=width,
-            query_params=query_params,
         )
 
     def _download_button(
@@ -1151,11 +926,9 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> bool:
         key = to_key(key)
 
@@ -1164,10 +937,6 @@ class ButtonMixin:
             if on_click is None or on_click in {"ignore", "rerun"}
             else cast("WidgetCallback", on_click)
         )
-
-        normalized_shortcut: str | None = None
-        if shortcut is not None:
-            normalized_shortcut = normalize_shortcut(shortcut)
 
         check_widget_policies(
             self.dg,
@@ -1189,8 +958,6 @@ class ButtonMixin:
             help=help,
             type=type,
             width=width,
-            icon_position=icon_position,
-            shortcut=normalized_shortcut,
         )
 
         if is_in_form(self.dg):
@@ -1212,16 +979,12 @@ class ButtonMixin:
             download_button_proto.help = dedent(help)
 
         if icon is not None:
-            download_button_proto.icon = validate_icon_or_emoji(icon)
-        download_button_proto.icon_position = _icon_position_to_proto(icon_position)
+            download_button_proto.icon = validate_icon_or_emoji(icon, element_id)
 
         if on_click == "ignore":
             download_button_proto.ignore_rerun = True
         else:
             download_button_proto.ignore_rerun = False
-
-        if normalized_shortcut is not None:
-            download_button_proto.shortcut = normalized_shortcut
 
         serde = ButtonSerde()
 
@@ -1251,33 +1014,10 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> DeltaGenerator:
         link_button_proto = LinkButtonProto()
-        normalized_shortcut: str | None = None
-        if shortcut is not None:
-            normalized_shortcut = normalize_shortcut(shortcut)
-
-        if normalized_shortcut is not None:
-            # We only register the element ID if a shortcut is provide.
-            # The ID is required to correctly register and handle the shortcut
-            # on the client side.
-            link_button_proto.id = compute_and_register_element_id(
-                "link_button",
-                user_key=None,
-                key_as_main_identity=False,
-                dg=self.dg,
-                label=label,
-                icon=icon,
-                url=url,
-                help=help,
-                type=type,
-                width=width,
-                shortcut=normalized_shortcut,
-            )
         link_button_proto.label = label
         link_button_proto.url = url
         link_button_proto.type = type
@@ -1288,10 +1028,6 @@ class ButtonMixin:
 
         if icon is not None:
             link_button_proto.icon = validate_icon_or_emoji(icon)
-        link_button_proto.icon_position = _icon_position_to_proto(icon_position)
-
-        if normalized_shortcut is not None:
-            link_button_proto.shortcut = normalized_shortcut
 
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)
@@ -1305,20 +1041,12 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         label: str | None = None,
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         help: str | None = None,
         disabled: bool = False,
         width: Width = "content",
-        query_params: QueryParamsInput | None = None,
     ) -> DeltaGenerator:
         page_link_proto = PageLinkProto()
-        if query_params:
-            page_link_proto.query_string = process_query_params(query_params)
-
         validate_width(width, allow_content=True)
-
-        # Set icon_position early so it's set even in early return paths
-        page_link_proto.icon_position = _icon_position_to_proto(icon_position)
 
         ctx = get_script_run_ctx()
         if not ctx:
@@ -1409,17 +1137,11 @@ class ButtonMixin:
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
-        icon_position: IconPosition = "left",
         disabled: bool = False,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
-        shortcut: str | None = None,
     ) -> bool:
         key = to_key(key)
-
-        normalized_shortcut: str | None = None
-        if shortcut is not None:
-            normalized_shortcut = normalize_shortcut(shortcut)
 
         check_widget_policies(
             self.dg,
@@ -1443,8 +1165,6 @@ class ButtonMixin:
             is_form_submitter=is_form_submitter,
             type=type,
             width=width,
-            icon_position=icon_position,
-            shortcut=normalized_shortcut,
         )
 
         # It doesn't make sense to create a button inside a form (except
@@ -1475,11 +1195,7 @@ class ButtonMixin:
             button_proto.help = dedent(help)
 
         if icon is not None:
-            button_proto.icon = validate_icon_or_emoji(icon)
-        button_proto.icon_position = _icon_position_to_proto(icon_position)
-
-        if normalized_shortcut is not None:
-            button_proto.shortcut = normalized_shortcut
+            button_proto.icon = validate_icon_or_emoji(icon, element_id)
 
         serde = ButtonSerde()
 

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -62,17 +62,44 @@ def is_material_icon(maybe_icon: str) -> bool:
     return maybe_icon in ALL_MATERIAL_ICONS
 
 
-def validate_icon_or_emoji(icon: str | None) -> str:
-    """Validate an icon or emoji and return it in normalized format if valid."""
+## Change function name to validate_icon_or_emoji_or_img, need to change parameter type
+def validate_icon_or_emoji(icon: str | None, delta_path: str | None = None) -> str:
+    """Validate an icon, emoji, or image and return normalized format."""
     if icon is None:
         return ""
 
-    # Support the special case of the spinner icon:
-    if icon == "spinner":
-        return "spinner"
-
-    if icon.startswith(":material"):
+    if isinstance(icon, str) and icon.startswith(":material"):
         return validate_material_icon(icon)
+
+    # Check if it's an obvious URL/data URI/absolute path -> return as-is
+    if isinstance(icon, str) and re.match(r"^(https?://|data:|/)", icon):
+        return icon
+
+    if isinstance(icon, str) and _contains_special_chars(icon):
+        return validate_emoji(icon)
+
+    # At this point: alphanumeric string like "local_image.png" or invalid like "invalid"
+    # Try to load as image if delta_path is provided
+    if delta_path is not None:
+        try:
+            from streamlit.elements.lib.image_utils import image_to_url
+            from streamlit.elements.lib.layout_utils import LayoutConfig
+
+            url = image_to_url(
+                icon,
+                layout_config=LayoutConfig(width="content"),
+                clamp=False,
+                channels="RGB",
+                output_format="auto",
+                image_id=delta_path,
+            )
+            return url
+        except Exception:
+            raise StreamlitAPIException(
+                "Image loading failed, fall through to emoji validation"
+            )
+
+    # validate as emoji (Previous test cases assumed validate_emoji was last)
     return validate_emoji(icon)
 
 

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -31,9 +31,6 @@ import streamlit as st
 from streamlit.elements.widgets.button import marshall_file
 from streamlit.errors import StreamlitAPIException, StreamlitPageNotFoundError
 from streamlit.navigation.page import StreamlitPage
-from streamlit.proto.ButtonLikeIconPosition_pb2 import (
-    ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
-)
 from streamlit.proto.DownloadButton_pb2 import (
     DownloadButton as DownloadButtonProto,
 )
@@ -143,34 +140,30 @@ class ButtonTest(DeltaGeneratorTestCase):
         c = getattr(self.get_delta_from_queue().new_element, name)
         assert c.icon == icon
 
-    @parameterized.expand(get_button_command_matrix())
-    def test_invalid_icon_position_raises(
-        self, name: str, command: Callable[..., Any]
-    ) -> None:
-        """Test that invalid icon_position values raise an error."""
-        with pytest.raises(StreamlitAPIException):
-            command(icon_position="center")  # type: ignore[arg-type]
+    def test_icon_img_url(self):
+        """Test that a submit button can be called with an img (url) icon."""
+        url = "https://docs.streamlit.io/logo.svg"
+        st.button("btn", icon=url)
 
-    @parameterized.expand(
-        [
-            (name, command, position)
-            for name, command in get_button_command_matrix()
-            for position in ["left", "right"]
-        ]
-    )
-    def test_icon_position(
-        self, name: str, command: Callable[..., Any], icon_position: str
-    ):
-        """Test that icon_position is serialized for button-like commands."""
-        command(icon_position=icon_position)
+        last_delta = self.get_delta_from_queue()
+        assert last_delta.new_element.button.icon == url
 
-        c = getattr(self.get_delta_from_queue().new_element, name)
-        expected = (
-            ProtoButtonLikeIconPosition.RIGHT
-            if icon_position == "right"
-            else ProtoButtonLikeIconPosition.LEFT
-        )
-        assert c.icon_position == expected
+    def test_icon_img_url_local(self):
+        """Test that a button can be called with an img (local to folder) icon."""
+        from unittest.mock import patch
+
+        url = "https://docs.streamlit.io/logo.svg"
+
+        # Mock image_to_url to return a media URL
+        with patch(
+            "streamlit.elements.lib.image_utils.image_to_url",
+            return_value=url,
+        ):
+            st.button("btn", icon="local_image.png")
+
+        last_delta = self.get_delta_from_queue()
+        icon_val = last_delta.new_element.button.icon
+        assert icon_val == url
 
     @parameterized.expand(get_button_command_matrix())
     def test_just_disabled(self, name: str, command: Callable[..., Any]):
@@ -179,81 +172,6 @@ class ButtonTest(DeltaGeneratorTestCase):
 
         c = getattr(self.get_delta_from_queue().new_element, name)
         assert c.disabled
-
-    @parameterized.expand(
-        [
-            (name, command)
-            for name, command in get_button_command_matrix()
-            if name in {"button", "download_button", "link_button"}
-        ]
-    )
-    def test_shortcut_serialization(
-        self, name: str, command: Callable[..., Any]
-    ) -> None:
-        """Test that shortcuts are serialized for supported buttons."""
-        command(shortcut="Ctrl+K")
-
-        proto = getattr(self.get_delta_from_queue().new_element, name)
-        assert proto.shortcut == "ctrl+k"
-
-    def test_cmd_shortcut_alias(self) -> None:
-        """Test that Cmd shortcuts are normalized."""
-        st.button("the label", shortcut="Cmd+O")
-
-        proto = self.get_delta_from_queue().new_element.button
-        assert proto.shortcut == "cmd+o"
-
-    @parameterized.expand(
-        [
-            (name, command)
-            for name, command in get_button_command_matrix()
-            if name in {"button", "download_button", "link_button"}
-        ]
-    )
-    def test_shortcut_ignores_case_and_whitespace(
-        self, name: str, command: Callable[..., Any]
-    ) -> None:
-        """Test that shortcuts ignore casing and extraneous whitespace."""
-        command(shortcut="  CtRl  +  OptIon +   ShIfT   +   N   ")
-
-        proto = getattr(self.get_delta_from_queue().new_element, name)
-        assert proto.shortcut == "ctrl+alt+shift+n"
-
-    @parameterized.expand(
-        [
-            (name, command)
-            for name, command in get_button_command_matrix()
-            if name in {"button", "download_button", "link_button"}
-        ]
-    )
-    def test_modifier_only_shortcuts_raise(
-        self, name: str, command: Callable[..., Any]
-    ) -> None:
-        """Test that modifier-only shortcuts raise an exception."""
-        with pytest.raises(StreamlitAPIException):
-            command(shortcut="ctrl")
-
-        with pytest.raises(StreamlitAPIException):
-            command(shortcut="   shift   ")
-
-    @parameterized.expand(
-        [
-            ("upper_r", "R"),
-            ("lower_r", "r"),
-            ("shift_r", "Shift+R"),
-            ("ctrl_c", "Ctrl+C"),
-            ("cmd_c", "cmd+c"),
-        ]
-    )
-    def test_reserved_shortcuts_raise(self, _name: str, shortcut: str) -> None:
-        """Test that reserved shortcuts raise an exception."""
-        with pytest.raises(StreamlitAPIException):
-            st.button("reserved", shortcut=shortcut)
-
-    def test_invalid_shortcut_raises(self) -> None:
-        """Test that invalid shortcuts raise an exception."""
-        with pytest.raises(StreamlitAPIException):
-            st.button("invalid", shortcut="A+B")
 
     def test_stable_id_button_with_key(self):
         """Test that the button ID is stable when a stable key is provided."""
@@ -398,7 +316,7 @@ class ButtonTest(DeltaGeneratorTestCase):
         st.cache_data(lambda: st.button("the label"))()
 
         # The widget itself is still created, so we need to go back one element more:
-        el = self.get_delta_from_queue(-3).new_element.exception
+        el = self.get_delta_from_queue(-2).new_element.exception
         assert el.type == "CachedWidgetWarning"
         assert el.is_warning
 


### PR DESCRIPTION
## Describe your changes
Using string_util.py's validate_icon_or_emoji function, I added functionality in validating images as well, where it reuses the streamlit.elements.lib.image_utils to display the images. I also added some frontend code to display the images afterwards. 

## Screenshot or video (only for visual changes)
<img width="208" height="187" alt="image" src="https://github.com/user-attachments/assets/e6e55229-f105-4653-aef5-b6c3cab2dc7e" />

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/9770#issuecomment-3500083885

## Testing Plan
I added two unit test cases which verify if an image URL will display, and also if an image via local directory (via mocking) will display. 
I also did manual testing within the server to see if the icons would appear, and tested via different images.

---
## NOTES
The original issue requested for all widgets that had an icon parameter, but I wasn't sure if I was headed in the right direction. If you feel like this code is fixable, please let me know and I can try to apply this to all other relevant widgets and fix their documentations. I'm a beginner in open source, so I wasn't sure how this process worked, if code review is possible... thank you!
**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
