### PR TITLE
Add Starlette server foundation and utilities

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -59,7 +59,8 @@ INSTALL_REQUIRES = [
     # Starting from Python 3.11, Python has built in support for reading TOML files.
     # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
     "toml>=0.10.1, <2",
-    "typing-extensions>=4.4.0, <5",
+    # Starlette requires typing-extensions >= 4.10.
+    "typing-extensions>=4.10.0, <5",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog>=2.1.5, <7; platform_system != 'Darwin'",
@@ -87,6 +88,21 @@ EXTRA_REQUIRES = {
         "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
         "snowflake-connector-python>=3.3.0; python_version<'3.12'",
     ],
+    # Optional dependency required for Starlette integration:
+    "starlette": [
+        # ASGI web-framework:
+        "starlette>=0.40.0",
+        # ASGI server:
+        "uvicorn>=0.30.0",
+        # Required by starlette:
+        "anyio>=4.0.0",
+        # Required for file-upload support:
+        "python-multipart>=0.0.10",
+        # Required for websocket support:
+        "websockets>=12.0.0",
+        # Required for cookie signing:
+        "itsdangerous>=2.1.2",
+    ],
     # Optional dependency required for PDF rendering:
     "pdf": [
         "streamlit-pdf>=1.0.0",
@@ -113,6 +129,8 @@ EXTRA_REQUIRES = {
         "orjson>=3.5.0",
         # uvloop speeds up the event loop:
         "uvloop>=0.15.2; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",  # noqa: E501
+        # Faster http parsing for Starlette server:
+        "httptools>=0.6.3",
     ],
     # Install all optional dependencies:
     "all": [
@@ -128,7 +146,7 @@ class VerifyVersionCommand(install):
 
     description = "verify that the git tag matches our version"
 
-    def run(self):
+    def run(self) -> None:
         tag = os.getenv("TAG")
 
         if tag != VERSION:

--- a/lib/streamlit/web/server/starlette/__init__.py
+++ b/lib/streamlit/web/server/starlette/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/web/server/starlette/starlette_app_utils.py
+++ b/lib/streamlit/web/server/starlette/starlette_app_utils.py
@@ -1,0 +1,306 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for the Starlette server implementation."""
+
+from __future__ import annotations
+
+import binascii
+import os
+import time
+
+
+def parse_range_header(range_header: str, total_size: int) -> tuple[int, int]:
+    """Parse the Range header and return the start and end byte positions.
+
+    This is used for serving media files with range requests.
+
+    Parameters
+    ----------
+    range_header : str
+        The value of the Range header (e.g. "bytes=0-1023").
+
+    total_size : int
+        The total size of the resource in bytes.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple containing (start, end) byte positions.
+    """
+    if total_size <= 0:
+        raise ValueError("empty content")
+
+    units, sep, range_spec = range_header.partition("=")
+    if units.strip().lower() != "bytes" or sep == "" or "," in range_spec:
+        raise ValueError("invalid range")
+
+    range_spec = range_spec.strip()
+    if range_spec.startswith("-"):
+        try:
+            suffix = int(range_spec[1:])
+        except ValueError:
+            raise ValueError("invalid suffix range") from None
+        if suffix <= 0:
+            raise ValueError("invalid suffix range")
+        if suffix >= total_size:
+            return 0, total_size - 1
+        return total_size - suffix, total_size - 1
+
+    start_str, sep, end_str = range_spec.partition("-")
+    if not start_str:
+        raise ValueError("missing range start")
+
+    start = int(start_str)
+    if start < 0 or start >= total_size:
+        raise ValueError("start out of range")
+
+    if sep == "" or not end_str:
+        end = total_size - 1
+    else:
+        end = int(end_str)
+        if end < start:
+            raise ValueError("end before start")
+        end = min(end, total_size - 1)
+
+    return start, end
+
+
+def websocket_mask(mask: bytes, data: bytes) -> bytes:
+    """Mask or unmask data for WebSocket transmission per RFC 6455.
+
+    Each byte of data is XORed with mask[i % 4]. This operation is
+    bidirectional - applying it twice with the same mask returns the
+    original data.
+
+    Parameters
+    ----------
+    mask : bytes
+        A 4-byte masking key.
+    data : bytes
+        The data to mask or unmask.
+
+    Returns
+    -------
+    bytes
+        The masked/unmasked data.
+    """
+    if len(mask) != 4:
+        raise ValueError("mask must be 4 bytes")
+
+    result = bytearray(len(data))
+    for i, byte in enumerate(data):
+        result[i] = byte ^ mask[i % 4]
+    return bytes(result)
+
+
+def create_signed_value(
+    secret: str,
+    name: str,
+    value: str | bytes,
+) -> bytes:
+    """Create a signed cookie value using itsdangerous.
+
+    Note: This uses itsdangerous for signing, which is NOT compatible with
+    Tornado's secure cookie format. Cookies signed by this function cannot
+    be read by Tornado's get_signed_cookie/get_secure_cookie, and vice versa.
+    Switching between Tornado and Starlette backends will invalidate existing
+    auth cookies (_streamlit_user), requiring users to re-authenticate.
+    This is expected behavior when switching between Tornado and Starlette backends.
+
+    Parameters
+    ----------
+    secret
+        The secret key used for signing.
+    name
+        The cookie name (used as salt for additional security).
+    value
+        The value to sign.
+
+    Returns
+    -------
+    bytes
+        The signed value as bytes.
+    """
+    from itsdangerous import URLSafeTimedSerializer
+
+    serializer = URLSafeTimedSerializer(secret, salt=name)
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    return serializer.dumps(value).encode("utf-8")
+
+
+def decode_signed_value(
+    secret: str,
+    name: str,
+    value: str | bytes,
+    max_age_days: float = 31,
+) -> bytes | None:
+    """Decode a signed cookie value using itsdangerous.
+
+    Parameters
+    ----------
+    secret
+        The secret key used for signing.
+    name
+        The cookie name (used as salt for additional security).
+    value
+        The signed value to decode.
+    max_age_days
+        Maximum age of the cookie in days (default: 31).
+
+    Returns
+    -------
+    bytes | None
+        The decoded value as bytes, or None if invalid/expired.
+    """
+    from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+    if not value:
+        return None
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+
+        serializer = URLSafeTimedSerializer(secret, salt=name)
+        decoded = serializer.loads(value, max_age=int(max_age_days * 86400))
+        if isinstance(decoded, str):
+            return decoded.encode("utf-8")
+        if isinstance(decoded, bytes):
+            return decoded
+        # Unexpected type from deserializer — treat as invalid
+        return None
+    except (BadSignature, SignatureExpired, UnicodeDecodeError):
+        return None
+
+
+def generate_xsrf_token_string(
+    token_bytes: bytes | None = None, timestamp: int | None = None
+) -> str:
+    """Generate a version 2 XSRF token string compatible with Tornado.
+
+    Format: 2|mask|masked_token|timestamp
+
+    Parameters
+    ----------
+    token_bytes
+        The raw token bytes to encode. If None, generates 16 random bytes.
+    timestamp
+        The Unix timestamp to include in the token. If None, uses current time.
+
+    Returns
+    -------
+    str
+        The encoded XSRF token string in version 2 format.
+    """
+    if token_bytes is None:
+        token_bytes = os.urandom(16)
+    if timestamp is None:
+        timestamp = int(time.time())
+
+    mask = os.urandom(4)
+    masked_token = websocket_mask(mask, token_bytes)
+    return "2|{}|{}|{}".format(
+        binascii.b2a_hex(mask).decode("ascii"),
+        binascii.b2a_hex(masked_token).decode("ascii"),
+        timestamp,
+    )
+
+
+def decode_xsrf_token_string(
+    cookie_value: str,
+) -> tuple[bytes | None, int | None]:
+    """Decode a Tornado XSRF token string.
+
+    Supports version 2 (masked) and version 1 (unmasked) tokens.
+
+    Parameters
+    ----------
+    cookie_value
+        The XSRF token cookie value to decode.
+
+    Returns
+    -------
+    tuple[bytes | None, int | None]
+        A tuple of (token_bytes, timestamp). Both values are None if decoding fails.
+    """
+    if not cookie_value:
+        return None, None
+
+    value = cookie_value.strip("\"'")
+    if not value:
+        return None, None
+
+    try:
+        # V2 tokens:
+        if value.startswith("2|"):
+            _, mask_hex, masked_hex, timestamp_str = value.split("|")
+            mask = binascii.a2b_hex(mask_hex.encode("ascii"))
+            masked = binascii.a2b_hex(masked_hex.encode("ascii"))
+            token = websocket_mask(mask, masked)
+            return token, int(timestamp_str)
+
+        # V1 tokens:
+        # TODO(lukasmasuch): This is likely unused in Streamlit since only V2 tokens
+        # are used. We might be able to just remove this part.
+        token = binascii.a2b_hex(value.encode("ascii"))
+        if not token:
+            return None, None
+        # V1 tokens don't have an embedded timestamp, so we use current time
+        # as a placeholder (matches Tornado's behavior). This timestamp is
+        # informational only and not used for token validation.
+        return token, int(time.time())
+    except (binascii.Error, ValueError):
+        return None, None
+
+
+def generate_random_hex_string(num_bytes: int = 32) -> str:
+    """Generate a cryptographically secure random hex string.
+
+    Parameters
+    ----------
+    num_bytes
+        Number of random bytes to generate (default: 32).
+        The resulting hex string will be twice this length.
+
+    Returns
+    -------
+    str
+        A hex-encoded random string.
+    """
+    return binascii.b2a_hex(os.urandom(num_bytes)).decode("ascii")
+
+
+def validate_xsrf_token(supplied_token: str | None, xsrf_cookie: str | None) -> bool:
+    """Validate the XSRF token from the WebSocket subprotocol against the cookie.
+
+    This mirrors Tornado's XSRF validation logic to ensure the frontend can share
+    XSRF logic between WebSocket handshake and HTTP uploads regardless of backend.
+    """
+
+    if not supplied_token or not xsrf_cookie:
+        return False
+
+    # Decode the supplied token from the subprotocol
+    supplied_token_bytes, _ = decode_xsrf_token_string(supplied_token)
+    # Decode the expected token from the cookie
+    expected_token_bytes, _ = decode_xsrf_token_string(xsrf_cookie)
+
+    if not supplied_token_bytes or not expected_token_bytes:
+        return False
+
+    import hmac
+
+    return hmac.compare_digest(supplied_token_bytes, expected_token_bytes)

--- a/lib/streamlit/web/server/starlette/starlette_gzip_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_gzip_middleware.py
@@ -1,0 +1,121 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom GZip middleware that excludes audio/video content from compression."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from starlette.datastructures import Headers
+from starlette.middleware.gzip import (
+    DEFAULT_EXCLUDED_CONTENT_TYPES,
+    GZipMiddleware,
+    GZipResponder,
+    IdentityResponder,
+)
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Extended exclusion list: Starlette's default + audio/video prefixes.
+# Compressing binary media content breaks playback in browsers,
+# especially with range requests.
+_EXCLUDED_CONTENT_TYPES: Final = (
+    *DEFAULT_EXCLUDED_CONTENT_TYPES,
+    "audio/",
+    "video/",
+)
+
+
+def _handle_response_start(
+    responder: IdentityResponder | GZipResponder, message: Message
+) -> None:
+    """Handle http.response.start message for media-aware responders.
+
+    This function extracts headers from the response start message and determines
+    whether the content should be excluded from compression based on its type.
+
+    Parameters
+    ----------
+    responder
+        The responder instance (either IdentityResponder or GZipResponder)
+        to update with response metadata.
+    message
+        The ASGI "http.response.start" message containing response headers.
+    """
+    responder.initial_message = message
+    headers = Headers(raw=responder.initial_message["headers"])
+    responder.content_encoding_set = "content-encoding" in headers
+    responder.content_type_is_excluded = headers.get("content-type", "").startswith(
+        _EXCLUDED_CONTENT_TYPES
+    )
+
+
+class _MediaAwareIdentityResponder(IdentityResponder):
+    """IdentityResponder that excludes audio/video from compression.
+
+    This responder extends Starlette's IdentityResponder to use our extended
+    list of excluded content types that includes audio/ and video/ prefixes.
+    Used when the client does not support gzip compression.
+    """
+
+    async def send_with_compression(self, message: Message) -> None:
+        """Process response messages, checking content type for exclusion."""
+        if message["type"] == "http.response.start":
+            _handle_response_start(self, message)
+        else:
+            await super().send_with_compression(message)
+
+
+class _MediaAwareGZipResponder(GZipResponder):
+    """GZipResponder that excludes audio/video from compression.
+
+    This responder extends Starlette's GZipResponder to use our extended
+    list of excluded content types that includes audio/ and video/ prefixes.
+    Used when the client supports gzip compression.
+    """
+
+    async def send_with_compression(self, message: Message) -> None:
+        """Process response messages, checking content type for exclusion."""
+        if message["type"] == "http.response.start":
+            _handle_response_start(self, message)
+        else:
+            await super().send_with_compression(message)
+
+
+class MediaAwareGZipMiddleware(GZipMiddleware):
+    """GZip middleware that excludes audio/video content from compression.
+
+    Extends Starlette's GZipMiddleware to also exclude audio/ and video/
+    content types. Avoiding compression for media content provides better
+    browser compatibility (some browsers like WebKit have issues with
+    explicit identity encoding on media).
+    """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        responder: ASGIApp
+        if "gzip" in headers.get("Accept-Encoding", ""):
+            responder = _MediaAwareGZipResponder(
+                self.app, self.minimum_size, compresslevel=self.compresslevel
+            )
+        else:
+            responder = _MediaAwareIdentityResponder(self.app, self.minimum_size)
+
+        await responder(scope, receive, send)

--- a/lib/streamlit/web/server/starlette/starlette_server_config.py
+++ b/lib/streamlit/web/server/starlette/starlette_server_config.py
@@ -1,0 +1,55 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the Starlette server."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Cookie name for storing signed user identity information.
+USER_COOKIE_NAME: Final = "_streamlit_user"
+# Cookie name for storing signed OAuth tokens (access_token, id_token).
+TOKENS_COOKIE_NAME: Final = "_streamlit_user_tokens"
+# Cookie name for Cross-Site Request Forgery (XSRF) token validation.
+XSRF_COOKIE_NAME: Final = "_streamlit_xsrf"
+# Cookie name for server-side session management.
+SESSION_COOKIE_NAME: Final = "_streamlit_session"
+
+# Max pending messages per client in the send queue before disconnecting.
+# Each connected client has its own queue; under normal conditions the queue drains
+# continuously and rarely exceeds single digits. This limit protects against slow
+# clients (bad network, paused tabs) causing unbounded server memory growth.
+# With N concurrent users, worst case memory is N * WEBSOCKET_MAX_SEND_QUEUE_SIZE * msg_size.
+WEBSOCKET_MAX_SEND_QUEUE_SIZE: Final = 500
+
+# Gzip middleware configuration:
+# Do not GZip responses that are smaller than this minimum size in bytes:
+GZIP_MINIMUM_SIZE: Final = 500
+# Used during GZip compression. It is an integer ranging from 1 to 9.
+# Lower value results in faster compression but larger file sizes, while higher value
+# results in slower compression but smaller file sizes.
+GZIP_COMPRESSLEVEL: Final = 6
+
+# When server.port is not available it will look for the next available port
+# up to this number of retries.
+MAX_PORT_SEARCH_RETRIES: Final = 100
+
+# Default address to bind to when no address is configured:
+DEFAULT_SERVER_ADDRESS: Final = "0.0.0.0"  # noqa: S104
+
+# Default WebSocket ping interval in seconds, can be configured by the user
+DEFAULT_WEBSOCKET_PING_INTERVAL: Final = 30
+# Default WebSocket ping timeout in seconds, can be configured by the user
+DEFAULT_WEBSOCKET_PING_TIMEOUT: Final = 30

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -23,6 +23,16 @@ pytest>=8.3.5
 pytest-cov
 requests-mock
 testfixtures
+
+# Required for Starlette support:
+starlette>=0.40.0
+uvicorn>=0.30.0
+python-multipart>=0.0.10
+websockets>=12.0.0
+itsdangerous>=2.1.2
+# only for unit tests:
+httpx>=0.24.1
+
 # We pin playwright to a minor version to avoid new browser versions
 # breaking our CI. But this version should be updated regularly as soon as
 # new playwright versions are released.

--- a/lib/tests/streamlit/web/server/starlette/__init__.py
+++ b/lib/tests/streamlit/web/server/starlette/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_utils_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_utils_test.py
@@ -1,0 +1,325 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_app_utils.py."""
+
+from __future__ import annotations
+
+import binascii
+import time
+import unittest
+
+import pytest
+from tornado.util import _websocket_mask
+
+from streamlit.web.server.starlette import starlette_app_utils
+
+
+class StarletteServerUtilsTest(unittest.TestCase):
+    def test_parse_range_header_bytes(self):
+        """Test parsing standard byte ranges."""
+        # Entire file
+        assert starlette_app_utils.parse_range_header("bytes=0-", 100) == (0, 99)
+        # First 10 bytes
+        assert starlette_app_utils.parse_range_header("bytes=0-9", 100) == (0, 9)
+        # Middle range
+        assert starlette_app_utils.parse_range_header("bytes=10-19", 100) == (10, 19)
+        # Last 10 bytes (suffix)
+        assert starlette_app_utils.parse_range_header("bytes=-10", 100) == (90, 99)
+        # Range exceeding end caps at end
+        assert starlette_app_utils.parse_range_header("bytes=90-200", 100) == (
+            90,
+            99,
+        )
+
+    def test_parse_range_header_errors(self):
+        """Test invalid range headers raise ValueError."""
+        # Empty content
+        with pytest.raises(ValueError, match="empty content"):
+            starlette_app_utils.parse_range_header("bytes=0-10", 0)
+
+        # Invalid units
+        with pytest.raises(ValueError, match="invalid range"):
+            starlette_app_utils.parse_range_header("bits=0-10", 100)
+
+        # Multiple ranges not supported
+        with pytest.raises(ValueError, match="invalid range"):
+            starlette_app_utils.parse_range_header("bytes=0-10, 20-30", 100)
+
+        # Invalid start
+        with pytest.raises(ValueError, match="invalid suffix range"):
+            starlette_app_utils.parse_range_header("bytes=-5-10", 100)
+
+        # Start > total
+        with pytest.raises(ValueError, match="start out of range"):
+            starlette_app_utils.parse_range_header("bytes=150-200", 100)
+
+        # End before start
+        with pytest.raises(ValueError, match="end before start"):
+            starlette_app_utils.parse_range_header("bytes=50-40", 100)
+
+    def test_websocket_mask_compatibility(self):
+        """Test that websocket_mask matches Tornado's implementation."""
+        mask = b"1234"
+        data = b"hello world"
+
+        expected = _websocket_mask(mask, data)
+        actual = starlette_app_utils.websocket_mask(mask, data)
+        assert actual == expected
+
+        # It should be reversible (XOR)
+        masked = actual
+        unmasked = starlette_app_utils.websocket_mask(mask, masked)
+        assert unmasked == data
+
+    def test_websocket_mask_empty_data(self):
+        """Test that masking empty data returns empty bytes."""
+        mask = b"1234"
+        data = b""
+
+        result = starlette_app_utils.websocket_mask(mask, data)
+        assert result == b""
+
+    def test_websocket_mask_invalid_mask_length(self):
+        """Test that invalid mask length raises ValueError."""
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"12", b"data")
+
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"12345", b"data")
+
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"", b"data")
+
+    def test_websocket_mask_various_lengths(self):
+        """Test masking data of various lengths matches Tornado."""
+        mask = b"\x01\x02\x03\x04"
+
+        # Test lengths 1-10 to cover different modulo cases
+        for length in range(1, 11):
+            data = bytes(range(length))
+            expected = _websocket_mask(mask, data)
+            actual = starlette_app_utils.websocket_mask(mask, data)
+            assert actual == expected, f"Mismatch for length {length}"
+
+    def test_signed_value_roundtrip(self):
+        """Test that create_signed_value and decode_signed_value work together."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = "test_value"
+
+        # Create a signed value
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+
+        # Decode using our utility
+        decoded = starlette_app_utils.decode_signed_value(secret, name, signed_value)
+        assert decoded is not None
+        assert decoded.decode("utf-8") == value
+
+    def test_signed_value_with_bytes(self):
+        """Test that signed value works with bytes input."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = b"test_value_bytes"
+
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+        decoded = starlette_app_utils.decode_signed_value(secret, name, signed_value)
+        assert decoded == value
+
+    def test_decode_signed_value_invalid_signature(self):
+        """Test that invalid signature returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+
+        # Tampered value
+        result = starlette_app_utils.decode_signed_value(
+            secret, name, "invalid_signed_value"
+        )
+        assert result is None
+
+    def test_decode_signed_value_wrong_secret(self):
+        """Test that wrong secret returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = "test_value"
+
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+        result = starlette_app_utils.decode_signed_value(
+            "wrong_secret", name, signed_value
+        )
+        assert result is None
+
+    def test_decode_signed_value_empty_value(self):
+        """Test that empty value returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+
+        # Empty string
+        assert starlette_app_utils.decode_signed_value(secret, name, "") is None
+        # Empty bytes
+        assert starlette_app_utils.decode_signed_value(secret, name, b"") is None
+
+    def test_decode_signed_value_non_utf8_bytes(self):
+        """Test that non-UTF-8 bytes return None instead of raising."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        # Invalid UTF-8 sequence
+        invalid_utf8 = b"\xff\xfe\x00\x01"
+
+        result = starlette_app_utils.decode_signed_value(secret, name, invalid_utf8)
+        assert result is None
+
+    def test_xsrf_token_roundtrip(self):
+        """Test generating and then decoding an XSRF token."""
+        token = b"some_random_token_bytes"
+        timestamp = int(time.time())
+
+        # Generate string
+        cookie_val = starlette_app_utils.generate_xsrf_token_string(token, timestamp)
+
+        # Verify format
+        assert cookie_val.startswith("2|")
+        parts = cookie_val.split("|")
+        assert len(parts) == 4
+
+        # Decode string
+        decoded_token, decoded_timestamp = starlette_app_utils.decode_xsrf_token_string(
+            cookie_val
+        )
+
+        assert decoded_token == token
+        assert decoded_timestamp == timestamp
+
+    def test_decode_xsrf_token_v1(self):
+        """Test decoding a legacy v1 XSRF token (unmasked hex)."""
+        token = b"legacy_token"
+        hex_token = binascii.b2a_hex(token).decode("ascii")
+
+        # decode_xsrf_token_string treats anything not starting with '2|' as v1
+        decoded_token, decoded_timestamp = starlette_app_utils.decode_xsrf_token_string(
+            hex_token
+        )
+
+        assert decoded_token == token
+        # For v1 tokens, it returns current time as timestamp
+        assert decoded_timestamp is not None
+        assert abs(decoded_timestamp - time.time()) < 2
+
+    def test_decode_xsrf_token_invalid(self):
+        """Test decoding invalid tokens returns (None, None)."""
+        assert starlette_app_utils.decode_xsrf_token_string("invalid") == (
+            None,
+            None,
+        )
+        assert starlette_app_utils.decode_xsrf_token_string("2|bad|format") == (
+            None,
+            None,
+        )
+
+    def test_decode_xsrf_token_empty(self):
+        """Test that empty/whitespace-only strings return (None, None)."""
+        # Empty string
+        assert starlette_app_utils.decode_xsrf_token_string("") == (None, None)
+        # Whitespace only (stripped to empty)
+        assert starlette_app_utils.decode_xsrf_token_string("   ") == (None, None)
+        # Only quotes (stripped to empty)
+        assert starlette_app_utils.decode_xsrf_token_string('""') == (None, None)
+        assert starlette_app_utils.decode_xsrf_token_string("''") == (None, None)
+
+    def test_generate_random_hex_string_default(self):
+        """Test generate_random_hex_string with default length."""
+        result = starlette_app_utils.generate_random_hex_string()
+        # Default is 32 bytes = 64 hex characters
+        assert len(result) == 64
+        # Should be valid hex
+        int(result, 16)
+
+    def test_generate_random_hex_string_custom_length(self):
+        """Test generate_random_hex_string with custom byte count."""
+        result = starlette_app_utils.generate_random_hex_string(16)
+        # 16 bytes = 32 hex characters
+        assert len(result) == 32
+        # Should be valid hex
+        int(result, 16)
+
+    def test_generate_random_hex_string_uniqueness(self):
+        """Test that generate_random_hex_string produces unique values."""
+        results = {starlette_app_utils.generate_random_hex_string() for _ in range(100)}
+        # All 100 should be unique
+        assert len(results) == 100
+
+
+class TestValidateXsrfToken:
+    """Tests for validate_xsrf_token function."""
+
+    def test_returns_false_when_supplied_token_none(self) -> None:
+        """Test that False is returned when supplied token is None."""
+        xsrf_cookie = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(None, xsrf_cookie)
+
+        assert result is False
+
+    def test_returns_false_when_cookie_none(self) -> None:
+        """Test that False is returned when cookie is None."""
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(xsrf_token, None)
+
+        assert result is False
+
+    def test_returns_false_when_both_none(self) -> None:
+        """Test that False is returned when both are None."""
+        result = starlette_app_utils.validate_xsrf_token(None, None)
+
+        assert result is False
+
+    def test_returns_true_for_matching_tokens(self) -> None:
+        """Test that True is returned when tokens match."""
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(xsrf_token, xsrf_token)
+
+        assert result is True
+
+    def test_returns_true_for_matching_tokens_with_different_timestamps(self) -> None:
+        """Test that validation succeeds when tokens have same bytes but different timestamps."""
+        token_bytes = b"0123456789abcdef"
+        token1 = starlette_app_utils.generate_xsrf_token_string(
+            token_bytes, timestamp=12345
+        )
+        token2 = starlette_app_utils.generate_xsrf_token_string(
+            token_bytes, timestamp=67890
+        )
+
+        result = starlette_app_utils.validate_xsrf_token(token1, token2)
+
+        assert result is True
+
+    def test_returns_false_for_different_tokens(self) -> None:
+        """Test that False is returned when tokens differ."""
+        token1 = starlette_app_utils.generate_xsrf_token_string()
+        token2 = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(token1, token2)
+
+        assert result is False
+
+    def test_returns_false_for_invalid_token_format(self) -> None:
+        """Test that False is returned for invalid token format."""
+        valid_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token("invalid-token", valid_token)
+
+        assert result is False

