### PR TITLE
Support full `host-config` in window

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -6145,11 +6145,11 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       )
       const metricsMgr = getStoredValue<MetricsManager>(MetricsManager)
 
+      // Only provided fields are set (no defaults for unprovided fields)
       expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith({
         allowedOrigins,
         useExternalAuthToken: true,
-        enableCustomParentMessages: false,
-        blockErrorDialogs: false,
+        // enableCustomParentMessages and blockErrorDialogs omitted (undefined)
       })
 
       expect(metricsMgr.setMetricsConfig).toHaveBeenCalledWith(metricsUrl)
@@ -6328,11 +6328,12 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       expect(metricsMgr.setMetricsConfig).not.toHaveBeenCalled()
     })
 
-    it("does not apply HOST_CONFIG when bypass validation fails (missing BACKEND_BASE_URL)", () => {
-      // HOST_CONFIG exists but BACKEND_BASE_URL is missing
-      // This should NOT be applied since it fails isHostConfigBypassEnabled() validation
+    it("does not apply HOST_CONFIG when BACKEND_BASE_URL is missing (bypass disabled)", () => {
+      // HOST_CONFIG exists with valid AppConfig fields but BACKEND_BASE_URL is missing
+      // Config should NOT be applied early since bypass mode is disabled
+      // Config will be applied later through onHostConfigResp reconciliation instead
       globalThis.__mockStreamlitConfig = {
-        // BACKEND_BASE_URL intentionally omitted
+        // BACKEND_BASE_URL intentionally omitted - disables bypass
         HOST_CONFIG: {
           allowedOrigins: ["https://example.com"],
           useExternalAuthToken: true,
@@ -6346,7 +6347,8 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       )
       const metricsMgr = getStoredValue<MetricsManager>(MetricsManager)
 
-      // Verify that setAllowedOrigins and setMetricsConfig were NOT called
+      // Verify that NO config was applied early (bypass mode is disabled)
+      // Config will be applied through onHostConfigResp reconciliation
       expect(hostCommunicationMgr.setAllowedOrigins).not.toHaveBeenCalled()
       expect(metricsMgr.setMetricsConfig).not.toHaveBeenCalled()
     })
@@ -6370,6 +6372,199 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       const metricsMgr = getStoredValue<MetricsManager>(MetricsManager)
 
       // Verify that setAllowedOrigins and setMetricsConfig were NOT called
+      expect(hostCommunicationMgr.setAllowedOrigins).not.toHaveBeenCalled()
+      expect(metricsMgr.setMetricsConfig).not.toHaveBeenCalled()
+    })
+
+    // Tests for expanded HOST_CONFIG fields (all 9 fields)
+    it("applies all AppConfig fields from HOST_CONFIG", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+
+      // Verify setAllowedOrigins was called with all AppConfig fields
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+        })
+      )
+    })
+
+    it("applies all provided fields from HOST_CONFIG including LibConfig", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          // AppConfig
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          // LibConfig fields (stored in state, tested via onHostConfigResp reconciliation)
+          mapboxToken: "test-mapbox-token",
+          disableFullscreenMode: true,
+          enforceDownloadInNewTab: true,
+          resourceCrossOriginMode: "use-credentials",
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+
+      // Verify AppConfig fields were applied (observable through manager calls)
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+        })
+      )
+      // Note: LibConfig fields are stored in state and will be reconciled when
+      // onHostConfigResp is called. Their precedence is tested in the reconciliation tests.
+    })
+
+    it("applies complete HOST_CONFIG with all 9 fields", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          // AppConfig
+          allowedOrigins: ["https://example1.com", "https://example2.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+          // LibConfig
+          mapboxToken: "complete-mapbox-token",
+          disableFullscreenMode: false,
+          enforceDownloadInNewTab: true,
+          resourceCrossOriginMode: "anonymous",
+          // MetricsConfig
+          metricsUrl: "postMessage",
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+      const metricsMgr = getStoredValue<MetricsManager>(MetricsManager)
+
+      // Verify AppConfig fields (observable through manager calls)
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedOrigins: ["https://example1.com", "https://example2.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+        })
+      )
+
+      // Verify MetricsConfig field (observable through manager call)
+      expect(metricsMgr.setMetricsConfig).toHaveBeenCalledWith("postMessage")
+
+      // Note: LibConfig fields are stored in state and tested via reconciliation when
+      // onHostConfigResp is called.
+    })
+
+    it("handles partial HOST_CONFIG with only some expanded fields", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          // Only provide some expanded fields
+          mapboxToken: "partial-token",
+          enableCustomParentMessages: true,
+          // Other fields omitted (will remain undefined until reconciliation)
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+
+      // Verify ONLY provided AppConfig fields are set (no defaults)
+      // blockErrorDialogs is not provided, so it won't be in the object
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith({
+        allowedOrigins: ["https://example.com"],
+        useExternalAuthToken: true,
+        enableCustomParentMessages: true,
+        // blockErrorDialogs is omitted (undefined) - will be set during reconciliation
+      })
+      // Note: Partial LibConfig fields (mapboxToken) are stored in state and tested
+      // via reconciliation when onHostConfigResp is called.
+    })
+
+    it("applies boolean false values correctly (not treated as undefined)", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: false, // Explicitly false
+          enableCustomParentMessages: false, // Explicitly false
+          blockErrorDialogs: false, // Explicitly false
+          disableFullscreenMode: false, // Explicitly false (in LibConfig)
+          enforceDownloadInNewTab: false, // Explicitly false (in LibConfig)
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+
+      // Verify false values are preserved in AppConfig (observable through manager calls)
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith(
+        expect.objectContaining({
+          useExternalAuthToken: false,
+          enableCustomParentMessages: false,
+          blockErrorDialogs: false,
+        })
+      )
+      // Note: LibConfig false values (disableFullscreenMode, enforceDownloadInNewTab)
+      // are stored in state and tested via reconciliation when onHostConfigResp is called.
+    })
+
+    it("does not apply any fields when bypass validation fails (empty allowedOrigins)", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: [], // Empty - fails bypass validation
+          useExternalAuthToken: true,
+          // Try to provide expanded fields
+          enableCustomParentMessages: true,
+          mapboxToken: "should-not-be-applied",
+        },
+      }
+
+      renderApp(getProps())
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+      const metricsMgr = getStoredValue<MetricsManager>(MetricsManager)
+
+      // Verify that NO config was applied (bypass validation failed)
+      // Neither AppConfig nor LibConfig nor MetricsConfig should be applied
       expect(hostCommunicationMgr.setAllowedOrigins).not.toHaveBeenCalled()
       expect(metricsMgr.setMetricsConfig).not.toHaveBeenCalled()
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -6568,5 +6568,27 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       expect(hostCommunicationMgr.setAllowedOrigins).not.toHaveBeenCalled()
       expect(metricsMgr.setMetricsConfig).not.toHaveBeenCalled()
     })
