### PR TITLE
Run min-constraints-gen check before tests.

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -183,18 +183,6 @@ jobs:
         uses: ./.github/actions/make_init
         with:
           use_cached_venv: false
-      - name: Install min dependencies (force reinstall)
-        run: |
-          source venv/bin/activate
-          uv pip install -r scripts/assets/min-constraints-gen.txt --force-reinstall
-      - name: Make local modules visible
-        run: |
-          source venv/bin/activate
-          uv pip install --editable ./lib --no-deps
-      - name: Run Python Tests
-        run: make python-tests
-      - name: CLI Smoke Tests
-        run: make cli-smoke-tests
       - name: Validate min-constraints-gen
         run: |
           make update-min-deps
@@ -209,6 +197,18 @@ jobs:
           else
             echo "min constraints file is up to date."
           fi
+      - name: Install min dependencies (force reinstall)
+        run: |
+          source venv/bin/activate
+          uv pip install -r scripts/assets/min-constraints-gen.txt --force-reinstall
+      - name: Make local modules visible
+        run: |
+          source venv/bin/activate
+          uv pip install --editable ./lib --no-deps
+      - name: Run Python Tests
+        run: make python-tests
+      - name: CLI Smoke Tests
+        run: make cli-smoke-tests
       - name: Upload coverage data
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Describe your changes

Move the generation check for `min-constraints-gen.txt` to before the test run. It's _much_ more helpful to get an error that you failed to update the constraints file than it is to get the same failure you were trying to fix by bumping the min version.

Follow-up to #13420 .

## Testing Plan

See runs in commit history of [this testing branch](https://github.com/streamlit/streamlit/tree/jkinkead-run-min-check-first):
* [fails early due to missing update](https://github.com/streamlit/streamlit/actions/runs/20385196131/job/58584579982)
* [after updating min versions, bad library version triggers error on tests](https://github.com/streamlit/streamlit/actions/runs/20385257898/job/58584769230)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
