### PR TITLE
Use the correct snowflake.com domains

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -186,7 +186,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     If you don't have a ``[connections.snowflake]`` dictionary in your
     ``secrets.toml`` file and use ``st.connection("snowflake")``, Streamlit
     will use the default connection for the `Snowflake Python Connector
-    <https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection>`_.
+    <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection>`_.
 
     If you have a Snowflake configuration file with a connection named
     ``my_connection`` as in Example 3, you can set an environment variable to
@@ -260,11 +260,11 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
                 conn_kwargs = {**st_secrets, **kwargs}
                 return snowflake.connector.connect(**conn_kwargs)
 
-            # Use the default configuration as defined in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
+            # Use the default configuration as defined in https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
             if self._connection_name == "snowflake":
                 _LOGGER.info(
                     "Connect to Snowflake using the default configuration as defined "
-                    "in https://docs.snowflake.cn/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection"
+                    "in https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection"
                 )
                 return snowflake.connector.connect()
 


### PR DESCRIPTION
## Describe your changes

Use snowflake.com instead of snowflake.cn domains when linking to the snowflake documentation.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/13361

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
