### PR TITLE
Add session state initialization to number_input callback example

### DIFF
--- a/e2e_playwright/st_number_input.py
+++ b/e2e_playwright/st_number_input.py
@@ -44,6 +44,10 @@ if runtime.exists():
     def on_change():
         st.session_state.number_input_changed = True
 
+    # Initialize session state variables to prevent AttributeError
+    if "number_input_9" not in st.session_state:
+        st.session_state.number_input_9 = 0.0
+
     st.number_input(
         "number input 9 (on_change)", key="number_input_9", on_change=on_change
     )


### PR DESCRIPTION
This commit adds proper session state initialization for the number_input_9 variable before it's used in the callback example. This prevents potential AttributeError and serves as a best practice example for users learning how to handle session state with callbacks.

The initialization pattern (checking if key exists before setting default) is consistent with the pattern already used in the same file for number_input_12 example.

## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
