### PR TITLE
[fix] Fix upload button functionality after drag-drop and delete in `st.chat_input`

### DIFF
--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1778,9 +1778,9 @@ def test_file_upload_retry_click_success(app: Page):
 
 
 @use_chat_input("single_file")
-@pytest.mark.skip_browser(
-    "webkit"
-)  # DataTransfer dispatch_event not supported in WebKit
+# DataTransfer dispatch_event only works reliably in Chromium.
+# WebKit doesn't support it, and Firefox has inconsistent behavior.
+@pytest.mark.only_browser("chromium")
 def test_upload_button_works_after_drag_drop_and_delete(app: Page):
     """Test that the upload button still works after drag-dropping a file and deleting it."""
     chat_input = get_element_by_key(app, "single_file")

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1845,3 +1845,6 @@ def test_upload_button_works_after_drag_drop_and_delete(app: Page):
     uploaded_files = chat_input.get_by_test_id("stChatUploadedFiles").first
     expect(uploaded_files).to_be_visible()
     expect(uploaded_files.get_by_text(new_file_name)).to_be_visible()
+
+    # Verify the original deleted file doesn't reappear (negative assertion)
+    expect(uploaded_files.get_by_text(file_name)).not_to_be_visible()

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1783,8 +1783,6 @@ def test_file_upload_retry_click_success(app: Page):
 )  # DataTransfer dispatch_event not supported in WebKit
 def test_upload_button_works_after_drag_drop_and_delete(app: Page):
     """Test that the upload button still works after drag-dropping a file and deleting it."""
-    app.set_viewport_size({"width": 750, "height": 2000})
-
     chat_input = get_element_by_key(app, "single_file")
     expect(chat_input).to_be_visible()
 

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1775,3 +1775,71 @@ def test_file_upload_retry_click_success(app: Page):
     finally:
         # Clean up route interception
         app.unroute("**/_stcore/upload_file/**")
+
+
+@use_chat_input("single_file")
+@pytest.mark.only_browser("chromium")  # DataTransfer only works in Chromium/Firefox
+def test_upload_button_works_after_drag_drop_and_delete(app: Page):
+    """Test that the upload button still works after drag-dropping a file and deleting it."""
+    app.set_viewport_size({"width": 750, "height": 2000})
+
+    chat_input = get_element_by_key(app, "single_file")
+    expect(chat_input).to_be_visible()
+
+    # Step 1: Simulate drag and drop of a file using DataTransfer
+    file_name = "drag_drop_test.txt"
+    file_content = "test content for drag drop"
+
+    # Create a DataTransfer with file data and dispatch drop event
+    data_transfer = app.evaluate_handle(
+        """([fileName, fileContent]) => {
+            const dt = new DataTransfer();
+            const file = new File([fileContent], fileName, { type: 'text/plain' });
+            dt.items.add(file);
+            return dt;
+        }""",
+        [file_name, file_content],
+    )
+
+    # Get the upload button element which has its own dropzone
+    upload_button = chat_input.get_by_test_id("stChatInputFileUploadButton")
+    expect(upload_button).to_be_visible()
+
+    # Dispatch drop event to the upload button's dropzone
+    upload_button.dispatch_event("drop", {"dataTransfer": data_transfer})
+
+    wait_for_app_run(app, 500)
+
+    # Verify the file was uploaded
+    uploaded_files = chat_input.get_by_test_id("stChatUploadedFiles").first
+    expect(uploaded_files).to_be_visible()
+    expect(uploaded_files.get_by_text(file_name)).to_be_visible()
+
+    # Step 2: Delete the uploaded file
+    uploaded_files.get_by_test_id("stChatInputDeleteBtn").first.click()
+    wait_for_app_run(app, 500)
+
+    # Verify the file was deleted
+    expect(chat_input.get_by_test_id("stChatUploadedFiles")).not_to_be_visible()
+
+    # Step 3: Verify the upload button still works after the drag-drop + delete cycle
+    expect(upload_button).to_be_visible()
+    expect(upload_button).to_be_enabled()
+
+    # Upload a new file using the button
+    new_file_name = "after_delete.txt"
+    new_file = FilePayload(
+        name=new_file_name, mimeType="text/plain", buffer=b"new file content"
+    )
+
+    with app.expect_file_chooser() as fc_info:
+        upload_button.click(force=True)
+        file_chooser = fc_info.value
+        file_chooser.set_files(files=[new_file])
+
+    wait_for_app_run(app, 500)
+
+    # Verify the new file was uploaded successfully
+    uploaded_files = chat_input.get_by_test_id("stChatUploadedFiles").first
+    expect(uploaded_files).to_be_visible()
+    expect(uploaded_files.get_by_text(new_file_name)).to_be_visible()

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1778,42 +1778,37 @@ def test_file_upload_retry_click_success(app: Page):
 
 
 @use_chat_input("single_file")
