### PR TITLE
Add CI workflow to run e2e tests with Starlette

### DIFF
--- a/.github/workflows/playwright-starlette.yml
+++ b/.github/workflows/playwright-starlette.yml
@@ -1,4 +1,4 @@
-# This is only a temporary workflow to test the Starlette server in CI.
+# TODO(lukasmasuch): This is only a temporary workflow to test the Starlette server in CI.
 # It will be removed once the Tornado server is replaced by the Starlette server.
 name: Playwright E2E Tests (Starlette)
 

--- a/.github/workflows/playwright-starlette.yml
+++ b/.github/workflows/playwright-starlette.yml
@@ -1,0 +1,67 @@
+# This is only a temporary workflow to test the Starlette server in CI.
+# It will be removed once the Tornado server is replaced by the Starlette server.
+name: Playwright E2E Tests (Starlette)
+
+on:
+  push:
+    branches:
+      - "develop"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Avoid duplicate workflows on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-playwright-starlette
+  cancel-in-progress: true
+
+jobs:
+  playwright-e2e-tests-starlette:
+    # Run on push to develop, or on PRs with the 'starlette-tests' label
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'starlette-tests'))
+    runs-on: ubuntu-latest-64-cores
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: 2
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+      - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: "${{ env.PYTHON_MAX_VERSION }}"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+      - name: Install playwright
+        uses: ./.github/actions/playwright_install
+      - name: Run make frontend-with-profiler
+        run: make frontend-with-profiler
+      - name: Get short SHA
+        id: short_sha
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
+          else
+            echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
+          fi
+      - name: Run playwright tests with Starlette server
+        run: |
+          cd e2e_playwright
+          rm -rf ./test-results
+          pytest --use-starlette --ignore ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1 -m "not performance"
+      - name: Upload failed test results
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: playwright_starlette_test_results_${{ steps.short_sha.outputs.sha_short }}
+          path: e2e_playwright/test-results

--- a/e2e_playwright/auth_test.py
+++ b/e2e_playwright/auth_test.py
@@ -90,12 +90,17 @@ def prepare_secrets_file(app_port: int, oidc_server_port: int):
 
 
 @pytest.fixture(scope="module")
-def app_server_extra_args(prepare_secrets_file: str) -> list[str]:
+def app_server_extra_args(
+    prepare_secrets_file: str, request: pytest.FixtureRequest
+) -> list[str]:
     """Fixture that returns extra arguments to pass to the Streamlit app server."""
-    return [
+    args = [
         "--secrets.files",
         prepare_secrets_file,
     ]
+    if request.config.getoption("--use-starlette"):
+        args.extend(["--server.useStarlette", "true"])
+    return args
 
 
 @pytest.mark.parametrize("fake_oidc_server", ["success"], indirect=True)

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -67,6 +67,16 @@ class StaticPage(Page):
     pass
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register custom command-line options."""
+    parser.addoption(
+        "--use-starlette",
+        action="store_true",
+        default=False,
+        help="Run tests with the experimental Starlette server instead of Tornado",
+    )
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Register custom markers."""
     config.addinivalue_line(
@@ -251,9 +261,12 @@ def app_port(worker_id: str) -> int:
 
 
 @pytest.fixture(scope="module")
-def app_server_extra_args() -> list[str]:
+def app_server_extra_args(request: pytest.FixtureRequest) -> list[str]:
     """Fixture that returns extra arguments to pass to the Streamlit app server."""
-    return []
+    args: list[str] = []
+    if request.config.getoption("--use-starlette"):
+        args.extend(["--server.useStarlette", "true"])
+    return args
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -69,6 +69,8 @@ class StaticPage(Page):
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom command-line options."""
+    # Temporary option for testing the Starlette server migration.
+    # This can be removed once Tornado is fully replaced by Starlette.
     parser.addoption(
         "--use-starlette",
         action="store_true",


### PR DESCRIPTION
## Describe your changes

Adds a temporary CI workflow to run our e2e tests with Starlette for every commit to `develop` and for PRs labeled with `starlette-tests`. This workflow can be removed once we have fully migrated from Tornado to Starlette. Always running the e2e tests with Tornado and Starlette would be a bit too expensive. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
