### PR TITLE
Add new session_duration_seconds_total stats

### DIFF
--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Final, NamedTuple, Protocol, runtime_checkable
 
 CACHE_MEMORY_FAMILY: Final = "cache_memory_bytes"
 SESSION_EVENTS_FAMILY: Final = "session_events_total"
+SESSION_DURATION_FAMILY: Final = "session_duration_seconds_total"
 ACTIVE_SESSIONS_FAMILY: Final = "active_sessions"
 
 if TYPE_CHECKING:

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from typing import TYPE_CHECKING, Final, cast
 
 from streamlit.logger import get_logger
@@ -28,6 +29,7 @@ from streamlit.runtime.session_manager import (
 )
 from streamlit.runtime.stats import (
     ACTIVE_SESSIONS_FAMILY,
+    SESSION_DURATION_FAMILY,
     SESSION_EVENTS_FAMILY,
     CounterStat,
     GaugeStat,
@@ -63,7 +65,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
 
     @property
     def stats_families(self) -> Sequence[str]:
-        return (SESSION_EVENTS_FAMILY, ACTIVE_SESSIONS_FAMILY)
+        return (SESSION_EVENTS_FAMILY, SESSION_DURATION_FAMILY, ACTIVE_SESSIONS_FAMILY)
 
     def __init__(
         self,
@@ -85,6 +87,10 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         self._connect_count: int = 0
         self._reconnect_count: int = 0
         self._disconnect_count: int = 0
+
+        # Session duration tracking
+        self._session_connect_times: dict[str, float] = {}
+        self._total_session_duration_seconds: float = 0
 
     def connect_session(
         self,
@@ -125,6 +131,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
 
             with self._stats_lock:
                 self._reconnect_count += 1
+                self._session_connect_times[existing_session.id] = time.monotonic()
             return existing_session.id
 
         session = AppSession(
@@ -149,6 +156,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
         with self._stats_lock:
             self._connect_count += 1
+            self._session_connect_times[session.id] = time.monotonic()
         return session.id
 
     def disconnect_session(self, session_id: str) -> None:
@@ -169,6 +177,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             del self._active_session_info_by_id[session_id]
             with self._stats_lock:
                 self._disconnect_count += 1
+                self._accumulate_session_duration(session_id)
 
         if not self._active_session_info_by_id:
             # Avoid stale cached scripts when all file watchers and sessions are disconnected
@@ -191,6 +200,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             # Count disconnect for active sessions being closed directly
             with self._stats_lock:
                 self._disconnect_count += 1
+                self._accumulate_session_duration(session_id)
 
             if not self._active_session_info_by_id:
                 # Avoid stale cached scripts when all file watchers and sessions are disconnected
@@ -203,6 +213,18 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         if session_info:
             self._session_storage.delete(session_id)
             session_info.session.shutdown()
+            with self._stats_lock:
+                self._accumulate_session_duration(session_id)
+
+    def _accumulate_session_duration(self, session_id: str) -> None:
+        """Accumulate the session duration for a closed session.
+
+        This method must be called while holding self._stats_lock.
+        """
+        connect_time = self._session_connect_times.pop(session_id, None)
+        if connect_time is not None:
+            duration = time.monotonic() - connect_time
+            self._total_session_duration_seconds += duration
 
     def get_session_info(self, session_id: str) -> SessionInfo | None:
         session_info = self.get_active_session_info(session_id)
@@ -250,6 +272,19 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
                     value=disconnect_count,
                     labels={"type": _EVENT_TYPE_DISCONNECT},
                     help="Total count of session events by type.",
+                ),
+            ]
+
+        if family_names is None or SESSION_DURATION_FAMILY in family_names:
+            with self._stats_lock:
+                total_duration = int(self._total_session_duration_seconds)
+
+            result[SESSION_DURATION_FAMILY] = [
+                CounterStat(
+                    family_name=SESSION_DURATION_FAMILY,
+                    value=total_duration,
+                    unit="seconds",
+                    help="Total time spent in active sessions, in seconds.",
                 ),
             ]
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -580,7 +580,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
     @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
     @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
     def test_session_duration_with_reconnect(self, mock_monotonic: MagicMock) -> None:
-        """Duration accumulated on disconnect should not be double-counted on close."""
+        """Session duration should accumulate across disconnect and reconnect cycles."""
         # Connect at 0, disconnect at 5, reconnect at 6, close at 16
         mock_monotonic.side_effect = [0.0, 5.0, 6.0, 16.0]
 
@@ -591,5 +591,5 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
 
         stats = self.session_mgr.get_stats()
         # Duration from connect (0) to disconnect (5) = 5 seconds
-        # Duration from reconnect (6) to close (16) = 15 seconds
+        # Duration from reconnect (6) to close (16) = 10 seconds
         assert self._get_stat_value(stats, "session_duration_seconds_total") == 15

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -343,8 +343,8 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
             raise ValueError(f"Family not found: {family_name}")
         for stat in stats_dict[family_name]:
             if label_type is None:
-                # For GaugeStat without labels
-                if isinstance(stat, GaugeStat):
+                # For GaugeStat or CounterStat without labels
+                if isinstance(stat, (GaugeStat, CounterStat)) and not stat.labels:
                     return stat.value
             # For CounterStat with labels
             elif (
@@ -362,6 +362,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         assert self._get_stat_value(stats, "session_events_total", "connect") == 0
         assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
         assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 0
         assert self._get_stat_value(stats, "active_sessions") == 0
 
     def test_new_connection_increments_counter(self) -> None:
@@ -465,8 +466,9 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.connect_session()
         stats_dict = self.session_mgr.get_stats()
 
-        assert len(stats_dict) == 2
+        assert len(stats_dict) == 3
         assert "session_events_total" in stats_dict
+        assert "session_duration_seconds_total" in stats_dict
         assert "active_sessions" in stats_dict
 
         # Check session_events_total counters
@@ -479,9 +481,115 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
             assert stat.labels is not None
             assert "type" in stat.labels
 
+        # Check session_duration_seconds_total counter
+        session_duration = stats_dict["session_duration_seconds_total"]
+        assert len(session_duration) == 1
+        assert isinstance(session_duration[0], CounterStat)
+        assert session_duration[0].family_name == "session_duration_seconds_total"
+        assert session_duration[0].type == "counter"
+        assert session_duration[0].unit == "seconds"
+
         # Check active_sessions gauge
         active_sessions = stats_dict["active_sessions"]
         assert len(active_sessions) == 1
         assert isinstance(active_sessions[0], GaugeStat)
         assert active_sessions[0].family_name == "active_sessions"
         assert active_sessions[0].type == "gauge"
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
+    def test_session_duration_accumulated_on_close(
+        self, mock_monotonic: MagicMock
+    ) -> None:
+        """Session duration should be accumulated when a session is closed."""
+        # Simulate 10 seconds of session time
+        mock_monotonic.side_effect = [0.0, 10.0]
+
+        session_id = self.connect_session()
+        self.session_mgr.close_session(session_id)
+
+        stats = self.session_mgr.get_stats()
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 10
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
+    def test_session_duration_accumulated_from_multiple_sessions(
+        self, mock_monotonic: MagicMock
+    ) -> None:
+        """Session duration should accumulate across multiple closed sessions."""
+        # Session 1 length: 10 seconds, Session 2 length: 20 seconds
+        mock_monotonic.side_effect = [0.0, 10.0, 11.0, 31.0]
+
+        session_id_1 = self.connect_session()
+        self.session_mgr.close_session(session_id_1)
+        session_id_2 = self.connect_session()
+        self.session_mgr.close_session(session_id_2)
+
+        stats = self.session_mgr.get_stats()
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 30
+
+    @patch(
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.request_script_stop",
+        new=MagicMock(),
+    )
+    @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
+    def test_session_duration_accumulated_on_disconnect(
+        self, mock_monotonic: MagicMock
+    ) -> None:
+        """Session duration should be accumulated when a session disconnects."""
+        # Connect at 0, disconnect at 10
+        mock_monotonic.side_effect = [0.0, 10.0]
+
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        stats = self.session_mgr.get_stats()
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 10
+
+    @patch(
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.request_script_stop",
+        new=MagicMock(),
+    )
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
+    def test_session_duration_not_double_counted_on_close_from_storage(
+        self, mock_monotonic: MagicMock
+    ) -> None:
+        """Duration accumulated on disconnect should not be double-counted on close."""
+        # Connect at 0, disconnect at 5, close at 15
+        mock_monotonic.side_effect = [0.0, 5.0, 15.0]
+
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+        self.session_mgr.close_session(session_id)
+
+        stats = self.session_mgr.get_stats()
+        # Duration from connect (0) to disconnect (5) = 5 seconds
+        # The time before the session was closed should not add more duration
+        # since no reconnect happened in between.
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 5
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
+    def test_session_duration_with_reconnect(self, mock_monotonic: MagicMock) -> None:
+        """Duration accumulated on disconnect should not be double-counted on close."""
+        # Connect at 0, disconnect at 5, reconnect at 6, close at 16
+        mock_monotonic.side_effect = [0.0, 5.0, 6.0, 16.0]
+
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+        session_id = self.connect_session(session_id)
+        self.session_mgr.close_session(session_id)
+
+        stats = self.session_mgr.get_stats()
+        # Duration from connect (0) to disconnect (5) = 5 seconds
+        # Duration from reconnect (6) to close (16) = 15 seconds
+        assert self._get_stat_value(stats, "session_duration_seconds_total") == 15


### PR DESCRIPTION
## Describe your changes

While this isn't exactly the best way of doing this, it'd be useful for us to have a new metric to track
the total length of time users spend in active sessions (see https://github.com/streamlit/streamlit/pull/13324#discussion_r2620155153). 

This PR adds this new metric by keeping track of session connect/reconnect times and incrementing
a simple accumulator for aggregate session length each time a session is either disconnected or
closed.

Note that one caveat of doing this is that long-lived active sessions won't be counted until disconnected
or closed, but we're not too worried our data being slow to update due to this.

## Testing Plan

- Unit Tests: Python unit tests added/modified
- Manual tests: curled `localhost:8501/_stcore/metrics` after opening/closing browser tabs
