### PR TITLE
[fix] Ensure help Tooltips are accessible

### DIFF
--- a/e2e_playwright/help_tooltip_test.py
+++ b/e2e_playwright/help_tooltip_test.py
@@ -48,7 +48,7 @@ def test_tooltip_does_not_overflow_on_the_right_side(app: Page):
     popover_button = (
         app.get_by_test_id("stPopover")
         .filter(has_text="Popover with toggle")
-        .locator("button")
+        .get_by_test_id("stPopoverButton")
     )
 
     # Ensure popover button is visible and stable before clicking

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -787,14 +787,16 @@ def test_directory_upload_disabled_state(app: Page):
 def test_directory_upload_button_interaction(app: Page):
     """Test directory upload button can be clicked when enabled."""
     chat_input = get_element_by_key(app, "directory")
-    upload_button = chat_input.get_by_test_id("stChatInputFileUploadButton")
+    upload_button = chat_input.get_by_role("button", name="Upload a directory")
 
     expect(upload_button).to_be_visible()
+    expect(upload_button).to_have_accessible_name("Upload a directory")
     expect(upload_button).to_be_enabled()
 
-    # Just verify that the button is clickable without interacting with file chooser
-    # Directory uploads require actual directory paths which we can't simulate
-    expect(upload_button).to_have_attribute("tabindex", "0")
+    # Verify that the button is focusable without interacting with file chooser.
+    # Directory uploads require actual directory paths which we can't simulate.
+    upload_button.focus()
+    expect(upload_button).to_be_focused()
 
 
 @use_chat_input("bottom_max_chars")

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -211,7 +211,7 @@ def test_number_input_has_correct_value_on_blur(app: Page):
 
 def test_number_input_typing_decimal_via_keyboard(app: Page):
     """Typing a decimal value using the keyboard should work and commit correctly."""
-    first_number_input_field = app.get_by_label("number input 1 (default)")
+    first_number_input_field = app.get_by_label("number input 1 (default)", exact=True)
     first_number_input_field.click()
     first_number_input_field.select_text()
     first_number_input_field.type("12.34")

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -32,6 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_slider,
     reset_focus,
     reset_hovering,
+    tab_until_focused,
 )
 
 NUM_SLIDER_WIDGETS = 25
