### PR TITLE
Add separate file/image support to chat input

### DIFF
--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -767,9 +767,9 @@ tab_a.write("tab 2 content")
 
 "st.chat_input"
 if st.toggle("Show chat input at the bottom of the screen", False):
-    st.chat_input(accept_file="multiple", disabled=disabled)
+    st.chat_input(accept_image="multiple", disabled=disabled)
 else:
-    st.container().chat_input(accept_file="multiple", disabled=disabled)
+    st.container().chat_input(accept_image="multiple", disabled=disabled)
 
 "st.chat_message"
 st.chat_message("assistant").write("Hello there!")

--- a/e2e_playwright/st_chat_input.py
+++ b/e2e_playwright/st_chat_input.py
@@ -25,7 +25,7 @@ col1, _ = st.columns(2)
 
 v2 = col1.chat_input(
     "Chat input 2 (in column, disabled)",
-    accept_file=True,
+    accept_image=True,
     disabled=True,
     key="chat_input_2",
 )
@@ -54,12 +54,15 @@ if runtime.exists():
 
 
 v4 = st.container().chat_input(
-    "Chat input 4 (single file)", accept_file=True, file_type="txt", key="chat_input_4"
+    "Chat input 4 (single file)",
+    accept_image=True,
+    image_type="txt",
+    key="chat_input_4",
 )
 st.write("Chat input 4 (single file) - value:", v4)
 
 v5 = st.container().chat_input(
-    "Chat input 5 (multiple files)", accept_file="multiple", key="chat_input_5"
+    "Chat input 5 (multiple files)", accept_image="multiple", key="chat_input_5"
 )
 st.write("Chat input 5 (multiple files) - value:", v5)
 
@@ -83,13 +86,13 @@ st.write("Chat input 8 (bottom, max_chars) - value:", v8)
 
 # Directory upload tests
 v9 = st.container().chat_input(
-    "Chat input 9 (directory upload)", accept_file="directory", key="chat_input_9"
+    "Chat input 9 (directory upload)", accept_image="directory", key="chat_input_9"
 )
 st.write("Chat input 9 (directory upload) - value:", v9)
 
 v10 = st.container().chat_input(
     "Chat input 10 (directory upload disabled)",
-    accept_file="directory",
+    accept_image="directory",
     disabled=True,
     key="chat_input_10",
 )
@@ -110,8 +113,8 @@ if st.toggle("Update chat input props"):
         kwargs={"param": "updated kwarg param"},
         # Whitelisted params:
         max_chars=200,
-        accept_file=False,
-        file_type=["txt"],
+        accept_image=False,
+        image_type=["txt"],
     )
     st.write("Updated chat input value:", dyn_val)
 else:
@@ -126,14 +129,14 @@ else:
         kwargs={"param": "initial kwarg param"},
         # Whitelisted params:
         max_chars=200,
-        accept_file=False,
-        file_type=["txt"],
+        accept_image=False,
+        image_type=["txt"],
     )
     st.write("Initial chat input value:", dyn_val)
 
 v11 = st.container().chat_input(
     "Chat input 11 (audio recording)",
-    accept_file="multiple",
+    accept_image="multiple",
     accept_audio=True,
     key="chat_input_11",
 )
@@ -196,7 +199,7 @@ with col_b:
     v15 = st.chat_input(
         "Chat input 15 (w/ files)",
         accept_audio=True,
-        accept_file="multiple",
+        accept_image="multiple",
         key="chat_input_15",
     )
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -48,7 +48,7 @@ const getProps = (
     placeholder: "Enter Text Here",
     disabled: false,
     default: "",
-    acceptFile: ChatInputProto.AcceptFile.NONE,
+    acceptImage: ChatInputProto.AcceptImage.NONE,
     ...elementProps,
   }),
   width: 300,
