### PR TITLE
[chore] fix PR body extraction in pr-create command

### DIFF
--- a/.cursor/commands/pr-create.md
+++ b/.cursor/commands/pr-create.md
@@ -119,10 +119,10 @@ Guide user through each command with prompts, letting them execute manually.
    ```bash
    # Parse frontmatter from the reviewed file
    title=$(grep '^title:' work-tmp/pr_description.md | sed 's/^title: //')
-   labels=$(grep '^labels:' work-tmp/pr_description.md | sed 's/^labels: //')
+   labels=$(grep '^labels:' work-tmp/pr_description.md | sed 's/^labels: //' | sed 's/, /,/g')
 
    # Extract body (everything after the closing --- of frontmatter)
-   sed '1,/^---$/d; /^---$/,$!d; /^---$/d' work-tmp/pr_description.md > work-tmp/pr_body.md
+   awk '/^---$/{if(++count==2) flag=1; next} flag' work-tmp/pr_description.md > work-tmp/pr_body.md
 
    # Create PR using parsed values
    gh pr create \


### PR DESCRIPTION

## Describe your changes

Fixes two issues in the `pr-create.md` Cursor command that caused PR bodies to be missing or labels to be rejected:

1. **Body extraction**: Broken `sed` command only extracted text after the second `---` delimiter (the CLA), not the PR description. Replaced with `awk` that correctly extracts everything after frontmatter.

2. **Label formatting**: Added removal of spaces after commas so `impact:users, change:bugfix` becomes `impact:users,change:bugfix` (required by GitHub).

## GitHub Issue Link (if applicable)

N/A - Internal tooling fix

## Testing Plan

- [x] Explanation of why no additional tests are needed

**Manual testing:**
Verified the extraction commands work correctly with test markdown file containing frontmatter, PR description, and CLA.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
