### PR TITLE
Add a TTLCache that supports release hooks.

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -36,7 +36,7 @@ INSTALL_REQUIRES = [
     # See: https://github.com/streamlit/streamlit/issues/12064
     "altair>=4.0, <7, !=5.4.0, !=5.4.1",
     "blinker>=1.5.0, <2",
-    "cachetools>=4.0, <7",
+    "cachetools>=5.5, <7",
     "click>=7.0, <9",
     "numpy>=1.23, <3",
     # The "packaging" package isn't version-capped because they use calendar-based

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -24,7 +24,17 @@ import threading
 import time
 from abc import abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast, overload
+from collections.abc import Callable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Generic,
+    TypeAlias,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from typing_extensions import ParamSpec
 
@@ -53,7 +63,6 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from types import FunctionType
 
     from streamlit.runtime.caching.cache_type import CacheType
@@ -67,6 +76,9 @@ TTLCACHE_TIMER = time.monotonic
 # Type-annotate the cached function.
 P = ParamSpec("P")
 R = TypeVar("R")
+
+# A function called with a cache entry as the argument when cache entries are removed.
+OnRelease: TypeAlias = Callable[[Any], None]
 
 
 class Cache(Generic[R]):

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -15,7 +15,7 @@
 """LRU cache supporting TTL and max entry count, as well as release hooks for cleanup."""
 
 from collections.abc import Callable
-from typing import Any
+from typing import TypeVar
 
 from cachetools import TTLCache
 
@@ -25,8 +25,11 @@ from typing_extensions import override
 
 from streamlit.runtime.caching.cache_utils import OnRelease
 
+K = TypeVar("K")
+V = TypeVar("V")
 
-class TTLCleanupCache(TTLCache):
+
+class TTLCleanupCache(TTLCache[K, V]):
     """A TTLCache that supports hooks called when items are released."""
 
     def __init__(
@@ -54,13 +57,13 @@ class TTLCleanupCache(TTLCache):
         self._on_release = on_release
 
     @override
-    def popitem(self) -> tuple[Any, Any]:
+    def popitem(self) -> tuple[K, V]:
         key, value = super().popitem()
         self._on_release(value)
         return key, value
 
     @override
-    def expire(self, time: float | None = None) -> list[tuple[Any, Any]]:
+    def expire(self, time: float | None = None) -> list[tuple[K, V]]:
         items = super().expire(time)
         for _, value in items:
             self._on_release(value)

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -15,9 +15,13 @@
 """LRU cache supporting TTL and max entry count, as well as release hooks for cleanup."""
 
 from collections.abc import Callable, Iterable
-from typing import Any, override
+from typing import Any
 
 from cachetools import TTLCache
+
+# override is in typing after Python 3.12 and can be imported from there after 3.11
+# support is retired.
+from typing_extensions import override
 
 from streamlit.runtime.caching.cache_utils import OnRelease
 

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -1,0 +1,59 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LRU cache supporting TTL and max entry count, as well as release hooks for cleanup."""
+
+from collections.abc import Callable
+from typing import override
+
+from cachetools import TTLCache
+
+from streamlit.runtime.caching.cache_utils import OnRelease
+
+
+class TTLCleanupCache(TTLCache):
+    """A TTLCache that supports hooks called when items are released."""
+
+    def __init__(
+        self,
+        maxsize: float,
+        ttl: float,
+        timer: Callable[[], float],
+        on_release: OnRelease,
+    ) -> None:
+        """Create a cache with the given size, TTL, and release hook.
+
+        maxsize : float
+            The maxiumum number of elements this cache should hold.
+        ttl : float
+            The amount of time a cache entry should remain valid, in seconds.
+        timer : Callable[[], float]
+            The timer function to use to fetch the current time.
+        on_release : OnRelease
+            The function to call with cache entries when they are removed from the
+            cache.
+        """
+        super().__init__(maxsize=maxsize, ttl=ttl, timer=timer)
+        self._on_release = on_release
+
+    @override
+    def popitem(self):
+        _, value = super().popitem()
+        self._on_release(value)
+
+    @override
+    def expire(self, time: float | None = None):
+        items = super().expire(time)
+        for _, value in items:
+            self._on_release(value)

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -14,7 +14,7 @@
 
 """LRU cache supporting TTL and max entry count, as well as release hooks for cleanup."""
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any
 
 from cachetools import TTLCache
@@ -60,7 +60,7 @@ class TTLCleanupCache(TTLCache):
         return key, value
 
     @override
-    def expire(self, time: float | None = None) -> Iterable[tuple[Any, Any]]:
+    def expire(self, time: float | None = None) -> list[tuple[Any, Any]]:
         items = super().expire(time)
         for _, value in items:
             self._on_release(value)

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -14,8 +14,8 @@
 
 """LRU cache supporting TTL and max entry count, as well as release hooks for cleanup."""
 
-from collections.abc import Callable
-from typing import override
+from collections.abc import Callable, Iterable
+from typing import Any, override
 
 from cachetools import TTLCache
 
@@ -34,8 +34,10 @@ class TTLCleanupCache(TTLCache):
     ) -> None:
         """Create a cache with the given size, TTL, and release hook.
 
+        Parameters
+        ----------
         maxsize : float
-            The maxiumum number of elements this cache should hold.
+            The maximum number of elements this cache should hold.
         ttl : float
             The amount of time a cache entry should remain valid, in seconds.
         timer : Callable[[], float]
@@ -48,12 +50,15 @@ class TTLCleanupCache(TTLCache):
         self._on_release = on_release
 
     @override
-    def popitem(self):
-        _, value = super().popitem()
+    def popitem(self) -> tuple[Any, Any]:
+        key, value = super().popitem()
         self._on_release(value)
+        return key, value
 
     @override
-    def expire(self, time: float | None = None):
+    def expire(self, time: float | None = None) -> Iterable[tuple[Any, Any]]:
         items = super().expire(time)
         for _, value in items:
             self._on_release(value)
+
+        return items

--- a/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
 
 from streamlit.runtime.caching.ttl_cleanup_cache import TTLCleanupCache
 
@@ -21,8 +20,13 @@ def fake_timer() -> float:
     return 1234
 
 
-class TTLCleanupCacheTest(TestCase):
+class TestTTLCleanupCache:
     def test_releases_when_hits_size(self):
+        """Unit test for on_release.
+
+        Tests that on_release is called when entries are removed from the cache due to
+        hitting the size limit.
+        """
         released_items = []
 
         def on_release(item: int) -> None:
@@ -55,6 +59,11 @@ class TTLCleanupCacheTest(TestCase):
         assert test_cache[12] == 22
 
     def test_releases_when_hits_ttl(self):
+        """Unit test for on_release.
+
+        Tests that on_release is called when entries are removed from the cache due to
+        hitting the TTL.
+        """
         released_items = []
 
         def on_release(item: int) -> None:

--- a/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
@@ -1,0 +1,83 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from streamlit.runtime.caching.ttl_cleanup_cache import TTLCleanupCache
+
+
+def fake_timer() -> float:
+    return 1234
+
+
+class TTLCleanupCacheTest(TestCase):
+    def test_releases_when_hits_size(self):
+        released_items = []
+
+        def on_release(item: int) -> None:
+            released_items.append(item)
+
+        maxsize = 5
+
+        test_cache = TTLCleanupCache(
+            maxsize=maxsize, ttl=120, timer=fake_timer, on_release=on_release
+        )
+
+        # Add a few elements to the cache.
+        for i in range(maxsize):
+            test_cache[i] = i + 10
+
+        # No items released yet.
+        assert released_items == []
+        # Access the third item.
+        assert test_cache[2] == 12
+
+        # Add three more items. The first, second, and fourth items should be released.
+        for i in range(3):
+            test_cache[i + 10] = i + 20
+
+        assert released_items == [10, 11, 13]
+        assert test_cache[2] == 12
+        assert test_cache[4] == 14
+        assert test_cache[10] == 20
+        assert test_cache[11] == 21
+        assert test_cache[12] == 22
+
+    def test_releases_when_hits_ttl(self):
+        released_items = []
+
+        def on_release(item: int) -> None:
+            released_items.append(item)
+
+        test_cache = TTLCleanupCache(
+            maxsize=500, ttl=0, timer=fake_timer, on_release=on_release
+        )
+
+        # Add a few elements to the cache.
+        for i in range(5):
+            test_cache[i] = i + 10
+
+        # Cache should have released all but the last item. This is an implementation
+        # quirk: It releases prior to write, and doesn't check TTL expiration on write.
+        assert released_items == [10, 11, 12, 13]
+
+        # Validate that the cache doesn't have the last item, either.
+        assert 4 not in test_cache
+        # Validate the last item was not released on read. This is a cache quirk: Items
+        # are not removed on read.
+        assert released_items == [10, 11, 12, 13]
+
+        # Manually expire, and validate the last item will be removed.
+        test_cache.expire()
+        assert released_items == [10, 11, 12, 13, 14]

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -1,6 +1,6 @@
 altair==4.0
 blinker==1.5.0
-cachetools==4.0
+cachetools==5.5
 click==7.0
 gitpython==3.0.7
 numpy==1.23


### PR DESCRIPTION

## Describe your changes

Add a subclass of TTLCache that supports release hooks.

This will be used to implement resource caches that close resources when they leave the cache. See [the spec](https://github.com/streamlit/streamlit/blob/develop/specs/0001-session-scoped-connections-and-rcr/product-spec.md).

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)

Added.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
