### PR TITLE
[Prototype] Use `key` as main identity for `st.pydeck_chart` with selections

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -556,11 +556,13 @@ class PydeckMixin:
             pydeck_proto.id = compute_and_register_element_id(
                 "deck_gl_json_chart",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity={"selection_mode", "is_selection_activated"},
                 dg=self.dg,
                 is_selection_activated=is_selection_activated,
                 selection_mode=selection_mode,
                 use_container_width=use_container_width,
+                width=width,
+                height=height,
                 spec=spec,
             )
 


### PR DESCRIPTION
## Describe your changes

If a custom `key` is passed to a `st.pydeck_chart` with selections activated, it will be used as the main identity. This allows for dynamically changing other parameters and the pydeck object between reruns without recreating the widgets in the frontend and losing their state.

## GitHub Issue Link (if applicable)

- Related to https://github.com/streamlit/streamlit/issues/11277

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
