### PR TITLE
Fix failing auth test

### DIFF
--- a/lib/streamlit/web/server/oidc_mixin.py
+++ b/lib/streamlit/web/server/oidc_mixin.py
@@ -83,7 +83,9 @@ class TornadoOAuth2App(OAuth2Mixin, OpenIDMixin, BaseApp):
             "state": request_handler.get_argument("state"),
         }
 
-        session = None
+        # Authlib 1.6.6+ requires session to be a dict, even when using cache.
+        # We provide an empty dict since we rely on cache for persistence.
+        session = {}
 
         claims_options = kwargs.pop("claims_options", None)
         state_data = self.framework.get_state_data(session, params.get("state"))
@@ -104,7 +106,9 @@ class TornadoOAuth2App(OAuth2Mixin, OpenIDMixin, BaseApp):
         """
         state = kwargs.pop("state", None)
         if state:
-            session = None
+            # Authlib 1.6.6+ requires session to be a dict, even when using cache.
+            # We provide an empty dict since we rely on cache for persistence.
+            session = {}
             self.framework.set_state_data(session, state, kwargs)
         else:
             raise RuntimeError("Missing state value")

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -67,16 +67,23 @@ class LoginHandlerTest(tornado.testing.AsyncHTTPTestCase):
             ]
         )
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.old_value = oauth_authlib_routes.auth_cache
+        oauth_authlib_routes.auth_cache = AuthCache()
+
+    def tearDown(self) -> None:
+        oauth_authlib_routes.auth_cache = self.old_value
+
     @patch(
-        "streamlit.web.server.oidc_mixin.TornadoOAuth2App.client_cls.request",
+        "streamlit.web.server.oidc_mixin.OAuth2Mixin.load_server_metadata",
         MagicMock(
-            return_value=MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-                    }
-                )
-            )
+            return_value={
+                # Minimal OIDC discovery metadata required by authlib
+                "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+                "token_endpoint": "https://oauth2.googleapis.com/token",
+                "issuer": "https://accounts.google.com",
+            }
         ),
     )
     def test_login_handler_success(self):
@@ -101,15 +108,11 @@ class LoginHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
 
     @patch(
-        "streamlit.web.server.oidc_mixin.TornadoOAuth2App.client_cls.request",
+        "streamlit.web.server.oidc_mixin.OAuth2Mixin.load_server_metadata",
         MagicMock(
-            return_value=MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "invalid": "payload",
-                    }
-                )
-            )
+            return_value={
+                "invalid": "payload",
+            }
         ),
     )
     def test_login_handler_fail_on_malformed_wellknown(self):
@@ -123,12 +126,8 @@ class LoginHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert "Location" not in response.headers
 
     @patch(
-        "streamlit.web.server.oidc_mixin.TornadoOAuth2App.client_cls.request",
-        MagicMock(
-            return_value=MagicMock(
-                raise_for_status=MagicMock(side_effect=Exception("Bad status")),
-            )
-        ),
+        "streamlit.web.server.oidc_mixin.OAuth2Mixin.load_server_metadata",
+        MagicMock(side_effect=Exception("Bad status")),
     )
     def test_login_handler_fail_on_bad_status(self):
         """Test login handler fail, when .well-known request fails."""

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -117,7 +117,9 @@ class LoginHandlerTest(tornado.testing.AsyncHTTPTestCase):
         token = encode_provider_token("google")
         response = self.fetch(f"/auth/login?provider={token}", follow_redirects=False)
         assert response.code == 400
-        assert b'400: Missing "authorize_url" value' in response.body
+        assert b"400: Missing" in response.body
+        assert b"authorize_url" in response.body
+        assert b"value" in response.body
         assert "Location" not in response.headers
 
     @patch(


### PR DESCRIPTION
## Describe your changes
Fix failing `LoginHandlerTest` tests
- Likely due to a tornado version update that more strictly HTML-encodes special characters like quotes in error messages is causing the failure.
- Also due to newer versions of authlib changed how it processes OAuth metadata internally, requiring mocks to be placed at a higher abstraction level