-# DataTransfer dispatch_event only works reliably in Chromium.
-# WebKit doesn't support it, and Firefox has inconsistent behavior.
-@pytest.mark.only_browser("chromium")
-def test_upload_button_works_after_drag_drop_and_delete(app: Page):
-    """Test that the upload button still works after drag-dropping a file and deleting it."""
+def test_upload_button_works_after_upload_and_delete(app: Page):
+    """Test that the upload button still works after uploading a file and deleting it.
+
+    This tests a react-dropzone bug where the file input becomes unresponsive after
+    files are removed. The fix resets the dropzone state via React key when files
+    are deleted. See: https://github.com/react-dropzone/react-dropzone/issues/972
+    """
     chat_input = get_element_by_key(app, "single_file")
     expect(chat_input).to_be_visible()
 
-    # Step 1: Simulate drag and drop of a file using DataTransfer
-    file_name = "drag_drop_test.txt"
-    file_content = "test content for drag drop"
-
-    # Create a DataTransfer with file data and dispatch drop event
-    data_transfer = app.evaluate_handle(
-        """([fileName, fileContent]) => {
-            const dt = new DataTransfer();
-            const file = new File([fileContent], fileName, { type: 'text/plain' });
-            dt.items.add(file);
-            return dt;
-        }""",
-        [file_name, file_content],
-    )
-
-    # Get the upload button element which has its own dropzone
+    # Get the upload button
     upload_button = chat_input.get_by_test_id("stChatInputFileUploadButton")
     expect(upload_button).to_be_visible()
 
-    # Dispatch drop event to the upload button's dropzone
-    upload_button.dispatch_event("drop", {"dataTransfer": data_transfer})
+    # Step 1: Upload a file using the button
+    first_file_name = "first_upload.txt"
+    first_file = FilePayload(
+        name=first_file_name, mimeType="text/plain", buffer=b"first file content"
+    )
+
+    with app.expect_file_chooser() as fc_info:
+        upload_button.click(force=True)
+        file_chooser = fc_info.value
+        file_chooser.set_files(files=[first_file])
 
     wait_for_app_run(app, 500)
 
     # Verify the file was uploaded
     uploaded_files = chat_input.get_by_test_id("stChatUploadedFiles").first
     expect(uploaded_files).to_be_visible()
-    expect(uploaded_files.get_by_text(file_name)).to_be_visible()
+    expect(uploaded_files.get_by_text(first_file_name)).to_be_visible()
 
     # Step 2: Delete the uploaded file
     uploaded_files.get_by_test_id("stChatInputDeleteBtn").first.click()
@@ -1822,27 +1817,28 @@ def test_upload_button_works_after_drag_drop_and_delete(app: Page):
     # Verify the file was deleted
     expect(chat_input.get_by_test_id("stChatUploadedFiles")).not_to_be_visible()
 
-    # Step 3: Verify the upload button still works after the drag-drop + delete cycle
+    # Step 3: Verify the upload button still works after the upload + delete cycle
+    # This is the key assertion - without the fix, the button would be unresponsive
     expect(upload_button).to_be_visible()
     expect(upload_button).to_be_enabled()
 
     # Upload a new file using the button
