### PR TITLE
Fix flaky number input e2e test

### DIFF
--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -38,7 +38,7 @@ def test_number_input_widget_display(
 ):
     """Test that st.number_input renders correctly."""
     expect(themed_app.get_by_test_id("stNumberInput")).to_have_count(NUMBER_INPUT_COUNT)
-    # reset hovering to avoid some flakiness with hovered clear button:
+    # Reset hovering to avoid some flakiness with hovered clear button:
     reset_hovering(themed_app)
 
     assert_snapshot(

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -27,6 +27,7 @@ from e2e_playwright.shared.app_utils import (
     fill_number_input,
     get_element_by_key,
     get_number_input,
+    reset_hovering,
 )
 
 NUMBER_INPUT_COUNT = 20
@@ -37,6 +38,8 @@ def test_number_input_widget_display(
 ):
     """Test that st.number_input renders correctly."""
     expect(themed_app.get_by_test_id("stNumberInput")).to_have_count(NUMBER_INPUT_COUNT)
+    # reset hovering to avoid some flakiness with hovered clear button:
+    reset_hovering(themed_app)
 
     assert_snapshot(
         get_number_input(themed_app, "number input 1 (default)"),


### PR DESCRIPTION
## Describe your changes

Fix a flaky number input e2e snapshot test by resetting the hovering. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
