### PR TITLE
[spec] Dynamic Expanders, Tabs and Popovers

### DIFF
--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -206,7 +206,7 @@ if tabs[0].open:  # Developer must add this check
 
 - ❌ Cannot be used inside `@st.cache_data` decorated functions
 - ❌ Cannot be used inside `@st.fragment` (fragments can't contain widgets that write outside their scope)
-- This is why `on_change=None` is the default - to avoid breaking existing apps that use tabs in these contexts
+- This is why `on_change="ignore"` is the default - to avoid breaking existing apps that use tabs in these contexts
 
 ### Examples
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -239,11 +239,11 @@ if tabs[0].open:  # Developer must add this check
         expensive_code()  # Only runs when check is True
 ```
 
-**Why opt-in is important:** When `on_change` is set, tabs/expander/popover register as widgets, which means they:
+**Why opt-in is important:** When `on_change` is set, tabs/expander/popover register as widgets, which means:
 
-- ❌ Cannot be used inside `@st.cache_data` decorated functions
-- ❌ Cannot be used inside `@st.fragment` (fragments can't contain widgets that write outside their scope)
-- This is why `on_change="ignore"` is the default - to avoid breaking existing apps that use tabs in these contexts
+- ❌ They cannot be created inside `@st.cache_data` decorated functions (widgets are not allowed in cached functions)
+- ❌ They cannot be created in external containers from inside a `@st.fragment` (fragments can't create widgets in external containers)
+- This is why `on_change="ignore"` is the default - to avoid breaking existing apps that use tabs/expander/popover in these contexts
 
 ### Examples
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -1,16 +1,14 @@
 ---
-Author(s): @sfc-gh-lwilby
-Status: Draft
-Related SEP: https://github.com/streamlit/streamlit-enhancement-proposals/pull/3
+author: sfc-gh-lwilby
+created: 2026-01-14
+status: Draft
 ---
 
 # Dynamic Tabs, Expander, and Popover (Lazy Execution)
 
 ## Summary
 
-Enable `st.tabs`, `st.expander`, and `st.popover` to execute content lazily (only for the active tab, when expanded, or when popover is open) instead of always executing on every rerun. This addresses a fundamental performance problem where all tab content runs regardless of which tab is visible, causing slower performance in apps with expensive operations across multiple tabs. Enabling state tracking may also unlocks programmatic control as a side benefit (depending on technical implementation decisions).
-
-**API Approach:** [Option 1b from SEP PR #3](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3) - Add `on_change` parameter and `.open` attribute to enable state tracking and conditional execution.
+Enable `st.tabs`, `st.expander`, and `st.popover` to execute content lazily (only for the active tab, when expanded, or when popover is open) instead of always executing on every rerun. This addresses a fundamental performance problem where all tab content runs regardless of which tab is visible, causing slower performance in apps with expensive operations across multiple tabs. Enabling state tracking also unlocks programmatic control as a side benefit.
 
 ## Problem
 
@@ -33,6 +31,8 @@ with tab3:
 
 This ensures instant visibility when tabs are switched, but significantly slows apps when tabs contain expensive computations.
 
+**Current workarounds:** Users resort to `st.selectbox`, `st.radio`, or `st.segmented_control` instead of tabs to control execution, losing the visual organization benefits of tabs.
+
 ### User Requests
 
 **Primary GitHub Issues:**
@@ -44,22 +44,23 @@ This ensures instant visibility when tabs are switched, but significantly slows 
 
 - [#8239](https://github.com/streamlit/streamlit/issues/8239) - st.tabs & expander frontend state/mount handling (79 👍) - addresses broader state management issues
 
-### Real-World Examples
+### Use Cases
 
-1. **ML/Data Science:** Multiple models, each requiring expensive inference - ALL run even though user views one
-2. **API Dashboards:** All API calls execute every rerun (rate limits, costs, 1.5+ seconds)
-3. **Database Tools:** All queries run simultaneously (5-10 seconds for multiple queries)
-4. **Complex Visualizations:** All viz rendered even though only one visible (Plotly 3D, network graphs, etc.)
+This feature enables better performance and new interaction patterns for several types of apps:
 
-**Current workarounds:** Users resort to `st.selectbox`, `st.radio` or `st.segmented_control` instead of tabs to control execution, losing the visual organization benefits of tabs.
+1. **ML/Data Science Apps:** Compare multiple models with expensive inference, running only the selected model
+2. **API Dashboards:** Display multiple API endpoints in tabs without hitting rate limits or incurring unnecessary costs
+3. **Database Tools:** Query multiple data sources or views, executing only the active query
+4. **Complex Visualizations:** Display expensive charts (Plotly 3D, network graphs) only when the relevant tab is visible
+5. **Multi-Step Workflows:** Build wizard-style interfaces with Next/Back navigation between steps
 
-**Side benefit:** Enabling state tracking can unlock programmatic control (setting active tab/expander via session state), which could enable new use cases like multi-step workflows (Next/Back buttons) and conditional tab switching (e.g., auto-advance when validation passes).
+**Additional benefit:** Programmatic control via session state enables new interaction patterns like automated tab switching based on validation or workflow progression.
 
 ---
 
 ## Proposal
 
-### API Design (Option 1b)
+### API Design
 
 Add `on_change` parameter and `.open` attribute following the pattern established for chart/dataframe selections.
 
@@ -120,7 +121,7 @@ if pop.open:  # Only when popover is open
   - `"ignore"`: Current behavior, always execute all content, no state tracking
   - `"rerun"`: Trigger full app rerun when tab changes/expander toggles, enables state tracking
   - `callback`: _(Future addition for API consistency with widgets)_ Function to call before rerun
-    - Note: Callbacks could theoretically be used to define tab/expander content (combining Option 2 with Option 1b), but this would be unintuitive (callbacks typically run side effects, not define content) and would face fragment limitations if auto-wrapped. Better to let users explicitly use `@st.fragment` where needed.
+    - Note: Callbacks are intended for side effects (like updating other state), not for defining content. Content should be defined inline with `if .open:` checks. Users can wrap content in `@st.fragment` explicitly where needed for performance optimization.
 
 #### New parameter: `key` (for tabs)
 
@@ -195,7 +196,7 @@ if tabs[0].open:  # Developer must add this check
 
 ### Examples
 
-**Full example apps demonstrating Option 1b:**
+**Example apps demonstrating the proposed API:**
 
 1. **Lazy Execution Demo:** `e2e_playwright/dynamic_containers/dynamic_expander_test.py`
 
@@ -214,75 +215,188 @@ if tabs[0].open:  # Developer must add this check
    - Programmatic navigation between steps
    - Demonstrates validation and conditional logic
 
-**Comparison apps (Option 2):**
+---
 
-_Note: Option 2 API is not implemented. These apps demonstrate what the code would look like with the function argument approach for comparison purposes._
+## Alternatives Considered
 
-- `e2e_playwright/dynamic_containers/database_query_app_option2.py`
-- `e2e_playwright/dynamic_containers/wizard_pipeline_app_option2.py`
+Several alternative API designs were evaluated before selecting the proposed approach:
+
+### Option 1a: Boolean Evaluation of Delta Generator
+
+**Approach:** Make the delta generator itself evaluate to `True` when open/active.
+
+```python
+exp = st.expander("Show details", on_change="rerun")
+if exp:  # True if open
+    with exp:
+        st.write("Expander is open")
+
+tab1, tab2 = st.tabs(["A", "B"], on_change="rerun")
+if tab1:  # True if active
+    with tab1:
+        st.write("Tab A active")
+elif tab2:
+    with tab2:
+        st.write("Tab B active")
+```
+
+**Pros:**
+
+- ✅ Clean and readable
+- ✅ Minimal changes to existing patterns
+- ✅ Concise syntax
+
+**Cons:**
+
+- ❌ "Magic" behavior - delta generators normally don't have truthiness semantics
+- ❌ Not explicit about what's being checked
+- ❌ Could be confusing when delta generator is falsy
+
+**Why not selected:** The implicit truthiness check feels too magical and could lead to confusion about what's actually being evaluated.
 
 ---
 
-### Design Rationale: Why Option 1b?
+### Option 1c: Session State Value
 
-#### Alternative Considered: Option 2 (Function Argument)
+**Approach:** Use session state exclusively to track open/closed state.
 
-From [SEP PR #3](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3), an alternative approach was considered:
+```python
+st.tabs(["A", "B"], key="tabs", on_change="rerun")
+if st.session_state.tabs == "A":
+    st.write("Tab A content")
+elif st.session_state.tabs == "B":
+    st.write("Tab B content")
 
-**Option 2:** Pass functions as arguments: `st.tabs({"A": func_a, "B": func_b}, args=(data,))`
+st.expander("Details", key="exp", on_change="rerun")
+if st.session_state.exp:
+    st.write("Expander content")
+```
 
-**Why not selected:**
+**Pros:**
 
-1. **Auto-fragmentation impractical** - Option 2's main performance advantage would be auto-wrapping functions in fragments (like `st.dialog`), but this imposes some restrictions:
+- ✅ Consistent with existing widget patterns
+- ✅ Familiar to users who understand session state
 
-   - ❌ Cannot use `st.sidebar` directly
-   - ❌ Widgets cannot write to external containers (breaks shared output area pattern)
-   - ❌ Elements accumulate/duplicate in external containers (duplication bug #12762)
-   - Note: Unlike `st.dialog` (isolated modals), tabs are part of main app flow where these patterns are likely
+**Cons:**
 
-2. **Not incrementally adoptable** - Requires refactoring existing code to functions
+- ❌ Verbose - requires explicit key parameter every time
+- ❌ Requires understanding of keys and session state (higher learning curve)
+- ❌ Less intuitive than accessing state directly from the element
+- ❌ Disconnects the state check from the element definition
 
-3. **Implicit execution** - Less clear when code runs
+**Why not selected:** Too verbose and requires extra boilerplate (keys) for a common use case.
 
-4. Programmatic control can still be implemented, but would likely still involve registering the element as a widget and adding a key and using session state to update the widget state (an established pattern with other elements). This control mechanism is more in sync with option 1b conceptually.
+---
 
-**Strengths:** Automatic execution, clean `args`/`kwargs`, less overhead. Automatic performance gain from fragments if we do auto-fragmentation.
+### Option 2: Function Argument
 
-#### Why Option 1b Was Selected
+**Approach:** Pass functions as arguments that get called only when the tab/expander is visible.
 
-**SteerCo Decision (Oct 15, 2024):** Strong support for Option 1b - "easier to grow into" and "feels more at home with Streamlit APIs"
+```python
+def show_expander(exp):
+    exp.write("Heavy content")
+
+st.expander("Show details", func=show_expander)
+
+def show_tab_a(tab):
+    tab.write("Tab A content")
+
+def show_tab_b(tab):
+    tab.write("Tab B content")
+
+st.tabs({"A": show_tab_a, "B": show_tab_b})
+```
+
+**Pros:**
+
+- ✅ Automatic lazy execution (no manual `if` checks needed)
+- ✅ Clean separation of tab/expander content
+- ✅ Could potentially auto-fragment for better performance
+- ✅ Aligns with lazy-loading patterns like deferred `st.download_button`
+
+**Cons:**
+
+- ❌ **Auto-fragmentation impractical** - Would impose fragment restrictions:
+  - Cannot use `st.sidebar` directly
+  - Widgets cannot write to external containers (breaks shared output area pattern)
+  - Elements accumulate/duplicate in external containers (duplication bug #12762)
+  - Unlike `st.dialog` (isolated modals), tabs are part of main app flow where these patterns are common
+- ❌ Not incrementally adoptable - requires refactoring existing code into functions
+- ❌ Implicit execution - less clear when code runs
+- ❌ No clear pattern in Streamlit (between widgets with `on_change` and decorators like `@st.fragment`)
+- ❌ Programmatic control would still require adding `key` parameter and using session state
+
+**Why not selected:** Would require refactoring existing code, and auto-fragmentation (the main performance benefit) is impractical due to common usage patterns that fragments don't support. Without auto-fragmentation, it offers no performance advantage over the selected approach.
+
+---
+
+### Option 3: Function Decorator
+
+**Approach:** Use a decorator pattern similar to `@st.fragment` and `@st.dialog`.
+
+```python
+@st.expander("Show details")
+def show_expander():
+    st.write("Heavy content")
+
+show_expander()
+```
+
+**Pros:**
+
+- ✅ Consistent with `@st.fragment` and `@st.dialog` decorators
+- ✅ Clean, Pythonic pattern
+
+**Cons:**
+
+- ❌ **Unclear how this works for `st.tabs`** with multiple functions
+- ❌ Should content automatically be a fragment? If so, inherits all fragment limitations (see Option 2)
+- ❌ Creates two ways to use `st.expander`/`st.tabs` - confusing for users
+- ❌ Not incrementally adoptable - requires refactoring to functions
+- ❌ Less flexible than context manager pattern
+
+**Why not selected:** Doesn't scale well to multi-tab scenarios, would create confusing dual APIs for the same elements, and inherits fragment limitations if auto-fragmented.
+
+---
+
+## Design Rationale
+
+**Selected Approach:** Option 1b (`.open` attribute + `on_change`)
+
+**SteerCo Decision (Oct 15, 2024):** Strong support for this approach - described as "easier to grow into" and "feels more at home with Streamlit APIs"
 
 **Key reasons:**
 
-1. ✅ **Consistency:** Matches `on_change` pattern (widgets, selections)
-2. ✅ **Explicitness:** `if tabs[i].open:` shows execution flow
-3. ✅ **Incremental adoption:** Add without refactoring
-4. ✅ **Programmatic control:** Well-defined via session state
-5. ✅ **No forced limitations:** Users can optionally use `@st.fragment` (not forced)
+1. ✅ **Consistency:** Matches `on_change` pattern established for chart/dataframe/map selections
+2. ✅ **Explicitness:** `if tabs[i].open:` clearly shows execution flow
+3. ✅ **Incremental adoption:** Can be added to existing code without refactoring
+4. ✅ **Programmatic control:** Well-defined via session state (established pattern)
+5. ✅ **No forced limitations:** Users can optionally use `@st.fragment` when needed (not forced)
+6. ✅ **Intuitive:** State is accessible directly from the element itself
 
-**Trade-off:** Full app rerun on tab switch (acceptable - avoids fragment restrictions that would break `st.sidebar`, external containers, etc.). Users can still control this with the st.fragment decorator applied as needed to tab/expander content.
+**Trade-off:** Full app rerun on tab switch/expander toggle (acceptable - avoids fragment restrictions that would break `st.sidebar`, external containers, etc.). Users can still optimize performance by wrapping tab/expander content in `@st.fragment` as needed.
 
 ---
 
 ## Checklist
 
-- [x] **Will this work on all deployment platforms?** Yes - uses session_state and widget callbacks (supported everywhere)
-- [x] **No breaking API changes?** Yes - new parameters are optional, existing code works unchanged
-- [x] **No new dependencies?** Yes - uses existing infrastructure
-- [x] **Metrics collected?** Yes
-- [x] **Any security or legal implications?** No - uses existing session_state mechanism
-- [x] **Anything to keep in mind for docs?**
-  - Explain trade-off: instant switching (static) vs lazy loading (dynamic)
-  - Document programmatic control pattern
-  - Show performance optimization use cases
-  - Cookbook recipe for expensive tab content
-- [] **Any other risks?**
+| Item                       | ✅ or comment                                                                                                                                                                                               |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Works on SiS, Cloud, etc?  | ✅ Yes - uses session_state and widget callbacks (supported everywhere)                                                                                                                                     |
+| No breaking API changes    | ✅ Yes - new parameters are optional, existing code works unchanged                                                                                                                                         |
+| No new dependencies        | ✅ Yes - uses existing infrastructure                                                                                                                                                                       |
+| Metrics collected          | ✅ Yes                                                                                                                                                                                                      |
+| Any security/legal impact? | ✅ No - uses existing session_state mechanism                                                                                                                                                               |
+| Any docs changes needed?   | ✅ Yes - Explain trade-off: instant switching (static) vs lazy loading (dynamic), document programmatic control pattern, show performance optimization use cases, cookbook recipe for expensive tab content |
+| Any other risks?           | None identified                                                                                                                                                                                             |
 
 ---
 
 ## References
 
-- **SEP:** [PR #3 - Dynamic tabs/expander/popover](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3)
 - **Prototype PR:** [#13277](https://github.com/streamlit/streamlit/pull/13277)
 - **Related PRs:** [#13233 - st.Tab class spec](https://github.com/streamlit/streamlit/pull/13233)
-- **GitHub Issues:** [#6004](https://github.com/streamlit/streamlit/issues/6004) (230 👍), [#2399](https://github.com/streamlit/streamlit/issues/2399) (93 👍), [#8239](https://github.com/streamlit/streamlit/issues/8239) (79 👍)
+- **GitHub Issues:**
+  - [#6004](https://github.com/streamlit/streamlit/issues/6004) - Dynamic tabs (230 👍)
+  - [#2399](https://github.com/streamlit/streamlit/issues/2399) - st.expander expanded/collapsed state (93 👍)
+  - [#8239](https://github.com/streamlit/streamlit/issues/8239) - st.tabs & expander frontend state/mount handling (79 👍)

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -301,7 +301,8 @@ if tabs[0].open:  # Developer must add this check
 
 Several alternative API designs were evaluated before selecting the proposed approach:
 
-### Boolean Evaluation of Delta Generator
+<details>
+<summary>Boolean Evaluation of Delta Generator</summary>
 
 **Approach:** Make the delta generator itself evaluate to `True` when open/active.
 
@@ -334,9 +335,10 @@ elif tab2:
 
 **Why not selected:** The implicit truthiness check feels too magical and could lead to confusion about what's actually being evaluated.
 
----
+</details>
 
-### Session State Value
+<details>
+<summary>Session State Value</summary>
 
 **Approach:** Use session state exclusively to track open/closed state.
 
@@ -366,9 +368,10 @@ if st.session_state.exp:
 
 **Why not selected:** Too verbose and requires extra boilerplate (keys) for a common use case.
 
----
+</details>
 
-### Function Argument
+<details>
+<summary>Function Argument</summary>
 
 **Approach:** Pass functions as arguments that get called only when the tab/expander is visible.
 
@@ -408,9 +411,10 @@ st.tabs({"A": show_tab_a, "B": show_tab_b})
 
 **Why not selected:** Would require refactoring existing code, and auto-fragmentation (the main performance benefit) is impractical due to common usage patterns that fragments don't support. Without auto-fragmentation, it offers no performance advantage over the selected approach.
 
----
+</details>
 
-### Function Decorator
+<details>
+<summary>Function Decorator</summary>
 
 **Approach:** Use a decorator pattern similar to `@st.fragment` and `@st.dialog`.
 
@@ -437,7 +441,7 @@ show_expander()
 
 **Why not selected:** Doesn't scale well to multi-tab scenarios, would create confusing dual APIs for the same elements, and inherits fragment limitations if auto-fragmented.
 
----
+</details>
 
 ## Design Rationale
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -37,6 +37,11 @@ This ensures instant visibility when tabs are switched, but significantly slows 
 - [#6004](https://github.com/streamlit/streamlit/issues/6004) - Dynamic tabs (230 👍)
 - [#2399](https://github.com/streamlit/streamlit/issues/2399) - st.expander expanded/collapsed state (93 👍)
 
+**Related - Addressed by programmatic control:**
+
+- [#6370](https://github.com/streamlit/streamlit/issues/6370) - Can't close st.expander after users open it themselves
+- [#8265](https://github.com/streamlit/streamlit/issues/8265) - [Coming soon] Add open/close parameter to st.popover
+
 **Related (but not directly addressed by lazy execution):**
 
 - [#8239](https://github.com/streamlit/streamlit/issues/8239) - st.tabs & expander frontend state/mount handling (79 👍) - addresses broader state management issues

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -160,7 +160,7 @@ exp = st.expander("Processing status", expanded=False)
 
 with exp:
     data = load_expensive_data()
-    exp.update(expanded=True)
+    exp.update(open=True)
     st.dataframe(data)
 ```
 
@@ -175,12 +175,14 @@ with tabs[0]:
     if st.button("Run Analysis"):
         results = run_analysis()
         st.session_state.results = results
-        tabs.update(active="Results")
+        tabs[0].update(open=True)
 
 with tabs[1]:
     if "results" in st.session_state:
         st.write(st.session_state.results)
 ```
+
+**Note:** `st.tabs` currently returns a Sequence of DeltaGenerator, so the proposal here is update the individual tab to be active. If we wanted to do tabs.update(active="Results") we would need to change the return value of `st.tabs` while also preserving the Sequence functionality (e.g. `tab1, tab2 = st.tabs(["one", "two"])`).
 
 **Potential API for `st.popover`:**
 
@@ -200,6 +202,8 @@ with pop:
 if "current_filter" in st.session_state:
     st.write(f"Showing: {st.session_state.current_filter}")
 ```
+
+**Alternative naming:** Ideally, the `.update()` method would use the same parameter names as the initial state parameters for each element. However, since `st.expander` uses `expanded` and `st.tabs` uses `default` (and `st.popover` doesn't currently have an initial state parameter), matching initial state parameters would create inconsistency across three dimensions: (1) between elements (expander vs tabs vs popover), (2) between operations (setting initial state vs checking state via `.open` vs updating state via `.update()`), and (3) semantically (`expanded` doesn't naturally fit `st.tabs` where "active" or "selected" is more intuitive, and `default` is awkward for runtime updates). Therefore, we chose `open` as a unified parameter name. This provides consistency for both the `.open` property and `.update()` method across all three elements. The trade-off is that initial state parameters remain element-specific (`expanded` for expander, `default` for tabs), but these are already established in the existing API.
 
 ### Parameters
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -112,17 +112,32 @@ if tabs[0].open:
 **For `st.expander`:**
 
 ```python
-exp = st.expander("Show details", on_change="rerun", key="details")
+# Auto-expand expander when warnings are detected
+exp = st.expander("⚠️ Warnings", on_change="rerun", key="warnings", expanded=False)
 
-# Control whether expander is open
-def open_details():
-    st.session_state.details = True
-
-st.button("Show Details", on_click=open_details)
+# Auto-expand if warnings are found
+warnings = check_data_quality()
+if warnings and not st.session_state.get("warnings", False):
+    st.session_state.warnings = True  # Auto-expand
 
 if exp.open:
     with exp:
-        expensive_operation()
+        display_warnings(warnings)
+```
+
+**For `st.popover`:**
+
+```python
+# Auto-open popover when validation fails
+pop = st.popover("⚠️ Validation Errors", on_change="rerun", key="errors")
+
+# Check for errors and auto-open popover if needed
+if has_validation_errors() and not st.session_state.get("errors", False):
+    st.session_state.errors = True
+
+if pop.open:
+    with pop:
+        show_error_details()
 ```
 
 #### Potential Future Extension: Direct State Updates via `.update()`
@@ -160,6 +175,25 @@ with tabs[0]:
 with tabs[1]:
     if "results" in st.session_state:
         st.write(st.session_state.results)
+```
+
+**Potential API for `st.popover`:**
+
+```python
+import streamlit as st
+
+# Create popover that auto-closes after form submission
+pop = st.popover("Filter Options")
+
+with pop:
+    filter_value = st.selectbox("Select filter", ["All", "Active", "Archived"])
+    if st.button("Apply Filters"):
+        st.session_state.current_filter = filter_value
+        pop.update(open=False)  # Auto-close after applying
+
+# Display filtered data based on selection
+if "current_filter" in st.session_state:
+    st.write(f"Showing: {st.session_state.current_filter}")
 ```
 
 ### Parameters

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -195,7 +195,7 @@ Each returned `DeltaGenerator` (tab or expander) has a new `.open` property:
 
 **For tabs specifically:** Session state stores the active tab's **label** (as a string), and `.open` checks if this tab's label matches the stored value.
 
-**Important caveat:** Since `.open` is added to `DeltaGenerator` (which is shared by all Streamlit elements), all elements will have this property. For elements that are not tabs/expanders/popovers, `.open` will always return `None`. This is an acceptable API trade-off for implementation simplicity.
+**Implementation Note:** We will investigate creating dedicated `DeltaGenerator` subclasses for these elements (e.g., `ExpanderContainer`, `TabContainer`, `PopoverContainer`) similar to what we do for `Dialog` and `StatusContainer`. This would keep the `.open` property and potential future `.update()` method scoped only to the appropriate container types, providing better type safety and API clarity. The alternative approach of adding `.open` to the base `DeltaGenerator` class would make the property available on all Streamlit elements (returning `None` for non-applicable elements), which is less ideal from an API design perspective.
 
 **Usage:**
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -221,7 +221,7 @@ if "current_filter" in st.session_state:
 
 - **Type:** `str | None`
 - **Default:** `None`
-- **Purpose:** Required if using `on_change` with callback, makes state accessible via `st.session_state[key]`
+- **Purpose:** Makes state accessible via `st.session_state[key]` for programmatic control. Not required for callbacks to work (widgets auto-generate internal IDs), but needed to access/control state programmatically.
 - **State value:** `str` (label of active tab) for tabs, `bool` for expander and popover
 
 #### New attribute: `.open` (on DeltaGenerator)

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -23,10 +23,7 @@ with tab1:
     load_large_dataset()  # ALWAYS runs, even if user is viewing tab2
 
 with tab2:
-    create_expensive_charts()  # ALWAYS runs, even if user is viewing tab3
-
-with tab3:
-    run_ml_inference()  # ALWAYS runs, even if user is viewing tab1
+    create_expensive_charts()  # ALWAYS runs, even if user is viewing tab1
 ```
 
 This ensures instant visibility when tabs are switched, but significantly slows apps when tabs contain expensive computations.
@@ -44,18 +41,6 @@ This ensures instant visibility when tabs are switched, but significantly slows 
 
 - [#8239](https://github.com/streamlit/streamlit/issues/8239) - st.tabs & expander frontend state/mount handling (79 👍) - addresses broader state management issues
 
-### Use Cases
-
-This feature enables better performance and new interaction patterns for several types of apps:
-
-1. **ML/Data Science Apps:** Compare multiple models with expensive inference, running only the selected model
-2. **API Dashboards:** Display multiple API endpoints in tabs without hitting rate limits or incurring unnecessary costs
-3. **Database Tools:** Query multiple data sources or views, executing only the active query
-4. **Complex Visualizations:** Display expensive charts (Plotly 3D, network graphs) only when the relevant tab is visible
-5. **Multi-Step Workflows:** Build wizard-style interfaces with Next/Back navigation between steps
-
-**Additional benefit:** Programmatic control via session state enables new interaction patterns like automated tab switching based on validation or workflow progression.
-
 ---
 
 ## Proposal
@@ -64,10 +49,12 @@ This feature enables better performance and new interaction patterns for several
 
 Add `on_change` parameter and `.open` attribute following the pattern established for chart/dataframe selections.
 
-#### For `st.tabs`:
+#### Lazy Execution with `.open` Attribute
+
+**For `st.tabs`:**
 
 ```python
-tabs = st.tabs(["Data", "Charts", "ML"], on_change="rerun", key="my_tabs")
+tabs = st.tabs(["Data", "Charts", "ML"], on_change="rerun")
 
 # Only execute content for the active tab
 if tabs[0].open:
@@ -77,37 +64,64 @@ if tabs[0].open:
 if tabs[1].open:
     with tabs[1]:
         create_expensive_charts()  # Only runs when this tab is active
-
-# Programmatic control
-def goto_charts():
-    st.session_state.my_tabs = "Charts"
-
-st.button("Go to Charts", on_click=goto_charts)
 ```
 
-#### For `st.expander`:
+**Alternative naming:** The following alternative property names were considered for checking if a tab is active: `.active`, `.selected`, `.visible`, and `.state`. `.open` was selected because it works naturally across tabs, expander, and popover with a simple boolean check. While `.active` is more precise for tabs, consistency across all three elements was prioritized.
+
+**For `st.expander`:**
 
 ```python
-exp = st.expander("Show details", on_change="rerun", key="details")
+exp = st.expander("Show details", on_change="rerun")
 
 if exp.open:  # Only when expanded
     with exp:
         expensive_operation()
+```
 
-# Programmatic control
+**For `st.popover`:**
+
+```python
+pop = st.popover("Options", on_change="rerun")
+
+if pop.open:  # Only when popover is open
+    with pop:
+        expensive_operation()
+```
+
+#### Programmatic Control via Session State
+
+When a `key` is provided, the element's state can be controlled programmatically via `st.session_state`:
+
+**For `st.tabs`:**
+
+```python
+tabs = st.tabs(["Data", "Charts", "ML"], on_change="rerun", key="my_tabs")
+
+# Control which tab is active
+def goto_charts():
+    st.session_state.my_tabs = "Charts"
+
+st.button("Go to Charts", on_click=goto_charts)
+
+# Conditional execution based on active tab
+if tabs[0].open:
+    with tabs[0]:
+        load_large_dataset()
+```
+
+**For `st.expander`:**
+
+```python
+exp = st.expander("Show details", on_change="rerun", key="details")
+
+# Control whether expander is open
 def open_details():
     st.session_state.details = True
 
 st.button("Show Details", on_click=open_details)
-```
 
-#### For `st.popover`:
-
-```python
-pop = st.popover("Options", on_change="rerun", key="options")
-
-if pop.open:  # Only when popover is open
-    with pop:
+if exp.open:
+    with exp:
         expensive_operation()
 ```
 
@@ -196,21 +210,21 @@ if tabs[0].open:  # Developer must add this check
 
 ### Examples
 
-**Example apps demonstrating the proposed API:**
+**Example apps demonstrating the proposed API** (see [prototype PR #13277](https://github.com/streamlit/streamlit/pull/13277)):
 
-1. **Lazy Execution Demo:** `e2e_playwright/dynamic_containers/dynamic_expander_test.py`
+1. **Lazy Execution Demo:** [`e2e_playwright/dynamic_containers/dynamic_expander_test.py`](https://github.com/streamlit/streamlit/pull/13277/files#diff-dynamic_expander_test.py)
 
    - Shows tabs and expander with `on_change="rerun"`
    - Demonstrates `.open` attribute usage
    - Programmatic control via session state
 
-2. **Database Query Dashboard:** `e2e_playwright/dynamic_containers/database_query_app_option1b.py`
+2. **Database Query Dashboard:** [`e2e_playwright/dynamic_containers/database_query_app_option1b.py`](https://github.com/streamlit/streamlit/pull/13277/files#diff-database_query_app_option1b.py)
 
    - Real-world example: Multiple database queries in tabs
    - Only active tab's query executes
    - Shows 70-80% performance improvement by simulating expensive database queries
 
-3. **Multi-Step Wizard:** `e2e_playwright/dynamic_containers/wizard_pipeline_app_option1b.py`
+3. **Multi-Step Wizard:** [`e2e_playwright/dynamic_containers/wizard_pipeline_app_option1b.py`](https://github.com/streamlit/streamlit/pull/13277/files#diff-wizard_pipeline_app_option1b.py)
    - Sequential workflow with Next/Back buttons
    - Programmatic navigation between steps
    - Demonstrates validation and conditional logic
@@ -221,7 +235,7 @@ if tabs[0].open:  # Developer must add this check
 
 Several alternative API designs were evaluated before selecting the proposed approach:
 
-### Option 1a: Boolean Evaluation of Delta Generator
+### Boolean Evaluation of Delta Generator
 
 **Approach:** Make the delta generator itself evaluate to `True` when open/active.
 
@@ -256,7 +270,7 @@ elif tab2:
 
 ---
 
-### Option 1c: Session State Value
+### Session State Value
 
 **Approach:** Use session state exclusively to track open/closed state.
 
@@ -288,7 +302,7 @@ if st.session_state.exp:
 
 ---
 
-### Option 2: Function Argument
+### Function Argument
 
 **Approach:** Pass functions as arguments that get called only when the tab/expander is visible.
 
@@ -330,7 +344,7 @@ st.tabs({"A": show_tab_a, "B": show_tab_b})
 
 ---
 
-### Option 3: Function Decorator
+### Function Decorator
 
 **Approach:** Use a decorator pattern similar to `@st.fragment` and `@st.dialog`.
 
@@ -361,7 +375,7 @@ show_expander()
 
 ## Design Rationale
 
-**Selected Approach:** Option 1b (`.open` attribute + `on_change`)
+**Selected Approach:** `.open` attribute + `on_change` parameter
 
 **SteerCo Decision (Oct 15, 2024):** Strong support for this approach - described as "easier to grow into" and "feels more at home with Streamlit APIs"
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -206,7 +206,7 @@ if "current_filter" in st.session_state:
   - `"ignore"`: Current behavior, always execute all content, no state tracking
   - `"rerun"`: Trigger full app rerun when tab changes/expander toggles, enables state tracking
   - `callback`: _(Future addition for API consistency with widgets)_ Function to call before rerun
-    - Note: Callbacks are intended for side effects (like updating other state), not for defining content. Content should be defined inline with `if .open:` checks. Users can wrap content in `@st.fragment` explicitly where needed for performance optimization.
+    - Note: elements defined in the callbacks will render top-level consistent with other widgets that already support callbacks.
 
 #### New parameter: `key`
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -14,7 +14,7 @@ Enable `st.tabs`, `st.expander`, and `st.popover` to execute content lazily (onl
 
 ### Current Behavior
 
-Currently, `st.tabs` and `st.expander` always execute their content, even when not visible:
+Currently, `st.tabs`, `st.expander`, and `st.popover` always execute their content, even when not visible:
 
 ```python
 tab1, tab2, tab3 = st.tabs(["Data", "Charts", "ML Model"])
@@ -127,7 +127,7 @@ if exp.open:
 
 #### Potential Future Extension: Direct State Updates via `.update()`
 
-Similar to `st.status`, which provides a `.update()` method to modify its state after creation, we could extend `st.tabs` and `st.expander` with similar functionality. This would allow updating the open state imperatively within the same script run, without requiring session state manipulation or reruns.
+Similar to `st.status`, which provides a `.update()` method to modify its state after creation, we could extend `st.tabs`, `st.expander`, and `st.popover` with similar functionality. This would allow updating the open state imperatively within the same script run, without requiring session state manipulation or reruns.
 
 **Potential API for `st.expander`:**
 
@@ -174,21 +174,21 @@ with tabs[1]:
   - `callback`: _(Future addition for API consistency with widgets)_ Function to call before rerun
     - Note: Callbacks are intended for side effects (like updating other state), not for defining content. Content should be defined inline with `if .open:` checks. Users can wrap content in `@st.fragment` explicitly where needed for performance optimization.
 
-#### New parameter: `key` (for tabs)
+#### New parameter: `key`
 
 - **Type:** `str | None`
 - **Default:** `None`
 - **Purpose:** Required if using `on_change` with callback, makes state accessible via `st.session_state[key]`
-- **State value:** `str` (label of active tab) for tabs, `bool` for expander
+- **State value:** `str` (label of active tab) for tabs, `bool` for expander and popover
 
 #### New attribute: `.open` (on DeltaGenerator)
 
-Each returned `DeltaGenerator` (tab or expander) has a new `.open` property:
+Each returned `DeltaGenerator` (tab, expander, or popover) has a new `.open` property:
 
 - **Type:** `bool | None`
 - **Returns:**
-  - `True` if tab is active or expander is expanded
-  - `False` if tab is not active or expander is collapsed
+  - `True` if tab is active, expander is expanded, or popover is open
+  - `False` if tab is not active, expander is collapsed, or popover is closed
   - `None` if `on_change` is `"ignore"` (state not tracked) OR if called on non-tab/expander/popover elements
 
 **Implementation:** The property is added to the `DeltaGenerator` class and checks `st.session_state[widget_id]` to determine current state.
@@ -221,7 +221,7 @@ button.open  # Always None (not a tab/expander/popover)
 1. Element registers as a widget (tracks state in session_state)
 2. `.open` attribute returns current state (`True`/`False`)
 3. User must explicitly check `.open` to get lazy execution
-4. Switching tabs/toggling expander triggers app rerun (if `on_change="rerun"` or callback)
+4. Switching tabs/toggling expander/opening popover triggers app rerun (if `on_change="rerun"` or callback)
 
 **When `on_change` is `"ignore"` (default):**
 
@@ -239,7 +239,7 @@ if tabs[0].open:  # Developer must add this check
         expensive_code()  # Only runs when check is True
 ```
 
-**Why opt-in is important:** When `on_change` is set, tabs/expander register as widgets, which means they:
+**Why opt-in is important:** When `on_change` is set, tabs/expander/popover register as widgets, which means they:
 
 - ❌ Cannot be used inside `@st.cache_data` decorated functions
 - ❌ Cannot be used inside `@st.fragment` (fragments can't contain widgets that write outside their scope)
@@ -251,7 +251,7 @@ if tabs[0].open:  # Developer must add this check
 
 1. **Lazy Execution Demo:** [`e2e_playwright/dynamic_containers/dynamic_expander_test.py`](https://github.com/streamlit/streamlit/pull/13277/files#diff-dynamic_expander_test.py)
 
-   - Shows tabs and expander with `on_change="rerun"`
+   - Shows tabs, expander, and popover with `on_change="rerun"`
    - Demonstrates `.open` attribute usage
    - Programmatic control via session state
 
@@ -397,7 +397,7 @@ show_expander()
 
 - ❌ **Unclear how this works for `st.tabs`** with multiple functions
 - ❌ Should content automatically be a fragment? If so, inherits all fragment limitations (see Option 2)
-- ❌ Creates two ways to use `st.expander`/`st.tabs` - confusing for users
+- ❌ Creates two ways to use `st.expander`/`st.tabs`/`st.popover` - confusing for users
 - ❌ Not incrementally adoptable - requires refactoring to functions
 - ❌ Less flexible than context manager pattern
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -1,0 +1,288 @@
+---
+Author(s): @sfc-gh-lwilby
+Status: Draft
+Related SEP: https://github.com/streamlit/streamlit-enhancement-proposals/pull/3
+---
+
+# Dynamic Tabs, Expander, and Popover (Lazy Execution)
+
+## Summary
+
+Enable `st.tabs`, `st.expander`, and `st.popover` to execute content lazily (only for the active tab, when expanded, or when popover is open) instead of always executing on every rerun. This addresses a fundamental performance problem where all tab content runs regardless of which tab is visible, causing slower performance in apps with expensive operations across multiple tabs. Enabling state tracking may also unlocks programmatic control as a side benefit (depending on technical implementation decisions).
+
+**API Approach:** [Option 1b from SEP PR #3](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3) - Add `on_change` parameter and `.open` attribute to enable state tracking and conditional execution.
+
+## Problem
+
+### Current Behavior
+
+Currently, `st.tabs` and `st.expander` always execute their content, even when not visible:
+
+```python
+tab1, tab2, tab3 = st.tabs(["Data", "Charts", "ML Model"])
+
+with tab1:
+    load_large_dataset()  # ALWAYS runs, even if user is viewing tab2
+
+with tab2:
+    create_expensive_charts()  # ALWAYS runs, even if user is viewing tab3
+
+with tab3:
+    run_ml_inference()  # ALWAYS runs, even if user is viewing tab1
+```
+
+This ensures instant visibility when tabs are switched, but significantly slows apps when tabs contain expensive computations.
+
+### User Requests
+
+**Primary GitHub Issues:**
+
+- [#6004](https://github.com/streamlit/streamlit/issues/6004) - Dynamic tabs (230 👍)
+- [#2399](https://github.com/streamlit/streamlit/issues/2399) - st.expander expanded/collapsed state (93 👍)
+
+**Related (but not directly addressed by lazy execution):**
+
+- [#8239](https://github.com/streamlit/streamlit/issues/8239) - st.tabs & expander frontend state/mount handling (79 👍) - addresses broader state management issues
+
+### Real-World Examples
+
+1. **ML/Data Science:** Multiple models, each requiring expensive inference - ALL run even though user views one
+2. **API Dashboards:** All API calls execute every rerun (rate limits, costs, 1.5+ seconds)
+3. **Database Tools:** All queries run simultaneously (5-10 seconds for multiple queries)
+4. **Complex Visualizations:** All viz rendered even though only one visible (Plotly 3D, network graphs, etc.)
+
+**Current workarounds:** Users resort to `st.selectbox`, `st.radio` or `st.segmented_control` instead of tabs to control execution, losing the visual organization benefits of tabs.
+
+**Side benefit:** Enabling state tracking can unlock programmatic control (setting active tab/expander via session state), which could enable new use cases like multi-step workflows (Next/Back buttons) and conditional tab switching (e.g., auto-advance when validation passes).
+
+---
+
+## Proposal
+
+### API Design (Option 1b)
+
+Add `on_change` parameter and `.open` attribute following the pattern established for chart/dataframe selections.
+
+#### For `st.tabs`:
+
+```python
+tabs = st.tabs(["Data", "Charts", "ML"], on_change="rerun", key="my_tabs")
+
+# Only execute content for the active tab
+if tabs[0].open:
+    with tabs[0]:
+        load_large_dataset()  # Only runs when this tab is active
+
+if tabs[1].open:
+    with tabs[1]:
+        create_expensive_charts()  # Only runs when this tab is active
+
+# Programmatic control
+def goto_charts():
+    st.session_state.my_tabs = "Charts"
+
+st.button("Go to Charts", on_click=goto_charts)
+```
+
+#### For `st.expander`:
+
+```python
+exp = st.expander("Show details", on_change="rerun", key="details")
+
+if exp.open:  # Only when expanded
+    with exp:
+        expensive_operation()
+
+# Programmatic control
+def open_details():
+    st.session_state.details = True
+
+st.button("Show Details", on_click=open_details)
+```
+
+#### For `st.popover`:
+
+```python
+pop = st.popover("Options", on_change="rerun", key="options")
+
+if pop.open:  # Only when popover is open
+    with pop:
+        expensive_operation()
+```
+
+### Parameters
+
+#### New parameter: `on_change`
+
+- **Type:** `Literal["ignore", "rerun"] | WidgetCallback`
+- **Default:** `"ignore"` (current behavior - always execute all content, no state tracking)
+- **Values:**
+  - `"ignore"`: Current behavior, always execute all content, no state tracking
+  - `"rerun"`: Trigger full app rerun when tab changes/expander toggles, enables state tracking
+  - `callback`: _(Future addition for API consistency with widgets)_ Function to call before rerun
+    - Note: Callbacks could theoretically be used to define tab/expander content (combining Option 2 with Option 1b), but this would be unintuitive (callbacks typically run side effects, not define content) and would face fragment limitations if auto-wrapped. Better to let users explicitly use `@st.fragment` where needed.
+
+#### New parameter: `key` (for tabs)
+
+- **Type:** `str | None`
+- **Default:** `None`
+- **Purpose:** Required if using `on_change` with callback, makes state accessible via `st.session_state[key]`
+- **State value:** `str` (label of active tab) for tabs, `bool` for expander
+
+#### New attribute: `.open` (on DeltaGenerator)
+
+Each returned `DeltaGenerator` (tab or expander) has a new `.open` property:
+
+- **Type:** `bool | None`
+- **Returns:**
+  - `True` if tab is active or expander is expanded
+  - `False` if tab is not active or expander is collapsed
+  - `None` if `on_change` is `"ignore"` (state not tracked) OR if called on non-tab/expander/popover elements
+
+**Implementation:** The property is added to the `DeltaGenerator` class and checks `st.session_state[widget_id]` to determine current state.
+
+**For tabs specifically:** Session state stores the active tab's **label** (as a string), and `.open` checks if this tab's label matches the stored value.
+
+**Important caveat:** Since `.open` is added to `DeltaGenerator` (which is shared by all Streamlit elements), all elements will have this property. For elements that are not tabs/expanders/popovers, `.open` will always return `None`. This is an acceptable API trade-off for implementation simplicity.
+
+**Usage:**
+
+```python
+tabs = st.tabs(["A", "B", "C"], key="my_tabs", on_change="rerun")
+
+# Each tab has .open property
+tabs[0].open  # True if "A" is active, False otherwise
+tabs[1].open  # True if "B" is active, False otherwise
+
+# Also accessible via session state
+st.session_state.my_tabs  # Returns "A", "B", or "C" (active tab label)
+
+# Note: Other elements also have .open but it returns None
+button = st.button("Click")
+button.open  # Always None (not a tab/expander/popover)
+```
+
+### Behavior
+
+**When `on_change` is set:**
+
+1. Element registers as a widget (tracks state in session_state)
+2. `.open` attribute returns current state (`True`/`False`)
+3. User must explicitly check `.open` to get lazy execution
+4. Switching tabs/toggling expander triggers app rerun (if `on_change="rerun"` or callback)
+
+**When `on_change` is `"ignore"` (default):**
+
+1. Element behaves as current (no state tracking)
+2. `.open` returns `None`
+3. All content always executes (backward compatible)
+
+**Explicit opt-in pattern:**
+
+```python
+tabs = st.tabs([...], on_change="rerun")  # Enable state tracking
+
+if tabs[0].open:  # Developer must add this check
+    with tabs[0]:
+        expensive_code()  # Only runs when check is True
+```
+
+**Why opt-in is important:** When `on_change` is set, tabs/expander register as widgets, which means they:
+
+- ❌ Cannot be used inside `@st.cache_data` decorated functions
+- ❌ Cannot be used inside `@st.fragment` (fragments can't contain widgets that write outside their scope)
+- This is why `on_change=None` is the default - to avoid breaking existing apps that use tabs in these contexts
+
+### Examples
+
+**Full example apps demonstrating Option 1b:**
+
+1. **Lazy Execution Demo:** `e2e_playwright/dynamic_containers/dynamic_expander_test.py`
+
+   - Shows tabs and expander with `on_change="rerun"`
+   - Demonstrates `.open` attribute usage
+   - Programmatic control via session state
+
+2. **Database Query Dashboard:** `e2e_playwright/dynamic_containers/database_query_app_option1b.py`
+
+   - Real-world example: Multiple database queries in tabs
+   - Only active tab's query executes
+   - Shows 70-80% performance improvement by simulating expensive database queries
+
+3. **Multi-Step Wizard:** `e2e_playwright/dynamic_containers/wizard_pipeline_app_option1b.py`
+   - Sequential workflow with Next/Back buttons
+   - Programmatic navigation between steps
+   - Demonstrates validation and conditional logic
+
+**Comparison apps (Option 2):**
+
+_Note: Option 2 API is not implemented. These apps demonstrate what the code would look like with the function argument approach for comparison purposes._
+
+- `e2e_playwright/dynamic_containers/database_query_app_option2.py`
+- `e2e_playwright/dynamic_containers/wizard_pipeline_app_option2.py`
+
+---
+
+### Design Rationale: Why Option 1b?
+
+#### Alternative Considered: Option 2 (Function Argument)
+
+From [SEP PR #3](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3), an alternative approach was considered:
+
+**Option 2:** Pass functions as arguments: `st.tabs({"A": func_a, "B": func_b}, args=(data,))`
+
+**Why not selected:**
+
+1. **Auto-fragmentation impractical** - Option 2's main performance advantage would be auto-wrapping functions in fragments (like `st.dialog`), but this imposes some restrictions:
+
+   - ❌ Cannot use `st.sidebar` directly
+   - ❌ Widgets cannot write to external containers (breaks shared output area pattern)
+   - ❌ Elements accumulate/duplicate in external containers (duplication bug #12762)
+   - Note: Unlike `st.dialog` (isolated modals), tabs are part of main app flow where these patterns are likely
+
+2. **Not incrementally adoptable** - Requires refactoring existing code to functions
+
+3. **Implicit execution** - Less clear when code runs
+
+4. Programmatic control can still be implemented, but would likely still involve registering the element as a widget and adding a key and using session state to update the widget state (an established pattern with other elements). This control mechanism is more in sync with option 1b conceptually.
+
+**Strengths:** Automatic execution, clean `args`/`kwargs`, less overhead. Automatic performance gain from fragments if we do auto-fragmentation.
+
+#### Why Option 1b Was Selected
+
+**SteerCo Decision (Oct 15, 2024):** Strong support for Option 1b - "easier to grow into" and "feels more at home with Streamlit APIs"
+
+**Key reasons:**
+
+1. ✅ **Consistency:** Matches `on_change` pattern (widgets, selections)
+2. ✅ **Explicitness:** `if tabs[i].open:` shows execution flow
+3. ✅ **Incremental adoption:** Add without refactoring
+4. ✅ **Programmatic control:** Well-defined via session state
+5. ✅ **No forced limitations:** Users can optionally use `@st.fragment` (not forced)
+
+**Trade-off:** Full app rerun on tab switch (acceptable - avoids fragment restrictions that would break `st.sidebar`, external containers, etc.). Users can still control this with the st.fragment decorator applied as needed to tab/expander content.
+
+---
+
+## Checklist
+
+- [x] **Will this work on all deployment platforms?** Yes - uses session_state and widget callbacks (supported everywhere)
+- [x] **No breaking API changes?** Yes - new parameters are optional, existing code works unchanged
+- [x] **No new dependencies?** Yes - uses existing infrastructure
+- [x] **Metrics collected?** Yes
+- [x] **Any security or legal implications?** No - uses existing session_state mechanism
+- [x] **Anything to keep in mind for docs?**
+  - Explain trade-off: instant switching (static) vs lazy loading (dynamic)
+  - Document programmatic control pattern
+  - Show performance optimization use cases
+  - Cookbook recipe for expensive tab content
+- [] **Any other risks?**
+
+---
+
+## References
+
+- **SEP:** [PR #3 - Dynamic tabs/expander/popover](https://github.com/streamlit/streamlit-enhancement-proposals/pull/3)
+- **Prototype PR:** [#13277](https://github.com/streamlit/streamlit/pull/13277)
+- **Related PRs:** [#13233 - st.Tab class spec](https://github.com/streamlit/streamlit/pull/13233)
+- **GitHub Issues:** [#6004](https://github.com/streamlit/streamlit/issues/6004) (230 👍), [#2399](https://github.com/streamlit/streamlit/issues/2399) (93 👍), [#8239](https://github.com/streamlit/streamlit/issues/8239) (79 👍)

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -90,7 +90,7 @@ if pop.open:  # Only when popover is open
 
 #### Programmatic Control via Session State
 
-When a `key` is provided, the element's state can be controlled programmatically via `st.session_state`:
+When a `key` is provided and on_change is "rerun" or a callback, the element's state can be controlled programmatically via `st.session_state`:
 
 **For `st.tabs`:**
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -250,7 +250,7 @@ button.open  # Always None (not a tab/expander/popover)
 
 ### Behavior
 
-**When `on_change` is set:**
+**When `on_change` is `"rerun"`:**
 
 1. Element registers as a widget (tracks state in session_state)
 2. `.open` attribute returns current state (`True`/`False`)

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -125,6 +125,43 @@ if exp.open:
         expensive_operation()
 ```
 
+#### Potential Future Extension: Direct State Updates via `.update()`
+
+Similar to `st.status`, which provides a `.update()` method to modify its state after creation, we could extend `st.tabs` and `st.expander` with similar functionality. This would allow updating the open state imperatively within the same script run, without requiring session state manipulation or reruns.
+
+**Potential API for `st.expander`:**
+
+```python
+import time
+import streamlit as st
+
+# Create expander
+exp = st.expander("Processing status", expanded=False)
+
+with exp:
+    data = load_expensive_data()
+    exp.update(expanded=True)
+    st.dataframe(data)
+```
+
+**Potential API for `st.tabs`:**
+
+```python
+import streamlit as st
+
+tabs = st.tabs(["Input", "Results"])
+
+with tabs[0]:
+    if st.button("Run Analysis"):
+        results = run_analysis()
+        st.session_state.results = results
+        tabs.update(active="Results")
+
+with tabs[1]:
+    if "results" in st.session_state:
+        st.write(st.session_state.results)
+```
+
 ### Parameters
 
 #### New parameter: `on_change`
@@ -223,11 +260,6 @@ if tabs[0].open:  # Developer must add this check
    - Real-world example: Multiple database queries in tabs
    - Only active tab's query executes
    - Shows 70-80% performance improvement by simulating expensive database queries
-
-3. **Multi-Step Wizard:** [`e2e_playwright/dynamic_containers/wizard_pipeline_app_option1b.py`](https://github.com/streamlit/streamlit/pull/13277/files#diff-wizard_pipeline_app_option1b.py)
-   - Sequential workflow with Next/Back buttons
-   - Programmatic navigation between steps
-   - Demonstrates validation and conditional logic
 
 ---
 

--- a/specs/0003-dynamic-tabs-expander/product-spec.md
+++ b/specs/0003-dynamic-tabs-expander/product-spec.md
@@ -95,7 +95,7 @@ if pop.open:  # Only when popover is open
 
 #### Programmatic Control via Session State
 
-When a `key` is provided and on_change is "rerun" or a callback, the element's state can be controlled programmatically via `st.session_state`:
+When a `key` is provided and `on_change="rerun"` or a callback, the element's state can be controlled programmatically via `st.session_state`:
 
 **For `st.tabs`:**
 


### PR DESCRIPTION
This PR adds a product specification for implementing dynamic (lazy-loading) tabs, expanders, and popovers in Streamlit. The spec proposes adding an on_change parameter and .open attribute to enable conditional execution of content only when tabs/expanders/popovers are active/open, addressing performance issues when multiple tabs contain expensive operations.

Changes:

Adds comprehensive product specification documenting API design, behavior, parameters, and implementation rationale for the API design.

Includes detailed examples, comparison with alternative approaches, and references to related GitHub issues and PRs

Rendered spec: https://issues.streamlit.app/spec_renderer?pr=13587

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
