### PR TITLE
Ignore Pillow deprecation warning in e2e tests

### DIFF
--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -14,6 +14,6 @@ filterwarnings =
     # Likely needs an update/fix in pixelmatch when Pillow 14 is released.
     ignore:Image.Image.getdata is deprecated.*:DeprecationWarning:pixelmatch.*:
     # Benchmarks are disabled when running with xdist (parallel execution).
-    ignore:Benchmarks are automatically disabled.*:pytest_benchmark.plugin.PytestBenchmarkWarning:pytest_benchmark.*:
+    ignore:Benchmarks are automatically disabled.*::pytest_benchmark.*:
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short
 timeout = 300

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -10,5 +10,8 @@ filterwarnings =
     # Deprecation warning about our early fixture marker trick:
     # Likely needs to be refactored to support pytest 9.
     ignore:Marks applied to fixtures have no effect.*:pytest.PytestWarning::
+    # Pillow deprecation warning from pixelmatch library.
+    # Likely needs an update/fix in pixelmatch when Pillow 14 is released.
+    ignore:Image.Image.getdata is deprecated.*:DeprecationWarning:pixelmatch.*:
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short
 timeout = 300

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -13,5 +13,7 @@ filterwarnings =
     # Pillow deprecation warning from pixelmatch library.
     # Likely needs an update/fix in pixelmatch when Pillow 14 is released.
     ignore:Image.Image.getdata is deprecated.*:DeprecationWarning:pixelmatch.*:
+    # Benchmarks are disabled when running with xdist (parallel execution).
+    ignore:Benchmarks are automatically disabled.*:pytest_benchmark.plugin.PytestBenchmarkWarning:pytest_benchmark.*:
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short
 timeout = 300


### PR DESCRIPTION
## Describe your changes

The latest pillow update is causing numerous deprecation warnings when running our end-to-end tests. This is caused by pixelmatch, a dependency that is only used within our e2e tests. Ignoring the deprecation warning since this isn't something caused from within Streamlit. 

<img width="1017" height="164" alt="image" src="https://github.com/user-attachments/assets/e6408f01-6951-479d-a703-46be67e0890e" />

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
