### PR TITLE
Add a note about `make update-min-deps`.

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -30,6 +30,8 @@ VERSION = "1.52.2"  # PEP-440
 # - Include relevant lower bound for any features we use from our dependencies
 # - Always include the lower bound as >= VERSION, to keep testing min versions easy
 # - And include an upper bound that's < NEXT_MAJOR_VERSION
+# NOTE: If you change the lower bound of a version, you will need to run
+# `make update-min-deps` and commit the changes to `min-constraints-gen.txt`.
 INSTALL_REQUIRES = [
     # Altair 5.4.0 and 5.4.1 have compatibility issues with narwhals library
     # that cause st.line_chart and other built-in charts to fail rendering.


### PR DESCRIPTION
## Describe your changes

Add a note to `setup.py` about changing min versions of a library.

Without doing this, `py-min-deps-test` will silently use the old min version.

Note that follow-up work should add a test to verify that this file is up-to-date, probably as a part of the `py-min-deps-test` action; and maybe add a precommit to run this automatically.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
