### PR TITLE
Support passing list of pydantic objects as dataframe-like structure

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -41,7 +41,7 @@ from typing import (
 from streamlit import config, errors, logger, string_util
 from streamlit.type_util import (
     CustomDict,
-    dump_pydantic_model,
+    dump_pydantic_sequence,
     has_callable_attr,
     is_custom_dict,
     is_dataclass_instance,
@@ -709,7 +709,7 @@ def convert_anything_to_pandas_df(
         # Try to convert pydantic models to DataFrame. If some elements are not
         # pydantic models (mixed sequence), fall through to pandas' native handling.
         try:
-            return pd.DataFrame(dump_pydantic_model(data))
+            return pd.DataFrame(dump_pydantic_sequence(data))
         except AttributeError:
             pass
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -710,7 +710,8 @@ def convert_anything_to_pandas_df(
         try:
             first_element = next(iter(data))
             if has_callable_attr(first_element, "model_dump"):
-                return pd.DataFrame([item.model_dump() for item in data])
+                # Use mode="json" to ensure proper serialization of types like Decimal
+                return pd.DataFrame([item.model_dump(mode="json") for item in data])
             return pd.DataFrame([item.dict() for item in data])
         except AttributeError:
             pass

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -47,6 +47,7 @@ from streamlit.type_util import (
     is_list_like,
     is_namedtuple,
     is_pydantic_model,
+    is_sequence_of_pydantic_models,
     is_type,
     is_version_less_than,
 )
@@ -369,14 +370,6 @@ def is_snowpark_row_list(obj: object) -> bool:
         and is_type(obj[0], _SNOWPARK_DF_ROW_TYPE_STR)
         and has_callable_attr(obj[0], "as_dict")
     )
-
-
-def _is_sequence_of_pydantic_models(obj: object) -> bool:
-    """True if obj is a non-empty list/tuple/set/frozenset of Pydantic model instances."""
-    if not isinstance(obj, (list, tuple, set, frozenset)) or len(obj) == 0:
-        return False
-    first_element = next(iter(obj))
-    return is_pydantic_model(first_element)
 
 
 def is_pyspark_data_object(obj: object) -> bool:
@@ -711,7 +704,7 @@ def convert_anything_to_pandas_df(
     if is_snowpark_row_list(data):
         return pd.DataFrame([row.as_dict() for row in data])
 
-    if _is_sequence_of_pydantic_models(data):
+    if is_sequence_of_pydantic_models(data):
         # Try to convert pydantic models to DataFrame. If some elements are not
         # pydantic models (mixed sequence), fall through to pandas' native handling.
         try:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -371,6 +371,11 @@ def is_snowpark_row_list(obj: object) -> bool:
     )
 
 
+def _is_list_of_pydantic_models(obj: object) -> bool:
+    """True if obj is a non-empty list of Pydantic model instances."""
+    return isinstance(obj, list) and len(obj) > 0 and is_pydantic_model(obj[0])
+
+
 def is_pyspark_data_object(obj: object) -> bool:
     """True if obj is a PySpark or PySpark Connect dataframe."""
     return (
@@ -702,6 +707,11 @@ def convert_anything_to_pandas_df(
 
     if is_snowpark_row_list(data):
         return pd.DataFrame([row.as_dict() for row in data])
+
+    if _is_list_of_pydantic_models(data):
+        if has_callable_attr(data[0], "model_dump"):
+            return pd.DataFrame([item.model_dump() for item in data])
+        return pd.DataFrame([item.dict() for item in data])
 
     if has_callable_attr(data, "to_pandas"):
         return pd.DataFrame(data.to_pandas())
@@ -1242,7 +1252,7 @@ def determine_data_format(input_data: Any) -> DataFormat:
         # This should always contain at least one element,
         # otherwise the values type from infer_dtype would have been empty
         first_element = next(iter(input_data))
-        if isinstance(first_element, dict):
+        if isinstance(first_element, dict) or is_pydantic_model(first_element):
             return DataFormat.LIST_OF_RECORDS
         if isinstance(first_element, (list, tuple, set, frozenset)):
             return DataFormat.LIST_OF_ROWS

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -41,6 +41,7 @@ from typing import (
 from streamlit import config, errors, logger, string_util
 from streamlit.type_util import (
     CustomDict,
+    dump_pydantic_model,
     has_callable_attr,
     is_custom_dict,
     is_dataclass_instance,
@@ -708,11 +709,7 @@ def convert_anything_to_pandas_df(
         # Try to convert pydantic models to DataFrame. If some elements are not
         # pydantic models (mixed sequence), fall through to pandas' native handling.
         try:
-            first_element = next(iter(data))
-            if has_callable_attr(first_element, "model_dump"):
-                # Use mode="json" to ensure proper serialization of types like Decimal
-                return pd.DataFrame([item.model_dump(mode="json") for item in data])
-            return pd.DataFrame([item.dict() for item in data])
+            return pd.DataFrame(dump_pydantic_model(data))
         except AttributeError:
             pass
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -371,9 +371,12 @@ def is_snowpark_row_list(obj: object) -> bool:
     )
 
 
-def _is_list_of_pydantic_models(obj: object) -> bool:
-    """True if obj is a non-empty list of Pydantic model instances."""
-    return isinstance(obj, list) and len(obj) > 0 and is_pydantic_model(obj[0])
+def _is_sequence_of_pydantic_models(obj: object) -> bool:
+    """True if obj is a non-empty list/tuple/set/frozenset of Pydantic model instances."""
+    if not isinstance(obj, (list, tuple, set, frozenset)) or len(obj) == 0:
+        return False
+    first_element = next(iter(obj))
+    return is_pydantic_model(first_element)
 
 
 def is_pyspark_data_object(obj: object) -> bool:
@@ -708,10 +711,16 @@ def convert_anything_to_pandas_df(
     if is_snowpark_row_list(data):
         return pd.DataFrame([row.as_dict() for row in data])
 
-    if _is_list_of_pydantic_models(data):
-        if has_callable_attr(data[0], "model_dump"):
-            return pd.DataFrame([item.model_dump() for item in data])
-        return pd.DataFrame([item.dict() for item in data])
+    if _is_sequence_of_pydantic_models(data):
+        # Try to convert pydantic models to DataFrame. If some elements are not
+        # pydantic models (mixed sequence), fall through to pandas' native handling.
+        try:
+            first_element = next(iter(data))
+            if has_callable_attr(first_element, "model_dump"):
+                return pd.DataFrame([item.model_dump() for item in data])
+            return pd.DataFrame([item.dict() for item in data])
+        except AttributeError:
+            pass
 
     if has_callable_attr(data, "to_pandas"):
         return pd.DataFrame(data.to_pandas())

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -27,7 +27,7 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.type_util import (
-    dump_pydantic_model,
+    dump_pydantic_sequence,
     is_custom_dict,
     is_list_like,
     is_namedtuple,
@@ -123,7 +123,7 @@ class JsonMixin:
 
         if is_list_like(body):
             if is_sequence_of_pydantic_models(body):
-                body = dump_pydantic_model(body)
+                body = dump_pydantic_sequence(body)
             else:
                 body = list(body)  # ty: ignore[invalid-argument-type]
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -123,7 +123,11 @@ class JsonMixin:
 
         if is_list_like(body):
             if is_sequence_of_pydantic_models(body):
-                body = dump_pydantic_sequence(body)
+                try:
+                    body = dump_pydantic_sequence(body)
+                except AttributeError:
+                    # Fallback to list(body) if it contains non-Pydantic models:
+                    body = list(body)  # ty: ignore[invalid-argument-type]
             else:
                 body = list(body)  # ty: ignore[invalid-argument-type]
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -122,12 +122,12 @@ class JsonMixin:
 
         if is_list_like(body):
             if is_sequence_of_pydantic_models(body):
-                first_item = next(iter(body))
+                first_item = next(iter(body))  # ty: ignore[no-matching-overload]
                 # Pydantic v2 uses model_dump(), v1 uses dict()
                 if hasattr(first_item, "model_dump"):
-                    body = [item.model_dump() for item in body]
+                    body = [item.model_dump() for item in body]  # ty: ignore[not-iterable]
                 else:
-                    body = [item.dict() for item in body]
+                    body = [item.dict() for item in body]  # ty: ignore[not-iterable]
             else:
                 body = list(body)  # ty: ignore[invalid-argument-type]
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -31,6 +31,7 @@ from streamlit.type_util import (
     is_list_like,
     is_namedtuple,
     is_pydantic_model,
+    is_sequence_of_pydantic_models,
 )
 
 if TYPE_CHECKING:
@@ -120,7 +121,15 @@ class JsonMixin:
             body = dict(body)  # type: ignore
 
         if is_list_like(body):
-            body = list(body)  # ty: ignore[invalid-argument-type]
+            if is_sequence_of_pydantic_models(body):
+                first_item = next(iter(body))
+                # Pydantic v2 uses model_dump(), v1 uses dict()
+                if hasattr(first_item, "model_dump"):
+                    body = [item.model_dump() for item in body]
+                else:
+                    body = [item.dict() for item in body]
+            else:
+                body = list(body)  # ty: ignore[invalid-argument-type]
 
         if not isinstance(body, str):
             try:

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -27,6 +27,7 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.type_util import (
+    dump_pydantic_model,
     is_custom_dict,
     is_list_like,
     is_namedtuple,
@@ -122,12 +123,7 @@ class JsonMixin:
 
         if is_list_like(body):
             if is_sequence_of_pydantic_models(body):
-                first_item = next(iter(body))  # ty: ignore[no-matching-overload]
-                # Pydantic v2 uses model_dump(), v1 uses dict()
-                if hasattr(first_item, "model_dump"):
-                    body = [item.model_dump() for item in body]  # ty: ignore[not-iterable]
-                else:
-                    body = [item.dict() for item in body]  # ty: ignore[not-iterable]
+                body = dump_pydantic_model(body)
             else:
                 body = list(body)  # ty: ignore[invalid-argument-type]
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -339,7 +339,7 @@ def is_sequence_of_pydantic_models(obj: object) -> TypeGuard[Sequence[Any]]:
     return is_pydantic_model(first_element)
 
 
-def dump_pydantic_sequence(obj: Sequence[Any]) -> list[dict[str, Any]]:
+def dump_pydantic_sequence(obj: Sequence[object]) -> list[dict[str, Any]]:
     """Dump a sequence of Pydantic models to a list of dictionaries."""
     first_element = next(iter(obj))
     # Pydantic v2 uses model_dump(), v1 uses dict()

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -331,7 +331,7 @@ def is_pydantic_model(obj: object) -> bool:
     return _is_type_instance(obj, "pydantic.main.BaseModel")
 
 
-def is_sequence_of_pydantic_models(obj: object) -> bool:
+def is_sequence_of_pydantic_models(obj: object) -> TypeGuard[Sequence[Any]]:
     """True if obj is a non-empty list/tuple/set/frozenset of Pydantic model instances."""
     if not isinstance(obj, (list, tuple, set, frozenset)) or len(obj) == 0:
         return False

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -345,8 +345,8 @@ def dump_pydantic_sequence(obj: Sequence[object]) -> list[dict[str, Any]]:
     # Pydantic v2 uses model_dump(), v1 uses dict()
     if has_callable_attr(first_element, "model_dump"):
         # Use mode="json" to ensure proper serialization of types like Decimal
-        return [item.model_dump(mode="json") for item in obj]
-    return [item.dict() for item in obj]
+        return [item.model_dump(mode="json") for item in obj]  # type: ignore
+    return [item.dict() for item in obj]  # type: ignore
 
 
 def _is_from_streamlit(obj: object) -> bool:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -339,6 +339,16 @@ def is_sequence_of_pydantic_models(obj: object) -> TypeGuard[Sequence[Any]]:
     return is_pydantic_model(first_element)
 
 
+def dump_pydantic_model(obj: Sequence[Any]) -> list[dict[str, Any]]:
+    """Dump a Pydantic model to a dictionary."""
+    first_element = next(iter(obj))
+    # Pydantic v2 uses model_dump(), v1 uses dict()
+    if has_callable_attr(first_element, "model_dump"):
+        # Use mode="json" to ensure proper serialization of types like Decimal
+        return [item.model_dump(mode="json") for item in obj]
+    return [item.dict() for item in obj]
+
+
 def _is_from_streamlit(obj: object) -> bool:
     """True if the object is from the streamlit package."""
     return obj.__class__.__module__.startswith("streamlit")

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -331,6 +331,14 @@ def is_pydantic_model(obj: object) -> bool:
     return _is_type_instance(obj, "pydantic.main.BaseModel")
 
 
+def is_sequence_of_pydantic_models(obj: object) -> bool:
+    """True if obj is a non-empty list/tuple/set/frozenset of Pydantic model instances."""
+    if not isinstance(obj, (list, tuple, set, frozenset)) or len(obj) == 0:
+        return False
+    first_element = next(iter(obj))
+    return is_pydantic_model(first_element)
+
+
 def _is_from_streamlit(obj: object) -> bool:
     """True if the object is from the streamlit package."""
     return obj.__class__.__module__.startswith("streamlit")

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -339,8 +339,8 @@ def is_sequence_of_pydantic_models(obj: object) -> TypeGuard[Sequence[Any]]:
     return is_pydantic_model(first_element)
 
 
-def dump_pydantic_model(obj: Sequence[Any]) -> list[dict[str, Any]]:
-    """Dump a Pydantic model to a dictionary."""
+def dump_pydantic_sequence(obj: Sequence[Any]) -> list[dict[str, Any]]:
+    """Dump a sequence of Pydantic models to a list of dictionaries."""
     first_element = next(iter(obj))
     # Pydantic v2 uses model_dump(), v1 uses dict()
     if has_callable_attr(first_element, "model_dump"):

--- a/lib/tests/streamlit/data_test_cases.py
+++ b/lib/tests/streamlit/data_test_cases.py
@@ -1250,6 +1250,33 @@ try:
                     dict,
                 ),
             ),
+            (
+                "List of Pydantic Models",
+                [
+                    ElementPydanticModel(
+                        name="st.number_input", is_widget=True, usage=0.32
+                    ),
+                    ElementPydanticModel(
+                        name="st.text_input", is_widget=True, usage=0.45
+                    ),
+                ],
+                CaseMetadata(
+                    2,
+                    3,
+                    DataFormat.LIST_OF_RECORDS,
+                    [
+                        ElementPydanticModel(
+                            name="st.number_input", is_widget=True, usage=0.32
+                        ),
+                        ElementPydanticModel(
+                            name="st.text_input", is_widget=True, usage=0.45
+                        ),
+                    ],
+                    "json",
+                    False,
+                    list,
+                ),
+            ),
         ]
     )
 except ModuleNotFoundError:

--- a/lib/tests/streamlit/data_test_cases.py
+++ b/lib/tests/streamlit/data_test_cases.py
@@ -1277,6 +1277,34 @@ try:
                     list,
                 ),
             ),
+            (
+                "Tuple of Pydantic Models",
+                (
+                    ElementPydanticModel(
+                        name="st.number_input", is_widget=True, usage=0.32
+                    ),
+                    ElementPydanticModel(
+                        name="st.text_input", is_widget=True, usage=0.45
+                    ),
+                ),
+                CaseMetadata(
+                    2,
+                    3,
+                    DataFormat.LIST_OF_RECORDS,
+                    [
+                        ElementPydanticModel(
+                            name="st.number_input", is_widget=True, usage=0.32
+                        ),
+                        ElementPydanticModel(
+                            name="st.text_input", is_widget=True, usage=0.45
+                        ),
+                    ],
+                    "json",
+                    False,
+                    # LIST_OF_RECORDS always converts back to list, not tuple
+                    list,
+                ),
+            ),
         ]
     )
 except ModuleNotFoundError:


### PR DESCRIPTION
## Describe your changes

Add support for passing a list of pydantic objects to `st.dataframe`, `st.data_editor`, charts, options widgets, and wherever else we support dataframe-like structures. 32% of Streamlit apps have pydantic as part of their dependencies and we already support single pydantic objects. 

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/13344

## Testing Plan

- Added unit tests (integration).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
