### PR TITLE
Add Starlette static assets route

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -59,7 +59,8 @@ INSTALL_REQUIRES = [
     # Starting from Python 3.11, Python has built in support for reading TOML files.
     # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
     "toml>=0.10.1, <2",
-    "typing-extensions>=4.4.0, <5",
+    # Starlette requires typing-extensions >= 4.10.
+    "typing-extensions>=4.10.0, <5",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog>=2.1.5, <7; platform_system != 'Darwin'",
@@ -87,6 +88,21 @@ EXTRA_REQUIRES = {
         "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
         "snowflake-connector-python>=3.3.0; python_version<'3.12'",
     ],
+    # Optional dependency required for Starlette integration:
+    "starlette": [
+        # ASGI web-framework:
+        "starlette>=0.40.0",
+        # ASGI server:
+        "uvicorn>=0.30.0",
+        # Required by starlette:
+        "anyio>=4.0.0",
+        # Required for file-upload support:
+        "python-multipart>=0.0.10",
+        # Required for websocket support:
+        "websockets>=12.0.0",
+        # Required for cookie signing:
+        "itsdangerous>=2.1.2",
+    ],
     # Optional dependency required for PDF rendering:
     "pdf": [
         "streamlit-pdf>=1.0.0",
@@ -113,6 +129,8 @@ EXTRA_REQUIRES = {
         "orjson>=3.5.0",
         # uvloop speeds up the event loop:
         "uvloop>=0.15.2; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",  # noqa: E501
+        # Faster http parsing for Starlette server:
+        "httptools>=0.6.3",
     ],
     # Install all optional dependencies:
     "all": [
@@ -128,7 +146,7 @@ class VerifyVersionCommand(install):
 
     description = "verify that the git tag matches our version"
 
-    def run(self):
+    def run(self) -> None:
         tag = os.getenv("TAG")
 
         if tag != VERSION:

--- a/lib/streamlit/web/server/starlette/__init__.py
+++ b/lib/streamlit/web/server/starlette/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/web/server/starlette/starlette_app_utils.py
+++ b/lib/streamlit/web/server/starlette/starlette_app_utils.py
@@ -1,0 +1,306 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for the Starlette server implementation."""
+
+from __future__ import annotations
+
+import binascii
+import os
+import time
+
+
+def parse_range_header(range_header: str, total_size: int) -> tuple[int, int]:
+    """Parse the Range header and return the start and end byte positions.
+
+    This is used for serving media files with range requests.
+
+    Parameters
+    ----------
+    range_header : str
+        The value of the Range header (e.g. "bytes=0-1023").
+
+    total_size : int
+        The total size of the resource in bytes.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple containing (start, end) byte positions.
+    """
+    if total_size <= 0:
+        raise ValueError("empty content")
+
+    units, sep, range_spec = range_header.partition("=")
+    if units.strip().lower() != "bytes" or sep == "" or "," in range_spec:
+        raise ValueError("invalid range")
+
+    range_spec = range_spec.strip()
+    if range_spec.startswith("-"):
+        try:
+            suffix = int(range_spec[1:])
+        except ValueError:
+            raise ValueError("invalid suffix range") from None
+        if suffix <= 0:
+            raise ValueError("invalid suffix range")
+        if suffix >= total_size:
+            return 0, total_size - 1
+        return total_size - suffix, total_size - 1
+
+    start_str, sep, end_str = range_spec.partition("-")
+    if not start_str:
+        raise ValueError("missing range start")
+
+    start = int(start_str)
+    if start < 0 or start >= total_size:
+        raise ValueError("start out of range")
+
+    if sep == "" or not end_str:
+        end = total_size - 1
+    else:
+        end = int(end_str)
+        if end < start:
+            raise ValueError("end before start")
+        end = min(end, total_size - 1)
+
+    return start, end
+
+
+def websocket_mask(mask: bytes, data: bytes) -> bytes:
+    """Mask or unmask data for WebSocket transmission per RFC 6455.
+
+    Each byte of data is XORed with mask[i % 4]. This operation is
+    bidirectional - applying it twice with the same mask returns the
+    original data.
+
+    Parameters
+    ----------
+    mask : bytes
+        A 4-byte masking key.
+    data : bytes
+        The data to mask or unmask.
+
+    Returns
+    -------
+    bytes
+        The masked/unmasked data.
+    """
+    if len(mask) != 4:
+        raise ValueError("mask must be 4 bytes")
+
+    result = bytearray(len(data))
+    for i, byte in enumerate(data):
+        result[i] = byte ^ mask[i % 4]
+    return bytes(result)
+
+
+def create_signed_value(
+    secret: str,
+    name: str,
+    value: str | bytes,
+) -> bytes:
+    """Create a signed cookie value using itsdangerous.
+
+    Note: This uses itsdangerous for signing, which is NOT compatible with
+    Tornado's secure cookie format. Cookies signed by this function cannot
+    be read by Tornado's get_signed_cookie/get_secure_cookie, and vice versa.
+    Switching between Tornado and Starlette backends will invalidate existing
+    auth cookies (_streamlit_user), requiring users to re-authenticate.
+    This is expected behavior when switching between Tornado and Starlette backends.
+
+    Parameters
+    ----------
+    secret
+        The secret key used for signing.
+    name
+        The cookie name (used as salt for additional security).
+    value
+        The value to sign.
+
+    Returns
+    -------
+    bytes
+        The signed value as bytes.
+    """
+    from itsdangerous import URLSafeTimedSerializer
+
+    serializer = URLSafeTimedSerializer(secret, salt=name)
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    return serializer.dumps(value).encode("utf-8")
+
+
+def decode_signed_value(
+    secret: str,
+    name: str,
+    value: str | bytes,
+    max_age_days: float = 31,
+) -> bytes | None:
+    """Decode a signed cookie value using itsdangerous.
+
+    Parameters
+    ----------
+    secret
+        The secret key used for signing.
+    name
+        The cookie name (used as salt for additional security).
+    value
+        The signed value to decode.
+    max_age_days
+        Maximum age of the cookie in days (default: 31).
+
+    Returns
+    -------
+    bytes | None
+        The decoded value as bytes, or None if invalid/expired.
+    """
+    from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+    if not value:
+        return None
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+
+        serializer = URLSafeTimedSerializer(secret, salt=name)
+        decoded = serializer.loads(value, max_age=int(max_age_days * 86400))
+        if isinstance(decoded, str):
+            return decoded.encode("utf-8")
+        if isinstance(decoded, bytes):
+            return decoded
+        # Unexpected type from deserializer — treat as invalid
+        return None
+    except (BadSignature, SignatureExpired, UnicodeDecodeError):
+        return None
+
+
+def generate_xsrf_token_string(
+    token_bytes: bytes | None = None, timestamp: int | None = None
+) -> str:
+    """Generate a version 2 XSRF token string compatible with Tornado.
+
+    Format: 2|mask|masked_token|timestamp
+
+    Parameters
+    ----------
+    token_bytes
+        The raw token bytes to encode. If None, generates 16 random bytes.
+    timestamp
+        The Unix timestamp to include in the token. If None, uses current time.
+
+    Returns
+    -------
+    str
+        The encoded XSRF token string in version 2 format.
+    """
+    if token_bytes is None:
+        token_bytes = os.urandom(16)
+    if timestamp is None:
+        timestamp = int(time.time())
+
+    mask = os.urandom(4)
+    masked_token = websocket_mask(mask, token_bytes)
+    return "2|{}|{}|{}".format(
+        binascii.b2a_hex(mask).decode("ascii"),
+        binascii.b2a_hex(masked_token).decode("ascii"),
+        timestamp,
+    )
+
+
+def decode_xsrf_token_string(
+    cookie_value: str,
+) -> tuple[bytes | None, int | None]:
+    """Decode a Tornado XSRF token string.
+
+    Supports version 2 (masked) and version 1 (unmasked) tokens.
+
+    Parameters
+    ----------
+    cookie_value
+        The XSRF token cookie value to decode.
+
+    Returns
+    -------
+    tuple[bytes | None, int | None]
+        A tuple of (token_bytes, timestamp). Both values are None if decoding fails.
+    """
+    if not cookie_value:
+        return None, None
+
+    value = cookie_value.strip("\"'")
+    if not value:
+        return None, None
+
+    try:
+        # V2 tokens:
+        if value.startswith("2|"):
+            _, mask_hex, masked_hex, timestamp_str = value.split("|")
+            mask = binascii.a2b_hex(mask_hex.encode("ascii"))
+            masked = binascii.a2b_hex(masked_hex.encode("ascii"))
+            token = websocket_mask(mask, masked)
+            return token, int(timestamp_str)
+
+        # V1 tokens:
+        # TODO(lukasmasuch): This is likely unused in Streamlit since only V2 tokens
+        # are used. We might be able to just remove this part.
+        token = binascii.a2b_hex(value.encode("ascii"))
+        if not token:
+            return None, None
+        # V1 tokens don't have an embedded timestamp, so we use current time
+        # as a placeholder (matches Tornado's behavior). This timestamp is
+        # informational only and not used for token validation.
+        return token, int(time.time())
+    except (binascii.Error, ValueError):
+        return None, None
+
+
+def generate_random_hex_string(num_bytes: int = 32) -> str:
+    """Generate a cryptographically secure random hex string.
+
+    Parameters
+    ----------
+    num_bytes
+        Number of random bytes to generate (default: 32).
+        The resulting hex string will be twice this length.
+
+    Returns
+    -------
+    str
+        A hex-encoded random string.
+    """
+    return binascii.b2a_hex(os.urandom(num_bytes)).decode("ascii")
+
+
+def validate_xsrf_token(supplied_token: str | None, xsrf_cookie: str | None) -> bool:
+    """Validate the XSRF token from the WebSocket subprotocol against the cookie.
+
+    This mirrors Tornado's XSRF validation logic to ensure the frontend can share
+    XSRF logic between WebSocket handshake and HTTP uploads regardless of backend.
+    """
+
+    if not supplied_token or not xsrf_cookie:
+        return False
+
+    # Decode the supplied token from the subprotocol
+    supplied_token_bytes, _ = decode_xsrf_token_string(supplied_token)
+    # Decode the expected token from the cookie
+    expected_token_bytes, _ = decode_xsrf_token_string(xsrf_cookie)
+
+    if not supplied_token_bytes or not expected_token_bytes:
+        return False
+
+    import hmac
+
+    return hmac.compare_digest(supplied_token_bytes, expected_token_bytes)

--- a/lib/streamlit/web/server/starlette/starlette_gzip_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_gzip_middleware.py
@@ -1,0 +1,121 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom GZip middleware that excludes audio/video content from compression."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from starlette.datastructures import Headers
+from starlette.middleware.gzip import (
+    DEFAULT_EXCLUDED_CONTENT_TYPES,
+    GZipMiddleware,
+    GZipResponder,
+    IdentityResponder,
+)
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Extended exclusion list: Starlette's default + audio/video prefixes.
+# Compressing binary media content breaks playback in browsers,
+# especially with range requests.
+_EXCLUDED_CONTENT_TYPES: Final = (
+    *DEFAULT_EXCLUDED_CONTENT_TYPES,
+    "audio/",
+    "video/",
+)
+
+
+def _handle_response_start(
+    responder: IdentityResponder | GZipResponder, message: Message
+) -> None:
+    """Handle http.response.start message for media-aware responders.
+
+    This function extracts headers from the response start message and determines
+    whether the content should be excluded from compression based on its type.
+
+    Parameters
+    ----------
+    responder
+        The responder instance (either IdentityResponder or GZipResponder)
+        to update with response metadata.
+    message
+        The ASGI "http.response.start" message containing response headers.
+    """
+    responder.initial_message = message
+    headers = Headers(raw=responder.initial_message["headers"])
+    responder.content_encoding_set = "content-encoding" in headers
+    responder.content_type_is_excluded = headers.get("content-type", "").startswith(
+        _EXCLUDED_CONTENT_TYPES
+    )
+
+
+class _MediaAwareIdentityResponder(IdentityResponder):
+    """IdentityResponder that excludes audio/video from compression.
+
+    This responder extends Starlette's IdentityResponder to use our extended
+    list of excluded content types that includes audio/ and video/ prefixes.
+    Used when the client does not support gzip compression.
+    """
+
+    async def send_with_compression(self, message: Message) -> None:
+        """Process response messages, checking content type for exclusion."""
+        if message["type"] == "http.response.start":
+            _handle_response_start(self, message)
+        else:
+            await super().send_with_compression(message)
+
+
+class _MediaAwareGZipResponder(GZipResponder):
+    """GZipResponder that excludes audio/video from compression.
+
+    This responder extends Starlette's GZipResponder to use our extended
+    list of excluded content types that includes audio/ and video/ prefixes.
+    Used when the client supports gzip compression.
+    """
+
+    async def send_with_compression(self, message: Message) -> None:
+        """Process response messages, checking content type for exclusion."""
+        if message["type"] == "http.response.start":
+            _handle_response_start(self, message)
+        else:
+            await super().send_with_compression(message)
+
+
+class MediaAwareGZipMiddleware(GZipMiddleware):
+    """GZip middleware that excludes audio/video content from compression.
+
+    Extends Starlette's GZipMiddleware to also exclude audio/ and video/
+    content types. Avoiding compression for media content provides better
+    browser compatibility (some browsers like WebKit have issues with
+    explicit identity encoding on media).
+    """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        responder: ASGIApp
+        if "gzip" in headers.get("Accept-Encoding", ""):
+            responder = _MediaAwareGZipResponder(
+                self.app, self.minimum_size, compresslevel=self.compresslevel
+            )
+        else:
+            responder = _MediaAwareIdentityResponder(self.app, self.minimum_size)
+
+        await responder(scope, receive, send)

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -112,8 +112,7 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
     if not is_xsrf_enabled():
         return
 
-    cookie_name = XSRF_COOKIE_NAME
-    raw_cookie = request.cookies.get(cookie_name)
+    raw_cookie = request.cookies.get(XSRF_COOKIE_NAME)
     token_bytes: bytes | None = None
     timestamp: int | None = None
     if raw_cookie:
@@ -127,7 +126,7 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
 
     _set_unquoted_cookie(
         response,
-        cookie_name,
+        XSRF_COOKIE_NAME,
         cookie_value,
         secure=bool(config.get_option("server.sslCertFile")),
     )
@@ -485,8 +484,14 @@ def create_upload_routes(
 
         # 1. Fast fail via header (if present) - check before reading the body
         content_length = request.headers.get("content-length")
-        if content_length and int(content_length) > max_size_bytes:
-            raise HTTPException(status_code=413, detail="File too large")
+        if content_length:
+            try:
+                if int(content_length) > max_size_bytes:
+                    raise HTTPException(status_code=413, detail="File too large")
+            except ValueError:
+                raise HTTPException(
+                    status_code=400, detail="Invalid Content-Length header"
+                )
 
         form = await request.form()
         uploads = [value for value in form.values() if isinstance(value, UploadFile)]

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -41,6 +41,7 @@ from streamlit.web.server.routes import (
 )
 from streamlit.web.server.server_util import get_url, is_xsrf_enabled
 from streamlit.web.server.starlette import starlette_app_utils
+from streamlit.web.server.starlette.starlette_app_utils import validate_xsrf_token
 from streamlit.web.server.starlette.starlette_server_config import XSRF_COOKIE_NAME
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
 
@@ -130,27 +131,6 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
         cookie_value,
         secure=bool(config.get_option("server.sslCertFile")),
     )
-
-
-def _validate_xsrf_token(supplied_token: str | None, xsrf_cookie: str | None) -> bool:
-    """Validate the XSRF token from the request header against the cookie.
-
-    This mirrors Tornado's XSRF validation logic to ensure compatibility.
-    """
-    import hmac
-
-    if not supplied_token or not xsrf_cookie:
-        return False
-
-    supplied_token_bytes, _ = starlette_app_utils.decode_xsrf_token_string(
-        supplied_token
-    )
-    expected_token_bytes, _ = starlette_app_utils.decode_xsrf_token_string(xsrf_cookie)
-
-    if not supplied_token_bytes or not expected_token_bytes:
-        return False
-
-    return hmac.compare_digest(supplied_token_bytes, expected_token_bytes)
 
 
 def _set_unquoted_cookie(
@@ -444,7 +424,7 @@ def create_upload_routes(
         xsrf_header = request.headers.get("X-Xsrftoken")
         xsrf_cookie = request.cookies.get(XSRF_COOKIE_NAME)
 
-        if not _validate_xsrf_token(xsrf_header, xsrf_cookie):
+        if not validate_xsrf_token(xsrf_header, xsrf_cookie):
             raise HTTPException(status_code=403, detail="XSRF token missing or invalid")
 
     async def _set_upload_headers(request: Request, response: Response) -> None:

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -84,7 +84,21 @@ _ROUTE_APP_STATIC: Final = "app/static/{path:path}"
 
 
 def _with_base(path: str, base_url: str | None = None) -> str:
-    """Prepend the base URL path to a route path."""
+    """Prepend the base URL path to a route path.
+
+    Parameters
+    ----------
+    path
+        The route path to prepend the base URL to (e.g., "_stcore/health").
+    base_url
+        Optional explicit base URL. If None, uses the configured server.baseUrlPath.
+        If an empty string, no base URL is prepended.
+
+    Returns
+    -------
+    str
+        The full route path with base URL prepended (e.g., "/myapp/_stcore/health").
+    """
     from streamlit.url_util import make_url_path
 
     base = (
@@ -94,7 +108,19 @@ def _with_base(path: str, base_url: str | None = None) -> str:
 
 
 async def _set_cors_headers(request: Request, response: Response) -> None:
-    """Set CORS headers on a response based on configuration."""
+    """Set CORS headers on a response based on configuration.
+
+    Configures the Access-Control-Allow-Origin header according to the following rules:
+    - If CORS is disabled or in development mode: allows all origins ("*")
+    - Otherwise: only allows origins that match the configured allowlist
+
+    Parameters
+    ----------
+    request
+        The incoming Starlette request (used to read the Origin header).
+    response
+        The outgoing Starlette response to set headers on.
+    """
     if allow_all_cross_origin_requests():
         response.headers["Access-Control-Allow-Origin"] = "*"
         return
@@ -105,14 +131,27 @@ async def _set_cors_headers(request: Request, response: Response) -> None:
 
 
 def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
-    """Ensure that the XSRF cookie is set.
+    """Ensure that the XSRF cookie is set on the response.
 
-    We manually manage XSRF generation and validation here to strictly match
-    Tornado's implementation and cookie format.
+    This function manages XSRF (Cross-Site Request Forgery) token generation
+    and cookie setting to maintain compatibility with Tornado's implementation.
+    If an existing valid XSRF cookie is present, its token bytes and timestamp
+    are preserved. Otherwise, a new token is generated.
+
+    The cookie is only set if XSRF protection is enabled in the configuration.
+    The Secure flag is added when SSL is configured.
+
+    Parameters
+    ----------
+    request
+        The incoming Starlette request (used to read existing XSRF cookie).
+    response
+        The outgoing Starlette response to set the cookie on.
     """
     if not is_xsrf_enabled():
         return
 
+    # Try to decode existing XSRF cookie to preserve token across requests
     raw_cookie = request.cookies.get(XSRF_COOKIE_NAME)
     token_bytes: bytes | None = None
     timestamp: int | None = None
@@ -121,6 +160,7 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
             raw_cookie
         )
 
+    # Generate token string (reuses existing token bytes/timestamp if available)
     cookie_value = starlette_app_utils.generate_xsrf_token_string(
         token_bytes, timestamp
     )
@@ -140,7 +180,27 @@ def _set_unquoted_cookie(
     *,
     secure: bool,
 ) -> None:
-    """Set a cookie without quoting the value (for Tornado compatibility)."""
+    """Set a cookie without URL-encoding or quoting the value.
+
+    Starlette's standard set_cookie() method URL-encodes special characters
+    (like `|`) in cookie values. This function bypasses that encoding to
+    maintain compatibility with Tornado's cookie format, which is required
+    for XSRF tokens that use the format "2|mask|token|timestamp".
+
+    If a cookie with the same name already exists, it is replaced.
+
+    Parameters
+    ----------
+    response
+        The Starlette response to set the cookie on.
+    cookie_name
+        The name of the cookie.
+    cookie_value
+        The raw cookie value (will not be URL-encoded or quoted).
+    secure
+        Whether to add the Secure flag (should be True when using HTTPS).
+    """
+    # Build the Set-Cookie header value manually to avoid encoding
     header_value = "; ".join(
         [
             f"{cookie_name}={cookie_value}",
@@ -150,6 +210,7 @@ def _set_unquoted_cookie(
         ]
     )
 
+    # Remove any existing cookie with the same name before adding the new one
     key_prefix = f"{cookie_name}=".encode("latin-1")
     filtered_headers: list[tuple[bytes, bytes]] = [
         (name, value)
@@ -164,7 +225,24 @@ def _set_unquoted_cookie(
 
 
 def create_health_routes(runtime: Runtime, base_url: str | None) -> list[BaseRoute]:
-    """Create health check route handlers."""
+    """Create health check route handlers for /_stcore/health.
+
+    The health endpoint returns 200 OK when the runtime is ready to accept
+    browser connections, or 503 Service Unavailable otherwise. This is used
+    by load balancers and orchestration systems to determine service readiness.
+
+    Parameters
+    ----------
+    runtime
+        The Streamlit runtime instance to check health status.
+    base_url
+        Optional base URL path prefix for the routes.
+
+    Returns
+    -------
+    list[BaseRoute]
+        List of Starlette Route objects for GET, HEAD, and OPTIONS methods.
+    """
     from starlette.responses import PlainTextResponse, Response
     from starlette.routing import Route
 
@@ -316,7 +394,24 @@ def create_host_config_routes(base_url: str | None) -> list[BaseRoute]:
 def create_media_routes(
     media_storage: MemoryMediaFileStorage, base_url: str | None
 ) -> list[BaseRoute]:
-    """Create media file route handlers."""
+    """Create media file route handlers for /media/{file_id}.
+
+    Serves media files (images, audio, video) stored by st.image, st.audio,
+    st.video, and st.download_button. Supports HTTP range requests for
+    streaming media playback.
+
+    Parameters
+    ----------
+    media_storage
+        The media file storage backend.
+    base_url
+        Optional base URL path prefix for the routes.
+
+    Returns
+    -------
+    list[BaseRoute]
+        List of Starlette Route objects for GET, HEAD, and OPTIONS methods.
+    """
     from starlette.exceptions import HTTPException
     from starlette.responses import Response
     from starlette.routing import Route
@@ -406,7 +501,25 @@ def create_upload_routes(
     upload_mgr: MemoryUploadedFileManager,
     base_url: str | None,
 ) -> list[BaseRoute]:
-    """Create file upload route handlers."""
+    """Create file upload route handlers for /_stcore/upload_file/{session_id}/{file_id}.
+
+    Handles file uploads from st.file_uploader widgets. Supports PUT for uploading
+    files and DELETE for removing them. XSRF protection is enforced when enabled.
+
+    Parameters
+    ----------
+    runtime
+        The Streamlit runtime instance (used to validate session IDs).
+    upload_mgr
+        The uploaded file manager to store/retrieve files.
+    base_url
+        Optional base URL path prefix for the routes.
+
+    Returns
+    -------
+    list[BaseRoute]
+        List of Starlette Route objects for PUT, DELETE, and OPTIONS methods.
+    """
     from starlette.datastructures import UploadFile
     from starlette.exceptions import HTTPException
     from starlette.responses import Response

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -260,7 +260,10 @@ def create_metrics_routes(runtime: Runtime, base_url: str | None) -> list[BaseRo
     from starlette.routing import Route
 
     async def _metrics_endpoint(request: Request) -> Response:
-        stats = runtime.stats_mgr.get_stats()
+        requested_families = request.query_params.getlist("families")
+        stats = runtime.stats_mgr.get_stats(
+            family_names=requested_families if requested_families else None
+        )
         accept = request.headers.get("Accept", "")
         if "application/x-protobuf" in accept:
             payload = StatsRequestHandler._stats_to_proto(stats).SerializeToString()

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -1,0 +1,752 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Route handlers for the Starlette server."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+from urllib.parse import quote
+
+from streamlit import config, file_util
+from streamlit.logger import get_logger
+from streamlit.runtime.media_file_storage import MediaFileKind, MediaFileStorageError
+from streamlit.runtime.memory_media_file_storage import get_extension_for_mimetype
+from streamlit.runtime.uploaded_file_manager import UploadedFileRec
+from streamlit.web.server.app_static_file_handler import (
+    MAX_APP_STATIC_FILE_SIZE,
+    SAFE_APP_STATIC_FILE_EXTENSIONS,
+)
+from streamlit.web.server.component_file_utils import (
+    build_safe_abspath,
+    guess_content_type,
+)
+from streamlit.web.server.routes import (
+    _DEFAULT_ALLOWED_MESSAGE_ORIGINS,
+    allow_all_cross_origin_requests,
+    is_allowed_origin,
+)
+from streamlit.web.server.server_util import get_url, is_xsrf_enabled
+from streamlit.web.server.starlette import starlette_app_utils
+from streamlit.web.server.starlette.starlette_server_config import XSRF_COOKIE_NAME
+from streamlit.web.server.stats_request_handler import StatsRequestHandler
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.routing import BaseRoute
+
+    from streamlit.components.types.base_component_registry import BaseComponentRegistry
+    from streamlit.components.v2.component_manager import BidiComponentManager
+    from streamlit.runtime import Runtime
+    from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+    from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
+
+_LOGGER: Final = get_logger(__name__)
+
+# Route path constants (without base URL prefix)
+# These define the canonical paths for all Starlette server endpoints.
+
+# Health check routes
+_ROUTE_HEALTH: Final = "_stcore/health"
+_ROUTE_SCRIPT_HEALTH: Final = "_stcore/script-health-check"
+
+# Metrics routes
+_ROUTE_METRICS: Final = "_stcore/metrics"
+
+# Host configuration
+_ROUTE_HOST_CONFIG: Final = "_stcore/host-config"
+
+# Media and file routes
+_ROUTE_MEDIA: Final = "media/{file_id:path}"
+_ROUTE_UPLOAD_FILE: Final = "_stcore/upload_file/{session_id}/{file_id}"
+
+# Component routes
+_ROUTE_COMPONENTS_V1: Final = "component/{path:path}"
+_ROUTE_COMPONENTS_V2: Final = "_stcore/bidi-components/{path:path}"
+
+# App static files
+_ROUTE_APP_STATIC: Final = "app/static/{path:path}"
+
+
+def _with_base(path: str, base_url: str | None = None) -> str:
+    """Prepend the base URL path to a route path."""
+    from streamlit.url_util import make_url_path
+
+    base = (
+        base_url if base_url is not None else config.get_option("server.baseUrlPath")
+    ) or ""
+    return make_url_path(base, path)
+
+
+async def _set_cors_headers(request: Request, response: Response) -> None:
+    """Set CORS headers on a response based on configuration."""
+    if allow_all_cross_origin_requests():
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        return
+
+    origin = request.headers.get("Origin")
+    if origin and is_allowed_origin(origin):
+        response.headers["Access-Control-Allow-Origin"] = origin
+
+
+def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
+    """Ensure that the XSRF cookie is set.
+
+    We manually manage XSRF generation and validation here to strictly match
+    Tornado's implementation and cookie format.
+    """
+    if not is_xsrf_enabled():
+        return
+
+    cookie_name = XSRF_COOKIE_NAME
+    raw_cookie = request.cookies.get(cookie_name)
+    token_bytes: bytes | None = None
+    timestamp: int | None = None
+    if raw_cookie:
+        token_bytes, timestamp = starlette_app_utils.decode_xsrf_token_string(
+            raw_cookie
+        )
+
+    cookie_value = starlette_app_utils.generate_xsrf_token_string(
+        token_bytes, timestamp
+    )
+
+    _set_unquoted_cookie(
+        response,
+        cookie_name,
+        cookie_value,
+        secure=bool(config.get_option("server.sslCertFile")),
+    )
+
+
+def _validate_xsrf_token(supplied_token: str | None, xsrf_cookie: str | None) -> bool:
+    """Validate the XSRF token from the request header against the cookie.
+
+    This mirrors Tornado's XSRF validation logic to ensure compatibility.
+    """
+    import hmac
+
+    if not supplied_token or not xsrf_cookie:
+        return False
+
+    supplied_token_bytes, _ = starlette_app_utils.decode_xsrf_token_string(
+        supplied_token
+    )
+    expected_token_bytes, _ = starlette_app_utils.decode_xsrf_token_string(xsrf_cookie)
+
+    if not supplied_token_bytes or not expected_token_bytes:
+        return False
+
+    return hmac.compare_digest(supplied_token_bytes, expected_token_bytes)
+
+
+def _set_unquoted_cookie(
+    response: Response,
+    cookie_name: str,
+    cookie_value: str,
+    *,
+    secure: bool,
+) -> None:
+    """Set a cookie without quoting the value (for Tornado compatibility)."""
+    header_value = "; ".join(
+        [
+            f"{cookie_name}={cookie_value}",
+            "Path=/",
+            "SameSite=Lax",
+            *(["Secure"] if secure else []),
+        ]
+    )
+
+    key_prefix = f"{cookie_name}=".encode("latin-1")
+    filtered_headers: list[tuple[bytes, bytes]] = [
+        (name, value)
+        for name, value in response.raw_headers
+        if not (
+            name.lower() == b"set-cookie"
+            and value.lower().startswith(key_prefix.lower())
+        )
+    ]
+    filtered_headers.append((b"set-cookie", header_value.encode("latin-1")))
+    response.raw_headers = filtered_headers
+
+
+def create_health_routes(runtime: Runtime, base_url: str | None) -> list[BaseRoute]:
+    """Create health check route handlers."""
+    from starlette.responses import PlainTextResponse, Response
+    from starlette.routing import Route
+
+    async def _health_endpoint(request: Request) -> PlainTextResponse:
+        ok, message = await runtime.is_ready_for_browser_connection
+        status = 200 if ok else 503
+        response = PlainTextResponse(message, status_code=status)
+        response.headers["Cache-Control"] = "no-cache"
+        await _set_cors_headers(request, response)
+        _ensure_xsrf_cookie(request, response)
+        return response
+
+    async def _health_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        response.headers["Cache-Control"] = "no-cache"
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_HEALTH, base_url),
+            _health_endpoint,
+            methods=["GET", "HEAD"],
+        ),
+        Route(
+            _with_base(_ROUTE_HEALTH, base_url),
+            _health_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_script_health_routes(
+    runtime: Runtime, base_url: str | None
+) -> list[BaseRoute]:
+    """Create script health check route handlers."""
+    from starlette.responses import PlainTextResponse, Response
+    from starlette.routing import Route
+
+    async def _script_health_endpoint(request: Request) -> PlainTextResponse:
+        ok, message = await runtime.does_script_run_without_error()
+        status = 200 if ok else 503
+        response = PlainTextResponse(message, status_code=status)
+        response.headers["Cache-Control"] = "no-cache"
+        await _set_cors_headers(request, response)
+        _ensure_xsrf_cookie(request, response)
+        return response
+
+    async def _script_health_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        response.headers["Cache-Control"] = "no-cache"
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_SCRIPT_HEALTH, base_url),
+            _script_health_endpoint,
+            methods=["GET", "HEAD"],
+        ),
+        Route(
+            _with_base(_ROUTE_SCRIPT_HEALTH, base_url),
+            _script_health_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_metrics_routes(runtime: Runtime, base_url: str | None) -> list[BaseRoute]:
+    """Create metrics route handlers."""
+    from starlette.responses import PlainTextResponse, Response
+    from starlette.routing import Route
+
+    async def _metrics_endpoint(request: Request) -> Response:
+        stats = runtime.stats_mgr.get_stats()
+        accept = request.headers.get("Accept", "")
+        if "application/x-protobuf" in accept:
+            payload = StatsRequestHandler._stats_to_proto(stats).SerializeToString()
+            response = Response(payload, media_type="application/x-protobuf")
+        else:
+            text = StatsRequestHandler._stats_to_text(stats)
+            response = PlainTextResponse(
+                text, media_type="application/openmetrics-text"
+            )
+        await _set_cors_headers(request, response)
+        return response
+
+    async def _metrics_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        response.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "Accept"
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_METRICS, base_url),
+            _metrics_endpoint,
+            methods=["GET"],
+        ),
+        Route(
+            _with_base(_ROUTE_METRICS, base_url),
+            _metrics_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_host_config_routes(base_url: str | None) -> list[BaseRoute]:
+    """Create host config route handlers."""
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    async def _host_config_endpoint(request: Request) -> JSONResponse:
+        allowed = list(_DEFAULT_ALLOWED_MESSAGE_ORIGINS)
+        if (
+            config.get_option("global.developmentMode")
+            and "http://localhost" not in allowed
+        ):
+            allowed.append("http://localhost")
+
+        response = JSONResponse(
+            {
+                "allowedOrigins": allowed,
+                "useExternalAuthToken": False,
+                "enableCustomParentMessages": False,
+                "enforceDownloadInNewTab": False,
+                "metricsUrl": "",
+                "blockErrorDialogs": False,
+                "resourceCrossOriginMode": None,
+            }
+        )
+        await _set_cors_headers(request, response)
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_HOST_CONFIG, base_url),
+            _host_config_endpoint,
+            methods=["GET"],
+        ),
+    ]
+
+
+def create_media_routes(
+    media_storage: MemoryMediaFileStorage, base_url: str | None
+) -> list[BaseRoute]:
+    """Create media file route handlers."""
+    from starlette.exceptions import HTTPException
+    from starlette.responses import Response
+    from starlette.routing import Route
+
+    async def _media_endpoint(request: Request) -> Response:
+        file_id = request.path_params["file_id"]
+
+        try:
+            media_file = media_storage.get_file(file_id)
+        except MediaFileStorageError as exc:
+            raise HTTPException(status_code=404, detail="File not found") from exc
+
+        headers: dict[str, str] = {}
+
+        if media_file.kind == MediaFileKind.DOWNLOADABLE:
+            filename = media_file.filename
+            if not filename:
+                filename = (
+                    f"streamlit_download"
+                    f"{get_extension_for_mimetype(media_file.mimetype)}"
+                )
+            try:
+                filename.encode("latin1")
+                disposition = f'filename="{filename}"'
+            except UnicodeEncodeError:
+                disposition = f"filename*=utf-8''{quote(filename)}"
+            headers["Content-Disposition"] = f"attachment; {disposition}"
+
+        # Ensure support for range requests (e.g. for video files)
+        headers["Accept-Ranges"] = "bytes"
+
+        content = media_file.content
+        content_length = len(content)
+        status_code = 200
+        range_header = request.headers.get("range")
+        if range_header:
+            try:
+                range_start, range_end = starlette_app_utils.parse_range_header(
+                    range_header, content_length
+                )
+            except ValueError:
+                raise HTTPException(
+                    status_code=416,
+                    detail="Invalid range",
+                    headers={"Content-Range": f"bytes */{content_length}"},
+                )
+            status_code = 206
+            content = content[range_start : range_end + 1]
+            headers["Content-Range"] = (
+                f"bytes {range_start}-{range_end}/{content_length}"
+            )
+            headers["Content-Length"] = str(len(content))
+        else:
+            headers["Content-Length"] = str(content_length)
+
+        response = Response(
+            content,
+            status_code=status_code,
+            media_type=media_file.mimetype or "text/plain",
+            headers=headers,
+        )
+        await _set_cors_headers(request, response)
+        return response
+
+    async def _media_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_MEDIA, base_url),
+            _media_endpoint,
+            # HEAD is needed for browsers (especially WebKit) to probe media files
+            methods=["GET", "HEAD"],
+        ),
+        Route(
+            _with_base(_ROUTE_MEDIA, base_url),
+            _media_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_upload_routes(
+    runtime: Runtime,
+    upload_mgr: MemoryUploadedFileManager,
+    base_url: str | None,
+) -> list[BaseRoute]:
+    """Create file upload route handlers."""
+    from starlette.datastructures import UploadFile
+    from starlette.exceptions import HTTPException
+    from starlette.responses import Response
+    from starlette.routing import Route
+
+    def _check_xsrf(request: Request) -> None:
+        """Validate XSRF token for non-safe HTTP methods.
+
+        Raises HTTPException with 403 if XSRF is enabled and validation fails.
+        This mirrors Tornado's automatic XSRF protection for non-GET requests.
+        """
+        if not is_xsrf_enabled():
+            return
+
+        xsrf_header = request.headers.get("X-Xsrftoken")
+        xsrf_cookie = request.cookies.get(XSRF_COOKIE_NAME)
+
+        if not _validate_xsrf_token(xsrf_header, xsrf_cookie):
+            raise HTTPException(status_code=403, detail="XSRF token missing or invalid")
+
+    async def _set_upload_headers(request: Request, response: Response) -> None:
+        response.headers["Access-Control-Allow-Methods"] = "PUT, OPTIONS, DELETE"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        if is_xsrf_enabled():
+            response.headers["Access-Control-Allow-Origin"] = get_url(
+                config.get_option("browser.serverAddress")
+            )
+            response.headers["Access-Control-Allow-Headers"] = (
+                "X-Xsrftoken, Content-Type"
+            )
+            response.headers["Vary"] = "Origin"
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+        else:
+            await _set_cors_headers(request, response)
+
+    async def _upload_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        await _set_upload_headers(request, response)
+        return response
+
+    async def _upload_put(request: Request) -> Response:
+        """Upload a file to the server."""
+
+        _check_xsrf(request)
+
+        session_id = request.path_params["session_id"]
+        file_id = request.path_params["file_id"]
+
+        if not runtime.is_active_session(session_id):
+            raise HTTPException(status_code=400, detail="Invalid session_id")
+
+        max_size_bytes = (  # maxUploadSize is in megabytes
+            config.get_option("server.maxUploadSize") * 1024 * 1024
+        )
+
+        # 1. Fast fail via header (if present) - check before reading the body
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > max_size_bytes:
+            raise HTTPException(status_code=413, detail="File too large")
+
+        form = await request.form()
+        uploads = [value for value in form.values() if isinstance(value, UploadFile)]
+
+        if len(uploads) != 1:
+            raise HTTPException(
+                status_code=400, detail=f"Expected 1 file, but got {len(uploads)}"
+            )
+
+        upload = uploads[0]
+
+        # 2. Check actual file size (Content-Length may be absent or inaccurate)
+        # TODO(lukasmasuch): Improve by using a streaming approach that rejects uploads as soon as
+        # they exceed max_size_bytes, rather than waiting for the full upload to complete.
+        data = await upload.read()
+        upload.file.close()
+        if len(data) > max_size_bytes:
+            raise HTTPException(status_code=413, detail="File too large")
+
+        upload_mgr.add_file(
+            session_id=session_id,
+            file=UploadedFileRec(
+                file_id=file_id,
+                name=upload.filename or "",
+                type=upload.content_type or "application/octet-stream",
+                data=data,
+            ),
+        )
+
+        response = Response(status_code=204)
+        await _set_upload_headers(request, response)
+        return response
+
+    async def _upload_delete(request: Request) -> Response:
+        """Delete a file from the server."""
+
+        _check_xsrf(request)
+
+        session_id = request.path_params["session_id"]
+        file_id = request.path_params["file_id"]
+
+        upload_mgr.remove_file(session_id=session_id, file_id=file_id)
+        response = Response(status_code=204)
+        await _set_upload_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_UPLOAD_FILE, base_url),
+            _upload_put,
+            methods=["PUT"],
+        ),
+        Route(
+            _with_base(_ROUTE_UPLOAD_FILE, base_url),
+            _upload_delete,
+            methods=["DELETE"],
+        ),
+        Route(
+            _with_base(_ROUTE_UPLOAD_FILE, base_url),
+            _upload_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_component_routes(
+    component_registry: BaseComponentRegistry, base_url: str | None
+) -> list[BaseRoute]:
+    """Create custom component route handlers."""
+    import anyio
+    from starlette.exceptions import HTTPException
+    from starlette.responses import Response
+    from starlette.routing import Route
+
+    async def _component_endpoint(request: Request) -> Response:
+        path = request.path_params["path"]
+        parts = path.split("/", maxsplit=1)
+
+        if len(parts) == 0 or not parts[0]:
+            raise HTTPException(status_code=404, detail="Component not found")
+
+        component_name = parts[0]
+        filename = parts[1] if len(parts) == 2 else ""
+
+        component_root = component_registry.get_component_path(component_name)
+        if component_root is None:
+            raise HTTPException(status_code=404, detail="Component not found")
+
+        # Use build_safe_abspath to properly resolve symlinks and prevent traversal
+        abspath = build_safe_abspath(component_root, filename)
+        if abspath is None:
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        try:
+            async with await anyio.open_file(abspath, "rb") as file:
+                data = await file.read()
+        except OSError as exc:
+            raise HTTPException(status_code=404, detail="read error") from exc
+
+        response = Response(content=data, media_type=guess_content_type(abspath))
+        await _set_cors_headers(request, response)
+
+        if not filename or filename.endswith(".html"):
+            response.headers["Cache-Control"] = "no-cache"
+        else:
+            response.headers["Cache-Control"] = "public"
+
+        return response
+
+    async def _component_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_COMPONENTS_V1, base_url),
+            _component_endpoint,
+            methods=["GET"],
+        ),
+        Route(
+            _with_base(_ROUTE_COMPONENTS_V1, base_url),
+            _component_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_bidi_component_routes(
+    bidi_component_manager: BidiComponentManager, base_url: str | None
+) -> list[BaseRoute]:
+    """Create bidirectional component route handlers."""
+    import anyio
+    from starlette.responses import PlainTextResponse, Response
+    from starlette.routing import Route
+
+    async def _bidi_component_endpoint(request: Request) -> Response:
+        async def _text_response(body: str, status_code: int) -> PlainTextResponse:
+            response = PlainTextResponse(body, status_code=status_code)
+            await _set_cors_headers(request, response)
+            return response
+
+        path = request.path_params["path"]
+        parts = path.split("/")
+        component_name = parts[0] if parts else ""
+        if not component_name:
+            return await _text_response("not found", 404)
+
+        if bidi_component_manager.get(component_name) is None:
+            return await _text_response("not found", 404)
+
+        component_root = bidi_component_manager.get_component_path(component_name)
+        if component_root is None:
+            return await _text_response("not found", 404)
+
+        filename = "/".join(parts[1:])
+        if not filename or filename.endswith("/"):
+            return await _text_response("not found", 404)
+
+        abspath = build_safe_abspath(component_root, filename)
+        if abspath is None:
+            return await _text_response("forbidden", 403)
+
+        if os.path.isdir(abspath):
+            return await _text_response("not found", 404)
+
+        try:
+            async with await anyio.open_file(abspath, "rb") as file:
+                data = await file.read()
+        except OSError:
+            sanitized_abspath = abspath.replace("\n", "").replace("\r", "")
+            _LOGGER.exception(
+                "Error reading bidi component asset: %s", sanitized_abspath
+            )
+            return await _text_response("read error", 404)
+
+        response = Response(content=data, media_type=guess_content_type(abspath))
+        await _set_cors_headers(request, response)
+
+        if filename.endswith(".html"):
+            response.headers["Cache-Control"] = "no-cache"
+        else:
+            response.headers["Cache-Control"] = "public"
+
+        return response
+
+    async def _bidi_component_options(request: Request) -> Response:
+        response = Response(status_code=204)
+        await _set_cors_headers(request, response)
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_COMPONENTS_V2, base_url),
+            _bidi_component_endpoint,
+            methods=["GET"],
+        ),
+        Route(
+            _with_base(_ROUTE_COMPONENTS_V2, base_url),
+            _bidi_component_options,
+            methods=["OPTIONS"],
+        ),
+    ]
+
+
+def create_app_static_serving_routes(
+    main_script_path: str | None, base_url: str | None
+) -> list[BaseRoute]:
+    """Create app static serving file route handlers."""
+    from starlette.exceptions import HTTPException
+    from starlette.responses import FileResponse, Response
+    from starlette.routing import Route
+
+    app_static_root = (
+        os.path.realpath(file_util.get_app_static_dir(main_script_path))
+        if main_script_path
+        else None
+    )
+
+    async def _app_static_endpoint(request: Request) -> Response:
+        if not app_static_root:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        relative_path = request.path_params.get("path", "")
+        safe_path = build_safe_abspath(app_static_root, relative_path)
+        if safe_path is None:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        if not os.path.exists(safe_path) or os.path.isdir(safe_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        if os.path.getsize(safe_path) > MAX_APP_STATIC_FILE_SIZE:
+            raise HTTPException(
+                status_code=404,
+                detail="File is too large",
+            )
+
+        ext = Path(safe_path).suffix.lower()
+        media_type = None
+        if ext not in SAFE_APP_STATIC_FILE_EXTENSIONS:
+            media_type = "text/plain"
+
+        response = FileResponse(safe_path, media_type=media_type)
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        return response
+
+    async def _app_static_options(_request: Request) -> Response:
+        response = Response(status_code=204)
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return response
+
+    return [
+        Route(
+            _with_base(_ROUTE_APP_STATIC, base_url),
+            _app_static_endpoint,
+            methods=["GET"],
+        ),
+        Route(
+            _with_base(_ROUTE_APP_STATIC, base_url),
+            _app_static_options,
+            methods=["OPTIONS"],
+        ),
+    ]

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -506,8 +506,10 @@ def create_upload_routes(
         # 2. Check actual file size (Content-Length may be absent or inaccurate)
         # TODO(lukasmasuch): Improve by using a streaming approach that rejects uploads as soon as
         # they exceed max_size_bytes, rather than waiting for the full upload to complete.
-        data = await upload.read()
-        upload.file.close()
+        try:
+            data = await upload.read()
+        finally:
+            upload.file.close()
         if len(data) > max_size_bytes:
             raise HTTPException(status_code=413, detail="File too large")
 

--- a/lib/streamlit/web/server/starlette/starlette_server_config.py
+++ b/lib/streamlit/web/server/starlette/starlette_server_config.py
@@ -1,0 +1,55 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the Starlette server."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Cookie name for storing signed user identity information.
+USER_COOKIE_NAME: Final = "_streamlit_user"
+# Cookie name for storing signed OAuth tokens (access_token, id_token).
+TOKENS_COOKIE_NAME: Final = "_streamlit_user_tokens"
+# Cookie name for Cross-Site Request Forgery (XSRF) token validation.
+XSRF_COOKIE_NAME: Final = "_streamlit_xsrf"
+# Cookie name for server-side session management.
+SESSION_COOKIE_NAME: Final = "_streamlit_session"
+
+# Max pending messages per client in the send queue before disconnecting.
+# Each connected client has its own queue; under normal conditions the queue drains
+# continuously and rarely exceeds single digits. This limit protects against slow
+# clients (bad network, paused tabs) causing unbounded server memory growth.
+# With N concurrent users, worst case memory is N * WEBSOCKET_MAX_SEND_QUEUE_SIZE * msg_size.
+WEBSOCKET_MAX_SEND_QUEUE_SIZE: Final = 500
+
+# Gzip middleware configuration:
+# Do not GZip responses that are smaller than this minimum size in bytes:
+GZIP_MINIMUM_SIZE: Final = 500
+# Used during GZip compression. It is an integer ranging from 1 to 9.
+# Lower value results in faster compression but larger file sizes, while higher value
+# results in slower compression but smaller file sizes.
+GZIP_COMPRESSLEVEL: Final = 6
+
+# When server.port is not available it will look for the next available port
+# up to this number of retries.
+MAX_PORT_SEARCH_RETRIES: Final = 100
+
+# Default address to bind to when no address is configured:
+DEFAULT_SERVER_ADDRESS: Final = "0.0.0.0"  # noqa: S104
+
+# Default WebSocket ping interval in seconds, can be configured by the user
+DEFAULT_WEBSOCKET_PING_INTERVAL: Final = 30
+# Default WebSocket ping timeout in seconds, can be configured by the user
+DEFAULT_WEBSOCKET_PING_TIMEOUT: Final = 30

--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -1,0 +1,168 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static file handling for the Starlette server.
+
+This is for serving the core Streamlit static assets (HTML/JS/CSS)
+not related to the app static file serving feature.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Final
+
+from streamlit import file_util
+from streamlit.url_util import make_url_path
+from streamlit.web.server.routes import (
+    NO_CACHE_PATTERN,
+    STATIC_ASSET_CACHE_MAX_AGE_SECONDS,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+    from starlette.routing import BaseRoute
+    from starlette.staticfiles import StaticFiles
+    from starlette.types import Receive, Scope, Send
+
+# Reserved paths that should return 404 instead of index.html fallback.
+_RESERVED_STATIC_PATH_SUFFIXES: Final = ("_stcore/health", "_stcore/host-config")
+
+
+def create_streamlit_static_handler(
+    directory: str, base_url: str | None
+) -> StaticFiles:
+    """Create a static file handler used for serving the Streamlit's static assets.
+
+    This also handles:
+    - SPA fallback (serving index.html on 404s for client-side routing)
+    - Long-term caching of hashed assets
+    - No-cache for HTML/manifest files
+    - Trailing slash redirect (301)
+    - Double-slash protection (403 for protocol-relative URL security)
+    """
+    from starlette.exceptions import HTTPException
+    from starlette.responses import FileResponse, RedirectResponse, Response
+    from starlette.staticfiles import StaticFiles
+
+    class _StreamlitStaticFiles(StaticFiles):
+        def __init__(self, directory: str, base_url: str | None) -> None:
+            super().__init__(directory=directory, html=True)
+            self._base_url = (base_url or "").strip("/")
+            self._index_path = os.path.join(directory, "index.html")
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            """Handle incoming requests with security checks and redirects."""
+            if scope["type"] != "http":
+                await super().__call__(scope, receive, send)
+                return
+
+            path = scope.get("path", "")
+
+            # Security check: Block paths starting with double slash (protocol-relative
+            # URL protection). A path like //example.com could be misinterpreted as a
+            # protocol-relative URL if redirected, which is a security risk.
+            # This matches Tornado's behavior where such paths would escape the static
+            # directory and trigger a 403 Forbidden.
+            if path.startswith("//"):
+                response = Response(content="Forbidden", status_code=403)
+                await response(scope, receive, send)
+                return
+
+            # Handle trailing slash redirect: return
+            # 301 for paths with trailing slashes (except root "/" or mount root).
+            # We replicate this for consistent URL handling and to avoid duplicate
+            # content issues. When mounted (e.g., at "/app"), scope["path"] is the
+            # full path "/app/" and scope["root_path"] is "/app", so we must not
+            # redirect the mount root to avoid infinite redirect loops.
+            root_path = scope.get("root_path", "")
+            if len(path) > 1 and path.endswith("/"):
+                redirect_path = path.rstrip("/")
+                # Don't redirect if we're at the mount root (path without slash equals root_path)
+                if redirect_path == root_path:
+                    await super().__call__(scope, receive, send)
+                    return
+                # Build redirect URL without trailing slash
+                query_string = scope.get("query_string", b"")
+                if query_string:
+                    redirect_path += "?" + query_string.decode("latin-1")
+                response = RedirectResponse(
+                    url=redirect_path,
+                    status_code=301,
+                    headers={"Cache-Control": "no-cache"},
+                )
+                await response(scope, receive, send)
+                return
+
+            await super().__call__(scope, receive, send)
+
+        async def get_response(
+            self, path: str, scope: MutableMapping[str, Any]
+        ) -> Response:
+            served_path = path
+            try:
+                response = await super().get_response(path, scope)
+            except HTTPException as exc:
+                if exc.status_code != 404 or self._is_reserved(scope["path"]):
+                    raise
+                # Serve index.html for 404s (existing behavior):
+                response = FileResponse(self._index_path)
+                served_path = "index.html"
+
+            self._apply_cache_headers(response, served_path)
+            return response
+
+        def _is_reserved(self, request_path: str) -> bool:
+            """Check if the request path is reserved and should not fallback."""
+            normalized = request_path.split("?", 1)[0].strip("/")
+            if self._base_url and normalized.startswith(self._base_url):
+                normalized = normalized[len(self._base_url) :].strip("/")
+            return any(
+                normalized == suffix or normalized.endswith("/" + suffix)
+                for suffix in _RESERVED_STATIC_PATH_SUFFIXES
+            )
+
+        def _apply_cache_headers(self, response: Response, served_path: str) -> None:
+            """Apply cache headers matching Tornado's behavior."""
+            if response.status_code in {301, 302, 303, 304, 307, 308}:
+                return
+
+            normalized = served_path.replace("\\", "/").lstrip("./")
+            # Tornado marks HTML/manifest assets as no-cache but lets hashed bundles
+            # live in cache. Keep that contract to avoid churning snapshots or CDNs.
+            cache_value = (
+                "no-cache"
+                if not normalized or NO_CACHE_PATTERN.search(normalized)
+                else f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}"
+            )
+            response.headers["Cache-Control"] = cache_value
+
+    return _StreamlitStaticFiles(directory=directory, base_url=base_url)
+
+
+def create_streamlit_static_assets_routes(base_url: str | None) -> list[BaseRoute]:
+    """Create the static assets mount for serving Streamlit's core assets."""
+    from starlette.routing import Mount
+
+    static_assets = create_streamlit_static_handler(
+        directory=file_util.get_static_dir(), base_url=base_url
+    )
+    return [
+        Mount(
+            make_url_path(base_url or "", ""),
+            app=static_assets,
+            name="static-assets",
+        )
+    ]

--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -44,7 +44,7 @@ _RESERVED_STATIC_PATH_SUFFIXES: Final = ("_stcore/health", "_stcore/host-config"
 def create_streamlit_static_handler(
     directory: str, base_url: str | None
 ) -> StaticFiles:
-    """Create a static file handler used for serving the Streamlit's static assets.
+    """Create a static file handler used for serving Streamlit's static assets.
 
     This also handles:
     - SPA fallback (serving index.html on 404s for client-side routing)
@@ -81,8 +81,8 @@ def create_streamlit_static_handler(
                 await response(scope, receive, send)
                 return
 
-            # Handle trailing slash redirect: return
-            # 301 for paths with trailing slashes (except root "/" or mount root).
+            # Handle trailing slash redirect: Returns 301 for paths with trailing
+            # slashes (except root "/" or mount root).
             # We replicate this for consistent URL handling and to avoid duplicate
             # content issues. When mounted (e.g., at "/app"), scope["path"] is the
             # full path "/app/" and scope["root_path"] is "/app", so we must not
@@ -126,13 +126,11 @@ def create_streamlit_static_handler(
 
         def _is_reserved(self, request_path: str) -> bool:
             """Check if the request path is reserved and should not fallback."""
-            normalized = request_path.split("?", 1)[0].strip("/")
-            if self._base_url and normalized.startswith(self._base_url):
-                normalized = normalized[len(self._base_url) :].strip("/")
-            return any(
-                normalized == suffix or normalized.endswith("/" + suffix)
-                for suffix in _RESERVED_STATIC_PATH_SUFFIXES
-            )
+            # Match Tornado's behavior: simple endswith check on the URL path.
+            # TODO: Consider making this path-segment-aware in the future to avoid
+            # false positives like "/my_stcore/health" matching "_stcore/health".
+            url_path = request_path.split("?", 1)[0]
+            return any(url_path.endswith(x) for x in _RESERVED_STATIC_PATH_SUFFIXES)
 
         def _apply_cache_headers(self, response: Response, served_path: str) -> None:
             """Apply cache headers matching Tornado's behavior."""
@@ -159,9 +157,14 @@ def create_streamlit_static_assets_routes(base_url: str | None) -> list[BaseRout
     static_assets = create_streamlit_static_handler(
         directory=file_util.get_static_dir(), base_url=base_url
     )
+    # Strip trailing slash from the path because Starlette's Mount with a trailing
+    # slash (e.g., "/myapp/") won't match requests without it (e.g., "/myapp").
+    # Mount without trailing slash handles both cases by redirecting "/myapp" to
+    # "/myapp/". Use "/" as fallback for root path.
+    mount_path = make_url_path(base_url or "", "").rstrip("/") or "/"
     return [
         Mount(
-            make_url_path(base_url or "", ""),
+            mount_path,
             app=static_assets,
             name="static-assets",
         )

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -23,6 +23,16 @@ pytest>=8.3.5
 pytest-cov
 requests-mock
 testfixtures
+
+# Required for Starlette support:
+starlette>=0.40.0
+uvicorn>=0.30.0
+python-multipart>=0.0.10
+websockets>=12.0.0
+itsdangerous>=2.1.2
+# only for unit tests:
+httpx>=0.24.1
+
 # We pin playwright to a minor version to avoid new browser versions
 # breaking our CI. But this version should be updated regularly as soon as
 # new playwright versions are released.

--- a/lib/tests/streamlit/web/server/starlette/__init__.py
+++ b/lib/tests/streamlit/web/server/starlette/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_utils_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_utils_test.py
@@ -1,0 +1,325 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_app_utils.py."""
+
+from __future__ import annotations
+
+import binascii
+import time
+import unittest
+
+import pytest
+from tornado.util import _websocket_mask
+
+from streamlit.web.server.starlette import starlette_app_utils
+
+
+class StarletteServerUtilsTest(unittest.TestCase):
+    def test_parse_range_header_bytes(self):
+        """Test parsing standard byte ranges."""
+        # Entire file
+        assert starlette_app_utils.parse_range_header("bytes=0-", 100) == (0, 99)
+        # First 10 bytes
+        assert starlette_app_utils.parse_range_header("bytes=0-9", 100) == (0, 9)
+        # Middle range
+        assert starlette_app_utils.parse_range_header("bytes=10-19", 100) == (10, 19)
+        # Last 10 bytes (suffix)
+        assert starlette_app_utils.parse_range_header("bytes=-10", 100) == (90, 99)
+        # Range exceeding end caps at end
+        assert starlette_app_utils.parse_range_header("bytes=90-200", 100) == (
+            90,
+            99,
+        )
+
+    def test_parse_range_header_errors(self):
+        """Test invalid range headers raise ValueError."""
+        # Empty content
+        with pytest.raises(ValueError, match="empty content"):
+            starlette_app_utils.parse_range_header("bytes=0-10", 0)
+
+        # Invalid units
+        with pytest.raises(ValueError, match="invalid range"):
+            starlette_app_utils.parse_range_header("bits=0-10", 100)
+
+        # Multiple ranges not supported
+        with pytest.raises(ValueError, match="invalid range"):
+            starlette_app_utils.parse_range_header("bytes=0-10, 20-30", 100)
+
+        # Invalid start
+        with pytest.raises(ValueError, match="invalid suffix range"):
+            starlette_app_utils.parse_range_header("bytes=-5-10", 100)
+
+        # Start > total
+        with pytest.raises(ValueError, match="start out of range"):
+            starlette_app_utils.parse_range_header("bytes=150-200", 100)
+
+        # End before start
+        with pytest.raises(ValueError, match="end before start"):
+            starlette_app_utils.parse_range_header("bytes=50-40", 100)
+
+    def test_websocket_mask_compatibility(self):
+        """Test that websocket_mask matches Tornado's implementation."""
+        mask = b"1234"
+        data = b"hello world"
+
+        expected = _websocket_mask(mask, data)
+        actual = starlette_app_utils.websocket_mask(mask, data)
+        assert actual == expected
+
+        # It should be reversible (XOR)
+        masked = actual
+        unmasked = starlette_app_utils.websocket_mask(mask, masked)
+        assert unmasked == data
+
+    def test_websocket_mask_empty_data(self):
+        """Test that masking empty data returns empty bytes."""
+        mask = b"1234"
+        data = b""
+
+        result = starlette_app_utils.websocket_mask(mask, data)
+        assert result == b""
+
+    def test_websocket_mask_invalid_mask_length(self):
+        """Test that invalid mask length raises ValueError."""
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"12", b"data")
+
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"12345", b"data")
+
+        with pytest.raises(ValueError, match="mask must be 4 bytes"):
+            starlette_app_utils.websocket_mask(b"", b"data")
+
+    def test_websocket_mask_various_lengths(self):
+        """Test masking data of various lengths matches Tornado."""
+        mask = b"\x01\x02\x03\x04"
+
+        # Test lengths 1-10 to cover different modulo cases
+        for length in range(1, 11):
+            data = bytes(range(length))
+            expected = _websocket_mask(mask, data)
+            actual = starlette_app_utils.websocket_mask(mask, data)
+            assert actual == expected, f"Mismatch for length {length}"
+
+    def test_signed_value_roundtrip(self):
+        """Test that create_signed_value and decode_signed_value work together."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = "test_value"
+
+        # Create a signed value
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+
+        # Decode using our utility
+        decoded = starlette_app_utils.decode_signed_value(secret, name, signed_value)
+        assert decoded is not None
+        assert decoded.decode("utf-8") == value
+
+    def test_signed_value_with_bytes(self):
+        """Test that signed value works with bytes input."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = b"test_value_bytes"
+
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+        decoded = starlette_app_utils.decode_signed_value(secret, name, signed_value)
+        assert decoded == value
+
+    def test_decode_signed_value_invalid_signature(self):
+        """Test that invalid signature returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+
+        # Tampered value
+        result = starlette_app_utils.decode_signed_value(
+            secret, name, "invalid_signed_value"
+        )
+        assert result is None
+
+    def test_decode_signed_value_wrong_secret(self):
+        """Test that wrong secret returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        value = "test_value"
+
+        signed_value = starlette_app_utils.create_signed_value(secret, name, value)
+        result = starlette_app_utils.decode_signed_value(
+            "wrong_secret", name, signed_value
+        )
+        assert result is None
+
+    def test_decode_signed_value_empty_value(self):
+        """Test that empty value returns None."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+
+        # Empty string
+        assert starlette_app_utils.decode_signed_value(secret, name, "") is None
+        # Empty bytes
+        assert starlette_app_utils.decode_signed_value(secret, name, b"") is None
+
+    def test_decode_signed_value_non_utf8_bytes(self):
+        """Test that non-UTF-8 bytes return None instead of raising."""
+        secret = "test_secret_key"
+        name = "test_cookie"
+        # Invalid UTF-8 sequence
+        invalid_utf8 = b"\xff\xfe\x00\x01"
+
+        result = starlette_app_utils.decode_signed_value(secret, name, invalid_utf8)
+        assert result is None
+
+    def test_xsrf_token_roundtrip(self):
+        """Test generating and then decoding an XSRF token."""
+        token = b"some_random_token_bytes"
+        timestamp = int(time.time())
+
+        # Generate string
+        cookie_val = starlette_app_utils.generate_xsrf_token_string(token, timestamp)
+
+        # Verify format
+        assert cookie_val.startswith("2|")
+        parts = cookie_val.split("|")
+        assert len(parts) == 4
+
+        # Decode string
+        decoded_token, decoded_timestamp = starlette_app_utils.decode_xsrf_token_string(
+            cookie_val
+        )
+
+        assert decoded_token == token
+        assert decoded_timestamp == timestamp
+
+    def test_decode_xsrf_token_v1(self):
+        """Test decoding a legacy v1 XSRF token (unmasked hex)."""
+        token = b"legacy_token"
+        hex_token = binascii.b2a_hex(token).decode("ascii")
+
+        # decode_xsrf_token_string treats anything not starting with '2|' as v1
+        decoded_token, decoded_timestamp = starlette_app_utils.decode_xsrf_token_string(
+            hex_token
+        )
+
+        assert decoded_token == token
+        # For v1 tokens, it returns current time as timestamp
+        assert decoded_timestamp is not None
+        assert abs(decoded_timestamp - time.time()) < 2
+
+    def test_decode_xsrf_token_invalid(self):
+        """Test decoding invalid tokens returns (None, None)."""
+        assert starlette_app_utils.decode_xsrf_token_string("invalid") == (
+            None,
+            None,
+        )
+        assert starlette_app_utils.decode_xsrf_token_string("2|bad|format") == (
+            None,
+            None,
+        )
+
+    def test_decode_xsrf_token_empty(self):
+        """Test that empty/whitespace-only strings return (None, None)."""
+        # Empty string
+        assert starlette_app_utils.decode_xsrf_token_string("") == (None, None)
+        # Whitespace only (stripped to empty)
+        assert starlette_app_utils.decode_xsrf_token_string("   ") == (None, None)
+        # Only quotes (stripped to empty)
+        assert starlette_app_utils.decode_xsrf_token_string('""') == (None, None)
+        assert starlette_app_utils.decode_xsrf_token_string("''") == (None, None)
+
+    def test_generate_random_hex_string_default(self):
+        """Test generate_random_hex_string with default length."""
+        result = starlette_app_utils.generate_random_hex_string()
+        # Default is 32 bytes = 64 hex characters
+        assert len(result) == 64
+        # Should be valid hex
+        int(result, 16)
+
+    def test_generate_random_hex_string_custom_length(self):
+        """Test generate_random_hex_string with custom byte count."""
+        result = starlette_app_utils.generate_random_hex_string(16)
+        # 16 bytes = 32 hex characters
+        assert len(result) == 32
+        # Should be valid hex
+        int(result, 16)
+
+    def test_generate_random_hex_string_uniqueness(self):
+        """Test that generate_random_hex_string produces unique values."""
+        results = {starlette_app_utils.generate_random_hex_string() for _ in range(100)}
+        # All 100 should be unique
+        assert len(results) == 100
+
+
+class TestValidateXsrfToken:
+    """Tests for validate_xsrf_token function."""
+
+    def test_returns_false_when_supplied_token_none(self) -> None:
+        """Test that False is returned when supplied token is None."""
+        xsrf_cookie = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(None, xsrf_cookie)
+
+        assert result is False
+
+    def test_returns_false_when_cookie_none(self) -> None:
+        """Test that False is returned when cookie is None."""
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(xsrf_token, None)
+
+        assert result is False
+
+    def test_returns_false_when_both_none(self) -> None:
+        """Test that False is returned when both are None."""
+        result = starlette_app_utils.validate_xsrf_token(None, None)
+
+        assert result is False
+
+    def test_returns_true_for_matching_tokens(self) -> None:
+        """Test that True is returned when tokens match."""
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(xsrf_token, xsrf_token)
+
+        assert result is True
+
+    def test_returns_true_for_matching_tokens_with_different_timestamps(self) -> None:
+        """Test that validation succeeds when tokens have same bytes but different timestamps."""
+        token_bytes = b"0123456789abcdef"
+        token1 = starlette_app_utils.generate_xsrf_token_string(
+            token_bytes, timestamp=12345
+        )
+        token2 = starlette_app_utils.generate_xsrf_token_string(
+            token_bytes, timestamp=67890
+        )
+
+        result = starlette_app_utils.validate_xsrf_token(token1, token2)
+
+        assert result is True
+
+    def test_returns_false_for_different_tokens(self) -> None:
+        """Test that False is returned when tokens differ."""
+        token1 = starlette_app_utils.generate_xsrf_token_string()
+        token2 = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token(token1, token2)
+
+        assert result is False
+
+    def test_returns_false_for_invalid_token_format(self) -> None:
+        """Test that False is returned for invalid token format."""
+        valid_token = starlette_app_utils.generate_xsrf_token_string()
+
+        result = starlette_app_utils.validate_xsrf_token("invalid-token", valid_token)
+
+        assert result is False

--- a/lib/tests/streamlit/web/server/starlette/starlette_gzip_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_gzip_middleware_test.py
@@ -1,0 +1,161 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_gzip_middleware module."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from streamlit.web.server.starlette.starlette_gzip_middleware import (
+    _EXCLUDED_CONTENT_TYPES,
+    MediaAwareGZipMiddleware,
+)
+
+
+def _create_test_app(content_type: str, body: bytes = b"x" * 1000) -> Starlette:
+    """Create a test Starlette app that returns a response with the given content type."""
+
+    async def endpoint(request):
+        return Response(content=body, media_type=content_type)
+
+    app = Starlette(routes=[Route("/", endpoint)])
+    app.add_middleware(MediaAwareGZipMiddleware, minimum_size=100)
+    return app
+
+
+class TestMediaAwareGZipMiddleware:
+    """Tests for MediaAwareGZipMiddleware."""
+
+    def test_compresses_text_content(self) -> None:
+        """Test that text content is compressed when client supports gzip."""
+        app = _create_test_app("text/plain")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_compresses_json_content(self) -> None:
+        """Test that JSON content is compressed when client supports gzip."""
+        app = _create_test_app("application/json")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_does_not_compress_audio_content(self) -> None:
+        """Test that audio content is not compressed."""
+        app = _create_test_app("audio/mpeg")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_video_content(self) -> None:
+        """Test that video content is not compressed."""
+        app = _create_test_app("video/mp4")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+            "audio/webm",
+            "video/mp4",
+            "video/webm",
+            "video/ogg",
+        ],
+        ids=[
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+            "audio/webm",
+            "video/mp4",
+            "video/webm",
+            "video/ogg",
+        ],
+    )
+    def test_excludes_various_media_types(self, content_type: str) -> None:
+        """Test that various audio/video types are excluded from compression."""
+        app = _create_test_app(content_type)
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_when_client_does_not_support_gzip(self) -> None:
+        """Test that content is not compressed when client doesn't support gzip."""
+        app = _create_test_app("text/plain")
+        client = TestClient(app)
+
+        # Explicitly set Accept-Encoding to something other than gzip
+        response = client.get("/", headers={"Accept-Encoding": "identity"})
+
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+
+    def test_does_not_compress_small_content(self) -> None:
+        """Test that small content is not compressed (below minimum_size)."""
+        app = _create_test_app("text/plain", body=b"small")
+        client = TestClient(app)
+
+        response = client.get("/", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        # Small content should not be compressed
+        assert response.headers.get("content-encoding") is None
+
+
+class TestExcludedContentTypes:
+    """Tests for the _EXCLUDED_CONTENT_TYPES constant."""
+
+    def test_includes_audio_prefix(self) -> None:
+        """Test that audio/ prefix is in the excluded types."""
+        assert "audio/" in _EXCLUDED_CONTENT_TYPES
+
+    def test_includes_video_prefix(self) -> None:
+        """Test that video/ prefix is in the excluded types."""
+        assert "video/" in _EXCLUDED_CONTENT_TYPES
+
+    def test_includes_starlette_defaults(self) -> None:
+        """Test that Starlette default exclusions are preserved."""
+        # text/event-stream is excluded by Starlette by default (for SSE)
+        assert "text/event-stream" in _EXCLUDED_CONTENT_TYPES
+
+    def test_extends_starlette_defaults(self) -> None:
+        """Test that our exclusion list extends (not replaces) Starlette defaults."""
+        from starlette.middleware.gzip import DEFAULT_EXCLUDED_CONTENT_TYPES
+
+        # All Starlette defaults should be included
+        for content_type in DEFAULT_EXCLUDED_CONTENT_TYPES:
+            assert content_type in _EXCLUDED_CONTENT_TYPES

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -19,8 +19,15 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import MagicMock
 
+from starlette.responses import Response
+
+from streamlit.web.server.starlette.starlette_app_utils import (
+    generate_xsrf_token_string,
+)
 from streamlit.web.server.starlette.starlette_routes import (
     _set_cors_headers,
+    _set_unquoted_cookie,
+    _validate_xsrf_token,
     _with_base,
 )
 from tests.testutil import patch_config_options
@@ -141,3 +148,111 @@ class TestSetCorsHeaders:
         asyncio.run(_set_cors_headers(request, response))
 
         assert "Access-Control-Allow-Origin" not in response.headers
+
+
+class TestValidateXsrfToken:
+    """Tests for _validate_xsrf_token function."""
+
+    def test_returns_false_when_supplied_token_is_none(self) -> None:
+        """Test that validation fails when supplied token is None."""
+
+        result = _validate_xsrf_token(None, "2|abcd|1234|12345")
+
+        assert result is False
+
+    def test_returns_false_when_cookie_is_none(self) -> None:
+        """Test that validation fails when cookie is None."""
+
+        result = _validate_xsrf_token("2|abcd|1234|12345", None)
+
+        assert result is False
+
+    def test_returns_false_when_both_are_none(self) -> None:
+        """Test that validation fails when both values are None."""
+
+        result = _validate_xsrf_token(None, None)
+
+        assert result is False
+
+    def test_returns_false_for_invalid_token_format(self) -> None:
+        """Test that validation fails for malformed tokens."""
+
+        result = _validate_xsrf_token("invalid", "also_invalid")
+
+        assert result is False
+
+    def test_returns_true_for_matching_tokens(self) -> None:
+        """Test that validation succeeds when tokens match."""
+
+        token_bytes = b"0123456789abcdef"
+        token1 = generate_xsrf_token_string(token_bytes, timestamp=12345)
+        token2 = generate_xsrf_token_string(token_bytes, timestamp=67890)
+
+        result = _validate_xsrf_token(token1, token2)
+
+        assert result is True
+
+    def test_returns_false_for_different_tokens(self) -> None:
+        """Test that validation fails when tokens don't match."""
+
+        token1 = generate_xsrf_token_string(b"0123456789abcdef", timestamp=12345)
+        token2 = generate_xsrf_token_string(b"different_token!", timestamp=12345)
+
+        result = _validate_xsrf_token(token1, token2)
+
+        assert result is False
+
+
+class TestSetUnquotedCookie:
+    """Tests for _set_unquoted_cookie function."""
+
+    def test_sets_cookie_without_quoting(self) -> None:
+        """Test that cookie value is set without URL encoding or quoting."""
+
+        response = Response()
+        cookie_value = "2|abcd1234|efgh5678|1234567890"
+
+        _set_unquoted_cookie(response, "test_cookie", cookie_value, secure=False)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert cookie_headers[0].startswith(f"test_cookie={cookie_value};")
+        assert "Path=/" in cookie_headers[0]
+        assert "SameSite=Lax" in cookie_headers[0]
+        assert "Secure" not in cookie_headers[0]
+
+    def test_sets_secure_flag_when_requested(self) -> None:
+        """Test that Secure flag is added when secure=True."""
+
+        response = Response()
+
+        _set_unquoted_cookie(response, "test_cookie", "value", secure=True)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "Secure" in cookie_headers[0]
+
+    def test_replaces_existing_cookie_with_same_name(self) -> None:
+        """Test that setting a cookie replaces any existing cookie with the same name."""
+
+        response = Response()
+        response.set_cookie("test_cookie", "old_value")
+
+        _set_unquoted_cookie(response, "test_cookie", "new_value", secure=False)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "new_value" in cookie_headers[0]
+        assert "old_value" not in cookie_headers[0]

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -17,15 +17,17 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from starlette.responses import Response
 
 from streamlit.web.server.starlette.starlette_routes import (
+    _ensure_xsrf_cookie,
     _set_cors_headers,
     _set_unquoted_cookie,
     _with_base,
 )
+from streamlit.web.server.starlette.starlette_server_config import XSRF_COOKIE_NAME
 from tests.testutil import patch_config_options
 
 
@@ -144,6 +146,114 @@ class TestSetCorsHeaders:
         asyncio.run(_set_cors_headers(request, response))
 
         assert "Access-Control-Allow-Origin" not in response.headers
+
+    @patch_config_options(
+        {
+            "server.enableCORS": True,
+            "global.developmentMode": False,
+            "server.corsAllowedOrigins": ["http://allowed.example.com"],
+        }
+    )
+    def test_allows_configured_origin(self) -> None:
+        """Test that configured allowed origins are permitted."""
+        request = MagicMock()
+        request.headers = MagicMock()
+        request.headers.get.return_value = "http://allowed.example.com"
+        response = MagicMock()
+        response.headers = {}
+
+        asyncio.run(_set_cors_headers(request, response))
+
+        assert (
+            response.headers["Access-Control-Allow-Origin"]
+            == "http://allowed.example.com"
+        )
+
+
+class TestEnsureXsrfCookie:
+    """Tests for _ensure_xsrf_cookie function."""
+
+    @patch_config_options({"server.enableXsrfProtection": False})
+    def test_no_cookie_when_xsrf_disabled(self) -> None:
+        """Test that no cookie is set when XSRF protection is disabled."""
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 0
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.sslCertFile": None}
+    )
+    def test_generates_new_token_when_no_cookie(self) -> None:
+        """Test that a new XSRF token is generated when no cookie exists."""
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert cookie_headers[0].startswith(f"{XSRF_COOKIE_NAME}=2|")
+        assert "Secure" not in cookie_headers[0]
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.sslCertFile": "/path/to/cert"}
+    )
+    def test_sets_secure_flag_with_ssl(self) -> None:
+        """Test that Secure flag is added when SSL is configured."""
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "Secure" in cookie_headers[0]
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.sslCertFile": None}
+    )
+    @patch(
+        "streamlit.web.server.starlette.starlette_routes.starlette_app_utils.decode_xsrf_token_string"
+    )
+    @patch(
+        "streamlit.web.server.starlette.starlette_routes.starlette_app_utils.generate_xsrf_token_string"
+    )
+    def test_preserves_existing_token(
+        self, mock_generate: MagicMock, mock_decode: MagicMock
+    ) -> None:
+        """Test that existing token bytes and timestamp are preserved."""
+        existing_token = b"existing_token_bytes"
+        existing_timestamp = 1234567890
+        mock_decode.return_value = (existing_token, existing_timestamp)
+        mock_generate.return_value = "2|mocked|token|1234567890"
+
+        request = MagicMock()
+        request.cookies = {XSRF_COOKIE_NAME: "existing_cookie_value"}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        mock_decode.assert_called_once_with("existing_cookie_value")
+        mock_generate.assert_called_once_with(existing_token, existing_timestamp)
 
 
 class TestSetUnquotedCookie:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -21,13 +21,9 @@ from unittest.mock import MagicMock
 
 from starlette.responses import Response
 
-from streamlit.web.server.starlette.starlette_app_utils import (
-    generate_xsrf_token_string,
-)
 from streamlit.web.server.starlette.starlette_routes import (
     _set_cors_headers,
     _set_unquoted_cookie,
-    _validate_xsrf_token,
     _with_base,
 )
 from tests.testutil import patch_config_options
@@ -148,59 +144,6 @@ class TestSetCorsHeaders:
         asyncio.run(_set_cors_headers(request, response))
 
         assert "Access-Control-Allow-Origin" not in response.headers
-
-
-class TestValidateXsrfToken:
-    """Tests for _validate_xsrf_token function."""
-
-    def test_returns_false_when_supplied_token_is_none(self) -> None:
-        """Test that validation fails when supplied token is None."""
-
-        result = _validate_xsrf_token(None, "2|abcd|1234|12345")
-
-        assert result is False
-
-    def test_returns_false_when_cookie_is_none(self) -> None:
-        """Test that validation fails when cookie is None."""
-
-        result = _validate_xsrf_token("2|abcd|1234|12345", None)
-
-        assert result is False
-
-    def test_returns_false_when_both_are_none(self) -> None:
-        """Test that validation fails when both values are None."""
-
-        result = _validate_xsrf_token(None, None)
-
-        assert result is False
-
-    def test_returns_false_for_invalid_token_format(self) -> None:
-        """Test that validation fails for malformed tokens."""
-
-        result = _validate_xsrf_token("invalid", "also_invalid")
-
-        assert result is False
-
-    def test_returns_true_for_matching_tokens(self) -> None:
-        """Test that validation succeeds when tokens match."""
-
-        token_bytes = b"0123456789abcdef"
-        token1 = generate_xsrf_token_string(token_bytes, timestamp=12345)
-        token2 = generate_xsrf_token_string(token_bytes, timestamp=67890)
-
-        result = _validate_xsrf_token(token1, token2)
-
-        assert result is True
-
-    def test_returns_false_for_different_tokens(self) -> None:
-        """Test that validation fails when tokens don't match."""
-
-        token1 = generate_xsrf_token_string(b"0123456789abcdef", timestamp=12345)
-        token2 = generate_xsrf_token_string(b"different_token!", timestamp=12345)
-
-        result = _validate_xsrf_token(token1, token2)
-
-        assert result is False
 
 
 class TestSetUnquotedCookie:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -1,0 +1,141 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_routes module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from streamlit.web.server.starlette.starlette_routes import (
+    _set_cors_headers,
+    _with_base,
+)
+from tests.testutil import patch_config_options
+
+
+class TestWithBase:
+    """Tests for _with_base function."""
+
+    @patch_config_options({"server.baseUrlPath": ""})
+    def test_no_base_url(self) -> None:
+        """Test path with no base URL configured."""
+        result = _with_base("_stcore/health")
+
+        assert result == "/_stcore/health"
+
+    @patch_config_options({"server.baseUrlPath": ""})
+    def test_no_base_url_with_leading_slash(self) -> None:
+        """Test path with leading slash and no base URL."""
+        result = _with_base("/_stcore/health")
+
+        assert result == "/_stcore/health"
+
+    @patch_config_options({"server.baseUrlPath": "myapp"})
+    def test_with_base_url(self) -> None:
+        """Test path with base URL configured."""
+        result = _with_base("_stcore/health")
+
+        assert result == "/myapp/_stcore/health"
+
+    @patch_config_options({"server.baseUrlPath": "/myapp/"})
+    def test_strips_slashes_from_base(self) -> None:
+        """Test that slashes are stripped from base URL."""
+        result = _with_base("_stcore/health")
+
+        assert result == "/myapp/_stcore/health"
+
+    def test_explicit_base_url_overrides_config(self) -> None:
+        """Test that explicit base_url parameter overrides config."""
+        result = _with_base("_stcore/health", base_url="custom")
+
+        assert result == "/custom/_stcore/health"
+
+    def test_explicit_empty_base_url(self) -> None:
+        """Test that explicit empty base_url works."""
+        result = _with_base("_stcore/health", base_url="")
+
+        assert result == "/_stcore/health"
+
+    def test_explicit_none_base_url_uses_config(self) -> None:
+        """Test that explicit None uses config."""
+        with patch_config_options({"server.baseUrlPath": "fromconfig"}):
+            result = _with_base("_stcore/health", base_url=None)
+
+        assert result == "/fromconfig/_stcore/health"
+
+
+class TestSetCorsHeaders:
+    """Tests for _set_cors_headers function."""
+
+    @patch_config_options({"server.enableCORS": False})
+    def test_allows_all_when_cors_disabled(self) -> None:
+        """Test that all origins are allowed when CORS is disabled."""
+
+        request = MagicMock()
+        response = MagicMock()
+        response.headers = {}
+
+        asyncio.run(_set_cors_headers(request, response))
+
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    @patch_config_options({"global.developmentMode": True, "server.enableCORS": True})
+    def test_allows_all_in_dev_mode(self) -> None:
+        """Test that all origins are allowed in development mode."""
+        request = MagicMock()
+        response = MagicMock()
+        response.headers = {}
+
+        asyncio.run(_set_cors_headers(request, response))
+
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    @patch_config_options(
+        {
+            "server.enableCORS": True,
+            "global.developmentMode": False,
+        }
+    )
+    def test_no_header_when_origin_not_allowed(self) -> None:
+        """Test that no header is set when origin is not in allowed list."""
+        request = MagicMock()
+        request.headers = MagicMock()
+        # This origin won't be in any allowed list by default
+        request.headers.get.return_value = "http://random-untrusted-origin.com"
+        response = MagicMock()
+        response.headers = {}
+
+        asyncio.run(_set_cors_headers(request, response))
+
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    @patch_config_options(
+        {
+            "server.enableCORS": True,
+            "global.developmentMode": False,
+        }
+    )
+    def test_no_header_when_no_origin(self) -> None:
+        """Test that no header is set when request has no Origin header."""
+        request = MagicMock()
+        request.headers = MagicMock()
+        request.headers.get.return_value = None
+        response = MagicMock()
+        response.headers = {}
+
+        asyncio.run(_set_cors_headers(request, response))
+
+        assert "Access-Control-Allow-Origin" not in response.headers

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -57,22 +57,24 @@ class TestWithBase:
 
         assert result == "/myapp/_stcore/health"
 
+    @patch_config_options({"server.baseUrlPath": "shouldbeignored"})
     def test_explicit_base_url_overrides_config(self) -> None:
         """Test that explicit base_url parameter overrides config."""
         result = _with_base("_stcore/health", base_url="custom")
 
         assert result == "/custom/_stcore/health"
 
+    @patch_config_options({"server.baseUrlPath": "shouldbeignored"})
     def test_explicit_empty_base_url(self) -> None:
         """Test that explicit empty base_url works."""
         result = _with_base("_stcore/health", base_url="")
 
         assert result == "/_stcore/health"
 
+    @patch_config_options({"server.baseUrlPath": "fromconfig"})
     def test_explicit_none_base_url_uses_config(self) -> None:
         """Test that explicit None uses config."""
-        with patch_config_options({"server.baseUrlPath": "fromconfig"}):
-            result = _with_base("_stcore/health", base_url=None)
+        result = _with_base("_stcore/health", base_url=None)
 
         assert result == "/fromconfig/_stcore/health"
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -258,3 +258,273 @@ class TestWithBaseUrl:
             response = client.get("/app")
             assert response.status_code == 200
             assert response.text == "<html>Nested</html>"
+
+
+class TestDoubleSlashProtection:
+    """Tests for double-slash (protocol-relative URL) security protection.
+
+    Note: We need to test these with raw ASGI scope because HTTP clients
+    interpret //evil.com as a protocol-relative URL, not a path.
+    """
+
+    @pytest.mark.anyio
+    async def test_double_slash_returns_403(self, tmp_path: Path) -> None:
+        """Test that paths starting with // return 403 Forbidden.
+
+        Double-slash paths like //example.com could be misinterpreted as
+        protocol-relative URLs if redirected, which is a security risk.
+        """
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+
+        # Create raw ASGI scope with // path
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "//evil.com",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+        }
+
+        response_started = False
+        response_status = 0
+        response_body = b""
+
+        async def receive() -> dict[str, object]:
+            return {"type": "http.request", "body": b""}
+
+        async def send(message: dict[str, object]) -> None:
+            nonlocal response_started, response_status, response_body
+            if message["type"] == "http.response.start":
+                response_started = True
+                response_status = message["status"]
+            elif message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        await static_files(scope, receive, send)
+
+        assert response_status == 403
+        assert response_body == b"Forbidden"
+
+    @pytest.mark.anyio
+    async def test_double_slash_with_path_returns_403(self, tmp_path: Path) -> None:
+        """Test that paths like //evil.com/path return 403."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "//evil.com/some/path",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+        }
+
+        response_status = 0
+        response_body = b""
+
+        async def receive() -> dict[str, object]:
+            return {"type": "http.request", "body": b""}
+
+        async def send(message: dict[str, object]) -> None:
+            nonlocal response_status, response_body
+            if message["type"] == "http.response.start":
+                response_status = message["status"]
+            elif message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        await static_files(scope, receive, send)
+
+        assert response_status == 403
+        assert response_body == b"Forbidden"
+
+    @pytest.mark.anyio
+    async def test_double_slash_at_root_returns_403(self, tmp_path: Path) -> None:
+        """Test that just // returns 403."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "//",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+        }
+
+        response_status = 0
+        response_body = b""
+
+        async def receive() -> dict[str, object]:
+            return {"type": "http.request", "body": b""}
+
+        async def send(message: dict[str, object]) -> None:
+            nonlocal response_status, response_body
+            if message["type"] == "http.response.start":
+                response_status = message["status"]
+            elif message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        await static_files(scope, receive, send)
+
+        assert response_status == 403
+        assert response_body == b"Forbidden"
+
+    def test_single_slash_path_works(self, static_app: TestClient) -> None:
+        """Test that normal single-slash paths still work correctly."""
+        response = static_app.get("/index.html")
+
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_path_with_double_slash_in_middle_works(
+        self, static_app: TestClient
+    ) -> None:
+        """Test that double slash not at start doesn't trigger protection.
+
+        Only paths starting with // are blocked. Paths like /foo//bar
+        are handled normally by the SPA fallback.
+        """
+        response = static_app.get("/foo//bar")
+
+        # This falls through to SPA fallback, not blocked
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+
+class TestTrailingSlashRedirect:
+    """Tests for trailing slash redirect behavior (301 redirects)."""
+
+    def test_trailing_slash_redirects_to_without(self, tmp_path: Path) -> None:
+        """Test that paths with trailing slash redirect to path without."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            response = client.get("/somepath/")
+
+            assert response.status_code == 301
+            assert response.headers["location"] == "/somepath"
+            assert response.headers["Cache-Control"] == "no-cache"
+
+    def test_nested_trailing_slash_redirects(self, tmp_path: Path) -> None:
+        """Test that nested paths with trailing slash redirect correctly."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            response = client.get("/deep/nested/path/")
+
+            assert response.status_code == 301
+            assert response.headers["location"] == "/deep/nested/path"
+
+    def test_trailing_slash_redirect_preserves_query_string(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that query string is preserved in trailing slash redirect."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            response = client.get("/somepath/?foo=bar&baz=qux")
+
+            assert response.status_code == 301
+            assert response.headers["location"] == "/somepath?foo=bar&baz=qux"
+
+    def test_root_slash_does_not_redirect(self, tmp_path: Path) -> None:
+        """Test that root path '/' does not redirect."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            response = client.get("/")
+
+            # Should serve content, not redirect
+            assert response.status_code == 200
+            assert response.text == "<html>Home</html>"
+
+
+class TestCacheHeadersOnRedirects:
+    """Tests for cache headers behavior on redirect responses."""
+
+    def test_redirect_responses_keep_their_cache_headers(self, tmp_path: Path) -> None:
+        """Test that redirect responses don't get cache headers overwritten.
+
+        The _apply_cache_headers method should skip adding cache headers
+        to redirect responses (301, 302, etc.) to avoid overwriting
+        the redirect-specific Cache-Control header.
+        """
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            response = client.get("/somepath/")
+
+            # Should have the redirect-specific no-cache header, not the
+            # static asset caching header
+            assert response.status_code == 301
+            assert response.headers["Cache-Control"] == "no-cache"
+            assert "immutable" not in response.headers["Cache-Control"]
+
+    def test_regular_html_has_no_cache(self, static_app: TestClient) -> None:
+        """Test that regular HTML files have no-cache header (not redirect)."""
+        response = static_app.get("/index.html")
+
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "no-cache"
+
+    def test_hashed_js_has_long_cache(self, static_app: TestClient) -> None:
+        """Test that hashed JS files have long cache headers (not redirect)."""
+        response = static_app.get("/app.abc123.js")
+
+        assert response.status_code == 200
+        expected = f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}"
+        assert response.headers["Cache-Control"] == expected

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -1,0 +1,261 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_static module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from starlette.testclient import TestClient
+
+from streamlit.web.server.routes import STATIC_ASSET_CACHE_MAX_AGE_SECONDS
+from streamlit.web.server.starlette.starlette_static_routes import (
+    _RESERVED_STATIC_PATH_SUFFIXES,
+    create_streamlit_static_handler,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def static_app(tmp_path: Path) -> Iterator[TestClient]:
+    """Create a test client with static files mounted."""
+
+    # Create static directory with test files
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<html>Home</html>")
+    (static_dir / "app.abc123.js").write_text("console.log('app')")
+    (static_dir / "manifest.json").write_text("{}")
+    (static_dir / "style.css").write_text("body {}")
+
+    # Create subdirectory
+    subdir = static_dir / "subdir"
+    subdir.mkdir()
+    (subdir / "page.html").write_text("<html>Page</html>")
+
+    static_files = create_streamlit_static_handler(
+        directory=str(static_dir), base_url=None
+    )
+    app = Starlette(routes=[Mount("/", app=static_files)])
+
+    with TestClient(app) as client:
+        yield client
+
+
+class TestStreamlitStaticFiles:
+    """Tests for the Streamlit static files handler."""
+
+    def test_serves_index_html(self, static_app: TestClient) -> None:
+        """Test that index.html is served."""
+        response = static_app.get("/index.html")
+
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_serves_root_as_index(self, static_app: TestClient) -> None:
+        """Test that root path serves index.html."""
+        response = static_app.get("/")
+
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_serves_js_files(self, static_app: TestClient) -> None:
+        """Test that JS files are served."""
+        response = static_app.get("/app.abc123.js")
+
+        assert response.status_code == 200
+        assert response.text == "console.log('app')"
+
+    def test_serves_css_files(self, static_app: TestClient) -> None:
+        """Test that CSS files are served."""
+        response = static_app.get("/style.css")
+
+        assert response.status_code == 200
+        assert response.text == "body {}"
+
+    def test_spa_fallback_returns_index(self, static_app: TestClient) -> None:
+        """Test that unknown paths fall back to index.html (SPA routing)."""
+        response = static_app.get("/unknown/path")
+
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_cache_control_for_index(self, static_app: TestClient) -> None:
+        """Test that index.html has no-cache header."""
+        response = static_app.get("/index.html")
+
+        assert response.headers["Cache-Control"] == "no-cache"
+
+    def test_cache_control_for_manifest(self, static_app: TestClient) -> None:
+        """Test that manifest.json has no-cache header."""
+        response = static_app.get("/manifest.json")
+
+        assert response.headers["Cache-Control"] == "no-cache"
+
+    def test_cache_control_for_hashed_assets(self, static_app: TestClient) -> None:
+        """Test that hashed assets have long cache headers."""
+        response = static_app.get("/app.abc123.js")
+
+        expected = f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}"
+        assert response.headers["Cache-Control"] == expected
+
+    def test_cache_control_for_css(self, static_app: TestClient) -> None:
+        """Test that CSS files have long cache headers."""
+        response = static_app.get("/style.css")
+
+        expected = f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}"
+        assert response.headers["Cache-Control"] == expected
+
+    def test_spa_fallback_has_no_cache(self, static_app: TestClient) -> None:
+        """Test that SPA fallback response has no-cache header."""
+        response = static_app.get("/some/spa/route")
+
+        assert response.headers["Cache-Control"] == "no-cache"
+
+
+class TestReservedPaths:
+    """Tests for reserved path handling."""
+
+    def test_reserved_paths_constant(self) -> None:
+        """Test that reserved paths are defined correctly."""
+        assert "_stcore/health" in _RESERVED_STATIC_PATH_SUFFIXES
+        assert "_stcore/host-config" in _RESERVED_STATIC_PATH_SUFFIXES
+
+    def test_reserved_path_returns_404(self, static_app: TestClient) -> None:
+        """Test that reserved paths return 404 instead of SPA fallback."""
+        response = static_app.get("/_stcore/health")
+
+        assert response.status_code == 404
+
+    def test_reserved_path_host_config_returns_404(
+        self, static_app: TestClient
+    ) -> None:
+        """Test that reserved host-config path returns 404."""
+        response = static_app.get("/_stcore/host-config")
+
+        assert response.status_code == 404
+
+    def test_user_path_ending_with_reserved_suffix_gets_spa_fallback(
+        self, static_app: TestClient
+    ) -> None:
+        """Test that user paths ending with reserved suffixes get SPA fallback.
+
+        Paths like /my_stcore/health should NOT be treated as reserved because
+        'my_stcore/health'.endswith('_stcore/health') is True but it's not
+        actually a reserved path - the check should be path-segment aware.
+        """
+        response = static_app.get("/my_stcore/health")
+
+        # Should get SPA fallback (index.html), not 404
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_user_path_custom_stcore_gets_spa_fallback(
+        self, static_app: TestClient
+    ) -> None:
+        """Test that /custom_stcore/host-config gets SPA fallback, not 404."""
+        response = static_app.get("/custom_stcore/host-config")
+
+        # Should get SPA fallback (index.html), not 404
+        assert response.status_code == 200
+        assert response.text == "<html>Home</html>"
+
+    def test_nested_reserved_path_returns_404(self, static_app: TestClient) -> None:
+        """Test that nested reserved paths like /foo/_stcore/health return 404."""
+        response = static_app.get("/foo/_stcore/health")
+
+        assert response.status_code == 404
+
+
+class TestWithBaseUrl:
+    """Tests for static files with base URL."""
+
+    def test_serves_files_with_base_url(self, tmp_path: Path) -> None:
+        """Test that files are served correctly with a base URL."""
+
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Base</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url="myapp"
+        )
+        app = Starlette(routes=[Mount("/myapp", app=static_files)])
+
+        with TestClient(app) as client:
+            response = client.get("/myapp/index.html")
+
+            assert response.status_code == 200
+            assert response.text == "<html>Base</html>"
+
+    def test_no_redirect_loop_when_mounted(self, tmp_path: Path) -> None:
+        """Test that mount root with trailing slash doesn't cause redirect loop.
+
+        When mounted at a path (e.g., /app), requests to /app/ should serve
+        index.html, not redirect to /app which would then redirect back to /app/.
+        """
+
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Mounted</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=""
+        )
+        app = Starlette(routes=[Mount("/app", app=static_files)])
+
+        with TestClient(app, follow_redirects=False) as client:
+            # /app should redirect to /app/ (Starlette's Mount behavior)
+            response = client.get("/app")
+            assert response.status_code == 307
+            assert response.headers["location"] == "http://testserver/app/"
+
+            # /app/ should serve content, NOT redirect to /app
+            response = client.get("/app/")
+            assert response.status_code == 200
+            assert response.text == "<html>Mounted</html>"
+
+    def test_nested_mount_no_redirect_loop(self, tmp_path: Path) -> None:
+        """Test that nested mounts (like FastAPI mounting Streamlit) work correctly."""
+
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Nested</html>")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=""
+        )
+        # Inner app with static files at root (like Streamlit does)
+        inner_app = Starlette(routes=[Mount("/", app=static_files)])
+        # Outer app mounting inner at /app (like FastAPI does)
+        outer_app = Starlette(routes=[Mount("/app", app=inner_app)])
+
+        with TestClient(outer_app, follow_redirects=False) as client:
+            # /app/ should serve content without redirect loop
+            response = client.get("/app/")
+            assert response.status_code == 200
+            assert response.text == "<html>Nested</html>"
+
+        # Also verify it works with follow_redirects
+        with TestClient(outer_app, follow_redirects=True) as client:
+            response = client.get("/app")
+            assert response.status_code == 200
+            assert response.text == "<html>Nested</html>"

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -153,30 +153,29 @@ class TestReservedPaths:
 
         assert response.status_code == 404
 
-    def test_user_path_ending_with_reserved_suffix_gets_spa_fallback(
+    def test_user_path_ending_with_reserved_suffix_returns_404(
         self, static_app: TestClient
     ) -> None:
-        """Test that user paths ending with reserved suffixes get SPA fallback.
+        """Test that paths ending with reserved suffixes return 404.
 
-        Paths like /my_stcore/health should NOT be treated as reserved because
-        'my_stcore/health'.endswith('_stcore/health') is True but it's not
-        actually a reserved path - the check should be path-segment aware.
+        This matches Tornado's behavior where endswith() is used for reserved
+        path matching. Paths like /my_stcore/health return 404 because they
+        end with '_stcore/health'.
+
+        TODO: Consider making this path-segment-aware in the future to avoid
+        false positives.
         """
         response = static_app.get("/my_stcore/health")
 
-        # Should get SPA fallback (index.html), not 404
-        assert response.status_code == 200
-        assert response.text == "<html>Home</html>"
+        # Matches Tornado: endswith check treats this as reserved
+        assert response.status_code == 404
 
-    def test_user_path_custom_stcore_gets_spa_fallback(
-        self, static_app: TestClient
-    ) -> None:
-        """Test that /custom_stcore/host-config gets SPA fallback, not 404."""
+    def test_user_path_custom_stcore_returns_404(self, static_app: TestClient) -> None:
+        """Test that /custom_stcore/host-config returns 404 (matches Tornado)."""
         response = static_app.get("/custom_stcore/host-config")
 
-        # Should get SPA fallback (index.html), not 404
-        assert response.status_code == 200
-        assert response.text == "<html>Home</html>"
+        # Matches Tornado: endswith check treats this as reserved
+        assert response.status_code == 404
 
     def test_nested_reserved_path_returns_404(self, static_app: TestClient) -> None:
         """Test that nested reserved paths like /foo/_stcore/health return 404."""

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -14,5 +14,5 @@ requests==2.27
 tenacity==8.1.0
 toml==0.10.1
 tornado==6.0.3
-typing-extensions==4.4.0
+typing-extensions==4.10.0
 watchdog==2.1.5


### PR DESCRIPTION
## Describe your changes

**Part 3 of 7 of optional [Starlette](https://starlette.dev/) support:** 

Adds static file serving for Streamlit's frontend assets (JS, CSS, etc.) with SPA fallback routing, proper MIME types, and cache headers. Supports both production and development modes.

## Testing Plan

- Added relevant unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
