### PR TITLE
Use `key` as main identity for `st.dataframe` with selections

### DIFF
--- a/e2e_playwright/st_dataframe_selections.py
+++ b/e2e_playwright/st_dataframe_selections.py
@@ -243,3 +243,36 @@ selection = st.dataframe(
     key="multi_row_multi_column_multi_cell_select",
 )
 st.write("Dataframe multi-row, multi-column & multi-cell selection:", str(selection))
+
+# Test for selection persistence with data changes (key_as_main_identity feature)
+st.header("Selection persistence with data changes:")
+
+# Initialize update counter in session state
+if "data_update_count" not in st.session_state:
+    st.session_state.data_update_count = 0
+
+
+def increment_data_count():
+    """Callback to increment the data update counter."""
+    st.session_state.data_update_count += 1
+
+
+# Create dynamic data based on update count - use fixed seed for reproducibility
+# but offset by the update count to ensure data actually changes
+rng = np.random.default_rng(42 + st.session_state.data_update_count)
+dynamic_df = pd.DataFrame({f"col_{i}": rng.standard_normal(5) for i in range(5)})
+
+selection = st.dataframe(
+    dynamic_df,
+    hide_index=True,
+    on_select="rerun",
+    selection_mode="multi-row",
+    column_config=column_config,
+    width="content",
+    key="persistent_selection_df",
+)
+st.write("Persistent selection:", str(selection))
+st.write("Data update count:", st.session_state.data_update_count)
+
+# Use on_click callback to ensure counter is incremented before the rerun completes
+st.button("Update data", key="update_data_btn", on_click=increment_data_count)

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -492,7 +492,7 @@ def test_selection_state_remains_after_unmounting(
     _expect_multi_row_multi_column_selection(app)
 
     # Click button to unmount the component
-    app.get_by_test_id("stButton").locator("button").click()
+    app.get_by_role("button", name="Create some elements to").click()
     wait_for_app_run(app, 4000)
 
     expect(canvas).to_be_visible()
@@ -732,5 +732,67 @@ def test_multi_row_column_and_cell_select(
         app,
         "Dataframe multi-row, multi-column & multi-cell selection:",
         "{'selection': {'rows': [], 'columns': [], 'cells': []}}",
+        exact_match=True,
+    )
+
+
+def _get_persistent_selection_df(app: Page) -> Locator:
+    return get_element_by_key(app, "persistent_selection_df").get_by_test_id(
+        "stDataFrame"
+    )
+
+
+def test_selection_persists_after_data_update(app: Page):
+    """Test that row selections persist when data changes but key remains the same.
+
+    This verifies the key_as_main_identity feature for st.dataframe selections.
+    When a key is provided and selection_mode stays the same, selections should
+    be preserved even when the underlying data changes.
+    """
+    # First scroll to the bottom of the page to ensure the test section is loaded
+    update_button = get_element_by_key(app, "update_data_btn").locator("button")
+    update_button.scroll_into_view_if_needed()
+    expect(update_button).to_be_visible()
+
+    canvas = _get_persistent_selection_df(app)
+    expect_canvas_to_be_visible(canvas)
+    canvas.scroll_into_view_if_needed()
+
+    # Initially no selection
+    expect_prefixed_markdown(
+        app,
+        "Persistent selection:",
+        "{'selection': {'rows': [], 'columns': [], 'cells': []}}",
+        exact_match=True,
+    )
+    expect_prefixed_markdown(app, "Data update count:", "0", exact_match=True)
+
+    # Select rows 0 and 2
+    select_row(canvas, 1)
+    select_row(canvas, 3)
+    wait_for_app_run(app)
+
+    expect_prefixed_markdown(
+        app,
+        "Persistent selection:",
+        "{'selection': {'rows': [0, 2], 'columns': [], 'cells': []}}",
+        exact_match=True,
+    )
+
+    # Click the button to update data (changes the dataframe content)
+    # Scroll to button again after dataframe selections (page may have scrolled)
+    update_button.scroll_into_view_if_needed()
+    expect(update_button).to_be_visible()
+    update_button.click()
+    wait_for_app_run(app)
+
+    # Data update count should be incremented
+    expect_prefixed_markdown(app, "Data update count:", "1", exact_match=True)
+
+    # Selection should persist after data update
+    expect_prefixed_markdown(
+        app,
+        "Persistent selection:",
+        "{'selection': {'rows': [0, 2], 'columns': [], 'cells': []}}",
         exact_match=True,
     )

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -773,8 +773,8 @@ class ArrowMixin:
                 user_key=key,
                 # There are some edge cases where selections can become orphaned when the data changes
                 # - e.g. when rows get removed. The frontend can handle this without errors,
-                # but it might be a nice enhancement to automatically reset the selection state in the backend
-                # and frontend in this case.
+                # but it might be a nice enhancement to automatically reset the backend & frontend
+                # selection state in this case.
                 key_as_main_identity={"selection_mode", "is_selection_activated"},
                 dg=self.dg,
                 data=proto.data,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -771,7 +771,7 @@ class ArrowMixin:
             proto.id = compute_and_register_element_id(
                 "dataframe",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity={"selection_mode", "is_selection_activated"},
                 dg=self.dg,
                 data=proto.data,
                 width=width,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -771,6 +771,10 @@ class ArrowMixin:
             proto.id = compute_and_register_element_id(
                 "dataframe",
                 user_key=key,
+                # There are some edge cases where selections can become orphaned when the data changes
+                # - e.g. when rows get removed. The frontend can handle this without errors,
+                # but it might be a nice enhancement to automatically reset the selection state in the backend
+                # and frontend in this case.
                 key_as_main_identity={"selection_mode", "is_selection_activated"},
                 dg=self.dg,
                 data=proto.data,

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -505,6 +505,104 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         self.benchmark(large_styler_df)
 
 
+class DataframeSelectionsStableIdTest(DeltaGeneratorTestCase):
+    """Tests for element ID stability when selections are enabled."""
+
+    def test_stable_id_with_key_and_selections(self):
+        """Test that the element ID is stable when data changes but key and selection_mode remain the same.
+
+        When selections are enabled and a key is provided, the element ID should remain
+        stable across data changes to preserve selection state. This test verifies that
+        changing data, column_config, column_order, and other non-whitelisted parameters
+        does not change the element ID.
+        """
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            # First render with certain params
+            df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            st.dataframe(
+                df1,
+                key="selectable_df",
+                height=200,
+                width=300,
+                column_order=["a", "b"],
+                hide_index=True,
+                # Whitelisted parameters
+                on_select="rerun",
+                selection_mode="multi-row",
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id1 = c1.id
+
+            # Second render with different data and params but same key and selection_mode
+            df2 = pd.DataFrame({"x": [10, 20], "y": [30, 40], "z": [50, 60]})
+            st.dataframe(
+                df2,
+                key="selectable_df",
+                height=400,
+                width=500,
+                column_order=["x", "y", "z"],
+                hide_index=False,
+                # Whitelisted parameters
+                on_select="rerun",
+                selection_mode="multi-row",
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id2 = c2.id
+
+            # ID should be stable since key and selection_mode are the same
+            assert id1 == id2
+
+    @parameterized.expand(
+        [
+            ("selection_mode_single_to_multi", "single-row", "multi-row"),
+            ("selection_mode_row_to_column", "multi-row", "multi-column"),
+            (
+                "selection_mode_single_to_list",
+                "single-row",
+                ["multi-row", "multi-column"],
+            ),
+        ]
+    )
+    def test_whitelisted_stable_key_kwargs(
+        self, name: str, value1: object, value2: object
+    ):
+        """Test that changing selection_mode changes the ID even when a key is provided.
+
+        The selection_mode parameter is whitelisted, meaning changes to it should
+        result in a new element ID to ensure the widget state is reset when the
+        selection mode fundamentally changes.
+        """
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+            st.dataframe(
+                df,
+                key="selectable_df_whitelisted",
+                on_select="rerun",
+                selection_mode=value1,
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id1 = c1.id
+
+            st.dataframe(
+                df,
+                key="selectable_df_whitelisted",
+                on_select="rerun",
+                selection_mode=value2,
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id2 = c2.id
+
+            # ID should change since selection_mode is whitelisted
+            assert id1 != id2
+
+
 class StArrowTableAPITest(DeltaGeneratorTestCase):
     """Test Public Streamlit Public APIs."""
 

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -555,6 +555,43 @@ class DataframeSelectionsStableIdTest(DeltaGeneratorTestCase):
             # ID should be stable since key and selection_mode are the same
             assert id1 == id2
 
+    def test_unstable_id_without_key_and_selections(self):
+        """Test that the element ID changes when data changes and no key is provided.
+
+        Without a key, the element ID is derived from all parameters including the data.
+        This test verifies that changing data or other parameters causes the element ID
+        to change, demonstrating that the key_as_main_identity feature is required for
+        ID stability.
+        """
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            # First render without a key
+            df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            st.dataframe(
+                df1,
+                height=200,
+                on_select="rerun",
+                selection_mode="multi-row",
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id1 = c1.id
+
+            # Second render with different data but no key
+            df2 = pd.DataFrame({"x": [10, 20], "y": [30, 40]})
+            st.dataframe(
+                df2,
+                height=200,
+                on_select="rerun",
+                selection_mode="multi-row",
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_data_frame
+            id2 = c2.id
+
+            # ID should change since no key is provided and data is different
+            assert id1 != id2
+
     @parameterized.expand(
         [
             ("selection_mode_single_to_multi", "single-row", "multi-row"),


### PR DESCRIPTION
## Describe your changes

If a custom `key` is passed to a `st.dataframe` with selections activated, it will be used as the main identity. This allows for dynamically changing other parameters and and the input data between reruns without recreating the widgets in the frontend and losing their state.

## GitHub Issue Link (if applicable)

- Related to https://github.com/streamlit/streamlit/issues/11277
- Closes https://github.com/streamlit/streamlit/issues/9527

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
