### PR TITLE
[chore] strip quotes from PR title in pr-create command
[fix] tooltip text leaking

### DIFF
--- a/.cursor/commands/pr-create.md
+++ b/.cursor/commands/pr-create.md
@@ -118,7 +118,7 @@ Guide user through each command with prompts, letting them execute manually.
 
    ```bash
    # Parse frontmatter from the reviewed file
-   title=$(grep '^title:' work-tmp/pr_description.md | sed 's/^title: //')
+   title=$(grep '^title:' work-tmp/pr_description.md | sed 's/^title: //' | sed 's/^"\(.*\)"$/\1/')
    labels=$(grep '^labels:' work-tmp/pr_description.md | sed 's/^labels: //')
 
    # Extract body (everything after the closing --- of frontmatter)


### PR DESCRIPTION

## Describe your changes

Fixes PR titles being created with extra quotes (e.g., `"[fix] something"` instead of `[fix] something`).

YAML frontmatter requires quotes around values containing square brackets, but GitHub CLI expects unquoted titles. Added `sed` command to strip surrounding quotes during title extraction.

**Example:**

```yaml
# In pr_description.md
title: "[fix] tooltip text leaking"
# Previously extracted as: "[fix] tooltip text leaking"
# Now correctly extracted as: [fix] tooltip text leaking
```

## GitHub Issue Link (if applicable)

N/A - Internal tooling fix

## Testing Plan

- [x] Explanation of why no additional tests are needed

**Manual testing:**
Verified title extraction strips quotes correctly with test YAML file.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
