### PR TITLE
Add shared e2e selectbox selection utility

### DIFF
--- a/e2e_playwright/custom_components/pdf_component_test.py
+++ b/e2e_playwright/custom_components/pdf_component_test.py
@@ -19,15 +19,12 @@ import re
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
+from e2e_playwright.shared.app_utils import select_selectbox_option
 
 
 def _select_pdf_scenario(app: Page, scenario: str):
     """Select a PDF test scenario from the dropdown."""
-    selectbox_input = app.get_by_test_id("stSelectbox").locator("input")
-    selectbox_input.clear()
-    selectbox_input.type(scenario)
-    selectbox_input.press("Enter")
-    wait_for_app_run(app)
+    select_selectbox_option(app, "PDF Test Scenarios", scenario)
 
 
 def _expect_pdf_container_attached(app: Page):

--- a/e2e_playwright/custom_components/popular_components_test.py
+++ b/e2e_playwright/custom_components/popular_components_test.py
@@ -17,16 +17,11 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import select_selectbox_option
 
 
 def _select_component(app: Page, component: str):
-    selectbox_input = app.get_by_test_id("stSelectbox").locator("input")
-
-    # Type an option (defined in the test app):
-    selectbox_input.type(component)
-    selectbox_input.press("Enter")
-    wait_for_app_run(app)
+    select_selectbox_option(app, "ComponentSelections", component)
 
 
 def _expect_no_exception(app: Page):

--- a/e2e_playwright/custom_components/popular_components_test.py
+++ b/e2e_playwright/custom_components/popular_components_test.py
@@ -17,11 +17,13 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.shared.app_utils import select_selectbox_option
+from e2e_playwright.shared.app_utils import reset_hovering, select_selectbox_option
 
 
 def _select_component(app: Page, component: str):
     select_selectbox_option(app, "ComponentSelections", component)
+    # reset hovering to avoid some flakiness:
+    reset_hovering(app)
 
 
 def _expect_no_exception(app: Page):

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -196,6 +196,42 @@ def get_selectbox(locator: Locator | Page, label: str | re.Pattern[str]) -> Loca
     return element
 
 
+def select_selectbox_option(
+    locator: Locator | Page,
+    label: str | re.Pattern[str],
+    option: str,
+) -> None:
+    """Select an option from a selectbox dropdown by exact text match.
+
+    Parameters
+    ----------
+    locator : Locator or Page
+        The locator or page containing the selectbox.
+
+    label : str or Pattern[str]
+        The label of the selectbox.
+
+    option : str
+        The exact text of the option to select.
+    """
+    selectbox = get_selectbox(locator, label)
+
+    # Click to open the dropdown
+    selectbox.click()
+
+    # Get the page from the locator
+    page = locator.page if isinstance(locator, Locator) else locator
+
+    # Select the option by exact text from the virtual dropdown
+    dropdown = page.get_by_test_id("stSelectboxVirtualDropdown")
+    dropdown.get_by_text(option, exact=True).click()
+
+    wait_for_app_run(page)
+
+    # Verify the selection was applied
+    expect(selectbox).to_contain_text(option)
+
+
 def get_multiselect(locator: Locator | Page, label: str | re.Pattern[str]) -> Locator:
     """Get a multiselect with the given label.
 

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -216,13 +216,16 @@ def select_selectbox_option(
     """
     selectbox = get_selectbox(locator, label)
 
-    # Click to open the dropdown
-    selectbox.click()
-
     # Get the page from the locator
     page = locator.page if isinstance(locator, Locator) else locator
 
-    # Select the option by exact text from the virtual dropdown
+    # Type to filter the dropdown (handles virtualized lists where options
+    # may not be rendered until scrolled into view)
+    selectbox_input = selectbox.locator("input")
+    selectbox_input.click()
+    selectbox_input.fill(option)
+
+    # Select the option by exact text from the filtered virtual dropdown
     dropdown = page.get_by_test_id("stSelectboxVirtualDropdown")
     dropdown.get_by_text(option, exact=True).click()
 

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -42,6 +42,7 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
     goto_app,
     reset_hovering,
+    select_selectbox_option,
 )
 
 
