### PR TITLE
Add to_dict to TokensProxy

### DIFF
--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -469,6 +469,9 @@ class TokensProxy(Mapping[str, str]):
     def __len__(self) -> int:
         return len(self._tokens)
 
+    def to_dict(self) -> dict[str, str]:
+        return self._tokens
+
 
 class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
     """

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -470,7 +470,14 @@ class TokensProxy(Mapping[str, str]):
         return len(self._tokens)
 
     def to_dict(self) -> dict[str, str]:
-        return self._tokens
+        """Return the token mapping as a standard dictionary.
+
+        Returns
+        -------
+        dict[str, str]
+            A dictionary mapping token names to token values.
+        """
+        return dict(self._tokens)
 
 
 class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -317,6 +317,13 @@ class TestTokensProxy:
         with pytest.raises(StreamlitAPIException):
             proxy["id"] = "modified"
 
+    def test_tokens_proxy_to_dict(self):
+        """Test that tokens can be converted to a dictionary."""
+        proxy = TokensProxy({"id": "test", "access": "test"})
+        assert proxy.to_dict() == {"id": "test", "access": "test"}
+        proxy.to_dict()["id"] = "modified"
+        assert proxy.to_dict() == {"id": "test", "access": "test"}
+
 
 class UserInfoTokensTest(DeltaGeneratorTestCase):
     """Test st.user.tokens functionality."""


### PR DESCRIPTION
## Describe your changes

This pull request adds a new utility method to the `TokensProxy` class in `lib/streamlit/user_info.py` to improve usability. Specifically, when writing `st.write(st.user.tokens)`, it should use `st.json` under the hood.

* Added a `to_dict` method to the `TokensProxy` class, allowing easy conversion of the proxy's internal token storage to a standard dictionary.

## Testing Plan

- Python unit test added

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