@@ -304,7 +304,7 @@ describe("ChatInput widget", () => {
   it("disables the textarea and button", () => {
     const props = getProps({
       disabled: true,
-      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      acceptImage: ChatInputProto.AcceptImage.SINGLE,
     })
     render(<ChatInput {...props} />)
 
@@ -374,7 +374,7 @@ describe("ChatInput widget", () => {
     it("disables submit button when files are uploading", async () => {
       const user = userEvent.setup()
       const props = getProps({
-        acceptFile: ChatInputProto.AcceptFile.SINGLE,
+        acceptImage: ChatInputProto.AcceptImage.SINGLE,
         maxUploadSizeMb: 1,
       })
 
@@ -439,8 +439,8 @@ describe("ChatInput widget", () => {
 
   it("displays directory upload button when directory upload is enabled", () => {
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
-      fileType: ["txt", "py", "md"],
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
+      imageType: ["txt", "py", "md"],
     })
 
     render(<ChatInput {...props} />)
@@ -465,8 +465,8 @@ describe("ChatInput widget", () => {
 
     const props = getProps(
       {
-        acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
-        fileType: ["txt", "py", "md"],
+        acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
+        imageType: ["txt", "py", "md"],
       },
       {
         widgetMgr: mockWidgetMgr,
@@ -483,7 +483,9 @@ describe("ChatInput widget", () => {
     expect(fileInput).toHaveAttribute("multiple")
 
     // Verify the component is configured to accept directory uploads
-    expect(props.element.acceptFile).toBe(ChatInputProto.AcceptFile.DIRECTORY)
+    expect(props.element.acceptImage).toBe(
+      ChatInputProto.AcceptImage.DIRECTORY
+    )
 
     // Verify we can still type messages
     const textarea = screen.getByTestId("stChatInputTextArea")
@@ -511,8 +513,8 @@ describe("ChatInput widget", () => {
 
   it("filters directory files by allowed types", () => {
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
-      fileType: ["txt"], // Only allow .txt files
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
+      imageType: ["txt"], // Only allow .txt files
     })
 
     render(<ChatInput {...props} />)
@@ -524,13 +526,13 @@ describe("ChatInput widget", () => {
     expect(fileInput).toHaveAttribute("multiple")
 
     // Verify the component is configured with file type restrictions
-    expect(props.element.fileType).toEqual(["txt"])
+    expect(props.element.imageType).toEqual(["txt"])
   })
 
   it("handles empty directory upload", async () => {
     const user = userEvent.setup()
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
     })
 
     render(<ChatInput {...props} />)
@@ -551,7 +553,7 @@ describe("ChatInput widget", () => {
 
   it("displays directory upload instructions correctly", () => {
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
       placeholder: "Upload a directory",
     })
 
@@ -578,7 +580,7 @@ describe("ChatInput widget", () => {
   it("removes directory files when deleted individually", async () => {
     const user = userEvent.setup()
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
       maxUploadSizeMb: 50,
     })
 
@@ -649,7 +651,7 @@ describe("ChatInput widget", () => {
   it("handles directory upload with multiple files and preserves paths", async () => {
     const user = userEvent.setup()
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
       maxUploadSizeMb: 50,
     })
 
@@ -705,7 +707,7 @@ describe("ChatInput widget", () => {
   it("shows directory structure preservation in file names", async () => {
     const user = userEvent.setup()
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
       maxUploadSizeMb: 50,
     })
 
@@ -735,7 +737,7 @@ describe("ChatInput widget", () => {
   it("enables submit button when directory files are uploaded", async () => {
     const user = userEvent.setup()
     const props = getProps({
-      acceptFile: ChatInputProto.AcceptFile.DIRECTORY,
+      acceptImage: ChatInputProto.AcceptImage.DIRECTORY,
       maxUploadSizeMb: 50,
     })
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -55,7 +55,9 @@ import { FileSize, sizeConverter } from "~lib/util/FileHelper"
 import { isEnterKeyPressed } from "~lib/util/inputUtils"
 import {
   AcceptFileValue,
+  AcceptImageValue,
   chatInputAcceptFileProtoValueToEnum,
+  chatInputAcceptImageProtoValueToEnum,
   isNullOrUndefined,
 } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -149,7 +151,25 @@ function ChatInput({
     return value !== "" || files.length > 0
   }, [files, value])
 
+  const acceptImage = chatInputAcceptImageProtoValueToEnum(element.acceptImage)
   const acceptFile = chatInputAcceptFileProtoValueToEnum(element.acceptFile)
+
+  // Determine if either images or files are accepted
+  const acceptsImages = acceptImage !== AcceptImageValue.None
+  const acceptsFiles = acceptFile !== AcceptFileValue.None
+  const acceptsAnyFiles = acceptsImages || acceptsFiles
+
+  // For upload behavior, use the most permissive setting from either system
+  const acceptMultipleFiles =
+    acceptImage === AcceptImageValue.Multiple ||
+    acceptImage === AcceptImageValue.Directory ||
+    acceptFile === AcceptFileValue.Multiple ||
+    acceptFile === AcceptFileValue.Directory
+
+  const acceptDirectoryFiles =
+    acceptImage === AcceptImageValue.Directory ||
+    acceptFile === AcceptFileValue.Directory
+
   const maxFileSize = sizeConverter(
     element.maxUploadSizeMb,
     FileSize.Megabyte,
@@ -201,10 +221,33 @@ function ChatInput({
     [deleteUploadedFile]
   )
 
-  const createChatInputWidgetFilesValue =
+  const createChatInputWidgetImageValue =
     useCallback((): FileUploaderStateProto => {
+      if (!acceptsImages) {
+        return new FileUploaderStateProto({ uploadedFileInfo: [] })
+      }
+
       const uploadedFileInfo: UploadedFileInfoProto[] = files
         .filter(f => f.status.type === "uploaded")
+        .filter(f => {
+          // Include files in image state only if:
+          // 1. acceptImage is enabled, AND
+          // 2. If acceptFile is also enabled, only include files matching image_type
+          // 3. If acceptFile is not enabled, include all files
+          if (!acceptsFiles) {
+            return true // Include all files if only images are accepted
+          }
+
+          // Both image and file are accepted, so categorize by file extension
+          const fileExtension = f.name.toLowerCase().replace(/.*\./, ".")
+          const imageTypes = element.imageType || []
+
+          // Check if this file matches any image type
+          return imageTypes.some(type => {
+            const normalizedType = type.startsWith(".") ? type : `.${type}`
+            return fileExtension === normalizedType.toLowerCase()
+          })
+        })
         .map(f => {
           const { name, size, status } = f
           const { fileId, fileUrls } = status as UploadedStatus
@@ -217,17 +260,56 @@ function ChatInput({
         })
 
       return new FileUploaderStateProto({ uploadedFileInfo })
-    }, [files])
+    }, [files, acceptsImages, acceptsFiles, element.imageType])
+
+  const createChatInputWidgetFileValue =
+    useCallback((): FileUploaderStateProto => {
+      if (!acceptsFiles) {
+        return new FileUploaderStateProto({ uploadedFileInfo: [] })
+      }
+
+      const uploadedFileInfo: UploadedFileInfoProto[] = files
+        .filter(f => f.status.type === "uploaded")
+        .filter(f => {
+          // Include files in file state only if:
+          // 1. acceptFile is enabled, AND
+          // 2. If acceptImage is also enabled, only include files matching file_type
+          // 3. If acceptImage is not enabled, include all files
+          if (!acceptsImages) {
+            return true // Include all files if only files are accepted
+          }
+
+          // Both image and file are accepted, so categorize by file extension
+          const fileExtension = f.name.toLowerCase().replace(/.*\./, ".")
+          const fileTypes = element.fileType || []
+
+          // Check if this file matches any file type
+          return fileTypes.some(type => {
+            const normalizedType = type.startsWith(".") ? type : `.${type}`
+            return fileExtension === normalizedType.toLowerCase()
+          })
+        })
+        .map(f => {
+          const { name, size, status } = f
+          const { fileId, fileUrls } = status as UploadedStatus
+          return new UploadedFileInfoProto({
+            fileId,
+            fileUrls,
+            name,
+            size,
+          })
+        })
+
+      return new FileUploaderStateProto({ uploadedFileInfo })
+    }, [files, acceptsImages, acceptsFiles, element.fileType])
 
   const getNextLocalFileId = (): number => {
     return counterRef.current++
   }
 
   const dropHandler = createDropHandler({
-    acceptMultipleFiles:
-      acceptFile === AcceptFileValue.Multiple ||
-      acceptFile === AcceptFileValue.Directory,
-    acceptDirectoryFiles: acceptFile === AcceptFileValue.Directory,
+    acceptMultipleFiles,
+    acceptDirectoryFiles,
     maxFileSize: maxFileSize,
     uploadClient: uploadClient,
     uploadFile: createUploadFileHandler({
@@ -299,9 +381,34 @@ function ChatInput({
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: dropHandler,
     multiple:
-      acceptFile === AcceptFileValue.Multiple ||
-      acceptFile === AcceptFileValue.Directory,
-    accept: getAccept(element.fileType),
+      acceptImage === AcceptImageValue.Multiple ||
+      acceptImage === AcceptImageValue.Directory,
+    accept: (() => {
+      // If files are enabled but no file types specified, accept all files
+      if (
+        acceptsFiles &&
+        (!element.fileType || element.fileType.length === 0)
+      ) {
+        return undefined
+      }
+
+      const combinedTypes: string[] = []
+
+      // Add image types if images are enabled
+      if (acceptsImages) {
+        const imageTypes = element.imageType?.length
+          ? element.imageType
+          : [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg"]
+        combinedTypes.push(...imageTypes)
+      }
+
+      // Add file types if files are enabled (we know file types are specified if we reach here)
+      if (acceptsFiles && element.fileType?.length) {
+        combinedTypes.push(...element.fileType)
+      }
+
+      return combinedTypes.length ? getAccept(combinedTypes) : undefined
+    })(),
     maxSize: maxFileSize,
   })
 
@@ -322,11 +429,13 @@ function ChatInput({
         return
       }
 
-      const filesValue = createChatInputWidgetFilesValue()
+      const imageValue = createChatInputWidgetImageValue()
+      const fileValue = createChatInputWidgetFileValue()
 
       const composedValue: IChatInputValue = {
         data: value,
-        fileUploaderState: filesValue,
+        fileUploaderState: fileValue,
+        imageUploaderState: imageValue,
         audioFileInfo: audioInfo,
       }
 
@@ -336,7 +445,26 @@ function ChatInput({
         { fromUi: true },
         fragmentId
       )
-      setFiles([])
+
+      // Clear files based on persistence rules:
+      // - Images are temporary: always clear after submission
+      // - Files are persistent: keep after submission (like st.file_uploader)
+      if (acceptsImages) {
+        setFiles(prevFiles =>
+          acceptsFiles
+            ? // Both enabled: only clear image files, keep non-image files
+              prevFiles.filter(
+                f =>
+                  !f.name
+                    .toLowerCase()
+                    .match(/\.(jpg|jpeg|png|gif|bmp|webp|svg)$/i)
+              )
+            : // Only images enabled: clear all files (images are temporary)
+              []
+        )
+      }
+      // If only files enabled or neither enabled, don't clear files
+
       setValue("")
       autoExpand.clearScrollHeight()
     },
@@ -344,7 +472,10 @@ function ChatInput({
       dirty,
       disabled,
       value,
-      createChatInputWidgetFilesValue,
+      createChatInputWidgetImageValue,
+      createChatInputWidgetFileValue,
+      acceptsImages,
+      acceptsFiles,
       widgetMgr,
       element,
       fragmentId,
@@ -541,13 +672,13 @@ function ChatInput({
     }
   }, [fileDragged, innerWidth, innerHeight])
 
-  const showDropzone = acceptFile !== AcceptFileValue.None && fileDragged
+  const showDropzone = acceptsAnyFiles && fileDragged
 
   return (
     <>
-      {acceptFile === AcceptFileValue.None ? null : (
+      {acceptsAnyFiles ? (
         <ChatUploadedFiles items={[...files]} onDelete={deleteFile} />
-      )}
+      ) : null}
       <StyledChatInputContainer
         className="stChatInput"
         data-testid="stChatInput"
@@ -557,6 +688,7 @@ function ChatInput({
           <ChatFileUploadDropzone
             getRootProps={getRootProps}
             getInputProps={getInputProps}
+            acceptImage={acceptImage}
             acceptFile={acceptFile}
             inputHeight={autoExpand.height}
           />
@@ -573,11 +705,11 @@ function ChatInput({
               <StyledChatAudioWave ref={waveformContainerRef} />
             </StyledWaveformContainer>
 
-            {acceptFile === AcceptFileValue.None ||
-            controller.state === "recording" ? null : (
+            {!acceptsAnyFiles || controller.state === "recording" ? null : (
               <ChatFileUploadButton
                 getRootProps={getRootProps}
                 getInputProps={getInputProps}
+                acceptImage={acceptImage}
                 acceptFile={acceptFile}
                 disabled={disabled}
                 theme={theme}

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadButton.tsx
@@ -23,7 +23,7 @@ import Icon from "~lib/components/shared/Icon"
 import { Placement } from "~lib/components/shared/Tooltip"
 import TooltipIcon from "~lib/components/shared/TooltipIcon"
 import { EmotionTheme } from "~lib/theme"
-import { AcceptFileValue } from "~lib/util/utils"
+import { AcceptFileValue, AcceptImageValue } from "~lib/util/utils"
 
 import {
   configureFileInputProps,
@@ -40,6 +40,7 @@ export interface Props {
   getRootProps: any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getInputProps: any
+  acceptImage: AcceptImageValue
   acceptFile: AcceptFileValue
   disabled: boolean
   theme: EmotionTheme
@@ -48,11 +49,31 @@ export interface Props {
 const ChatFileUploadButton = ({
   getRootProps,
   getInputProps,
+  acceptImage,
   acceptFile,
   disabled,
   theme,
 }: Props): React.ReactElement => {
-  const inputProps = configureFileInputProps(getInputProps(), acceptFile)
+  // Use the primary accept type for configuration
+  const primaryAcceptType =
+    acceptImage !== AcceptImageValue.None ? acceptImage : acceptFile
+  const inputProps = configureFileInputProps(
+    getInputProps(),
+    primaryAcceptType
+  )
+
+  // Determine the description based on what's enabled
+  let description = ""
+  if (
+    acceptImage !== AcceptImageValue.None &&
+    acceptFile !== AcceptFileValue.None
+  ) {
+    description = "files and images"
+  } else if (acceptImage !== AcceptImageValue.None) {
+    description = getUploadDescription(acceptImage)
+  } else {
+    description = getUploadDescription(acceptFile)
+  }
 
   return (
     <StyledFileUploadButtonContainer disabled={disabled}>
@@ -63,7 +84,7 @@ const ChatFileUploadButton = ({
       >
         <input {...inputProps} />
         <TooltipIcon
-          content={`Upload or drag and drop ${getUploadDescription(acceptFile)}`}
+          content={`Upload or drag and drop ${description}`}
           placement={Placement.TOP}
           onMouseEnterDelay={500}
         >

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
@@ -16,7 +16,7 @@
 
 import React, { memo } from "react"
 
-import { AcceptFileValue } from "~lib/util/utils"
+import { AcceptFileValue, AcceptImageValue } from "~lib/util/utils"
 
 import {
   configureFileInputProps,
@@ -32,6 +32,7 @@ export interface Props {
   getRootProps: any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
   getInputProps: any
+  acceptImage: AcceptImageValue
   acceptFile: AcceptFileValue
   inputHeight: string
 }
@@ -39,10 +40,30 @@ export interface Props {
 const ChatFileUploadDropzone = ({
   getRootProps,
   getInputProps,
+  acceptImage,
   acceptFile,
   inputHeight,
 }: Props): React.ReactElement => {
-  const inputProps = configureFileInputProps(getInputProps(), acceptFile)
+  // Use the primary accept type for configuration
+  const primaryAcceptType =
+    acceptImage !== AcceptImageValue.None ? acceptImage : acceptFile
+  const inputProps = configureFileInputProps(
+    getInputProps(),
+    primaryAcceptType
+  )
+
+  // Determine the description based on what's enabled
+  let description = ""
+  if (
+    acceptImage !== AcceptImageValue.None &&
+    acceptFile !== AcceptFileValue.None
+  ) {
+    description = "files and images"
+  } else if (acceptImage !== AcceptImageValue.None) {
+    description = getUploadDescription(acceptImage)
+  } else {
+    description = getUploadDescription(acceptFile)
+  }
 
   return (
     <>
@@ -50,7 +71,7 @@ const ChatFileUploadDropzone = ({
         <input {...inputProps} />
       </StyledChatFileUploadDropzone>
       <StyledChatFileUploadDropzoneLabel height={inputHeight}>
-        {`Drag and drop ${getUploadDescription(acceptFile)} here`}
+        {`Drag and drop ${description} here`}
       </StyledChatFileUploadDropzoneLabel>
     </>
   )

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
@@ -53,7 +53,7 @@ const filterDirectoryFiles = (
   const rejected: FileRejection[] = []
 
   files.forEach(file => {
-    const validation = validateFileType(file, element.fileType)
+    const validation = validateFileType(file, element.imageType)
     if (validation.isValid) {
       accepted.push(file)
     } else {

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.test.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from "vitest"
 
 import { createTestFile } from "~lib/test_util"
-import { AcceptFileValue } from "~lib/util/utils"
+import { AcceptImageValue } from "~lib/util/utils"
 
 import {
   configureFileInputProps,
@@ -122,22 +122,22 @@ describe("fileUploadUtils", () => {
   })
 
   describe("getUploadDescription", () => {
-    it("returns correct description for single file", () => {
-      expect(getUploadDescription(AcceptFileValue.Single)).toBe("a file")
+    it("returns correct description for single image", () => {
+      expect(getUploadDescription(AcceptImageValue.Single)).toBe("an image")
     })
 
-    it("returns correct description for multiple files", () => {
-      expect(getUploadDescription(AcceptFileValue.Multiple)).toBe("files")
+    it("returns correct description for multiple images", () => {
+      expect(getUploadDescription(AcceptImageValue.Multiple)).toBe("images")
     })
 
     it("returns correct description for directory", () => {
-      expect(getUploadDescription(AcceptFileValue.Directory)).toBe(
+      expect(getUploadDescription(AcceptImageValue.Directory)).toBe(
         "a directory"
       )
     })
 
     it("returns correct description for none", () => {
-      expect(getUploadDescription(AcceptFileValue.None)).toBe("a file")
+      expect(getUploadDescription(AcceptImageValue.None)).toBe("an image")
     })
   })
 
@@ -146,7 +146,7 @@ describe("fileUploadUtils", () => {
       const inputProps = { accept: ".txt" }
       const result = configureFileInputProps(
         inputProps,
-        AcceptFileValue.Directory
+        AcceptImageValue.Directory
       )
       expect(result.webkitdirectory).toBe("")
       expect(result.multiple).toBe(true)
@@ -157,17 +157,17 @@ describe("fileUploadUtils", () => {
       const inputProps = { accept: ".pdf", multiple: false }
       const result = configureFileInputProps(
         inputProps,
-        AcceptFileValue.Single
+        AcceptImageValue.Single
       )
       expect(result).toEqual(inputProps)
       expect(result.webkitdirectory).toBeUndefined()
     })
 
-    it("preserves original props for multiple file uploads", () => {
+    it("preserves original props for multiple image uploads", () => {
       const inputProps = { accept: ".jpg,.png", multiple: true }
       const result = configureFileInputProps(
         inputProps,
-        AcceptFileValue.Multiple
+        AcceptImageValue.Multiple
       )
       expect(result).toEqual(inputProps)
       expect(result.webkitdirectory).toBeUndefined()

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { assertNever } from "~lib/util/assertNever"
-import { AcceptFileValue } from "~lib/util/utils"
+import { AcceptFileValue, AcceptImageValue } from "~lib/util/utils"
 
 /**
  * Configures input props for file upload based on the accept file type.
@@ -23,10 +22,13 @@ import { AcceptFileValue } from "~lib/util/utils"
  */
 export const configureFileInputProps = (
   inputProps: Record<string, unknown>,
-  acceptFile: AcceptFileValue
+  acceptType: AcceptImageValue | AcceptFileValue
 ): Record<string, unknown> => {
   // Apply webkitdirectory attribute for directory uploads
-  if (acceptFile === AcceptFileValue.Directory) {
+  if (
+    acceptType === AcceptImageValue.Directory ||
+    acceptType === AcceptFileValue.Directory
+  ) {
     return {
       ...inputProps,
       webkitdirectory: "",
@@ -92,8 +94,29 @@ export const validateFileType = (
 /**
  * Gets a human-readable description for the upload type.
  */
-export const getUploadDescription = (acceptFile: AcceptFileValue): string => {
-  switch (acceptFile) {
+export const getUploadDescription = (
+  acceptType: AcceptImageValue | AcceptFileValue
+): string => {
+  // Handle AcceptImageValue cases
+  if (
+    Object.values(AcceptImageValue).includes(acceptType as AcceptImageValue)
+  ) {
+    switch (acceptType as AcceptImageValue) {
+      case AcceptImageValue.None:
+        return "an image"
+      case AcceptImageValue.Single:
+        return "an image"
+      case AcceptImageValue.Multiple:
+        return "images"
+      case AcceptImageValue.Directory:
+        return "a directory"
+      default:
+        return "an image"
+    }
+  }
+
+  // Handle AcceptFileValue cases
+  switch (acceptType as AcceptFileValue) {
     case AcceptFileValue.None:
       return "a file"
     case AcceptFileValue.Single:
@@ -103,7 +126,6 @@ export const getUploadDescription = (acceptFile: AcceptFileValue): string => {
     case AcceptFileValue.Directory:
       return "a directory"
     default:
-      assertNever(acceptFile)
       return "a file"
   }
 }

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -455,6 +455,31 @@ export function labelVisibilityProtoValueToEnum(
   }
 }
 
+export enum AcceptImageValue {
+  None,
+  Single,
+  Multiple,
+  Directory,
+}
+
+export function chatInputAcceptImageProtoValueToEnum(
+  value: ChatInputProto.AcceptImage
+): AcceptImageValue {
+  switch (value) {
+    case ChatInputProto.AcceptImage.NONE:
+      return AcceptImageValue.None
+    case ChatInputProto.AcceptImage.SINGLE:
+      return AcceptImageValue.Single
+    case ChatInputProto.AcceptImage.MULTIPLE:
+      return AcceptImageValue.Multiple
+    case ChatInputProto.AcceptImage.DIRECTORY:
+      return AcceptImageValue.Directory
+    default:
+      assertNever(value)
+      return AcceptImageValue.None
+  }
+}
+
 export enum AcceptFileValue {
   None,
   Single,
@@ -466,13 +491,13 @@ export function chatInputAcceptFileProtoValueToEnum(
   value: ChatInputProto.AcceptFile
 ): AcceptFileValue {
   switch (value) {
-    case ChatInputProto.AcceptFile.NONE:
+    case ChatInputProto.AcceptFile.FILE_NONE:
       return AcceptFileValue.None
-    case ChatInputProto.AcceptFile.SINGLE:
+    case ChatInputProto.AcceptFile.FILE_SINGLE:
       return AcceptFileValue.Single
-    case ChatInputProto.AcceptFile.MULTIPLE:
+    case ChatInputProto.AcceptFile.FILE_MULTIPLE:
       return AcceptFileValue.Multiple
-    case ChatInputProto.AcceptFile.DIRECTORY:
+    case ChatInputProto.AcceptFile.FILE_DIRECTORY:
       return AcceptFileValue.Directory
     default:
       assertNever(value)

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -81,19 +81,36 @@ def get_label_visibility_proto_value(
     raise ValueError(f"Unknown label visibility value: {label_visibility_string}")
 
 
+def get_chat_input_accept_image_proto_value(
+    accept_image_value: Literal["multiple", "directory"] | bool | None,
+) -> ChatInput.AcceptImage.ValueType:
+    """Returns one of ChatInput.AcceptImage enum value based on string value."""
+
+    if accept_image_value is False or accept_image_value is None:
+        return ChatInput.AcceptImage.NONE
+    if accept_image_value is True:
+        return ChatInput.AcceptImage.SINGLE
+    if accept_image_value == "multiple":
+        return ChatInput.AcceptImage.MULTIPLE
+    if accept_image_value == "directory":
+        return ChatInput.AcceptImage.DIRECTORY
+
+    raise ValueError(f"Unknown accept image value: {accept_image_value}")
+
+
 def get_chat_input_accept_file_proto_value(
     accept_file_value: Literal["multiple", "directory"] | bool,
 ) -> ChatInput.AcceptFile.ValueType:
     """Returns one of ChatInput.AcceptFile enum value based on string value."""
 
     if accept_file_value is False:
-        return ChatInput.AcceptFile.NONE
+        return ChatInput.AcceptFile.FILE_NONE
     if accept_file_value is True:
-        return ChatInput.AcceptFile.SINGLE
+        return ChatInput.AcceptFile.FILE_SINGLE
     if accept_file_value == "multiple":
-        return ChatInput.AcceptFile.MULTIPLE
+        return ChatInput.AcceptFile.FILE_MULTIPLE
     if accept_file_value == "directory":
-        return ChatInput.AcceptFile.DIRECTORY
+        return ChatInput.AcceptFile.FILE_DIRECTORY
 
     raise ValueError(f"Unknown accept file value: {accept_file_value}")
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, MutableMapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -44,6 +44,7 @@ from streamlit.elements.lib.utils import (
     Key,
     compute_and_register_element_id,
     get_chat_input_accept_file_proto_value,
+    get_chat_input_accept_image_proto_value,
     save_for_app_testing,
     to_key,
 )
@@ -97,8 +98,10 @@ class ChatInputValue(MutableMapping[str, Any]):
     ----------
     text : str
         The text input provided by the user.
+    images : list[UploadedFile]
+        A list of image files uploaded by the user via accept_image (one-time use).
     files : list[UploadedFile]
-        A list of files uploaded by the user.
+        A list of files uploaded by the user via accept_file (persistent).
     audio : UploadedFile or None, optional
         An audio recording uploaded by the user, if any.
 
@@ -109,7 +112,8 @@ class ChatInputValue(MutableMapping[str, Any]):
     """
 
     text: str
-    files: list[UploadedFile]
+    images: list[UploadedFile] = field(default_factory=list)
+    files: list[UploadedFile] = field(default_factory=list)
     audio: UploadedFile | None = None
 
     def __len__(self) -> int:
@@ -309,21 +313,39 @@ def _pop_audio_file(
 
 @dataclass
 class ChatInputSerde:
+    accept_images: bool = False
     accept_files: bool = False
     accept_audio: bool = False
-    allowed_types: Sequence[str] | None = None
+    allowed_image_types: Sequence[str] | None = None
+    allowed_file_types: Sequence[str] | None = None
 
     def deserialize(
         self, ui_value: ChatInputValueProto | None
     ) -> str | ChatInputValue | None:
         if ui_value is None or not ui_value.HasField("data"):
             return None
-        if not self.accept_files and not self.accept_audio:
+        if not self.accept_images and not self.accept_files and not self.accept_audio:
             return ui_value.data
-        uploaded_files = _pop_upload_files(ui_value.file_uploader_state)
+
+        # Extract image files from image_uploader_state
+        uploaded_images = (
+            _pop_upload_files(ui_value.image_uploader_state)
+            if ui_value.HasField("image_uploader_state")
+            else []
+        )
+        for file in uploaded_images:
+            if self.allowed_image_types and not isinstance(file, DeletedFile):
+                enforce_filename_restriction(file.name, self.allowed_image_types)
+
+        # Extract regular files from file_uploader_state
+        uploaded_files = (
+            _pop_upload_files(ui_value.file_uploader_state)
+            if ui_value.HasField("file_uploader_state")
+            else []
+        )
         for file in uploaded_files:
-            if self.allowed_types and not isinstance(file, DeletedFile):
-                enforce_filename_restriction(file.name, self.allowed_types)
+            if self.allowed_file_types and not isinstance(file, DeletedFile):
+                enforce_filename_restriction(file.name, self.allowed_file_types)
 
         # Extract audio file separately from the audio_file_info field
         audio_file = _pop_audio_file(
@@ -332,6 +354,7 @@ class ChatInputSerde:
 
         return ChatInputValue(
             text=ui_value.data,
+            images=uploaded_images,
             files=uploaded_files,
             audio=audio_file,
         )
@@ -492,6 +515,8 @@ class ChatMixin:
         *,
         key: Key | None = None,
         max_chars: int | None = None,
+        accept_image: Literal[False] | None = False,
+        image_type: str | Sequence[str] | None = None,
         accept_file: Literal[False] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: Literal[False] = False,
@@ -509,6 +534,8 @@ class ChatMixin:
         *,
         key: Key | None = None,
         max_chars: int | None = None,
+        accept_image: Literal[False] | None = False,
+        image_type: str | Sequence[str] | None = None,
         accept_file: Literal[False] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: Literal[True],
@@ -526,6 +553,46 @@ class ChatMixin:
         *,
         key: Key | None = None,
         max_chars: int | None = None,
+        accept_image: Literal[True, "multiple", "directory"],
+        image_type: str | Sequence[str] | None = None,
+        accept_file: Literal[False] = False,
+        file_type: str | Sequence[str] | None = None,
+        accept_audio: bool = False,
+        disabled: bool = False,
+        on_submit: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        width: WidthWithoutContent = "stretch",
+    ) -> ChatInputValue | None: ...
+
+    @overload
+    def chat_input(
+        self,
+        placeholder: str = "Your message",
+        *,
+        key: Key | None = None,
+        max_chars: int | None = None,
+        accept_image: Literal[False] | None = False,
+        image_type: str | Sequence[str] | None = None,
+        accept_file: Literal[True, "multiple", "directory"],
+        file_type: str | Sequence[str] | None = None,
+        accept_audio: bool = False,
+        disabled: bool = False,
+        on_submit: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        width: WidthWithoutContent = "stretch",
+    ) -> ChatInputValue | None: ...
+
+    @overload
+    def chat_input(
+        self,
+        placeholder: str = "Your message",
+        *,
+        key: Key | None = None,
+        max_chars: int | None = None,
+        accept_image: Literal[True, "multiple", "directory"],
+        image_type: str | Sequence[str] | None = None,
         accept_file: Literal[True, "multiple", "directory"],
         file_type: str | Sequence[str] | None = None,
         accept_audio: bool = False,
@@ -543,6 +610,8 @@ class ChatMixin:
         *,
         key: Key | None = None,
         max_chars: int | None = None,
+        accept_image: bool | Literal["multiple", "directory"] | None = False,
+        image_type: str | Sequence[str] | None = None,
         accept_file: bool | Literal["multiple", "directory"] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: bool = False,
@@ -570,12 +639,51 @@ class ChatMixin:
             The maximum number of characters that can be entered. If this is
             ``None`` (default), there will be no maximum.
 
-        accept_file : bool, "multiple", or "directory"
-            Whether the chat input should accept files. This can be one of the
+        accept_image : bool, "multiple", or "directory"
+            Whether the chat input should accept images. This can be one of the
             following values:
 
-            - ``False`` (default): No files are accepted and the user can only
+            - ``False`` (default): No images are accepted and the user can only
               submit a message.
+            - ``True``: The user can add a single image to their submission.
+            - ``"multiple"``: The user can add multiple images to their
+              submission.
+            - ``"directory"``: The user can add multiple images to their
+              submission by selecting a directory. If ``image_type`` is set,
+              only images matching those type(s) will be uploaded.
+
+            By default, uploaded images are limited to 200 MB each. You can
+            configure this using the ``server.maxUploadSize`` config option.
+            For more information on how to set config options, see
+            |config.toml|_.
+
+            .. |config.toml| replace:: ``config.toml``
+            .. _config.toml: https://docs.streamlit.io/develop/api-reference/configuration/config.toml
+
+        image_type : str, Sequence[str], or None
+            The allowed image extension(s) for uploaded images. This can be one
+            of the following types:
+
+            - ``None`` (default): All image extensions are allowed.
+            - A string: A single image extension is allowed. For example, to
+              only accept PNG images, use ``"png"``.
+            - A sequence of strings: Multiple image extensions are allowed. For
+              example, to only accept JPG/JPEG and PNG images, use
+              ``["jpg", "jpeg", "png"]``.
+
+            .. note::
+                This is a best-effort check, but doesn't provide a
+                security guarantee against users uploading images of other types
+                or type extensions. The correct handling of uploaded images is
+                part of the app developer's responsibility.
+
+        accept_file : bool, "multiple", or "directory"
+            Whether the chat input should accept files for persistent use.
+            Unlike images (accept_image), files uploaded via this parameter
+            remain attached after message submission, similar to st.file_uploader
+            behavior. This can be one of the following values:
+
+            - ``False`` (default): No files are accepted.
             - ``True``: The user can add a single file to their submission.
             - ``"multiple"``: The user can add multiple files to their
               submission.
@@ -585,11 +693,6 @@ class ChatMixin:
 
             By default, uploaded files are limited to 200 MB each. You can
             configure this using the ``server.maxUploadSize`` config option.
-            For more information on how to set config options, see
-            |config.toml|_.
-
-            .. |config.toml| replace:: ``config.toml``
-            .. _config.toml: https://docs.streamlit.io/develop/api-reference/configuration/config.toml
 
         file_type : str, Sequence[str], or None
             The allowed file extension(s) for uploaded files. This can be one
@@ -599,8 +702,7 @@ class ChatMixin:
             - A string: A single file extension is allowed. For example, to
               only accept CSV files, use ``"csv"``.
             - A sequence of strings: Multiple file extensions are allowed. For
-              example, to only accept JPG/JPEG and PNG files, use
-              ``["jpg", "jpeg", "png"]``.
+              example, to only accept text and CSV files, use ``["txt", "csv"]``.
 
             .. note::
                 This is a best-effort check, but doesn't provide a
@@ -646,28 +748,34 @@ class ChatMixin:
         None, str, or dict-like
             The user's submission. This is one of the following types:
 
-            - ``None``: If the user didn't submit a message, file, or audio
+            - ``None``: If the user didn't submit a message, image, file, or audio
               in the last rerun, the widget returns ``None``.
-            - A string: When the widget is not configured to accept files or
-              audio and the user submitted a message in the last rerun, the
+            - A string: When the widget is not configured to accept images, files,
+              or audio and the user submitted a message in the last rerun, the
               widget returns the user's message as a string.
-            - A dict-like object: When the widget is configured to accept files
-              and/or audio and the user submitted a message and/or file(s)
-              and/or audio in the last rerun, the widget returns a dict-like
-              object with three attributes: ``text``, ``files``, and ``audio``.
+            - A dict-like object: When the widget is configured to accept images,
+              files, and/or audio and the user submitted a message and/or image(s)
+              and/or file(s) and/or audio in the last rerun, the widget returns
+              a dict-like object with four attributes: ``text``, ``images``,
+              ``files``, and ``audio``.
 
-            When the widget is configured to accept files or audio and the user
-            submits something in the last rerun, you can access the user's
-            submission with key or attribute notation from the dict-like object.
-            This is shown in Example 3 below.
+            When the widget is configured to accept images, files, or audio and
+            the user submits something in the last rerun, you can access the
+            user's submission with key or attribute notation from the dict-like
+            object. This is shown in Example 3 below.
 
             The ``text`` attribute holds a string, which is the user's message.
-            This is an empty string if the user only submitted one or more
-            files or audio.
+            This is an empty string if the user only submitted images, files,
+            or audio.
 
-            The ``files`` attribute holds a list of UploadedFile objects.
-            The list is empty if the user only submitted a message or audio.
-            Unlike ``st.file_uploader``, this attribute always returns a list,
+            The ``images`` attribute holds a list of ``UploadedFile`` objects
+            containing image files uploaded via ``accept_image``. These images
+            are cleared after each submission (one-time use).
+
+            The ``files`` attribute holds a list of ``UploadedFile`` objects
+            containing files uploaded via ``accept_file``. These files persist
+            across submissions until manually removed by the user. Unlike
+            ``st.file_uploader``, this attribute always returns a list,
             even when the widget is configured to accept only one file at a time.
 
             The ``audio`` attribute holds an UploadedFile object representing
@@ -714,26 +822,32 @@ class ChatMixin:
             https://doc-chat-input-inline.streamlit.app/
             height: 350px
 
-        **Example 3: Let users upload files**
+        **Example 3: Let users upload images and files**
 
-        When you configure your chat input widget to allow file attachments, it
-        will return a dict-like object when the user sends a submission. You
+        When you configure your chat input widget to allow image and file attachments,
+        it will return a dict-like object when the user sends a submission. You
         can access the user's message through the ``text`` attribute of this
-        dictionary. You can access a list of the user's submitted file(s)
-        through the ``files`` attribute. Similar to ``st.session_state``, you
-        can use key or attribute notation.
+        dictionary. You can access a list of the user's submitted image(s)
+        through the ``images`` attribute and files through the ``files`` attribute.
+        Similar to ``st.session_state``, you can use key or attribute notation.
 
         >>> import streamlit as st
         >>>
         >>> prompt = st.chat_input(
-        >>>     "Say something and/or attach an image",
-        >>>     accept_file=True,
-        >>>     file_type=["jpg", "jpeg", "png"],
+        >>>     "Say something and/or attach images/files",
+        >>>     accept_image=True,
+        >>>     image_type=["jpg", "jpeg", "png"],
+        >>>     accept_file="multiple",
+        >>>     file_type=["txt", "csv", "pdf"],
         >>> )
         >>> if prompt and prompt.text:
         >>>     st.markdown(prompt.text)
+        >>> if prompt and prompt["images"]:
+        >>>     st.image(prompt["images"][0])
         >>> if prompt and prompt["files"]:
-        >>>     st.image(prompt["files"][0])
+        >>>     st.write(f"Uploaded {len(prompt.files)} file(s)")
+        >>>     for file in prompt.files:
+        >>>         st.write(f"- {file.name}")
 
         .. output ::
             https://doc-chat-input-file-uploader.streamlit.app/
@@ -757,8 +871,9 @@ class ChatMixin:
         **Example 5: Enable audio recording**
 
         You can enable audio recording by setting ``accept_audio=True``.
-        The ``accept_audio`` parameter works independently of ``accept_file``,
-        allowing you to enable audio recording with or without file uploads.
+        The ``accept_audio`` parameter works independently of ``accept_image``
+        and ``accept_file``, allowing you to enable audio recording with or
+        without image/file uploads.
 
         >>> import streamlit as st
         >>>
@@ -783,7 +898,12 @@ class ChatMixin:
             writes_allowed=True,
         )
 
-        if accept_file not in {True, False, "multiple", "directory"}:
+        if accept_image not in {None, True, False, "multiple", "directory"}:
+            raise StreamlitAPIException(
+                "The `accept_image` parameter must be a boolean or 'multiple' or 'directory'."
+            )
+
+        if accept_file not in {None, True, False, "multiple", "directory"}:
             raise StreamlitAPIException(
                 "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
             )
@@ -796,21 +916,46 @@ class ChatMixin:
             # Treat the provided key as the main identity. Only include
             # properties that can invalidate the current widget state
             # when changed. For chat_input, those are:
+            # - accept_image: Changes whether images can be attached (and how)
+            # - image_type: Restricts the accepted image types
             # - accept_file: Changes whether files can be attached (and how)
             # - file_type: Restricts the accepted file types
             # - max_chars: Changes the maximum allowed characters for the input
-            key_as_main_identity={"accept_file", "file_type", "max_chars"},
+            key_as_main_identity={
+                "accept_image",
+                "image_type",
+                "accept_file",
+                "file_type",
+                "max_chars",
+            },
             dg=self.dg,
             placeholder=placeholder,
             max_chars=max_chars,
+            accept_image=accept_image,
+            image_type=image_type,
             accept_file=accept_file,
             file_type=file_type,
             accept_audio=accept_audio,
             width=width,
         )
 
+        if image_type:
+            image_type = normalize_upload_file_type(image_type)
+
         if file_type:
             file_type = normalize_upload_file_type(file_type)
+
+        # Validate that image_type and file_type don't have overlapping extensions
+        if image_type and file_type:
+            image_extensions = set(image_type)
+            file_extensions = set(file_type)
+            overlapping_extensions = image_extensions.intersection(file_extensions)
+            if overlapping_extensions:
+                extensions_str = ", ".join(sorted(overlapping_extensions))
+                raise StreamlitAPIException(
+                    f"File extensions cannot be specified in both `image_type` and `file_type` parameters. "
+                    f"Overlapping extensions: {extensions_str}"
+                )
 
         # It doesn't make sense to create a chat input inside a form.
         # We throw an error to warn the user about this.
@@ -844,6 +989,12 @@ class ChatMixin:
         # Setting a default value is currently not supported for chat input.
         chat_input_proto.default = ""
 
+        chat_input_proto.accept_image = get_chat_input_accept_image_proto_value(
+            accept_image
+        )
+
+        chat_input_proto.image_type[:] = image_type if image_type is not None else []
+
         chat_input_proto.accept_file = get_chat_input_accept_file_proto_value(
             accept_file
         )
@@ -853,9 +1004,11 @@ class ChatMixin:
         chat_input_proto.accept_audio = accept_audio
 
         serde = ChatInputSerde(
+            accept_images=accept_image in {True, "multiple", "directory"},
             accept_files=accept_file in {True, "multiple", "directory"},
             accept_audio=accept_audio,
-            allowed_types=file_type,
+            allowed_image_types=image_type,
+            allowed_file_types=file_type,
         )
         widget_state = register_widget(  # type: ignore[misc]
             chat_input_proto.id,

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -139,9 +139,9 @@ class ChatTest(DeltaGeneratorTestCase):
         assert c.value == ""
         assert not c.set_value
         assert c.max_chars == 100
-        assert c.accept_file == ChatInput.AcceptFile.NONE
+        assert c.accept_image == ChatInput.AcceptImage.NONE
         assert not c.disabled
-        assert c.file_type == []
+        assert c.image_type == []
 
     def test_chat_not_allowed_in_form(self):
         """Test that it disallows being called in a form."""
@@ -210,30 +210,31 @@ class ChatTest(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (False, ChatInput.AcceptFile.NONE),
-            (True, ChatInput.AcceptFile.SINGLE),
-            ("multiple", ChatInput.AcceptFile.MULTIPLE),
+            (None, ChatInput.AcceptImage.NONE),
+            (False, ChatInput.AcceptImage.NONE),
+            (True, ChatInput.AcceptImage.SINGLE),
+            ("multiple", ChatInput.AcceptImage.MULTIPLE),
         ]
     )
-    def test_chat_input_accept_file(self, accept_file, expected):
-        st.chat_input(accept_file=accept_file)
+    def test_chat_input_accept_image(self, accept_image, expected):
+        st.chat_input(accept_image=accept_image)
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == expected
+        assert c.accept_image == expected
 
-    def test_chat_input_invalid_accept_file(self):
+    def test_chat_input_invalid_accept_image(self):
         with pytest.raises(StreamlitAPIException) as ex:
-            st.chat_input(accept_file="invalid")
+            st.chat_input(accept_image="invalid")
 
         assert (
             str(ex.value)
-            == "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
+            == "The `accept_image` parameter must be a boolean or 'multiple' or 'directory'."
         )
 
-    def test_file_type(self):
+    def test_image_type(self):
         """Test that it can be called using string(s) for type parameter."""
-        st.chat_input(file_type="png")
+        st.chat_input(image_type="png")
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.file_type == [".png"]
+        assert c.image_type == [".png"]
 
     @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
     def test_multiple_files(self, deserialize_patch):
@@ -253,7 +254,7 @@ class ChatTest(DeltaGeneratorTestCase):
             text="placeholder", files=uploaded_files
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_image="multiple")
 
         assert return_val.files == uploaded_files
         for actual, expected in zip(return_val.files, uploaded_files, strict=False):
@@ -287,8 +288,8 @@ class ChatTest(DeltaGeneratorTestCase):
         # These file_uploaders have different labels so that we don't cause
         # a DuplicateKey error - but because we're patching the get_files
         # function, both file_uploaders will refer to the same files.
-        file0 = st.chat_input(key="key0", accept_file=True).files[0]
-        file1 = st.chat_input(key="key1", accept_file=True).files[0]
+        file0 = st.chat_input(key="key0", accept_image=True).files[0]
+        file1 = st.chat_input(key="key1", accept_image=True).files[0]
 
         assert id(file0) != id(file1)
 
@@ -308,10 +309,10 @@ class ChatTest(DeltaGeneratorTestCase):
         ]
         deserialize_patch.return_value = ChatInputValue(text="placeholder", files=files)
 
-        value = st.chat_input("Placeholder", accept_file=True)
+        value = st.chat_input("Placeholder", accept_image=True)
         assert is_custom_dict(value)
 
-        value = st.chat_input("Placeholder", accept_file="multiple")
+        value = st.chat_input("Placeholder", accept_image="multiple")
         assert is_custom_dict(value)
 
     def test_chat_message_width_config_default(self):
@@ -427,12 +428,12 @@ class ChatTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (
-                "accept_file",
+                "accept_image",
                 True,
                 "multiple",
             ),
             (
-                "file_type",
+                "image_type",
                 ["txt"],
                 ["csv"],
             ),
@@ -455,8 +456,8 @@ class ChatTest(DeltaGeneratorTestCase):
                 "placeholder": "Label 1",
                 "key": "chat_input_key",
                 # Keep other whitelisted params stable depending on the tested kwarg
-                "accept_file": True,
-                "file_type": ["txt"],
+                "accept_image": True,
+                "image_type": ["txt"],
                 "max_chars": 100,
             }
             base_kwargs[kwarg_name] = value1
@@ -487,8 +488,8 @@ class ChatTest(DeltaGeneratorTestCase):
                 args=("arg1", "arg2"),
                 kwargs={"kwarg1": "kwarg1"},
                 # Whitelisted kwargs (keep stable):
-                accept_file=True,
-                file_type=["txt"],
+                accept_image=True,
+                image_type=["txt"],
                 max_chars=100,
             )
             c1 = self.get_delta_from_queue().new_element.chat_input
@@ -504,8 +505,8 @@ class ChatTest(DeltaGeneratorTestCase):
                 args=("arg_1", "arg_2"),
                 kwargs={"kwarg_1": "kwarg_1"},
                 # Keep whitelisted the same to ensure ID stability
-                accept_file=True,
-                file_type=["txt"],
+                accept_image=True,
+                image_type=["txt"],
                 max_chars=100,
             )
             c2 = self.get_delta_from_queue().new_element.chat_input
@@ -537,73 +538,73 @@ class ChatTest(DeltaGeneratorTestCase):
         assert c.placeholder == "the label"
         assert c.max_chars == 10
 
-    def test_accept_file_single(self):
-        """Test st.chat_input with accept_file=True."""
-        st.chat_input("the label", accept_file=True, file_type=["txt", "csv"])
+    def test_accept_image_single(self):
+        """Test st.chat_input with accept_image=True."""
+        st.chat_input("the label", accept_image=True, image_type=["txt", "csv"])
 
         c = self.get_delta_from_queue().new_element.chat_input
         assert c.placeholder == "the label"
-        assert c.accept_file == ChatInput.AcceptFile.SINGLE
-        assert c.file_type == [".txt", ".csv"]
+        assert c.accept_image == ChatInput.AcceptImage.SINGLE
+        assert c.image_type == [".txt", ".csv"]
 
-    def test_accept_file_multiple(self):
-        """Test st.chat_input with accept_file='multiple'."""
-        st.chat_input("the label", accept_file="multiple", file_type=["txt"])
+    def test_accept_image_multiple(self):
+        """Test st.chat_input with accept_image='multiple'."""
+        st.chat_input("the label", accept_image="multiple", image_type=["txt"])
 
         c = self.get_delta_from_queue().new_element.chat_input
         assert c.placeholder == "the label"
-        assert c.accept_file == ChatInput.AcceptFile.MULTIPLE
-        assert c.file_type == [".txt"]
+        assert c.accept_image == ChatInput.AcceptImage.MULTIPLE
+        assert c.image_type == [".txt"]
 
-    def test_accept_file_directory(self):
-        """Test st.chat_input with accept_file='directory'."""
+    def test_accept_image_directory(self):
+        """Test st.chat_input with accept_image='directory'."""
         st.chat_input(
-            "the label", accept_file="directory", file_type=["py", "md", "txt"]
+            "the label", accept_image="directory", image_type=["py", "md", "txt"]
         )
 
         c = self.get_delta_from_queue().new_element.chat_input
         assert c.placeholder == "the label"
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
-        assert c.file_type == [".py", ".md", ".txt"]
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
+        assert c.image_type == [".py", ".md", ".txt"]
 
-    def test_directory_upload_with_no_file_type(self):
+    def test_directory_upload_no_image_type_restriction(self):
         """Test directory upload without file type restrictions."""
-        st.chat_input("Upload any directory", accept_file="directory")
+        st.chat_input("Upload any directory", accept_image="directory")
 
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
-        assert c.file_type == []  # No restrictions
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
+        assert c.image_type == []  # No restrictions
 
     def test_directory_upload_with_width(self):
         """Test directory upload with width parameter."""
-        st.chat_input("Directory chat", accept_file="directory", width=400)
+        st.chat_input("Directory chat", accept_image="directory", width=400)
 
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
 
     def test_directory_upload_disabled(self):
         """Test disabled directory upload."""
-        st.chat_input("Disabled directory", accept_file="directory", disabled=True)
+        st.chat_input("Disabled directory", accept_image="directory", disabled=True)
 
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
         assert c.disabled
 
     def test_directory_upload_with_max_chars(self):
         """Test directory upload with character limit."""
-        st.chat_input("Limited text", accept_file="directory", max_chars=100)
+        st.chat_input("Limited text", accept_image="directory", max_chars=100)
 
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
         assert c.max_chars == 100
 
-    def test_accept_file_invalid_value(self):
-        """Test that invalid accept_file values raise an error."""
+    def test_accept_image_invalid_value(self):
+        """Test that invalid accept_image values raise an error."""
         with pytest.raises(StreamlitAPIException) as cm:
-            st.chat_input("the label", accept_file="invalid")
+            st.chat_input("the label", accept_image="invalid")
 
         assert (
-            "The `accept_file` parameter must be a boolean or 'multiple' or 'directory'."
+            "The `accept_image` parameter must be a boolean or 'multiple' or 'directory'."
             in str(cm.value)
         )
 
@@ -614,24 +615,24 @@ class ChatTest(DeltaGeneratorTestCase):
             pass
 
         st.chat_input(
-            "Directory with callback", accept_file="directory", on_submit=callback
+            "Directory with callback", accept_image="directory", on_submit=callback
         )
 
         c = self.get_delta_from_queue().new_element.chat_input
-        assert c.accept_file == ChatInput.AcceptFile.DIRECTORY
+        assert c.accept_image == ChatInput.AcceptImage.DIRECTORY
 
-    def test_file_type_normalization_for_directory(self):
+    def test_image_type_normalization_for_directory(self):
         """Test that file types are properly normalized for directory upload."""
         # Test with various file type formats
-        st.chat_input("Directory", accept_file="directory", file_type=".txt")
+        st.chat_input("Directory", accept_image="directory", image_type=".txt")
         c1 = self.get_delta_from_queue().new_element.chat_input
-        assert c1.file_type == [".txt"]
+        assert c1.image_type == [".txt"]
 
         st.chat_input(
-            "Directory", accept_file="directory", file_type=["py", ".md", "txt"]
+            "Directory", accept_image="directory", image_type=["py", ".md", "txt"]
         )
         c2 = self.get_delta_from_queue().new_element.chat_input
-        assert c2.file_type == [".py", ".md", ".txt"]
+        assert c2.image_type == [".py", ".md", ".txt"]
 
     @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
     def test_audio_file(self, deserialize_patch):
@@ -646,7 +647,7 @@ class ChatTest(DeltaGeneratorTestCase):
             text="", files=[], audio=audio_file
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_image="multiple")
 
         assert return_val.audio == audio_file
         assert return_val.audio.name == "recording.wav"
@@ -660,7 +661,7 @@ class ChatTest(DeltaGeneratorTestCase):
             text="hello", files=[], audio=None
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_image="multiple")
 
         assert return_val.audio is None
         assert return_val.text == "hello"
@@ -677,18 +678,19 @@ class ChatTest(DeltaGeneratorTestCase):
             text="test", files=[], audio=audio_file
         )
 
-        return_val = st.chat_input(accept_file="multiple")
+        return_val = st.chat_input(accept_image="multiple")
 
         # Test dict-like access
         assert return_val["audio"] == audio_file
         assert return_val["text"] == "test"
         assert "audio" in return_val
-        assert len(return_val) == 3  # text, files, audio
+        assert len(return_val) == 4  # text, images, files, audio
 
         # Test to_dict
         as_dict = return_val.to_dict()
         assert as_dict["audio"] == audio_file
         assert as_dict["text"] == "test"
+        assert as_dict["images"] == []
         assert as_dict["files"] == []
 
     def test_chat_input_accept_audio_false(self):
@@ -702,3 +704,112 @@ class ChatTest(DeltaGeneratorTestCase):
         st.chat_input(accept_audio=True)
         c = self.get_delta_from_queue().new_element.chat_input
         assert c.accept_audio is True
+
+    # Tests for new dual file upload system (accept_file parameter)
+    def test_chat_input_accept_file_single(self):
+        """Test that accept_file=True correctly sets the proto field."""
+        st.chat_input(accept_file=True)
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_SINGLE
+
+    def test_chat_input_accept_file_multiple(self):
+        """Test that accept_file='multiple' correctly sets the proto field."""
+        st.chat_input(accept_file="multiple")
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_MULTIPLE
+
+    def test_chat_input_accept_file_directory(self):
+        """Test that accept_file='directory' correctly sets the proto field."""
+        st.chat_input(accept_file="directory")
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_DIRECTORY
+
+    def test_chat_input_accept_file_none(self):
+        """Test that accept_file=False sets FILE_NONE (default)."""
+        st.chat_input(accept_file=False)
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_NONE
+
+    def test_chat_input_accept_file_invalid_value(self):
+        """Test that invalid accept_file values raise StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException) as excinfo:
+            st.chat_input(accept_file="invalid")
+        assert "The `accept_file` parameter must be" in str(excinfo.value)
+
+    def test_chat_input_accept_both_image_and_file(self):
+        """Test that both accept_image and accept_file can be set simultaneously."""
+        st.chat_input(accept_image=True, accept_file="multiple")
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_image == ChatInput.AcceptImage.SINGLE
+        assert c.accept_file == ChatInput.AcceptFile.FILE_MULTIPLE
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_with_dual_uploads(self, deserialize_patch):
+        """Test ChatInputValue with both images and files."""
+        # Create mock uploaded files
+        image_rec = UploadedFileRec("img0", "image.png", "image/png", b"image data")
+        image_file = UploadedFile(
+            image_rec, FileURLsProto(file_id="img0", delete_url="d0", upload_url="u0")
+        )
+
+        file_rec = UploadedFileRec(
+            "file0", "document.pdf", "application/pdf", b"pdf data"
+        )
+        regular_file = UploadedFile(
+            file_rec, FileURLsProto(file_id="file0", delete_url="d1", upload_url="u1")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="test with uploads",
+            images=[image_file],
+            files=[regular_file],
+            audio=None,
+        )
+
+        return_val = st.chat_input(accept_image=True, accept_file=True)
+
+        # Test dict-like access
+        assert return_val["text"] == "test with uploads"
+        assert return_val["images"] == [image_file]
+        assert return_val["files"] == [regular_file]
+        assert "images" in return_val
+        assert "files" in return_val
+        assert len(return_val) == 4  # text, images, files, audio
+
+        # Test to_dict
+        as_dict = return_val.to_dict()
+        assert as_dict["text"] == "test with uploads"
+        assert as_dict["images"] == [image_file]
+        assert as_dict["files"] == [regular_file]
+        assert as_dict["audio"] is None
+
+    def test_chat_input_file_type_parameter(self):
+        """Test that file_type parameter works with accept_file."""
+        st.chat_input(accept_file=True, file_type=[".pdf", ".docx"])
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_SINGLE
+        assert list(c.file_type) == [".pdf", ".docx"]
+
+    def test_chat_input_whitelisted_stable_key_kwargs_accept_file(self):
+        """Test that accept_file is included in whitelisted stable key kwargs."""
+        st.chat_input(accept_file=True, key="test_key")
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_file == ChatInput.AcceptFile.FILE_SINGLE
+
+    def test_chat_input_whitelisted_stable_key_kwargs_file_type(self):
+        """Test that file_type is included in whitelisted stable key kwargs."""
+        st.chat_input(accept_file=True, file_type=[".txt"], key="test_key")
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert list(c.file_type) == [".txt"]
+
+    def test_chat_input_overlapping_file_extensions_error(self):
+        """Test that overlapping extensions in image_type and file_type raise an error."""
+        with pytest.raises(StreamlitAPIException) as excinfo:
+            st.chat_input(
+                accept_image=True,
+                image_type=[".png", ".jpg"],
+                accept_file=True,
+                file_type=[".jpg", ".pdf"],
+            )
+        assert "overlapping extensions" in str(excinfo.value).lower()
+        assert ".jpg" in str(excinfo.value)

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -34,16 +34,28 @@ message ChatInput {
   }
   Position position = 8;
 
-  enum AcceptFile {
+  enum AcceptImage {
     NONE = 0;
     SINGLE = 1;
     MULTIPLE = 2;
     DIRECTORY = 3;
   }
-  AcceptFile accept_file = 9;
+  AcceptImage accept_image = 9;
 
-  // Supported file types: For example: ["png","jpg","img"]
-  repeated string file_type = 10;
+  // Supported image types: For example: ["png","jpg","img"]
+  repeated string image_type = 10;
+
+  // New file upload support (persistent files, like file_uploader)
+  enum AcceptFile {
+    FILE_NONE = 0;
+    FILE_SINGLE = 1;
+    FILE_MULTIPLE = 2;
+    FILE_DIRECTORY = 3;
+  }
+  AcceptFile accept_file = 13;
+
+  // Supported file types for persistent files: For example: ["txt","csv","pdf"]
+  repeated string file_type = 14;
 
   // Max file size allowed by server config
   int32 max_upload_size_mb = 11;

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -103,4 +103,5 @@ message ChatInputValue {
   optional string data = 1;
   optional FileUploaderState file_uploader_state = 2;
   optional UploadedFileInfo audio_file_info = 3;
+  optional FileUploaderState image_uploader_state = 4;
 }


### PR DESCRIPTION
- Add accept_image parameter alongside existing accept_file parameter
- Support separate image and file upload workflows in chat input
- Images are temporary (cleared after submission), files are persistent
- Update protobuf definitions to support dual upload system
- Add comprehensive tests for both frontend and backend
- Update E2E tests to use new accept_image parameter
- Maintain backward compatibility with existing accept_file parameter

## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