@@ -1590,14 +1591,7 @@ def test_audio_sample_rate_validation(app: Page, option_text: str, expected_hz: 
     grant_microphone_permissions(app)
 
     # Select the specified sample rate from dropdown
-    selectbox = app.get_by_test_id("stSelectbox").first
-    selectbox.click()
-    # Click the option in the dropdown (not the selected value display)
-    app.get_by_test_id("stSelectboxVirtualDropdown").get_by_text(option_text).click()
-    wait_for_app_run(app)
-
-    # Verify the selection
-    expect(selectbox).to_contain_text(option_text)
+    select_selectbox_option(app, "Select audio sample rate", option_text)
 
     # Get the chat input for audio recording
     chat_input = get_element_by_key(app, "audio_sample_rate_test")

--- a/e2e_playwright/st_effects_with_fragment_interactions_test.py
+++ b/e2e_playwright/st_effects_with_fragment_interactions_test.py
@@ -22,6 +22,7 @@ from e2e_playwright.shared.animation_utils import (
     check_if_onscreen,
     wait_for_animation_to_be_hidden,
 )
+from e2e_playwright.shared.app_utils import select_selectbox_option
 
 
 def test_balloons_visibility_with_fragment_interactions(app: Page):
@@ -54,10 +55,7 @@ def test_balloons_visibility_with_fragment_interactions(app: Page):
     wait_for_animation_to_be_hidden(app, animation_images)
 
     # Trigger the fragment re-run by changing the select box value
-    selectbox = app.get_by_test_id("stSelectbox").nth(0).locator("input")
-    selectbox.click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
+    select_selectbox_option(app, "Choose a color", "yellow")
 
     # Wait briefly to be sure that the animations aren't running
     app.wait_for_timeout(500)
@@ -107,10 +105,7 @@ def test_snow_visibility_with_fragment_interactions(app: Page):
     wait_for_animation_to_be_hidden(app, animation_images)
 
     # Trigger the fragment re-run by changing the select box value
-    selectbox = app.get_by_test_id("stSelectbox").nth(0).locator("input")
-    selectbox.click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
+    select_selectbox_option(app, "Choose a color", "yellow")
 
     # Wait briefly to be sure that the animations aren't running
     app.wait_for_timeout(500)

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -22,6 +22,7 @@ from e2e_playwright.shared.app_utils import (
     click_toggle,
     expect_prefixed_markdown,
     get_element_by_key,
+    select_selectbox_option,
 )
 
 
@@ -60,8 +61,7 @@ def change_widget_values(app: Page):
     ).click(force=True)
 
     # Change the selectbox value.
-    form_1.get_by_test_id("stSelectbox").locator("input").click()
-    app.locator("[data-baseweb='popover']").locator("li").nth(1).click()
+    select_selectbox_option(app, "Selectbox", "bar")
 
     # Change the select slider value.
     form_1.get_by_test_id("stSlider").nth(0).get_by_role("slider").press("ArrowRight")

--- a/e2e_playwright/st_fragment_basics_test.py
+++ b/e2e_playwright/st_fragment_basics_test.py
@@ -161,9 +161,6 @@ def test_selectbox_in_fragment(app: Page):
     old_text_in_fragment, old_text_outside_fragment = get_uuids(app)
 
     select_selectbox_option(app, "a selectbox", "b")
-    # Open dropdown again to verify it still works after selection
-    app.get_by_test_id("stSelectbox").locator("input").click()
-    wait_for_app_run(app)
 
     expect_only_fragment_uuid_changed(
         app, old_text_in_fragment, old_text_outside_fragment

--- a/e2e_playwright/st_fragment_basics_test.py
+++ b/e2e_playwright/st_fragment_basics_test.py
@@ -16,7 +16,11 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
-from e2e_playwright.shared.app_utils import click_button, click_checkbox
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    select_selectbox_option,
+)
 
 
 def get_uuids(app: Page) -> tuple[str, str]:
@@ -156,9 +160,8 @@ def test_radio_in_fragment(app: Page):
 def test_selectbox_in_fragment(app: Page):
     old_text_in_fragment, old_text_outside_fragment = get_uuids(app)
 
-    app.get_by_test_id("stSelectbox").locator("input").click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
+    select_selectbox_option(app, "a selectbox", "b")
+    # Open dropdown again to verify it still works after selection
     app.get_by_test_id("stSelectbox").locator("input").click()
     wait_for_app_run(app)
 

--- a/e2e_playwright/st_fragment_dynamic_form_test.py
+++ b/e2e_playwright/st_fragment_dynamic_form_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import select_selectbox_option
 
 
 def expect_correct_app_state(
@@ -34,10 +34,7 @@ def test_dynamic_form(app: Page):
     )
 
     # Select a country
