### PR TITLE
[test] Add e2e typing test utils

### DIFF
--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -527,6 +527,56 @@ div {
     st.text(f"session_state: {st.session_state.get('basic_component_1')}")
     st.write(f"Click count: {st.session_state.basic_click_count}")
 
+st.divider()
+
+with st.container():
+    st.subheader("Global hotkey interface")
+
+    if "hotkey_runs" not in st.session_state:
+        st.session_state.hotkey_runs = 0
+    st.session_state.hotkey_runs += 1
+
+    _HOTKEY_JS = """
+export default function(component) {
+  const { parentElement, setStateValue } = component
+
+  const form = parentElement.querySelector("form")
+  const input = parentElement.querySelector("#hotkey-text")
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    setStateValue("text", input?.value ?? "")
+  }
+
+  form.addEventListener("submit", handleSubmit)
+
+  return () => {
+    form.removeEventListener("submit", handleSubmit)
+  }
+}
+"""
+
+    _HOTKEY_HTML = """
+<form>
+  <label for="hotkey-text">Hotkey Text</label>
+  <input type="text" id="hotkey-text" name="hotkey-text" value="" />
+  <button type="submit">Submit</button>
+</form>
+"""
+
+    _HOTKEY_CMP = st.components.v2.component(
+        name="bidi_hotkey_regression",
+        js=_HOTKEY_JS,
+        html=_HOTKEY_HTML,
+    )
+
+    def hotkey_regression_component(*, key: str) -> BidiComponentResult:
+        return _HOTKEY_CMP(key=key)
+
+    hotkey_result = hotkey_regression_component(key="hotkey_regression_component")
+    st.write(f"Hotkey runs: {st.session_state.hotkey_runs}")
+    st.write(f"Result: {hotkey_result}")
+
 
 st.divider()
 

--- a/e2e_playwright/bidi_components/basics_test.py
+++ b/e2e_playwright/bidi_components/basics_test.py
@@ -18,6 +18,10 @@ from e2e_playwright.shared.app_utils import (
     expect_no_exception,
     get_element_by_key,
 )
+from e2e_playwright.shared.input_utils import (
+    expect_global_hotkeys_not_fired,
+    type_common_characters_into_input,
+)
 
 
 def section(app: Page, heading_name: str) -> Locator:
@@ -132,18 +136,18 @@ def test_form_interactions_deferred_until_submit(app: Page) -> None:
     )
 
     # Initial state
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
     expect(form.get_by_text("Form Text changes: 0")).to_be_visible()
     expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
 
     # Before submitting the form, interactions should NOT trigger a rerun.
     form.get_by_text("Set text (Form)").click()
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
     expect(form.get_by_text("Form Text changes: 0")).to_be_visible()
 
     # Triggers are disallowed in forms for CCv2; this must be a no-op.
     form.get_by_text("Trigger click (Form)").click()
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
     expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
 
     # Also the displayed state should still be empty before submit.
@@ -152,7 +156,7 @@ def test_form_interactions_deferred_until_submit(app: Page) -> None:
     # Submit the form and verify rerun + updates (only stateful changes apply).
     click_form_button(app, "Submit Form")
 
-    expect(app.get_by_text("Runs: 2")).to_be_visible()
+    expect(app.get_by_text("Runs: 2", exact=True)).to_be_visible()
     # Trigger callback remains unchanged due to no-op in form.
     expect(form.get_by_text("Form Text changes: 1")).to_be_visible()
     expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
@@ -168,7 +172,7 @@ def test_fragment_interactions_rerun_only_fragment(app: Page) -> None:
     fragment = section(app, "Fragment context (partial reruns and local counters)")
 
     # Initial state for fragments
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
     expect(fragment.get_by_text("Fragment session state: {}"))
     expect(fragment.get_by_text("Fragment Text changes: 0")).to_be_visible()
     expect(fragment.get_by_text("Fragment Clicked count: 0")).to_be_visible()
@@ -182,12 +186,12 @@ def test_fragment_interactions_rerun_only_fragment(app: Page) -> None:
     )
     expect(fragment.get_by_text("Fragment Text changes: 1")).to_be_visible()
     # Assert Runs remains 1
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
 
     fragment.get_by_text("Trigger click (Fragment)").click()
     # Trigger inside fragment updates fragment-local UI/state; full Runs remains 1.
     expect(fragment.get_by_text("Fragment Clicked count: 1")).to_be_visible()
-    expect(app.get_by_text("Runs: 1")).to_be_visible()
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
 
 
 def test_basic_initial_and_submission(app: Page) -> None:
@@ -227,6 +231,29 @@ def test_basic_initial_and_submission(app: Page) -> None:
     expect(session_state).to_contain_text("'range': '55'")
     expect(session_state).to_contain_text("'text': 'Updated'")
     expect(basic.get_by_text("Click count: 1")).to_be_visible()
+
+
+def test_typing_in_component_input_does_not_trigger_global_hotkeys(app: Page) -> None:
+    hotkey = section(app, "Global hotkey interface")
+
+    # This input is component-owned HTML <input>, not a Streamlit widget.
+    text_input = hotkey.get_by_label("Hotkey Text")
+    runs_text = hotkey.get_by_text("Hotkey runs: 1", exact=True)
+
+    hotkey.scroll_into_view_if_needed()
+    text_input.focus()
+
+    expect_global_hotkeys_not_fired(app, expected_runs=1, runs_locator=runs_text)
+
+    typed = type_common_characters_into_input(
+        text_input,
+        after_each=lambda _ch: expect_global_hotkeys_not_fired(
+            app,
+            expected_runs=1,
+            runs_locator=runs_text,
+        ),
+    )
+    expect(text_input).to_have_value(typed)
 
 
 def test_arrow_serialization_works(app: Page) -> None:

--- a/e2e_playwright/shared/input_utils.py
+++ b/e2e_playwright/shared/input_utils.py
@@ -1,0 +1,133 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared input helpers for Streamlit Playwright E2E tests.
+
+These utilities centralize common input interactions and assertions used across
+E2E tests, with a focus on stability and guarding against regressions from
+global hotkeys.
+"""
+
+from __future__ import annotations
+
+import string
+from typing import TYPE_CHECKING
+
+from playwright.sync_api import Locator, Page, expect
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# A curated set of characters that covers common key inputs while staying stable in
+# Playwright typing semantics (no enter/tab/newline, which can submit forms or move focus).
+_COMMON_TYPED_CHARACTERS = (
+    string.ascii_lowercase
+    + string.ascii_uppercase
+    + string.digits
+    + " "
+    + ".,-_@/:;?!'\"()[]{}<>+=*&^%$#~`|\\"
+)
+
+
+def type_common_characters_into_input(
+    input_locator: Locator,
+    *,
+    after_each: Callable[[str], None] | None = None,
+) -> str:
+    """Type a broad set of common characters into a focused input.
+
+    This is intended for regression tests where we want to ensure that typing
+    into an editable target remains isolated from global hotkeys.
+
+    Parameters
+    ----------
+    input_locator : Locator
+        The input element to type into.
+    after_each : Callable[[str], None] | None, optional
+        Optional callback invoked after each typed character (useful for
+        asserting that global hotkey side effects did not occur), by default
+        None.
+
+    Returns
+    -------
+    str
+        The full string that was typed.
+    """
+    expect(input_locator).to_be_visible()
+    input_locator.click()
+    input_locator.fill("")
+
+    expected_value = ""
+    for ch in _COMMON_TYPED_CHARACTERS:
+        input_locator.type(ch)
+        expected_value += ch
+        expect(input_locator).to_have_value(expected_value)
+        if after_each is not None:
+            after_each(ch)
+
+    return expected_value
+
+
+def expect_global_hotkeys_not_fired(
+    app: Page,
+    *,
+    expected_runs: int | None = None,
+    runs_locator: Locator | None = None,
+) -> None:
+    """Assert that global hotkeys did not trigger their UI side effects.
+
+    This helper verifies that global hotkeys such as rerun and clear-cache did
+    not fire while interacting with an input widget during a test.
+
+    Parameters
+    ----------
+    app : Page
+        The Playwright page representing the Streamlit app under test.
+    expected_runs : int | None, optional
+        If provided, the expected number of script runs. When set, the function
+        asserts that a corresponding UI element reflecting this count is
+        visible, by default None.
+    runs_locator : Locator | None, optional
+        Optional locator for the element that displays the run count. If not
+        provided, a default locator is derived from ``expected_runs``, by
+        default None.
+
+    Returns
+    -------
+    None
+        This function is used for assertions and does not return a value.
+
+    Examples
+    --------
+    Assert that typing did not trigger a rerun or open the clear-cache dialog:
+
+    >>> expect_global_hotkeys_not_fired(app, expected_runs=1)
+    """
+
+    # Rerun hotkey: must not start a script run while we're typing.
+    expect(app.get_by_test_id("stApp")).to_have_attribute(
+        "data-test-script-state",
+        "notRunning",
+    )
+
+    if expected_runs is not None:
+        locator = (
+            runs_locator
+            if runs_locator is not None
+            else app.get_by_text(f"Runs: {expected_runs}", exact=True)
+        )
+        expect(locator).to_be_visible()
+
+    # Clear-cache hotkey: must not open the clear-cache dialog while we're typing.
+    expect(app.get_by_test_id("stClearCacheDialog")).not_to_be_visible()

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -25,6 +25,10 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
     get_text_input,
 )
+from e2e_playwright.shared.input_utils import (
+    expect_global_hotkeys_not_fired,
+    type_common_characters_into_input,
+)
 
 TEXT_INPUT_ELEMENTS = 19
 
@@ -119,6 +123,27 @@ def test_text_input_has_correct_initial_values(app: Page):
     expect_markdown(app, "text input 12 (value from state) - value: xyz")
     expect_markdown(app, "text input 13 (value from form) - value:")
     expect_markdown(app, "Rerun counter: 1")
+
+
+def test_text_input_typing_common_characters_does_not_trigger_global_hotkeys(
+    app: Page,
+) -> None:
+    """Typing into st.text_input must not trigger global hotkeys (e.g. c/r)."""
+    text_input_field = (
+        get_text_input(app, "text input 1 (default)").locator("input").first
+    )
+    rerun_counter = app.get_by_text("Rerun counter: 1", exact=True)
+
+    expect_global_hotkeys_not_fired(app, expected_runs=1, runs_locator=rerun_counter)
+    typed = type_common_characters_into_input(
+        text_input_field,
+        after_each=lambda _ch: expect_global_hotkeys_not_fired(
+            app,
+            expected_runs=1,
+            runs_locator=rerun_counter,
+        ),
+    )
+    expect(text_input_field).to_have_value(typed)
 
 
 def test_text_input_shows_instructions_when_dirty(


### PR DESCRIPTION
## Describe your changes

In an effort to get better coverage of the intersection of Global Hotkeys and common input elements, this PR:
- Created a new shared utility module `input_utils.py` with helper functions for typing tests
- Added a test that types various characters into a `st.text_input` and a CCv2-owned input and verifies no global hotkeys are triggered

## Testing Plan

- E2E Tests: Added tests that types a wide range of characters into any input and verifies that global hotkeys (like rerun or clear-cache) aren't triggered

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.