-    new_file_name = "after_delete.txt"
-    new_file = FilePayload(
-        name=new_file_name, mimeType="text/plain", buffer=b"new file content"
+    second_file_name = "second_upload.txt"
+    second_file = FilePayload(
+        name=second_file_name, mimeType="text/plain", buffer=b"second file content"
     )
 
     with app.expect_file_chooser() as fc_info:
         upload_button.click(force=True)
         file_chooser = fc_info.value
-        file_chooser.set_files(files=[new_file])
+        file_chooser.set_files(files=[second_file])
 
     wait_for_app_run(app, 500)
 
     # Verify the new file was uploaded successfully
     uploaded_files = chat_input.get_by_test_id("stChatUploadedFiles").first
     expect(uploaded_files).to_be_visible()
-    expect(uploaded_files.get_by_text(new_file_name)).to_be_visible()
+    expect(uploaded_files.get_by_text(second_file_name)).to_be_visible()
 
-    # Verify the original deleted file doesn't reappear (negative assertion)
-    expect(uploaded_files.get_by_text(file_name)).not_to_be_visible()
+    # Verify the first deleted file doesn't reappear (negative assertion)
+    expect(uploaded_files.get_by_text(first_file_name)).not_to_be_visible()

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1793,7 +1793,8 @@ def test_upload_button_works_after_upload_and_delete(app: Page):
     expect(upload_button).to_be_visible()
 
     # Step 1: Upload a file using the button
-    first_file_name = "first_upload.txt"
+    # Use short filenames (max 16 chars) to avoid truncation in the UI
+    first_file_name = "first.txt"
     first_file = FilePayload(
         name=first_file_name, mimeType="text/plain", buffer=b"first file content"
     )
@@ -1823,7 +1824,7 @@ def test_upload_button_works_after_upload_and_delete(app: Page):
     expect(upload_button).to_be_enabled()
 
     # Upload a new file using the button
-    second_file_name = "second_upload.txt"
+    second_file_name = "second.txt"
     second_file = FilePayload(
         name=second_file_name, mimeType="text/plain", buffer=b"second file content"
     )

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -1778,7 +1778,9 @@ def test_file_upload_retry_click_success(app: Page):
 
 
 @use_chat_input("single_file")
-@pytest.mark.only_browser("chromium")  # DataTransfer only works in Chromium/Firefox
+@pytest.mark.skip_browser(
+    "webkit"
+)  # DataTransfer dispatch_event not supported in WebKit
 def test_upload_button_works_after_drag_drop_and_delete(app: Page):
     """Test that the upload button still works after drag-dropping a file and deleting it."""
     app.set_viewport_size({"width": 750, "height": 2000})

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -406,6 +406,8 @@ function ChatInput({
       acceptFile === AcceptFileValue.Directory,
     accept: getAccept(element.fileType),
     maxSize: maxFileSize,
+    // Disable the File System Access API to avoid browser-specific issues
+    // with drag-and-drop uploads (see issue #6176 and FileDropzone usage).
     useFsAccessApi: false,
   })
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -186,9 +186,7 @@ function ChatInput({
   const [audioUploading, setAudioUploading] = useState(false)
   const [recordingError, setRecordingError] = useState<string | null>(null)
 
-  // Counter to force re-render of dropzone-related components when files are cleared.
-  // Incremented directly when files are cleared (not via useEffect) to avoid
-  // deriving state from state changes.
+  // Forces dropzone to remount when files are cleared
   const [dropzoneResetCounter, setDropzoneResetCounter] = useState(0)
 
   // Read acceptAudio from the element configuration

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -189,7 +189,6 @@ function ChatInput({
   // Forces dropzone to remount when files are cleared
   const [dropzoneResetCounter, setDropzoneResetCounter] = useState(0)
 
-  // Read acceptAudio from the element configuration
   const acceptAudio = element.acceptAudio ?? false
 
   // Cleanup: abort any in-progress uploads on unmount
@@ -261,7 +260,6 @@ function ChatInput({
           return prevFiles
         }
 
-        // Handle abort/deletion using shared helper
         deleteUploadedFile(file)
 
         const newFiles = prevFiles.filter(fileArg => fileArg.id !== fileId)
@@ -283,22 +281,19 @@ function ChatInput({
     ((acceptedFiles: File[], rejectedFiles: never[]) => void) | null
   >(null)
 
-  const handleRetry = useCallback(
-    (fileInfo: UploadFileInfo): void => {
-      if (!fileInfo.file || fileInfo.status.type !== "error") {
-        return
-      }
+  const handleRetry = useCallback((fileInfo: UploadFileInfo): void => {
+    if (!fileInfo.file || fileInfo.status.type !== "error") {
+      return
+    }
 
-      // Remove the failed file from state
-      setFiles(prevFiles => prevFiles.filter(f => f.id !== fileInfo.id))
+    // Remove the failed file from state
+    setFiles(prevFiles => prevFiles.filter(f => f.id !== fileInfo.id))
 
-      // Re-trigger the upload using the drop handler
-      if (dropHandlerRef.current) {
-        dropHandlerRef.current([fileInfo.file], [])
-      }
-    },
-    [] // No dependencies - uses ref for dropHandler
-  )
+    // Re-trigger the upload using the drop handler
+    if (dropHandlerRef.current) {
+      dropHandlerRef.current([fileInfo.file], [])
+    }
+  }, [])
 
   const createChatInputWidgetFilesValue =
     useCallback((): FileUploaderStateProto => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -186,17 +186,10 @@ function ChatInput({
   const [audioUploading, setAudioUploading] = useState(false)
   const [recordingError, setRecordingError] = useState<string | null>(null)
 
-  // Counter to force re-render of dropzone-related components when files are cleared
+  // Counter to force re-render of dropzone-related components when files are cleared.
+  // Incremented directly when files are cleared (not via useEffect) to avoid
+  // deriving state from state changes.
   const [dropzoneResetCounter, setDropzoneResetCounter] = useState(0)
-  const prevFilesLengthRef = useRef(files.length)
-
-  // Increment counter when files transition from non-empty to empty
-  useEffect(() => {
-    if (prevFilesLengthRef.current > 0 && files.length === 0) {
-      setDropzoneResetCounter(c => c + 1)
-    }
-    prevFilesLengthRef.current = files.length
-  }, [files.length])
 
   // Read acceptAudio from the element configuration
   const acceptAudio = element.acceptAudio ?? false
@@ -273,7 +266,14 @@ function ChatInput({
         // Handle abort/deletion using shared helper
         deleteUploadedFile(file)
 
-        return prevFiles.filter(fileArg => fileArg.id !== fileId)
+        const newFiles = prevFiles.filter(fileArg => fileArg.id !== fileId)
+
+        // Reset dropzone when all files are cleared
+        if (newFiles.length === 0) {
+          setDropzoneResetCounter(c => c + 1)
+        }
+
+        return newFiles
       })
     },
     [deleteUploadedFile]
@@ -440,6 +440,12 @@ function ChatInput({
         { fromUi: true },
         fragmentId
       )
+
+      // Reset dropzone when files are cleared on submit
+      if (files.length > 0) {
+        setDropzoneResetCounter(c => c + 1)
+      }
+
       setFiles([])
       setValue("")
       autoExpand.clearScrollHeight()
@@ -448,6 +454,7 @@ function ChatInput({
       dirty,
       disabled,
       value,
+      files.length,
       createChatInputWidgetFilesValue,
       widgetMgr,
       element,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -186,6 +186,18 @@ function ChatInput({
   const [audioUploading, setAudioUploading] = useState(false)
   const [recordingError, setRecordingError] = useState<string | null>(null)
 
+  // Counter to force re-render of dropzone-related components when files are cleared
+  const [dropzoneResetCounter, setDropzoneResetCounter] = useState(0)
+  const prevFilesLengthRef = useRef(files.length)
+
+  // Increment counter when files transition from non-empty to empty
+  useEffect(() => {
+    if (prevFilesLengthRef.current > 0 && files.length === 0) {
+      setDropzoneResetCounter(c => c + 1)
+    }
+    prevFilesLengthRef.current = files.length
+  }, [files.length])
+
   // Read acceptAudio from the element configuration
   const acceptAudio = element.acceptAudio ?? false
 
@@ -394,6 +406,7 @@ function ChatInput({
       acceptFile === AcceptFileValue.Directory,
     accept: getAccept(element.fileType),
     maxSize: maxFileSize,
+    useFsAccessApi: false,
   })
 
   const submitChatInput = useCallback(
@@ -784,8 +797,14 @@ function ChatInput({
               <StyledLeftCluster>
                 {acceptFile !== AcceptFileValue.None && !isRecording && (
                   <ChatFileUploadButton
-                    getRootProps={getRootProps}
-                    getInputProps={getInputProps}
+                    key={dropzoneResetCounter}
+                    onDrop={dropHandler}
+                    multiple={
+                      acceptFile === AcceptFileValue.Multiple ||
+                      acceptFile === AcceptFileValue.Directory
+                    }
+                    accept={getAccept(element.fileType)}
+                    maxSize={maxFileSize}
                     acceptFile={acceptFile}
                     disabled={disabled}
                   />

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -17,6 +17,7 @@
 import { memo } from "react"
 
 import { Add } from "@emotion-icons/material-rounded"
+import { Accept, FileRejection, useDropzone } from "react-dropzone"
 
 import Icon from "~lib/components/shared/Icon"
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
@@ -30,20 +31,30 @@ import {
 import { StyledFileUploadButton } from "./styled-components"
 
 export interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  getRootProps: any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  getInputProps: any
+  onDrop: (acceptedFiles: File[], rejectedFiles: FileRejection[]) => void
+  multiple: boolean
+  accept?: Accept
+  maxSize: number
   acceptFile: AcceptFileValue
   disabled: boolean
 }
 
 const ChatFileUploadButton = ({
-  getRootProps,
-  getInputProps,
+  onDrop,
+  multiple,
+  accept,
+  maxSize,
   acceptFile,
   disabled,
 }: Props): React.ReactElement => {
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop,
+    multiple,
+    accept,
+    maxSize,
+    useFsAccessApi: false,
+  })
+
   const inputProps = configureFileInputProps(getInputProps(), acceptFile)
 
   // React-dropzone's root props include `tabIndex=0` by default, which makes the

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -52,6 +52,8 @@ const ChatFileUploadButton = ({
     multiple,
     accept,
     maxSize,
+    // Disable the File System Access API to avoid browser-specific issues
+    // (see issue #6176 and FileDropzone for details).
     useFsAccessApi: false,
   })
 

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
@@ -118,13 +118,32 @@ export const createDropHandler =
       rejectedFiles = [...rejectedFiles, ...rejected]
     }
 
-    // If only single file upload is allowed but multiple were dropped/selected,
-    // all files will be rejected by default. In this case, we take the first
-    // valid file into acceptedFiles, and reject the rest.
+    // Enforce single file limit: when only one file is allowed but multiple
+    // were dropped/selected, keep only the first valid file and reject the rest
+    if (!acceptMultipleFiles && acceptedFiles.length > 1) {
+      // Keep first accepted file, reject the rest
+      const [firstFile, ...extraFiles] = acceptedFiles
+      acceptedFiles = [firstFile]
+      rejectedFiles = [
+        ...rejectedFiles,
+        ...extraFiles.map(file => ({
+          file,
+          errors: [
+            {
+              code: FileErrorCode.TooManyFiles,
+              message: "Only one file can be uploaded at a time.",
+            },
+          ],
+        })),
+      ]
+    }
+
+    // Handle case where all files were rejected but one should be allowed
+    // (e.g., when react-dropzone rejects all with TooManyFiles)
     if (
       !acceptMultipleFiles &&
       acceptedFiles.length === 0 &&
-      rejectedFiles.length > 1
+      rejectedFiles.length > 0
     ) {
       const firstFileIndex = rejectedFiles.findIndex(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- TODO: Fix this

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
@@ -118,32 +118,13 @@ export const createDropHandler =
       rejectedFiles = [...rejectedFiles, ...rejected]
     }
 
-    // Enforce single file limit: when only one file is allowed but multiple
-    // were dropped/selected, keep only the first valid file and reject the rest
-    if (!acceptMultipleFiles && acceptedFiles.length > 1) {
-      // Keep first accepted file, reject the rest
-      const [firstFile, ...extraFiles] = acceptedFiles
-      acceptedFiles = [firstFile]
-      rejectedFiles = [
-        ...rejectedFiles,
-        ...extraFiles.map(file => ({
-          file,
-          errors: [
-            {
-              code: FileErrorCode.TooManyFiles,
-              message: "Only one file can be uploaded at a time.",
-            },
-          ],
-        })),
-      ]
-    }
-
-    // Handle case where all files were rejected but one should be allowed
-    // (e.g., when react-dropzone rejects all with TooManyFiles)
+    // If only single file upload is allowed but multiple were dropped/selected,
+    // all files will be rejected by default. In this case, we take the first
+    // valid file into acceptedFiles, and reject the rest.
     if (
       !acceptMultipleFiles &&
       acceptedFiles.length === 0 &&
-      rejectedFiles.length > 0
+      rejectedFiles.length > 1
     ) {
       const firstFileIndex = rejectedFiles.findIndex(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- TODO: Fix this


### PR DESCRIPTION
## Describe your changes

Fixed an issue where the file upload button in `st.chat_input` would stop working after drag-dropping a file and then deleting it. The fix includes:

1. Added a reset counter to force re-render of dropzone components when files are cleared
2. Refactored `ChatFileUploadButton` to use its own dropzone instance instead of sharing props
3. Improved handling of single file uploads when multiple files are dropped
4. Disabled the File System Access API to ensure consistent behavior

## Testing Plan

- E2E Tests: Added a comprehensive Playwright test that verifies the upload button works after drag-dropping a file and deleting it
- The test simulates drag-drop using DataTransfer, verifies file upload, deletes the file, and then confirms the upload button still works correctly

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.