### PR TITLE
[fix] Stabilize potential JS unit test flakes

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/Heading.test.tsx
@@ -31,7 +31,7 @@ const getHeadingProps = (
     anchor: "some-anchor",
     tag: "h1",
     body: `hello world
-this is a new line`,
+             this is a new line`,
     ...elementProps,
   }),
 })
@@ -166,9 +166,9 @@ describe("Heading", () => {
   it("does not render tables", async () => {
     const props = getHeadingProps({
       body: `| Syntax | Description |
-| ----------- | ----------- |
-| Header      | Title       |
-| Paragraph   | Text        |`,
+           | ----------- | ----------- |
+           | Header      | Title       |
+           | Paragraph   | Text        |`,
     })
     render(<Heading {...props} />)
 
@@ -179,7 +179,7 @@ describe("Heading", () => {
     // Wait for lazy-loaded content to render
     await waitFor(() => {
       expect(screen.getByTestId("stMarkdownContainer")).toHaveTextContent(
-        "| Syntax | Description || ----------- | ----------- | | Header | Title | | Paragraph | Text |"
+        "| Syntax | Description | | ----------- | ----------- | | Header | Title | | Paragraph | Text |"
       )
     })
 

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -15,8 +15,13 @@
  */
 
 import "@testing-library/jest-dom/vitest"
+import { configure } from "@testing-library/react"
 import { vi } from "vitest"
 import "vitest-canvas-mock"
+
+// Bump the default timeout for async utilities to 5 seconds (default is 1000ms)
+// due to the slower machine speeds in our CI environment.
+configure({ asyncUtilTimeout: 5_000 })
 
 // In the event a sub-library uses the jest global, we need to make sure it's
 // aliased to the vi global. An example is timers using dom testing library


### PR DESCRIPTION
## Describe your changes

- Increased the default timeout for async utilities in testing from 1000ms to 5000ms to accommodate slower CI environment speeds.
  - This increased timeout becomes important when dealing with async loaded components. Before the last month or so, we didn't really have any tests that would hit a `Suspense` boundary. With the perf work, this case is going to be hit more often. It is important that our tests continue to validate expected exercised behavior.
- Reverted the previous changes so that we explicitly test the cases that are async loading other components. This should prove that this change actually fixes the root cause, rather than side-stepping the `Suspense` boundaries.
- I ran this 3 times with the `flaky-verify-js` label and didn't get a failure.

## Testing Plan

- No additional tests are needed as this PR is specifically addressing test configuration and formatting.
- The existing tests will now have a more appropriate timeout value, reducing flaky test failures in CI.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.