### PR TITLE
Fix bar chart error with uniform column values

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
@@ -262,6 +262,29 @@ describe("ChartColumn", () => {
     expect((mockCell3 as SparklineCellType).data?.values).toEqual([0, 0])
   })
 
+  it("handles uniform values without explicit y_min/y_max configuration", () => {
+    // This tests the fix for https://github.com/streamlit/streamlit/issues/13584
+    const mockColumn = getBarChartColumn()
+
+    // Uniform positive values should render with y_min=0 and y_max=value
+    const mockCell1 = mockColumn.getCell([4, 4, 4, 4])
+    expect(isErrorCell(mockCell1)).toEqual(false)
+    expect((mockCell1 as SparklineCellType).data?.values).toEqual([4, 4, 4, 4])
+    expect((mockCell1 as SparklineCellType).data?.yAxis).toEqual([0, 4])
+
+    // Uniform zero values should render with y_min=0 and y_max=1
+    const mockCell2 = mockColumn.getCell([0, 0, 0])
+    expect(isErrorCell(mockCell2)).toEqual(false)
+    expect((mockCell2 as SparklineCellType).data?.values).toEqual([0, 0, 0])
+    expect((mockCell2 as SparklineCellType).data?.yAxis).toEqual([0, 1])
+
+    // Uniform negative values should render with y_min=value and y_max=0
+    const mockCell3 = mockColumn.getCell([-5, -5, -5])
+    expect(isErrorCell(mockCell3)).toEqual(false)
+    expect((mockCell3 as SparklineCellType).data?.values).toEqual([-5, -5, -5])
+    expect((mockCell3 as SparklineCellType).data?.yAxis).toEqual([-5, 0])
+  })
+
   it("supports named color mapping and custom colors", () => {
     const blueColumn = getLineChartColumn({ color: "blue" })
     const blueCell = blueColumn.getCell([0, 1]) as SparklineCellType

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -204,14 +204,15 @@ function BaseChartColumn(
       let maxValueDefault: number
       let minValueDefault: number
 
-      if (chartData.length === 1) {
+      // Handle case where all values are identical (including single-element arrays)
+      if (minValue === maxValue) {
         let newMaxValue: number
 
         if (maxValue <= 0) newMaxValue = maxValue === 0 ? 1 : 0
         else newMaxValue = maxValue
 
         maxValueDefault = parameters.y_max ?? newMaxValue
-        minValueDefault = parameters.y_min ?? (maxValue >= 0 ? 0 : maxValue) //maxValue = minValue (only one value in chartData)
+        minValueDefault = parameters.y_min ?? (maxValue >= 0 ? 0 : maxValue)
       } else {
         maxValueDefault = parameters.y_max ?? maxValue
         minValueDefault = parameters.y_min ?? minValue


### PR DESCRIPTION
## Describe your changes

Fixed the "Invalid min/max y-axis configuration" error that occurred when rendering bar charts with uniform (identical) values in a column without explicit y_min/y_max bounds. The fix changes the condition from checking single-element arrays to checking if all values are identical (minValue === maxValue), applying the same bounds logic to both cases.

## GitHub Issue Link

Fixes #13584

## Testing Plan

- Added comprehensive unit tests covering uniform positive values, zero values, and negative values
- All 28 existing and new tests pass
- Verified linting passes on modified files

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.