### PR TITLE
Fixes #11109 (fragments): Add opt-in validation for cross-fragment state modifi…

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,169 @@
+## Summary
+
+Fixes #11109
+
+This PR adds opt-in validation to detect and prevent cross-fragment session state modifications that can cause frontend/backend state desynchronization.
+
+### The Problem
+
+When a fragment rerun modifies `st.session_state` for a widget that belongs to a *different* fragment, the modification succeeds on the backend but the frontend UI doesn't update (since only the current fragment is re-rendered). This creates a silent desync between what the user sees and what the backend believes is the current state.
+
+**Example of the problematic pattern:**
+```python
+@st.fragment
+def fragment_a():
+    st.number_input("Counter", key="counter")  # Widget belongs to fragment_a
+
+@st.fragment
+def fragment_b():
+    if st.button("Increment"):
+        st.session_state.counter += 1  # Modifies fragment_a's widget - CAUSES DESYNC!
+
+fragment_a()
+fragment_b()
+```
+
+When the button in `fragment_b` is clicked, only `fragment_b` reruns. The backend updates `counter` to the new value, but `fragment_a`'s number input doesn't re-render, so the user still sees the old value.
+
+### The Solution
+
+This PR adds a new config option `runner.enforceFragmentStateIsolation` (default: `false`). When enabled:
+
+- **`__setitem__`**: Raises `StreamlitAPIException` if a fragment attempts to modify session state for a widget belonging to a different fragment
+- **`__delitem__`**: Raises `StreamlitAPIException` if a fragment attempts to delete session state for a widget belonging to a different fragment
+
+### Why Opt-In (Default: False)?
+
+Making this opt-in is **critical for backward compatibility**. Many existing Streamlit apps legitimately share state between fragments:
+
+```python
+# Common pattern that would break if we raised errors by default
+@st.fragment
+def increment_button():
+    if st.button("Add 1"):
+        st.session_state.counter += 1  # Modifying shared state
+
+st.number_input("Counter", key="counter")
+increment_button()
+```
+
+By making this opt-in, developers can:
+1. Enable it for new projects to catch potential bugs early
+2. Gradually migrate existing apps
+3. Choose their own tradeoff between strictness and flexibility
+
+This follows the same pattern as the existing `runner.enforceSerializableSessionState` option.
+
+---
+
+## Files Changed
+
+### 1. `lib/streamlit/config.py`
+Added new config option:
+```python
+_create_option(
+    "runner.enforceFragmentStateIsolation",
+    description="""
+        Raise an exception when a fragment attempts to modify session state
+        for widgets that belong to a different fragment.
+        ...
+    """,
+    default_val=False,
+    type_=bool,
+)
+```
+
+### 2. `lib/streamlit/runtime/state/session_state.py`
+
+**`__setitem__` method** - Added validation after existing widget/form checks:
+- Gets the widget_id for the key being modified
+- Looks up the widget's metadata to find its `fragment_id`
+- If the widget belongs to a different fragment than the one currently running, raises `StreamlitAPIException`
+
+**`__delitem__` method** - Added same validation logic for deletions
+
+### 3. `lib/tests/streamlit/runtime/state/session_state_test.py`
+
+Added 7 comprehensive test cases covering all edge cases.
+
+---
+
+## Test Cases Added
+
+1. **`test_setitem_disallows_cross_fragment_modification_when_enforced`**
+   - Modify widget from different fragment with config ON
+   - Expected: Raises `StreamlitAPIException`
+
+2. **`test_setitem_allows_cross_fragment_modification_when_not_enforced`**
+   - Modify widget from different fragment with config OFF
+   - Expected: Succeeds (backward compat)
+
+3. **`test_setitem_allows_same_fragment_modification`**
+   - Modify widget from same fragment with config ON
+   - Expected: Succeeds
+
+4. **`test_setitem_allows_modification_of_pre_fragment_widget`**
+   - Modify widget with `fragment_id=None`
+   - Expected: Succeeds (pre-fragment widgets are always modifiable)
+
+5. **`test_setitem_allows_modification_during_full_app_run`**
+   - Modify any widget during full app run
+   - Expected: Succeeds (`fragment_ids_this_run=None` means full run)
+
+6. **`test_delitem_disallows_cross_fragment_deletion_when_enforced`**
+   - Delete widget from different fragment with config ON
+   - Expected: Raises `StreamlitAPIException`
+
+7. **`test_delitem_allows_cross_fragment_deletion_when_not_enforced`**
+   - Delete widget from different fragment with config OFF
+   - Expected: Succeeds (backward compat)
+
+---
+
+## Edge Cases Handled
+
+1. **Nested fragments** - Checks if widget's `fragment_id` is in `ctx.fragment_ids_this_run` (list of all fragments in current rerun)
+
+2. **Pre-fragment widgets** - Widgets with `fragment_id=None` (created before any fragment) are always modifiable
+
+3. **Full app run** - When `fragment_ids_this_run=None`, validation is skipped entirely
+
+4. **Non-widget keys** - Only validated when `widget_id` is not None (regular session state keys are unaffected)
+
+5. **Missing metadata** - If widget metadata doesn't exist, validation is skipped
+
+---
+
+## How to Test
+
+1. Enable the config option:
+```toml
+# .streamlit/config.toml
+[runner]
+enforceFragmentStateIsolation = true
+```
+
+2. Run this test app:
+```python
+import streamlit as st
+
+@st.fragment
+def fragment_a():
+    st.number_input("Counter", key="counter", value=0)
+
+@st.fragment
+def fragment_b():
+    if st.button("Try to modify counter"):
+        st.session_state.counter += 1  # Should raise error
+
+fragment_a()
+fragment_b()
+```
+
+3. Click the button - you should see a `StreamlitAPIException` explaining that cross-fragment modification is not allowed.
+
+---
+
+## Future Considerations
+
+In a future major version, the default could be flipped to `true` to enforce fragment isolation by default, with the option to opt-out for apps that need cross-fragment state sharing.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -659,6 +659,21 @@ _create_option(
 )
 
 _create_option(
+    "runner.enforceFragmentStateIsolation",
+    description="""
+        Raise an exception when a fragment attempts to modify session state
+        for widgets that belong to a different fragment.
+
+        When enabled, this helps catch potential frontend/backend state
+        desynchronization issues caused by cross-fragment state modifications.
+        This is opt-in to maintain backward compatibility with existing apps
+        that intentionally share state between fragments.
+    """,
+    default_val=False,
+    type_=bool,
+)
+
+_create_option(
     "runner.enumCoercion",
     description="""
         Adjust how certain 'options' widgets like radio, selectbox, and

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -533,6 +533,10 @@ class SessionState:
 
         If the key corresponds to a widget or form that's been instantiated
         during the current script run, raise a StreamlitAPIException instead.
+
+        If enforceFragmentStateIsolation is enabled and we're in a fragment
+        rerun, also raise an exception if attempting to modify a widget that
+        belongs to a different fragment.
         """
         ctx = get_script_run_ctx()
 
@@ -547,13 +551,57 @@ class SessionState:
                     f" with key `{user_key}` is instantiated."
                 )
 
