### PR TITLE
[feat] Allow for optional js, css, and html params in CCv2

### DIFF
--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -30,6 +30,17 @@ st.header("Custom Components v2 - Basics")
 
 
 # ---------------------------------------------------------------------------
+# Empty content: component with no HTML/CSS/JS should not error
+# ---------------------------------------------------------------------------
+_EMPTY_CMP = st.components.v2.component("bidi_empty_content")
+
+with st.container(key="empty_component_container"):
+    st.subheader("Empty content")
+    _EMPTY_CMP(isolate_styles=False, key="empty_component")
+    st.write("After empty component")
+
+
+# ---------------------------------------------------------------------------
 # Shared: simple stateful component (range + text) used in multiple sections
 # ---------------------------------------------------------------------------
 _STATEFUL_JS = """

--- a/e2e_playwright/bidi_components/basics_test.py
+++ b/e2e_playwright/bidi_components/basics_test.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.shared.app_utils import click_form_button
+from e2e_playwright.shared.app_utils import (
+    click_form_button,
+    expect_no_exception,
+    get_element_by_key,
+)
 
 
 def section(app: Page, heading_name: str) -> Locator:
@@ -23,6 +27,15 @@ def section(app: Page, heading_name: str) -> Locator:
     """
     heading = app.get_by_role("heading", name=heading_name, exact=True)
     return app.locator("[data-testid='stLayoutWrapper']").filter(has=heading).first
+
+
+def test_empty_content_does_not_crash(app: Page) -> None:
+    """CCv2 should allow empty component definitions (no js/html/css) without errors."""
+    empty_container = get_element_by_key(app, "empty_component_container")
+    expect(empty_container.get_by_role("heading", name="Empty content")).to_be_visible()
+    expect_no_exception(app)
+    expect(empty_container.get_by_test_id("stBidiComponentRegular")).to_have_count(1)
+    expect(empty_container.get_by_text("After empty component")).to_be_visible()
 
 
 def test_stateful_interactions(app: Page) -> None:

--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -202,8 +202,9 @@ def component(
 ) -> BidiComponentCallable:
     '''Register an ``st.components.v2`` component and return a callable to mount it.
 
-    A component must have HTML, JavaScript, or both. If you want a component
-    with only CSS, use ``st.html`` instead.
+    Components may provide any combination of HTML, CSS, and JavaScript. If none
+    are provided, the component will render as an empty element without raising
+    an error.
 
     If your component is defined in an installed package, you can declare an
     asset directory (``asset_dir``) through ``pyproject.toml`` files in the
@@ -250,9 +251,6 @@ def component(
         element and populate it via JavaScript. Alternatively, you can append
         a new element to the parent. For more information, see Example 2.
 
-        ``html`` and ``js`` can't both be ``None``. At least one of them must
-        be provided.
-
     css : str or None
         Inline CSS. This can be one of the following strings:
 
@@ -266,9 +264,6 @@ def component(
         - Raw JavaScript (without a ``<script>`` block).
         - A path or glob to a JS file, relative to the component's
           asset directory.
-
-        ``html`` and ``js`` can't both be ``None``. At least one of them must
-        be provided.
 
     Returns
     -------

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -50,7 +50,6 @@ from streamlit.errors import (
     BidiComponentInvalidCallbackNameError,
     BidiComponentInvalidDefaultKeyError,
     BidiComponentInvalidIdError,
-    BidiComponentMissingContentError,
     BidiComponentUnserializableDataError,
 )
 from streamlit.proto.ArrowData_pb2 import ArrowData as ArrowDataProto
@@ -348,13 +347,6 @@ class BidiComponentMixin:
 
         if component_def is None:
             raise ValueError(f"Component '{component_name}' is not registered")
-
-        # Validate that the component has the required content
-        has_js = bool(component_def.js_content or component_def.js_url)
-        has_html = bool(component_def.html_content)
-
-        if not has_js and not has_html:
-            raise BidiComponentMissingContentError(component_name)
 
         # ------------------------------------------------------------------
         # 1. Parse user-supplied callbacks

--- a/lib/streamlit/components/v2/types.py
+++ b/lib/streamlit/components/v2/types.py
@@ -22,6 +22,10 @@ authoring wrappers/utilities around `st.components.v2.component`.
 The goal is to keep the public argument surface documented in one place and
 reusable across both the user-facing factory in `components/v2/__init__.py`
 and the internal implementation in `components/v2/bidi_component/main.py`.
+
+Component definitions may provide any combination of HTML, CSS, and
+JavaScript. If none are supplied, the component renders as an empty
+placeholder without raising an error.
 """
 
 from __future__ import annotations

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -476,18 +476,6 @@ class BidiComponentInvalidIdError(LocalizableStreamlitException):
         )
 
 
-class BidiComponentMissingContentError(LocalizableStreamlitException):
-    """Exception raised when a component is missing required content."""
-
-    def __init__(self, component_name: str) -> None:
-        super().__init__(
-            "Component `{component_name}` must have either JavaScript content "
-            "(`js_content` or `js_url`) or HTML content (`html_content`), or both. "
-            "Please ensure the component definition includes at least one of these.",
-            component_name=component_name,
-        )
-
-
 class BidiComponentInvalidCallbackNameError(LocalizableStreamlitException):
     """Exception raised when a callback with an invalid name is provided."""
 

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -441,9 +441,8 @@ class BidiComponentTest(DeltaGeneratorTestCase):
         assert bidi_component_proto.html_content == "<div>Hello World</div>"
         assert bidi_component_proto.css_content == "div { color: red; }"
 
-    def test_component_with_no_js_or_html_raises_exception(self):
-        """Test that component with neither JS nor HTML content raises StreamlitAPIException."""
-        # Register a component with only CSS content (no JS or HTML)
+    def test_component_with_css_only_succeeds(self):
+        """Test that a CSS-only component mounts without raising."""
         self.mock_component_manager.register(
             BidiComponentDefinition(
                 name="css_only_component",
@@ -451,42 +450,31 @@ class BidiComponentTest(DeltaGeneratorTestCase):
             )
         )
 
-        # Call the component and expect an exception
-        with pytest.raises(StreamlitAPIException) as exc_info:
-            st._bidi_component("css_only_component")
+        st._bidi_component("css_only_component")
 
-        # Verify the error message
-        error_message = str(exc_info.value)
-        assert "css_only_component" in error_message
-        assert "must have either JavaScript content" in error_message
-        assert (
-            "(`js_content` or `js_url`) or HTML content (`html_content`)"
-            in error_message
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "css_only_component"
+        assert bidi_component_proto.css_content == "div { color: red; }"
+        assert bidi_component_proto.js_content == ""
+        assert bidi_component_proto.html_content == ""
+
+    def test_component_with_no_content_succeeds(self):
+        """Test that a component with no JS/HTML/CSS mounts without raising."""
+        self.mock_component_manager.register(
+            BidiComponentDefinition(
+                name="empty_component",
+            )
         )
 
-    def test_component_with_empty_js_and_html_raises_exception(self):
-        """Test that component with empty JS and HTML content raises StreamlitAPIException."""
-        # Create a mock component definition with empty content
-        mock_component_def = MagicMock(spec=BidiComponentDefinition)
-        mock_component_def.js_content = ""  # Empty string
-        mock_component_def.js_url = None
-        mock_component_def.html_content = ""  # Empty string
-        mock_component_def.css_content = "div { color: red; }"
-        mock_component_def.css_url = None
-        mock_component_def.isolate_styles = True
+        st._bidi_component("empty_component")
 
-        # Mock the registry to return our component
-        with patch.object(
-            self.mock_component_manager, "get", return_value=mock_component_def
-        ):
-            # Call the component and expect an exception
-            with pytest.raises(StreamlitAPIException) as exc_info:
-                st._bidi_component("empty_component")
-
-            # Verify the error message
-            error_message = str(exc_info.value)
-            assert "empty_component" in error_message
-            assert "must have either JavaScript content" in error_message
+        delta = self.get_delta_from_queue()
+        bidi_component_proto = delta.new_element.bidi_component
+        assert bidi_component_proto.component_name == "empty_component"
+        assert bidi_component_proto.css_content == ""
+        assert bidi_component_proto.js_content == ""
+        assert bidi_component_proto.html_content == ""
 
     def test_unregistered_component_raises_value_error(self):
         """Test that calling an unregistered component raises ValueError."""


### PR DESCRIPTION
## Describe your changes

Allow CCv2 components with no HTML, CSS, or JavaScript content to render without errors. Previously, the system would raise a `BidiComponentMissingContentError` if a component didn't have at least HTML or JavaScript content. This change removes that restriction, allowing empty components to render as empty placeholders.

Updated the component documentation to reflect that components can have any combination of HTML, CSS, and JavaScript, including none at all.

## Testing Plan

- Unit Tests (Python): Added tests to verify that components with only CSS or no content at all can be mounted without raising exceptions
- E2E Tests: Added a test case with an empty component to verify it renders correctly without crashing the app
- Manual Testing: The empty component can be visually verified in the e2e test app

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.