### PR TITLE
[chore] Update e2e test guidance for AGENTS

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -75,7 +75,9 @@ When adding or modifying tests for an element, ensure the following are covered:
 
 ## Running tests
 
-- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
+- Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -73,7 +73,9 @@ When adding or modifying tests for an element, ensure the following are covered:
 
 ## Running tests
 
-- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
+- Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,9 @@ debug-e2e-test:
 		exit 1; \
 	fi
 	@echo "Running test: $(filter-out $@,$(MAKECMDGOALS)) in debug mode."
+	@if [[ -n "$$PYTEST_ADDOPTS" ]]; then \
+		echo "Using PYTEST_ADDOPTS=$$PYTEST_ADDOPTS"; \
+	fi
 	@TEST_SCRIPT=$$(echo $(filter-out $@,$(MAKECMDGOALS)) | sed 's|^e2e_playwright/||'); \
 	cd e2e_playwright && PWDEBUG=1 pytest $$TEST_SCRIPT --tracing on || ( \
 		echo "If you implemented changes in the frontend, make sure to call \`make frontend-fast\` to use the up-to-date frontend build in the test."; \
@@ -346,6 +349,9 @@ run-e2e-test:
 		exit 1; \
 	fi
 	@echo "Running test: $(filter-out $@,$(MAKECMDGOALS))"
+	@if [[ -n "$$PYTEST_ADDOPTS" ]]; then \
+		echo "Using PYTEST_ADDOPTS=$$PYTEST_ADDOPTS"; \
+	fi
 	@TEST_SCRIPT=$$(echo $(filter-out $@,$(MAKECMDGOALS)) | sed 's|^e2e_playwright/||'); \
 	cd e2e_playwright && pytest $$TEST_SCRIPT --tracing retain-on-failure --reruns 0 || ( \
 		echo "If you implemented changes in the frontend, make sure to call \`make frontend-fast\` to use the up-to-date frontend build in the test."; \

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -69,7 +69,9 @@ When adding or modifying tests for an element, ensure the following are covered:
 
 ## Running tests
 
-- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
+- Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
+- Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.


### PR DESCRIPTION
## Describe your changes

- Updates LLM Agents guidance on how to more efficiently run e2e tests.
  - This includes explicit instructions on running a single test (rather than an entire test file), and how to use `PYTEST_ADDOPTS` with the make command.

## Testing Plan

- Manually tested

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
