### PR TITLE
[Fix] auth type issue caused by dependency update

### DIFF
--- a/lib/streamlit/web/server/authlib_tornado_integration.py
+++ b/lib/streamlit/web/server/authlib_tornado_integration.py
@@ -101,7 +101,7 @@ class TornadoIntegration(FrameworkIntegration):
         """
 
     @staticmethod
-    def load_config(  # type: ignore[override]
+    def load_config(
         oauth: TornadoOAuth, name: str, params: Sequence[str]
     ) -> dict[str, Any]:
         """Configure Authlib integration with provider parameters


### PR DESCRIPTION
## Describe your changes
Nightly failed due to update in `types-authlib` dependency (from `1.6.6.20251214` to `1.6.6.20251220` - see [here](https://pypi.org/project/types-Authlib/#history)). See passing run based on commit [here](https://github.com/streamlit/streamlit/actions/runs/20383652173/job/58579883133) and failing nightly run based on the same commit [here](https://github.com/streamlit/streamlit/actions/runs/20390627199/job/58601389615).

The return type for the `load_config' function - which we override in `streamlit/web/server/authlib_tornado_integration.py` - was updated from `None` to implicitly `Any`. 

Our override return value of `dict[str, Any]` previously needed `# type: ignore[override]` to suppress the error, but with the new `Any` return value this is no longer necessary.