+
+    // Test resourceCrossOriginMode in bypass mode
+    // Note: Window config does not support deprecated setAnonymousCrossOriginPropertyOnMediaElements.
+    // The deprecated field is only supported via endpoint response (non-bypass path).
+    it("applies resourceCrossOriginMode from HOST_CONFIG in bypass mode", () => {
+      globalThis.__mockStreamlitConfig = {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          resourceCrossOriginMode: "use-credentials",
+        },
+      }
+
+      renderApp(getProps())
+
+      // Bypass enabled - resourceCrossOriginMode is applied
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -152,7 +152,10 @@ import { showDevelopmentOptions } from "./showDevelopmentOptions"
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
 import { AppNavigation, MaybeStateUpdate } from "./util/AppNavigation"
-import { reconcileHostConfigValues } from "./util/hostConfigHelpers"
+import {
+  includeIfDefined,
+  reconcileHostConfigValues,
+} from "./util/hostConfigHelpers"
 import { ThemeManager } from "./util/useThemeManager"
 
 // vite config builds global variable PACKAGE_METADATA
@@ -459,37 +462,61 @@ export class App extends PureComponent<Props, State> {
   }
 
   private applyInitialHostConfig(): void {
-    // Apply minimal host configuration from StreamlitConfig.HOST_CONFIG only when
-    // bypass mode is enabled. This ensures the initial config is valid and complete
-    // (has BACKEND_BASE_URL, allowedOrigins, and useExternalAuthToken).
-    // Partial or invalid HOST_CONFIG should be ignored to prevent inconsistent state.
+    // Apply window host configuration early when bypass mode is enabled.
+    //
+    // When bypass is enabled: WebSocket connects immediately (before host-config endpoint),
+    // so we need to apply window config early to enable host communication & apply app/lib configs
+    // for the first render.
+    //
+    // When bypass is disabled: WebSocket waits for host-config endpoint anyway,
+    // so window config will be applied during reconciliation in onHostConfigResp.
+    //
+    // This ensures we only set state when necessary and keeps the logic clear:
+    // - Bypass path: Apply ONLY provided window config early, reconcile when endpoint responds
+    // - Default path: Wait for endpoint, apply reconciled config once
+    //
+    // Note: We only set values that are explicitly provided. Components
+    // are designed to handle undefined config values gracefully.
+    // The endpoint response will fill in any missing values during reconciliation.
     if (!isHostConfigBypassEnabled()) {
       return
     }
 
-    // isHostConfigBypassEnabled() guarantees HOST_CONFIG exists and is valid
-    const { allowedOrigins, useExternalAuthToken, metricsUrl } =
+    // isHostConfigBypassEnabled() guarantees HOST_CONFIG exists and has valid
+    // allowedOrigins (non-empty array) and useExternalAuthToken (boolean)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const hostConfig = StreamlitConfig.HOST_CONFIG!
+
+    // Build AppConfig with only provided fields - don't set defaults
+    // Required fields are guaranteed by isHostConfigBypassEnabled()
+    const appConfig: AppConfig = includeIfDefined<AppConfig>({
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      StreamlitConfig.HOST_CONFIG!
-
-    const appConfig: AppConfig = {
-      allowedOrigins,
-      useExternalAuthToken,
-      enableCustomParentMessages: false,
-      blockErrorDialogs: false,
-    }
-
-    const libConfig: LibConfig = {}
-
-    // metricsUrl is optional (so not required for isHostConfigBypassEnabled)
-    // so we only set it if it exists
-    if (metricsUrl !== undefined) {
-      this.metricsMgr.setMetricsConfig(metricsUrl)
-    }
+      allowedOrigins: hostConfig.allowedOrigins!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      useExternalAuthToken: hostConfig.useExternalAuthToken!,
+      enableCustomParentMessages: hostConfig.enableCustomParentMessages,
+      blockErrorDialogs: hostConfig.blockErrorDialogs,
+    })
 
     this.hostCommunicationMgr.setAllowedOrigins(appConfig)
     this.setAppConfig(appConfig)
-    this.setLibConfig(libConfig)
+
+    // Build LibConfig with only provided fields
+    const libConfig: LibConfig = includeIfDefined<LibConfig>({
+      mapboxToken: hostConfig.mapboxToken,
+      disableFullscreenMode: hostConfig.disableFullscreenMode,
+      enforceDownloadInNewTab: hostConfig.enforceDownloadInNewTab,
+      resourceCrossOriginMode: hostConfig.resourceCrossOriginMode,
+    })
+
+    if (Object.keys(libConfig).length > 0) {
+      this.setLibConfig(libConfig)
+    }
+
+    // Apply metrics config if provided
+    if (hostConfig.metricsUrl !== undefined) {
+      this.metricsMgr.setMetricsConfig(hostConfig.metricsUrl)
+    }
   }
 
   initializeConnectionManager(): void {
@@ -520,8 +547,10 @@ export class App extends PureComponent<Props, State> {
       },
       onHostConfigResp: (response: IHostConfigResponse) => {
         // Reconcile window config values with endpoint response.
-        // Window values for allowedOrigins, useExternalAuthToken, and metricsUrl
-        // take precedence when present.
+        // All provided window config values take precedence over endpoint values:
+        // AppConfig: allowedOrigins, useExternalAuthToken, enableCustomParentMessages, blockErrorDialogs
+        // LibConfig: mapboxToken, disableFullscreenMode, enforceDownloadInNewTab, resourceCrossOriginMode
+        // MetricsConfig: metricsUrl
         const reconciledConfig = reconcileHostConfigValues(
           StreamlitConfig.HOST_CONFIG,
           response

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -52,7 +52,7 @@ import {
   ConnectionState,
   DefaultStreamlitEndpoints,
   ErrorDetails,
-  IHostConfigResponse,
+  IHostConfigProperties,
   isHostConfigBypassEnabled,
   LibConfig,
   parseUriIntoBaseParts,
@@ -502,6 +502,8 @@ export class App extends PureComponent<Props, State> {
     this.setAppConfig(appConfig)
 
     // Build LibConfig with only provided fields
+    // Note: Window config does not support deprecated setAnonymousCrossOriginPropertyOnMediaElements.
+    // Use resourceCrossOriginMode instead. The deprecated field is only supported via endpoint.
     const libConfig: LibConfig = includeIfDefined<LibConfig>({
       mapboxToken: hostConfig.mapboxToken,
       disableFullscreenMode: hostConfig.disableFullscreenMode,
@@ -545,7 +547,7 @@ export class App extends PureComponent<Props, State> {
           source,
         })
       },
-      onHostConfigResp: (response: IHostConfigResponse) => {
+      onHostConfigResp: (response: IHostConfigProperties) => {
         // Reconcile window config values with endpoint response.
         // All provided window config values take precedence over endpoint values:
         // AppConfig: allowedOrigins, useExternalAuthToken, enableCustomParentMessages, blockErrorDialogs
@@ -580,11 +582,13 @@ export class App extends PureComponent<Props, State> {
           mapboxToken,
           disableFullscreenMode,
           enforceDownloadInNewTab,
+          // Use resourceCrossOriginMode if provided, otherwise fall back to
+          // deprecated setAnonymousCrossOriginPropertyOnMediaElements (if true, use "anonymous")
           resourceCrossOriginMode:
-            (resourceCrossOriginMode ??
-            setAnonymousCrossOriginPropertyOnMediaElements)
+            resourceCrossOriginMode ??
+            (setAnonymousCrossOriginPropertyOnMediaElements
               ? "anonymous"
-              : undefined,
+              : undefined),
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/util/hostConfigHelpers.test.ts
+++ b/frontend/app/src/util/hostConfigHelpers.test.ts
@@ -36,34 +36,15 @@ describe("includeIfDefined", () => {
     expect(result).not.toHaveProperty("alsoUndefined")
   })
 
-  it("keeps false values", () => {
-    const input = { flag: false, other: undefined }
+  it.each([
+    ["false", { flag: false, other: undefined }, { flag: false }],
+    ["null", { value: null, other: undefined }, { value: null }],
+    ["0", { count: 0, other: undefined }, { count: 0 }],
+    ["empty string", { text: "", other: undefined }, { text: "" }],
+    ["empty array", { items: [], other: undefined }, { items: [] }],
+  ] as const)("keeps %s values", (_description, input, expected) => {
     const result = includeIfDefined(input)
-    expect(result).toEqual({ flag: false })
-  })
-
-  it("keeps null values", () => {
-    const input = { value: null, other: undefined }
-    const result = includeIfDefined(input)
-    expect(result).toEqual({ value: null })
-  })
-
-  it("keeps 0 values", () => {
-    const input = { count: 0, other: undefined }
-    const result = includeIfDefined(input)
-    expect(result).toEqual({ count: 0 })
-  })
-
-  it("keeps empty string values", () => {
-    const input = { text: "", other: undefined }
-    const result = includeIfDefined(input)
-    expect(result).toEqual({ text: "" })
-  })
-
-  it("keeps empty array values", () => {
-    const input = { items: [], other: undefined }
-    const result = includeIfDefined(input)
-    expect(result).toEqual({ items: [] })
+    expect(result).toEqual(expected)
   })
 
   it("returns empty object when all values are undefined", () => {
@@ -79,39 +60,34 @@ describe("includeIfDefined", () => {
 })
 
 describe("isValidAllowedOrigins", () => {
-  it("returns true for valid allowedOrigins", () => {
-    expect(isValidAllowedOrigins(["https://example.com"])).toBe(true)
-    expect(
-      isValidAllowedOrigins(["https://example1.com", "https://example2.com"])
-    ).toBe(true)
+  it.each([
+    [["https://example.com"], "single valid origin"],
+    [
+      ["https://example1.com", "https://example2.com"],
+      "multiple valid origins",
+    ],
+  ])("returns true for %s (%s)", (input, _description) => {
+    expect(isValidAllowedOrigins(input)).toBe(true)
   })
 
-  it("returns false for empty array", () => {
-    expect(isValidAllowedOrigins([])).toBe(false)
-  })
-
-  it("returns false for non-array values", () => {
-    expect(isValidAllowedOrigins(undefined)).toBe(false)
-    expect(isValidAllowedOrigins(null)).toBe(false)
-    expect(isValidAllowedOrigins("https://example.com")).toBe(false)
-    expect(isValidAllowedOrigins({ 0: "https://example.com" })).toBe(false)
-  })
-
-  it("returns false when array contains non-string values", () => {
-    expect(isValidAllowedOrigins([123])).toBe(false)
-    expect(isValidAllowedOrigins([null])).toBe(false)
-    expect(isValidAllowedOrigins([undefined])).toBe(false)
-    expect(isValidAllowedOrigins(["https://example.com", 123])).toBe(false)
-  })
-
-  it("returns false when array contains empty strings", () => {
-    expect(isValidAllowedOrigins([""])).toBe(false)
-    expect(isValidAllowedOrigins(["https://example.com", ""])).toBe(false)
-    expect(isValidAllowedOrigins(["", "https://example.com"])).toBe(false)
-  })
-
-  it("returns false when array contains only empty strings", () => {
-    expect(isValidAllowedOrigins(["", ""])).toBe(false)
+  it.each([
+    [[], "empty array"],
+    [undefined, "undefined"],
+    [null, "null"],
+    ["https://example.com", "string instead of array"],
+    [{ 0: "https://example.com" }, "object instead of array"],
+    [[123], "array with number"],
+    [[null], "array with null"],
+    [[undefined], "array with undefined"],
+    [["https://example.com", 123], "array with mixed types"],
+    [[""], "array with empty string"],
+    [["https://example.com", ""], "array with valid and empty string"],
+    [["", "https://example.com"], "array starting with empty string"],
+    [["", ""], "array with only empty strings"],
+    [["  "], "array with whitespace-only string"],
+    [["https://example.com", "  "], "array with valid and whitespace-only"],
+  ])("returns false for %s (%s)", (input, _description) => {
+    expect(isValidAllowedOrigins(input)).toBe(false)
   })
 })
 
@@ -120,21 +96,16 @@ describe("preferWindowValue", () => {
     expect(preferWindowValue("window", "endpoint")).toBe("window")
   })
 
-  it("returns endpoint value when window value is undefined", () => {
-    expect(preferWindowValue(undefined, "endpoint")).toBe("endpoint")
-  })
-
-  it("handles boolean false as defined window value", () => {
-    expect(preferWindowValue(false, true)).toBe(false)
-  })
-
-  it("handles number 0 as defined window value", () => {
-    expect(preferWindowValue(0, 100)).toBe(0)
-  })
-
-  it("handles empty string as defined window value", () => {
-    expect(preferWindowValue("", "endpoint")).toBe("")
-  })
+  it.each([
+    ["boolean false", false, true, false],
+    ["number 0", 0, 100, 0],
+    ["empty string", "", "endpoint", ""],
+  ] as const)(
+    "handles %s as defined window value",
+    (_description, windowValue, endpointValue, expected) => {
+      expect(preferWindowValue(windowValue, endpointValue)).toBe(expected)
+    }
+  )
 
   it("handles empty array as defined window value", () => {
     const emptyArray: string[] = []
@@ -154,13 +125,15 @@ describe("preferWindowValue", () => {
     expect(preferWindowValue(windowArr, endpointArr)).toEqual(["a", "b"])
   })
 
-  it("treats null as not provided (uses endpoint value)", () => {
-    expect(preferWindowValue(null, "endpoint")).toBe("endpoint")
-  })
-
-  it("treats undefined as not provided (uses endpoint value)", () => {
-    expect(preferWindowValue(undefined, "endpoint")).toBe("endpoint")
-  })
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ] as const)(
+    "treats %s as not provided (uses endpoint value)",
+    (_, value) => {
+      expect(preferWindowValue(value, "endpoint")).toBe("endpoint")
+    }
+  )
 
   it("prefers window value even when endpoint is null", () => {
     expect(preferWindowValue("window", null as unknown as string)).toBe(

--- a/frontend/app/src/util/hostConfigHelpers.test.ts
+++ b/frontend/app/src/util/hostConfigHelpers.test.ts
@@ -14,19 +14,106 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 
-import { isHostConfigBypassEnabled } from "@streamlit/connection"
+import { isValidAllowedOrigins } from "@streamlit/utils"
 
 import {
+  includeIfDefined,
   preferWindowValue,
   reconcileHostConfigValues,
 } from "./hostConfigHelpers"
 
-// Mock the isHostConfigBypassEnabled function
-vi.mock("@streamlit/connection", () => ({
-  isHostConfigBypassEnabled: vi.fn(),
-}))
+describe("includeIfDefined", () => {
+  it("filters out undefined values", () => {
+    const input = {
+      defined: "value",
+      alsoUndefined: undefined,
+      number: 42,
+    }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ defined: "value", number: 42 })
+    expect(result).not.toHaveProperty("alsoUndefined")
+  })
+
+  it("keeps false values", () => {
+    const input = { flag: false, other: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ flag: false })
+  })
+
+  it("keeps null values", () => {
+    const input = { value: null, other: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ value: null })
+  })
+
+  it("keeps 0 values", () => {
+    const input = { count: 0, other: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ count: 0 })
+  })
+
+  it("keeps empty string values", () => {
+    const input = { text: "", other: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ text: "" })
+  })
+
+  it("keeps empty array values", () => {
+    const input = { items: [], other: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({ items: [] })
+  })
+
+  it("returns empty object when all values are undefined", () => {
+    const input = { a: undefined, b: undefined }
+    const result = includeIfDefined(input)
+    expect(result).toEqual({})
+  })
+
+  it("handles empty input object", () => {
+    const result = includeIfDefined({})
+    expect(result).toEqual({})
+  })
+})
+
+describe("isValidAllowedOrigins", () => {
+  it("returns true for valid allowedOrigins", () => {
+    expect(isValidAllowedOrigins(["https://example.com"])).toBe(true)
+    expect(
+      isValidAllowedOrigins(["https://example1.com", "https://example2.com"])
+    ).toBe(true)
+  })
+
+  it("returns false for empty array", () => {
+    expect(isValidAllowedOrigins([])).toBe(false)
+  })
+
+  it("returns false for non-array values", () => {
+    expect(isValidAllowedOrigins(undefined)).toBe(false)
+    expect(isValidAllowedOrigins(null)).toBe(false)
+    expect(isValidAllowedOrigins("https://example.com")).toBe(false)
+    expect(isValidAllowedOrigins({ 0: "https://example.com" })).toBe(false)
+  })
+
+  it("returns false when array contains non-string values", () => {
+    expect(isValidAllowedOrigins([123])).toBe(false)
+    expect(isValidAllowedOrigins([null])).toBe(false)
+    expect(isValidAllowedOrigins([undefined])).toBe(false)
+    expect(isValidAllowedOrigins(["https://example.com", 123])).toBe(false)
+  })
+
+  it("returns false when array contains empty strings", () => {
+    expect(isValidAllowedOrigins([""])).toBe(false)
+    expect(isValidAllowedOrigins(["https://example.com", ""])).toBe(false)
+    expect(isValidAllowedOrigins(["", "https://example.com"])).toBe(false)
+  })
+
+  it("returns false when array contains only empty strings", () => {
+    expect(isValidAllowedOrigins(["", ""])).toBe(false)
+  })
+})
 
 describe("preferWindowValue", () => {
   it("returns window value when it is defined", () => {
@@ -66,184 +153,261 @@ describe("preferWindowValue", () => {
     const endpointArr = ["c", "d"]
     expect(preferWindowValue(windowArr, endpointArr)).toEqual(["a", "b"])
   })
+
+  it("treats null as not provided (uses endpoint value)", () => {
+    expect(preferWindowValue(null, "endpoint")).toBe("endpoint")
+  })
+
+  it("treats undefined as not provided (uses endpoint value)", () => {
+    expect(preferWindowValue(undefined, "endpoint")).toBe("endpoint")
+  })
+
+  it("prefers window value even when endpoint is null", () => {
+    expect(preferWindowValue("window", null as unknown as string)).toBe(
+      "window"
+    )
+  })
 })
 
 describe("reconcileHostConfigValues", () => {
   const mockEndpointConfig = {
+    // AppConfig fields
     allowedOrigins: ["https://endpoint.com"],
     useExternalAuthToken: false,
-    metricsUrl: "https://metrics.endpoint.com",
-    disableFullscreenMode: true,
     enableCustomParentMessages: false,
-    mapboxToken: "endpoint-token",
-    enforceDownloadInNewTab: false,
     blockErrorDialogs: false,
+    // LibConfig fields
+    mapboxToken: "endpoint-token",
+    disableFullscreenMode: true,
+    enforceDownloadInNewTab: false,
+    resourceCrossOriginMode: "anonymous" as const,
+    // MetricsConfig fields
+    metricsUrl: "https://metrics.endpoint.com",
   }
 
-  beforeEach(() => {
-    // By default, assume bypass is enabled (valid config provided)
-    vi.mocked(isHostConfigBypassEnabled).mockReturnValue(true)
-  })
-
-  it("returns endpoint config unchanged when initialHostConfig is undefined", () => {
+  it("returns endpoint config unchanged when windowConfig is undefined", () => {
     const result = reconcileHostConfigValues(undefined, mockEndpointConfig)
     expect(result).toEqual(mockEndpointConfig)
   })
 
+  // Test AppConfig fields
   it("overrides allowedOrigins with window value", () => {
-    const initialHostConfig = {
+    const windowConfig = {
       allowedOrigins: ["https://window.com"],
       useExternalAuthToken: true,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     expect(result.allowedOrigins).toEqual(["https://window.com"])
     expect(result.useExternalAuthToken).toBe(true)
   })
 
   it("overrides useExternalAuthToken with window value", () => {
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
+    const windowConfig = {
       useExternalAuthToken: true,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     expect(result.useExternalAuthToken).toBe(true)
+    // Other fields should use endpoint values
+    expect(result.allowedOrigins).toEqual(["https://endpoint.com"])
   })
 
+  it("overrides enableCustomParentMessages with window value", () => {
+    const windowConfig = {
+      enableCustomParentMessages: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.enableCustomParentMessages).toBe(true)
+    // Other fields should use endpoint values
+    expect(result.useExternalAuthToken).toBe(false)
+  })
+
+  it("overrides blockErrorDialogs with window value", () => {
+    const windowConfig = {
+      blockErrorDialogs: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.blockErrorDialogs).toBe(true)
+    // Other fields should use endpoint values
+    expect(result.enableCustomParentMessages).toBe(false)
+  })
+
+  // Test LibConfig fields
+  it("overrides mapboxToken with window value", () => {
+    const windowConfig = {
+      mapboxToken: "window-token",
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.mapboxToken).toBe("window-token")
+    // Other fields should use endpoint values
+    expect(result.disableFullscreenMode).toBe(true)
+  })
+
+  it("overrides disableFullscreenMode with window value", () => {
+    const windowConfig = {
+      disableFullscreenMode: false,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.disableFullscreenMode).toBe(false)
+    // Other fields should use endpoint values
+    expect(result.mapboxToken).toBe("endpoint-token")
+  })
+
+  it("overrides enforceDownloadInNewTab with window value", () => {
+    const windowConfig = {
+      enforceDownloadInNewTab: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.enforceDownloadInNewTab).toBe(true)
+    // Other fields should use endpoint values
+    expect(result.disableFullscreenMode).toBe(true)
+  })
+
+  it("overrides resourceCrossOriginMode with window value", () => {
+    const windowConfig = {
+      resourceCrossOriginMode: "use-credentials" as const,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    expect(result.resourceCrossOriginMode).toBe("use-credentials")
+    // Other fields should use endpoint values
+    expect(result.mapboxToken).toBe("endpoint-token")
+  })
+
+  // Test MetricsConfig fields
   it("overrides metricsUrl with window value", () => {
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
-      useExternalAuthToken: true,
+    const windowConfig = {
       metricsUrl: "postMessage" as const,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     expect(result.metricsUrl).toBe("postMessage")
   })
 
-  it("preserves non-minimal config fields from endpoint", () => {
-    const initialHostConfig = {
+  // Test partial window config
+  it("handles partial window config (only some fields provided)", () => {
+    const windowConfig = {
       allowedOrigins: ["https://window.com"],
-      useExternalAuthToken: true,
-      metricsUrl: "postMessage" as const,
+      mapboxToken: "window-token",
+      // Other fields undefined
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
-
-    // These should NOT be overridden
-    expect(result.disableFullscreenMode).toBe(true)
-    expect(result.enableCustomParentMessages).toBe(false)
-    expect(result.mapboxToken).toBe("endpoint-token")
-    expect(result.enforceDownloadInNewTab).toBe(false)
-    expect(result.blockErrorDialogs).toBe(false)
-  })
-
-  it("uses endpoint values for minimal fields when window values are undefined", () => {
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
-      useExternalAuthToken: true,
-      // metricsUrl is undefined
-    }
-
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     // Window values should be used
     expect(result.allowedOrigins).toEqual(["https://window.com"])
-    expect(result.useExternalAuthToken).toBe(true)
-    // Endpoint value should be used for metricsUrl
+    expect(result.mapboxToken).toBe("window-token")
+    // Endpoint values should be used for unprovided fields
+    expect(result.useExternalAuthToken).toBe(false)
+    expect(result.enableCustomParentMessages).toBe(false)
+    expect(result.blockErrorDialogs).toBe(false)
+    expect(result.disableFullscreenMode).toBe(true)
+    expect(result.enforceDownloadInNewTab).toBe(false)
+    expect(result.resourceCrossOriginMode).toBe("anonymous")
     expect(result.metricsUrl).toBe("https://metrics.endpoint.com")
   })
 
+  // Test complete window config
+  it("handles complete window config (all 9 fields provided)", () => {
+    const windowConfig = {
+      // AppConfig
+      allowedOrigins: ["https://window1.com", "https://window2.com"],
+      useExternalAuthToken: true,
+      enableCustomParentMessages: true,
+      blockErrorDialogs: true,
+      // LibConfig
+      mapboxToken: "window-mapbox-token",
+      disableFullscreenMode: false,
+      enforceDownloadInNewTab: true,
+      resourceCrossOriginMode: "use-credentials" as const,
+      // MetricsConfig
+      metricsUrl: "postMessage" as const,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // All window values should be used
+    expect(result.allowedOrigins).toEqual([
+      "https://window1.com",
+      "https://window2.com",
+    ])
+    expect(result.useExternalAuthToken).toBe(true)
+    expect(result.enableCustomParentMessages).toBe(true)
+    expect(result.blockErrorDialogs).toBe(true)
+    expect(result.mapboxToken).toBe("window-mapbox-token")
+    expect(result.disableFullscreenMode).toBe(false)
+    expect(result.enforceDownloadInNewTab).toBe(true)
+    expect(result.resourceCrossOriginMode).toBe("use-credentials")
+    expect(result.metricsUrl).toBe("postMessage")
+  })
+
   it("handles all window values being undefined", () => {
-    const initialHostConfig = {
+    const windowConfig = {
       // All optional fields undefined
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     // Should use all endpoint values
     expect(result).toEqual(mockEndpointConfig)
   })
 
-  it("returns endpoint config when bypass is not enabled", () => {
-    // Simulate invalid config that fails bypass eligibility check
-    vi.mocked(isHostConfigBypassEnabled).mockReturnValue(false)
-
-    const initialHostConfig = {
-      allowedOrigins: [] as string[], // Empty array - invalid for bypass
-      useExternalAuthToken: false,
+  // Test allowedOrigins validation
+  it("validates allowedOrigins and rejects empty array", () => {
+    const windowConfig = {
+      allowedOrigins: [] as string[], // Empty array - invalid
+      useExternalAuthToken: true,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
-    // Should use endpoint values because bypass is not eligible
+    // Empty array should be rejected, endpoint value should be used
     expect(result.allowedOrigins).toEqual(["https://endpoint.com"])
-    expect(result.useExternalAuthToken).toBe(false) // From endpoint
-    expect(result).toEqual(mockEndpointConfig)
+    // But other window values should still be applied
+    expect(result.useExternalAuthToken).toBe(true)
   })
 
-  it("returns endpoint config when bypass eligibility check fails", () => {
-    // Even if initialHostConfig is provided, if bypass check fails, use endpoint
-    vi.mocked(isHostConfigBypassEnabled).mockReturnValue(false)
-
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
-      useExternalAuthToken: true,
-      metricsUrl: "postMessage" as const,
-    }
-
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
-
-    // Should use endpoint config unchanged when bypass is not enabled
-    expect(result).toEqual(mockEndpointConfig)
-  })
-
+  // Test special values
   it("handles metricsUrl: 'off' from window", () => {
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
-      useExternalAuthToken: true,
+    const windowConfig = {
       metricsUrl: "off" as const,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     expect(result.metricsUrl).toBe("off")
   })
 
+  it("handles resourceCrossOriginMode: undefined from window (treated as not provided)", () => {
+    const windowConfig = {
+      resourceCrossOriginMode: undefined,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // Undefined is treated as "not provided", so endpoint value is used
+    // (JavaScript undefined is the same as not setting the property)
+    expect(result.resourceCrossOriginMode).toBe("anonymous")
+  })
+
+  // Test boolean edge cases
   it("handles useExternalAuthToken: false from window (not undefined)", () => {
-    const initialHostConfig = {
-      allowedOrigins: ["https://window.com"],
+    const windowConfig = {
       useExternalAuthToken: false, // Explicitly false
     }
 
@@ -252,24 +416,196 @@ describe("reconcileHostConfigValues", () => {
       useExternalAuthToken: true, // Different from window
     }
 
-    const result = reconcileHostConfigValues(initialHostConfig, endpointConfig)
+    const result = reconcileHostConfigValues(windowConfig, endpointConfig)
 
     // Window value (false) should be used, not endpoint (true)
     expect(result.useExternalAuthToken).toBe(false)
   })
 
-  it("preserves endpoint config object reference for non-overridden fields", () => {
-    const initialHostConfig = {
+  it("handles boolean false values correctly for all boolean fields", () => {
+    const windowConfig = {
+      useExternalAuthToken: false,
+      enableCustomParentMessages: false,
+      blockErrorDialogs: false,
+      disableFullscreenMode: false,
+      enforceDownloadInNewTab: false,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // All false values should be preserved (not treated as undefined)
+    expect(result.useExternalAuthToken).toBe(false)
+    expect(result.enableCustomParentMessages).toBe(false)
+    expect(result.blockErrorDialogs).toBe(false)
+    expect(result.disableFullscreenMode).toBe(false)
+    expect(result.enforceDownloadInNewTab).toBe(false)
+  })
+
+  // Test object reference
+  it("returns a new object (does not modify endpoint config)", () => {
+    const windowConfig = {
       allowedOrigins: ["https://window.com"],
       useExternalAuthToken: true,
     }
 
-    const result = reconcileHostConfigValues(
-      initialHostConfig,
-      mockEndpointConfig
-    )
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
 
     // The result should be a new object
     expect(result).not.toBe(mockEndpointConfig)
+    // Original endpoint config should be unchanged
+    expect(mockEndpointConfig.allowedOrigins).toEqual(["https://endpoint.com"])
+  })
+
+  // Test field precedence with different values
+  it("applies all provided window fields even when they differ from endpoint", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://window.com"],
+      useExternalAuthToken: true,
+      enableCustomParentMessages: true,
+      blockErrorDialogs: true,
+      mapboxToken: "window-token",
+      disableFullscreenMode: false,
+      enforceDownloadInNewTab: true,
+      resourceCrossOriginMode: "use-credentials" as const,
+      metricsUrl: "postMessage" as const,
+    }
+
+    const endpointConfig = {
+      ...mockEndpointConfig,
+      // All values different from window
+      allowedOrigins: ["https://endpoint1.com", "https://endpoint2.com"],
+      useExternalAuthToken: false,
+      enableCustomParentMessages: false,
+      blockErrorDialogs: false,
+      mapboxToken: "endpoint-token",
+      disableFullscreenMode: true,
+      enforceDownloadInNewTab: false,
+      resourceCrossOriginMode: "anonymous" as const,
+      metricsUrl: "https://endpoint-metrics.com",
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, endpointConfig)
+
+    // All window values should take precedence
+    expect(result.allowedOrigins).toEqual(["https://window.com"])
+    expect(result.useExternalAuthToken).toBe(true)
+    expect(result.enableCustomParentMessages).toBe(true)
+    expect(result.blockErrorDialogs).toBe(true)
+    expect(result.mapboxToken).toBe("window-token")
+    expect(result.disableFullscreenMode).toBe(false)
+    expect(result.enforceDownloadInNewTab).toBe(true)
+    expect(result.resourceCrossOriginMode).toBe("use-credentials")
+    expect(result.metricsUrl).toBe("postMessage")
+  })
+
+  it("preserves deprecated setAnonymousCrossOriginPropertyOnMediaElements from endpoint", () => {
+    const endpointConfig = {
+      ...mockEndpointConfig,
+      setAnonymousCrossOriginPropertyOnMediaElements: true,
+    }
+
+    const result = reconcileHostConfigValues(undefined, endpointConfig)
+
+    expect(result.setAnonymousCrossOriginPropertyOnMediaElements).toBe(true)
+  })
+
+  it("preserves deprecated field even when window config is provided", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://window.com"],
+      useExternalAuthToken: true,
+    }
+    const endpointConfig = {
+      ...mockEndpointConfig,
+      setAnonymousCrossOriginPropertyOnMediaElements: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, endpointConfig)
+
+    // Window values override
+    expect(result.allowedOrigins).toEqual(["https://window.com"])
+    // Deprecated field preserved from endpoint
+    expect(result.setAnonymousCrossOriginPropertyOnMediaElements).toBe(true)
+  })
+
+  it("rejects allowedOrigins with empty strings", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://valid.com", ""],
+      useExternalAuthToken: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // Should use endpoint value, not window value with empty string
+    expect(result.allowedOrigins).toEqual(mockEndpointConfig.allowedOrigins)
+  })
+
+  it("rejects allowedOrigins with only empty strings", () => {
+    const windowConfig = {
+      allowedOrigins: ["", ""],
+      useExternalAuthToken: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // Should use endpoint value
+    expect(result.allowedOrigins).toEqual(mockEndpointConfig.allowedOrigins)
+  })
+
+  it("rejects allowedOrigins with non-string values", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://valid.com", 123] as unknown as string[],
+      useExternalAuthToken: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // Should use endpoint value due to invalid window config
+    expect(result.allowedOrigins).toEqual(mockEndpointConfig.allowedOrigins)
+  })
+
+  it("correctly overrides all boolean fields when set to false", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://window.com"],
+      useExternalAuthToken: false, // false, not undefined
+      enableCustomParentMessages: false,
+      blockErrorDialogs: false,
+      disableFullscreenMode: false,
+      enforceDownloadInNewTab: false,
+    }
+    const endpointConfig = {
+      ...mockEndpointConfig,
+      // All endpoint values are true
+      useExternalAuthToken: true,
+      enableCustomParentMessages: true,
+      blockErrorDialogs: true,
+      disableFullscreenMode: true,
+      enforceDownloadInNewTab: true,
+    }
+
+    const result = reconcileHostConfigValues(windowConfig, endpointConfig)
+
+    // Window false values should override endpoint true values
+    expect(result.useExternalAuthToken).toBe(false)
+    expect(result.enableCustomParentMessages).toBe(false)
+    expect(result.blockErrorDialogs).toBe(false)
+    expect(result.disableFullscreenMode).toBe(false)
+    expect(result.enforceDownloadInNewTab).toBe(false)
+  })
+
+  it("treats null window values as not provided", () => {
+    const windowConfig = {
+      allowedOrigins: ["https://window.com"],
+      useExternalAuthToken: true,
+      mapboxToken: null,
+      metricsUrl: null,
+    } as unknown as typeof mockEndpointConfig
+
+    const result = reconcileHostConfigValues(windowConfig, mockEndpointConfig)
+
+    // Null values should not override endpoint
+    expect(result.mapboxToken).toBe(mockEndpointConfig.mapboxToken)
+    expect(result.metricsUrl).toBe(mockEndpointConfig.metricsUrl)
+    // Valid values should still override
+    expect(result.allowedOrigins).toEqual(["https://window.com"])
   })
 })

--- a/frontend/app/src/util/hostConfigHelpers.ts
+++ b/frontend/app/src/util/hostConfigHelpers.ts
@@ -21,18 +21,21 @@ import { type HostWindowConfig, isValidAllowedOrigins } from "@streamlit/utils"
  * Helper to conditionally include object properties only if they are defined.
  * This prevents polluting config objects with explicit undefined values.
  *
+ * Note: This intentionally keeps null values, as null represents an explicit
+ * value (e.g., "no token configured") whereas undefined means "not provided".
+ *
  * @param obj - Partial object with potentially undefined values
- * @returns Object with only the defined properties
+ * @returns Object with only the defined properties (null values are kept)
  */
 export function includeIfDefined<T extends Record<string, unknown>>(
   obj: Partial<T>
 ): Partial<T> {
-  return Object.entries(obj).reduce((acc, [key, value]) => {
+  return Object.entries(obj).reduce<Partial<T>>((acc, [key, value]) => {
     if (value !== undefined) {
       acc[key as keyof T] = value
     }
     return acc
-  }, {} as Partial<T>)
+  }, {})
 }
 
 /**

--- a/frontend/app/src/util/hostConfigHelpers.ts
+++ b/frontend/app/src/util/hostConfigHelpers.ts
@@ -15,64 +15,120 @@
  */
 
 import type { IHostConfigResponse } from "@streamlit/connection"
-import { isHostConfigBypassEnabled } from "@streamlit/connection"
-import type { MinimalHostConfig } from "@streamlit/utils"
+import { type HostWindowConfig, isValidAllowedOrigins } from "@streamlit/utils"
+
+/**
+ * Helper to conditionally include object properties only if they are defined.
+ * This prevents polluting config objects with explicit undefined values.
+ *
+ * @param obj - Partial object with potentially undefined values
+ * @returns Object with only the defined properties
+ */
+export function includeIfDefined<T extends Record<string, unknown>>(
+  obj: Partial<T>
+): Partial<T> {
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    if (value !== undefined) {
+      acc[key as keyof T] = value
+    }
+    return acc
+  }, {} as Partial<T>)
+}
 
 /**
  * Helper function to prefer window.__streamlit values over endpoint values
  * when both are present. This ensures that configuration provided via the
  * window object takes precedence for the fast-path connection.
  *
+ * Note: null and undefined are treated as "not provided" and will not override
+ * the endpoint value, as they are not valid configuration values.
+ *
  * @param windowValue - Value from window.__streamlit (StreamlitConfig)
  * @param endpointValue - Value from the host-config endpoint response
- * @returns The window value if defined, otherwise the endpoint value
+ * @returns The window value if defined and not null, otherwise the endpoint value
  */
 export function preferWindowValue<T>(
-  windowValue: T | undefined,
+  windowValue: T | undefined | null,
   endpointValue: T
 ): T {
-  return windowValue !== undefined ? windowValue : endpointValue
+  return windowValue !== undefined && windowValue !== null
+    ? windowValue
+    : endpointValue
 }
 
 /**
- * Reconciles the minimal host config values from window.__streamlit with
+ * Reconciles host config values from window.__streamlit with
  * the full host config response from the endpoint.
  *
- * For the three minimal config fields (allowedOrigins, useExternalAuthToken,
- * metricsUrl), window values take precedence over endpoint values when bypass mode
- * is enabled .
- * All other fields from the endpoint response are preserved as-is.
+ * ALL provided window config values take precedence over endpoint values,
+ * with validation for allowedOrigins (must be non-empty array of non-empty strings).
  *
- * @param initialHostConfig - Minimal config from window.__streamlit.HOST_CONFIG
+ * This ensures that configuration provided via window.__streamlit.HOST_CONFIG
+ * takes precedence for the fast-path connection while still allowing the
+ * endpoint to provide fallback values for unprovided fields.
+ *
+ * @param windowConfig - Config from window.__streamlit.HOST_CONFIG
  * @param endpointConfig - Full config from the host-config endpoint
- * @returns Merged config with window values taking precedence for minimal fields
- *          only when bypass mode is eligible, otherwise returns endpoint config
+ * @returns Merged config with window values taking precedence when provided
  */
 export function reconcileHostConfigValues(
-  initialHostConfig: MinimalHostConfig | undefined,
+  windowConfig: HostWindowConfig | undefined,
   endpointConfig: IHostConfigResponse
 ): IHostConfigResponse {
-  // Only apply window config precedence when bypass mode is eligible.
-  // isHostConfigBypassEnabled() validates that HOST_CONFIG exists and is valid,
-  // preventing invalid configs (e.g., empty allowedOrigins) from overriding
-  // valid endpoint values. We also check initialHostConfig (redundant) to avoid
-  // typescript errors below.
-  if (!isHostConfigBypassEnabled() || !initialHostConfig) {
+  if (!windowConfig) {
     return endpointConfig
   }
 
+  // Validate allowedOrigins using shared validation logic
+  const validAllowedOrigins = isValidAllowedOrigins(
+    windowConfig.allowedOrigins
+  )
+    ? windowConfig.allowedOrigins
+    : undefined
+
   return {
     ...endpointConfig,
+    // AppConfig fields
     allowedOrigins: preferWindowValue(
-      initialHostConfig.allowedOrigins,
+      validAllowedOrigins,
       endpointConfig.allowedOrigins
     ),
     useExternalAuthToken: preferWindowValue(
-      initialHostConfig.useExternalAuthToken,
+      windowConfig.useExternalAuthToken,
       endpointConfig.useExternalAuthToken
     ),
+    enableCustomParentMessages: preferWindowValue(
+      windowConfig.enableCustomParentMessages,
+      endpointConfig.enableCustomParentMessages
+    ),
+    blockErrorDialogs: preferWindowValue(
+      windowConfig.blockErrorDialogs,
+      endpointConfig.blockErrorDialogs
+    ),
+    // LibConfig fields
+    mapboxToken: preferWindowValue(
+      windowConfig.mapboxToken,
+      endpointConfig.mapboxToken
+    ),
+    disableFullscreenMode: preferWindowValue(
+      windowConfig.disableFullscreenMode,
+      endpointConfig.disableFullscreenMode
+    ),
+    enforceDownloadInNewTab: preferWindowValue(
+      windowConfig.enforceDownloadInNewTab,
+      endpointConfig.enforceDownloadInNewTab
+    ),
+    resourceCrossOriginMode: preferWindowValue(
+      windowConfig.resourceCrossOriginMode,
+      endpointConfig.resourceCrossOriginMode
+    ),
+    // Deprecated field - preserve from endpoint (not overridable via window)
+    // This is used as a fallback for resourceCrossOriginMode in App.tsx
+    setAnonymousCrossOriginPropertyOnMediaElements:
+      endpointConfig.setAnonymousCrossOriginPropertyOnMediaElements,
+    // MetricsConfig fields
     metricsUrl: preferWindowValue(
-      initialHostConfig.metricsUrl,
+      windowConfig.metricsUrl,
       endpointConfig.metricsUrl
     ),
   }

--- a/frontend/app/src/util/hostConfigHelpers.ts
+++ b/frontend/app/src/util/hostConfigHelpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IHostConfigResponse } from "@streamlit/connection"
+import type { IHostConfigProperties } from "@streamlit/connection"
 import { type HostWindowConfig, isValidAllowedOrigins } from "@streamlit/utils"
 
 /**
@@ -73,8 +73,8 @@ export function preferWindowValue<T>(
  */
 export function reconcileHostConfigValues(
   windowConfig: HostWindowConfig | undefined,
-  endpointConfig: IHostConfigResponse
-): IHostConfigResponse {
+  endpointConfig: IHostConfigProperties
+): IHostConfigProperties {
   if (!windowConfig) {
     return endpointConfig
   }

--- a/frontend/connection/src/ConnectionManager.ts
+++ b/frontend/connection/src/ConnectionManager.ts
@@ -21,7 +21,11 @@ import { BackMsg, ForwardMsg } from "@streamlit/protobuf"
 import { ConnectionState } from "./ConnectionState"
 import { MAX_RETRIES_BEFORE_CLIENT_ERROR } from "./constants"
 import { establishStaticConnection } from "./StaticConnection"
-import { ErrorDetails, IHostConfigResponse, StreamlitEndpoints } from "./types"
+import {
+  ErrorDetails,
+  IHostConfigProperties,
+  StreamlitEndpoints,
+} from "./types"
 import { getPossibleBaseUris, isHostConfigBypassEnabled } from "./utils"
 import { WebsocketConnection } from "./WebsocketConnection"
 
@@ -76,7 +80,7 @@ interface Props {
    * Function to set the host config for this app (if in a relevant deployment
    * scenario).
    */
-  onHostConfigResp: (resp: IHostConfigResponse) => void
+  onHostConfigResp: (resp: IHostConfigProperties) => void
 }
 
 /**

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -36,7 +36,7 @@ import {
   PING_TIMEOUT_MS,
   SERVER_PING_PATH,
 } from "./constants"
-import { ErrorDetails, IHostConfigResponse, OnRetry } from "./types"
+import { ErrorDetails, IHostConfigProperties, OnRetry } from "./types"
 import {
   FetchError,
   fetchWithTimeout,
@@ -67,7 +67,7 @@ export function doInitPings(
     message: string,
     source: string
   ) => void,
-  onHostConfigResp: (resp: IHostConfigResponse) => void
+  onHostConfigResp: (resp: IHostConfigProperties) => void
 ): AsyncPingRequest {
   const { promise, resolve, reject } = Promise.withResolvers<number>()
   let totalTries = 0
@@ -185,7 +185,7 @@ If you are trying to access a Streamlit app running on another server, this coul
       fetchWithTimeout(hostConfigUri, PING_TIMEOUT_MS),
     ])
       .then(([_, hostConfigResp]) => {
-        onHostConfigResp(hostConfigResp.data as IHostConfigResponse)
+        onHostConfigResp(hostConfigResp.data as IHostConfigProperties)
         resolve(uriNumber)
       })
       .catch((error: FetchError) => {

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -39,7 +39,7 @@ import { ForwardMsgCache } from "./ForwardMessageCache"
 import {
   ErrorDetails,
   Event,
-  IHostConfigResponse,
+  IHostConfigProperties,
   OnConnectionStateChange,
   OnMessage,
   OnRetry,
@@ -103,7 +103,7 @@ export interface Args {
    * Function to set the host config and allowed-message-origins for this app (if in a relevant deployment
    * scenario).
    */
-  onHostConfigResp: (resp: IHostConfigResponse) => void
+  onHostConfigResp: (resp: IHostConfigProperties) => void
 
   /**
    * Enables host to bypass waiting for health/host-config endpoint responses

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -184,12 +184,3 @@ export type {
   LibConfig,
   MetricsConfig,
 } from "@streamlit/utils"
-
-/**
- * The response structure of the `_stcore/host-config` endpoint.
- * This combines streamlit-lib specific configuration options with
- * streamlit-app specific options (e.g. allowed message origins).
- *
- * Note: This is structurally equivalent to IHostConfigProperties from @streamlit/utils.
- */
-export type { IHostConfigProperties as IHostConfigResponse } from "@streamlit/utils"

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -176,83 +176,20 @@ export interface StreamlitEndpoints {
   setFileUploadClientConfig?(config: FileUploadClientConfig): void
 }
 
-/**
- * The lib config contains various configurations that the host platform can
- * use to configure streamlit-lib frontend behavior. This should to be treated as part of the public
- * API, and changes need to be backwards-compatible meaning that an old host configuration
- * should still work with a new frontend versions.
- */
-export type LibConfig = {
-  /**
-   * The mapbox token that can be configured by a platform.
-   */
-  mapboxToken?: string
-
-  /**
-   * Whether to disable the full screen mode all elements / widgets.
-   */
-  disableFullscreenMode?: boolean
-
-  enforceDownloadInNewTab?: boolean
-
-  /**
-   * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
-   * If it is set to undefined, the `crossOrigin` property will not be set on media elements at all.
-   * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
-   */
-  resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
-
-  /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
-  setAnonymousCrossOriginPropertyOnMediaElements?: boolean
-}
-
-/**
- * The app config contains various configurations that the host platform can
- * use to configure streamlit-app frontend behavior. This should to be treated as part of the public
- * API, and changes need to be backwards-compatible meaning that an old host configuration
- * should still work with a new frontend versions.
- *
- * TODO(lukasmasuch): Potentially refactor HostCommunicationManager and move this type
- * to AppContext.tsx.
- */
-export type AppConfig = {
-  /**
-   * A list of origins that we're allowed to receive cross-iframe messages
-   * from via the browser's window.postMessage API.
-   */
-  allowedOrigins?: string[]
-  /**
-   * Whether to wait until we've received a SET_AUTH_TOKEN message before
-   * resolving deferredAuthToken.promise. The WebsocketConnection class waits
-   * for this promise to resolve before attempting to establish a connection
-   * with the Streamlit server.
-   */
-  useExternalAuthToken?: boolean
-  /**
-   * Enables custom string messages to be sent to the host
-   */
-  enableCustomParentMessages?: boolean
-  /**
-   * Whether host wants to block error dialogs. If true, blocks error dialogs
-   * from being shown to the user, sends error info to host via postMessage
-   */
-  blockErrorDialogs?: boolean
-}
-
-export type MetricsConfig = {
-  /**
-   * URL to send metrics data to via POST request.
-   * Setting to "postMessage" sends metrics events via postMessage to host.
-   * Setting to "off" disables metrics collection.
-   * If undefined, metricsUrl requested from centralized config file.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-  metricsUrl?: string | "postMessage" | "off"
-}
+// Re-export base config types from @streamlit/utils for backward compatibility
+// These types are now defined in the utils package to avoid duplication
+export type {
+  AppConfig,
+  IHostConfigProperties,
+  LibConfig,
+  MetricsConfig,
+} from "@streamlit/utils"
 
 /**
  * The response structure of the `_stcore/host-config` endpoint.
  * This combines streamlit-lib specific configuration options with
  * streamlit-app specific options (e.g. allowed message origins).
+ *
+ * Note: This is structurally equivalent to IHostConfigProperties from @streamlit/utils.
  */
-export type IHostConfigResponse = LibConfig & AppConfig & MetricsConfig
+export type { IHostConfigProperties as IHostConfigResponse } from "@streamlit/utils"

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -27,8 +27,8 @@ import {
 } from "./utils"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
-vi.mock("@streamlit/utils", async () => {
-  const actual = await vi.importActual("@streamlit/utils")
+vi.mock("@streamlit/utils", async importOriginal => {
+  const actual = await importOriginal<typeof import("@streamlit/utils")>()
   return {
     ...actual,
     get StreamlitConfig() {
@@ -581,49 +581,106 @@ describe("isHostConfigBypassEnabled", () => {
     globalThis.__mockStreamlitConfig = {}
   })
 
-  it("returns false when StreamlitConfig is empty", () => {
-    globalThis.__mockStreamlitConfig = {}
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false when BACKEND_BASE_URL is missing", () => {
-    globalThis.__mockStreamlitConfig = {
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
+  // Tests for invalid configurations that should return false
+  it.each([
+    ["StreamlitConfig is empty", {}],
+    [
+      "BACKEND_BASE_URL is missing",
+      {
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+        },
       },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false when HOST_CONFIG is missing", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false when allowedOrigins is missing", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        useExternalAuthToken: true,
+    ],
+    [
+      "HOST_CONFIG is missing",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
       },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false when allowedOrigins is empty array", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: [],
-        useExternalAuthToken: true,
+    ],
+    [
+      "allowedOrigins is missing",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          useExternalAuthToken: true,
+        },
       },
-    }
+    ],
+    [
+      "allowedOrigins is empty array",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: [],
+          useExternalAuthToken: true,
+        },
+      },
+    ],
+    [
+      "useExternalAuthToken is missing",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+        },
+      },
+    ],
+    [
+      "only expanded fields but missing minimal required fields",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          metricsUrl: "postMessage",
+          enableCustomParentMessages: true,
+          mapboxToken: "test-token",
+          disableFullscreenMode: true,
+        },
+      },
+    ],
+    [
+      "only LibConfig fields (no minimal required fields)",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          mapboxToken: "test-token",
+          disableFullscreenMode: true,
+          enforceDownloadInNewTab: true,
+          resourceCrossOriginMode: "anonymous" as const,
+        },
+      },
+    ],
+    [
+      "allowedOrigins but missing useExternalAuthToken even if other fields present",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          metricsUrl: "postMessage",
+          enableCustomParentMessages: true,
+          mapboxToken: "test-token",
+        },
+      },
+    ],
+    [
+      "useExternalAuthToken but missing allowedOrigins even if other fields present",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          useExternalAuthToken: true,
+          metricsUrl: "postMessage",
+          mapboxToken: "test-token",
+          disableFullscreenMode: true,
+        },
+      },
+    ],
+  ])("returns false when %s", (_description, config) => {
+    globalThis.__mockStreamlitConfig = config
     expect(isHostConfigBypassEnabled()).toBe(false)
   })
 
+  // Tests for invalid allowedOrigins values (require @ts-expect-error)
   it("returns false when allowedOrigins is not an array", () => {
     globalThis.__mockStreamlitConfig = {
       BACKEND_BASE_URL: "https://backend.example.com",
@@ -648,190 +705,108 @@ describe("isHostConfigBypassEnabled", () => {
     expect(isHostConfigBypassEnabled()).toBe(false)
   })
 
-  it("returns false when allowedOrigins contains empty strings", () => {
+  it.each([
+    ["contains empty strings", ["https://valid.com", ""]],
+    ["contains only empty strings", ["", ""]],
+  ])("returns false when allowedOrigins %s", (_description, origins) => {
     globalThis.__mockStreamlitConfig = {
       BACKEND_BASE_URL: "https://backend.example.com",
       HOST_CONFIG: {
-        allowedOrigins: ["https://valid.com", ""],
+        allowedOrigins: origins,
         useExternalAuthToken: true,
       },
     }
     expect(isHostConfigBypassEnabled()).toBe(false)
   })
 
-  it("returns false when allowedOrigins contains only empty strings", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["", ""],
-        useExternalAuthToken: true,
+  // Tests for valid configurations that should return true
+  it.each([
+    [
+      "all required fields are present with useExternalAuthToken=true",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+        },
       },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false when useExternalAuthToken is missing", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
+    ],
+    [
+      "all required fields are present with useExternalAuthToken=false",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: false,
+        },
       },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns true when all required fields are present with useExternalAuthToken=true", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
+    ],
+    [
+      "multiple allowed origins",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com", "https://other.example.com"],
+          useExternalAuthToken: true,
+        },
       },
-    }
+    ],
+    [
+      "additional HOST_CONFIG fields are present",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          metricsUrl: "postMessage",
+        },
+      },
+    ],
+    [
+      "minimal fields plus all expanded AppConfig fields",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+        },
+      },
+    ],
+    [
+      "minimal fields plus all expanded LibConfig fields",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          mapboxToken: "test-token",
+          disableFullscreenMode: true,
+          enforceDownloadInNewTab: true,
+          resourceCrossOriginMode: "anonymous" as const,
+        },
+      },
+    ],
+    [
+      "minimal fields plus all 9 HOST_CONFIG fields",
+      {
+        BACKEND_BASE_URL: "https://backend.example.com",
+        HOST_CONFIG: {
+          allowedOrigins: ["https://example.com"],
+          useExternalAuthToken: true,
+          metricsUrl: "postMessage",
+          enableCustomParentMessages: true,
+          blockErrorDialogs: true,
+          mapboxToken: "test-token",
+          disableFullscreenMode: false,
+          enforceDownloadInNewTab: true,
+          resourceCrossOriginMode: "use-credentials" as const,
+        },
+      },
+    ],
+  ])("returns true when %s", (_description, config) => {
+    globalThis.__mockStreamlitConfig = config
     expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns true when all required fields are present with useExternalAuthToken=false", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: false,
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns true with multiple allowed origins", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com", "https://other.example.com"],
-        useExternalAuthToken: true,
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns true when additional HOST_CONFIG fields are present", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
-        metricsUrl: "postMessage",
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  // Tests confirming bypass eligibility unchanged with expanded fields
-  it("returns true with minimal fields plus all expanded AppConfig fields", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
-        // Additional AppConfig fields
-        enableCustomParentMessages: true,
-        blockErrorDialogs: true,
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns true with minimal fields plus all expanded LibConfig fields", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
-        // Additional LibConfig fields
-        mapboxToken: "test-token",
-        disableFullscreenMode: true,
-        enforceDownloadInNewTab: true,
-        resourceCrossOriginMode: "anonymous",
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns true with minimal fields plus all 9 HOST_CONFIG fields", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        // Minimal required
-        allowedOrigins: ["https://example.com"],
-        useExternalAuthToken: true,
-        // All additional fields
-        metricsUrl: "postMessage",
-        enableCustomParentMessages: true,
-        blockErrorDialogs: true,
-        mapboxToken: "test-token",
-        disableFullscreenMode: false,
-        enforceDownloadInNewTab: true,
-        resourceCrossOriginMode: "use-credentials",
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(true)
-  })
-
-  it("returns false with only expanded fields but missing minimal required fields", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        // Missing allowedOrigins and useExternalAuthToken
-        // Only provide expanded fields
-        metricsUrl: "postMessage",
-        enableCustomParentMessages: true,
-        mapboxToken: "test-token",
-        disableFullscreenMode: true,
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false with only LibConfig fields (no minimal required fields)", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        // Only LibConfig fields, missing minimal required
-        mapboxToken: "test-token",
-        disableFullscreenMode: true,
-        enforceDownloadInNewTab: true,
-        resourceCrossOriginMode: "anonymous",
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false with allowedOrigins but missing useExternalAuthToken even if other fields present", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        allowedOrigins: ["https://example.com"],
-        // useExternalAuthToken missing
-        // Other fields present
-        metricsUrl: "postMessage",
-        enableCustomParentMessages: true,
-        mapboxToken: "test-token",
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
-  })
-
-  it("returns false with useExternalAuthToken but missing allowedOrigins even if other fields present", () => {
-    globalThis.__mockStreamlitConfig = {
-      BACKEND_BASE_URL: "https://backend.example.com",
-      HOST_CONFIG: {
-        // allowedOrigins missing
-        useExternalAuthToken: true,
-        // Other fields present
-        metricsUrl: "postMessage",
-        mapboxToken: "test-token",
-        disableFullscreenMode: true,
-      },
-    }
-    expect(isHostConfigBypassEnabled()).toBe(false)
   })
 })

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -724,4 +724,114 @@ describe("isHostConfigBypassEnabled", () => {
     }
     expect(isHostConfigBypassEnabled()).toBe(true)
   })
+
+  // Tests confirming bypass eligibility unchanged with expanded fields
+  it("returns true with minimal fields plus all expanded AppConfig fields", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        allowedOrigins: ["https://example.com"],
+        useExternalAuthToken: true,
+        // Additional AppConfig fields
+        enableCustomParentMessages: true,
+        blockErrorDialogs: true,
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(true)
+  })
+
+  it("returns true with minimal fields plus all expanded LibConfig fields", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        allowedOrigins: ["https://example.com"],
+        useExternalAuthToken: true,
+        // Additional LibConfig fields
+        mapboxToken: "test-token",
+        disableFullscreenMode: true,
+        enforceDownloadInNewTab: true,
+        resourceCrossOriginMode: "anonymous",
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(true)
+  })
+
+  it("returns true with minimal fields plus all 9 HOST_CONFIG fields", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        // Minimal required
+        allowedOrigins: ["https://example.com"],
+        useExternalAuthToken: true,
+        // All additional fields
+        metricsUrl: "postMessage",
+        enableCustomParentMessages: true,
+        blockErrorDialogs: true,
+        mapboxToken: "test-token",
+        disableFullscreenMode: false,
+        enforceDownloadInNewTab: true,
+        resourceCrossOriginMode: "use-credentials",
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(true)
+  })
+
+  it("returns false with only expanded fields but missing minimal required fields", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        // Missing allowedOrigins and useExternalAuthToken
+        // Only provide expanded fields
+        metricsUrl: "postMessage",
+        enableCustomParentMessages: true,
+        mapboxToken: "test-token",
+        disableFullscreenMode: true,
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(false)
+  })
+
+  it("returns false with only LibConfig fields (no minimal required fields)", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        // Only LibConfig fields, missing minimal required
+        mapboxToken: "test-token",
+        disableFullscreenMode: true,
+        enforceDownloadInNewTab: true,
+        resourceCrossOriginMode: "anonymous",
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(false)
+  })
+
+  it("returns false with allowedOrigins but missing useExternalAuthToken even if other fields present", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        allowedOrigins: ["https://example.com"],
+        // useExternalAuthToken missing
+        // Other fields present
+        metricsUrl: "postMessage",
+        enableCustomParentMessages: true,
+        mapboxToken: "test-token",
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(false)
+  })
+
+  it("returns false with useExternalAuthToken but missing allowedOrigins even if other fields present", () => {
+    globalThis.__mockStreamlitConfig = {
+      BACKEND_BASE_URL: "https://backend.example.com",
+      HOST_CONFIG: {
+        // allowedOrigins missing
+        useExternalAuthToken: true,
+        // Other fields present
+        metricsUrl: "postMessage",
+        mapboxToken: "test-token",
+        disableFullscreenMode: true,
+      },
+    }
+    expect(isHostConfigBypassEnabled()).toBe(false)
+  })
 })

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { makePath, StreamlitConfig } from "@streamlit/utils"
+import {
+  isValidAllowedOrigins,
+  makePath,
+  StreamlitConfig,
+} from "@streamlit/utils"
 
 const FINAL_SLASH_RE = /\/+$/
 const INITIAL_SLASH_RE = /^\/+/
@@ -27,7 +31,7 @@ const INITIAL_SLASH_RE = /^\/+/
  *
  * Required fields:
  * - BACKEND_BASE_URL: string
- * - HOST_CONFIG.allowedOrigins: non-empty array of strings
+ * - HOST_CONFIG.allowedOrigins: non-empty array of non-empty strings
  * - HOST_CONFIG.useExternalAuthToken: boolean (true or false)
  *
  * NOTE: changes to this function must be reflected in the mock in App.test.tsx
@@ -41,17 +45,9 @@ export function isHostConfigBypassEnabled(): boolean {
 
   const { allowedOrigins, useExternalAuthToken } = initialHostConfig
 
-  // Validate required fields
+  // Validate required fields using shared validation logic
   const hasValidBackendBaseUrl = Boolean(StreamlitConfig.BACKEND_BASE_URL)
-
-  // Validate allowedOrigins is a non-empty array of non-empty strings
-  const hasValidAllowedOrigins =
-    Array.isArray(allowedOrigins) &&
-    allowedOrigins.length > 0 &&
-    allowedOrigins.every(
-      origin => typeof origin === "string" && origin.length > 0
-    )
-
+  const hasValidAllowedOrigins = isValidAllowedOrigins(allowedOrigins)
   const hasValidUseExternalAuthToken =
     typeof useExternalAuthToken === "boolean"
 

--- a/frontend/test-globals.d.ts
+++ b/frontend/test-globals.d.ts
@@ -19,7 +19,7 @@
  * These are initialized in vitest.setup.ts.
  */
 
-import type { MinimalHostConfig } from "@streamlit/utils"
+import type { HostWindowConfig } from "@streamlit/utils"
 
 /**
  * Type for the shared mock StreamlitConfig state used in tests.
@@ -34,7 +34,7 @@ interface MockStreamlitConfigState {
   LIGHT_THEME?: unknown
   DARK_THEME?: unknown
   ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION?: boolean
-  HOST_CONFIG?: MinimalHostConfig
+  HOST_CONFIG?: HostWindowConfig
 }
 
 declare global {

--- a/frontend/utils/src/config/index.ts
+++ b/frontend/utils/src/config/index.ts
@@ -17,36 +17,115 @@
 import { ICustomThemeConfig } from "@streamlit/protobuf"
 
 /**
- * Minimal host configuration for websocket connection and host communication
- * without waiting for the health and host-config endpoint responses.
- *
- * All fields are optional in the type because host can provide incomplete or no config
- * via window.__streamlit.HOST_CONFIG. Use isHostConfigBypassEnabled() to validate that
- * required fields (useExternalAuthToken, allowedOrigins) are present.
- *
- * Required for bypass:
- * - useExternalAuthToken (boolean)
- * - allowedOrigins (non-empty array)
- *
- * Optional:
- * - metricsUrl
- *
- *  Note: The full host config (IHostConfigResponse) includes additional fields
+ * The lib config contains various configurations that the host platform can
+ * use to configure streamlit-lib frontend behavior. This should to be treated as part of the public
+ * API, and changes need to be backwards-compatible meaning that an old host configuration
+ * should still work with a new frontend versions.
  */
-export interface MinimalHostConfig {
+export type LibConfig = {
   /**
-   * Whether to wait for external auth token via postMessage before connecting.
+   * The mapbox token that can be configured by a platform.
    */
-  useExternalAuthToken?: boolean
+  mapboxToken?: string
+
   /**
-   * List of allowed origins for postMessage communication with the host.
+   * Whether to disable the full screen mode all elements / widgets.
+   */
+  disableFullscreenMode?: boolean
+
+  enforceDownloadInNewTab?: boolean
+
+  /**
+   * Whether and which value to set the `crossOrigin` property on media elements (img, video, audio).
+   * If it is set to undefined, the `crossOrigin` property will not be set on media elements at all.
+   * For img elements, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
+   */
+  resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
+
+  /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
+  setAnonymousCrossOriginPropertyOnMediaElements?: boolean
+}
+
+/**
+ * App-specific configuration options that can be set by the host platform.
+ * These control app behavior and host communication.
+ * This should be treated as part of the public API, and changes need to be
+ * backwards-compatible meaning that an old host configuration should still
+ * work with new frontend versions.
+ */
+export type AppConfig = {
+  /**
+   * A list of origins that we're allowed to receive cross-iframe messages
+   * from via the browser's window.postMessage API.
    */
   allowedOrigins?: string[]
   /**
-   * Where to send metrics data. Can be a URL, "postMessage", or "off".
+   * Whether to wait until we've received a SET_AUTH_TOKEN message before
+   * resolving deferredAuthToken.promise. The WebsocketConnection class waits
+   * for this promise to resolve before attempting to establish a connection
+   * with the Streamlit server.
+   */
+  useExternalAuthToken?: boolean
+  /**
+   * Enables custom string messages to be sent to the host
+   */
+  enableCustomParentMessages?: boolean
+  /**
+   * Whether host wants to block error dialogs. If true, blocks error dialogs
+   * from being shown to the user, sends error info to host via postMessage
+   */
+  blockErrorDialogs?: boolean
+}
+
+/**
+ * Metrics configuration options that control where and how metrics are sent.
+ */
+export type MetricsConfig = {
+  /**
+   * URL to send metrics data to via POST request.
+   * Setting to "postMessage" sends metrics events via postMessage to host.
+   * Setting to "off" disables metrics collection.
+   * If undefined, metricsUrl requested from centralized config file.
    */
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   metricsUrl?: string | "postMessage" | "off"
+}
+
+/**
+ * Combined host configuration properties from all config categories.
+ * This represents the complete set of host-configurable options.
+ */
+export type IHostConfigProperties = LibConfig & AppConfig & MetricsConfig
+
+/**
+ * Host configuration that can be provided via window.__streamlit.HOST_CONFIG
+ * which take precedence over the values from the /_stcore/host-config endpoint.
+ *
+ * All fields are optional (Partial of IHostConfigProperties).
+ *
+ * Note: Bypass mode (fast-path WebSocket connection) only activates when BACKEND_BASE_URL
+ * and minimal required fields (allowedOrigins, useExternalAuthToken) are provided and valid.
+ * Other fields can be provided but don't enable bypass on their own.
+ */
+export type HostWindowConfig = Partial<IHostConfigProperties>
+
+/**
+ * Validates that allowedOrigins is a non-empty array of non-empty strings.
+ * This ensures consistency between bypass validation and config reconciliation.
+ *
+ * @param allowedOrigins - The allowedOrigins value to validate
+ * @returns true if valid, false otherwise
+ */
+export function isValidAllowedOrigins(
+  allowedOrigins: unknown
+): allowedOrigins is string[] {
+  return (
+    Array.isArray(allowedOrigins) &&
+    allowedOrigins.length > 0 &&
+    allowedOrigins.every(
+      origin => typeof origin === "string" && origin.length > 0
+    )
+  )
 }
 
 /**
@@ -70,8 +149,8 @@ interface StreamlitWindowConfig {
   DARK_THEME?: ICustomThemeConfig
   // Other options.
   ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION?: boolean
-  // Minimal host configuration for fast-path websocket connection.
-  HOST_CONFIG?: MinimalHostConfig
+  // Host configuration (including enabling bypass mode for fast-path websocket connection).
+  HOST_CONFIG?: HostWindowConfig
 }
 
 // Extend Window interface for TypeScript
@@ -200,7 +279,7 @@ export const StreamlitConfig = {
     | undefined {
     return capturedConfig?.ENABLE_RELOAD_BASED_ON_HARDCODED_STREAMLIT_VERSION
   },
-  get HOST_CONFIG(): MinimalHostConfig | undefined {
+  get HOST_CONFIG(): HostWindowConfig | undefined {
     return capturedConfig?.HOST_CONFIG
   },
 } as const

--- a/frontend/utils/src/config/index.ts
+++ b/frontend/utils/src/config/index.ts
@@ -129,7 +129,7 @@ export function isValidAllowedOrigins(
     Array.isArray(allowedOrigins) &&
     allowedOrigins.length > 0 &&
     allowedOrigins.every(
-      origin => typeof origin === "string" && origin.length > 0
+      origin => typeof origin === "string" && origin.trim().length > 0
     )
   )
 }

--- a/frontend/utils/src/config/index.ts
+++ b/frontend/utils/src/config/index.ts
@@ -101,13 +101,16 @@ export type IHostConfigProperties = LibConfig & AppConfig & MetricsConfig
  * Host configuration that can be provided via window.__streamlit.HOST_CONFIG
  * which take precedence over the values from the /_stcore/host-config endpoint.
  *
- * All fields are optional (Partial of IHostConfigProperties).
+ * All fields are optional. The deprecated setAnonymousCrossOriginPropertyOnMediaElements
+ * field is excluded - use resourceCrossOriginMode instead.
  *
  * Note: Bypass mode (fast-path WebSocket connection) only activates when BACKEND_BASE_URL
  * and minimal required fields (allowedOrigins, useExternalAuthToken) are provided and valid.
  * Other fields can be provided but don't enable bypass on their own.
  */
-export type HostWindowConfig = Partial<IHostConfigProperties>
+export type HostWindowConfig = Partial<
+  Omit<IHostConfigProperties, "setAnonymousCrossOriginPropertyOnMediaElements">
+>
 
 /**
  * Validates that allowedOrigins is a non-empty array of non-empty strings.

--- a/frontend/utils/src/config/index.ts
+++ b/frontend/utils/src/config/index.ts
@@ -18,7 +18,7 @@ import { ICustomThemeConfig } from "@streamlit/protobuf"
 
 /**
  * The lib config contains various configurations that the host platform can
- * use to configure streamlit-lib frontend behavior. This should to be treated as part of the public
+ * use to configure streamlit-lib frontend behavior. This should be treated as part of the public
  * API, and changes need to be backwards-compatible meaning that an old host configuration
  * should still work with a new frontend versions.
  */
@@ -29,10 +29,13 @@ export type LibConfig = {
   mapboxToken?: string
 
   /**
-   * Whether to disable the full screen mode all elements / widgets.
+   * Whether to disable the full screen mode for all elements / widgets.
    */
   disableFullscreenMode?: boolean
 
+  /**
+   * Whether to force file downloads initiated by the app to open in a new browser tab.
+   */
   enforceDownloadInNewTab?: boolean
 
   /**


### PR DESCRIPTION
## Describe your changes
Support providing all `host-config` values via `window.__streamlit.HOST_CONFIG`. These are applied in both default and bypass connection modes. 

Values provided via window var take precedence over endpoint values.

## Testing Plan
- JS Unit Tests: ✅ Added
- E2E Tests: See next PR in stack