### PR TITLE
Fix #12417: feat: Add title parameter to st.info, st.error, st.warning, st.success  Closes #12417

### DIFF
--- a/e2e_playwright/st_alert.py
+++ b/e2e_playwright/st_alert.py
@@ -119,3 +119,14 @@ st.error("This is an error with width='stretch' and icon", width="stretch", icon
 
 # Alerts with width=200 and icon
 st.info("This is an info message with width=200 and icon", width=200, icon="👉🏻")
+
+### Test title parameter ###
+
+# Basic title for all alert types
+st.error("Error body content", title="Error Title")
+st.warning("Warning body content", title="Warning Title")
+st.info("Info body content", title="Info Title")
+st.success("Success body content", title="Success Title")
+
+# Title with icon
+st.error("Error with title and icon", title="Critical Error", icon="🚨")

--- a/e2e_playwright/st_alert_test.py
+++ b/e2e_playwright/st_alert_test.py
@@ -23,7 +23,7 @@ def test_alerts_rendering_themed(
 ):
     """Test that alerts render correctly with theme-dependent styling."""
     alert_elements = themed_app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(32)
+    expect(alert_elements).to_have_count(37)
 
     # The first 4 alerts are super basic, no need to screenshot test those
     expect(alert_elements.nth(0)).to_have_text("This is an error")
@@ -52,11 +52,18 @@ def test_alerts_rendering_themed(
     # Alert with heading (heading colors differ by theme)
     assert_snapshot(alert_elements.nth(20), name="st_alert-error_with_heading")
 
+    # Title parameter tests (title styling may differ by theme)
+    assert_snapshot(alert_elements.nth(32), name="st_alert-error_with_title")
+    assert_snapshot(alert_elements.nth(33), name="st_alert-warning_with_title")
+    assert_snapshot(alert_elements.nth(34), name="st_alert-info_with_title")
+    assert_snapshot(alert_elements.nth(35), name="st_alert-success_with_title")
+    assert_snapshot(alert_elements.nth(36), name="st_alert-error_with_title_and_icon")
+
 
 def test_alerts_rendering_layout(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that alerts layout variations render correctly (theme-independent)."""
     alert_elements = app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(32)
+    expect(alert_elements).to_have_count(37)
 
     # Line wrapping (layout behavior)
     assert_snapshot(alert_elements.nth(8), name="st_alert-error_line_wrapping_1")
@@ -93,6 +100,6 @@ def test_material_symbol_from_latest_font_version_rendering(
 ):
     """Test that icon from latest version material symbols font renders correctly."""
     alert_elements = app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(32)
+    expect(alert_elements).to_have_count(37)
 
     assert_snapshot(alert_elements.nth(21), name="st_alert-latest_material_symbol")

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -206,6 +206,7 @@ const RawElementNodeRenderer = (
         <AlertElement
           icon={alertProto.icon}
           body={alertProto.body}
+          title={alertProto.title}
           kind={getAlertElementKind(alertProto.format)}
           {...elementProps}
         />

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -98,4 +98,43 @@ describe("Alert element", () => {
     expect(screen.getByTestId("stAlertDynamicIcon")).toHaveTextContent("👉🏻")
     expect(screen.getByText("It's dangerous to go alone.")).toBeInTheDocument()
   })
+
+  it("renders a title when provided", () => {
+    const props = getProps({
+      kind: getAlertElementKind(AlertProto.Format.INFO),
+      body: "This is the body content.",
+      title: "Important Notice",
+    })
+    render(<AlertElement {...props} />)
+    expect(screen.getByTestId("stAlert")).toBeInTheDocument()
+    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent(
+      "Important Notice"
+    )
+    expect(screen.getByText("This is the body content.")).toBeInTheDocument()
+  })
+
+  it("does not render title element when title is not provided", () => {
+    const props = getProps({
+      kind: getAlertElementKind(AlertProto.Format.INFO),
+      body: "Body without title.",
+    })
+    render(<AlertElement {...props} />)
+    expect(screen.getByTestId("stAlert")).toBeInTheDocument()
+    expect(screen.queryByTestId("stAlertTitle")).not.toBeInTheDocument()
+    expect(screen.getByText("Body without title.")).toBeInTheDocument()
+  })
+
+  it("renders both title and icon together", () => {
+    const props = getProps({
+      kind: getAlertElementKind(AlertProto.Format.WARNING),
+      body: "Warning message body.",
+      title: "Warning Title",
+      icon: "⚠️",
+    })
+    render(<AlertElement {...props} />)
+    expect(screen.getByTestId("stAlert")).toBeInTheDocument()
+    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent("Warning Title")
+    expect(screen.getByTestId("stAlertDynamicIcon")).toHaveTextContent("⚠️")
+    expect(screen.getByText("Warning message body.")).toBeInTheDocument()
+  })
 })

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -133,7 +133,9 @@ describe("Alert element", () => {
     })
     render(<AlertElement {...props} />)
     expect(screen.getByTestId("stAlert")).toBeInTheDocument()
-    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent("Warning Title")
+    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent(
+      "Warning Title"
+    )
     expect(screen.getByTestId("stAlertDynamicIcon")).toHaveTextContent("⚠️")
     expect(screen.getByText("Warning message body.")).toBeInTheDocument()
   })

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -67,7 +67,11 @@ function AlertElement({
 
           <div style={markdownWidth}>
             {title && (
-              <StyledAlertTitle data-testid="stAlertTitle">
+              <StyledAlertTitle
+                role="heading"
+                aria-level={2}
+                data-testid="stAlertTitle"
+              >
                 {title}
               </StyledAlertTitle>
             )}

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -21,11 +21,16 @@ import { DynamicIcon } from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
-import { StyledAlertContent, StyledAlertIcon } from "./styled-components"
+import {
+  StyledAlertContent,
+  StyledAlertIcon,
+  StyledAlertTitle,
+} from "./styled-components"
 
 export interface AlertElementProps {
   body: string
   icon?: string
+  title?: string
   kind: Kind
 }
 
@@ -35,6 +40,7 @@ export interface AlertElementProps {
 function AlertElement({
   icon,
   body,
+  title,
   kind,
 }: Readonly<AlertElementProps>): ReactElement {
   const theme = useEmotionTheme()
@@ -59,11 +65,14 @@ function AlertElement({
             </StyledAlertIcon>
           )}
 
-          <StreamlitMarkdown
-            source={body}
-            allowHTML={false}
-            style={markdownWidth}
-          />
+          <div style={markdownWidth}>
+            {title && (
+              <StyledAlertTitle data-testid="stAlertTitle">
+                {title}
+              </StyledAlertTitle>
+            )}
+            <StreamlitMarkdown source={body} allowHTML={false} />
+          </div>
         </StyledAlertContent>
       </AlertContainer>
     </div>

--- a/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
@@ -32,3 +32,8 @@ export const StyledAlertIcon = styled.div(({ theme }) => ({
   position: "relative",
   top: theme.spacing.threeXS,
 }))
+
+export const StyledAlertTitle = styled.div(({ theme }) => ({
+  fontWeight: theme.fontWeights.bold,
+  marginBottom: theme.spacing.sm,
+}))

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -35,6 +35,7 @@ class AlertMixin:
         body: SupportsStr,
         *,  # keyword-only args:
         icon: str | None = None,
+        title: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display error message.
@@ -70,6 +71,11 @@ class AlertMixin:
 
             - ``"spinner"``: Displays a spinner as an icon.
 
+        title : str, None
+            An optional title to display above the body. If ``title`` is
+            ``None`` (default), no title is displayed. The title is displayed
+            in bold text above the body content.
+
         width : "stretch" or int
             The width of the alert element. This can be one of the following:
 
@@ -92,6 +98,8 @@ class AlertMixin:
         alert_proto.icon = validate_icon_or_emoji(icon)
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.ERROR
+        if title is not None:
+            alert_proto.title = clean_text(title)
 
         validate_width(width)
 
@@ -112,6 +120,7 @@ class AlertMixin:
         body: SupportsStr,
         *,  # keyword-only args:
         icon: str | None = None,
+        title: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display warning message.
@@ -147,6 +156,11 @@ class AlertMixin:
 
             - ``"spinner"``: Displays a spinner as an icon.
 
+        title : str, None
+            An optional title to display above the body. If ``title`` is
+            ``None`` (default), no title is displayed. The title is displayed
+            in bold text above the body content.
+
         width : "stretch" or int
             The width of the warning element. This can be one of the following:
 
@@ -168,6 +182,8 @@ class AlertMixin:
         alert_proto.body = clean_text(body)
         alert_proto.icon = validate_icon_or_emoji(icon)
         alert_proto.format = AlertProto.WARNING
+        if title is not None:
+            alert_proto.title = clean_text(title)
 
         validate_width(width)
 
@@ -188,6 +204,7 @@ class AlertMixin:
         body: SupportsStr,
         *,  # keyword-only args:
         icon: str | None = None,
+        title: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display an informational message.
@@ -223,6 +240,11 @@ class AlertMixin:
 
             - ``"spinner"``: Displays a spinner as an icon.
 
+        title : str, None
+            An optional title to display above the body. If ``title`` is
+            ``None`` (default), no title is displayed. The title is displayed
+            in bold text above the body content.
+
         width : "stretch" or int
             The width of the info element. This can be one of the following:
 
@@ -245,6 +267,8 @@ class AlertMixin:
         alert_proto.body = clean_text(body)
         alert_proto.icon = validate_icon_or_emoji(icon)
         alert_proto.format = AlertProto.INFO
+        if title is not None:
+            alert_proto.title = clean_text(title)
 
         validate_width(width)
 
@@ -265,6 +289,7 @@ class AlertMixin:
         body: SupportsStr,
         *,  # keyword-only args:
         icon: str | None = None,
+        title: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
         """Display a success message.
@@ -300,6 +325,11 @@ class AlertMixin:
 
             - ``"spinner"``: Displays a spinner as an icon.
 
+        title : str, None
+            An optional title to display above the body. If ``title`` is
+            ``None`` (default), no title is displayed. The title is displayed
+            in bold text above the body content.
+
         width : "stretch" or int
             The width of the success element. This can be one of the following:
 
@@ -321,6 +351,8 @@ class AlertMixin:
         alert_proto.body = clean_text(body)
         alert_proto.icon = validate_icon_or_emoji(icon)
         alert_proto.format = AlertProto.SUCCESS
+        if title is not None:
+            alert_proto.title = clean_text(title)
 
         validate_width(width)
 

--- a/lib/tests/streamlit/elements/alert_test.py
+++ b/lib/tests/streamlit/elements/alert_test.py
@@ -82,6 +82,20 @@ class StErrorAPITest(DeltaGeneratorTestCase):
         )
         assert el.alert.width_config.use_stretch
 
+    def test_st_error_with_title(self):
+        """Test st.error with title."""
+        st.error("some error", title="Error Title")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.body == "some error"
+        assert el.alert.title == "Error Title"
+        assert el.alert.format == Alert.ERROR
+        assert (
+            el.alert.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.alert.width_config.use_stretch
+
     def test_st_error_with_width_pixels(self):
         """Test st.error with width in pixels."""
         st.error("some error", width=500)
@@ -132,6 +146,20 @@ class StInfoAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.alert.body == "some info"
         assert el.alert.icon == "❓"
+        assert el.alert.format == Alert.INFO
+        assert (
+            el.alert.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.alert.width_config.use_stretch
+
+    def test_st_info_with_title(self):
+        """Test st.info with title."""
+        st.info("some info", title="Info Title")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.body == "some info"
+        assert el.alert.title == "Info Title"
         assert el.alert.format == Alert.INFO
         assert (
             el.alert.width_config.WhichOneof("width_spec")
@@ -196,6 +224,20 @@ class StSuccessAPITest(DeltaGeneratorTestCase):
         )
         assert el.alert.width_config.use_stretch
 
+    def test_st_success_with_title(self):
+        """Test st.success with title."""
+        st.success("some success", title="Success Title")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.body == "some success"
+        assert el.alert.title == "Success Title"
+        assert el.alert.format == Alert.SUCCESS
+        assert (
+            el.alert.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.alert.width_config.use_stretch
+
     def test_st_success_with_width_pixels(self):
         """Test st.success with width in pixels."""
         st.success("some success", width=500)
@@ -246,6 +288,20 @@ class StWarningAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.alert.body == "some warning"
         assert el.alert.icon == "⚠️"
+        assert el.alert.format == Alert.WARNING
+        assert (
+            el.alert.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert el.alert.width_config.use_stretch
+
+    def test_st_warning_with_title(self):
+        """Test st.warning with title."""
+        st.warning("some warning", title="Warning Title")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.body == "some warning"
+        assert el.alert.title == "Warning Title"
         assert el.alert.format == Alert.WARNING
         assert (
             el.alert.width_config.WhichOneof("width_spec")

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -265,6 +265,7 @@ def test_alert_proto_stable():
         ("format", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
         ("icon", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
         ("width_config", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+        ("title", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
     }
 
 

--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -33,6 +33,9 @@ message Alert {
   // Indicates the width setting: "stetch", "content" or a pixel value.
   streamlit.WidthConfig width_config = 4;
 
+  // Optional title to display above the body.
+  string title = 5;
+
   // Type of Alert
   enum Format {
     // Plain, fixed width text.


### PR DESCRIPTION
 ## Summary
  Adds an optional `title` parameter to `st.info()`, `st.error()`, `st.warning()`, and `st.success()` that displays a bold title above the body content.
 Closes #12417
 
  **Example:**
  ```python
  st.info("Your session will expire in 5 minutes.", title="Session Notice")

  Changes

  - Added title field to Alert.proto
  - Added title parameter to all 4 alert functions in alert.py
  - Updated AlertElement.tsx to render title with styled component
  - Added Python and frontend unit tests

  Closes #12417

  Note

  Protobuf compilation (make protobuf) needs to be run after merge to generate the proto files.
  
  
  
