### PR TITLE
[chore] Update GH issue template to point to Community Cloud support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
 
         If you are not sure whether you have found a bug, please consider asking in our [community forum](https://discuss.streamlit.io/) first.
 
-        If your issue is about Streamlit Community Cloud (e.g., fair-use / usage limits, account access, being blocked with a 403, or other Community Cloud platform support), please **do not** file a GitHub issue. Submit a support case instead: [How to submit a support case for Streamlit Community Cloud](https://docs.streamlit.io/knowledge-base/deploy/how-to-submit-a-support-case-for-streamlit-community-cloud).
+        If your issue is about Streamlit Community Cloud (e.g., fair-use / usage limits, account access, being blocked with a 403 error, or other Community Cloud platform support), please **do not** file a GitHub issue. Submit a support case instead: [How to submit a support case for Streamlit Community Cloud](https://docs.streamlit.io/knowledge-base/deploy/how-to-submit-a-support-case-for-streamlit-community-cloud).
   - type: checkboxes
     attributes:
       label: Checklist

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,8 @@ body:
         We really appreciate the community's efforts to improve Streamlit.
 
         If you are not sure whether you have found a bug, please consider asking in our [community forum](https://discuss.streamlit.io/) first.
+
+        If your issue is about Streamlit Community Cloud (e.g., fair-use / usage limits, account access, being blocked with a 403, or other Community Cloud platform support), please **do not** file a GitHub issue. Submit a support case instead: [How to submit a support case for Streamlit Community Cloud](https://docs.streamlit.io/knowledge-base/deploy/how-to-submit-a-support-case-for-streamlit-community-cloud).
   - type: checkboxes
     attributes:
       label: Checklist

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: ☁️ Streamlit Community Cloud support (usage limits, accounts, 403 errors)
+    url: https://docs.streamlit.io/knowledge-base/deploy/how-to-submit-a-support-case-for-streamlit-community-cloud
+    about: "Community Cloud support (usage limits/403): submit a support case (not a GitHub issue)."
   - name: 📚 Documentation request
     url: https://github.com/streamlit/docs/issues/new/choose
     about: Let us know how our docs could be better


### PR DESCRIPTION
## Describe your changes

Updated the bug report template and config to direct Streamlit Community Cloud support issues to the proper channel. Added clear instructions in both files that Community Cloud issues (such as usage limits, account access, 403 errors) should be submitted as support cases rather than GitHub issues, with a link to the documentation on how to submit a support case.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: This change only affects GitHub issue templates and doesn't modify any code functionality.
- No additional tests needed as this is a documentation update to the GitHub issue templates.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.