+            # Check for cross-fragment state modification (opt-in validation)
+            if (
+                config.get_option("runner.enforceFragmentStateIsolation")
+                and ctx.fragment_ids_this_run
+                and widget_id is not None
+            ):
+                metadata = self._new_widget_state.widget_metadata.get(widget_id)
+                if metadata is not None and metadata.fragment_id is not None:
+                    if metadata.fragment_id not in ctx.fragment_ids_this_run:
+                        raise StreamlitAPIException(
+                            f"`st.session_state.{user_key}` belongs to a widget in a "
+                            f"different fragment and cannot be modified from this "
+                            f"fragment rerun. This can cause frontend/backend state "
+                            f"desynchronization. To allow cross-fragment state "
+                            f"modification, set `runner.enforceFragmentStateIsolation "
+                            f"= false` in your config."
+                        )
+
         self._new_session_state[user_key] = value
 
     def __delitem__(self, key: str) -> None:
+        """Delete a session state entry.
+
+        If enforceFragmentStateIsolation is enabled and we're in a fragment
+        rerun, raise an exception if attempting to delete a widget that
+        belongs to a different fragment.
+        """
         widget_id = self._get_widget_id(key)
 
         if not (key in self or widget_id in self):
             raise KeyError(_missing_key_error_message(key))