@@ -93,6 +94,28 @@ def test_slider_rendering(themed_app: Page, assert_snapshot: ImageCompareFunctio
 def test_help_tooltip_works(app: Page):
     element_with_help = get_slider(app, "Label 1")
     expect_help_tooltip(app, element_with_help, "This is some help tooltip!")
+
+
+def test_help_tooltip_is_keyboard_accessible(app: Page):
+    """Test that slider help tooltips can be opened via keyboard focus."""
+    slider = get_slider(app, "Label 1")
+    slider.scroll_into_view_if_needed()
+
+    # Ensure no stale tooltip from hover/focus state:
+    reset_hovering(app)
+    reset_focus(app)
+
+    help_button = slider.get_by_role("button", name="Help for Label 1")
+    tab_until_focused(app, help_button)
+    expect(help_button).to_be_focused()
+
+    tooltip = app.get_by_test_id("stTooltipContent")
+    expect(tooltip).to_be_visible()
+    expect(tooltip).to_have_text("This is some help tooltip!")
+
+    # Blur to close:
+    reset_focus(app)
+    expect(tooltip).not_to_be_attached()
 
 
 def test_slider_in_expander(app: Page, assert_snapshot: ImageCompareFunction):

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -33,8 +33,7 @@ import {
 import Icon from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
-import { StyledWidgetLabelHelpInline } from "~lib/components/widgets/BaseWidget"
+import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { formatNumber, isNumericString } from "~lib/util/formatNumber"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
@@ -353,9 +352,11 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
             <StreamlitMarkdown source={label} allowHTML={false} isLabel />
           </StyledTruncateText>
           {help && (
-            <StyledWidgetLabelHelpInline>
-              <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
-            </StyledWidgetLabelHelpInline>
+            <WidgetLabelHelpIconInline
+              content={help}
+              placement={Placement.TOP_RIGHT}
+              label={label}
+            />
           )}
         </StyledMetricLabelText>
         <StyledMetricValueText data-testid="stMetricValue">

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -21,10 +21,9 @@ import { ChromePicker, ColorResult } from "react-color"
 import SaturationComponent from "react-color/es/components/common/Saturation"
 
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelpInline,
   WidgetLabel,
+  WidgetLabelHelpIconInline,
 } from "~lib/components/widgets/BaseWidget"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
@@ -139,9 +138,11 @@ const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
         labelVisibility={labelVisibility}
       >
         {help && (
-          <StyledWidgetLabelHelpInline>
-            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
-          </StyledWidgetLabelHelpInline>
+          <WidgetLabelHelpIconInline
+            content={help}
+            placement={Placement.TOP_RIGHT}
+            label={label}
+          />
         )}
       </WidgetLabel>
       <UIPopover

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -30,11 +30,9 @@ import { type OnChangeParams, Select as UISelect } from "baseui/select"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
 import VirtualDropdown from "~lib/components/shared/Dropdown/VirtualDropdown"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
@@ -140,11 +138,7 @@ const Selectbox: FC<Props> = ({
         labelVisibility={labelVisibility}
         disabled={selectDisabled}
       >
-        {help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
-          </StyledWidgetLabelHelp>
-        )}
+        {help && <WidgetLabelHelpIcon content={help} label={label} />}
       </WidgetLabel>
       <UISelect
         creatable={acceptNewOptions}

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -20,10 +20,9 @@ import { ALIGN, RadioGroup, Radio as UIRadio } from "baseui/radio"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelpInline,
   WidgetLabel,
+  WidgetLabelHelpIconInline,
 } from "~lib/components/widgets/BaseWidget"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { addCssUnit, convertRemToPx, EmotionTheme } from "~lib/theme"
@@ -126,9 +125,11 @@ function Radio({
         labelVisibility={labelVisibility}
       >
         {help && (
-          <StyledWidgetLabelHelpInline>
-            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
-          </StyledWidgetLabelHelpInline>
+          <WidgetLabelHelpIconInline
+            content={help}
+            placement={Placement.TOP_RIGHT}
+            label={label}
+          />
         )}
       </WidgetLabel>
       <RadioGroup

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { BaseProvider, LightTheme } from "baseui"
 
@@ -91,5 +91,25 @@ describe("Tooltip element", () => {
 
     const tooltipContent = await screen.findByTestId("stTooltipErrorContent")
     expect(tooltipContent).toHaveTextContent("Error Text")
+  })
+
+  it("closes on Escape when focus-triggered without blurring the trigger", async () => {
+    const user = userEvent.setup()
+    renderTooltip({ children: <button type="button">Trigger</button> })
+
+    const trigger = screen.getByRole("button", { name: "Trigger" })
+    expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+
+    await user.tab()
+    expect(trigger).toHaveFocus()
+
+    await screen.findByTestId("stTooltipContent")
+
+    await user.keyboard("{Escape}")
+
+    expect(trigger).toHaveFocus()
+    await waitFor(() =>
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+    )
   })
 })

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, ReactNode, useCallback, useState } from "react"
+import {
+  memo,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 import {
   ACCESSIBILITY_TYPE,
@@ -124,33 +132,74 @@ function Tooltip({
     null
   )
   const [isOpen, setIsOpen] = useState(false)
+  const closeRef = useRef<(() => void) | null>(null)
 
   const handleOpen = useCallback(() => {
     setIsOpen(true)
   }, [])
   const handleClose = useCallback(() => {
     setIsOpen(false)
+    closeRef.current = null
   }, [])
+
+  useEffect(() => {
+    return () => {
+      closeRef.current = null
+    }
+  }, [])
+
+  const handleKeyDownCapture = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Escape" || !isOpen) {
+        return
+      }
+
+      // BaseWeb tooltips don't consistently dismiss on Escape across trigger
+      // types. Close the tooltip without blurring the trigger to avoid
+      // disrupting keyboard navigation.
+      //
+      // Only close if the active element is inside this tooltip's wrapper to
+      // avoid unintended dismissal for unrelated controls.
+      const wrapper = event.currentTarget
+      const activeElement = wrapper.ownerDocument?.activeElement
+
+      if (
+        activeElement instanceof HTMLElement &&
+        wrapper.contains(activeElement)
+      ) {
+        closeRef.current?.()
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    },
+    [isOpen]
+  )
 
   useTooltipMeasurementSideEffect(tooltipElement, isOpen)
 
   const tooltipOverrides = generateDefaultTooltipOverrides(theme, overrides)
 
+  const renderContent = useCallback(
+    ({ close }: { close: () => void }) => {
+      closeRef.current = close
+      return (
+        <StyledTooltipContentWrapper
+          className={error ? "stTooltipErrorContent" : "stTooltipContent"}
+          data-testid={error ? "stTooltipErrorContent" : "stTooltipContent"}
+          ref={setTooltipElement}
+        >
+          {content}
+        </StyledTooltipContentWrapper>
+      )
+    },
+    [content, error, setTooltipElement]
+  )
+
   return (
     <StatefulTooltip
       onOpen={handleOpen}
       onClose={handleClose}
-      content={
-        content ? (
-          <StyledTooltipContentWrapper
-            className={error ? "stTooltipErrorContent" : "stTooltipContent"}
-            data-testid={error ? "stTooltipErrorContent" : "stTooltipContent"}
-            ref={setTooltipElement}
-          >
-            {content}
-          </StyledTooltipContentWrapper>
-        ) : null
-      }
+      content={content ? renderContent : null}
       placement={PLACEMENT[placement]}
       accessibilityType={ACCESSIBILITY_TYPE.tooltip}
       showArrow={false}
@@ -167,6 +216,7 @@ function Tooltip({
           width: containerWidth ? "100%" : "auto",
           ...style,
         }}
+        onKeyDownCapture={handleKeyDownCapture}
         data-testid={
           error ? "stTooltipErrorHoverTarget" : "stTooltipHoverTarget"
         }

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
 
 import ThemeProvider from "~lib/components/core/ThemeProvider"
 import { mockTheme } from "~lib/mocks/mockTheme"
 import { render } from "~lib/test_util"
 
-import TooltipIcon from "./TooltipIcon"
+import TooltipIcon, {
+  getHelpTooltipAriaLabel,
+  InlineTooltipIcon,
+} from "./TooltipIcon"
 
 describe("TooltipIcon element", () => {
   it("renders a TooltipIcon", () => {
@@ -29,10 +34,175 @@ describe("TooltipIcon element", () => {
         theme={mockTheme.emotion}
         baseuiTheme={mockTheme.basewebTheme}
       >
-        <TooltipIcon content="" />
+        <TooltipIcon content="" ariaLabel="Help" />
       </ThemeProvider>
     )
     const tooltipIcon = screen.getByTestId("stTooltipIcon")
     expect(tooltipIcon).toBeInTheDocument()
+  })
+
+  it("InlineTooltipIcon uses a default 'Help' aria-label", () => {
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <InlineTooltipIcon content="Help text" />
+      </ThemeProvider>
+    )
+
+    expect(screen.getByRole("button", { name: "Help" })).toBeInTheDocument()
+  })
+
+  it("InlineTooltipIcon ariaLabel can be overridden", () => {
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <InlineTooltipIcon content="Help text" ariaLabel="More information" />
+      </ThemeProvider>
+    )
+
+    expect(
+      screen.getByRole("button", { name: "More information" })
+    ).toBeInTheDocument()
+  })
+
+  describe("InlineTooltipIcon prop forwarding", () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("forwards containerWidth and onMouseEnterDelay to TooltipIcon", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <ThemeProvider
+          theme={mockTheme.emotion}
+          baseuiTheme={mockTheme.basewebTheme}
+        >
+          <InlineTooltipIcon
+            content="Help text"
+            containerWidth
+            onMouseEnterDelay={500}
+          />
+        </ThemeProvider>
+      )
+
+      // containerWidth -> Tooltip hover target wrapper spans full width.
+      expect(screen.getByTestId("stTooltipHoverTarget")).toHaveStyle(
+        "width: 100%"
+      )
+
+      // onMouseEnterDelay -> tooltip should not show until delay has elapsed.
+      await user.hover(screen.getByRole("button", { name: "Help" }))
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+      expect(await screen.findByTestId("stTooltipContent")).toHaveTextContent(
+        "Help text"
+      )
+    })
+  })
+
+  it("falls back to a default aria-label when ariaLabel is an empty string", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentionally bypass types to validate runtime safety. */}
+        <TooltipIcon content="Help text" ariaLabel={"" as any} />
+      </ThemeProvider>
+    )
+
+    await user.tab()
+    expect(screen.getByRole("button", { name: "Help" })).toHaveFocus()
+  })
+
+  it("renders a focusable trigger button by default", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <TooltipIcon content="Help text" ariaLabel="Help for widget" />
+      </ThemeProvider>
+    )
+
+    await user.tab()
+    expect(
+      screen.getByRole("button", { name: "Help for widget" })
+    ).toHaveFocus()
+  })
+
+  it("shows tooltip content on keyboard focus and closes on blur", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <TooltipIcon content="Help text" ariaLabel="Help for widget" />
+        <button type="button">After</button>
+      </ThemeProvider>
+    )
+
+    await user.tab()
+    expect(
+      screen.getByRole("button", { name: "Help for widget" })
+    ).toHaveFocus()
+
+    const tooltipContent = await screen.findByTestId("stTooltipContent")
+    expect(tooltipContent).toHaveTextContent("Help text")
+
+    // Blur by tabbing to the next focusable element.
+    await user.tab()
+    expect(screen.getByRole("button", { name: "After" })).toHaveFocus()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+    })
+  })
+
+  it("closes the tooltip on Escape", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <TooltipIcon content="Help text" ariaLabel="Help for widget" />
+      </ThemeProvider>
+    )
+
+    await user.tab()
+    const trigger = screen.getByRole("button", { name: "Help for widget" })
+    expect(trigger).toHaveFocus()
+    await screen.findByTestId("stTooltipContent")
+
+    await user.keyboard("{Escape}")
+    await waitFor(() => {
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+    })
+    // Closing a tooltip should not steal focus from its trigger.
+    expect(trigger).toHaveFocus()
+  })
+
+  it("normalizes whitespace in getHelpTooltipAriaLabel", () => {
+    expect(getHelpTooltipAriaLabel("  My \n widget\tlabel  ")).toBe(
+      "Help for My widget label"
+    )
+    expect(getHelpTooltipAriaLabel("")).toBe("Help")
+    expect(getHelpTooltipAriaLabel(null)).toBe("Help")
   })
 })

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement, ReactNode } from "react"
+import { isValidElement, ReactElement } from "react"
 
 import { HelpCircle as HelpCircleIcon } from "react-feather"
 
