### PR TITLE
Fix data editor regression when starting from empty column

### DIFF
--- a/e2e_playwright/shared/dataframe_utils.py
+++ b/e2e_playwright/shared/dataframe_utils.py
@@ -24,6 +24,7 @@ from playwright.sync_api import (
     expect,
 )
 
+from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.react18_utils import wait_for_react_stability
 
 if TYPE_CHECKING:
@@ -344,6 +345,30 @@ def get_open_cell_overlay(page: Page | Locator) -> Locator:
     cell_overlay = page.get_by_test_id("portal").locator(".gdg-clip-region")
     expect(cell_overlay).to_be_visible()
     return cell_overlay
+
+
+def edit_cell_value(page: Page, value: str, *, wait_for_run: bool = True) -> None:
+    """Edit the currently open cell by filling a value and pressing Enter.
+
+    This helper function fills a value in the currently open cell editor
+    and submits it by pressing Enter. The cell must already be open for editing
+    (e.g., via click_on_cell with double_click=True).
+
+    Parameters
+    ----------
+    page : Page
+        The Playwright page.
+    value : str
+        The value to fill in the cell.
+    wait_for_run : bool
+        Whether to wait for the app to complete a run after submitting.
+        Defaults to True.
+    """
+    cell_overlay = get_open_cell_overlay(page)
+    cell_overlay.locator(".gdg-input").fill(value)
+    page.keyboard.press("Enter")
+    if wait_for_run:
+        wait_for_app_run(page)
 
 
 def expect_canvas_to_be_stable(

--- a/e2e_playwright/st_data_editor_config.py
+++ b/e2e_playwright/st_data_editor_config.py
@@ -589,8 +589,6 @@ st.data_editor(
 )
 
 st.header("Test editing empty columns")
-# Regression test for issues #13305 and #13307:
-# Editing cells in columns with None values should return scalar values, not lists.
 
 empty_column_df = pd.DataFrame(
     {

--- a/e2e_playwright/st_data_editor_config.py
+++ b/e2e_playwright/st_data_editor_config.py
@@ -587,3 +587,27 @@ st.data_editor(
     },
     key="dynamic-editor",
 )
+
+st.header("Test editing empty columns")
+# Regression test for issues #13305 and #13307:
+# Editing cells in columns with None values should return scalar values, not lists.
+
+empty_column_df = pd.DataFrame(
+    {
+        "number_col": [None],
+        "text_col": [None],
+    }
+)
+
+empty_col_result = st.data_editor(
+    empty_column_df,
+    hide_index=True,
+    column_config={
+        "number_col": st.column_config.NumberColumn(width="medium"),
+        "text_col": st.column_config.TextColumn(width="medium"),
+    },
+    width="content",
+    key="empty-column-editor",
+)
+
+st.write("Empty column result:", str(empty_col_result))

--- a/e2e_playwright/st_data_editor_config.py
+++ b/e2e_playwright/st_data_editor_config.py
@@ -602,6 +602,7 @@ empty_column_df = pd.DataFrame(
 empty_col_result = st.data_editor(
     empty_column_df,
     hide_index=True,
+    num_rows="dynamic",
     column_config={
         "number_col": st.column_config.NumberColumn(width="medium"),
         "text_col": st.column_config.TextColumn(width="medium"),

--- a/e2e_playwright/st_data_editor_config.py
+++ b/e2e_playwright/st_data_editor_config.py
@@ -609,4 +609,5 @@ empty_col_result = st.data_editor(
     key="empty-column-editor",
 )
 
-st.write("Empty column result:", str(empty_col_result))
+# Use to_dict() for deterministic output format that's easy to verify in tests
+st.write("Empty column result:", str(empty_col_result.to_dict()))

--- a/e2e_playwright/st_data_editor_config_test.py
+++ b/e2e_playwright/st_data_editor_config_test.py
@@ -23,6 +23,7 @@ from e2e_playwright.shared.app_utils import (
 )
 from e2e_playwright.shared.dataframe_utils import (
     click_on_cell,
+    edit_cell_value,
     expect_canvas_to_be_stable,
     expect_canvas_to_be_visible,
     get_open_cell_overlay,
@@ -321,7 +322,7 @@ def test_data_editor_dynamic_mode(app: Page, assert_snapshot: ImageCompareFuncti
 
 
 def test_editing_empty_column_returns_scalar_not_list(app: Page):
-    """Test that editing cells in empty (None-only) columns returns scalar values.
+    """Test that editing and adding rows in empty (None-only) columns returns scalars.
 
     Regression test for GitHub issues #13305 and #13307 where editing cells in
     columns that start with None values would incorrectly wrap the edited value
@@ -332,20 +333,32 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
 
     # Test editing the number column (first column)
     click_on_cell(data_editor, 1, 0, double_click=True, column_width="medium")
-    cell_overlay = get_open_cell_overlay(app)
-    cell_overlay.locator(".gdg-input").fill("42")
-    app.keyboard.press("Enter")
-    wait_for_app_run(app)
+    edit_cell_value(app, "42")
 
     # Verify the value is stored as a scalar (42), not a list ([42])
     expect_prefixed_markdown(app, "Empty column result:", "42")
 
     # Test editing the text column (second column)
     click_on_cell(data_editor, 1, 1, double_click=True, column_width="medium")
-    cell_overlay = get_open_cell_overlay(app)
-    cell_overlay.locator(".gdg-input").fill("hello")
-    app.keyboard.press("Enter")
-    wait_for_app_run(app)
+    edit_cell_value(app, "hello")
 
     # Verify the text value is stored as a scalar string, not a list
     expect_prefixed_markdown(app, "Empty column result:", "hello")
+
+    # Test adding a new row with values - should also return scalars
+    toolbar = data_editor.get_by_test_id("stElementToolbar")
+    data_editor.hover()
+    expect(toolbar).to_have_css("opacity", "1")
+
+    add_row_button = toolbar.get_by_test_id("stElementToolbarButton").get_by_label(
+        "Add row"
+    )
+    add_row_button.click()
+    wait_for_app_run(app)
+
+    # Edit the new row's number column (row index 2)
+    click_on_cell(data_editor, 2, 0, double_click=True, column_width="medium")
+    edit_cell_value(app, "99")
+
+    # Verify the new row value is also a scalar
+    expect_prefixed_markdown(app, "Empty column result:", "99")

--- a/e2e_playwright/st_data_editor_config_test.py
+++ b/e2e_playwright/st_data_editor_config_test.py
@@ -327,6 +327,8 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     Regression test for GitHub issues #13305 and #13307 where editing cells in
     columns that start with None values would incorrectly wrap the edited value
     in a list (e.g., entering "42" would return [42] instead of 42).
+
+    The app outputs the dataframe as str(.to_dict()) for deterministic verification.
     """
     data_editor = _get_editor(app, "empty-column-editor")
     expect_canvas_to_be_visible(data_editor)
@@ -335,15 +337,25 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     click_on_cell(data_editor, 1, 0, double_click=True, column_width="medium")
     edit_cell_value(app, "42")
 
-    # Verify the value is stored as a scalar (42), not a list ([42])
-    expect_prefixed_markdown(app, "Empty column result:", "42", exact_match=True)
+    # Verify the complete dict output with scalar value 42.0 (not [42])
+    expect_prefixed_markdown(
+        app,
+        "Empty column result:",
+        "{'number_col': {0: 42.0}, 'text_col': {0: None}}",
+        exact_match=True,
+    )
 
     # Test editing the text column (second column)
     click_on_cell(data_editor, 1, 1, double_click=True, column_width="medium")
     edit_cell_value(app, "hello")
 
-    # Verify the text value is stored as a scalar string, not a list
-    expect_prefixed_markdown(app, "Empty column result:", "hello", exact_match=True)
+    # Verify the complete dict output with scalar 'hello' (not ['hello'])
+    expect_prefixed_markdown(
+        app,
+        "Empty column result:",
+        "{'number_col': {0: 42.0}, 'text_col': {0: 'hello'}}",
+        exact_match=True,
+    )
 
     # Test adding a new row with values - should also return scalars
     toolbar = data_editor.get_by_test_id("stElementToolbar")
@@ -360,5 +372,10 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     click_on_cell(data_editor, 2, 0, double_click=True, column_width="medium")
     edit_cell_value(app, "99")
 
-    # Verify the new row value is also a scalar
-    expect_prefixed_markdown(app, "Empty column result:", "99", exact_match=True)
+    # Verify the complete dict output with new row scalar 99.0 (not [99])
+    expect_prefixed_markdown(
+        app,
+        "Empty column result:",
+        "{'number_col': {0: 42.0, 1: 99.0}, 'text_col': {0: 'hello', 1: None}}",
+        exact_match=True,
+    )

--- a/e2e_playwright/st_data_editor_config_test.py
+++ b/e2e_playwright/st_data_editor_config_test.py
@@ -337,11 +337,11 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     click_on_cell(data_editor, 1, 0, double_click=True, column_width="medium")
     edit_cell_value(app, "42")
 
-    # Verify the complete dict output with scalar value 42.0 (not [42])
+    # Verify the complete dict output with scalar value 42 (not [42])
     expect_prefixed_markdown(
         app,
         "Empty column result:",
-        "{'number_col': {0: 42.0}, 'text_col': {0: None}}",
+        "{'number_col': {0: 42}, 'text_col': {0: None}}",
         exact_match=True,
     )
 
@@ -353,7 +353,7 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     expect_prefixed_markdown(
         app,
         "Empty column result:",
-        "{'number_col': {0: 42.0}, 'text_col': {0: 'hello'}}",
+        "{'number_col': {0: 42}, 'text_col': {0: 'hello'}}",
         exact_match=True,
     )
 
@@ -372,10 +372,10 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     click_on_cell(data_editor, 2, 0, double_click=True, column_width="medium")
     edit_cell_value(app, "99")
 
-    # Verify the complete dict output with new row scalar 99.0 (not [99])
+    # Verify the complete dict output with new row scalar 99 (not [99])
     expect_prefixed_markdown(
         app,
         "Empty column result:",
-        "{'number_col': {0: 42.0, 1: 99.0}, 'text_col': {0: 'hello', 1: None}}",
+        "{'number_col': {0: 42, 1: 99}, 'text_col': {0: 'hello', 1: None}}",
         exact_match=True,
     )

--- a/e2e_playwright/st_data_editor_config_test.py
+++ b/e2e_playwright/st_data_editor_config_test.py
@@ -318,3 +318,34 @@ def test_data_editor_dynamic_mode(app: Page, assert_snapshot: ImageCompareFuncti
     )
 
     assert_snapshot(dynamic_editor, name="st_data_editor-dynamic_mode_after_delete")
+
+
+def test_editing_empty_column_returns_scalar_not_list(app: Page):
+    """Test that editing cells in empty (None-only) columns returns scalar values.
+
+    Regression test for GitHub issues #13305 and #13307 where editing cells in
+    columns that start with None values would incorrectly wrap the edited value
+    in a list (e.g., entering "42" would return [42] instead of 42).
+    """
+    data_editor = _get_editor(app, "empty-column-editor")
+    expect_canvas_to_be_visible(data_editor)
+
+    # Test editing the number column (first column)
+    click_on_cell(data_editor, 1, 0, double_click=True, column_width="medium")
+    cell_overlay = get_open_cell_overlay(app)
+    cell_overlay.locator(".gdg-input").fill("42")
+    app.keyboard.press("Enter")
+    wait_for_app_run(app)
+
+    # Verify the value is stored as a scalar (42), not a list ([42])
+    expect_prefixed_markdown(app, "Empty column result:", "42")
+
+    # Test editing the text column (second column)
+    click_on_cell(data_editor, 1, 1, double_click=True, column_width="medium")
+    cell_overlay = get_open_cell_overlay(app)
+    cell_overlay.locator(".gdg-input").fill("hello")
+    app.keyboard.press("Enter")
+    wait_for_app_run(app)
+
+    # Verify the text value is stored as a scalar string, not a list
+    expect_prefixed_markdown(app, "Empty column result:", "hello")

--- a/e2e_playwright/st_data_editor_config_test.py
+++ b/e2e_playwright/st_data_editor_config_test.py
@@ -336,14 +336,14 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     edit_cell_value(app, "42")
 
     # Verify the value is stored as a scalar (42), not a list ([42])
-    expect_prefixed_markdown(app, "Empty column result:", "42")
+    expect_prefixed_markdown(app, "Empty column result:", "42", exact_match=True)
 
     # Test editing the text column (second column)
     click_on_cell(data_editor, 1, 1, double_click=True, column_width="medium")
     edit_cell_value(app, "hello")
 
     # Verify the text value is stored as a scalar string, not a list
-    expect_prefixed_markdown(app, "Empty column result:", "hello")
+    expect_prefixed_markdown(app, "Empty column result:", "hello", exact_match=True)
 
     # Test adding a new row with values - should also return scalars
     toolbar = data_editor.get_by_test_id("stElementToolbar")
@@ -361,4 +361,4 @@ def test_editing_empty_column_returns_scalar_not_list(app: Page):
     edit_cell_value(app, "99")
 
     # Verify the new row value is also a scalar
-    expect_prefixed_markdown(app, "Empty column result:", "99")
+    expect_prefixed_markdown(app, "Empty column result:", "99", exact_match=True)

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -201,8 +201,14 @@ def _parse_value(
     import pandas as pd
 
     try:
-        if column_data_kind in (ColumnDataKind.LIST, ColumnDataKind.EMPTY):
+        if column_data_kind == ColumnDataKind.LIST:
             return list(value) if is_list_like(value) else [value]  # ty: ignore
+
+        if column_data_kind == ColumnDataKind.EMPTY:
+            # For empty columns, preserve the value type from the frontend.
+            # If it's a list (e.g., from multiselect), return as list.
+            # If it's a scalar (e.g., from number input), return as scalar.
+            return list(value) if is_list_like(value) else value
 
         if column_data_kind == ColumnDataKind.STRING:
             return str(value)

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -208,7 +208,7 @@ def _parse_value(
             # For empty columns, preserve the value type from the frontend.
             # If it's a list (e.g., from multiselect), return as list.
             # If it's a scalar (e.g., from number input), return as scalar.
-            return list(value) if is_list_like(value) else value
+            return list(value) if is_list_like(value) else value  # ty: ignore
 
         if column_data_kind == ColumnDataKind.STRING:
             return str(value)

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -253,7 +253,9 @@ class DataEditorUtilTest(unittest.TestCase):
             }
         )
 
-        edited_rows: Mapping[int, Mapping[str, str | int | float | bool | None]] = {
+        edited_rows: Mapping[
+            int, Mapping[str, str | int | float | bool | list[str] | None]
+        ] = {
             0: {
                 "number_col": 42,
                 "text_col": "hello",

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -158,6 +158,27 @@ class DataEditorUtilTest(unittest.TestCase):
                 ColumnDataKind.EMPTY,
                 ["foo"],
             ),
+            # Scalar values with EMPTY data kind should remain scalars (fix for #13305, #13307)
+            (
+                42,
+                ColumnDataKind.EMPTY,
+                42,
+            ),
+            (
+                "text",
+                ColumnDataKind.EMPTY,
+                "text",
+            ),
+            (
+                3.14,
+                ColumnDataKind.EMPTY,
+                3.14,
+            ),
+            (
+                True,
+                ColumnDataKind.EMPTY,
+                True,
+            ),
         ]
     )
     def test_parse_value(
@@ -211,6 +232,44 @@ class DataEditorUtilTest(unittest.TestCase):
         assert not df.iat[0, 2]
         assert df.iat[0, 3] == pd.Timestamp("2020-03-20T14:28:23")
         assert df.iat[0, 4] == Decimal("2.3")
+
+    def test_apply_cell_edits_empty_columns(self):
+        """Test applying cell edits to empty (None-only) columns.
+
+        Regression test for issues #13305 and #13307 where scalar values
+        were incorrectly wrapped in lists when editing empty columns.
+        """
+        # Create DataFrame with None values in all columns
+        df = pd.DataFrame(
+            {
+                "number_col": [None],
+                "text_col": [None],
+                "list_col": [None],
+            }
+        )
+
+        edited_rows: Mapping[int, Mapping[str, str | int | float | bool | None]] = {
+            0: {
+                "number_col": 42,
+                "text_col": "hello",
+                "list_col": ["a", "b"],
+            },
+        }
+
+        _apply_cell_edits(
+            df, edited_rows, determine_dataframe_schema(df, _get_arrow_schema(df))
+        )
+
+        # Scalar values should remain scalars, not be wrapped in lists
+        assert df.iat[0, 0] == 42
+        assert not isinstance(df.iat[0, 0], list)
+
+        assert df.iat[0, 1] == "hello"
+        assert not isinstance(df.iat[0, 1], list)
+
+        # List values should remain lists
+        assert df.iat[0, 2] == ["a", "b"]
+        assert isinstance(df.iat[0, 2], list)
 
     def test_apply_row_additions(self):
         """Test applying row additions to a DataFrame."""

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -160,6 +160,11 @@ class DataEditorUtilTest(unittest.TestCase):
             ),
             # Scalar values with EMPTY data kind should remain scalars (fix for #13305, #13307)
             (
+                None,
+                ColumnDataKind.EMPTY,
+                None,
+            ),
+            (
                 42,
                 ColumnDataKind.EMPTY,
                 42,


### PR DESCRIPTION
## Describe your changes

Fixes a regression where starting with an empty column in data editor leads to the value being returned as list.

## GitHub Issue Link (if applicable)

- Closes #13305

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