+
+        # Check for cross-fragment state modification (opt-in validation)
+        ctx = get_script_run_ctx()
+        if (
+            ctx is not None
+            and config.get_option("runner.enforceFragmentStateIsolation")
+            and ctx.fragment_ids_this_run
+            and widget_id is not None
+        ):
+            metadata = self._new_widget_state.widget_metadata.get(widget_id)
+            if metadata is not None and metadata.fragment_id is not None:
+                if metadata.fragment_id not in ctx.fragment_ids_this_run:
+                    raise StreamlitAPIException(
+                        f"`st.session_state.{key}` belongs to a widget in a "
+                        f"different fragment and cannot be deleted from this "
+                        f"fragment rerun. This can cause frontend/backend state "
+                        f"desynchronization. To allow cross-fragment state "
+                        f"modification, set `runner.enforceFragmentStateIsolation "
+                        f"= false` in your config."
+                    )
 
         if key in self._new_session_state:
             del self._new_session_state[key]

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -598,8 +598,11 @@ class SessionState:
                         f"`st.session_state.{key}` belongs to a widget in a "
                         f"different fragment and cannot be deleted from this "
                         f"fragment rerun. This can cause frontend/backend state "
-                        f"desynchronization. To allow cross-fragment state "
-                        f"modification, set `runner.enforceFragmentStateIsolation "
+                        f"desynchronization. To fix this, either move the widget "
+                        f"into the same fragment, trigger a full app rerun using "
+                        f"`st.rerun()`, or use a non-widget `st.session_state` key "
+                        f"for cross-fragment communication. If you want to disable "
+                        f"this safety check, set `runner.enforceFragmentStateIsolation "
                         f"= false` in your config."
                     )
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -294,6 +294,19 @@ def _missing_key_error_message(key: str) -> str:
     )
 
 
+def _cross_fragment_error_message(key: str, action: str) -> str:
+    """Generate error message for cross-fragment state modification attempts."""
+    return (
+        f"`st.session_state.{key}` belongs to a widget in a different fragment "
+        f"and cannot be {action} from this fragment rerun. This can cause "
+        f"frontend/backend state desynchronization. To fix this, either move "
+        f"the widget into the same fragment, trigger a full app rerun using "
+        f"`st.rerun()`, or use a non-widget `st.session_state` key for "
+        f"cross-fragment communication. If you want to disable this safety "
+        f"check, set `runner.enforceFragmentStateIsolation = false` in your config."
+    )
+
+
 @dataclass
 class KeyIdMapper:
     """A mapping of user-provided keys to element IDs.
@@ -528,6 +541,38 @@ class SessionState:
         # We'll never get here
         raise KeyError
 
+    def _validate_cross_fragment_access(
+        self, user_key: str, widget_id: str | None, action: str
+    ) -> None:
+        """Validate that cross-fragment state access is allowed.
+
+        When runner.enforceFragmentStateIsolation is enabled and we're in a
+        fragment rerun, raise an exception if attempting to modify/delete a
+        widget that belongs to a different fragment.
+
+        Parameters
+        ----------
+        user_key : str
+            The user-provided key for the session state entry.
+        widget_id : str | None
+            The widget ID associated with the key, or None if not a widget.
+        action : str
+            The action being performed ("modified" or "deleted").
+        """
+        ctx = get_script_run_ctx()
+        if (
+            ctx is not None
+            and config.get_option("runner.enforceFragmentStateIsolation")
+            and ctx.fragment_ids_this_run
+            and widget_id is not None
+        ):
+            metadata = self._new_widget_state.widget_metadata.get(widget_id)
+            if metadata is not None and metadata.fragment_id is not None:
+                if metadata.fragment_id not in ctx.fragment_ids_this_run:
+                    raise StreamlitAPIException(
+                        _cross_fragment_error_message(user_key, action)
+                    )
+
     def __setitem__(self, user_key: str, value: Any) -> None:
         """Set the value of the session_state entry with the given user_key.
 
