### PR TITLE
Support client info in `st.context` for Starlette server

### DIFF
--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Mapping
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from streamlit import runtime
 from streamlit.runtime.context_util import maybe_add_page_path, maybe_trim_page_path
@@ -28,11 +28,18 @@ from streamlit.util import AttributeDictionary
 if TYPE_CHECKING:
     from http.cookies import Morsel
 
-    from tornado.httputil import HTTPHeaders, HTTPServerRequest
-    from tornado.web import RequestHandler
+    from tornado.httputil import HTTPHeaders
+
+    from streamlit.runtime.session_manager import ClientContext
 
 
-def _get_request() -> HTTPServerRequest | None:
+def _get_client_context() -> ClientContext | None:
+    """Get the ClientContext for the current session.
+
+    Returns the client context from the session client if available,
+    or None if not available (e.g., no active session or the session
+    client doesn't provide a client context).
+    """
     ctx = get_script_run_ctx()
     if ctx is None:
         return None
@@ -41,17 +48,7 @@ def _get_request() -> HTTPServerRequest | None:
     if session_client is None:
         return None
 
-    # We return websocket request only if session_client is an instance of
-    # BrowserWebSocketHandler (which is True for the Streamlit open-source
-    # implementation). For any other implementation, we return None.
-    # We are not using `type_util.is_type` here to avoid circular import.
-    if (
-        f"{type(session_client).__module__}.{type(session_client).__qualname__}"
-        != "streamlit.web.server.browser_websocket_handler.BrowserWebSocketHandler"
-    ):
-        return None
-
-    return cast("RequestHandler", session_client).request
+    return session_client.client_context
 
 
 @lru_cache
@@ -195,12 +192,12 @@ class ContextProxy:
         """
         # We have a docstring in line above as one-liner, to have a correct docstring
         # in the st.write(st,context) call.
-        session_client_request = _get_request()
+        client_context = _get_client_context()
 
-        if session_client_request is None:
+        if client_context is None:
             return StreamlitHeaders({})
 
-        return StreamlitHeaders.from_tornado_headers(session_client_request.headers)
+        return StreamlitHeaders(client_context.headers)
 
     @property
     @gather_metrics("context.cookies")
@@ -228,13 +225,12 @@ class ContextProxy:
         """
         # We have a docstring in line above as one-liner, to have a correct docstring
         # in the st.write(st,context) call.
-        session_client_request = _get_request()
+        client_context = _get_client_context()
 
-        if session_client_request is None:
+        if client_context is None:
             return StreamlitCookies({})
 
-        cookies = session_client_request.cookies
-        return StreamlitCookies.from_tornado_cookies(cookies)
+        return StreamlitCookies(client_context.cookies)
 
     @property
     @gather_metrics("context.theme")
@@ -399,11 +395,7 @@ class ContextProxy:
         This should not be used for security measures because it can easily be
         spoofed. When a user accesses the app through ``localhost``, the IP
         address is ``None``. Otherwise, the IP address is determined from the
-        |remote_ip|_ attribute of the Tornado request object and may be an
-        IPv4 or IPv6 address.
-
-        .. |remote_ip| replace:: ``remote_ip``
-        .. _remote_ip: https://www.tornadoweb.org/en/stable/httputil.html#tornado.httputil.HTTPServerRequest.remote_ip
+        WebSocket connection and may be an IPv4 or IPv6 address.
 
         Example
         -------
