### PR TITLE
[refactor] Do not import default from React

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { act } from "react"
+import { act } from "react"
 
 import {
   fireEvent,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { PureComponent, ReactNode } from "react"
+import { PureComponent, ReactNode } from "react"
 
 import classNames from "classnames"
 import { enableMapSet, enablePatches } from "immer"

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import React, { PureComponent, ReactElement } from "react"
+import { PureComponent, ReactElement } from "react"
 
 import { screen, waitFor } from "@testing-library/react"
 

--- a/frontend/app/src/ThemedApp.test.tsx
+++ b/frontend/app/src/ThemedApp.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { render, screen } from "@testing-library/react"
 
 import { baseTheme, ThemeContext } from "@streamlit/lib"

--- a/frontend/app/src/ThemedApp.tsx
+++ b/frontend/app/src/ThemedApp.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclaration"
 import FontSources from "@streamlit/app/src/components/FontSources"
 import {

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { fireEvent, screen } from "@testing-library/react"
 
 import { shouldShowNavigation } from "@streamlit/app/src/components/Navigation"

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   ReactElement,
   useCallback,
   useContext,

--- a/frontend/app/src/components/AppView/ScrollToBottomContainer.tsx
+++ b/frontend/app/src/components/AppView/ScrollToBottomContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { useScrollToBottom } from "@streamlit/lib"
 

--- a/frontend/app/src/components/Countdown/Countdown.test.tsx
+++ b/frontend/app/src/components/Countdown/Countdown.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "@streamlit/lib/testing"

--- a/frontend/app/src/components/Countdown/Countdown.tsx
+++ b/frontend/app/src/components/Countdown/Countdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react"
+import { useState } from "react"
 
 import { StyledCountdown } from "./styled-components"
 

--- a/frontend/app/src/components/DeployButton/DeployButton.tsx
+++ b/frontend/app/src/components/DeployButton/DeployButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, MouseEvent } from "react"
+import { FC, MouseEvent } from "react"
 
 import { BaseButton, BaseButtonKind } from "@streamlit/lib"
 

--- a/frontend/app/src/components/EventContainer/EventContainer.test.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "@streamlit/lib/testing"

--- a/frontend/app/src/components/EventContainer/EventContainer.tsx
+++ b/frontend/app/src/components/EventContainer/EventContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { PLACEMENT, ToasterContainer } from "baseui/toast"
 

--- a/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
+++ b/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { css, Global } from "@emotion/react"
 

--- a/frontend/app/src/components/FontSources/FontSources.tsx
+++ b/frontend/app/src/components/FontSources/FontSources.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { Helmet } from "react-helmet-async"
 
 import { FontSources as FontSourcesType } from "@streamlit/app/src/util/useThemeManager"

--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "@streamlit/lib/testing"

--- a/frontend/app/src/components/Header/Header.tsx
+++ b/frontend/app/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useContext } from "react"
+import { ReactElement, ReactNode, useContext } from "react"
 
 import {
   BaseButton,

--- a/frontend/app/src/components/Logo/LogoComponent.test.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useCallback, useContext, useMemo } from "react"
+import { ReactElement, useCallback, useContext, useMemo } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, within } from "@testing-library/react"
 
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { forwardRef, memo, MouseEvent, ReactElement } from "react"
+import { forwardRef, memo, MouseEvent, ReactElement } from "react"
 
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { StatefulMenu } from "baseui/menu"

--- a/frontend/app/src/components/Navigation/NavSection.tsx
+++ b/frontend/app/src/components/Navigation/NavSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { DynamicIcon } from "@streamlit/lib"
 

--- a/frontend/app/src/components/Navigation/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/app/src/components/Navigation/SidebarNav.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   MouseEvent,
   ReactElement,
   ReactNode,

--- a/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNavLink.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 

--- a/frontend/app/src/components/Navigation/SidebarNavLink.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNavLink.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { MouseEvent, ReactElement } from "react"
+import { MouseEvent, ReactElement } from "react"
 
 import { DynamicIcon, isMaterialIcon, useEmotionTheme } from "@streamlit/lib"
 

--- a/frontend/app/src/components/Navigation/TopNav.tsx
+++ b/frontend/app/src/components/Navigation/TopNav.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useContext, useMemo } from "react"
+import { useCallback, useContext, useMemo } from "react"
 
 import Overflow from "rc-overflow"
 