@@ -552,22 +597,7 @@ class SessionState:
                 )
 
             # Check for cross-fragment state modification (opt-in validation)
-            if (
-                config.get_option("runner.enforceFragmentStateIsolation")
-                and ctx.fragment_ids_this_run
-                and widget_id is not None
-            ):
-                metadata = self._new_widget_state.widget_metadata.get(widget_id)
-                if metadata is not None and metadata.fragment_id is not None:
-                    if metadata.fragment_id not in ctx.fragment_ids_this_run:
-                        raise StreamlitAPIException(
-                            f"`st.session_state.{user_key}` belongs to a widget in a "
-                            f"different fragment and cannot be modified from this "
-                            f"fragment rerun. This can cause frontend/backend state "
-                            f"desynchronization. To allow cross-fragment state "
-                            f"modification, set `runner.enforceFragmentStateIsolation "
-                            f"= false` in your config."
-                        )
+            self._validate_cross_fragment_access(user_key, widget_id, "modified")
 
         self._new_session_state[user_key] = value
 
@@ -584,27 +614,7 @@ class SessionState:
             raise KeyError(_missing_key_error_message(key))
 
         # Check for cross-fragment state modification (opt-in validation)
-        ctx = get_script_run_ctx()
-        if (
-            ctx is not None
-            and config.get_option("runner.enforceFragmentStateIsolation")
-            and ctx.fragment_ids_this_run
-            and widget_id is not None
-        ):
-            metadata = self._new_widget_state.widget_metadata.get(widget_id)
-            if metadata is not None and metadata.fragment_id is not None:
-                if metadata.fragment_id not in ctx.fragment_ids_this_run:
-                    raise StreamlitAPIException(
-                        f"`st.session_state.{key}` belongs to a widget in a "
-                        f"different fragment and cannot be deleted from this "
-                        f"fragment rerun. This can cause frontend/backend state "
-                        f"desynchronization. To fix this, either move the widget "
-                        f"into the same fragment, trigger a full app rerun using "
-                        f"`st.rerun()`, or use a non-widget `st.session_state` key "
-                        f"for cross-fragment communication. If you want to disable "
-                        f"this safety check, set `runner.enforceFragmentStateIsolation "
-                        f"= false` in your config."
-                    )
+        self._validate_cross_fragment_access(key, widget_id, "deleted")
 
         if key in self._new_session_state:
             del self._new_session_state[key]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1705,4 +1705,115 @@ def test_delitem_allows_cross_fragment_deletion_when_not_enforced() -> None:
             assert user_key not in session_state
 
 