@@ -421,9 +413,9 @@ class ContextProxy:
         >>> else:
         >>>     st.error("This should not happen.")
         """
-        session_client_request = _get_request()
-        if session_client_request is not None:
-            remote_ip = session_client_request.remote_ip
+        client_context = _get_client_context()
+        if client_context is not None:
+            remote_ip = client_context.remote_ip
             if remote_ip in {"::1", "127.0.0.1"}:
                 return None
             return remote_ip

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable, Mapping
 
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.runtime.app_session import AppSession
@@ -33,6 +33,31 @@ class SessionClientDisconnectedError(Exception):
     """Raised by operations on a disconnected SessionClient."""
 
 
+@runtime_checkable
+class ClientContext(Protocol):
+    """Framework-agnostic context for the client WebSocket connection.
+
+    This protocol abstracts away framework-specific request types (Tornado/Starlette)
+    to provide a consistent interface for accessing headers, cookies, and client info
+    from the initial WebSocket handshake.
+    """
+
+    @property
+    def headers(self) -> Iterable[tuple[str, str]]:
+        """All headers as (name, value) tuples. Headers may be repeated."""
+        ...
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        """Cookies as a name-to-value mapping."""
+        ...
+
+    @property
+    def remote_ip(self) -> str | None:
+        """The remote IP address of the client, or None if unavailable."""
+        ...
+
+
 class SessionClient(Protocol):
     """Interface for sending data to a session's client."""
 
@@ -44,6 +69,14 @@ class SessionClient(Protocol):
         SessionClientDisconnectedError.
         """
         raise NotImplementedError
+
+    @property
+    def client_context(self) -> ClientContext | None:
+        """The client's connection context (headers, cookies, IP).
+
+        Returns None if request context information is not available.
+        """
+        return None
 
 
 @dataclass

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -45,17 +45,17 @@ class ClientContext(Protocol):
     @property
     def headers(self) -> Iterable[tuple[str, str]]:
         """All headers as (name, value) tuples. Headers may be repeated."""
-        raise NotImplementedError
+        ...
 
     @property
     def cookies(self) -> Mapping[str, str]:
         """Cookies as a name-to-value mapping."""
-        raise NotImplementedError
+        ...
 
     @property
     def remote_ip(self) -> str | None:
         """The remote IP address of the client, or None if unavailable."""
-        raise NotImplementedError
+        ...
 
 
 class SessionClient(Protocol):

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -45,17 +45,17 @@ class ClientContext(Protocol):
     @property
     def headers(self) -> Iterable[tuple[str, str]]:
         """All headers as (name, value) tuples. Headers may be repeated."""
-        ...
+        raise NotImplementedError
 
     @property
     def cookies(self) -> Mapping[str, str]:
         """Cookies as a name-to-value mapping."""
-        ...
+        raise NotImplementedError
 
     @property
     def remote_ip(self) -> str | None:
         """The remote IP address of the client, or None if unavailable."""
-        ...
+        raise NotImplementedError
 
 
 class SessionClient(Protocol):

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -175,8 +175,16 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
 
     @property
     def client_context(self) -> ClientContext:
-        """Return the client's connection context."""
-        return TornadoClientContext(self.request)
+        """Return the client's connection context.
+
+        The context is cached on first access to avoid repeatedly
+        constructing a new TornadoClientContext instance.
+        """
+        context = getattr(self, "_client_context", None)
+        if context is None:
+            context = TornadoClientContext(self.request)
+            self._client_context = context
+        return context
 
     def select_subprotocol(self, subprotocols: list[str]) -> str | None:
         """Return the first subprotocol in the given list.

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -19,10 +19,6 @@ import json
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
-import tornado.concurrent
-import tornado.locks
-import tornado.netutil
-import tornado.web
 import tornado.websocket
 from tornado.escape import utf8
 from tornado.websocket import WebSocketHandler
@@ -33,6 +29,7 @@ from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.runtime import Runtime, SessionClient, SessionClientDisconnectedError
 from streamlit.runtime.runtime_util import serialize_forward_msg
+from streamlit.runtime.session_manager import ClientContext
 from streamlit.web.server.server_util import (
     AUTH_COOKIE_NAME,
     TOKENS_COOKIE_NAME,
@@ -41,11 +38,44 @@ from streamlit.web.server.server_util import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Iterable, Mapping
+
+    from tornado.httputil import HTTPServerRequest
 
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 _LOGGER: Final = get_logger(__name__)
+
+
+class TornadoClientContext(ClientContext):
+    """Tornado-specific implementation of ClientContext.
+
+    Captures headers, cookies, and client info from the initial WebSocket handshake.
+    Values are cached at construction time since they represent the initial request
+    context and should not change during the connection lifetime.
+    """
+
+    def __init__(self, tornado_request: HTTPServerRequest) -> None:
+        self._headers: list[tuple[str, str]] = list(tornado_request.headers.get_all())
+        self._cookies: dict[str, str] = {
+            k: m.value for k, m in tornado_request.cookies.items()
+        }
+        self._remote_ip: str | None = tornado_request.remote_ip
+
+    @property
+    def headers(self) -> Iterable[tuple[str, str]]:
+        """All headers as (name, value) tuples."""
+        return self._headers
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        """Cookies as a name-to-value mapping."""
+        return self._cookies
+
+    @property
+    def remote_ip(self) -> str | None:
+        """The client's remote IP address."""
+        return self._remote_ip
 
 
 class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
