### PR TITLE
Collect websocket metrics and allow filtering by endpoint family

### DIFF
--- a/e2e_playwright/web_server.py
+++ b/e2e_playwright/web_server.py
@@ -48,7 +48,9 @@ st.download_button(
     key="test_download",
 )
 
-# Display session info
+# Display session info.
+# Setting session state here also ensures cache_memory_bytes metrics are available
+# for the metrics endpoint tests to verify filtering works correctly.
 st.subheader("Session Info")
 if "counter" not in st.session_state:
     st.session_state.counter = 0

--- a/e2e_playwright/web_server_test.py
+++ b/e2e_playwright/web_server_test.py
@@ -122,6 +122,131 @@ def test_metrics_endpoint_accepts_protobuf(app: Page, app_port: int):
     assert "protobuf" in content_type
 
 
+def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_port: int):
+    """Test that metrics endpoint filters results by families query parameter.
+
+    When requesting families=cache_memory_bytes, only cache memory metrics
+    should be returned. The web_server.py app initializes session state to
+    ensure these metrics are always present.
+    """
+    wait_for_app_loaded(app)
+
+    response = app.request.get(
+        f"http://localhost:{app_port}/_stcore/metrics?families=cache_memory_bytes"
+    )
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should contain cache_memory_bytes metrics (guaranteed by session state in web_server.py)
+    assert "cache_memory_bytes" in text
+    # Should NOT contain session_events_total or active_sessions metrics
+    assert "session_events_total" not in text
+    assert "active_sessions" not in text
+
+
+def test_metrics_endpoint_filters_by_family_session_events(app: Page, app_port: int):
+    """Test that metrics endpoint returns session_events_total when requested.
+
+    Session events metrics track connections, reconnections, and disconnections.
+    """
+    response = app.request.get(
+        f"http://localhost:{app_port}/_stcore/metrics?families=session_events_total"
+    )
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should contain session_events_total metrics
+    assert "session_events_total" in text
+    # Should NOT contain cache_memory_bytes or active_sessions metrics
+    assert "cache_memory_bytes" not in text
+    assert "active_sessions" not in text
+
+
+def test_metrics_endpoint_filters_by_family_active_sessions(app: Page, app_port: int):
+    """Test that metrics endpoint returns active_sessions when requested.
+
+    Active sessions metrics track the current number of connected sessions.
+    """
+    response = app.request.get(
+        f"http://localhost:{app_port}/_stcore/metrics?families=active_sessions"
+    )
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should contain active_sessions metrics
+    assert "active_sessions" in text
+    # Should NOT contain cache_memory_bytes or session_events_total metrics
+    assert "cache_memory_bytes" not in text
+    assert "session_events_total" not in text
+
+
+def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_port: int):
+    """Test that metrics endpoint supports filtering by multiple families.
+
+    Multiple families query params should return metrics for all requested families.
+    """
+    response = app.request.get(
+        f"http://localhost:{app_port}/_stcore/metrics"
+        "?families=session_events_total&families=active_sessions"
+    )
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should contain both session_events_total and active_sessions metrics
+    assert "session_events_total" in text
+    assert "active_sessions" in text
+    # Should NOT contain cache_memory_bytes metrics
+    assert "cache_memory_bytes" not in text
+
+
+def test_metrics_endpoint_unknown_family_returns_empty(app: Page, app_port: int):
+    """Test that metrics endpoint returns empty response for unknown families.
+
+    When requesting a family that doesn't exist, the response should contain
+    only the EOF marker.
+    """
+    response = app.request.get(
+        f"http://localhost:{app_port}/_stcore/metrics?families=unknown_family"
+    )
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should only contain the EOF marker
+    assert text.strip() == "# EOF"
+
+
+def test_metrics_endpoint_no_filter_returns_all_families(app: Page, app_port: int):
+    """Test that metrics endpoint without filter returns all metric families.
+
+    When no families query param is provided, all available metrics should be returned.
+    The web_server.py app initializes session state to ensure cache_memory_bytes
+    metrics are always present.
+    """
+    wait_for_app_loaded(app)
+
+    response = app.request.get(f"http://localhost:{app_port}/_stcore/metrics")
+
+    expect(response).to_be_ok()
+    assert response.status == 200
+
+    text = response.text()
+    # Should contain metrics from all families
+    # cache_memory_bytes is guaranteed by session state initialization in web_server.py
+    assert "cache_memory_bytes" in text
+    assert "session_events_total" in text
+    assert "active_sessions" in text
+
+
 # =============================================================================
 # Host Config Endpoint Tests
 # =============================================================================

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -62,7 +62,12 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
+from streamlit.runtime.stats import (
+    CACHE_MEMORY_FAMILY,
+    CacheStat,
+    StatsProvider,
+    group_cache_stats,
+)
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
@@ -241,7 +246,12 @@ class DataCaches(StatsProvider):
                     data_cache.storage.close()
             self._function_caches = {}
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
@@ -249,8 +259,12 @@ class DataCaches(StatsProvider):
 
         stats: list[CacheStat] = []
         for cache in function_caches.values():