+def test_setitem_allows_non_widget_keys_across_fragments() -> None:
+    """Test that non-widget session state keys work across fragments.
+
+    Regular session state keys (not associated with widgets) should be freely
+    modifiable between fragments even when enforcement is enabled.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        regular_key = "my_regular_key"
+
+        # No widget ID mapping - this is a regular session state key
+        # (not associated with any widget)
+
+        # Mock context: currently running in fragment_b
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["fragment_b"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise - regular keys are not subject to fragment isolation
+            session_state[regular_key] = "some_value"
+            assert session_state[regular_key] == "some_value"
+
+            # Deletion should also work
+            del session_state[regular_key]
+            assert regular_key not in session_state
+
+
+def test_setitem_allows_nested_fragment_modification() -> None:
+    """Test that nested fragments can modify their own widgets.
+
+    When fragment_ids_this_run contains multiple IDs (nested fragments),
+    a widget belonging to any of those fragments should be modifiable.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_child_fragment"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id="child_fragment"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="child_fragment",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: nested fragments - both parent and child are running
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["parent_fragment", "child_fragment"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise - child_fragment is in fragment_ids_this_run
+            session_state[user_key] = 42
+            assert session_state[user_key] == 42
+
+
+def test_setitem_disallows_sibling_fragment_modification() -> None:
+    """Test that sibling fragments cannot modify each other's widgets.
+
+    When running in a nested fragment context, widgets from sibling fragments
+    (not in fragment_ids_this_run) should still be protected.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_sibling_fragment"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id="sibling_fragment"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="sibling_fragment",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: nested fragments - parent and child, but NOT sibling
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["parent_fragment", "child_fragment"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                session_state[user_key] = 42
+            assert "different fragment" in str(e.value)
+            assert user_key in str(e.value)
+
+
 # endregion Cross-Fragment State Isolation Tests

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1427,3 +1427,282 @@ def test_session_state_iteration_excludes_trigger_widgets() -> None:
     assert (
         len([k for k in visible_keys if k.startswith("$$STREAMLIT_INTERNAL_KEY")]) == 0
     )
+
+
+# region Cross-Fragment State Isolation Tests
+
+
+def test_setitem_disallows_cross_fragment_modification_when_enforced() -> None:
+    """Test that setitem raises error for cross-fragment modification when enforced.
+
+    When runner.enforceFragmentStateIsolation is True, modifying a widget's
+    session state from a different fragment should raise StreamlitAPIException.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id="fragment_a"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in fragment_b (different from fragment_a)
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["fragment_b"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                session_state[user_key] = 42
+            assert "different fragment" in str(e.value)
+            assert user_key in str(e.value)
+
+
+def test_setitem_allows_cross_fragment_modification_when_not_enforced() -> None:
+    """Test that setitem allows cross-fragment modification when not enforced.
+
+    When runner.enforceFragmentStateIsolation is False (default), modifying
+    a widget's session state from a different fragment should succeed.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": False}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id="fragment_a"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in fragment_b (different from fragment_a)
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["fragment_b"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise, modification is allowed
+            session_state[user_key] = 42
+            assert session_state[user_key] == 42
+
+
+def test_setitem_allows_same_fragment_modification() -> None:
+    """Test that setitem allows modification within the same fragment.
+
+    When runner.enforceFragmentStateIsolation is True, modifying a widget's
+    session state from the same fragment should succeed.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id="fragment_a"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in fragment_a (same as widget)
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["fragment_a"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise, modification is within the same fragment
+            session_state[user_key] = 42
+            assert session_state[user_key] == 42
+
+
+def test_setitem_allows_modification_of_pre_fragment_widget() -> None:
+    """Test that setitem allows modification of widgets without a fragment_id.
+
+    Widgets created before fragments (fragment_id=None) should be modifiable
+    from any fragment to maintain backward compatibility.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "pre_fragment_widget"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata without fragment_id (pre-fragment widget)
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id=None,  # No fragment association
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in some fragment
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = ["some_fragment"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise, pre-fragment widgets are always modifiable
+            session_state[user_key] = 42
+            assert session_state[user_key] == 42
+
+
+def test_setitem_allows_modification_during_full_app_run() -> None:
+    """Test that setitem allows modification during a full app run.
+
+    When fragment_ids_this_run is None (full app run, not a fragment rerun),
+    all modifications should be allowed.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping
+        session_state._key_id_mapper[user_key] = widget_id
+
+        # Add widget metadata with fragment_id
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: full app run (fragment_ids_this_run is None)
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = set()
+        mock_ctx.form_ids_this_run = set()
+        mock_ctx.fragment_ids_this_run = None
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise, full app run allows all modifications
+            session_state[user_key] = 42
+            assert session_state[user_key] == 42
+
+
+def test_delitem_disallows_cross_fragment_deletion_when_enforced() -> None:
+    """Test that delitem raises error for cross-fragment deletion when enforced.
+
+    When runner.enforceFragmentStateIsolation is True, deleting a widget's
+    session state from a different fragment should raise StreamlitAPIException.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": True}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping and initial value
+        session_state._key_id_mapper[user_key] = widget_id
+        session_state._new_session_state[user_key] = 100
+
+        # Add widget metadata with fragment_id="fragment_a"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in fragment_b (different from fragment_a)
+        mock_ctx = MagicMock()
+        mock_ctx.fragment_ids_this_run = ["fragment_b"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                del session_state[user_key]
+            assert "different fragment" in str(e.value)
+            assert user_key in str(e.value)
+
+
+def test_delitem_allows_cross_fragment_deletion_when_not_enforced() -> None:
+    """Test that delitem allows cross-fragment deletion when not enforced.
+
+    When runner.enforceFragmentStateIsolation is False (default), deleting
+    a widget's session state from a different fragment should succeed.
+    """
+    with patch_config_options({"runner.enforceFragmentStateIsolation": False}):
+        session_state = SessionState()
+        widget_id = "widget_in_fragment_a"
+        user_key = "my_widget"
+
+        # Set up key mapping and initial value
+        session_state._key_id_mapper[user_key] = widget_id
+        session_state._new_session_state[user_key] = 100
+
+        # Add widget metadata with fragment_id="fragment_a"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x,
+            serializer=lambda x: x,
+            value_type="int_value",
+            fragment_id="fragment_a",
+        )
+        session_state._new_widget_state.widget_metadata[widget_id] = metadata
+
+        # Mock context: currently running in fragment_b (different from fragment_a)
+        mock_ctx = MagicMock()
+        mock_ctx.fragment_ids_this_run = ["fragment_b"]
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=mock_ctx,
+        ):
+            # Should not raise, deletion is allowed
+            del session_state[user_key]
+            assert user_key not in session_state
+
+
+# endregion Cross-Fragment State Isolation Tests

--- a/test_title_app.py
+++ b/test_title_app.py
@@ -1,0 +1,17 @@
+import streamlit as st
+
+st.title("Alert Title Feature Demo")
+
+st.header("Without Title")
+st.info("This is a standard info message without a title.")
+st.error("This is a standard error message without a title.")
+st.warning("This is a standard warning message without a title.")
+st.success("This is a standard success message without a title.")
+
+st.divider()
+
+st.header("With Title")
+st.info("Your session will expire in 5 minutes.", title="Session Notice")
+st.error("Failed to connect to the database. Please check your credentials.", title="Connection Error")
+st.warning("This feature will be deprecated in the next version.", title="Deprecation Warning")
+st.success("Your changes have been saved successfully!", title="Success")


### PR DESCRIPTION
Summary

Fixes #11109

This PR adds opt-in validation to detect and prevent cross-fragment session state modifications that can cause frontend/backend state desynchronization.

The Problem

When a fragment rerun modifies `st.session_state` for a widget that belongs to a *different* fragment, the modification succeeds on the backend but the frontend UI doesn't update (since only the current fragment is re-rendered). This creates a silent desync between what the user sees and what the backend believes is the current state.

**Example of the problematic pattern:**
```python
@st.fragment
def fragment_a():
    st.number_input("Counter", key="counter")  # Widget belongs to fragment_a

@st.fragment
def fragment_b():
    if st.button("Increment"):
        st.session_state.counter += 1  # Modifies fragment_a's widget - CAUSES DESYNC!

fragment_a()
fragment_b()
```

When the button in `fragment_b` is clicked, only `fragment_b` reruns. The backend updates `counter` to the new value, but `fragment_a`'s number input doesn't re-render, so the user still sees the old value.

The Solution

This PR adds a new config option `runner.enforceFragmentStateIsolation` (default: `false`). When enabled:

- **`__setitem__`**: Raises `StreamlitAPIException` if a fragment attempts to modify session state for a widget belonging to a different fragment
- **`__delitem__`**: Raises `StreamlitAPIException` if a fragment attempts to delete session state for a widget belonging to a different fragment

Why Opt-In (Default: False)?

Making this opt-in is **critical for backward compatibility**. Many existing Streamlit apps legitimately share state between fragments:

```python
# Common pattern that would break if we raised errors by default
@st.fragment
def increment_button():
    if st.button("Add 1"):
        st.session_state.counter += 1  # Modifying shared state

st.number_input("Counter", key="counter")
increment_button()
```

By making this opt-in, developers can:
1. Enable it for new projects to catch potential bugs early
2. Gradually migrate existing apps
3. Choose their own tradeoff between strictness and flexibility

This follows the same pattern as the existing `runner.enforceSerializableSessionState` option.

---

Files Changed

1. `lib/streamlit/config.py`
Added new config option:
```python
_create_option(
    "runner.enforceFragmentStateIsolation",
    description="""
        Raise an exception when a fragment attempts to modify session state
        for widgets that belong to a different fragment.
        ...
    """,
    default_val=False,
    type_=bool,
)
```

2. `lib/streamlit/runtime/state/session_state.py`

**`__setitem__` method** - Added validation after existing widget/form checks:
- Gets the widget_id for the key being modified
- Looks up the widget's metadata to find its `fragment_id`
- If the widget belongs to a different fragment than the one currently running, raises `StreamlitAPIException`

**`__delitem__` method** - Added same validation logic for deletions

3. `lib/tests/streamlit/runtime/state/session_state_test.py`

Added 7 comprehensive test cases covering all edge cases.

---

Test Cases Added

1. **`test_setitem_disallows_cross_fragment_modification_when_enforced`**
   - Modify widget from different fragment with config ON
   - Expected: Raises `StreamlitAPIException`

2. **`test_setitem_allows_cross_fragment_modification_when_not_enforced`**
   - Modify widget from different fragment with config OFF
   - Expected: Succeeds (backward compat)

3. **`test_setitem_allows_same_fragment_modification`**
   - Modify widget from same fragment with config ON
   - Expected: Succeeds

4. **`test_setitem_allows_modification_of_pre_fragment_widget`**
   - Modify widget with `fragment_id=None`
   - Expected: Succeeds (pre-fragment widgets are always modifiable)

5. **`test_setitem_allows_modification_during_full_app_run`**
   - Modify any widget during full app run
   - Expected: Succeeds (`fragment_ids_this_run=None` means full run)

6. **`test_delitem_disallows_cross_fragment_deletion_when_enforced`**
   - Delete widget from different fragment with config ON
   - Expected: Raises `StreamlitAPIException`

7. **`test_delitem_allows_cross_fragment_deletion_when_not_enforced`**
   - Delete widget from different fragment with config OFF
   - Expected: Succeeds (backward compat)

---

Edge Cases Handled

1. **Nested fragments** - Checks if widget's `fragment_id` is in `ctx.fragment_ids_this_run` (list of all fragments in current rerun)

2. **Pre-fragment widgets** - Widgets with `fragment_id=None` (created before any fragment) are always modifiable

3. **Full app run** - When `fragment_ids_this_run=None`, validation is skipped entirely

4. **Non-widget keys** - Only validated when `widget_id` is not None (regular session state keys are unaffected)

5. **Missing metadata** - If widget metadata doesn't exist, validation is skipped

---

How to Test

1. Enable the config option:
```toml
# .streamlit/config.toml
[runner]
enforceFragmentStateIsolation = true
```

2. Run this test app:
```python
import streamlit as st

@st.fragment
def fragment_a():
    st.number_input("Counter", key="counter", value=0)

@st.fragment
def fragment_b():
    if st.button("Try to modify counter"):
        st.session_state.counter += 1  # Should raise error

fragment_a()
fragment_b()
```

3. Click the button - you should see a `StreamlitAPIException` explaining that cross-fragment modification is not allowed.

---

Future Considerations

In a future major version, the default could be flipped to `true` to enforce fragment isolation by default, with the option to opt-out for apps that need cross-fragment state sharing.
