### PR TITLE
Add session-scoped connection support.

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -195,5 +195,9 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
 
         ``close`` is registered as an ``on_release`` hook in the resource cache when a
         connection is created with ``st.connection``.
+
+        Returns
+        -------
+        None
         """
         # NOTE: Default implementation is intentionally a no-op.

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, Literal, TypeVar, cast
 
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
 from streamlit.util import calc_md5
@@ -174,3 +174,26 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
             The underlying connection object.
         """
         raise NotImplementedError
+
+    @classmethod
+    def scope(cls) -> Literal["global", "session"]:
+        """Returns the scope of this connection type.
+
+        "global" connection instances will be cached globally, and typically created
+        once during the lifetime of an application. "session" connection instances will
+        be cached per session, and typically will be created once per user session.
+
+        Returns
+        -------
+        "global" or "session"
+            The scope of this connection type.
+        """
+        return "global"
+
+    def close(self) -> None:
+        """A function to invoke when this connection needs to be cleaned up.
+
+        ``close`` is registered as an ``on_release`` hook in the resource cache when a
+        connection is created with ``st.connection``.
+        """
+        # NOTE: Default implementation is intentionally a no-op.

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -95,10 +95,23 @@ def _create_connection(
     __create_connection.__qualname__ = (
         f"{__create_connection.__qualname__}_{ttl_str}_{max_entries}"
     )
+
+    scope = connection_class.scope()
+    if scope not in ("global", "session"):
+        raise StreamlitAPIException(
+            f"Connection class {connection_class} has scope '{scope}'. Valid values "
+            "are 'global' or 'session'."
+        )
+
+    def on_release_wrapped(connection: ConnectionClass) -> None:
+        connection.close()
+
     __create_connection = cache_resource(
         max_entries=max_entries,
         show_spinner="Running `st.connection(...)`.",
         ttl=ttl,
+        scope=scope,
+        on_release=on_release_wrapped,
     )(__create_connection)
 
     return __create_connection(name, connection_class, **kwargs)
@@ -220,7 +233,8 @@ def connection_factory(  # type: ignore
     - Any connection-specific configuration files.
 
     The connection returned from ``st.connection`` is internally cached with
-    ``st.cache_resource`` and is therefore shared between sessions.
+    ``st.cache_resource``. Connection types with a scope of ``"global"`` will be shared
+    between sessions.
 
     Parameters
     ----------

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -30,6 +30,7 @@ from streamlit.connections import (
     SQLConnection,
 )
 from streamlit.errors import StreamlitAPIException, StreamlitSecretNotFoundError
+from streamlit.runtime import connection_factory as connection_factory_module
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
     _create_connection,
@@ -207,6 +208,81 @@ type="snowpark"
             connection_factory("my_connection2", MockConnection, max_entries=20)
 
         assert patched_init.call_count == 2
+
+    def test_friendly_error_for_bad_scope(self):
+        """A bad scope on a BaseConnection class triggers an exception."""
+
+        class BadScopeConnection(BaseConnection):
+            @classmethod
+            def scope(cls) -> str:
+                return "request"
+
+            def _connect(self, **kwargs):
+                pass
+
+        with pytest.raises(StreamlitAPIException) as e:
+            connection_factory("my_connection", BadScopeConnection)
+
+        e.match("BadScopeConnection.*has scope 'request'")
+
+    def test_scope_is_passed_to_cache(self):
+        """Scope should be passed to the underlying cache."""
+
+        class SessionScopedConnection(BaseConnection):
+            @classmethod
+            def scope(cls) -> str:
+                return "session"
+
+            def _connect(self, **kwargs):
+                pass
+
+        class GloballyScopedConnection(BaseConnection):
+            @classmethod
+            def scope(cls) -> str:
+                return "global"
+
+            def _connect(self, **kwargs):
+                pass
+
+        with patch.object(
+            connection_factory_module, "cache_resource"
+        ) as mock_cache_resource:
+            connection_factory("my_connection", SessionScopedConnection)
+
+        mock_cache_resource.assert_called_once()
+        assert mock_cache_resource.call_args.kwargs["scope"] == "session"
+
+        with patch.object(
+            connection_factory_module, "cache_resource"
+        ) as mock_cache_resource:
+            connection_factory("my_connection", GloballyScopedConnection)
+
+        mock_cache_resource.assert_called_once()
+        assert mock_cache_resource.call_args.kwargs["scope"] == "global"
+
+    def test_close_is_passed_to_cache(self):
+        """Close should be passed to the underlying cache as on_release."""
+
+        class ConnectionWithClose(BaseConnection):
+            def __init__(self):
+                self.close_count = 0
+
+            def _connect(self, **kwargs):
+                pass
+
+            def close(self):
+                self.close_count += 1
+
+        with patch.object(
+            connection_factory_module, "cache_resource"
+        ) as mock_cache_resource:
+            connection_factory("my_connection", ConnectionWithClose)
+
+        fake_connection = ConnectionWithClose()
+        mock_cache_resource.assert_called_once()
+        on_release = mock_cache_resource.call_args.kwargs["on_release"]
+        on_release(fake_connection)
+        assert fake_connection.close_count == 1, "connection should have been closed"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -265,6 +265,7 @@ type="snowpark"
 
         class ConnectionWithClose(BaseConnection):
             def __init__(self):
+                super().__init__("test")
                 self.close_count = 0
 
             def _connect(self, **kwargs):

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -18,6 +18,7 @@ import os
 import sys
 import threading
 import unittest
+from typing import Literal
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -214,7 +215,7 @@ type="snowpark"
 
         class BadScopeConnection(BaseConnection):
             @classmethod
-            def scope(cls) -> str:
+            def scope(cls) -> Literal["request"]:
                 return "request"
 
             def _connect(self, **kwargs):
@@ -230,7 +231,7 @@ type="snowpark"
 
         class SessionScopedConnection(BaseConnection):
             @classmethod
-            def scope(cls) -> str:
+            def scope(cls) -> Literal["session"]:
                 return "session"
 
             def _connect(self, **kwargs):
@@ -238,7 +239,7 @@ type="snowpark"
 
         class GloballyScopedConnection(BaseConnection):
             @classmethod
-            def scope(cls) -> str:
+            def scope(cls) -> Literal["global"]:
                 return "global"
 
             def _connect(self, **kwargs):


### PR DESCRIPTION
## Describe your changes

Add class-level `scope` method to `BaseConnection`. Use it when caching instances created by `st.connection`.

Add instance-level `close` method to `BaseConnection`. Register it as the `on_release` hook when caching instances created by `st.connection`.

This is part of [the session-scoped connections plan](https://github.com/streamlit/streamlit/tree/develop/specs/0001-session-scoped-connections-and-rcr), and will be used to create a Snowflake RCR connection.

## Testing Plan

See unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
