### PR TITLE
Fix the spinner time text alignment

### DIFF
--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -46,7 +46,9 @@ export const StyledSpinnerText = styled.div(({ theme }) => ({
 
 // TODO: Maybe move this to `theme/consts.ts`, see
 // https://github.com/streamlit/streamlit/pull/10085/files#diff-a5cce939bf6c73209a258132c71ccb368a3a1fd57b68b373d242736adb920093
-export const StyledSpinnerTimeText = styled.div(({ theme }) => ({
+export const StyledSpinnerTimeText = styled.span(({ theme }) => ({
   opacity: 0.6,
   fontSize: theme.fontSizes.sm,
+  lineHeight: theme.lineHeights.none,
+  whiteSpace: "nowrap",
 }))


### PR DESCRIPTION
## Describe your changes

Fixes the misaligned spinner label and timer text if `show_time=True`:

<img width="454" height="106" alt="image" src="https://github.com/user-attachments/assets/e6345d8e-75e0-4579-8d2d-3f081267771b" />

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/13387

## Testing Plan

- Testing the visual aspect here is really tricky since a snapshot would be quite indeterministic :( 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