@@ -142,6 +172,11 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             self.write_message(serialize_forward_msg(msg), binary=True)
         except tornado.websocket.WebSocketClosedError as e:
             raise SessionClientDisconnectedError from e
+
+    @property
+    def client_context(self) -> ClientContext:
+        """Return the client's connection context."""
+        return TornadoClientContext(self.request)
 
     def select_subprotocol(self, subprotocols: list[str]) -> str | None:
         """Return the first subprotocol in the given list.

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -28,6 +28,7 @@ from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.runtime.session_manager import (
+    ClientContext,
     SessionClient,
     SessionClientDisconnectedError,
 )
@@ -45,6 +46,8 @@ from streamlit.web.server.starlette.starlette_server_config import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from starlette.datastructures import Headers
     from starlette.routing import BaseRoute
     from starlette.websockets import WebSocket
@@ -234,6 +237,36 @@ def _get_signed_cookie_with_chunks(
     return get_cookie_with_chunks(get_single_cookie, cookie_name)
 
 
+class StarletteClientContext(ClientContext):
+    """Starlette-specific implementation of ClientContext.
+
+    Captures headers, cookies, and client info from the initial WebSocket handshake.
+    Values are cached at construction time since they represent the initial request
+    context and should not change during the connection lifetime.
+    """
+
+    def __init__(self, websocket: WebSocket) -> None:
+        self._headers: list[tuple[str, str]] = list(websocket.headers.items())
+        self._cookies: dict[str, str] = dict(websocket.cookies)
+        client = websocket.client
+        self._remote_ip: str | None = client.host if client else None
+
+    @property
+    def headers(self) -> Iterable[tuple[str, str]]:
+        """All headers as (name, value) tuples."""
+        return self._headers
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        """Cookies as a name-to-value mapping."""
+        return self._cookies
+
+    @property
+    def remote_ip(self) -> str | None:
+        """The client's remote IP address."""
+        return self._remote_ip
+
+
 class StarletteSessionClient(SessionClient):
     """WebSocket client for Starlette that implements the SessionClient interface.
 
@@ -249,6 +282,7 @@ class StarletteSessionClient(SessionClient):
 
     def __init__(self, websocket: WebSocket) -> None:
         self._websocket = websocket
+        self._client_context = StarletteClientContext(websocket)
         # The queue bridges sync write_forward_msg calls to async WebSocket sends.
         # Overwhelmed clients get disconnected via SessionClientDisconnectedError.
         self._send_queue: asyncio.Queue[bytes] = asyncio.Queue(
@@ -309,6 +343,11 @@ class StarletteSessionClient(SessionClient):
         except asyncio.QueueFull as exc:  # pragma: no cover - defensive
             self._closed.set()
             raise SessionClientDisconnectedError from exc
+
+    @property
+    def client_context(self) -> ClientContext:
+        """Return the client's connection context."""
+        return self._client_context
 
     async def aclose(self) -> None:
         """Close the client and release resources.

--- a/lib/tests/streamlit/runtime/context_test.py
+++ b/lib/tests/streamlit/runtime/context_test.py
@@ -27,31 +27,41 @@ from streamlit.runtime.context import (
     StreamlitCookies,
     StreamlitHeaders,
     StreamlitTheme,
-    _get_request,
+    _get_client_context,
     _normalize_header,
 )
 
 
-class StContextTest(unittest.TestCase):
-    mocked_cookie = Morsel()
-    mocked_cookie.set("cookieName", "cookieValue", "cookieValue")
+def _create_mock_client_context(
+    headers: list[tuple[str, str]] | None = None,
+    cookies: dict[str, str] | None = None,
+    remote_ip: str | None = None,
+) -> MagicMock:
+    """Create a mock ClientContext for testing."""
+    mock_context = MagicMock()
+    mock_context.headers = headers or []
+    mock_context.cookies = cookies or {}
+    mock_context.remote_ip = remote_ip
+    return mock_context
 
-    @patch(
-        "streamlit.runtime.context._get_request",
-        MagicMock(
-            return_value=MagicMock(headers=HTTPHeaders({"the-header": "header-value"}))
-        ),
-    )
-    def test_context_headers(self):
-        """Test that `st.context.headers` returns headers from ScriptRunContext"""
+
+class StContextTest(unittest.TestCase):
+    """Test st.context API."""
+
+    @patch("streamlit.runtime.context._get_client_context")
+    def test_context_headers(self, mock_get_client_context: MagicMock) -> None:
+        """Test that `st.context.headers` returns headers from ClientContext."""
+        mock_get_client_context.return_value = _create_mock_client_context(
+            headers=[("the-header", "header-value")]
+        )
         assert st.context.headers.to_dict() == {"The-Header": "header-value"}
 
-    @patch(
-        "streamlit.runtime.context._get_request",
-        MagicMock(return_value=MagicMock(cookies={"cookieName": mocked_cookie})),
-    )
-    def test_context_cookies(self):
-        """Test that `st.context.cookies` returns cookies from ScriptRunContext"""
+    @patch("streamlit.runtime.context._get_client_context")
+    def test_context_cookies(self, mock_get_client_context: MagicMock) -> None:
+        """Test that `st.context.cookies` returns cookies from ClientContext."""
+        mock_get_client_context.return_value = _create_mock_client_context(
+            cookies={"cookieName": "cookieValue"}
+        )
         assert st.context.cookies.to_dict() == {"cookieName": "cookieValue"}
 
     @parameterized.expand(
@@ -62,10 +72,17 @@ class StContextTest(unittest.TestCase):
             ("::1", None),  # IPv6 localhost
         ]
     )
-    @patch("streamlit.runtime.context._get_request")
-    def test_ip_address_values(self, remote_ip, expected_value, mock_get_request):
-        """Test that `st.context.ip_address` handles different IP addresses correctly"""
-        mock_get_request.return_value = MagicMock(remote_ip=remote_ip)
+    @patch("streamlit.runtime.context._get_client_context")
+    def test_ip_address_values(
+        self,
+        remote_ip: str,
+        expected_value: str | None,
+        mock_get_client_context: MagicMock,
+    ) -> None:
+        """Test that `st.context.ip_address` handles different IP addresses correctly."""
+        mock_get_client_context.return_value = _create_mock_client_context(
+            remote_ip=remote_ip
+        )
         assert st.context.ip_address == expected_value
 
     @patch(
@@ -234,15 +251,19 @@ class StreamlitThemeTest(unittest.TestCase):
 class ContextPropertiesNoneTest(unittest.TestCase):
     """Test context properties when context or request is None."""
 
-    @patch("streamlit.runtime.context._get_request", MagicMock(return_value=None))
-    def test_headers_none_request(self):
-        """Test that headers returns empty when request is None."""
+    @patch(
+        "streamlit.runtime.context._get_client_context", MagicMock(return_value=None)
+    )
+    def test_headers_none_client_context(self) -> None:
+        """Test that headers returns empty when client_context is None."""
         headers = st.context.headers
         assert headers.to_dict() == {}
 
-    @patch("streamlit.runtime.context._get_request", MagicMock(return_value=None))
-    def test_cookies_none_request(self):
-        """Test that cookies returns empty when request is None."""
+    @patch(
+        "streamlit.runtime.context._get_client_context", MagicMock(return_value=None)
+    )
+    def test_cookies_none_client_context(self) -> None:
+        """Test that cookies returns empty when client_context is None."""
         cookies = st.context.cookies
         assert cookies.to_dict() == {}
 
@@ -314,26 +335,28 @@ class ContextPropertiesNoneTest(unittest.TestCase):
         else:
             assert getattr(st.context, property_name) == expected_value
 
-    @patch("streamlit.runtime.context._get_request", MagicMock(return_value=None))
-    def test_ip_address_none_request(self):
-        """Test that ip_address returns None when request is None."""
+    @patch(
+        "streamlit.runtime.context._get_client_context", MagicMock(return_value=None)
+    )
+    def test_ip_address_none_client_context(self) -> None:
+        """Test that ip_address returns None when client_context is None."""
         assert st.context.ip_address is None
 
 
-class GetRequestTest(unittest.TestCase):
-    """Test _get_request function edge cases."""
+class GetClientContextTest(unittest.TestCase):
+    """Test _get_client_context function edge cases."""
 
     @patch("streamlit.runtime.context.get_script_run_ctx", MagicMock(return_value=None))
-    def test_get_request_none_context(self):
-        """Test that _get_request returns None when context is None."""
-        assert _get_request() is None
+    def test_get_client_context_none_context(self) -> None:
+        """Test that _get_client_context returns None when script context is None."""
+        assert _get_client_context() is None
 
     @patch("streamlit.runtime.context.get_script_run_ctx")
     @patch("streamlit.runtime.context.runtime")
-    def test_get_request_none_session_client(
-        self, mock_runtime, mock_get_script_run_ctx
-    ):
-        """Test that _get_request returns None when session_client is None."""
+    def test_get_client_context_none_session_client(
+        self, mock_runtime: MagicMock, mock_get_script_run_ctx: MagicMock
+    ) -> None:
+        """Test that _get_client_context returns None when session_client is None."""
         mock_ctx = MagicMock()
         mock_ctx.session_id = "test_session"
         mock_get_script_run_ctx.return_value = mock_ctx
@@ -342,51 +365,49 @@ class GetRequestTest(unittest.TestCase):
         mock_instance.get_client.return_value = None
         mock_runtime.get_instance.return_value = mock_instance
 
-        assert _get_request() is None
+        assert _get_client_context() is None
 
     @patch("streamlit.runtime.context.get_script_run_ctx")
     @patch("streamlit.runtime.context.runtime")
-    def test_get_request_non_websocket_handler(
-        self, mock_runtime, mock_get_script_run_ctx
-    ):
-        """Test that _get_request returns None for non-BrowserWebSocketHandler."""
+    def test_get_client_context_no_client_context_property(
+        self, mock_runtime: MagicMock, mock_get_script_run_ctx: MagicMock
+    ) -> None:
+        """Test that _get_client_context returns None when client has no context."""
         mock_ctx = MagicMock()
         mock_ctx.session_id = "test_session"
         mock_get_script_run_ctx.return_value = mock_ctx
 
-        # Create a mock session client that is not a BrowserWebSocketHandler
+        # Create a mock session client without a client_context
         mock_session_client = MagicMock()
-        type(mock_session_client).__module__ = "some.other.module"
-        type(mock_session_client).__qualname__ = "SomeOtherHandler"
+        mock_session_client.client_context = None
 
         mock_instance = MagicMock()
         mock_instance.get_client.return_value = mock_session_client
         mock_runtime.get_instance.return_value = mock_instance
 
-        assert _get_request() is None
+        assert _get_client_context() is None
 
     @patch("streamlit.runtime.context.get_script_run_ctx")
     @patch("streamlit.runtime.context.runtime")
-    def test_get_request_valid_websocket_handler(
-        self, mock_runtime, mock_get_script_run_ctx
-    ):
-        """Test that _get_request returns request for valid BrowserWebSocketHandler."""
+    def test_get_client_context_valid_session_client(
+        self, mock_runtime: MagicMock, mock_get_script_run_ctx: MagicMock
+    ) -> None:
+        """Test that _get_client_context returns client_context from valid client."""
         mock_ctx = MagicMock()
         mock_ctx.session_id = "test_session"
         mock_get_script_run_ctx.return_value = mock_ctx
 
-        # Create a mock session client that is a BrowserWebSocketHandler
-        mock_request = MagicMock()
+        # Create a mock session client with a client_context
+        mock_client_context = _create_mock_client_context(
+            headers=[("test-header", "test-value")],
+            cookies={"test": "cookie"},
+            remote_ip="1.2.3.4",
+        )
         mock_session_client = MagicMock()
-        # Use type() to properly mock the module and qualname
-        type(
-            mock_session_client
-        ).__module__ = "streamlit.web.server.browser_websocket_handler"
-        type(mock_session_client).__qualname__ = "BrowserWebSocketHandler"
-        mock_session_client.request = mock_request
+        mock_session_client.client_context = mock_client_context
 
         mock_instance = MagicMock()
         mock_instance.get_client.return_value = mock_session_client
         mock_runtime.get_instance.return_value = mock_instance
 
-        assert _get_request() == mock_request
+        assert _get_client_context() == mock_client_context

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -198,6 +198,37 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
 
                 patched_stop_runtime.assert_called_once()
 
+    @tornado.testing.gen_test
+    async def test_client_context_returns_tornado_client_context(self):
+        """Test that client_context property returns a TornadoClientContext instance."""
+        with self._patch_app_session():
+            await self.server.start()
+            await self.ws_connect()
+
+            # Get our BrowserWebSocketHandler
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
+            websocket_handler: BrowserWebSocketHandler = session_info.client
+
+            client_context = websocket_handler.client_context
+
+            assert isinstance(client_context, TornadoClientContext)
+
+    @tornado.testing.gen_test
+    async def test_client_context_is_cached(self):
+        """Test that client_context property returns the same instance on repeated access."""
+        with self._patch_app_session():
+            await self.server.start()
+            await self.ws_connect()
+
+            # Get our BrowserWebSocketHandler
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
+            websocket_handler: BrowserWebSocketHandler = session_info.client
+
+            context1 = websocket_handler.client_context
+            context2 = websocket_handler.client_context
+
+            assert context1 is context2
+
 
 class TornadoClientContextTest(tornado.testing.AsyncTestCase):
     """Tests for TornadoClientContext class."""

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -14,17 +14,18 @@
 
 from __future__ import annotations
 
+from http.cookies import Morsel
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-import tornado.httpserver
 import tornado.testing
-import tornado.web
 import tornado.websocket
+from tornado.httputil import HTTPHeaders
 
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime, SessionClientDisconnectedError
+from streamlit.web.server.browser_websocket_handler import TornadoClientContext
 from streamlit.web.server.server import BrowserWebSocketHandler
 from tests.streamlit.web.server.server_test_case import ServerTestCase
 from tests.testutil import patch_config_options
@@ -196,3 +197,57 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
                 )
 
                 patched_stop_runtime.assert_called_once()
+
+
+class TornadoClientContextTest(tornado.testing.AsyncTestCase):
+    """Tests for TornadoClientContext class."""
+
+    def test_headers_returns_all_headers(self) -> None:
+        """Test that headers property returns all headers including duplicates."""
+        mock_request = MagicMock()
+        headers = HTTPHeaders()
+        headers.add("Content-Type", "text/html")
+        headers.add("Accept", "application/json")
+        headers.add("Accept", "text/plain")
+        mock_request.headers = headers
+
+        ctx = TornadoClientContext(mock_request)
+        result_headers = list(ctx.headers)
+
+        assert len(result_headers) == 3
+        # Tornado normalizes header names to title case
+        assert ("Content-Type", "text/html") in result_headers
+        assert ("Accept", "application/json") in result_headers
+        assert ("Accept", "text/plain") in result_headers
+
+    def test_cookies_returns_all_cookies(self) -> None:
+        """Test that cookies property returns all cookies as a mapping."""
+        mock_request = MagicMock()
+
+        morsel1 = Morsel()
+        morsel1.set("session", "abc123", "abc123")
+        morsel2 = Morsel()
+        morsel2.set("user", "test_user", "test_user")
+        mock_request.cookies = {"session": morsel1, "user": morsel2}
+
+        ctx = TornadoClientContext(mock_request)
+
+        assert ctx.cookies == {"session": "abc123", "user": "test_user"}
+
+    def test_remote_ip_returns_ip(self) -> None:
+        """Test that remote_ip property returns the client's IP address."""
+        mock_request = MagicMock()
+        mock_request.remote_ip = "192.168.1.100"
+
+        ctx = TornadoClientContext(mock_request)
+
+        assert ctx.remote_ip == "192.168.1.100"
+
+    def test_remote_ip_returns_none_when_no_ip(self) -> None:
+        """Test that remote_ip property returns None when remote_ip is None."""
+        mock_request = MagicMock()
+        mock_request.remote_ip = None
+
+        ctx = TornadoClientContext(mock_request)
+
+        assert ctx.remote_ip is None

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -24,6 +24,7 @@ import pytest
 
 from streamlit.web.server.starlette import starlette_app_utils
 from streamlit.web.server.starlette.starlette_websocket import (
+    StarletteClientContext,
     StarletteSessionClient,
     _gather_user_info,
     _get_signed_cookie_with_chunks,
@@ -620,3 +621,77 @@ class TestCreateWebsocketRoutes:
 
         assert len(routes) == 1
         assert routes[0].path == "/myapp/_stcore/stream"
+
+
+class TestStarletteClientContext:
+    """Tests for StarletteClientContext class."""
+
+    def test_headers_returns_all_headers(self) -> None:
+        """Test that headers property returns all headers including duplicates."""
+        mock_websocket = MagicMock()
+        mock_websocket.headers.items.return_value = [
+            ("Content-Type", "text/html"),
+            ("Accept", "application/json"),
+            ("Accept", "text/plain"),
+        ]
+
+        ctx = StarletteClientContext(mock_websocket)
+        headers = list(ctx.headers)
+
+        assert len(headers) == 3
+        assert ("Content-Type", "text/html") in headers
+        assert ("Accept", "application/json") in headers
+        assert ("Accept", "text/plain") in headers
+
+    def test_cookies_returns_all_cookies(self) -> None:
+        """Test that cookies property returns all cookies."""
+        mock_websocket = MagicMock()
+        mock_websocket.cookies = {"session": "abc123", "user": "test"}
+
+        ctx = StarletteClientContext(mock_websocket)
+
+        assert ctx.cookies == {"session": "abc123", "user": "test"}
+
+    def test_remote_ip_returns_client_host(self) -> None:
+        """Test that remote_ip property returns client host."""
+        mock_websocket = MagicMock()
+        mock_client = MagicMock()
+        mock_client.host = "192.168.1.100"
+        mock_websocket.client = mock_client
+
+        ctx = StarletteClientContext(mock_websocket)
+
+        assert ctx.remote_ip == "192.168.1.100"
+
+    def test_remote_ip_returns_none_when_no_client(self) -> None:
+        """Test that remote_ip property returns None when client is None."""
+        mock_websocket = MagicMock()
+        mock_websocket.client = None
+
+        ctx = StarletteClientContext(mock_websocket)
+
+        assert ctx.remote_ip is None
+
+
+class TestStarletteSessionClientClientContext:
+    """Tests for client_context property on StarletteSessionClient."""
+
+    @pytest.mark.anyio
+    async def test_client_context_returns_starlette_context(self) -> None:
+        """Test that client_context property returns a StarletteClientContext."""
+        mock_websocket = MagicMock()
+        mock_websocket.headers.items.return_value = [("Host", "localhost")]
+        mock_websocket.cookies = {"test": "cookie"}
+
+        client = StarletteSessionClient(mock_websocket)
+
+        ctx = client.client_context
+        assert isinstance(ctx, StarletteClientContext)
+
+        # Verify it wraps the same websocket
+        headers = list(ctx.headers)
+        assert headers == [("Host", "localhost")]
+        assert ctx.cookies == {"test": "cookie"}
+
+        # Cleanup
+        await client.aclose()


### PR DESCRIPTION
## Describe your changes

Add support for returning the correct information from `st.context.headers`, `st.context.cookies`, `st.context.remote_ip` when Starlette is used as server.

## Testing Plan

- Added unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
