### PR TITLE
[feat] Update eslint rules for better a11y support

### DIFF
--- a/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.tsx
+++ b/frontend/app/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.tsx
@@ -73,6 +73,7 @@ const ScreencastDialog: React.FC<Props> = ({
             <input
               type="checkbox"
               name="recordAudio"
+              aria-label="Also record audio"
               checked={recordAudio}
               onChange={handleRecordAudioCheckbox}
             />{" "}

--- a/frontend/eslint-plugin-streamlit-custom/src/index.test.ts
+++ b/frontend/eslint-plugin-streamlit-custom/src/index.test.ts
@@ -27,6 +27,7 @@ describe("eslint-plugin-streamlit-custom", () => {
       "no-hardcoded-theme-values",
       "enforce-memo",
       "no-force-reflow-access",
+      "no-aria-hidden-with-focusable-children",
     ]
 
     expect(Object.keys(plugin.rules)).toHaveLength(EXPECTED_RULES.length)

--- a/frontend/eslint-plugin-streamlit-custom/src/index.ts
+++ b/frontend/eslint-plugin-streamlit-custom/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 import enforceMemo from "./enforce-memo"
+import noAriaHiddenWithFocusableChildren from "./no-aria-hidden-with-focusable-children"
 import noForceReflowAccess from "./no-force-reflow-access"
 import noHardcodedThemeValues from "./no-hardcoded-theme-values"
 import useStrictNullEqualityChecks from "./use-strict-null-equality-checks"
@@ -23,6 +24,8 @@ export default {
   rules: {
     "enforce-memo": enforceMemo,
     "no-force-reflow-access": noForceReflowAccess,
+    "no-aria-hidden-with-focusable-children":
+      noAriaHiddenWithFocusableChildren,
     "no-hardcoded-theme-values": noHardcodedThemeValues,
     "use-strict-null-equality-checks": useStrictNullEqualityChecks,
   },

--- a/frontend/eslint-plugin-streamlit-custom/src/no-aria-hidden-with-focusable-children.test.ts
+++ b/frontend/eslint-plugin-streamlit-custom/src/no-aria-hidden-with-focusable-children.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import rule from "./no-aria-hidden-with-focusable-children"
+import { ruleTester } from "./utils/ruleTester"
+
+ruleTester.run("no-aria-hidden-with-focusable-children", rule, {
+  valid: [
+    {
+      name: "aria-hidden wrapper with only static children",
+      code: `
+        const El = () => (
+          <div aria-hidden="true">
+            <span>Text</span>
+          </div>
+        )
+      `,
+    },
+    {
+      name: "aria-hidden applied only to a text span inside a label",
+      code: `
+        const El = () => (
+          <label>
+            <span aria-hidden="true">Label</span>
+            <button type="button" aria-label="Help" />
+          </label>
+        )
+      `,
+    },
+    {
+      name: "tabIndex -1 is not focusable",
+      code: `
+        const El = () => (
+          <div aria-hidden="true">
+            <span tabIndex={-1} />
+          </div>
+        )
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "aria-hidden wrapper contains a button",
+      code: `
+        const El = () => (
+          <div aria-hidden="true">
+            <button type="button">Click</button>
+          </div>
+        )
+      `,
+      errors: [{ messageId: "ariaHiddenWithFocusableChildren" }],
+    },
+    {
+      name: "aria-hidden wrapper contains an anchor",
+      code: `
+        const El = () => (
+          <div aria-hidden>
+            <a href="#foo">Link</a>
+          </div>
+        )
+      `,
+      errors: [{ messageId: "ariaHiddenWithFocusableChildren" }],
+    },
+    {
+      name: "aria-hidden wrapper contains a focusable element via tabIndex",
+      code: `
+        const El = () => (
+          <div aria-hidden="true">
+            <span tabIndex={0}>Focusable</span>
+          </div>
+        )
+      `,
+      errors: [{ messageId: "ariaHiddenWithFocusableChildren" }],
+    },
+    {
+      name: "aria-hidden wrapper contains a known focusable component",
+      code: `
+        const TooltipIcon = () => <button type="button" aria-label="Help" />
+        const El = () => (
+          <div aria-hidden="true">
+            <TooltipIcon />
+          </div>
+        )
+      `,
+      errors: [{ messageId: "ariaHiddenWithFocusableChildren" }],
+    },
+  ],
+})

--- a/frontend/eslint-plugin-streamlit-custom/src/no-aria-hidden-with-focusable-children.ts
+++ b/frontend/eslint-plugin-streamlit-custom/src/no-aria-hidden-with-focusable-children.ts
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils"
+
+import { createRule } from "./utils/createRule"
+
+type Options = [
+  {
+    /**
+     * Additional JSX component names that should be treated as focusable
+     * (interactive). This is useful for components like TooltipIcon that render
+     * a focusable trigger by default.
+     */
+    additionalFocusableComponents?: string[]
+  }?,
+]
+
+type MessageIds = "ariaHiddenWithFocusableChildren"
+
+const DEFAULT_FOCUSABLE_COMPONENTS = new Set([
+  // Streamlit components that render focusable triggers by default.
+  "TooltipIcon",
+  "InlineTooltipIcon",
+  "WidgetLabelHelpIcon",
+  "WidgetLabelHelpIconInline",
+  // Common Streamlit "button-like" components.
+  "BaseButton",
+])
+
+function getJsxNameText(name: TSESTree.JSXTagNameExpression): string | null {
+  if (name.type === AST_NODE_TYPES.JSXIdentifier) {
+    return name.name
+  }
+  if (name.type === AST_NODE_TYPES.JSXMemberExpression) {
+    // e.g. Foo.Bar -> "Foo.Bar"
+    const object = getJsxNameText(name.object)
+    if (object === null) {
+      return null
+    }
+    const property = name.property.name
+    return `${object}.${property}`
+  }
+  return null
+}
+
+function isAriaHiddenTruthy(attr: TSESTree.JSXAttribute): boolean {
+  if (attr.value === null || attr.value === undefined) {
+    // <div aria-hidden />
+    return true
+  }
+
+  if (attr.value.type === AST_NODE_TYPES.Literal) {
+    return attr.value.value === true || attr.value.value === "true"
+  }
+
+  if (attr.value.type === AST_NODE_TYPES.JSXExpressionContainer) {
+    const expr = attr.value.expression
+    if (
+      expr.type === AST_NODE_TYPES.Literal &&
+      (expr.value === true || expr.value === "true")
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function getJsxAttribute(
+  node: TSESTree.JSXOpeningElement,
+  attributeName: string
+): TSESTree.JSXAttribute | null {
+  for (const attr of node.attributes) {
+    if (
+      attr.type === AST_NODE_TYPES.JSXAttribute &&
+      attr.name.type === AST_NODE_TYPES.JSXIdentifier &&
+      attr.name.name === attributeName
+    ) {
+      return attr
+    }
+  }
+  return null
+}
+
+function getTabIndexValue(
+  openingElement: TSESTree.JSXOpeningElement
+): number | null {
+  const attr = getJsxAttribute(openingElement, "tabIndex")
+  if (!attr) {
+    return null
+  }
+
+  if (attr.value === null || attr.value === undefined) {
+    // <div tabIndex /> is uncommon; treat as focusable.
+    return 0
+  }
+
+  if (attr.value.type === AST_NODE_TYPES.Literal) {
+    return typeof attr.value.value === "number" ? attr.value.value : null
+  }
+
+  if (attr.value.type === AST_NODE_TYPES.JSXExpressionContainer) {
+    const expr = attr.value.expression
+    if (
+      expr.type === AST_NODE_TYPES.Literal &&
+      typeof expr.value === "number"
+    ) {
+      return expr.value
+    }
+  }
+
+  return null
+}
+
+function isFocusableHtmlTag(tagName: string): boolean {
+  // This is intentionally conservative: we only include tags that are
+  // unambiguously interactive/focusable in common usage.
+  return (
+    tagName === "button" ||
+    tagName === "a" ||
+    tagName === "input" ||
+    tagName === "select" ||
+    tagName === "textarea" ||
+    tagName === "summary"
+  )
+}
+
+function hasFocusableDescendant(
+  node: TSESTree.JSXElement | TSESTree.JSXFragment,
+  focusableComponents: Set<string>
+): boolean {
+  for (const child of node.children) {
+    if (child.type === AST_NODE_TYPES.JSXElement) {
+      const nameText = getJsxNameText(child.openingElement.name)
+      if (nameText) {
+        if (isFocusableHtmlTag(nameText.toLowerCase())) {
+          return true
+        }
+
+        if (focusableComponents.has(nameText)) {
+          return true
+        }
+      }
+
+      const tabIndex = getTabIndexValue(child.openingElement)
+      if (tabIndex !== null && tabIndex >= 0) {
+        return true
+      }
+
+      // Recurse.
+      if (hasFocusableDescendant(child, focusableComponents)) {
+        return true
+      }
+    } else if (child.type === AST_NODE_TYPES.JSXFragment) {
+      if (hasFocusableDescendant(child, focusableComponents)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+const noAriaHiddenWithFocusableChildren = createRule<Options, MessageIds>({
+  name: "no-aria-hidden-with-focusable-children",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow aria-hidden on elements that contain focusable descendants",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalFocusableComponents: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      ariaHiddenWithFocusableChildren:
+        "Do not set aria-hidden on a wrapper that contains focusable descendants. This hides interactive controls from assistive technology. Apply aria-hidden only to the specific visual text node instead (e.g. a <span>).",
+    },
+  },
+  defaultOptions: [{}],
+  create(context, [options]) {
+    const focusableComponents = new Set(DEFAULT_FOCUSABLE_COMPONENTS)
+    for (const name of options?.additionalFocusableComponents ?? []) {
+      focusableComponents.add(name)
+    }
+
+    return {
+      JSXElement(node) {
+        const ariaHiddenAttr = getJsxAttribute(
+          node.openingElement,
+          "aria-hidden"
+        )
+        if (
+          !ariaHiddenAttr ||
+          ariaHiddenAttr.type !== AST_NODE_TYPES.JSXAttribute ||
+          !isAriaHiddenTruthy(ariaHiddenAttr)
+        ) {
+          return
+        }
+
+        if (hasFocusableDescendant(node, focusableComponents)) {
+          context.report({
+            node: ariaHiddenAttr,
+            messageId: "ariaHiddenWithFocusableChildren",
+          })
+        }
+      },
+    }
+  },
+})
+
+export default noAriaHiddenWithFocusableChildren

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -380,6 +380,7 @@ export default defineConfig([
       // We only turn this rule on for certain directories
       "streamlit-custom/enforce-memo": "off",
       "streamlit-custom/no-force-reflow-access": "error",
+      "streamlit-custom/no-aria-hidden-with-focusable-children": "error",
       "no-restricted-imports": getNoRestrictedImports(),
       // React configuration
       "react/jsx-uses-react": "off",
@@ -393,6 +394,13 @@ export default defineConfig([
       // prohibit autoFocus prop
       // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md
       "jsx-a11y/no-autofocus": ["error", { ignoreNonDOM: true }],
+      // Stricter a11y enforcement beyond the recommended ruleset:
+      // - Require accessible names for icon-only controls
+      "jsx-a11y/control-has-associated-label": "error",
+      // - Do not hide focusable controls from assistive technology
+      "jsx-a11y/no-aria-hidden-on-focusable": "error",
+      // - Avoid making non-interactive elements keyboard-focusable via tabIndex>=0
+      "jsx-a11y/no-noninteractive-tabindex": "error",
     },
     settings: {
       react: {


### PR DESCRIPTION
## Describe your changes

- Created a new ESLint rule `no-aria-hidden-with-focusable-children` to prevent hiding interactive elements from screen readers.
- Enabled stricter accessibility linting rules:
   - `jsx-a11y/control-has-associated-label` - Requires accessible names for icon-only controls
   - `jsx-a11y/no-aria-hidden-on-focusable` - Prevents hiding focusable elements from assistive technology
   - `jsx-a11y/no-noninteractive-tabindex` - Avoids making non-interactive elements keyboard-focusable
- Fixes an existing violation of these rules.

## Testing Plan

- The new ESLint rule includes comprehensive test cases covering various scenarios of proper and improper `aria-hidden` usage.
- The rule is now enabled in our ESLint configuration, which is run in CI.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.