### PR TITLE
Remove typecheck exclusion line for authlib_tornado_integration.py

### DIFF
--- a/lib/streamlit/web/server/authlib_tornado_integration.py
+++ b/lib/streamlit/web/server/authlib_tornado_integration.py
@@ -101,7 +101,7 @@ class TornadoIntegration(FrameworkIntegration):
         """
 
     @staticmethod
-    def load_config(  # type: ignore[override]
+    def load_config(
         oauth: TornadoOAuth, name: str, params: Sequence[str]
     ) -> dict[str, Any]:
         """Configure Authlib integration with provider parameters


### PR DESCRIPTION
## Describe your changes

A new version of types-Authlib no longer needs this type check which fixes the 

## Testing Plan

- Tests should pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
