### PR TITLE
[fix] Ensure crossOrigin attribute is properly set for CCv2 stylesheets

### DIFF
--- a/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/BidiComponent/BidiComponent.test.tsx
@@ -28,6 +28,16 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 import BidiComponent from "./BidiComponent"
 import { blobUrlManager } from "./utils/blobUrl"
 
+vi.mock("@streamlit/utils", async () => {
+  const actual = await vi.importActual("@streamlit/utils")
+  return {
+    ...actual,
+    get StreamlitConfig() {
+      return globalThis.__mockStreamlitConfig
+    },
+  }
+})
+
 // Mock WidgetStateManager
 vi.mock("~lib/WidgetStateManager")
 
@@ -69,6 +79,7 @@ describe("BidiComponent", () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    globalThis.__mockStreamlitConfig = {}
   })
 
   const createMockElement = (
@@ -356,13 +367,87 @@ describe("BidiComponent", () => {
       )
 
       await waitFor(() => {
-        const linkElements = document.querySelectorAll(
-          "link[rel='stylesheet']"
+        const container = screen.getByTestId("stBidiComponentRegular")
+        const linkElement = container.querySelector("link[rel='stylesheet']")
+
+        expect(linkElement).toBeInTheDocument()
+        expect(linkElement?.getAttribute("href")).toContain(
+          "TestComponent/styles.css"
         )
-        const hasExpectedLink = Array.from(linkElements).some(link =>
-          link.getAttribute("href")?.includes("TestComponent/styles.css")
+        expect(linkElement).not.toHaveAttribute("crossOrigin")
+      })
+    })
+
+    describe("linked CSS crossOrigin attribute", () => {
+      beforeEach(() => {
+        globalThis.__mockStreamlitConfig.BACKEND_BASE_URL =
+          "https://backend.example.com:8080/app"
+      })
+
+      it.each([
+        { resourceCrossOriginMode: "anonymous", expected: "anonymous" },
+        {
+          resourceCrossOriginMode: "use-credentials",
+          expected: "use-credentials",
+        },
+      ] as const)(
+        "sets crossOrigin=$expected when cssSourcePath is relative and mode=$resourceCrossOriginMode",
+        async ({ resourceCrossOriginMode, expected }) => {
+          const element = createMockElement({
+            isolateStyles: false,
+            cssSourcePath: "styles.css",
+          })
+
+          const customRegistry = createMockComponentRegistry(
+            (componentName, path) => `/components/${componentName}/${path}`
+          )
+
+          renderWithContexts(
+            <BidiComponent
+              element={element}
+              widgetMgr={mockWidgetMgr}
+              fragmentId={mockFragmentId}
+              componentRegistry={customRegistry}
+            />,
+            { libConfigContext: { resourceCrossOriginMode } }
+          )
+
+          await waitFor(() => {
+            const container = screen.getByTestId("stBidiComponentRegular")
+            const linkElement = container.querySelector(
+              "link[rel='stylesheet']"
+            )
+            expect(linkElement).toHaveAttribute("crossOrigin", expected)
+          })
+        }
+      )
+
+      it("does not set crossOrigin when css URL is absolute and not the backend origin", async () => {
+        const element = createMockElement({
+          isolateStyles: false,
+          cssSourcePath: "styles.css",
+        })
+
+        const customRegistry = createMockComponentRegistry(
+          (componentName, path) =>
+            `https://external.example.com/components/${componentName}/${path}`
         )
-        expect(hasExpectedLink).toBe(true)
+
+        renderWithContexts(
+          <BidiComponent
+            element={element}
+            widgetMgr={mockWidgetMgr}
+            fragmentId={mockFragmentId}
+            componentRegistry={customRegistry}
+          />,
+          { libConfigContext: { resourceCrossOriginMode: "anonymous" } }
+        )
+
+        await waitFor(() => {
+          const container = screen.getByTestId("stBidiComponentRegular")
+          const linkElement = container.querySelector("link[rel='stylesheet']")
+          expect(linkElement).not.toHaveAttribute("crossOrigin")
+        })
       })
     })
   })

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
@@ -19,6 +19,7 @@ import React, { useEffect, useMemo, useRef } from "react"
 import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
 import { handleError } from "~lib/components/widgets/BidiComponent/utils/error"
 import { LOG } from "~lib/components/widgets/BidiComponent/utils/logger"
+import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
 
 /**
@@ -112,6 +113,9 @@ export const useHandleHtmlAndCssContent = ({
     return getBidiComponentURL(componentName, cssSourcePath)
   }, [componentName, cssSourcePath, getBidiComponentURL])
 
+  // Match the app-wide crossOrigin behavior used for media elements.
+  const cssLinkCrossOrigin = useCrossOriginAttribute(cssLinkHref)
+
   useEffect(() => {
     if (skip) {
       return
@@ -144,6 +148,14 @@ export const useHandleHtmlAndCssContent = ({
         const linkElement = document.createElement("link")
         linkElement.href = cssLinkHref
         linkElement.rel = "stylesheet"
+
+        if (cssLinkCrossOrigin) {
+          // Use the computed attribute value to keep behavior consistent with
+          // the rest of the app (see `useCrossOriginAttribute` /
+          // `getCrossOriginAttribute`).
+          linkElement.crossOrigin = cssLinkCrossOrigin
+        }
+
         linkElement.onerror = () => {
           handleError(
             new Error(`Failed to load CSS from ${cssLinkHref}`),
@@ -157,7 +169,15 @@ export const useHandleHtmlAndCssContent = ({
     } catch (error) {
       handleError(error, setError, "Failed to process HTML/CSS content")
     }
-  }, [html, cssContent, containerRef, cssLinkHref, setError, skip])
+  }, [
+    html,
+    cssContent,
+    containerRef,
+    cssLinkCrossOrigin,
+    cssLinkHref,
+    setError,
+    skip,
+  ])
 
   return contentRef
 }


### PR DESCRIPTION
## Describe your changes

Added support for the `crossOrigin` attribute on CSS link elements to CCv2 instances. This ensures that CSS resources loaded from different origins follow the same cross-origin policy as other resources in the application. The implementation:

1. Uses the existing `useCrossOriginAttribute` hook to determine the appropriate crossOrigin value
2. Applies the crossOrigin attribute to link elements when loading CSS from relative paths
3. Maintains consistent behavior with other media elements in the application

## Testing Plan

- Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.