### PR TITLE
Use `key` as main identity for vega charts with selections

### DIFF
--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -315,3 +315,59 @@ if "runs" not in st.session_state:
     st.session_state.runs = 0
 st.session_state.runs += 1
 st.write("Runs:", st.session_state.runs)
+
+# SELECTION PERSISTENCE WITH DATA CHANGES (key_as_main_identity feature)
+st.header("Selection persistence with data changes:")
+
+# Initialize update counter in session state
+if "chart_data_update_count" not in st.session_state:
+    st.session_state.chart_data_update_count = 0
+
+
+def increment_chart_data():
+    st.session_state.chart_data_update_count += 1
+
+
+# Create dynamic data based on update count
+# Use a fixed base but add the update count to values so data clearly changes
+persistent_df = pd.DataFrame(
+    {
+        "category": ["A", "B", "C", "D", "E"],
+        "value": [
+            10 + st.session_state.chart_data_update_count * 5,
+            25 + st.session_state.chart_data_update_count * 5,
+            15 + st.session_state.chart_data_update_count * 5,
+            30 + st.session_state.chart_data_update_count * 5,
+            20 + st.session_state.chart_data_update_count * 5,
+        ],
+    }
+)
+
+point_persistent = alt.selection_point(name="persistent_selection")
+persistent_chart = (
+    alt.Chart(persistent_df)
+    .mark_bar()
+    .encode(
+        x=alt.X("category:N"),
+        y=alt.Y("value:Q"),
+        fillOpacity=alt.condition(point_persistent, alt.value(1), alt.value(0.3)),
+        tooltip=alt.value(None),
+    )
+    .add_params(point_persistent)
+)
+
+# Don't use container width so the chart has a predictable size for clicking
+selection = st.altair_chart(
+    persistent_chart,
+    on_select="rerun",
+    key="persistent_selection_chart",
+    width="content",
+)
+st.write("Persistent selection:", str(selection))
+st.write("Chart data update count:", st.session_state.chart_data_update_count)
+
+st.button(
+    "Update chart data",
+    key="update_chart_data_btn",
+    on_click=increment_chart_data,
+)

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -467,3 +467,52 @@ def test_selection_state_remains_after_unmounting_snapshot(
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
     expect(get_element_by_key(app, "scatter_point")).to_be_visible()
+
+
+def _get_persistent_selection_chart(app: Page) -> Locator:
+    return get_element_by_key(app, "persistent_selection_chart").locator(
+        "[role='graphics-document']"
+    )
+
+
+def test_selection_persists_after_data_update(app: Page):
+    """Test that selections persist when data changes but key remains the same.
+
+    This verifies the key_as_main_identity feature for st.altair_chart selections.
+    When a key is provided and selection_mode stays the same, selections should
+    be preserved even when the underlying data changes.
+    """
+    chart = _get_persistent_selection_chart(app)
+    expect(chart).to_be_visible()
+    chart.scroll_into_view_if_needed()
+
+    # Initially no selection
+    empty_selection = re.compile(
+        "\\{'selection': \\{'persistent_selection': \\{\\}\\}\\}"
+    )
+    expect_prefixed_markdown(app, "Persistent selection:", empty_selection)
+    expect_prefixed_markdown(app, "Chart data update count:", "0", exact_match=True)
+
+    # Click on a bar to select it
+    # Using coordinates similar to bar_point test which works at (150, 180)
+    _click(app, chart, _MousePosition(150, 180))
+
+    # Verify selection was made - could be any category depending on exact position
+    expected_selection = re.compile(
+        "\\{'selection': \\{'persistent_selection': \\[\\{'category': '[A-E]'.+\\}\\]\\}\\}"
+    )
+    expect_prefixed_markdown(app, "Persistent selection:", expected_selection)
+
+    # Click the button to update data (changes the chart data)
+    # Use the key-based locator for precise selection
+    update_button = get_element_by_key(app, "update_chart_data_btn").locator("button")
+    update_button.scroll_into_view_if_needed()
+    update_button.click()
+    wait_for_app_run(app)
+
+    # Verify data was updated
+    expect_prefixed_markdown(app, "Chart data update count:", "1", exact_match=True)
+
+    # Verify selection persisted after data change
+    # The selection should still show the same category even though values changed
+    expect_prefixed_markdown(app, "Persistent selection:", expected_selection)

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -2404,6 +2404,9 @@ class VegaChartsMixin:
             vega_lite_proto.id = compute_and_register_element_id(
                 "arrow_vega_lite_chart",
                 user_key=key,
+                # There are some edge cases where selections can become orphaned when the data changes.
+                #  The frontend can handle this without errors, but it might be a nice enhancement
+                # to automatically reset the backend & frontend selection state in this case.
                 key_as_main_identity={"selection_mode"},
                 dg=self.dg,
                 vega_lite_spec=vega_lite_proto.spec,

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -2404,7 +2404,7 @@ class VegaChartsMixin:
             vega_lite_proto.id = compute_and_register_element_id(
                 "arrow_vega_lite_chart",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity={"selection_mode"},
                 dg=self.dg,
                 vega_lite_spec=vega_lite_proto.spec,
                 # The data is either in vega_lite_proto.data.data

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -3500,10 +3500,6 @@ class VegaChartsSelectionsStableIdTest(DeltaGeneratorTestCase):
             # ID should be stable since key and selection_mode are the same
             assert id1 == id2
 
-    @unittest.skipIf(
-        is_altair_version_less_than("5.0.0") is True,
-        "This test only runs if altair is >= 5.0.0",
-    )
     @parameterized.expand(
         [
             (
@@ -3512,6 +3508,10 @@ class VegaChartsSelectionsStableIdTest(DeltaGeneratorTestCase):
                 "my_interval_selection",
             ),
         ]
+    )
+    @unittest.skipIf(
+        is_altair_version_less_than("5.0.0") is True,
+        "This test only runs if altair is >= 5.0.0",
     )
     def test_whitelisted_stable_key_kwargs(
         self, name: str, selection1: str, selection2: str

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -3500,22 +3500,11 @@ class VegaChartsSelectionsStableIdTest(DeltaGeneratorTestCase):
             # ID should be stable since key and selection_mode are the same
             assert id1 == id2
 
-    @parameterized.expand(
-        [
-            (
-                "selection_mode_point_to_interval",
-                "my_point_selection",
-                "my_interval_selection",
-            ),
-        ]
-    )
     @unittest.skipIf(
         is_altair_version_less_than("5.0.0") is True,
         "This test only runs if altair is >= 5.0.0",
     )
-    def test_whitelisted_stable_key_kwargs(
-        self, name: str, selection1: str, selection2: str
-    ):
+    def test_id_changes_when_selection_mode_changes(self):
         """Test that changing selection_mode changes the ID even when a key is provided.
 
         The selection_mode parameter is whitelisted, meaning changes to it should
@@ -3527,26 +3516,26 @@ class VegaChartsSelectionsStableIdTest(DeltaGeneratorTestCase):
         ):
             df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
-            # First render with first selection
-            point = alt.selection_point(name=selection1)
+            # First render with point selection
+            point = alt.selection_point(name="my_point_selection")
             chart1 = alt.Chart(df).mark_bar().encode(x="a", y="b").add_params(point)
             st.altair_chart(
                 chart1,
                 key="changing_selection_chart",
                 on_select="rerun",
-                selection_mode=selection1,
+                selection_mode="my_point_selection",
             )
             c1 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
             id1 = c1.id
 
-            # Second render with different selection mode
-            interval = alt.selection_interval(name=selection2)
+            # Second render with interval selection (different selection mode)
+            interval = alt.selection_interval(name="my_interval_selection")
             chart2 = alt.Chart(df).mark_bar().encode(x="a", y="b").add_params(interval)
             st.altair_chart(
                 chart2,
                 key="changing_selection_chart",
                 on_select="rerun",
-                selection_mode=selection2,
+                selection_mode="my_interval_selection",
             )
             c2 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
             id2 = c2.id

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -3407,3 +3407,177 @@ class VegaLiteAutosizeTest(DeltaGeneratorTestCase):
         # Layer charts (not nested inside vconcat) should use fit
         assert parsed_spec["autosize"]["type"] == "fit"
         assert parsed_spec["autosize"]["contains"] == "padding"
+
+
+class VegaChartsSelectionsStableIdTest(DeltaGeneratorTestCase):
+    """Tests for element ID stability when selections are enabled for Vega/Altair charts."""
+
+    @unittest.skipIf(
+        is_altair_version_less_than("5.0.0") is True,
+        "This test only runs if altair is >= 5.0.0",
+    )
+    def test_stable_id_with_key_and_selections_altair(self):
+        """Test that the element ID is stable when data changes but key and selection_mode remain the same.
+
+        When selections are enabled and a key is provided, the element ID should remain
+        stable across data changes to preserve selection state.
+        """
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            # First render with certain data
+            df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            point = alt.selection_point(name="my_selection")
+            chart1 = alt.Chart(df1).mark_bar().encode(x="a", y="b").add_params(point)
+            st.altair_chart(
+                chart1,
+                key="selectable_chart",
+                on_select="rerun",
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id1 = c1.id
+
+            # Second render with different data but same key and selection
+            df2 = pd.DataFrame({"x": [10, 20], "y": [30, 40], "z": [50, 60]})
+            chart2 = (
+                alt.Chart(df2)
+                .mark_point()
+                .encode(x="x", y="y", size="z")
+                .add_params(point)
+            )
+            st.altair_chart(
+                chart2,
+                key="selectable_chart",
+                on_select="rerun",
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id2 = c2.id
+
+            # ID should be stable since key and selection_mode are the same
+            assert id1 == id2
+
+    @unittest.skipIf(
+        is_altair_version_less_than("5.0.0") is True,
+        "This test only runs if altair is >= 5.0.0",
+    )
+    def test_stable_id_with_key_and_selections_vega_lite(self):
+        """Test that the element ID is stable for vega_lite_chart when data changes but key remains the same."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            # First render
+            df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            spec = {
+                "mark": "bar",
+                "encoding": {
+                    "x": {"field": "a", "type": "ordinal"},
+                    "y": {"field": "b", "type": "quantitative"},
+                },
+                "params": [{"name": "my_selection", "select": "point"}],
+            }
+            st.vega_lite_chart(
+                df1,
+                spec,
+                key="selectable_vega_chart",
+                on_select="rerun",
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id1 = c1.id
+
+            # Second render with different data but same key and selection mode
+            df2 = pd.DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]})
+            st.vega_lite_chart(
+                df2,
+                spec,
+                key="selectable_vega_chart",
+                on_select="rerun",
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id2 = c2.id
+
+            # ID should be stable since key and selection_mode are the same
+            assert id1 == id2
+
+    @unittest.skipIf(
+        is_altair_version_less_than("5.0.0") is True,
+        "This test only runs if altair is >= 5.0.0",
+    )
+    @parameterized.expand(
+        [
+            (
+                "selection_mode_point_to_interval",
+                "my_point_selection",
+                "my_interval_selection",
+            ),
+        ]
+    )
+    def test_whitelisted_stable_key_kwargs(
+        self, name: str, selection1: str, selection2: str
+    ):
+        """Test that changing selection_mode changes the ID even when a key is provided.
+
+        The selection_mode parameter is whitelisted, meaning changes to it should
+        result in a new element ID.
+        """
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+            # First render with first selection
+            point = alt.selection_point(name=selection1)
+            chart1 = alt.Chart(df).mark_bar().encode(x="a", y="b").add_params(point)
+            st.altair_chart(
+                chart1,
+                key="changing_selection_chart",
+                on_select="rerun",
+                selection_mode=selection1,
+            )
+            c1 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id1 = c1.id
+
+            # Second render with different selection mode
+            interval = alt.selection_interval(name=selection2)
+            chart2 = alt.Chart(df).mark_bar().encode(x="a", y="b").add_params(interval)
+            st.altair_chart(
+                chart2,
+                key="changing_selection_chart",
+                on_select="rerun",
+                selection_mode=selection2,
+            )
+            c2 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id2 = c2.id
+
+            # ID should change since selection_mode changed
+            assert id1 != id2
+
+    @unittest.skipIf(
+        is_altair_version_less_than("5.0.0") is True,
+        "This test only runs if altair is >= 5.0.0",
+    )
+    def test_id_changes_without_key(self):
+        """Test that changing data changes the ID when no key is provided."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            # First render
+            df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            point = alt.selection_point(name="my_selection")
+            chart1 = alt.Chart(df1).mark_bar().encode(x="a", y="b").add_params(point)
+            st.altair_chart(chart1, on_select="rerun")
+            c1 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id1 = c1.id
+
+            # Second render with different data
+            df2 = pd.DataFrame({"x": [10, 20], "y": [30, 40]})
+            chart2 = alt.Chart(df2).mark_point().encode(x="x", y="y").add_params(point)
+            st.altair_chart(chart2, on_select="rerun")
+            c2 = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+            id2 = c2.id
+
+            # ID should change since no key is provided and data changed
+            assert id1 != id2


### PR DESCRIPTION
## Describe your changes

If a custom `key` is passed to a `st.altair_chart` and `st.vega_lite_chart` with selections activated, it will be used as the main identity. This allows for dynamically changing other parameters between reruns without recreating the widgets in the frontend and losing their state.

## GitHub Issue Link (if applicable)

- Related to https://github.com/streamlit/streamlit/issues/11277

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
