### PR TITLE
[feat] Move the isolate_styles param in CCv2

### DIFF
--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -32,11 +32,11 @@ st.header("Custom Components v2 - Basics")
 # ---------------------------------------------------------------------------
 # Empty content: component with no HTML/CSS/JS should not error
 # ---------------------------------------------------------------------------
-_EMPTY_CMP = st.components.v2.component("bidi_empty_content")
+_EMPTY_CMP = st.components.v2.component("bidi_empty_content", isolate_styles=False)
 
 with st.container(key="empty_component_container"):
     st.subheader("Empty content")
-    _EMPTY_CMP(isolate_styles=False, key="empty_component")
+    _EMPTY_CMP(key="empty_component")
     st.write("After empty component")
 
 
@@ -109,7 +109,6 @@ def stateful_component(
     default: dict[str, Any] | None = None,
 ) -> BidiComponentResult:
     return _STATEFUL_CMP(
-        isolate_styles=True,
         key=key,
         data=data,
         on_range_change=on_range_change,
@@ -168,7 +167,6 @@ def trigger_component(
     on_bar_change: WidgetCallback | None = None,
 ) -> BidiComponentResult:
     return _TRIGGER_CMP(
-        isolate_styles=True,
         key=key,
         data=data,
         on_foo_change=on_foo_change,
@@ -232,7 +230,6 @@ def ctx_component(
     on_clicked_change: WidgetCallback | None = None,
 ) -> BidiComponentResult:
     return _CTX_CMP(
-        isolate_styles=True,
         key=key,
         data=data,
         on_text_change=on_text_change,
@@ -501,7 +498,6 @@ div {
         default: dict[str, Any] | None = None,
     ) -> BidiComponentResult:
         return _BASIC_CMP(
-            isolate_styles=True,
             key=key,
             data=data,
             on_formValues_change=on_formValues_change,

--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from streamlit import deprecation_util
 from streamlit.components.v2.component_definition_resolver import (
     build_definition_with_validation,
 )
@@ -106,6 +107,7 @@ def _create_component_callable(
     html: str | None = None,
     css: str | None = None,
     js: str | None = None,
+    isolate_styles: bool = True,
 ) -> Callable[..., Any]:
     """Create a component callable, handling both lookup and registration cases.
 
@@ -121,6 +123,9 @@ def _create_component_callable(
     js : str | None
         Inline JavaScript (string) or a string path/glob to a file under
         ``asset_dir``; see :func:`_register_component` for path validation semantics.
+    isolate_styles : bool
+        Whether to sandbox the component's styles in a shadow root.
+        Defaults to True.
 
     Returns
     -------
@@ -143,7 +148,6 @@ def _create_component_callable(
         default: dict[str, Any] | None = None,
         width: Width = "stretch",
         height: Height = "content",
-        isolate_styles: bool = True,
         **on_callbacks: WidgetCallback | None,
     ) -> BidiComponentResult:
         """Mount the component.
@@ -161,9 +165,6 @@ def _create_component_callable(
             The width of the component.
         height : Height
             The height of the component.
-        isolate_styles : bool
-            Whether to sandbox the component styles in a shadow-root. Defaults to
-            True.
         **on_callbacks : WidgetCallback
             Callback functions for handling component events. Use pattern
             on_{state_name}_change (e.g., on_click_change, on_value_change).
@@ -174,6 +175,20 @@ def _create_component_callable(
             Component state.
         """
         import streamlit as st
+
+        # Backwards-tolerant: old code may still pass isolate_styles at mount
+        # time. Since isolate_styles is now configured on component(), ignore it
+        # here to prevent a runtime error.
+        if "isolate_styles" in on_callbacks:
+            on_callbacks.pop("isolate_styles", None)
+
+            deprecation_util.show_deprecation_warning(
+                "Passing `isolate_styles` when mounting a component created via "
+                "`st.components.v2.component` is deprecated and will be ignored. "
+                "Set `isolate_styles` when creating the component instead "
+                "(`st.components.v2.component(..., isolate_styles=...)`).",
+                show_in_browser=False,
+            )
 
         return st._bidi_component(
             component_key,
@@ -186,10 +201,6 @@ def _create_component_callable(
             **on_callbacks,
         )
 
-    # Ensure the function remains compatible with the shared public callable type.
-    # Static type assertion to ensure the callable matches the shared signature
-    _typed_check_mount_component: BidiComponentCallable = _mount_component
-
     return _mount_component
 
 
@@ -199,6 +210,7 @@ def component(
     html: str | None = None,
     css: str | None = None,
     js: str | None = None,
+    isolate_styles: bool = True,
 ) -> BidiComponentCallable:
     '''Register an ``st.components.v2`` component and return a callable to mount it.
 
@@ -264,6 +276,14 @@ def component(
         - Raw JavaScript (without a ``<script>`` block).
         - A path or glob to a JS file, relative to the component's
           asset directory.
+
+    isolate_styles : bool
+        Whether to sandbox the component styles in a shadow root. If this is
+        ``True`` (default), the component's HTML is mounted inside a shadow DOM
+        and, in your component's JavaScript, ``parentElement`` returns a
+        ``ShadowRoot``. If this is ``False``, the component's HTML is mounted
+        directly into the app's DOM tree, and ``parentElement`` returns a
+        regular ``HTMLElement``.
 
     Returns
     -------
@@ -501,7 +521,9 @@ def component(
         height: 250px
 
     '''
-    return _create_component_callable(name, html=html, css=css, js=js)
+    return _create_component_callable(
+        name, html=html, css=css, js=js, isolate_styles=isolate_styles
+    )
 
 
 __all__ = [

--- a/lib/streamlit/components/v2/types.py
+++ b/lib/streamlit/components/v2/types.py
@@ -141,14 +141,6 @@ class BidiComponentCallable(Protocol):
         You are responsible for ensuring the component's inner HTML content is
         responsive to the ``<div>`` wrapper.
 
-    isolate_styles : bool
-        Whether to sandbox the component styles in a shadow root. If this is
-        ``True`` (default), the component's HTML is mounted inside a shadow DOM
-        and, in your component's JavaScript, ``parentElement`` returns a
-        ``ShadowRoot``. If this is ``False``, the component's HTML is mounted
-        directly into the app's DOM tree, and ``parentElement`` returns a
-        regular ``HTMLElement``.
-
     **callbacks : Callable or None
         Callbacks with the naming pattern ``on_<key>_change`` for each state and
         trigger key. For example, if your component has a state key of
@@ -255,11 +247,12 @@ class BidiComponentCallable(Protocol):
 
     **Example 2: Add Tailwind CSS to a component**
 
-    You can use the ``isolate_styles`` parameter to disable shadow DOM
-    isolation and apply global styles like Tailwind CSS to your component. The
-    following example creates a simple button styled with Tailwind CSS. This
-    example also demonstrates using different keys to mount multiple instances
-    of the same component in one app.
+    You can use the ``isolate_styles`` parameter in
+    ``st.components.v2.component`` to disable shadow DOM isolation and apply
+    global styles like Tailwind CSS to your component. The following example
+    creates a simple button styled with Tailwind CSS. This example also
+    demonstrates using different keys to mount multiple instances of the same
+    component in one app.
 
     .. code-block:: python
 
@@ -289,15 +282,12 @@ class BidiComponentCallable(Protocol):
             "my_tailwind_button",
             html=HTML,
             js=JS,
+            isolate_styles=False,
         )
-        result_1 = my_component(
-            isolate_styles=False, on_clicked_change=lambda: None, key="one"
-        )
+        result_1 = my_component(on_clicked_change=lambda: None, key="one")
         result_1
 
-        result_2 = my_component(
-            isolate_styles=False, on_clicked_change=lambda: None, key="two"
-        )
+        result_2 = my_component(on_clicked_change=lambda: None, key="two")
         result_2
 
     .. output::
@@ -314,7 +304,6 @@ class BidiComponentCallable(Protocol):
         default: BidiComponentDefaults = None,
         width: Width = "stretch",
         height: Height = "content",
-        isolate_styles: ComponentIsolateStyles = True,
         **on_callbacks: WidgetCallback | None,
     ) -> BidiComponentResult: ...
 

--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -467,6 +467,46 @@ def test_public_api_path_object_rejection() -> None:
         component("test", css=["invalid", "list"])  # List instead of string/Path
 
 
+def test_component_mount_ignores_isolate_styles_kwarg() -> None:
+    """Verify mount-time isolate_styles is ignored (and does not raise).
+
+    Without the mount-time kwarg being stripped, the mount callable would end
+    up calling ``st._bidi_component(..., isolate_styles=<from component()>, **kwargs)``
+    where ``kwargs`` also contains ``isolate_styles``. That would raise a
+    ``TypeError`` about multiple values for the same keyword argument before
+    `_bidi_component` runs.
+    """
+    import streamlit as st
+
+    on_clicked_change = MagicMock(name="on_clicked_change")
+
+    with (
+        patch.object(
+            st.components.v2, "_register_component", return_value="test_component"
+        ),
+        patch.object(
+            st, "_bidi_component", return_value=MagicMock()
+        ) as mock_bidi_component,
+    ):
+        mount = component(
+            "test_component",
+            js="console.log('test');",
+            isolate_styles=False,
+        )
+
+        mount(
+            key="k",
+            isolate_styles=True,  # legacy-style kwarg should be dropped silently
+            on_clicked_change=on_clicked_change,
+        )
+
+    args, kwargs = mock_bidi_component.call_args
+    assert args[0] == "test_component"
+    assert kwargs["isolate_styles"] is False
+    assert kwargs["key"] == "k"
+    assert kwargs["on_clicked_change"] is on_clicked_change
+
+
 def test_register_from_manifest_basic(temp_manager_setup) -> None:
     """Test basic manifest registration with a single component.
 


### PR DESCRIPTION
## Describe your changes

Move `isolate_styles` parameter from component mount-time to component registration time. This change makes the API more intuitive by setting style isolation when defining a component rather than when mounting it.

Key changes:
- Added `isolate_styles` parameter to `component()` function
- Removed `isolate_styles` parameter from the component mount function
- Added backward compatibility to silently ignore `isolate_styles` if passed at mount time
- Updated documentation and type hints to reflect the new API
- Removed `isolate_styles=True` from component calls in e2e tests

## Testing Plan

- Unit Tests: Added a new test `test_component_mount_ignores_isolate_styles_kwarg()` to verify that passing `isolate_styles` at mount time is properly handled for backward compatibility
- E2E tests continue to pass with the updated parameter location

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.