-    app.get_by_test_id("stSelectbox").locator("input").first.click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
-    wait_for_app_run(app)
+    select_selectbox_option(app, "Country", "USA")
 
     expect_correct_app_state(
         app,
@@ -47,10 +44,7 @@ def test_dynamic_form(app: Page):
     )
 
     # Select a state
-    app.get_by_test_id("stSelectbox").locator("input").last.click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
-    wait_for_app_run(app)
+    select_selectbox_option(app, "State", "California")
 
     expect_correct_app_state(
         app,

--- a/e2e_playwright/st_logo_test.py
+++ b/e2e_playwright/st_logo_test.py
@@ -14,10 +14,8 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import (
-    ImageCompareFunction,
-    wait_for_app_run,
-)
+from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_utils import select_selectbox_option
 
 
 def test_logo_no_sidebar(
@@ -134,7 +132,4 @@ def test_logo_w_sidebar_and_nav(
 
 
 def select_subtest(app: Page, name: str) -> None:
-    selectbox_input = app.get_by_test_id("stSelectbox").nth(0).locator("input")
-    selectbox_input.type(name)
-    selectbox_input.press("Enter")
-    wait_for_app_run(app)
+    select_selectbox_option(app, "Test to run", name)

--- a/e2e_playwright/st_map_ensure_no_stale_maps_test.py
+++ b/e2e_playwright/st_map_ensure_no_stale_maps_test.py
@@ -14,6 +14,8 @@
 
 from playwright.sync_api import Page, expect
 
+from e2e_playwright.shared.app_utils import select_selectbox_option
+
 
 def test_st_map_has_no_stale_elements(
     themed_app: Page,
@@ -21,15 +23,10 @@ def test_st_map_has_no_stale_elements(
     maps = themed_app.get_by_test_id("stDeckGlJsonChart")
     expect(maps).to_have_count(3)
 
-    selectbox = themed_app.get_by_test_id("stSelectbox").first
-    selectbox.locator("input").first.click()
-    selection_dropdown = themed_app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(1).click()
+    select_selectbox_option(themed_app, "which dataframe to use?", "2")
 
     expect(maps).to_have_count(3)
 
-    selectbox.locator("input").first.click()
-    selection_dropdown = themed_app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").nth(0).click()
+    select_selectbox_option(themed_app, "which dataframe to use?", "1")
 
     expect(maps).to_have_count(3)

--- a/e2e_playwright/st_pydeck_chart_test.py
+++ b/e2e_playwright/st_pydeck_chart_test.py
@@ -16,7 +16,10 @@ import pytest
 from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
-from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.app_utils import (
+    check_top_level_class,
+    select_selectbox_option,
+)
 from e2e_playwright.shared.toolbar_utils import (
     assert_fullscreen_toolbar_button_interactions,
 )
@@ -203,9 +206,7 @@ def test_height_parameter(app: Page, assert_snapshot: ImageCompareFunction) -> N
 
 def select_subtest(app: Page, name: str) -> Locator:
     # Select the text in the UI:
-    selectbox_input = app.get_by_test_id("stSelectbox").nth(0).locator("input")
-    selectbox_input.type(name)
-    selectbox_input.press("Enter")
+    select_selectbox_option(app, "Test to run", name)
 
     # The pydeck chart takes a while to load so check that
     # at least one gets attached with an increased timeout.

--- a/e2e_playwright/st_rerun_test.py
+++ b/e2e_playwright/st_rerun_test.py
@@ -14,11 +14,11 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     click_button,
     expect_markdown,
     expect_prefixed_markdown,
+    select_selectbox_option,
 )
 
 
@@ -69,10 +69,7 @@ def test_state_retained_on_app_scoped_rerun(app: Page):
     expect_prefixed_markdown(app, "selectbox selection:", "None")
 
     # Click on the selectbox and select the first option.
-    app.get_by_test_id("stSelectbox").first.locator("input").click()
-    selection_dropdown = app.locator('[data-baseweb="popover"]').first
-    selection_dropdown.locator("li").first.click()
-    wait_for_app_run(app)
+    select_selectbox_option(app, "i should retain my state", "a")
 
     # Sanity check 2
     expect_markdown(app, "selectbox selection: a")


### PR DESCRIPTION
## Describe your changes

Adds a `select_selectbox_option` to make it easy to select an option in a selectbox in our e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