--- a/frontend/app/src/components/Navigation/TopNavSection.tsx
+++ b/frontend/app/src/components/Navigation/TopNavSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react"
+import { Fragment, useState } from "react"
 
 import {
   KeyboardArrowDown,
@@ -95,7 +95,7 @@ const TopNavSection = ({
               const pageName = String(item.pageName || "")
 
               return (
-                <React.Fragment key={`${item.pageScriptHash}-${pageName}`}>
+                <Fragment key={`${item.pageScriptHash}-${pageName}`}>
                   {index === 0 && showSections && (
                     <StyledSectionName>{sectionName}</StyledSectionName>
                   )}
@@ -116,7 +116,7 @@ const TopNavSection = ({
                       {pageName}
                     </SidebarNavLink>
                   </StyledTopNavSidebarNavLinkContainer>
-                </React.Fragment>
+                </Fragment>
               )
             })
           })}

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import {
   fireEvent,

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   ReactElement,
   useCallback,
   useContext,

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import {

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext } from "react"
+import { ReactElement, useContext } from "react"
 
 import {
   createSidebarTheme,

--- a/frontend/app/src/components/StatusWidget/IconRunning.tsx
+++ b/frontend/app/src/components/StatusWidget/IconRunning.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import {
   AccessibilityNew,

--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {
+import {
   ReactElement,
   ReactNode,
   useCallback,

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, PropsWithChildren, useMemo } from "react"
+import { memo, PropsWithChildren, useMemo } from "react"
 
 import {
   DownloadContext,

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { Card } from "baseui/card"
 

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useCallback } from "react"
+import { ReactElement, ReactNode, useCallback } from "react"
 
 import { StyledAction, StyledBody } from "baseui/card"
 

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployListElement.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployListElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import Checkmark from "@streamlit/app/src/assets/svg/checkmark.svg"
 

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployModal.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { ModalBody as UIModalBody } from "baseui/modal"
 import { CloseSource } from "baseui/modal/types"

--- a/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/DetachedHead.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/DetachedHead.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { IDeployErrorDialog } from "./types"
 
 function DetachedHead(): IDeployErrorDialog {

--- a/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/ModuleIsNotAdded.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/ModuleIsNotAdded.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { StreamlitMarkdown } from "@streamlit/lib"
 
 import { IDeployErrorDialog } from "./types"

--- a/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { STREAMLIT_COMMUNITY_CLOUD_DOCS_URL } from "@streamlit/app/src/urls"
 
 import { StyledParagraph } from "./styled-components"

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 

--- a/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DialogErrorMessage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, memo, ReactElement, ReactNode } from "react"
+import { Fragment, memo, ReactElement, ReactNode } from "react"
 
 import { StreamlitErrorCodeBlock } from "@streamlit/lib"
 

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/SettingsDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   ChangeEvent,
   FC,
   memo,

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from "react"
+import { Fragment } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { DialogType } from "@streamlit/app/src/components/StreamlitDialog/constants"
 import {

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import {

--- a/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { BaseProvider, LightTheme } from "baseui"

--- a/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ChangeEvent, useCallback, useState } from "react"
+import { ChangeEvent, useCallback, useState } from "react"
 
 import {
   BaseButtonKind,

--- a/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
 

--- a/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { Modal, ModalBody, ModalHeader } from "@streamlit/lib"
 

--- a/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { BaseProvider, LightTheme } from "baseui"

--- a/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent } from "react"
+import { FunctionComponent } from "react"
 
 import {
   BaseButton,

--- a/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { PureComponent, ReactElement } from "react"
+import { PureComponent, ReactElement } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/app/src/hocs/withScreencast/withScreencast.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   ComponentType,
   FC,
   PropsWithChildren,

--- a/frontend/app/src/hooks/useViewportSize.test.tsx
+++ b/frontend/app/src/hooks/useViewportSize.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, renderHook } from "@testing-library/react"
 
 import {

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -17,7 +17,7 @@
 // Timestamp when the Streamlit execution started for GUEST_READY message
 const streamlitExecutionStartedAt = Date.now()
 
-import React, { StrictMode } from "react"
+import { StrictMode } from "react"
 
 import log from "loglevel"
 import { createRoot } from "react-dom/client"

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -74,6 +74,12 @@ export const getNoRestrictedImports = (
       importNames: ["CancelToken"],
       message: "Please use the `AbortController` API instead of `CancelToken`",
     },
+    {
+      name: "react",
+      importNames: ["default"],
+      message:
+        "Please use named imports for React (e.g., import { useState } from 'react';)",
+    },
   ]
 
   const basePaths = isTestFile

--- a/frontend/lib/declarations.d.ts
+++ b/frontend/lib/declarations.d.ts
@@ -29,6 +29,7 @@ declare module "native-file-system-adapter"
 // some of it to fix a bug in the color picker that triggers a security error when
 // the color picker is closed in a cross-origin iframe, see `BaseColorPicker.tsx`.
 declare module "react-color/es/components/common/Saturation" {
+  // eslint-disable-next-line no-restricted-imports -- In a .d.ts file.
   import React from "react"
   export default class Saturation extends React.Component<any, any> {
     container: HTMLElement

--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import createCache from "@emotion/cache"
 import {

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext } from "react"
+import { ReactElement, useContext } from "react"
 
 import classNames from "classnames"
 

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 
 import {

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { lazy, ReactElement, Suspense, useContext } from "react"
+import { lazy, ReactElement, Suspense, useContext } from "react"
 
 import classNames from "classnames"
 

--- a/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
+++ b/frontend/lib/src/components/core/Block/RenderNodeVisitor.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import { isValidElement } from "react"
 
 import { BlockNode, TransientNode } from "~lib/AppNode"
 import { ComponentRegistry } from "~lib/components/widgets/CustomComponent"
@@ -67,7 +67,7 @@ describe("RenderNodeVisitor", () => {
       const result = visitor.visitElementNode(elementNode)
 
       expect(result).not.toBeNull()
-      expect(React.isValidElement(result)).toBe(true)
+      expect(isValidElement(result)).toBe(true)
       expect(visitor.reactElements).toHaveLength(1)
       expect(visitor.reactElements[0]).toBe(result)
     })
@@ -103,7 +103,7 @@ describe("RenderNodeVisitor", () => {
       // Only one widget should be rendered
       expect(visitor.reactElements).toHaveLength(1)
       expect(result1).not.toBeNull()
-      expect(React.isValidElement(result1)).toBe(true)
+      expect(isValidElement(result1)).toBe(true)
       expect(visitor.reactElements[0]).toBe(result1)
       expect(result2).toBeNull()
     })
@@ -119,7 +119,7 @@ describe("RenderNodeVisitor", () => {
 
       expect(visitor.reactElements).toHaveLength(1)
       expect(result).not.toBeNull()
-      expect(React.isValidElement(result)).toBe(true)
+      expect(isValidElement(result)).toBe(true)
       expect(visitor.reactElements[0]).toBe(result)
       expect((result as React.ReactElement).key).toBe(
         element.element?.textInput?.id
@@ -137,7 +137,7 @@ describe("RenderNodeVisitor", () => {
       const result = visitor.visitBlockNode(blockNode)
 
       expect(result).not.toBeNull()
-      expect(React.isValidElement(result)).toBe(true)
+      expect(isValidElement(result)).toBe(true)
       expect(visitor.reactElements).toHaveLength(1)
       expect(visitor.reactElements[0]).toBe(result)
     })
@@ -167,7 +167,7 @@ describe("RenderNodeVisitor", () => {
       const result = visitor.visitBlockNode(blockNode)
 
       expect(result).not.toBeNull()
-      expect(React.isValidElement(result)).toBe(true)
+      expect(isValidElement(result)).toBe(true)
       // The key should be "0" for the first block
       expect((result as React.ReactElement).key).toBe("0")
     })
@@ -184,7 +184,7 @@ describe("RenderNodeVisitor", () => {
       const result = visitor.visitBlockNode(blockNode)
 
       expect(result).not.toBeNull()
-      expect(React.isValidElement(result)).toBe(true)
+      expect(isValidElement(result)).toBe(true)
       // Check that the props contain disableFullscreenMode: true
       const props = (result as React.ReactElement).props
       expect(props.disableFullscreenMode).toBe(true)
@@ -204,9 +204,9 @@ describe("RenderNodeVisitor", () => {
       const blockResult = visitor.visitBlockNode(blockNode)
 
       expect(elementResult).not.toBeNull()
-      expect(React.isValidElement(elementResult)).toBe(true)
+      expect(isValidElement(elementResult)).toBe(true)
       expect(blockResult).not.toBeNull()
-      expect(React.isValidElement(blockResult)).toBe(true)
+      expect(isValidElement(blockResult)).toBe(true)
 
       expect(visitor.reactElements).toHaveLength(2)
       expect(visitor.reactElements[0]).toBe(elementResult)
@@ -238,7 +238,7 @@ describe("RenderNodeVisitor", () => {
       expect(result).toHaveLength(3)
       result.forEach(element => {
         expect(element).not.toBeNull()
-        expect(React.isValidElement(element)).toBe(true)
+        expect(isValidElement(element)).toBe(true)
       })
     })
 
@@ -253,7 +253,7 @@ describe("RenderNodeVisitor", () => {
 
       expect(result).toHaveLength(1)
       expect(result[0]).not.toBeNull()
-      expect(React.isValidElement(result[0])).toBe(true)
+      expect(isValidElement(result[0])).toBe(true)
       // Check that the props contain disableFullscreenMode: true
       const props = result[0].props
       expect(props.disableFullscreenMode).toBe(true)
@@ -289,7 +289,7 @@ describe("RenderNodeVisitor", () => {
       expect(result).toHaveLength(4)
       result.forEach(element => {
         expect(element).not.toBeNull()
-        expect(React.isValidElement(element)).toBe(true)
+        expect(isValidElement(element)).toBe(true)
       })
     })
   })
@@ -308,7 +308,7 @@ describe("RenderNodeVisitor", () => {
       expect(result).toHaveLength(3)
       result.forEach(element => {
         expect(element).not.toBeNull()
-        expect(React.isValidElement(element)).toBe(true)
+        expect(isValidElement(element)).toBe(true)
       })
     })
   })

--- a/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
+++ b/frontend/lib/src/components/core/Block/StyledElementContainerLayoutWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useMemo } from "react"
+import { FC, useMemo } from "react"
 
 import { ButtonGroup } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { CSSProperties } from "react"
+import { CSSProperties } from "react"
 
 import styled from "@emotion/styled"
 

--- a/frontend/lib/src/components/core/DownloadContext.test.tsx
+++ b/frontend/lib/src/components/core/DownloadContext.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useContext } from "react"
+import { useContext } from "react"
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"

--- a/frontend/lib/src/components/core/Layout/FlexContext.test.tsx
+++ b/frontend/lib/src/components/core/Layout/FlexContext.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useContext } from "react"
+import { FC, useContext } from "react"
 
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"

--- a/frontend/lib/src/components/core/Layout/FlexContext.tsx
+++ b/frontend/lib/src/components/core/Layout/FlexContext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { createContext, FC, PropsWithChildren, useMemo } from "react"
+import { createContext, FC, PropsWithChildren, useMemo } from "react"
 
 import { Direction } from "./utils"
 

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import { ReactNode } from "react"
 /**
  * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
  *

--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"

--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ComponentType, ReactElement } from "react"
+import { ComponentType, ReactElement } from "react"
 
 import hoistNonReactStatics from "hoist-non-react-statics"
 

--- a/frontend/lib/src/components/core/Maybe/Maybe.test.tsx
+++ b/frontend/lib/src/components/core/Maybe/Maybe.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/core/Maybe/Maybe.tsx
+++ b/frontend/lib/src/components/core/Maybe/Maybe.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { memo, PropsWithChildren } from "react"
+import { memo, PropsWithChildren } from "react"
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface MaybeProps extends PropsWithChildren<{

--- a/frontend/lib/src/components/core/Portal/PortalProvider.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalProvider.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, PropsWithChildren, useCallback, useRef } from "react"
+import { FC, PropsWithChildren, useCallback, useRef } from "react"
 
 import { StyledDataFrameOverlay } from "~lib/styled-components"
 

--- a/frontend/lib/src/components/core/Portal/RenderInPortalIfExists.tsx
+++ b/frontend/lib/src/components/core/Portal/RenderInPortalIfExists.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PropsWithChildren, useContext } from "react"
+import { FC, PropsWithChildren, useContext } from "react"
 
 import { createPortal } from "react-dom"
 

--- a/frontend/lib/src/components/core/ThemeProvider.tsx
+++ b/frontend/lib/src/components/core/ThemeProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react"
 import { ThemeProvider as BaseUIThemeProvider } from "baseui"

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Alert as AlertProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import AlertContainer, { Kind } from "~lib/components/shared/AlertContainer"
 import { DynamicIcon } from "~lib/components/shared/Icon"

--- a/frontend/lib/src/components/elements/ArrowTable/ArrowTable.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowTable/ArrowTable.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/ArrowTable/ArrowTable.tsx
+++ b/frontend/lib/src/components/elements/ArrowTable/ArrowTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { range } from "lodash-es"
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import { useMemo } from "react"
 
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -23,7 +23,7 @@ import userEvent from "@testing-library/user-event"
 vi.mock("./useVegaEmbed", () => ({
   useVegaEmbed: () => {
     // Satisfy hooks rule by calling a React hook in this mock
-    React.useMemo(() => null, [])
+    useMemo(() => null, [])
     return {
       createView: () => Promise.resolve(null),
       updateView: () => Promise.resolve(null),

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useEffect, useLayoutEffect, useState } from "react"
+import { FC, memo, useEffect, useLayoutEffect, useState } from "react"
 
 import { Global } from "@emotion/react"
 import { InsertChart, TableChart } from "@emotion-icons/material-outlined"

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { fireEvent, screen } from "@testing-library/react"
 
 import { Audio as AudioProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
+import { memo, ReactElement, useEffect, useMemo, useRef } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render, renderWithContexts } from "~lib/test_util"

--- a/frontend/lib/src/components/elements/Balloons/Balloons.tsx
+++ b/frontend/lib/src/components/elements/Balloons/Balloons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo } from "react"
+import { FC, memo } from "react"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is

--- a/frontend/lib/src/components/elements/ChatMessage/ChatMessage.test.tsx
+++ b/frontend/lib/src/components/elements/ChatMessage/ChatMessage.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
+++ b/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/CopyButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, useCallback, useRef } from "react"
+import { memo, useCallback, useRef } from "react"
 
 import { Check as CheckIcon, Copy as CopyIcon } from "react-feather"
 

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitErrorCodeBlock.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import CopyButton from "./CopyButton"
 import {

--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { render } from "~lib/test_util"
 
 import StreamlitSyntaxHighlighter, {

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  FC,
-  memo,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react"
+import { FC, memo, useCallback, useContext, useEffect, useState } from "react"
 
 import { LayersList, PickingInfo } from "@deck.gl/core"
 import { DeckGL } from "@deck.gl/react"

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/MapBoxCss.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/MapBoxCss.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 import "mapbox-gl/dist/mapbox-gl.css"
 
 /**

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 
 import { PickingInfo, ViewStateChangeParameters } from "@deck.gl/core"
 import { act, screen } from "@testing-library/react"

--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { vi } from "vitest"

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useState,
-} from "react"
+import { memo, ReactElement, useCallback, useEffect, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/DocString/DocString.test.tsx
+++ b/frontend/lib/src/components/elements/DocString/DocString.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { DocString as DocStringProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/DocString/DocString.tsx
+++ b/frontend/lib/src/components/elements/DocString/DocString.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { DocString as DocStringProto, IMember } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { MockInstance } from "vitest"
 

--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useRef, useState } from "react"
+import { memo, ReactElement, useEffect, useRef, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { graphviz } from "d3-graphviz"
 import { Mock, MockInstance } from "vitest"

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect } from "react"
+import { memo, ReactElement, useEffect } from "react"
 
 import { Engine, graphviz } from "d3-graphviz"
 import { getLogger } from "loglevel"

--- a/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { IFrame as IFrameProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { IFrame as IFrameProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { fireEvent, screen } from "@testing-library/react"
 
 import { ImageList as ImageListProto, streamlit } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { CSSProperties, memo, ReactElement } from "react"
+import { CSSProperties, memo, ReactElement } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/elements/Json/Json.test.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Json as JsonProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/LinkButton/BaseLinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/BaseLinkButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { forwardRef, memo, ReactElement } from "react"
+import { forwardRef, memo, ReactElement } from "react"
 
 import {
   BaseButtonKind,

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { vi } from "vitest"

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  MouseEvent,
-  ReactElement,
-  useCallback,
-  useRef,
-} from "react"
+import { memo, MouseEvent, ReactElement, useCallback, useRef } from "react"
 
 import { LinkButton as LinkButtonProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
+++ b/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 import embed from "vega-embed"
 import { TopLevelSpec } from "vega-lite"

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useRef } from "react"
+import { memo, ReactElement, useEffect, useRef } from "react"
 
 import { Global } from "@emotion/react"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"

--- a/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/PageLink/PageLink.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useContext } from "react"
+import { memo, ReactElement, useContext } from "react"
 
 import { PageLink as PageLinkProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/Particles/Particles.test.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/elements/Particles/Particles.tsx
+++ b/frontend/lib/src/components/elements/Particles/Particles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useContext, useMemo } from "react"
+import { FC, memo, useContext, useMemo } from "react"
 
 import { range } from "lodash-es"
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, render, screen } from "@testing-library/react"
 
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   FC,
   memo,
   ReactElement,

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useContext, useState } from "react"
+import { memo, ReactElement, useContext, useState } from "react"
 
 import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
 

--- a/frontend/lib/src/components/elements/Progress/Progress.test.tsx
+++ b/frontend/lib/src/components/elements/Progress/Progress.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Progress as ProgressProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Progress/Progress.tsx
+++ b/frontend/lib/src/components/elements/Progress/Progress.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { Progress as ProgressProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/Skeleton/AppSkeleton.test.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/AppSkeleton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/elements/Skeleton/AppSkeleton.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/AppSkeleton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useEffect, useState } from "react"
+import { FC, memo, useEffect, useState } from "react"
 
 import {
   ParagraphSkeleton,

--- a/frontend/lib/src/components/elements/Skeleton/Skeleton.test.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/Skeleton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { Skeleton as SkeletonProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Skeleton/Skeleton.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/Skeleton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo } from "react"
+import { FC, memo } from "react"
 
 import { Skeleton as SkeletonProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/Snow/Snow.test.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import Snow, {

--- a/frontend/lib/src/components/elements/Snow/Snow.tsx
+++ b/frontend/lib/src/components/elements/Snow/Snow.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo } from "react"
+import { FC, memo } from "react"
 
 /*
  * IMPORTANT: If you change the asset imports below, make sure they still work if Streamlit is

--- a/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, waitFor } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
 

--- a/frontend/lib/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useRef, useState } from "react"
+import { memo, ReactElement, useEffect, useRef, useState } from "react"
 
 import classNames from "classnames"
 

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, within } from "@testing-library/react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useContext,

--- a/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
+++ b/frontend/lib/src/components/elements/TextElement/TextElement.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/elements/TextElement/TextElement.tsx
+++ b/frontend/lib/src/components/elements/TextElement/TextElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { Text as TextProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/elements/Toast/Toast.test.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import {
   act,

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { fireEvent, screen } from "@testing-library/react"
 
 import { Video as VideoProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useEffect, useMemo, useRef } from "react"
+import { memo, ReactElement, useEffect, useMemo, useRef } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { KIND, Notification } from "baseui/notification"
 

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import {
   BaseButtonKind,

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { Placement } from "~lib/components/shared/Tooltip"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"

--- a/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { vi } from "vitest"
 

--- a/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react"
+import { useMemo } from "react"
 
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, useCallback, useState } from "react"
+import { memo, useCallback, useState } from "react"
 
 import { StatefulPopover as UIPopover } from "baseui/popover"
 import { ChromePicker, ColorResult } from "react-color"

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Children, forwardRef, ReactElement } from "react"
+import { Children, forwardRef, ReactElement } from "react"
 
 import {
   type OptionListProps,

--- a/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/ElementFullscreenWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PropsWithChildren, useMemo } from "react"
+import { FC, PropsWithChildren, useMemo } from "react"
 
 import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
 import { StyledFullScreenFrame } from "~lib/components/shared/FullScreenWrapper/styled-components"

--- a/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
+++ b/frontend/lib/src/components/shared/ElementFullscreen/testUtils.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PropsWithChildren, ReactElement } from "react"
+import { FC, PropsWithChildren, ReactElement } from "react"
 
 import {
   renderHook as reactTestingLibraryRenderHook,

--- a/frontend/lib/src/components/shared/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/lib/src/components/shared/ErrorBoundary/ErrorBoundary.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { PureComponent } from "react"
+import { PureComponent } from "react"
 
 import { getLogger } from "loglevel"
 

--- a/frontend/lib/src/components/shared/ErrorElement/ErrorElement.test.tsx
+++ b/frontend/lib/src/components/shared/ErrorElement/ErrorElement.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/ErrorElement/ErrorElement.tsx
+++ b/frontend/lib/src/components/shared/ErrorElement/ErrorElement.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { StyledCode } from "~lib/components/elements/CodeBlock/styled-components"
 import AlertContainer, { Kind } from "~lib/components/shared/AlertContainer"

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PureComponent, ReactNode } from "react"
+import { FC, PureComponent, ReactNode } from "react"
 
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
+++ b/frontend/lib/src/components/shared/FullScreenWrapper/withFullScreenWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentType, ReactElement } from "react"
+import { ComponentType, ReactElement } from "react"
 
 import hoistNonReactStatics from "hoist-non-react-statics"
 

--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Suspense } from "react"
+import { Suspense } from "react"
 
 import { IconSize } from "~lib/theme"
 

--- a/frontend/lib/src/components/shared/Icon/Icon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Icon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 

--- a/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Material/MaterialFontIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { IconSize } from "~lib/theme"
 

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { StyledWidgetInstructions } from "~lib/components/widgets/BaseWidget"
 import { isFromMac } from "~lib/util/utils"

--- a/frontend/lib/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { BaseProvider, LightTheme } from "baseui"
 

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, ReactElement, ReactNode } from "react"
+import { FunctionComponent, ReactElement, ReactNode } from "react"
 
 import {
   type ModalProps,

--- a/frontend/lib/src/components/shared/Profiler/Profiler.tsx
+++ b/frontend/lib/src/components/shared/Profiler/Profiler.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   FC,
   ProfilerOnRenderCallback,
   PropsWithChildren,

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { mergeOverrides } from "baseui"
 import { Overrides } from "baseui/overrides"

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useState,
-} from "react"
+import { memo, ReactElement, useCallback, useEffect, useState } from "react"
 
 import { ALIGN, RadioGroup, Radio as UIRadio } from "baseui/radio"
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 
 import { Heading as HeadingProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, ReactElement, useContext } from "react"
+import { Fragment, ReactElement, useContext } from "react"
 
 import { Components } from "react-markdown"
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { cleanup, screen } from "@testing-library/react"
 import { transparentize } from "color2k"

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import React, {
+import {
+  createContext,
   CSSProperties,
   type FC,
   type HTMLProps,
@@ -461,7 +462,7 @@ export const CustomMediaTag: FC<
   return <Tag {...attributes} />
 }
 
-const HelpTextContext = React.createContext<string | undefined>(undefined)
+const HelpTextContext = createContext<string | undefined>(undefined)
 HelpTextContext.displayName = "HelpTextContext"
 
 interface CustomHelpIconProps {

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.test.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { Info } from "@emotion-icons/material-outlined"
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { StyledComponent } from "@emotion/styled"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"

--- a/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
@@ -24,22 +22,35 @@ import { TestAppWrapper } from "~lib/test_util"
 import OverflowTooltip from "./OverflowTooltip"
 import { Placement } from "./Tooltip"
 
+const { useRefMock, useEffectMock } = vi.hoisted(() => ({
+  useRefMock: vi.fn(),
+  useEffectMock: vi.fn((f: () => void) => f()),
+}))
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react")
+
+  return {
+    ...actual,
+    useRef: useRefMock,
+    useEffect: useEffectMock,
+  }
+})
+
 describe("Tooltip component", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it("should render when it fits onscreen", async () => {
     const user = userEvent.setup()
-    const useRefSpy = vi.spyOn(React, "useRef").mockReturnValue({
+    useRefMock.mockReturnValue({
       current: {
         // Pretend the body is greater than its onscreen area.
         offsetWidth: 200,
         scrollWidth: 100,
       },
     })
-
-    vi.spyOn(React, "useEffect").mockImplementation(f => f())
 
     render(
       <OverflowTooltip
@@ -59,20 +70,18 @@ describe("Tooltip component", () => {
 
     expect(screen.queryByText("the content")).not.toBeInTheDocument()
 
-    expect(useRefSpy).toHaveBeenCalledWith(null)
+    expect(useRefMock).toHaveBeenCalledWith(null)
   })
 
   it("should render when ellipsized", async () => {
     const user = userEvent.setup()
-    const useRefSpy = vi.spyOn(React, "useRef").mockReturnValue({
+    useRefMock.mockReturnValue({
       current: {
         // Pretend the body is smaller than its onscreen area.
         offsetWidth: 100,
         scrollWidth: 200,
       },
     })
-
-    vi.spyOn(React, "useEffect").mockImplementation(f => f())
 
     render(
       <OverflowTooltip
@@ -93,6 +102,6 @@ describe("Tooltip component", () => {
     const tooltipContent = await screen.findByText("the content")
     expect(tooltipContent).toBeInTheDocument()
 
-    expect(useRefSpy).toHaveBeenCalledWith(null)
+    expect(useRefMock).toHaveBeenCalledWith(null)
   })
 })

--- a/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode, useState } from "react"
+import { ReactElement, ReactNode, useEffect, useRef, useState } from "react"
 
 import { StyledEllipsizedDiv, StyledWrapper } from "./styled-components"
 import Tooltip, { Placement } from "./Tooltip"
@@ -38,15 +38,16 @@ function OverflowTooltip({
   inline,
   style,
 }: OverflowTooltipProps): ReactElement {
-  const childRef = React.useRef<HTMLDivElement>(null)
+  const childRef = useRef<HTMLDivElement>(null)
   const [allowTooltip, setAllowTooltip] = useState(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const newAllowTooltip = childRef?.current
       ? // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
         childRef.current.offsetWidth < childRef.current.scrollWidth
       : false
     if (newAllowTooltip !== allowTooltip) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Existing usage
       setAllowTooltip(newAllowTooltip)
     }
   }, [children, allowTooltip])

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { BaseProvider, LightTheme } from "baseui"

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  ReactElement,
-  ReactNode,
-  useCallback,
-  useState,
-} from "react"
+import { memo, ReactElement, ReactNode, useCallback, useState } from "react"
 
 import {
   ACCESSIBILITY_TYPE,

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import ThemeProvider from "~lib/components/core/ThemeProvider"

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 import { HelpCircle as HelpCircleIcon } from "react-feather"
 

--- a/frontend/lib/src/components/shared/WindowDimensions/Provider.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/Provider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PropsWithChildren, useContext } from "react"
+import { FC, PropsWithChildren, useContext } from "react"
 
 import { WindowDimensionsContext } from "~lib/components/shared/WindowDimensions"
 import { useWindowDimensions } from "~lib/components/shared/WindowDimensions/useWindowDimensions"

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.test.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInputActionButtons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 import { Mic } from "@emotion-icons/material-outlined"

--- a/frontend/lib/src/components/widgets/AudioInput/AudioInputErrorState.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/AudioInputErrorState.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import {
   StyledErrorContainerDiv,

--- a/frontend/lib/src/components/widgets/AudioInput/NoMicPermissions.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/NoMicPermissions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { ENABLE_PERIPHERALS_DOCS_URL } from "~lib/urls"
 

--- a/frontend/lib/src/components/widgets/AudioInput/Placeholder.tsx
+++ b/frontend/lib/src/components/widgets/AudioInput/Placeholder.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import {
   StyledPlaceholderContainerDiv,

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import { isNullOrUndefined, LabelVisibilityOptions } from "~lib/util/utils"
 

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleHtmlAndCssContent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
 import { handleError } from "~lib/components/widgets/BidiComponent/utils/error"

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import { v4 as uuidv4 } from "uuid"
 

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { vi } from "vitest"

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
 import { Button as ButtonProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   forwardRef,
   memo,
   ReactElement,

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import createFetchMock from "vitest-fetch-mock"

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   useCallback,
   useEffect,

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, MouseEvent, ReactElement, ReactNode } from "react"
+import { memo, MouseEvent, ReactElement, ReactNode } from "react"
 
 import ProgressBar, {
   Size as ProgressBarSize,

--- a/frontend/lib/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { SwitchCamera } from "@emotion-icons/material-rounded"
 

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   ChangeEvent,
   KeyboardEvent,
   memo,

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { Add } from "@emotion-icons/material-rounded"
 

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { AcceptFileValue } from "~lib/util/utils"
 

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFile.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFile.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback } from "react"
+import { FC, memo, useCallback } from "react"
 
 import { ErrorOutline } from "@emotion-icons/material-outlined"
 import { Cancel } from "@emotion-icons/material-rounded"

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFileIconTooltip.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFileIconTooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFiles.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatUploadedFiles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { UploadFileInfo } from "~lib/components/widgets/FileUploader/UploadFileInfo"
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
 import {
   LABEL_PLACEMENT,

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback } from "react"
+import { FC, memo, useCallback } from "react"
 
 import { ColorPicker as ColorPickerProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, fireEvent, screen } from "@testing-library/react"
 import { Mock, MockInstance } from "vitest"
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useEffect,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import * as glideDataGridModule from "@glideapps/glide-data-grid"
 import { screen } from "@testing-library/react"
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/DataFrame/ReadOnlyGrid.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/ReadOnlyGrid.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 

--- a/frontend/lib/src/components/widgets/DataFrame/ReadOnlyGrid.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/ReadOnlyGrid.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { Arrow, Arrow as ArrowProto, streamlit } from "@streamlit/protobuf"
 
 import { Quiver } from "~lib/dataframes/Quiver"

--- a/frontend/lib/src/components/widgets/DataFrame/Tooltip.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/Tooltip.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/DataFrame/Tooltip.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/Tooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback, useState } from "react"
+import { memo, ReactElement, useCallback, useState } from "react"
 
 import { ACCESSIBILITY_TYPE, PLACEMENT, Popover } from "baseui/popover"
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/ImageCellEditor.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/ImageCellEditor.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/ImageCellEditor.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/ImageCellEditor.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from "react"
 
 import styled from "@emotion/styled"
 import { ImageEditorType } from "@glideapps/glide-data-grid"

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react"
-
 import {
   type CustomCell,
   type CustomRenderer,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import styled from "@emotion/styled"
 import { TextCellEntry } from "@glideapps/glide-data-grid"

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react"
+import { useCallback } from "react"
 
 import { updateColumnConfigTypeProps } from "./columnConfigUtils"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnReordering.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnReordering.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react"
+import { useCallback } from "react"
 
 import { DataEditorProps } from "@glideapps/glide-data-grid"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react"
+import { useCallback } from "react"
 
 import { updateColumnConfigTypeProps } from "./columnConfigUtils"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react"
+import { useCallback } from "react"
 
 import { DataEditorProps, GridCell } from "@glideapps/glide-data-grid"
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useTableSizer.ts
@@ -17,7 +17,7 @@
 // TODO: fix incorrect hook usage and delete this lint suppression
 /* eslint-disable react-hooks/exhaustive-deps -- TODO: Update to match React best practices */
 
-import React, { useLayoutEffect, useState } from "react"
+import { useLayoutEffect, useState } from "react"
 
 import { Size as ResizableSize } from "re-resizable"
 

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { Field, Int64 } from "apache-arrow"

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { Field, Int64, Utf8 } from "apache-arrow"

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import {
   LABEL_PLACEMENT,

--- a/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import { PLACEMENT, Popover, TRIGGER_TYPE } from "baseui/popover"
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import {
   act,
   fireEvent,

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { vi } from "vitest"

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import Dropzone, { FileRejection } from "react-dropzone"
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { CloudUpload } from "@emotion-icons/material-outlined"
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import {
   act,
   fireEvent,

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { isEqual, zip } from "lodash-es"
 import { flushSync } from "react-dom"

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import {
   Clear,

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFiles.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFiles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import {
   StyledUploadedFiles,

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/Pagination.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react"
+import { memo } from "react"
 
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
 

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import type { ComponentType, PropsWithChildren } from "react"
 
 import { screen } from "@testing-library/react"
 
@@ -22,9 +22,9 @@ import { render } from "~lib/test_util"
 
 import withPagination, { Props as HocProps } from "./withPagination"
 
-const TestComponent: React.ComponentType<
-  React.PropsWithChildren<unknown>
-> = () => <div>test</div>
+const TestComponent: ComponentType<PropsWithChildren<unknown>> = () => (
+  <div>test</div>
+)
 
 const getProps = (props: Partial<HocProps> = {}): HocProps => ({
   items: [{}, {}, {}, {}],
@@ -34,11 +34,6 @@ const getProps = (props: Partial<HocProps> = {}): HocProps => ({
 })
 
 describe("withPagination HOC", () => {
-  const setState = vi.fn()
-  const useStateSpy = vi.spyOn(React, "useState")
-  // @ts-expect-error
-  useStateSpy.mockImplementation(init => [init, setState])
-
   it("renders without crashing", () => {
     const props = getProps()
     const WithHoc = withPagination(TestComponent)

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentType, ReactElement, useEffect, useState } from "react"
+import { ComponentType, ReactElement, useEffect, useState } from "react"
 
 import hoistNonReactStatics from "hoist-non-react-statics"
 

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen } from "@testing-library/react"
 
 import { ScriptRunState } from "~lib/ScriptRunState"

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   ReactNode,

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from "react"
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useCallback, useEffect } from "react"
+import { ReactElement, useCallback, useEffect } from "react"
 
 import { Button as ButtonProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/Form/FormSubmitContent.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import { ReactElement } from "react"
 
 import { FormSubmitButton, Props } from "./FormSubmitButton"
 import { StyledFormSubmitContent } from "./styled-components"

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from "react"
 
 import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   memo,
   ReactElement,
   useCallback,

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
 import { Radio as RadioProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback } from "react"
+import { FC, memo, useCallback } from "react"
 
 import { Selectbox as SelectboxProto } from "@streamlit/protobuf"
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, fireEvent, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
+import {
   createRef,
   forwardRef,
   memo,

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, memo, useCallback, useRef, useState } from "react"
+import { FC, memo, useCallback, useRef, useState } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 import { uniqueId } from "lodash-es"

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback, useState } from "react"
+import { memo, ReactElement, useCallback, useState } from "react"
 
 import { Input as UIInput } from "baseui/input"
 import { uniqueId } from "lodash-es"

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
-
 import { act, screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, ReactElement, useCallback, useContext } from "react"
+import { memo, ReactElement, useCallback, useContext } from "react"
 
 import { ChevronDown } from "baseui/icon"
 import { StyledClearIcon } from "baseui/input/styled-components"

--- a/frontend/lib/src/hooks/useCrossOriginAttribute.test.tsx
+++ b/frontend/lib/src/hooks/useCrossOriginAttribute.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react"
+import { useMemo } from "react"
 
 import { renderHook } from "@testing-library/react"
 

--- a/frontend/lib/src/hooks/useRegisterShortcut.test.tsx
+++ b/frontend/lib/src/hooks/useRegisterShortcut.test.tsx
@@ -18,7 +18,7 @@
  * Tests for the useRegisterShortcut hook.
  */
 
-import React, { act, ReactElement } from "react"
+import { act, ReactElement } from "react"
 
 import * as hotkeysModule from "hotkeys-js"
 import { Mock, vi } from "vitest"

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from "react"
+import { FC } from "react"
 
 import { act, renderHook, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, PropsWithChildren, ReactElement } from "react"
+import { FC, PropsWithChildren, ReactElement } from "react"
 
 import {
   render as reactTestingLibraryRender,


### PR DESCRIPTION
## Describe your changes

- Removed explicit React imports in favor of named imports across the frontend codebase.
  - This change aligns with modern React best practices by using named imports (e.g., `import { useState } from 'react'`) instead of the default import pattern (e.g., `import React from 'react'`).
- Adds an ESLint rule to enforce this pattern going forward, preventing the use of default React imports.
- For context see https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

## Testing Plan

- No additional tests are needed as this is a purely syntactic change that doesn't affect functionality.
- Existing tests continue to validate component behavior.
- The build process will verify that all imports are correctly resolved.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.