-            stats.extend(cache.get_stats())
-        return group_cache_stats(stats)
+            cache_stats = cache.get_stats(family_names)
+            for family_stats in cache_stats.values():
+                stats.extend(family_stats)
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}
 
     def validate_cache_params(
         self,
@@ -631,10 +645,17 @@ class DataCache(Cache[R]):
         self.max_entries = max_entries
         self.persist = persist
 
-    def get_stats(self) -> Sequence[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         if isinstance(self.storage, StatsProvider):
-            return cast("Sequence[CacheStat]", self.storage.get_stats())
-        return []
+            return cast(
+                "dict[str, list[CacheStat]]", self.storage.get_stats(family_names)
+            )
+        return {}
 
     def read_result(self, key: str) -> CachedResult[R]:
         """Read a value and messages from the cache. Raise `CacheKeyNotFoundError`

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -161,6 +161,10 @@ class DataCaches(StatsProvider):
         self._caches_lock = threading.Lock()
         self._function_caches: dict[str, DataCache[Any]] = {}
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
+
     def get_cache(
         self,
         key: str,
@@ -247,11 +251,8 @@ class DataCaches(StatsProvider):
             self._function_caches = {}
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
@@ -259,11 +260,14 @@ class DataCaches(StatsProvider):
 
         stats: list[CacheStat] = []
         for cache in function_caches.values():
-            cache_stats = cache.get_stats(family_names)
+            cache_stats = cache.get_stats()
             for family_stats in cache_stats.values():
                 stats.extend(family_stats)
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}
 
     def validate_cache_params(
@@ -646,15 +650,13 @@ class DataCache(Cache[R]):
         self.persist = persist
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         if isinstance(self.storage, StatsProvider):
-            return cast(
-                "dict[str, list[CacheStat]]", self.storage.get_stats(family_names)
-            )
+            return cast("dict[str, list[CacheStat]]", self.storage.get_stats())
         return {}
 
     def read_result(self, key: str) -> CachedResult[R]:

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -86,6 +86,10 @@ class ResourceCaches(StatsProvider):
         self._caches_lock = threading.Lock()
         self._function_caches: dict[str, ResourceCache[Any]] = {}
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
+
     def get_cache(
         self,
         key: str,
@@ -133,11 +137,8 @@ class ResourceCaches(StatsProvider):
             self._function_caches = {}
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
@@ -145,11 +146,14 @@ class ResourceCaches(StatsProvider):
 
         stats: list[CacheStat] = []
         for cache in function_caches.values():
-            cache_stats = cache.get_stats(family_names)
+            cache_stats = cache.get_stats()
             for family_stats in cache_stats.values():
                 stats.extend(family_stats)
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}
 
 
@@ -552,11 +556,8 @@ class ResourceCache(Cache[R]):
                 del self._mem_cache[key]
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         # Shallow clone our cache. Computing item sizes is potentially
         # expensive, and we want to minimize the time we spend holding
         # the lock.
@@ -577,4 +578,7 @@ class ResourceCache(Cache[R]):
             )
             for entry in cache_entries
         ]
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: stats}

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import math
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -49,7 +49,12 @@ from streamlit.runtime.caching.cached_message_replay import (
     MsgData,
 )
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
+from streamlit.runtime.stats import (
+    CACHE_MEMORY_FAMILY,
+    CacheStat,
+    StatsProvider,
+    group_cache_stats,
+)
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
@@ -127,7 +132,12 @@ class ResourceCaches(StatsProvider):
         with self._caches_lock:
             self._function_caches = {}
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
@@ -135,8 +145,12 @@ class ResourceCaches(StatsProvider):
 
         stats: list[CacheStat] = []
         for cache in function_caches.values():
-            stats.extend(cache.get_stats())
-        return group_cache_stats(stats)
+            cache_stats = cache.get_stats(family_names)
+            for family_stats in cache_stats.values():
+                stats.extend(family_stats)
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}
 
 
 # Singleton ResourceCaches instance
@@ -537,17 +551,25 @@ class ResourceCache(Cache[R]):
             elif key in self._mem_cache:
                 del self._mem_cache[key]
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         # Shallow clone our cache. Computing item sizes is potentially
         # expensive, and we want to minimize the time we spend holding
         # the lock.
         with self._mem_cache_lock:
             cache_entries = list(self._mem_cache.values())
 
+        if not cache_entries:
+            return {}
+
         # Lazy-load vendored package to prevent import of numpy
         from streamlit.vendor.pympler.asizeof import asizeof
 
-        return [
+        stats = [
             CacheStat(
                 category_name="st_cache_resource",
                 cache_name=self.display_name,
@@ -555,3 +577,4 @@ class ResourceCache(Cache[R]):
             )
             for entry in cache_entries
         ]
+        return {CACHE_MEMORY_FAMILY: stats}

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -84,6 +84,10 @@ class InMemoryCacheStorageWrapper(CacheStorage):
     def max_entries(self) -> float:
         return float(self._max_entries) if self._max_entries is not None else math.inf
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
+
     def get(self, key: str) -> bytes:
         """
         Returns the stored value for the key or raise CacheStorageKeyNotFoundError if
@@ -113,12 +117,9 @@ class InMemoryCacheStorageWrapper(CacheStorage):
         self._persist_storage.clear()
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
         """Returns stats in bytes for the cache memory storage per item."""
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         with self._mem_cache_lock:
             stats = [
                 CacheStat(
@@ -130,6 +131,9 @@ class InMemoryCacheStorageWrapper(CacheStorage):
             ]
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: stats}
 
     def close(self) -> None:

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import math
 import threading
+from typing import TYPE_CHECKING
 
 from cachetools import TTLCache
 
@@ -25,7 +26,10 @@ from streamlit.runtime.caching.storage.cache_storage_protocol import (
     CacheStorageContext,
     CacheStorageKeyNotFoundError,
 )
-from streamlit.runtime.stats import CacheStat
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _LOGGER = get_logger(__name__)
 
@@ -108,10 +112,15 @@ class InMemoryCacheStorageWrapper(CacheStorage):
             self._mem_cache.clear()
         self._persist_storage.clear()
 
-    def get_stats(self) -> list[CacheStat]:
-        """Returns a list of stats in bytes for the cache memory storage per item."""
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        """Returns stats in bytes for the cache memory storage per item."""
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         with self._mem_cache_lock:
-            return [
+            stats = [
                 CacheStat(
                     category_name="st_cache_data",
                     cache_name=self.function_display_name,
@@ -119,6 +128,9 @@ class InMemoryCacheStorageWrapper(CacheStorage):
                 )
                 for item in self._mem_cache.values()
             ]
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: stats}
 
     def close(self) -> None:
         """Closes the cache storage."""

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -109,6 +109,10 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
         self._files_by_id: dict[str, MemoryFile] = {}
         self._media_endpoint = media_endpoint
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
+
     def load_and_get_id(
         self,
         path_or_data: str | bytes,
@@ -175,11 +179,8 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
             raise MediaFileStorageError(f"Error opening '{filename}'") from ex
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         # We operate on a copy of our dict, to avoid race conditions
         # with other threads that may be manipulating the cache.
         files_by_id = self._files_by_id.copy()
@@ -194,4 +195,7 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
         ]
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -20,7 +20,7 @@ import contextlib
 import hashlib
 import mimetypes
 import os.path
-from typing import Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 from streamlit.logger import get_logger
 from streamlit.runtime.media_file_storage import (
@@ -28,7 +28,15 @@ from streamlit.runtime.media_file_storage import (
     MediaFileStorage,
     MediaFileStorageError,
 )
-from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
+from streamlit.runtime.stats import (
+    CACHE_MEMORY_FAMILY,
+    CacheStat,
+    StatsProvider,
+    group_cache_stats,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -166,7 +174,12 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
         except Exception as ex:
             raise MediaFileStorageError(f"Error opening '{filename}'") from ex
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         # We operate on a copy of our dict, to avoid race conditions
         # with other threads that may be manipulating the cache.
         files_by_id = self._files_by_id.copy()
@@ -179,4 +192,6 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
             )
             for _, file in files_by_id.items()
         ]
-        return group_cache_stats(stats)
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -39,6 +39,10 @@ class MemoryUploadedFileManager(UploadedFileManager):
         self.file_storage: dict[str, dict[str, UploadedFileRec]] = defaultdict(dict)
         self.endpoint = upload_endpoint
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
+
     def get_files(
         self, session_id: str, file_ids: Sequence[str]
     ) -> list[UploadedFileRec]:
@@ -114,15 +118,12 @@ class MemoryUploadedFileManager(UploadedFileManager):
         return result
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
         """Return the manager's CacheStats.
 
         Safe to call from any thread.
         """
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         # Flatten all files into a single list
         all_files: list[UploadedFileRec] = []
         # Make copy of self.file_storage for thread safety, to be sure
@@ -142,4 +143,7 @@ class MemoryUploadedFileManager(UploadedFileManager):
         ]
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from streamlit import util
-from streamlit.runtime.stats import CacheStat, group_cache_stats
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat, group_cache_stats
 from streamlit.runtime.uploaded_file_manager import (
     UploadedFileManager,
     UploadedFileRec,
@@ -113,11 +113,16 @@ class MemoryUploadedFileManager(UploadedFileManager):
             )
         return result
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
         """Return the manager's CacheStats.
 
         Safe to call from any thread.
         """
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         # Flatten all files into a single list
         all_files: list[UploadedFileRec] = []
         # Make copy of self.file_storage for thread safety, to be sure
@@ -135,4 +140,6 @@ class MemoryUploadedFileManager(UploadedFileManager):
             )
             for file in all_files
         ]
-        return group_cache_stats(stats)
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -49,7 +49,13 @@ from streamlit.runtime.state import (
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
     SessionStateStatProvider,
 )
-from streamlit.runtime.stats import StatsManager
+from streamlit.runtime.stats import (
+    ACTIVE_SESSIONS_FAMILY,
+    CACHE_MEMORY_FAMILY,
+    SESSION_EVENTS_FAMILY,
+    StatsManager,
+    StatsProvider,
+)
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 
 if TYPE_CHECKING:
@@ -225,15 +231,23 @@ class Runtime:
 
         self._stats_mgr = StatsManager()
         self._stats_mgr.register_provider(
-            "cache_memory_bytes", get_data_cache_stats_provider()
+            get_data_cache_stats_provider(), [CACHE_MEMORY_FAMILY]
         )
         self._stats_mgr.register_provider(
-            "cache_memory_bytes", get_resource_cache_stats_provider()
+            get_resource_cache_stats_provider(), [CACHE_MEMORY_FAMILY]
         )
-        self._stats_mgr.register_provider("cache_memory_bytes", self._uploaded_file_mgr)
         self._stats_mgr.register_provider(
-            "cache_memory_bytes", SessionStateStatProvider(self._session_mgr)
+            self._uploaded_file_mgr, [CACHE_MEMORY_FAMILY]
         )
+        self._stats_mgr.register_provider(
+            SessionStateStatProvider(self._session_mgr), [CACHE_MEMORY_FAMILY]
+        )
+
+        # Register session manager for session event metrics if it implements StatsProvider
+        if isinstance(self._session_mgr, StatsProvider):
+            self._stats_mgr.register_provider(
+                self._session_mgr, [SESSION_EVENTS_FAMILY, ACTIVE_SESSIONS_FAMILY]
+            )
 
     @property
     def state(self) -> RuntimeState:

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -50,9 +50,6 @@ from streamlit.runtime.state import (
     SessionStateStatProvider,
 )
 from streamlit.runtime.stats import (
-    ACTIVE_SESSIONS_FAMILY,
-    CACHE_MEMORY_FAMILY,
-    SESSION_EVENTS_FAMILY,
     StatsManager,
     StatsProvider,
 )
@@ -230,24 +227,15 @@ class Runtime:
         )
 
         self._stats_mgr = StatsManager()
-        self._stats_mgr.register_provider(
-            get_data_cache_stats_provider(), [CACHE_MEMORY_FAMILY]
-        )
-        self._stats_mgr.register_provider(
-            get_resource_cache_stats_provider(), [CACHE_MEMORY_FAMILY]
-        )
-        self._stats_mgr.register_provider(
-            self._uploaded_file_mgr, [CACHE_MEMORY_FAMILY]
-        )
-        self._stats_mgr.register_provider(
-            SessionStateStatProvider(self._session_mgr), [CACHE_MEMORY_FAMILY]
-        )
+        self._stats_mgr.register_provider(get_data_cache_stats_provider())
+        self._stats_mgr.register_provider(get_resource_cache_stats_provider())
+        if self._uploaded_file_mgr is not None:
+            self._stats_mgr.register_provider(self._uploaded_file_mgr)
+        self._stats_mgr.register_provider(SessionStateStatProvider(self._session_mgr))
 
         # Register session manager for session event metrics if it implements StatsProvider
         if isinstance(self._session_mgr, StatsProvider):
