### PR TITLE
Link agent rules in dev wiki

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -7,3 +7,15 @@ This wiki contains documentation for the Streamlit development process.
 - [Contributing](../CONTRIBUTING.md): How to contribute to Streamlit.
 - [Code Style Guide](code-style-guide.md): Tips and best practices for writing code in Streamlit.
 - [Running e2e tests and updating snapshots](running-e2e-tests.md): How to run e2e tests and update snapshots.
+
+## Development Guides
+
+Development guides for different parts of the Streamlit codebase, useful for both AI agents and human developers.
+
+- [Repo Overview](../AGENTS.md)
+- [TypeScript](../frontend/AGENTS.md)
+- [Python](../lib/AGENTS.md)
+- [Streamlit Library (Python)](../lib/streamlit/AGENTS.md)
+- [Python Unit Tests](../lib/tests/AGENTS.md)
+- [Protobuf](../proto/streamlit/proto/AGENTS.md)
+- [E2E Tests](../e2e_playwright/AGENTS.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -10,7 +10,7 @@ This wiki contains documentation for the Streamlit development process.
 
 ## Development Guides
 
-Development guides for different parts of the Streamlit codebase, useful for both AI agents and human developers.
+Development guides for different parts of the Streamlit codebase. While written primarily for AI agents, these guides are also helpful for human developers.
 
 - [Repo Overview](../AGENTS.md)
 - [TypeScript](../frontend/AGENTS.md)

--- a/wiki/code-style-guide.md
+++ b/wiki/code-style-guide.md
@@ -3,7 +3,7 @@
 Streamlit uses code auto-formatters and linters on pre-commit. Most of the style-related work is automatically done for you. For everything else, there's this page.
 
 > [!NOTE]
-> We have added [development guides](README.md#development-guides) for different parts of the Streamlit codebase, useful for both AI agents and human developers.
+> We have added [development guides](README.md#development-guides) for different parts of the Streamlit codebase. While written primarily for AI agents, these guides are also helpful for human developers.
 
 ## Every language
 

--- a/wiki/code-style-guide.md
+++ b/wiki/code-style-guide.md
@@ -2,6 +2,9 @@
 
 Streamlit uses code auto-formatters and linters on pre-commit. Most of the style-related work is automatically done for you. For everything else, there's this page.
 
+> [!NOTE]
+> We have added [development guides](README.md#development-guides) for different parts of the Streamlit codebase, useful for both AI agents and human developers.
+
 ## Every language
 
 - **Write tests!** It is very rare that any contribution will be accepted without tests.
@@ -22,6 +25,7 @@ We use [PEP8 style](https://pep8.org) for Python code, with a few adjustments:
 - Use [Numpydoc style](https://numpydoc.readthedocs.io/en/latest/format.html).
 - Docstrings are meant for users of a function, not developers who may edit the internals of that function in the future. If you want to talk to future developers, use comments.
 - All modules that we expect users to interact with must have top-level docstrings. If a user is not meant to interact with a module, docstrings are optional.
+- Brief docstring comments on test functions are recommended, but not enforced.
 - A docstring should not be a simple re-statement of the function name / class name / filename. For example, this is a bad docstring for DeltaGenerator.py: "Declares the DeltaGenerator class".
 
 ### Logging and printing


### PR DESCRIPTION
## Describe your changes

While our agent rules have been primarily written for AI agents, they are also useful for humans since they are currently our "ground-truth" of development guidelines and best practices. Therefore, linking this in our wiki and style guide. 


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
