### PR TITLE
[feat] Run workspace scripts in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ frontend-init:
 .PHONY: frontend
 # Build the frontend.
 frontend:
-	cd frontend/ ; yarn workspaces foreach --all --topological run build
+	cd frontend/ ; yarn workspaces foreach --all --topological --parallel run build
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 	# Move manifest.json to a location that can actually be served by the Tornado
@@ -225,7 +225,7 @@ frontend:
 # Build the frontend with the profiler enabled.
 frontend-with-profiler:
 	# Build frontend dependent libraries (excluding app and lib):
-	cd frontend/ ; yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological run build
+	cd frontend/ ; yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build
 	# Build the app with the profiler enabled:
 	cd frontend/ ; yarn workspace @streamlit/app buildWithProfiler
 	rsync -av --delete --delete-excluded --exclude=reports \
@@ -234,7 +234,7 @@ frontend-with-profiler:
 .PHONY: frontend-fast
 # Build the frontend (as fast as possible).
 frontend-fast:
-	cd frontend/ ; yarn workspaces foreach --recursive --topological --from @streamlit/app --exclude @streamlit/lib run build
+	cd frontend/ ; yarn workspaces foreach --recursive --topological --parallel --from @streamlit/app --exclude @streamlit/lib run build
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/app/build/ lib/streamlit/static/
 
@@ -246,18 +246,18 @@ frontend-dev:
 .PHONY: frontend-lint
 # Lint and check formatting of frontend files.
 frontend-lint:
-	cd frontend/ ; yarn workspaces foreach --all run formatCheck
-	cd frontend/ ; yarn workspaces foreach --all run lint
+	cd frontend/ ; yarn workspaces foreach --all --parallel run formatCheck
+	cd frontend/ ; yarn workspaces foreach --all --parallel run lint
 
 .PHONY: frontend-types
 # Run the frontend type checker.
 frontend-types:
-	cd frontend/ ; yarn workspaces foreach --all run typecheck
+	cd frontend/ ; yarn workspaces foreach --all --parallel run typecheck
 
 .PHONY: frontend-format
 # Format frontend files.
 frontend-format:
-	cd frontend/ ; yarn workspaces foreach --all run format
+	cd frontend/ ; yarn workspaces foreach --all --parallel run format
 
 .PHONY: frontend-tests
 # Run frontend unit tests and generate coverage report.
@@ -412,7 +412,7 @@ autofix:
 	# JS fixes:
 	make frontend-init
 	make frontend-format
-	cd frontend/ ; yarn workspaces foreach --all run lint --fix
+	cd frontend/ ; yarn workspaces foreach --all --parallel run lint --fix
 	# Dedupe yarn.lock
 	cd frontend ; yarn dedupe
 	# Other fixes:


### PR DESCRIPTION
## Describe your changes

Updates make targets to utilize parallel processing for commands that would benefit from it.

Results:
- `time make frontend-types`
  - Before: 16.239s
  - After: 8.149s
  - Impact: **50% reduction**
- `time make frontend-lint`
  - Before: 48.39s
  - After: 30.558s
  - Impact: **37% reduction**
- `time make frontend-format`
  - Before: 7.312s
  - After: 5.468s
  - Impact: **25% reduction**

Note: These measurements are taken from a single run on my Mac. Results will vary in different environments.

## GitHub Issue Link (if applicable)

## Testing Plan

- Covered by existing CI checks

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