-            self._stats_mgr.register_provider(
-                self._session_mgr, [SESSION_EVENTS_FAMILY, ACTIVE_SESSIONS_FAMILY]
-            )
+            self._stats_mgr.register_provider(self._session_mgr)
 
     @property
     def state(self) -> RuntimeState:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import pickle
-from collections.abc import Iterator, KeysView, Mapping, MutableMapping
+from collections.abc import Iterator, KeysView, Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import (
@@ -46,7 +46,12 @@ from streamlit.runtime.state.common import (
 )
 from streamlit.runtime.state.presentation import apply_presenter
 from streamlit.runtime.state.query_params import QueryParams
-from streamlit.runtime.stats import CacheStat, StatsProvider, group_cache_stats
+from streamlit.runtime.stats import (
+    CACHE_MEMORY_FAMILY,
+    CacheStat,
+    StatsProvider,
+    group_cache_stats,
+)
 
 if TYPE_CHECKING:
     from streamlit.runtime.session_manager import SessionManager
@@ -934,12 +939,17 @@ class SessionState:
         else:
             return True
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         # Lazy-load vendored package to prevent import of numpy
         from streamlit.vendor.pympler.asizeof import asizeof
 
         stat = CacheStat("st_session_state", "", asizeof(self))
-        return [stat]
+        return {CACHE_MEMORY_FAMILY: [stat]}
 
     def _check_serializable(self) -> None:
         """Verify that everything added to session state can be serialized.
@@ -995,9 +1005,18 @@ def _is_stale_widget(
 class SessionStateStatProvider(StatsProvider):
     _session_mgr: SessionManager
 
-    def get_stats(self) -> list[CacheStat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
+            return {}
+
         stats: list[CacheStat] = []
         for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state
-            stats.extend(session_state.get_stats())
-        return group_cache_stats(stats)
+            session_stats = session_state.get_stats(family_names)
+            for family_stats in session_stats.values():
+                stats.extend(family_stats)
+        if not stats:
+            return {}
+        return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -940,15 +940,15 @@ class SessionState:
             return True
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
-
         # Lazy-load vendored package to prevent import of numpy
         from streamlit.vendor.pympler.asizeof import asizeof
 
         stat = CacheStat("st_session_state", "", asizeof(self))
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: [stat]}
 
     def _check_serializable(self) -> None:
@@ -1005,18 +1005,22 @@ def _is_stale_widget(
 class SessionStateStatProvider(StatsProvider):
     _session_mgr: SessionManager
 
-    def get_stats(
-        self, family_names: Sequence[str] | None = None
-    ) -> dict[str, list[CacheStat]]:
-        if family_names is not None and CACHE_MEMORY_FAMILY not in family_names:
-            return {}
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (CACHE_MEMORY_FAMILY,)
 
+    def get_stats(
+        self, _family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
         stats: list[CacheStat] = []
         for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state
-            session_stats = session_state.get_stats(family_names)
+            session_stats = session_state.get_stats()
             for family_stats in session_stats.values():
                 stats.extend(family_stats)
         if not stats:
             return {}
+        # In general, get_stats methods need to be able to return only requested stat
+        # families, but this method only returns a single family, and we're guaranteed
+        # that it was one of those requested if we make it here.
         return {CACHE_MEMORY_FAMILY: group_cache_stats(stats)}

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -15,10 +15,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Final, NamedTuple, Protocol, runtime_checkable
+
+CACHE_MEMORY_FAMILY: Final = "cache_memory_bytes"
+SESSION_EVENTS_FAMILY: Final = "session_events_total"
+ACTIVE_SESSIONS_FAMILY: Final = "active_sessions"
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from streamlit.proto.openmetrics_data_model_pb2 import (
         Metric as MetricProto,
@@ -65,6 +69,9 @@ class Stat(Protocol):
         pass
 
 
+# TODO(vdonato): Could we use GaugeStat below and get rid of this class?
+# We'd have to make some minor changes to use the other class, but overall the
+# changes should be relatively minor.
 class CacheStat(NamedTuple):
     """Describes a single cache entry.
 
@@ -89,7 +96,7 @@ class CacheStat(NamedTuple):
     # Stat Protocol fields with default values for cache metrics
     @property
     def family_name(self) -> str:
-        return "cache_memory_bytes"
+        return CACHE_MEMORY_FAMILY
 
     @property
     def type(self) -> str:
@@ -142,6 +149,96 @@ def group_cache_stats(stats: list[CacheStat]) -> list[CacheStat]:
     return result
 
 
+class CounterStat(NamedTuple):
+    """A counter stat.
+
+    Properties
+    ----------
+    family_name : str
+        The name of the metric family (e.g. 'session_events_total').
+    value : int
+        The current count value.
+    labels : dict[str, str] | None
+        Labels to identify this specific counter (e.g. {"type": "connection"}).
+    unit : str
+        The unit of the metric (e.g. '' for unitless).
+    help : str
+        A description of the metric.
+    """
+
+    family_name: str
+    value: int
+    labels: dict[str, str] | None = None
+    unit: str = ""
+    help: str = ""
+
+    @property
+    def type(self) -> str:
+        return "counter"
+
+    def to_metric_str(self) -> str:
+        if self.labels:
+            labels_str = ",".join(f'{k}="{v}"' for k, v in sorted(self.labels.items()))
+            return f"{self.family_name}{{{labels_str}}} {self.value}"
+        return f"{self.family_name} {self.value}"
+
+    def marshall_metric_proto(self, metric: MetricProto) -> None:
+        """Fill an OpenMetrics `Metric` protobuf object."""
+        if self.labels:
+            for name, value in sorted(self.labels.items()):
+                label = metric.labels.add()
+                label.name = name
+                label.value = value
+
+        metric_point = metric.metric_points.add()
+        metric_point.counter_value.int_value = self.value
+
+
+class GaugeStat(NamedTuple):
+    """A gauge stat.
+
+    Properties
+    ----------
+    family_name : str
+        The name of the metric family (e.g. 'active_sessions').
+    value : int
+        The current gauge value.
+    labels : dict[str, str] | None
+        Optional labels to identify this specific gauge.
+    unit : str
+        The unit of the metric (e.g. '' for unitless).
+    help : str
+        A description of the metric.
+    """
+
+    family_name: str
+    value: int
+    labels: dict[str, str] | None = None
+    unit: str = ""
+    help: str = ""
+
+    @property
+    def type(self) -> str:
+        return "gauge"
+
+    def to_metric_str(self) -> str:
+        if self.labels:
+            labels_str = ",".join(f'{k}="{v}"' for k, v in sorted(self.labels.items()))
+            return f"{self.family_name}{{{labels_str}}} {self.value}"
+        return f"{self.family_name} {self.value}"
+
+    def marshall_metric_proto(self, metric: MetricProto) -> None:
+        """Fill an OpenMetrics `Metric` protobuf object."""
+        if self.labels:
+            for name, value in sorted(self.labels.items()):
+                label = metric.labels.add()
+                label.name = name
+                label.value = value
+
+        metric_point = metric.metric_points.add()
+        metric_point.gauge_value.int_value = self.value
+
+
 def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
     """Convert a metric type string to its corresponding proto enum value."""
     from streamlit.proto.openmetrics_data_model_pb2 import (
@@ -169,48 +266,95 @@ def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
 
 @runtime_checkable
 class StatsProvider(Protocol):
-    def get_stats(self) -> Sequence[Stat]:
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> Mapping[str, Sequence[Stat]]:
+        """Return stats for the specified metric families.
+
+        Parameters
+        ----------
+        family_names : Sequence[str] | None
+            If provided, only stats for these metric families should be computed
+            and returned. If None, stats for all families this provider supports
+            should be returned. Providers should check this parameter and skip
+            computing expensive stats for families that aren't requested.
+
+        Returns
+        -------
+        Mapping[str, Sequence[Stat]]
+            A mapping from metric family names to sequences of Stat objects.
+        """
         raise NotImplementedError
 
 
 class StatsManager:
     def __init__(self) -> None:
-        self._stats_providers: dict[str, list[StatsProvider]] = {}
+        self._providers_by_family: dict[str, list[StatsProvider]] = {}
 
-    def register_provider(self, family_name: str, provider: StatsProvider) -> None:
-        """Register a StatsProvider with the manager for a given metric family.
+    def register_provider(
+        self, provider: StatsProvider, family_names: Sequence[str]
+    ) -> None:
+        """Register a StatsProvider with the manager for specific metric families.
 
-        Multiple providers can be registered for the same family name, and their
-        stats will be combined when get_stats() is called.
-
-        This function is not thread-safe. Call it immediately after
-        creation.
+        This function is not thread-safe. Call it immediately after creation.
 
         Parameters
         ----------
-        family_name : str
-            The name of the metric family that this provider produces stats for.
         provider : StatsProvider
             The stats provider to register.
+        family_names : Sequence[str]
+            The metric family names that this provider supports. The manager
+            will only call this provider when stats for these families are
+            requested.
         """
-        if family_name not in self._stats_providers:
-            self._stats_providers[family_name] = []
-        self._stats_providers[family_name].append(provider)
+        for family in family_names:
+            if family not in self._providers_by_family:
+                self._providers_by_family[family] = []
+            self._providers_by_family[family].append(provider)
 
-    def get_stats(self) -> dict[str, Sequence[Stat]]:
-        """Return all registered stats grouped by metric family name.
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> Mapping[str, Sequence[Stat]]:
+        """Return registered stats grouped by metric family name.
+
+        Parameters
+        ----------
+        family_names : Sequence[str] | None
+            If provided, only stats for these metric families will be returned.
+            If None, stats for all registered families are returned.
 
         Returns
         -------
-        dict[str, Sequence[Stat]]
-            A dictionary mapping metric family names (as registered with
-            register_provider) to sequences of Stat objects from all providers
-            registered under that family name.
+        Mapping[str, Sequence[Stat]]
+            A mapping from metric family names to sequences of Stat objects
+            from all providers.
         """
         result: dict[str, Sequence[Stat]] = {}
-        for family_name, providers in self._stats_providers.items():
-            all_stats: list[Stat] = []
-            for provider in providers:
-                all_stats.extend(provider.get_stats())
-            result[family_name] = all_stats
+
+        families_to_query = (
+            family_names if family_names else list(self._providers_by_family.keys())
+        )
+
+        # Track which providers we've already queried to avoid duplicates.
+        # The same provider may be registered for multiple families, and we call
+        # `provider.get_stats(family_names)` below to fetch all stat families for
+        # a given stats provider at once.
+        queried_providers: set[int] = set()
+
+        for family in families_to_query:
+            for provider in self._providers_by_family.get(family, []):
+                provider_id = id(provider)
+                if provider_id in queried_providers:
+                    continue
+                queried_providers.add(provider_id)
+
+                provider_stats = provider.get_stats(family_names)
+                for fname, stats in provider_stats.items():
+                    if fname not in result:
+                        result[fname] = []
+                    # Use list() to convert Sequence to list for concatenation.
+                    # This is needed for type covariance: providers return
+                    # Mapping[str, Sequence[Stat]] but we build a dict of lists.
+                    result[fname] = list(result[fname]) + list(stats)
+
         return result

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -266,6 +266,15 @@ def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
 
 @runtime_checkable
 class StatsProvider(Protocol):
+    @property
+    def stats_families(self) -> Sequence[str]:
+        """The metric family names that this provider supports.
+
+        The StatsManager uses this property to determine which providers to call
+        when specific metric families are requested.
+        """
+        pass
+
     def get_stats(
         self, family_names: Sequence[str] | None = None
     ) -> Mapping[str, Sequence[Stat]]:
@@ -291,23 +300,18 @@ class StatsManager:
     def __init__(self) -> None:
         self._providers_by_family: dict[str, list[StatsProvider]] = {}
 
-    def register_provider(
-        self, provider: StatsProvider, family_names: Sequence[str]
-    ) -> None:
-        """Register a StatsProvider with the manager for specific metric families.
+    def register_provider(self, provider: StatsProvider) -> None:
+        """Register a StatsProvider with the manager.
 
         This function is not thread-safe. Call it immediately after creation.
 
         Parameters
         ----------
         provider : StatsProvider
-            The stats provider to register.
-        family_names : Sequence[str]
-            The metric family names that this provider supports. The manager
-            will only call this provider when stats for these families are
-            requested.
+            The stats provider to register. The provider's `stats_families`
+            property determines which metric families it will be called for.
         """
-        for family in family_names:
+        for family in provider.stats_families:
             if family not in self._providers_by_family:
                 self._providers_by_family[family] = []
             self._providers_by_family[family].append(provider)

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -60,6 +60,10 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
     to the specific SessionStorage that a WebsocketSessionManager is instantiated with.
     """
 
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return (SESSION_EVENTS_FAMILY, ACTIVE_SESSIONS_FAMILY)
+
     def __init__(
         self,
         session_storage: SessionStorage,

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Final, cast
 
 from streamlit.logger import get_logger
@@ -25,9 +26,17 @@ from streamlit.runtime.session_manager import (
     SessionManager,
     SessionStorage,
 )
+from streamlit.runtime.stats import (
+    ACTIVE_SESSIONS_FAMILY,
+    SESSION_EVENTS_FAMILY,
+    CounterStat,
+    GaugeStat,
+    Stat,
+    StatsProvider,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
 
     from streamlit.runtime.script_data import ScriptData
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
@@ -36,7 +45,12 @@ if TYPE_CHECKING:
 _LOGGER: Final = get_logger(__name__)
 
 
-class WebsocketSessionManager(SessionManager):
+_EVENT_TYPE_CONNECT: Final = "connect"
+_EVENT_TYPE_RECONNECT: Final = "reconnect"
+_EVENT_TYPE_DISCONNECT: Final = "disconnect"
+
+
+class WebsocketSessionManager(SessionManager, StatsProvider):
     """A SessionManager used to manage sessions with lifecycles tied to those of a
     browser tab's websocket connection.
 
@@ -60,6 +74,12 @@ class WebsocketSessionManager(SessionManager):
 
         # Mapping of AppSession.id -> ActiveSessionInfo.
         self._active_session_info_by_id: dict[str, ActiveSessionInfo] = {}
+
+        # Session event counters for metrics
+        self._stats_lock = threading.Lock()
+        self._connect_count: int = 0
+        self._reconnect_count: int = 0
+        self._disconnect_count: int = 0
 
     def connect_session(
         self,
@@ -98,6 +118,8 @@ class WebsocketSessionManager(SessionManager):
             )
             self._session_storage.delete(existing_session.id)
 
+            with self._stats_lock:
+                self._reconnect_count += 1
             return existing_session.id
 
         session = AppSession(
@@ -120,6 +142,8 @@ class WebsocketSessionManager(SessionManager):
             )
 
         self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
+        with self._stats_lock:
+            self._connect_count += 1
         return session.id
 
     def disconnect_session(self, session_id: str) -> None:
@@ -138,6 +162,8 @@ class WebsocketSessionManager(SessionManager):
                 )
             )
             del self._active_session_info_by_id[session_id]
+            with self._stats_lock:
+                self._disconnect_count += 1
 
         if not self._active_session_info_by_id:
             # Avoid stale cached scripts when all file watchers and sessions are disconnected
@@ -157,12 +183,17 @@ class WebsocketSessionManager(SessionManager):
             active_session_info = self._active_session_info_by_id[session_id]
             del self._active_session_info_by_id[session_id]
             active_session_info.session.shutdown()
+            # Count disconnect for active sessions being closed directly
+            with self._stats_lock:
+                self._disconnect_count += 1
 
             if not self._active_session_info_by_id:
                 # Avoid stale cached scripts when all file watchers and sessions are disconnected
                 self._script_cache.clear()
             return
 
+        # For sessions in storage, the disconnect was already counted when
+        # disconnect_session was called earlier.
         session_info = self._session_storage.get(session_id)
         if session_info:
             self._session_storage.delete(session_id)
@@ -179,3 +210,51 @@ class WebsocketSessionManager(SessionManager):
             cast("list[SessionInfo]", self.list_active_sessions())
             + self._session_storage.list()
         )
+
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> Mapping[str, Sequence[Stat]]:
+        """Return session-related metrics.
+
+        Returns session event counters (connections, reconnections, disconnections)
+        and the current count of active sessions.
+        """
+        result: dict[str, list[Stat]] = {}
+
+        if family_names is None or SESSION_EVENTS_FAMILY in family_names:
+            with self._stats_lock:
+                connect_count = self._connect_count
+                reconnect_count = self._reconnect_count
+                disconnect_count = self._disconnect_count
+
+            result[SESSION_EVENTS_FAMILY] = [
+                CounterStat(
+                    family_name=SESSION_EVENTS_FAMILY,
+                    value=connect_count,
+                    labels={"type": _EVENT_TYPE_CONNECT},
+                    help="Total count of session events by type.",
+                ),
+                CounterStat(
+                    family_name=SESSION_EVENTS_FAMILY,
+                    value=reconnect_count,
+                    labels={"type": _EVENT_TYPE_RECONNECT},
+                    help="Total count of session events by type.",
+                ),
+                CounterStat(
+                    family_name=SESSION_EVENTS_FAMILY,
+                    value=disconnect_count,
+                    labels={"type": _EVENT_TYPE_DISCONNECT},
+                    help="Total count of session events by type.",
+                ),
+            ]
+
+        if family_names is None or ACTIVE_SESSIONS_FAMILY in family_names:
+            result[ACTIVE_SESSIONS_FAMILY] = [
+                GaugeStat(
+                    family_name=ACTIVE_SESSIONS_FAMILY,
+                    value=len(self._active_session_info_by_id),
+                    help="Current number of active sessions.",
+                ),
+            ]
+
+        return result

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,7 +34,6 @@ from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
-from streamlit.runtime.stats import CACHE_MEMORY_FAMILY
 from streamlit.web.cache_storage_manager_config import (
     create_default_cache_storage_manager,
 )
@@ -316,9 +315,7 @@ class Server:
             ),
         )
 
-        self._runtime.stats_mgr.register_provider(
-            media_file_storage, [CACHE_MEMORY_FAMILY]
-        )
+        self._runtime.stats_mgr.register_provider(media_file_storage)
 
     @classmethod
     def initialize_mimetypes(cls) -> None:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,6 +34,7 @@ from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY
 from streamlit.web.cache_storage_manager_config import (
     create_default_cache_storage_manager,
 )
@@ -316,7 +317,7 @@ class Server:
         )
 
         self._runtime.stats_mgr.register_provider(
-            "cache_memory_bytes", media_file_storage
+            media_file_storage, [CACHE_MEMORY_FAMILY]
         )
 
     @classmethod

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -23,7 +23,7 @@ from streamlit.web.server import allow_all_cross_origin_requests, is_allowed_ori
 from streamlit.web.server.server_util import emit_endpoint_deprecation_notice
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
     from streamlit.runtime.stats import Stat, StatsManager
@@ -44,15 +44,17 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         self.set_status(204)
         self.finish()
 
-    # TODO(vdonato): Allow a caller to request specific metric families since we
-    # know cache stats are slow to compute so would like to avoid paying the
-    # cost of doing so frequently.
     def get(self) -> None:
         if self.request.uri and "_stcore/" not in self.request.uri:
             emit_endpoint_deprecation_notice(self, new_path="/_stcore/metrics")
 
-        stats = self._manager.get_stats()
-
+        # Allow caller to request specific metric families via query parameter.
+        # If no families are specified, all metrics are returned.
+        # Example: /_stcore/metrics?families=session_events_total&families=active_sessions
+        requested_families = self.get_arguments("families")
+        stats = self._manager.get_stats(
+            family_names=requested_families if requested_families else None
+        )
         # If the request asked for protobuf output, we return a serialized
         # protobuf. Else we return text.
         if "application/x-protobuf" in self.request.headers.get_list("Accept"):
@@ -65,7 +67,7 @@ class StatsRequestHandler(tornado.web.RequestHandler):
             self.set_status(200)
 
     @staticmethod
-    def _stats_to_text(stats_by_family: dict[str, Sequence[Stat]]) -> str:
+    def _stats_to_text(stats_by_family: Mapping[str, Sequence[Stat]]) -> str:
         result: list[str] = []
 
         for stats in stats_by_family.values():
@@ -85,7 +87,9 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         return "\n".join(result)
 
     @staticmethod
-    def _stats_to_proto(stats_by_family: dict[str, Sequence[Stat]]) -> MetricSetProto:
+    def _stats_to_proto(
+        stats_by_family: Mapping[str, Sequence[Stat]],
+    ) -> MetricSetProto:
         # Lazy load the import of this proto message for better performance:
         from streamlit.proto.openmetrics_data_model_pb2 import (
             MetricSet as MetricSetProto,

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -58,7 +58,7 @@ from streamlit.runtime.caching.storage.local_disk_cache_storage import (
     get_cache_folder_path,
 )
 from streamlit.runtime.scriptrunner import add_script_run_ctx
-from streamlit.runtime.stats import CacheStat
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.element_mocks import (
     ELEMENT_PRODUCER,
@@ -573,7 +573,7 @@ class CacheDataStatsProviderTest(unittest.TestCase):
         st.cache_data.clear()
 
     def test_no_stats(self):
-        assert get_data_cache_stats_provider().get_stats() == []
+        assert get_data_cache_stats_provider().get_stats() == {}
 
     def test_multiple_stats(self):
         @st.cache_data
@@ -610,7 +610,9 @@ class CacheDataStatsProviderTest(unittest.TestCase):
 
         # The order of these is non-deterministic, so check Set equality
         # instead of List equality
-        assert set(expected) == set(get_data_cache_stats_provider().get_stats())
+        stats_dict = get_data_cache_stats_provider().get_stats()
+        assert CACHE_MEMORY_FAMILY in stats_dict
+        assert set(expected) == set(stats_dict[CACHE_MEMORY_FAMILY])
 
 
 class CacheDataValidateParamsTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -32,7 +32,7 @@ from streamlit.runtime.caching import (
 )
 from streamlit.runtime.caching.hashing import UserHashError
 from streamlit.runtime.scriptrunner import add_script_run_ctx
-from streamlit.runtime.stats import CacheStat
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
 from streamlit.vendor.pympler.asizeof import asizeof
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.element_mocks import (
@@ -302,7 +302,7 @@ class CacheResourceStatsProviderTest(unittest.TestCase):
         st.cache_resource.clear()
 
     def test_no_stats(self):
-        assert get_resource_cache_stats_provider().get_stats() == []
+        assert get_resource_cache_stats_provider().get_stats() == {}
 
     def test_multiple_stats(self):
         @st.cache_resource(show_spinner=False)
@@ -339,7 +339,9 @@ class CacheResourceStatsProviderTest(unittest.TestCase):
 
         # The order of these is non-deterministic, so check Set equality
         # instead of List equality
-        assert set(expected) == set(get_resource_cache_stats_provider().get_stats())
+        stats_dict = get_resource_cache_stats_provider().get_stats()
+        assert CACHE_MEMORY_FAMILY in stats_dict
+        assert set(expected) == set(stats_dict[CACHE_MEMORY_FAMILY])
 
 
 class CacheResourceMessageReplayTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
@@ -29,6 +29,7 @@ from streamlit.runtime.memory_media_file_storage import (
     MemoryMediaFileStorage,
     get_extension_for_mimetype,
 )
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY
 
 
 class MemoryMediaFileStorageTest(unittest.TestCase):
@@ -179,7 +180,7 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
 
     def test_cache_stats(self):
         """Test our StatsProvider implementation."""
-        assert len(self.storage.get_stats()) == 0
+        assert self.storage.get_stats() == {}
 
         # Add several files to storage. We'll unique-ify them by filename.
         mock_data = b"some random mock binary data"
@@ -192,7 +193,9 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
                 filename=f"{ii}.mp4",
             )
 
-        stats = self.storage.get_stats()
+        stats_dict = self.storage.get_stats()
+        assert CACHE_MEMORY_FAMILY in stats_dict
+        stats = stats_dict[CACHE_MEMORY_FAMILY]
         assert len(stats) == 1
         assert stats[0].category_name == "st_memory_media_file_storage"
         assert len(mock_data) * num_files == sum(stat.byte_length for stat in stats)
@@ -201,7 +204,7 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
         for file_id in list(self.storage._files_by_id.keys()):
             self.storage.delete_file(file_id)
 
-        assert len(self.storage.get_stats()) == 0
+        assert self.storage.get_stats() == {}
 
 
 class MemoryMediaFileStorageUtilTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -46,6 +46,7 @@ from streamlit.runtime.state.session_state import (
     WStates,
     _is_stale_widget,
 )
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 from streamlit.testing.v1.app_test import AppTest
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -1051,7 +1052,7 @@ class SessionStateStatProviderTests(DeltaGeneratorTestCase):
         #  we don't care about actual byte values, but rather that our
         #  SessionState isn't getting unexpectedly massive.
         state = _raw_session_state()
-        stat = state.get_stats()[0]
+        stat = state.get_stats()[CACHE_MEMORY_FAMILY][0]
         assert stat.category_name == "st_session_state"
 
         # The expected size of the session state in bytes.
@@ -1062,21 +1063,21 @@ class SessionStateStatProviderTests(DeltaGeneratorTestCase):
         assert init_size < expected_session_state_size_bytes
 
         state["foo"] = 2
-        new_size = state.get_stats()[0].byte_length
+        new_size = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
         assert new_size > init_size
         assert new_size < expected_session_state_size_bytes
 
         state["foo"] = 1
-        new_size_2 = state.get_stats()[0].byte_length
+        new_size_2 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
         assert new_size_2 == new_size
 
         st.checkbox("checkbox", key="checkbox")
-        new_size_3 = state.get_stats()[0].byte_length
+        new_size_3 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
         assert new_size_3 > new_size_2
         assert new_size_3 - new_size_2 < expected_session_state_size_bytes
 
         state._compact_state()
-        new_size_4 = state.get_stats()[0].byte_length
+        new_size_4 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
         assert new_size_4 <= new_size_3
 
 

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+from typing import TYPE_CHECKING
 
 from parameterized import parameterized
 
@@ -29,65 +30,133 @@ from streamlit.proto.openmetrics_data_model_pb2 import (
     UNKNOWN,
 )
 from streamlit.runtime.stats import (
+    CACHE_MEMORY_FAMILY,
     CacheStat,
+    CounterStat,
+    GaugeStat,
     StatsManager,
     StatsProvider,
     group_cache_stats,
     metric_type_string_to_proto,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 class MockStatsProvider(StatsProvider):
-    def __init__(self) -> None:
-        self.stats: list[CacheStat] = []
+    """A mock provider that can return stats for one or multiple families."""
 
-    def get_stats(self) -> list[CacheStat]:
-        return self.stats
+    def __init__(self, supported_families: list[str]) -> None:
+        self.supported_families = supported_families
+        self.stats_by_family: dict[str, list[CacheStat]] = {}
+
+    def get_stats(
+        self, family_names: Sequence[str] | None = None
+    ) -> dict[str, list[CacheStat]]:
+        result: dict[str, list[CacheStat]] = {}
+        for family in self.supported_families:
+            # Skip if this family isn't requested
+            if family_names is not None and family not in family_names:
+                continue
+            if self.stats_by_family.get(family):
+                result[family] = self.stats_by_family[family]
+        return result
 
 
 class StatsManagerTest(unittest.TestCase):
     def test_get_stats(self) -> None:
         """StatsManager.get_stats should return all providers' stats grouped by family."""
         manager = StatsManager()
-        provider1 = MockStatsProvider()
-        provider2 = MockStatsProvider()
-        manager.register_provider("cache_memory_bytes", provider1)
-        manager.register_provider("cache_memory_bytes", provider2)
+        provider1 = MockStatsProvider([CACHE_MEMORY_FAMILY])
+        provider2 = MockStatsProvider([CACHE_MEMORY_FAMILY])
+        manager.register_provider(provider1, [CACHE_MEMORY_FAMILY])
+        manager.register_provider(provider2, [CACHE_MEMORY_FAMILY])
 
         # No stats
-        assert manager.get_stats() == {"cache_memory_bytes": []}
+        assert manager.get_stats() == {}
 
         # Some stats
-        provider1.stats = [
+        provider1.stats_by_family[CACHE_MEMORY_FAMILY] = [
             CacheStat("provider1", "foo", 1),
             CacheStat("provider1", "bar", 2),
         ]
 
-        provider2.stats = [
+        provider2.stats_by_family[CACHE_MEMORY_FAMILY] = [
             CacheStat("provider2", "baz", 3),
             CacheStat("provider2", "qux", 4),
         ]
 
         result = manager.get_stats()
-        assert "cache_memory_bytes" in result
-        assert provider1.stats + provider2.stats == result["cache_memory_bytes"]
+        assert CACHE_MEMORY_FAMILY in result
+        expected_stats = (
+            provider1.stats_by_family[CACHE_MEMORY_FAMILY]
+            + provider2.stats_by_family[CACHE_MEMORY_FAMILY]
+        )
+        assert expected_stats == result[CACHE_MEMORY_FAMILY]
 
     def test_get_stats_multiple_families(self) -> None:
         """StatsManager should support multiple metric families."""
         manager = StatsManager()
-        provider1 = MockStatsProvider()
-        provider2 = MockStatsProvider()
-        manager.register_provider("family_a", provider1)
-        manager.register_provider("family_b", provider2)
+        provider1 = MockStatsProvider(["family_a"])
+        provider2 = MockStatsProvider(["family_b"])
+        manager.register_provider(provider1, ["family_a"])
+        manager.register_provider(provider2, ["family_b"])
 
-        provider1.stats = [CacheStat("family_a", "cache1", 100)]
-        provider2.stats = [CacheStat("family_b", "cache2", 200)]
+        provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
 
         result = manager.get_stats()
         assert "family_a" in result
         assert "family_b" in result
-        assert result["family_a"] == provider1.stats
-        assert result["family_b"] == provider2.stats
+        assert result["family_a"] == provider1.stats_by_family["family_a"]
+        assert result["family_b"] == provider2.stats_by_family["family_b"]
+
+    def test_only_queries_relevant_providers(self) -> None:
+        """StatsManager should only call providers registered for requested families."""
+        manager = StatsManager()
+        provider_a = MockStatsProvider(["family_a"])
+        provider_b = MockStatsProvider(["family_b"])
+        manager.register_provider(provider_a, ["family_a"])
+        manager.register_provider(provider_b, ["family_b"])
+
+        provider_a.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider_b.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
+
+        # Request only family_a. provider_b should not be called
+        result = manager.get_stats(family_names=["family_a"])
+        assert "family_a" in result
+        assert "family_b" not in result
+
+    def test_provider_registered_for_multiple_families(self) -> None:
+        """A provider can be registered for multiple families."""
+        manager = StatsManager()
+        provider = MockStatsProvider(["family_a", "family_b"])
+        manager.register_provider(provider, ["family_a", "family_b"])
+
+        provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+
+        result = manager.get_stats()
+        assert "family_a" in result
+        assert result["family_a"] == provider.stats_by_family["family_a"]
+
+    def test_filtering_excludes_unrequested_families_from_multi_family_provider(
+        self,
+    ) -> None:
+        """When requesting one family, stats for other families should be excluded."""
+        manager = StatsManager()
+        provider = MockStatsProvider(["family_a", "family_b"])
+        manager.register_provider(provider, ["family_a", "family_b"])
+
+        provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
+
+        result = manager.get_stats(family_names=["family_a"])
+
+        # Should only get family_a stats, not family_b
+        assert "family_a" in result
+        assert "family_b" not in result
+        assert result["family_a"] == provider.stats_by_family["family_a"]
 
     def test_group_cache_stats(self) -> None:
         """Should return stats grouped by category_name and cache_name.
@@ -137,7 +206,7 @@ class CacheStatProtocolTest(unittest.TestCase):
         """CacheStat should have all the properties required by the Stat protocol."""
         stat = CacheStat("test_category", "test_cache", 1024)
 
-        assert stat.family_name == "cache_memory_bytes"
+        assert stat.family_name == CACHE_MEMORY_FAMILY
         assert stat.type == "gauge"
         assert stat.unit == "bytes"
         assert stat.help == "Total memory consumed by a cache."
@@ -146,6 +215,155 @@ class CacheStatProtocolTest(unittest.TestCase):
         """CacheStat.to_metric_str should use family_name."""
         stat = CacheStat("st.cache_data", "my_func", 512)
         expected = 'cache_memory_bytes{cache_type="st.cache_data",cache="my_func"} 512'
+        assert stat.to_metric_str() == expected
+
+
+class StatsManagerFilterTest(unittest.TestCase):
+    def test_get_stats_with_family_filter(self) -> None:
+        """StatsManager.get_stats should filter by family names when provided."""
+        manager = StatsManager()
+        provider1 = MockStatsProvider(["family_a"])
+        provider2 = MockStatsProvider(["family_b"])
+        manager.register_provider(provider1, ["family_a"])
+        manager.register_provider(provider2, ["family_b"])
+
+        provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
+
+        result = manager.get_stats(family_names=["family_a"])
+        assert "family_a" in result
+        assert "family_b" not in result
+        assert result["family_a"] == provider1.stats_by_family["family_a"]
+
+    def test_get_stats_with_multiple_family_filter(self) -> None:
+        """StatsManager.get_stats should support filtering by multiple families."""
+        manager = StatsManager()
+        provider1 = MockStatsProvider(["family_a"])
+        provider2 = MockStatsProvider(["family_b"])
+        provider3 = MockStatsProvider(["family_c"])
+        manager.register_provider(provider1, ["family_a"])
+        manager.register_provider(provider2, ["family_b"])
+        manager.register_provider(provider3, ["family_c"])
+
+        provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
+        provider3.stats_by_family["family_c"] = [CacheStat("family_c", "cache3", 300)]
+
+        result = manager.get_stats(family_names=["family_a", "family_c"])
+        assert "family_a" in result
+        assert "family_b" not in result
+        assert "family_c" in result
+        assert result["family_a"] == provider1.stats_by_family["family_a"]
+        assert result["family_c"] == provider3.stats_by_family["family_c"]
+
+    def test_get_stats_with_unknown_family(self) -> None:
+        """StatsManager.get_stats should return empty result for unknown families."""
+        manager = StatsManager()
+        provider = MockStatsProvider(["family_a"])
+        manager.register_provider(provider, ["family_a"])
+        provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+
+        result = manager.get_stats(family_names=["unknown_family"])
+        assert "unknown_family" not in result
+        assert result == {}
+
+    def test_get_stats_no_filter_returns_all(self) -> None:
+        """StatsManager.get_stats with no filter should return all families."""
+        manager = StatsManager()
+        provider1 = MockStatsProvider(["family_a"])
+        provider2 = MockStatsProvider(["family_b"])
+        manager.register_provider(provider1, ["family_a"])
+        manager.register_provider(provider2, ["family_b"])
+
+        provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
+        provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
+
+        result = manager.get_stats(family_names=None)
+        assert "family_a" in result
+        assert "family_b" in result
+
+
+class CounterStatTest(unittest.TestCase):
+    def test_counter_stat_implements_stat_protocol(self) -> None:
+        """CounterStat should have all the properties required by the Stat protocol."""
+        stat = CounterStat(
+            family_name="test_counter",
+            value=42,
+            labels={"type": "test"},
+            unit="",
+            help="A test counter.",
+        )
+
+        assert stat.family_name == "test_counter"
+        assert stat.type == "counter"
+        assert stat.unit == ""
+        assert stat.help == "A test counter."
+        assert stat.value == 42
+        assert stat.labels == {"type": "test"}
+
+    def test_counter_stat_to_metric_str(self) -> None:
+        """CounterStat.to_metric_str should format correctly."""
+        stat = CounterStat(
+            family_name="session_events_total",
+            value=10,
+            labels={"type": "connection"},
+        )
+        expected = 'session_events_total{type="connection"} 10'
+        assert stat.to_metric_str() == expected
+
+    def test_counter_stat_to_metric_str_multiple_labels(self) -> None:
+        """CounterStat.to_metric_str should handle multiple labels sorted."""
+        stat = CounterStat(
+            family_name="my_counter",
+            value=5,
+            labels={"z_label": "z_val", "a_label": "a_val"},
+        )
+        expected = 'my_counter{a_label="a_val",z_label="z_val"} 5'
+        assert stat.to_metric_str() == expected
+
+    def test_counter_stat_to_metric_str_no_labels(self) -> None:
+        """CounterStat.to_metric_str should format correctly without labels."""
+        stat = CounterStat(
+            family_name="simple_counter",
+            value=7,
+        )
+        expected = "simple_counter 7"
+        assert stat.to_metric_str() == expected
+
+
+class GaugeStatTest(unittest.TestCase):
+    def test_gauge_stat_implements_stat_protocol(self) -> None:
+        """GaugeStat should have all the properties required by the Stat protocol."""
+        stat = GaugeStat(
+            family_name="active_sessions",
+            value=3,
+            unit="",
+            help="Current number of active sessions.",
+        )
+
+        assert stat.family_name == "active_sessions"
+        assert stat.type == "gauge"
+        assert stat.unit == ""
+        assert stat.help == "Current number of active sessions."
+        assert stat.value == 3
+
+    def test_gauge_stat_to_metric_str(self) -> None:
+        """GaugeStat.to_metric_str should format correctly without labels."""
+        stat = GaugeStat(
+            family_name="active_sessions",
+            value=5,
+        )
+        expected = "active_sessions 5"
+        assert stat.to_metric_str() == expected
+
+    def test_gauge_stat_to_metric_str_with_labels(self) -> None:
+        """GaugeStat.to_metric_str should format correctly with labels."""
+        stat = GaugeStat(
+            family_name="active_sessions",
+            value=5,
+            labels={"region": "us-west"},
+        )
+        expected = 'active_sessions{region="us-west"} 5'
         assert stat.to_metric_str() == expected
 
 

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -48,14 +48,18 @@ class MockStatsProvider(StatsProvider):
     """A mock provider that can return stats for one or multiple families."""
 
     def __init__(self, supported_families: list[str]) -> None:
-        self.supported_families = supported_families
+        self._supported_families = supported_families
         self.stats_by_family: dict[str, list[CacheStat]] = {}
+
+    @property
+    def stats_families(self) -> Sequence[str]:
+        return self._supported_families
 
     def get_stats(
         self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
         result: dict[str, list[CacheStat]] = {}
-        for family in self.supported_families:
+        for family in self._supported_families:
             # Skip if this family isn't requested
             if family_names is not None and family not in family_names:
                 continue
@@ -70,8 +74,8 @@ class StatsManagerTest(unittest.TestCase):
         manager = StatsManager()
         provider1 = MockStatsProvider([CACHE_MEMORY_FAMILY])
         provider2 = MockStatsProvider([CACHE_MEMORY_FAMILY])
-        manager.register_provider(provider1, [CACHE_MEMORY_FAMILY])
-        manager.register_provider(provider2, [CACHE_MEMORY_FAMILY])
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
 
         # No stats
         assert manager.get_stats() == {}
@@ -100,8 +104,8 @@ class StatsManagerTest(unittest.TestCase):
         manager = StatsManager()
         provider1 = MockStatsProvider(["family_a"])
         provider2 = MockStatsProvider(["family_b"])
-        manager.register_provider(provider1, ["family_a"])
-        manager.register_provider(provider2, ["family_b"])
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
 
         provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
@@ -117,8 +121,8 @@ class StatsManagerTest(unittest.TestCase):
         manager = StatsManager()
         provider_a = MockStatsProvider(["family_a"])
         provider_b = MockStatsProvider(["family_b"])
-        manager.register_provider(provider_a, ["family_a"])
-        manager.register_provider(provider_b, ["family_b"])
+        manager.register_provider(provider_a)
+        manager.register_provider(provider_b)
 
         provider_a.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider_b.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
@@ -132,7 +136,7 @@ class StatsManagerTest(unittest.TestCase):
         """A provider can be registered for multiple families."""
         manager = StatsManager()
         provider = MockStatsProvider(["family_a", "family_b"])
-        manager.register_provider(provider, ["family_a", "family_b"])
+        manager.register_provider(provider)
 
         provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
 
@@ -146,7 +150,7 @@ class StatsManagerTest(unittest.TestCase):
         """When requesting one family, stats for other families should be excluded."""
         manager = StatsManager()
         provider = MockStatsProvider(["family_a", "family_b"])
-        manager.register_provider(provider, ["family_a", "family_b"])
+        manager.register_provider(provider)
 
         provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
@@ -224,8 +228,8 @@ class StatsManagerFilterTest(unittest.TestCase):
         manager = StatsManager()
         provider1 = MockStatsProvider(["family_a"])
         provider2 = MockStatsProvider(["family_b"])
-        manager.register_provider(provider1, ["family_a"])
-        manager.register_provider(provider2, ["family_b"])
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
 
         provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
@@ -241,9 +245,9 @@ class StatsManagerFilterTest(unittest.TestCase):
         provider1 = MockStatsProvider(["family_a"])
         provider2 = MockStatsProvider(["family_b"])
         provider3 = MockStatsProvider(["family_c"])
-        manager.register_provider(provider1, ["family_a"])
-        manager.register_provider(provider2, ["family_b"])
-        manager.register_provider(provider3, ["family_c"])
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
+        manager.register_provider(provider3)
 
         provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]
@@ -260,7 +264,7 @@ class StatsManagerFilterTest(unittest.TestCase):
         """StatsManager.get_stats should return empty result for unknown families."""
         manager = StatsManager()
         provider = MockStatsProvider(["family_a"])
-        manager.register_provider(provider, ["family_a"])
+        manager.register_provider(provider)
         provider.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
 
         result = manager.get_stats(family_names=["unknown_family"])
@@ -272,8 +276,8 @@ class StatsManagerFilterTest(unittest.TestCase):
         manager = StatsManager()
         provider1 = MockStatsProvider(["family_a"])
         provider2 = MockStatsProvider(["family_b"])
-        manager.register_provider(provider1, ["family_a"])
-        manager.register_provider(provider2, ["family_b"])
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
 
         provider1.stats_by_family["family_a"] = [CacheStat("family_a", "cache1", 100)]
         provider2.stats_by_family["family_b"] = [CacheStat("family_b", "cache2", 200)]

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -93,19 +93,18 @@ class UploadedFileManagerTest(unittest.TestCase):
         """Test StatsProvider implementation."""
 
         # Test empty manager
-        assert self.mgr.get_stats() == []
+        assert self.mgr.get_stats() == {}
 
         # Test manager with files
         self.mgr.add_file("session1", FILE_1)
         self.mgr.add_file("session1", FILE_2)
 
-        expected = [
-            CacheStat(
-                category_name="UploadedFileManager",
-                cache_name="",
-                byte_length=len(FILE_1.data) + len(FILE_2.data),
-            ),
-        ]
+        expected_stat = CacheStat(
+            category_name="UploadedFileManager",
+            cache_name="",
+            byte_length=len(FILE_1.data) + len(FILE_2.data),
+        )
+        expected = {expected_stat.family_name: [expected_stat]}
         assert expected == self.mgr.get_stats()
 
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -21,6 +21,7 @@ import pytest
 
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import SessionStorage
+from streamlit.runtime.stats import CounterStat, GaugeStat, Stat
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 
 
@@ -299,3 +300,188 @@ class WebsocketSessionManagerTests(unittest.TestCase):
         assert {s.session.id for s in self.session_mgr.list_sessions()} == set(
             session_ids
         )
+
+
+@patch(
+    "streamlit.runtime.app_session.asyncio.get_running_loop",
+    new=MagicMock(),
+)
+@patch("streamlit.runtime.app_session.LocalSourcesWatcher", new=MagicMock())
+@patch("streamlit.runtime.app_session.ScriptRunner", new=MagicMock())
+class WebsocketSessionManagerMetricsTests(unittest.TestCase):
+    """Tests for session metrics collection in WebsocketSessionManager."""
+
+    def setUp(self) -> None:
+        self.session_mgr = WebsocketSessionManager(
+            session_storage=MockSessionStorage(),
+            uploaded_file_manager=MagicMock(),
+            script_cache=MagicMock(),
+            message_enqueued_callback=MagicMock(),
+        )
+
+    def connect_session(
+        self,
+        existing_session_id: str | None = None,
+        session_id_override: str | None = None,
+    ) -> str:
+        return self.session_mgr.connect_session(
+            client=MagicMock(),
+            script_data=ScriptData("/fake/script_path.py", is_hello=False),
+            user_info={},
+            existing_session_id=existing_session_id,
+            session_id_override=session_id_override,
+        )
+
+    def _get_stat_value(
+        self,
+        stats_dict: dict[str, list[Stat]],
+        family_name: str,
+        label_type: str | None = None,
+    ) -> int:
+        """Helper to extract a stat value from the stats dict."""
+        if family_name not in stats_dict:
+            raise ValueError(f"Family not found: {family_name}")
+        for stat in stats_dict[family_name]:
+            if label_type is None:
+                # For GaugeStat without labels
+                if isinstance(stat, GaugeStat):
+                    return stat.value
+            # For CounterStat with labels
+            elif (
+                isinstance(stat, CounterStat)
+                and stat.labels
+                and stat.labels.get("type") == label_type
+            ):
+                return stat.value
+        raise ValueError(f"Stat not found: {family_name}, {label_type}")
+
+    def test_initial_stats_are_zero(self) -> None:
+        """Stats should all be zero initially."""
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 0
+        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
+        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "active_sessions") == 0
+
+    def test_new_connection_increments_counter(self) -> None:
+        """Creating a new session should increment connection counter."""
+        self.connect_session()
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
+        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
+        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "active_sessions") == 1
+
+    def test_multiple_connections(self) -> None:
+        """Multiple new sessions should increment connection counter."""
+        self.connect_session()
+        self.connect_session()
+        self.connect_session()
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 3
+        assert self._get_stat_value(stats, "active_sessions") == 3
+
+    @patch(
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.request_script_stop",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.register_file_watchers",
+        new=MagicMock(),
+    )
+    def test_reconnection_increments_counter(self) -> None:
+        """Reconnecting an existing session should increment reconnection counter."""
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+        self.connect_session(existing_session_id=session_id)
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
+        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 1
+        assert self._get_stat_value(stats, "active_sessions") == 1
+
+    def test_disconnect_session_increments_disconnection(self) -> None:
+        """Disconnecting a session should increment disconnection counter."""
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
+        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 1
+        assert self._get_stat_value(stats, "active_sessions") == 0
+
+    def test_disconnect_session_on_invalid_session_does_not_increment(self) -> None:
+        """Disconnecting an invalid session should not increment disconnection counter."""
+        self.session_mgr.disconnect_session("nonexistent_session")
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_active_session_increments_disconnection(self) -> None:
+        """Closing an active session should increment disconnection counter."""
+        session_id = self.connect_session()
+        self.session_mgr.close_session(session_id)
+        stats = self.session_mgr.get_stats()
+
+        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
+        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 1
+        assert self._get_stat_value(stats, "active_sessions") == 0
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_stored_session_does_not_increment_disconnection(self) -> None:
+        """Closing a session from storage should not increment disconnection counter.
+
+        The disconnect was already counted when disconnect_session was called.
+        """
+        session_id = self.connect_session()
+        # Disconnect moves session to storage and increments counter
+        self.session_mgr.disconnect_session(session_id)
+        stats_after_disconnect = self.session_mgr.get_stats()
+        disconnect_count = self._get_stat_value(
+            stats_after_disconnect, "session_events_total", "disconnect"
+        )
+
+        # Close the stored session - should not increment counter again
+        self.session_mgr.close_session(session_id)
+        stats_after_close = self.session_mgr.get_stats()
+
+        assert (
+            self._get_stat_value(
+                stats_after_close, "session_events_total", "disconnect"
+            )
+            == disconnect_count
+        )
+
+    def test_get_stats_returns_correct_format(self) -> None:
+        """get_stats should return stats in the correct format."""
+        self.connect_session()
+        stats_dict = self.session_mgr.get_stats()
+
+        assert len(stats_dict) == 2
+        assert "session_events_total" in stats_dict
+        assert "active_sessions" in stats_dict
+
+        # Check session_events_total counters
+        session_events = stats_dict["session_events_total"]
+        assert len(session_events) == 3
+        for stat in session_events:
+            assert isinstance(stat, CounterStat)
+            assert stat.family_name == "session_events_total"
+            assert stat.type == "counter"
+            assert stat.labels is not None
+            assert "type" in stat.labels
+
+        # Check active_sessions gauge
+        active_sessions = stats_dict["active_sessions"]
+        assert len(active_sessions) == 1
+        assert isinstance(active_sessions[0], GaugeStat)
+        assert active_sessions[0].family_name == "active_sessions"
+        assert active_sessions[0].type == "gauge"

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -22,7 +22,7 @@ from google.protobuf.json_format import MessageToDict
 from tornado.httputil import HTTPHeaders
 
 from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
-from streamlit.runtime.stats import CacheStat
+from streamlit.runtime.stats import CacheStat, CounterStat, GaugeStat
 from streamlit.web.server.server import METRIC_ENDPOINT
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
 
@@ -31,7 +31,9 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):
         self.mock_stats: dict[str, list[CacheStat]] = {"cache_memory_bytes": []}
         mock_stats_manager = MagicMock()
-        mock_stats_manager.get_stats = MagicMock(side_effect=lambda: self.mock_stats)
+        mock_stats_manager.get_stats = MagicMock(
+            side_effect=lambda family_names=None: self.mock_stats
+        )
         return tornado.web.Application(
             [
                 (
@@ -158,3 +160,101 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         }
 
         assert expected == MessageToDict(metric_set)
+
+
+class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests for filtering metrics by family name."""
+
+    def get_app(self):
+        self.mock_stats: dict[str, list] = {
+            "cache_memory_bytes": [
+                CacheStat(
+                    category_name="st.memo",
+                    cache_name="foo",
+                    byte_length=128,
+                )
+            ],
+            "session_events_total": [
+                CounterStat(
+                    family_name="session_events_total",
+                    value=5,
+                    labels={"type": "connect"},
+                    help="Total count of session events by type.",
+                ),
+            ],
+            "active_sessions": [
+                GaugeStat(
+                    family_name="active_sessions",
+                    value=3,
+                    help="Current number of active sessions.",
+                ),
+            ],
+        }
+
+        def get_stats_side_effect(family_names=None):
+            if family_names is None:
+                return self.mock_stats
+            return {k: self.mock_stats.get(k, []) for k in family_names}
+
+        mock_stats_manager = MagicMock()
+        mock_stats_manager.get_stats = MagicMock(side_effect=get_stats_side_effect)
+        return tornado.web.Application(
+            [
+                (
+                    rf"/{METRIC_ENDPOINT}",
+                    StatsRequestHandler,
+                    dict(stats_manager=mock_stats_manager),
+                )
+            ]
+        )
+
+    def test_no_filter_returns_all(self):
+        """Without filter, all metric families should be returned."""
+        response = self.fetch("/_stcore/metrics")
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "cache_memory_bytes" in body
+        assert "session_events_total" in body
+        assert "active_sessions" in body
+
+    def test_filter_single_family(self):
+        """Filter should return only the requested family."""
+        response = self.fetch("/_stcore/metrics?families=session_events_total")
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "session_events_total" in body
+        assert "cache_memory_bytes" not in body
+        # Use TYPE declaration to avoid false matches in help text
+        assert "# TYPE active_sessions" not in body
+
+    def test_filter_multiple_families(self):
+        """Filter should support multiple family names."""
+        response = self.fetch(
+            "/_stcore/metrics?families=session_events_total&families=active_sessions"
+        )
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "session_events_total" in body
+        assert "active_sessions" in body
+        assert "cache_memory_bytes" not in body
+
+    def test_counter_stat_format(self):
+        """CounterStat should be formatted correctly in text output."""
+        response = self.fetch("/_stcore/metrics?families=session_events_total")
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "# TYPE session_events_total counter" in body
+        assert 'session_events_total{type="connect"} 5' in body
+
+    def test_gauge_stat_format(self):
+        """GaugeStat without labels should be formatted correctly."""
+        response = self.fetch("/_stcore/metrics?families=active_sessions")
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "# TYPE active_sessions gauge" in body
+        assert "active_sessions 3" in body


### PR DESCRIPTION
## Describe your changes

In #13265, we began the process of extending our metrics collection to be more general than
just being able to collect cache stats.

In this PR, we do a few things to continue the work done in the previous PR:
* continue to iterate on the interface to support requesting only specific metrics families.
   We need to do this because cache stats are naturally slow to compute (we should try to optimize
   this, but naturally it'll take time to serialize an object to compute its size), and some of the new
   metrics we'll be adding will be polled for frequently
* Add new metrics to track websocket connects, disconnects, reconnects, and the number
   of active user sessions.
* Make some changes to the metrics endpoint itself to allow the caller to request specific
   metrics families.

## Testing Plan

- Unit Tests (JS and/or Python)
   Python unit tests added
- Any manual testing needed?
   Validated the new endpoint on a local dev environment via curl
