### PR TITLE
[chore] flaky custom light theme test due to hover state

### DIFF
--- a/e2e_playwright/theming/custom_light_theme_test.py
+++ b/e2e_playwright/theming/custom_light_theme_test.py
@@ -19,7 +19,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import expect_no_skeletons, reset_focus
+from e2e_playwright.shared.app_utils import expect_no_skeletons
 
 
 @pytest.fixture(scope="module")
@@ -227,11 +227,11 @@ def test_theme_preference_persists_on_reload(
     # Close settings dialog
     settings_dialog.get_by_role("button", name="Close").click()
 
-    # Wait for dialog to fully disappear
+    # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
-    # Reset focus and hover states to avoid them appearing in snapshot
-    reset_focus(app)
+    # Give a moment for theme CSS to fully stabilize
+    app.wait_for_timeout(300)
 
     assert_snapshot(app, name="persisted_on_reload_before", image_threshold=0.0003)
 
@@ -258,10 +258,10 @@ def test_theme_preference_persists_on_reload(
     # Close the dialog
     settings_dialog.get_by_role("button", name="Close").click()
 
-    # Wait for dialog to fully disappear
+    # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
-    # Reset focus and hover states to avoid them appearing in snapshot
-    reset_focus(app)
+    # Give a moment for theme CSS to fully stabilize
+    app.wait_for_timeout(300)
 
     assert_snapshot(app, name="persisted_on_reload_after", image_threshold=0.0003)

--- a/e2e_playwright/theming/custom_light_theme_test.py
+++ b/e2e_playwright/theming/custom_light_theme_test.py
@@ -19,7 +19,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import expect_no_skeletons, reset_hovering
+from e2e_playwright.shared.app_utils import expect_no_skeletons
 
 
 @pytest.fixture(scope="module")
@@ -230,9 +230,6 @@ def test_theme_preference_persists_on_reload(
     # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
-    # Reset hover state to avoid any hover effects in snapshot
-    reset_hovering(app)
-
     # Give a moment for theme CSS to fully stabilize
     app.wait_for_timeout(300)
 
@@ -263,9 +260,6 @@ def test_theme_preference_persists_on_reload(
 
     # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
-
-    # Reset hover state to avoid any hover effects in snapshot
-    reset_hovering(app)
 
     # Give a moment for theme CSS to fully stabilize
     app.wait_for_timeout(300)

--- a/e2e_playwright/theming/custom_light_theme_test.py
+++ b/e2e_playwright/theming/custom_light_theme_test.py
@@ -19,7 +19,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import expect_no_skeletons
+from e2e_playwright.shared.app_utils import expect_no_skeletons, reset_hovering
 
 
 @pytest.fixture(scope="module")
@@ -230,6 +230,9 @@ def test_theme_preference_persists_on_reload(
     # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
+    # Reset hover state to avoid any hover effects in snapshot
+    reset_hovering(app)
+
     # Give a moment for theme CSS to fully stabilize
     app.wait_for_timeout(300)
 
@@ -260,6 +263,9 @@ def test_theme_preference_persists_on_reload(
 
     # Wait for dialog to fully disappear and theme CSS to be applied
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
+
+    # Reset hover state to avoid any hover effects in snapshot
+    reset_hovering(app)
 
     # Give a moment for theme CSS to fully stabilize
     app.wait_for_timeout(300)

--- a/e2e_playwright/theming/custom_light_theme_test.py
+++ b/e2e_playwright/theming/custom_light_theme_test.py
@@ -227,6 +227,12 @@ def test_theme_preference_persists_on_reload(
     # Close settings dialog
     settings_dialog.get_by_role("button", name="Close").click()
 
+    # Wait for dialog to fully disappear
+    expect(app.get_by_test_id("stDialog")).to_have_count(0)
+
+    # Move mouse away from interactive elements to avoid hover states in snapshot
+    app.mouse.move(0, 0)
+
     assert_snapshot(app, name="persisted_on_reload_before", image_threshold=0.0003)
 
     # Force a full page reload
@@ -251,5 +257,11 @@ def test_theme_preference_persists_on_reload(
 
     # Close the dialog
     settings_dialog.get_by_role("button", name="Close").click()
+
+    # Wait for dialog to fully disappear
+    expect(app.get_by_test_id("stDialog")).to_have_count(0)
+
+    # Move mouse away from interactive elements to avoid hover states in snapshot
+    app.mouse.move(0, 0)
 
     assert_snapshot(app, name="persisted_on_reload_after", image_threshold=0.0003)

--- a/e2e_playwright/theming/custom_light_theme_test.py
+++ b/e2e_playwright/theming/custom_light_theme_test.py
@@ -19,7 +19,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import expect_no_skeletons
+from e2e_playwright.shared.app_utils import expect_no_skeletons, reset_focus
 
 
 @pytest.fixture(scope="module")
@@ -230,8 +230,8 @@ def test_theme_preference_persists_on_reload(
     # Wait for dialog to fully disappear
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
-    # Move mouse away from interactive elements to avoid hover states in snapshot
-    app.mouse.move(0, 0)
+    # Reset focus and hover states to avoid them appearing in snapshot
+    reset_focus(app)
 
     assert_snapshot(app, name="persisted_on_reload_before", image_threshold=0.0003)
 
@@ -261,7 +261,7 @@ def test_theme_preference_persists_on_reload(
     # Wait for dialog to fully disappear
     expect(app.get_by_test_id("stDialog")).to_have_count(0)
 
-    # Move mouse away from interactive elements to avoid hover states in snapshot
-    app.mouse.move(0, 0)
+    # Reset focus and hover states to avoid them appearing in snapshot
+    reset_focus(app)
 
     assert_snapshot(app, name="persisted_on_reload_after", image_threshold=0.0003)


### PR DESCRIPTION
## Describe your changes

Fixes flaky failure in `test_theme_preference_persists_on_reload`. Looking at the test, it seems the Option 2 radio button should have a hazard orange colour border due to the overrides. In the original snapshot, it is gray. This PR adds some more wait before both snapshots to ensure there is time for the theme to load properly. 

The snapshots for this were already updated to have the hazard orange border yesterday in one of Nico's PRs. So this is just to make sure we don't get a flaky gray result. 

## GitHub Issue Link (if applicable)

N/A - Internal test stability fix

## Testing Plan

- [x] E2E Tests - Modified existing test with proper waits
- [ ] Manual testing needed

**Modified test:**

- `e2e_playwright/theming/custom_light_theme_test.py` - Added dialog wait before snapshots

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.