### PR TITLE
[fix] Update `st.chat_input` upload file chip x button color to use bgColor instead of fadedText

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/styled-components.ts
@@ -174,14 +174,14 @@ export const StyledChatUploadedFileDeleteButton = styled.small(
       maxWidth: "unset",
       borderRadius: "50%",
       backgroundColor: "transparent",
-      color: theme.colors.fadedText20,
+      color: theme.colors.bgColor,
       padding: 0,
       overflow: "hidden",
       boxSizing: "border-box",
       lineHeight: 0,
       "&:hover": {
         backgroundColor: "transparent",
-        color: theme.colors.fadedText40,
+        color: theme.colors.bgColor,
       },
     },
   })


### PR DESCRIPTION
## Describe your changes

Updated the color of the file delete button in the chat upload component to use `theme.colors.bgColor` instead of `fadedText20` and `fadedText40` for both normal and hover states.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- No additional tests needed as this is a simple color change using existing theme variables
- Manual testing to verify the delete button is visible and has proper contrast against its background

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.