### PR TITLE
[fix] Ensure all node_modules folders are removed in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,8 @@ clean:
 	rm -rf lib/streamlit/static
 	rm -f lib/Pipfile.lock
 	rm -rf frontend/app/build
-	rm -rf frontend/node_modules
+	find . -name node_modules -type d -prune -exec rm -rf {} \; || true
 	rm -rf frontend/app/performance/lighthouse/reports
-	rm -rf frontend/app/node_modules
-	rm -rf frontend/lib/node_modules
-	rm -rf frontend/connection/node_modules
 	rm -rf frontend/test_results
 	rm -f frontend/protobuf/proto.js
 	rm -f frontend/protobuf/proto.d.ts


### PR DESCRIPTION
## Describe your changes

- Simplified the `clean` target in the Makefile by replacing multiple `rm -rf` commands for different `node_modules` directories with a single `find` command that removes all `node_modules` directories in the project.

## Testing Plan

- No additional tests are needed as this is a build process improvement that doesn't affect runtime behavior
- Manual testing: Run `make clean` and verify that all node_modules directories are properly removed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.