### PR TITLE
st.logo now accepts a Material icon shortcode string

### DIFF
--- a/frontend/app/src/components/Logo/LogoComponent.tsx
+++ b/frontend/app/src/components/Logo/LogoComponent.tsx
@@ -25,6 +25,7 @@ import {
 } from "@streamlit/app/src/components/Sidebar/styled-components"
 import { StreamlitEndpoints } from "@streamlit/connection"
 import {
+  DynamicIcon,
   getCrossOriginAttribute,
   LibConfigContext,
   NavigationContext,
@@ -85,28 +86,42 @@ const LogoComponent = ({
     )
   }
 
-  // Use icon image when collapsed in sidebar mode, otherwise use the main image
+  const hasIconLogo = !!appLogo.icon
+
+  // Use icon image when collapsed in sidebar mode, otherwise use the main image.
+  // If an explicit icon is provided, we always render it via DynamicIcon.
   const displayImage =
-    collapsed && appLogo.iconImage ? appLogo.iconImage : appLogo.image
+    collapsed && appLogo.iconImage && !hasIconLogo
+      ? appLogo.iconImage
+      : appLogo.image
 
-  const source = endpoints.buildMediaURL(displayImage)
-
-  const crossOrigin = getCrossOriginAttribute(
-    resourceCrossOriginMode,
-    displayImage
-  )
-
-  const logo = (
-    <StyledLogo
-      src={source}
-      size={appLogo.size}
-      alt="Logo"
-      className="stLogo"
-      data-testid={dataTestId}
-      // Save to logo's src to send on load error
-      onError={_ => handleLogoError(source)}
-      crossOrigin={crossOrigin}
+  const logo = hasIconLogo ? (
+    <DynamicIcon
+      iconValue={appLogo.icon}
+      size="lg"
+      testid={dataTestId}
     />
+  ) : (
+    (() => {
+      const source = endpoints.buildMediaURL(displayImage)
+      const crossOrigin = getCrossOriginAttribute(
+        resourceCrossOriginMode,
+        displayImage
+      )
+
+      return (
+        <StyledLogo
+          src={source}
+          size={appLogo.size}
+          alt="Logo"
+          className="stLogo"
+          data-testid={dataTestId}
+          // Save to logo's src to send on load error
+          onError={_ => handleLogoError(source)}
+          crossOrigin={crossOrigin}
+        />
+      )
+    })()
   )
 
   // If an explicit link is provided, use it (opens in new tab)

--- a/lib/streamlit/commands/logo.py
+++ b/lib/streamlit/commands/logo.py
@@ -25,6 +25,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.string_util import validate_icon_or_emoji
 
 
 def _invalid_logo_text(field_name: str) -> str:
@@ -37,7 +38,7 @@ def _invalid_logo_text(field_name: str) -> str:
 
 @gather_metrics("logo")
 def logo(
-    image: AtomicImage,
+    image: AtomicImage | str,
     *,  # keyword-only args:
     size: Literal["small", "medium", "large"] = "medium",
     link: str | None = None,
@@ -140,18 +141,27 @@ def logo(
 
     fwd_msg = ForwardMsg()
 
-    try:
-        image_url = image_to_url(
-            image,
-            layout_config=LayoutConfig(width="content"),
-            clamp=False,
-            channels="RGB",
-            output_format="auto",
-            image_id="logo",
-        )
-        fwd_msg.logo.image = image_url
-    except Exception as ex:
-        raise StreamlitAPIException(_invalid_logo_text("image")) from ex
+    # Support passing a Material icon or emoji directly as the logo source.
+    # In this case we bypass media storage and send the validated icon string
+    # to the frontend, which is responsible for rendering it.
+    if isinstance(image, str) and image.startswith(":material/"):
+        try:
+            fwd_msg.logo.icon = validate_icon_or_emoji(image)
+        except StreamlitAPIException as ex:
+            raise StreamlitAPIException(_invalid_logo_text("image")) from ex
+    else:
+        try:
+            image_url = image_to_url(
+                image,
+                layout_config=LayoutConfig(width="content"),
+                clamp=False,
+                channels="RGB",
+                output_format="auto",
+                image_id="logo",
+            )
+            fwd_msg.logo.image = image_url
+        except Exception as ex:
+            raise StreamlitAPIException(_invalid_logo_text("image")) from ex
 
     if link:
         # Handle external links:

--- a/lib/tests/streamlit/commands/logo_test.py
+++ b/lib/tests/streamlit/commands/logo_test.py
@@ -41,6 +41,17 @@ class LogoTest(DeltaGeneratorTestCase):
         assert c.icon_image == ""
         assert c.size == "medium"
 
+    def test_material_icon_logo(self):
+        """Test that it can be called with a Material icon shortcode."""
+        st.logo(":material/thumb_up:")
+
+        c = self.get_message_from_queue().logo
+        assert c.image == ""
+        assert c.icon == ":material/thumb_up:"
+        assert c.link == ""
+        assert c.icon_image == ""
+        assert c.size == "medium"
+
     def test_image_and_link(self):
         """Test that it can be called with image & link."""
         streamlit = Image.open(

--- a/proto/streamlit/proto/Logo.proto
+++ b/proto/streamlit/proto/Logo.proto
@@ -25,4 +25,7 @@ message Logo {
   string link = 2;
   string icon_image = 3;
   string size = 4;
+  // Optional icon (emoji or Material icon shortcode) used instead of an image.
+  // When this field is set, the frontend renders an icon-based logo.
+  string icon = 5;
 }


### PR DESCRIPTION
Link to github issue - https://github.com/streamlit/streamlit/issues/13385
#13385 

st.logo now accepts a Material icon shortcode string (e.g. ":material/bath_outdoor:") as the image argument and:
Validates it via validate_icon_or_emoji.
Sends it through the new Logo.icon protobuf field instead of uploading an image.
The frontend LogoComponent renders Logo.icon via DynamicIcon, so Material icons and emojis display correctly as the app logo.
Existing image-based usage of st.logo is unchanged, and there’s a new Python test confirming the icon-logo behavior.