### PR TITLE
[fix] Utilize yarn instead of npm in CI script

### DIFF
--- a/.github/workflows/bump-component-v2-lib.yml
+++ b/.github/workflows/bump-component-v2-lib.yml
@@ -53,7 +53,8 @@ jobs:
           NEXT="${{ inputs.new_version }}"
           if ! echo "$NEXT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then echo "invalid semver: $NEXT"; exit 1; fi
           if [ "$NEXT" = "$CURR" ]; then echo "new_version equals current"; exit 1; fi
-          npm version "${{ inputs.new_version }}" --no-git-tag-version
+          # Bump the version in the package.json file
+          yarn version "${{ inputs.new_version }}"
           echo "next=$NEXT" >> $GITHUB_OUTPUT
 
       - name: Create branch and commit (@streamlit/component-v2-lib)


### PR DESCRIPTION
## Describe your changes

Updated the version bumping command in the `bump-component-v2-lib.yml` workflow from `npm version` to `yarn version` so that the command writes the expected value to `package.json`

## Testing Plan

- Ran and verified the workflow here:
  - https://github.com/streamlit/streamlit/actions/runs/20928379507
  - https://github.com/streamlit/streamlit/actions/runs/20928432448

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.