### PR TITLE
[fix] Apply apt mirror fix to all CI workflows that require it

### DIFF
--- a/.github/actions/apt_mirror_fix/action.yml
+++ b/.github/actions/apt_mirror_fix/action.yml
@@ -1,0 +1,12 @@
+name: Fix Ubuntu apt mirrors (avoid slow Azure mirror)
+description: Adjust Ubuntu apt mirror priorities to avoid slow azure.archive.ubuntu.com
+
+runs:
+  using: composite
+  steps:
+    - name: Adjust apt mirror priorities (Linux only)
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        set -e
+        "${GITHUB_ACTION_PATH}/apt_mirror_fix.sh"

--- a/.github/actions/apt_mirror_fix/apt_mirror_fix.sh
+++ b/.github/actions/apt_mirror_fix/apt_mirror_fix.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+MIRRORS_FILE="/etc/apt/apt-mirrors.txt"
+
+echo "apt_mirror_fix: begin"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "apt_mirror_fix: non-Linux runner, skipping"
+  exit 0
+fi
+
+if [[ ! -f "${MIRRORS_FILE}" ]]; then
+  echo "apt_mirror_fix: ${MIRRORS_FILE} not found, skipping"
+  exit 0
+fi
+
+# Adjust apt mirror priorities to avoid slow Azure mirror (see
+# https://github.com/actions/runner-images/issues/7048). Inspired by
+# https://github.com/CrowdStrike/glide-core/pull/1113 and
+# https://github.com/servo/servo/pull/39190.
+sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' "${MIRRORS_FILE}"
+sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' "${MIRRORS_FILE}"
+sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' "${MIRRORS_FILE}"
+
+echo "apt_mirror_fix: updated ${MIRRORS_FILE}:"
+sudo cat "${MIRRORS_FILE}"
+
+echo "apt_mirror_fix: done"

--- a/.github/actions/playwright_install/action.yml
+++ b/.github/actions/playwright_install/action.yml
@@ -73,6 +73,17 @@ runs:
           sudo apt-get -y autoremove || true
         fi
 
+    - name: Fix apt mirrors
+      if: ${{ inputs.with-deps == 'true' && runner.os == 'Linux' }}
+      uses: ./.github/actions/apt_mirror_fix
+
+    - name: apt-get update
+      if: ${{ inputs.with-deps == 'true' && runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        set -e
+        sudo apt-get update
+
     # Install the Playwright browsers. On cache hits, this is mostly a quick
     # validation and no-op. When inputs.with-deps is true, Playwright installs
     # required system packages using apt; we set DEBIAN_FRONTEND=noninteractive
@@ -85,17 +96,6 @@ runs:
         #   - Then run this action to install browsers
         # This ensures a single source of truth and proper caching.
         if [[ "${{ inputs.with-deps }}" == "true" ]]; then
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            # Adjust apt mirror priorities to avoid slow Azure mirror (see
-            # https://github.com/actions/runner-images/issues/7048). Inspired by
-            # https://github.com/CrowdStrike/glide-core/pull/1113 and
-            # https://github.com/servo/servo/pull/39190 and
-            sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
-            sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
-            sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
-            sudo cat /etc/apt/apt-mirrors.txt
-            sudo apt-get update
-          fi
           DEBIAN_FRONTEND=noninteractive python -m playwright install --with-deps
         else
           python -m playwright install

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -35,6 +35,9 @@ jobs:
           python-version: "${{ env.PYTHON_MAX_VERSION }}"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
+      - name: Fix apt mirrors
+        if: ${{ runner.os == 'Linux' }}
+        uses: ./.github/actions/apt_mirror_fix
       - name: Build Package - Fast
         timeout-minutes: 120
         run: |

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -47,6 +47,9 @@ jobs:
           curl -sO "https://repo.anaconda.com/miniconda/${MINICONDA_RELEASE}.sh"
           bash "${MINICONDA_RELEASE}.sh" -b
           conda install conda-build
+      - name: Fix apt mirrors
+        if: ${{ runner.os == 'Linux' }}
+        uses: ./.github/actions/apt_mirror_fix
       - name: Build Snowpark Conda Package - Fast
         timeout-minutes: 120
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,6 +168,9 @@ jobs:
         run: |
           cd lib
           python setup.py verify
+      - name: Fix apt mirrors
+        if: ${{ runner.os == 'Linux' }}
+        uses: ./.github/actions/apt_mirror_fix
       - name: Build Package
         timeout-minutes: 120
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -166,6 +166,9 @@ jobs:
           python-version: "${{ env.PYTHON_MAX_VERSION }}"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
+      - name: Fix apt mirrors
+        if: ${{ runner.os == 'Linux' }}
+        uses: ./.github/actions/apt_mirror_fix
       - name: Create Wheel File
         timeout-minutes: 120
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
         env:
           GIT_TAG: ${{ env.GIT_TAG }}
         run: echo "STREAMLIT_RELEASE_VERSION=$GIT_TAG" >> $GITHUB_ENV
+      - name: Fix apt mirrors
+        if: ${{ runner.os == 'Linux' }}
+        uses: ./.github/actions/apt_mirror_fix
       - name: Create Package
         timeout-minutes: 120
         run: |


### PR DESCRIPTION
## Describe your changes

- Centralizes the Ubuntu apt mirror workaround into a new reusable composite action (`.github/actions/apt_mirror_fix`) that deprioritizes the slow `azure.archive.ubuntu.com` mirror.
- Adopt it everywhere we run apt in CI (Playwright installer + pr-preview, nightly, release, conda-build, cli-regression) by inserting a single `uses:` step right before existing apt commands.
- Keep behavior unchanged beyond mirror selection.

## GitHub Issue Link (if applicable)

## Testing Plan

- This edits CI actions

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