@@ -28,28 +28,104 @@ import { convertRemToPx } from "~lib/theme"
 import {
   StyledLabelHelpInline,
   StyledTooltipIconWrapper,
+  StyledTooltipTriggerButton,
 } from "./styled-components"
 
-export interface TooltipIconProps {
+interface TooltipIconCommonProps {
   placement?: Placement
   isLatex?: boolean
   content: string
-  children?: ReactNode
   markdownProps?: Partial<StreamlitMarkdownProps>
   onMouseEnterDelay?: number
   containerWidth?: boolean
 }
 
-function TooltipIcon({
-  placement = Placement.AUTO,
-  isLatex = false,
-  content,
-  children,
-  markdownProps,
-  onMouseEnterDelay,
-  containerWidth = false,
-}: TooltipIconProps): ReactElement {
+/**
+ * TooltipIconProps is intentionally a union to prevent unlabeled, focusable
+ * tooltip triggers from being introduced.
+ *
+ * - If you pass `children`, `TooltipIcon` will *not* render its own button. In
+ *   that case the child should already be an interactive element with its own
+ *   accessible name, so requiring `ariaLabel` would be redundant/noisy.
+ * - If you do *not* pass `children`, `TooltipIcon` renders a `<button>`
+ *   trigger. That trigger must have an accessible name, so `ariaLabel` is
+ *   required.
+ *
+ * Usage examples:
+ *
+ * ```tsx
+ * // With children: children must already be interactive and labeled.
+ * <TooltipIcon content="More info">
+ *   <button aria-label="Show details">i</button>
+ * </TooltipIcon>
+ *
+ * // Without children: TooltipIcon renders its own button, so ariaLabel is required.
+ * <TooltipIcon content="More info" ariaLabel="Show help" />
+ * ```
+ */
+export type TooltipIconProps =
+  | (TooltipIconCommonProps & {
+      children: ReactElement
+      ariaLabel?: never
+    })
+  | (TooltipIconCommonProps & {
+      ariaLabel: string
+      children?: never
+    })
+
+function TooltipIcon(props: TooltipIconProps): ReactElement {
+  const {
+    placement = Placement.AUTO,
+    isLatex = false,
+    content,
+    markdownProps,
+    onMouseEnterDelay,
+    containerWidth = false,
+  } = props
   const theme = useEmotionTheme()
+
+  const renderDefaultTriggerButton = (ariaLabel: string): ReactElement => {
+    return (
+      <StyledTooltipTriggerButton type="button" aria-label={ariaLabel}>
+        <HelpCircleIcon
+          className="icon"
+          aria-hidden="true"
+          focusable="false"
+          /* Convert size to px because using rem works but logs a console error (at least on webkit) */
+          size={convertRemToPx(theme.iconSizes.base)}
+        />
+      </StyledTooltipTriggerButton>
+    )
+  }
+
+  /**
+   * Render a tooltip trigger.
+   *
+   * - If `children` are provided, we assume the child is already interactive and
+   *   properly labeled.
+   * - Otherwise we render a default button trigger that requires an accessible name.
+   */
+  const renderTrigger = (): ReactElement => {
+    if ("children" in props) {
+      if (isValidElement(props.children)) {
+        return props.children
+      }
+
+      return renderDefaultTriggerButton("Help")
+    }
+
+    const ariaLabel = props.ariaLabel.trim()
+
+    if (!ariaLabel.length) {
+      // `ariaLabel` is required by the type when no children are provided, but
+      // we still guard at runtime because: it may be derived from dynamic data
+      // (e.g. widget labels) and end up empty.
+      return renderDefaultTriggerButton("Help")
+    }
+
+    return renderDefaultTriggerButton(ariaLabel)
+  }
+
   return (
     <StyledTooltipIconWrapper
       className="stTooltipIcon"
@@ -70,25 +146,42 @@ function TooltipIcon({
         inline
         containerWidth={containerWidth}
       >
-        {children || (
-          <HelpCircleIcon
-            className="icon"
-            /* Convert size to px because using rem works but logs a console error (at least on webkit) */
-            size={convertRemToPx(theme.iconSizes.base)}
-          />
-        )}
+        {renderTrigger()}
       </Tooltip>
     </StyledTooltipIconWrapper>
   )
+}
+
+export function getHelpTooltipAriaLabel(label?: string | null): string {
+  // We try to generate a widget-specific accessible name when possible. In some
+  // cases `label` can be missing/empty (e.g. widgets created without a visible
+  // label), so we fall back to a generic "Help" label rather than returning an
+  // empty accessible name.
+  const trimmed = label?.trim()
+  const normalized = trimmed ? trimmed.replace(/\s+/g, " ") : null
+  return normalized ? `Help for ${normalized}` : "Help"
+}
+
+/**
+ * InlineTooltipIcon is a convenience wrapper used in places like markdown and
+ * headings, where we always want a standard "help" icon next to text.
+ *
+ * Unlike `TooltipIcon`, it always provides an accessible name by default to
+ * keep call sites terse while still meeting accessibility requirements.
+ */
+export interface InlineTooltipIconProps extends TooltipIconCommonProps {
+  ariaLabel?: string
 }
 
 export const InlineTooltipIcon = ({
   placement = Placement.TOP_RIGHT,
   isLatex = false,
   content,
-  children,
   markdownProps,
-}: TooltipIconProps): ReactElement => {
+  onMouseEnterDelay,
+  containerWidth,
+  ariaLabel = "Help",
+}: InlineTooltipIconProps): ReactElement => {
   return (
     <StyledLabelHelpInline>
       <TooltipIcon
@@ -96,9 +189,10 @@ export const InlineTooltipIcon = ({
         isLatex={isLatex}
         content={content}
         markdownProps={markdownProps}
-      >
-        {children}
-      </TooltipIcon>
+        onMouseEnterDelay={onMouseEnterDelay}
+        containerWidth={containerWidth}
+        ariaLabel={ariaLabel}
+      />
     </StyledLabelHelpInline>
   )
 }

--- a/frontend/lib/src/components/shared/TooltipIcon/styled-components.ts
+++ b/frontend/lib/src/components/shared/TooltipIcon/styled-components.ts
@@ -16,6 +16,29 @@
 
 import styled from "@emotion/styled"
 
+import { getPrimaryFocusBoxShadow } from "~lib/theme/utils"
+
+export const StyledTooltipTriggerButton = styled.button(({ theme }) => ({
+  background: "none",
+  border: "none",
+  padding: 0,
+  margin: 0,
+  color: "inherit",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  lineHeight: 0,
+  cursor: "help",
+
+  "&:focus": {
+    outline: "none",
+  },
+  "&:focus-visible": {
+    boxShadow: getPrimaryFocusBoxShadow(theme),
+    borderRadius: theme.radii.default,
+  },
+}))
+
 interface StyledTooltipIconWrapperProps {
   isLatex?: boolean
 }
@@ -30,7 +53,11 @@ export const StyledTooltipIconWrapper =
     alignItems: "center",
     marginTop: isLatex ? theme.spacing.md : "0",
 
-    "& .stTooltipHoverTarget > svg": {
+    // The tooltip hover target wraps the trigger for accessibility.
+    // Only style TooltipIcon's default trigger glyph (HelpCircleIcon).
+    // TooltipIcon is also used as a wrapper around arbitrary triggers (e.g. a
+    // button with its own Icon). Those triggers should keep their own styling.
+    "& .stTooltipHoverTarget svg.icon": {
       stroke: theme.colors.fadedText60,
       strokeWidth: 2.25,
     },

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -30,8 +30,10 @@ import { AudioInput as AudioInputProto } from "@streamlit/protobuf"
 import { useWaveformController } from "~lib/components/audio"
 import Toolbar, { ToolbarAction } from "~lib/components/shared/Toolbar"
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
-import { WidgetLabel } from "~lib/components/widgets/BaseWidget"
+import {
+  WidgetLabel,
+  WidgetLabelHelpIcon,
+} from "~lib/components/widgets/BaseWidget"
 import { FormClearHelper } from "~lib/components/widgets/Form"
 import { FileUploadClient } from "~lib/FileUploadClient"
 import useDownloadUrl from "~lib/hooks/useDownloadUrl"
@@ -56,7 +58,6 @@ import {
   StyledWaveformInnerDiv,
   StyledWaveformTimeCode,
   StyledWaveSurferDiv,
-  StyledWidgetLabelHelp,
 } from "./styled-components"
 
 export interface Props {
@@ -535,9 +536,11 @@ const AudioInput: React.FC<Props> = ({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon content={element.help} placement={Placement.TOP} />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon
+            content={element.help}
+            placement={Placement.TOP}
+            label={element.label}
+          />
         )}
       </WidgetLabel>
       <StyledWaveformContainerDiv disabled={disabled}>

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
@@ -16,10 +16,13 @@
 
 import { screen } from "@testing-library/react"
 
+import ThemeProvider from "~lib/components/core/ThemeProvider"
+import { mockTheme } from "~lib/mocks/mockTheme"
 import { render } from "~lib/test_util"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
 import { LabelProps, WidgetLabel } from "./WidgetLabel"
+import { WidgetLabelHelpIconInline } from "./WidgetLabelHelpIconInline"
 
 const getProps = (props?: Partial<LabelProps>): LabelProps => ({
   label: "Label",
@@ -27,6 +30,53 @@ const getProps = (props?: Partial<LabelProps>): LabelProps => ({
 })
 
 describe("Widget Label", () => {
+  it("does not hide help icons from assistive tech", () => {
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <WidgetLabel label="My widget">
+          <WidgetLabelHelpIconInline
+            content="help text"
+            ariaLabel="Help for My widget"
+          />
+        </WidgetLabel>
+      </ThemeProvider>
+    )
+
+    const label = screen.getByTestId("stWidgetLabel")
+    expect(label).not.toHaveAttribute("aria-hidden", "true")
+
+    const helpButton = screen.getByRole("button", {
+      name: "Help for My widget",
+    })
+    expect(helpButton.closest('[aria-hidden="true"]')).toBeNull()
+  })
+
+  it("does not render nested <label> elements when using inline help wrapper", () => {
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <WidgetLabel label="My widget">
+          <WidgetLabelHelpIconInline
+            content="help text"
+            ariaLabel="Help for My widget"
+          />
+        </WidgetLabel>
+      </ThemeProvider>
+    )
+
+    const outerLabel = screen.getByTestId("stWidgetLabel")
+    expect(outerLabel.tagName.toLowerCase()).toBe("label")
+
+    // This used to happen when our inline help wrapper was implemented as a <label>,
+    // producing invalid nested labels: <label>...<label>...</label></label>.
+    expect(outerLabel.querySelector("label")).toBeNull()
+  })
+
   it("renders WidgetLabel as expected", () => {
     const props = getProps()
     render(<WidgetLabel {...props} />)

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
@@ -48,16 +48,20 @@ export function WidgetLabel({
   }
 
   return (
-    // we use aria-hidden to disable ARIA for StyleWidgetLabel, because each
-    // widget should have its own aria-label and/or implement accessibility.
     <StyledWidgetLabel
       data-testid="stWidgetLabel"
-      aria-hidden="true"
       disabled={disabled}
       labelVisibility={labelVisibility}
       htmlFor={htmlFor}
     >
-      <StreamlitMarkdown source={label} allowHTML={false} isLabel />
+      {/* Accessibility contract:
+          Widget inputs must expose their own accessible name (e.g. via aria-label
+          and/or aria-labelledby). We hide the visual label text from assistive tech
+          to avoid duplicate announcements, while keeping any children (e.g. help
+          icons) accessible. */}
+      <span aria-hidden="true">
+        <StreamlitMarkdown source={label} allowHTML={false} isLabel />
+      </span>
       {children}
     </StyledWidgetLabel>
   )

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIcon.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIcon.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement } from "react"
+
+import { StreamlitMarkdownProps } from "~lib/components/shared/StreamlitMarkdown"
+import { Placement } from "~lib/components/shared/Tooltip"
+import TooltipIcon, {
+  getHelpTooltipAriaLabel,
+} from "~lib/components/shared/TooltipIcon"
+
+import { StyledWidgetLabelHelp } from "./styled-components"
+
+export type WidgetLabelHelpIconProps = {
+  /** Tooltip contents (markdown). */
+  content: string
+  /**
+   * Widget label used to generate an accessible name (e.g. "Help for My
+   * widget"). If omitted/empty, the accessible name falls back to a generic
+   * "Help".
+   */
+  label?: string | null
+  /** Override accessible name. If omitted, it is derived from `label`. */
+  ariaLabel?: string
+  placement?: Placement
+  isLatex?: boolean
+  markdownProps?: Partial<StreamlitMarkdownProps>
+  onMouseEnterDelay?: number
+  containerWidth?: boolean
+}
+
+export function WidgetLabelHelpIcon({
+  content,
+  label,
+  ariaLabel,
+  placement = Placement.TOP_RIGHT,
+  isLatex,
+  markdownProps,
+  onMouseEnterDelay,
+  containerWidth,
+}: WidgetLabelHelpIconProps): ReactElement {
+  return (
+    <StyledWidgetLabelHelp>
+      <TooltipIcon
+        content={content}
+        placement={placement}
+        isLatex={isLatex}
+        markdownProps={markdownProps}
+        onMouseEnterDelay={onMouseEnterDelay}
+        containerWidth={containerWidth}
+        ariaLabel={ariaLabel ?? getHelpTooltipAriaLabel(label)}
+      />
+    </StyledWidgetLabelHelp>
+  )
+}

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIconInline.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIconInline.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement } from "react"
+
+import { StreamlitMarkdownProps } from "~lib/components/shared/StreamlitMarkdown"
+import { Placement } from "~lib/components/shared/Tooltip"
+import TooltipIcon, {
+  getHelpTooltipAriaLabel,
+} from "~lib/components/shared/TooltipIcon"
+
+import { StyledWidgetLabelHelpInline } from "./styled-components"
+
+export type WidgetLabelHelpIconInlineProps = {
+  /** Tooltip contents (markdown). */
+  content: string
+  /**
+   * Widget label used to generate an accessible name (e.g. "Help for My
+   * widget"). If omitted/empty, the accessible name falls back to a generic
+   * "Help".
+   */
+  label?: string | null
+  /** Override accessible name. If omitted, it is derived from `label`. */
+  ariaLabel?: string
+  placement?: Placement
+  isLatex?: boolean
+  markdownProps?: Partial<StreamlitMarkdownProps>
+  onMouseEnterDelay?: number
+  containerWidth?: boolean
+}
+
+export function WidgetLabelHelpIconInline({
+  content,
+  label,
+  ariaLabel,
+  placement = Placement.TOP_RIGHT,
+  isLatex,
+  markdownProps,
+  onMouseEnterDelay,
+  containerWidth,
+}: WidgetLabelHelpIconInlineProps): ReactElement {
+  return (
+    <StyledWidgetLabelHelpInline>
+      <TooltipIcon
+        content={content}
+        placement={placement}
+        isLatex={isLatex}
+        markdownProps={markdownProps}
+        onMouseEnterDelay={onMouseEnterDelay}
+        containerWidth={containerWidth}
+        ariaLabel={ariaLabel ?? getHelpTooltipAriaLabel(label)}
+      />
+    </StyledWidgetLabelHelpInline>
+  )
+}

--- a/frontend/lib/src/components/widgets/BaseWidget/index.ts
+++ b/frontend/lib/src/components/widgets/BaseWidget/index.ts
@@ -22,3 +22,5 @@ export {
 } from "./styled-components"
 
 export { WidgetLabel } from "./WidgetLabel"
+export { WidgetLabelHelpIcon } from "./WidgetLabelHelpIcon"
+export { WidgetLabelHelpIconInline } from "./WidgetLabelHelpIconInline"

--- a/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
+++ b/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
@@ -40,6 +40,11 @@ export const StyledWidgetLabel = styled.label<StyledWidgetProps>(
   })
 )
 
+/**
+ * @deprecated Please utilize `WidgetLabelHelpIcon` instead of using this
+ * directly in order to support a11y best practices and keep behavior consistent
+ * across widgets.
+ */
 export const StyledWidgetLabelHelp = styled.div({
   display: "flex",
   flexDirection: "row",
@@ -57,7 +62,12 @@ export const StyledWidgetInstructions = styled.div(({ theme }) => ({
   right: `calc(${theme.fontSizes.mdLg} * 0.5)`,
 }))
 
-export const StyledWidgetLabelHelpInline = styled.label(({ theme }) => ({
+/**
+ * @deprecated Please utilize `WidgetLabelHelpIconInline` instead of using this
+ * directly in order to support a11y best practices and keep behavior consistent
+ * across widgets.
+ */
+export const StyledWidgetLabelHelpInline = styled.span(({ theme }) => ({
   marginLeft: theme.spacing.xs,
   position: "relative",
   display: "flex",

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -40,10 +40,9 @@ import BaseButton, {
 } from "~lib/components/shared/BaseButton"
 import { StyledButtonGroup } from "~lib/components/shared/BaseButton/styled-components"
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelpInline,
   WidgetLabel,
+  WidgetLabelHelpIconInline,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -381,9 +380,11 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
         )}
       >
         {help && (
-          <StyledWidgetLabelHelpInline>
-            <TooltipIcon content={help} placement={Placement.TOP} />
-          </StyledWidgetLabelHelpInline>
+          <WidgetLabelHelpIconInline
+            content={help}
+            placement={Placement.TOP}
+            label={label}
+          />
         )}
       </WidgetLabel>
       <BasewebButtonGroup

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -38,11 +38,9 @@ import {
 } from "@streamlit/protobuf"
 
 import Icon from "~lib/components/shared/Icon"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   UploadedStatus,
@@ -579,12 +577,7 @@ const CameraInput = ({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       {imgSrc ? (

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -46,11 +46,16 @@ const ChatFileUploadButton = ({
 }: Props): React.ReactElement => {
   const inputProps = configureFileInputProps(getInputProps(), acceptFile)
 
+  // React-dropzone's root props include `tabIndex=0` by default, which makes the
+  // wrapper a keyboard focus target. Since we render an actual <button> inside
+  // the wrapper, we don't want two tab stops for the same control.
+  const rootProps = getRootProps({ tabIndex: -1 })
+
   return (
     <StyledFileUploadButton
       data-testid="stChatInputFileUploadButton"
       disabled={disabled}
-      {...getRootProps()}
+      {...rootProps}
     >
       <input {...inputProps} />
       <Tooltip

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -21,20 +21,19 @@ import {
   STYLE_TYPE,
   Checkbox as UICheckbox,
 } from "baseui/checkbox"
-import { transparentize } from "color2k"
 
 import { Checkbox as CheckboxProto } from "@streamlit/protobuf"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
-import { StyledWidgetLabelHelpInline } from "~lib/components/widgets/BaseWidget"
+import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { hasLightBackgroundColor } from "~lib/theme"
+import { getFocusBoxShadow } from "~lib/theme/utils"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -179,7 +178,7 @@ function Checkbox({
                 marginBottom: 0,
                 boxShadow:
                   $isFocusVisible && $checked
-                    ? `0 0 0 0.2rem ${transparentize(colors.primary, 0.5)}`
+                    ? getFocusBoxShadow(colors.primary)
                     : "",
                 // This is painfully verbose, but baseweb seems to internally
                 // use the long-hand version, which means we can't use the
@@ -219,12 +218,11 @@ function Checkbox({
             largerLabel
           />
           {element.help && (
-            <StyledWidgetLabelHelpInline color={color}>
-              <TooltipIcon
-                content={element.help}
-                placement={Placement.TOP_RIGHT}
-              />
-            </StyledWidgetLabelHelpInline>
+            <WidgetLabelHelpIconInline
+              content={element.help}
+              placement={Placement.TOP_RIGHT}
+              label={element.label}
+            />
           )}
         </StyledContent>
       </UICheckbox>

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -37,10 +37,9 @@ import { getBorderColor } from "~lib/components/shared/Base/styled-components"
 import Icon from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -254,12 +253,7 @@ function DateInput({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <UIDatePicker

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
@@ -32,11 +32,9 @@ import { DateTimeInput as DateTimeInputProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { LibConfigContext } from "~lib/components/core/LibConfigContext"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import { useIntlLocale } from "~lib/components/widgets/DateInput/useIntlLocale"
 import { useBasicWidgetState } from "~lib/hooks/useBasicWidgetState"
@@ -216,12 +214,7 @@ function DateTimeInput({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <UIDatePicker

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -28,11 +28,9 @@ import {
   UploadedFileInfo as UploadedFileInfoProto,
 } from "@streamlit/protobuf"
 
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import { useFormClearHelper } from "~lib/components/widgets/Form"
 import { FileUploadClient } from "~lib/FileUploadClient"
@@ -600,12 +598,7 @@ const FileUploader = ({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <FileDropzone

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -30,11 +30,9 @@ import { MultiSelect as MultiSelectProto } from "@streamlit/protobuf"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
 import { VirtualDropdown } from "~lib/components/shared/Dropdown"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import { StyledUISelect } from "~lib/components/widgets/Multiselect/styled-components"
 import {
@@ -224,12 +222,7 @@ const Multiselect: FC<Props> = props => {
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <StyledUISelect>

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -31,11 +31,9 @@ import { NumberInput as NumberInputProto } from "@streamlit/protobuf"
 
 import Icon, { DynamicIcon, isMaterialIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import { useFormClearHelper } from "~lib/components/widgets/Form"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
@@ -374,12 +372,7 @@ const NumberInput: React.FC<Props> = ({
         htmlFor={id.current}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <StyledInputContainer

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -39,11 +39,9 @@ import { Slider as SliderProto } from "@streamlit/protobuf"
 
 import { withCalculatedWidth } from "~lib/components/core/Layout/withCalculatedWidth"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -327,12 +325,7 @@ function Slider({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <UISlider

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -23,11 +23,9 @@ import { Element, TextArea as TextAreaProto } from "@streamlit/protobuf"
 
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -224,12 +222,7 @@ const TextArea: FC<Props> = ({
         htmlFor={id}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -24,11 +24,9 @@ import { TextInput as TextInputProto } from "@streamlit/protobuf"
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
 import { DynamicIcon, isMaterialIcon } from "~lib/components/shared/Icon"
 import InputInstructions from "~lib/components/shared/InputInstructions/InputInstructions"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -158,12 +156,7 @@ function TextInput({
         htmlFor={id}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <UIInput

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -24,11 +24,9 @@ import { TimeInput as TimeInputProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
-import { Placement } from "~lib/components/shared/Tooltip"
-import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import {
-  StyledWidgetLabelHelp,
   WidgetLabel,
+  WidgetLabelHelpIcon,
 } from "~lib/components/widgets/BaseWidget"
 import {
   useBasicWidgetState,
@@ -205,12 +203,7 @@ function TimeInput({
         )}
       >
         {element.help && (
-          <StyledWidgetLabelHelp>
-            <TooltipIcon
-              content={element.help}
-              placement={Placement.TOP_RIGHT}
-            />
-          </StyledWidgetLabelHelp>
+          <WidgetLabelHelpIcon content={element.help} label={element.label} />
         )}
       </WidgetLabel>
       <UITimePicker


### PR DESCRIPTION
## Describe your changes

Improved accessibility of help tooltips across Streamlit components:

1. Made help tooltips keyboard accessible:
    - Help icons are now proper buttons with appropriate ARIA labels
    - Tooltips can be opened via keyboard focus
    - Tooltips can be dismissed with Escape key without losing focus
    - Added tests to verify keyboard accessibility
2. Refactored widget help icon implementation:
    - Created dedicated `WidgetLabelHelpIcon` and `WidgetLabelHelpIconInline` components
    - Ensured consistent accessible names for help buttons (e.g., "Help for Label")
    - Fixed nested label issues in widget labels with help icons
    - Updated all widget components to use the new help icon components
3. Fixed test selectors:
    - Updated selectors in e2e tests
    - Added explicit focus testing in directory upload button test

## Screenshot or video (only for visual changes)

In this video, I navigate to the Tooltip via keyboard, it displays. I tab away and it is hidden. When I tab back, it displays, I click `escape` and the Tooltip itself is hidden but the trigger focus state remains:

https://github.com/user-attachments/assets/c7ff72d9-310d-4f14-8a8b-85583fec2210

In this video, I use the keyboard to bring focus to the `Help` on a Streamlit component (in this case, a Slider), to show how keyboarding works here too:

https://github.com/user-attachments/assets/0a4b5b02-0858-4f1c-a9e5-210c31dac960

## GitHub Issue Link (if applicable)

- Fixes #13330

## Testing Plan

- ✅ Adds e2e tests
- ✅ Adds unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.