### PR TITLE
[fix] Remove "do-not-merge" label when PR is AI approved

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -255,4 +255,7 @@ jobs:
           if [ "$VERDICT" = "CHANGES_REQUESTED" ]; then
             echo "Adding 'do-not-merge' label"
             gh pr edit ${{ env.PR_NUMBER }} --add-label "do-not-merge" --repo ${{ github.repository }}
+          elif [ "$VERDICT" = "APPROVED" ]; then
+            echo "Removing 'do-not-merge' label if present"
+            gh pr edit ${{ env.PR_NUMBER }} --remove-label "do-not-merge" --repo ${{ github.repository }} || true
           fi


### PR DESCRIPTION
## Describe your changes

I noticed while using the `ai-review` label/workflow, if it fails the first time and puts the `do-not-merge` label on a PR, a subsequent approval does not remove that `do-not-merge` label so this PR does just that.



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