--- a/lib/tests/streamlit/web/server/starlette/starlette_gzip_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_gzip_middleware_test.py
@@ -1,0 +1,161 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_gzip_middleware module."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from streamlit.web.server.starlette.starlette_gzip_middleware import (
+    _EXCLUDED_CONTENT_TYPES,
+    MediaAwareGZipMiddleware,
+)
+
+
+def _create_test_app(content_type: str, body: bytes = b"x" * 1000) -> Starlette:
+    """Create a test Starlette app that returns a response with the given content type."""
+
+    async def endpoint(request):
+        return Response(content=body, media_type=content_type)
+
+    app = Starlette(routes=[Route("/", endpoint)])
+    app.add_middleware(MediaAwareGZipMiddleware, minimum_size=100)
+    return app
+
+
+class TestMediaAwareGZipMiddleware:
+    """Tests for MediaAwareGZipMiddleware."""
+
+    def test_compresses_text_content(self) -> None:
+        """Test that text content is compressed when client supports gzip."""
+        app = _create_test_app("text/plain")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_compresses_json_content(self) -> None:
+        """Test that JSON content is compressed when client supports gzip."""
+        app = _create_test_app("application/json")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_does_not_compress_audio_content(self) -> None:
+        """Test that audio content is not compressed."""
+        app = _create_test_app("audio/mpeg")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_video_content(self) -> None:
+        """Test that video content is not compressed."""
+        app = _create_test_app("video/mp4")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+            "audio/webm",
+            "video/mp4",
+            "video/webm",
+            "video/ogg",
+        ],
+        ids=[
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+            "audio/webm",
+            "video/mp4",
+            "video/webm",
+            "video/ogg",
+        ],
+    )
+    def test_excludes_various_media_types(self, content_type: str) -> None:
+        """Test that various audio/video types are excluded from compression."""
+        app = _create_test_app(content_type)
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_when_client_does_not_support_gzip(self) -> None:
+        """Test that content is not compressed when client doesn't support gzip."""
+        app = _create_test_app("text/plain")
+        client = TestClient(app)
+
+        # Explicitly set Accept-Encoding to something other than gzip
+        response = client.get("/", headers={"Accept-Encoding": "identity"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_small_content(self) -> None:
+        """Test that small content is not compressed (below minimum_size)."""
+        app = _create_test_app("text/plain", body=b"small")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        # Small content should not be compressed
+        assert response.headers.get("content-encoding") is None
+
+
+class TestExcludedContentTypes:
+    """Tests for the _EXCLUDED_CONTENT_TYPES constant."""
+
+    def test_includes_audio_prefix(self) -> None:
+        """Test that audio/ prefix is in the excluded types."""
+        assert "audio/" in _EXCLUDED_CONTENT_TYPES
+
+    def test_includes_video_prefix(self) -> None:
+        """Test that video/ prefix is in the excluded types."""
+        assert "video/" in _EXCLUDED_CONTENT_TYPES
+
+    def test_includes_starlette_defaults(self) -> None:
+        """Test that Starlette default exclusions are preserved."""
+        # text/event-stream is excluded by Starlette by default (for SSE)
+        assert "text/event-stream" in _EXCLUDED_CONTENT_TYPES
+
+    def test_extends_starlette_defaults(self) -> None:
+        """Test that our exclusion list extends (not replaces) Starlette defaults."""
+        from starlette.middleware.gzip import DEFAULT_EXCLUDED_CONTENT_TYPES
+
+        # All Starlette defaults should be included
+        for content_type in DEFAULT_EXCLUDED_CONTENT_TYPES:
+            assert content_type in _EXCLUDED_CONTENT_TYPES

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -14,5 +14,5 @@ requests==2.27
 tenacity==8.1.0
 toml==0.10.1
 tornado==6.0.3
-typing-extensions==4.4.0
+typing-extensions==4.10.0
 watchdog==2.1.5


### PR DESCRIPTION
## Describe your changes

**Part 1 of 7 of optional [Starlette](https://starlette.dev/) support:** 

Adds Starlette dependencies to setup.py and implements shared utilities for the Starlette server, including configuration constants, cookie signing helpers, XSRF token generation, and a custom GZip middleware.

## Testing Plan

- Added relevant unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
