### PR TITLE
[fix] font 404 error in Vite dev proxy config

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -113,7 +113,9 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
-      "^.*/media/.*": {
+      // Use negative lookahead to avoid matching /static/media/* (Vite's font files)
+      // while still matching /media/* and /basepath/media/* (backend user uploads)
+      "^(?!.*/static/media).*/media/.*": {
         target: DEV_SERVER_BACKEND_URL,
         changeOrigin: true,
       },


### PR DESCRIPTION

## Describe your changes

Fixes font file 404 errors in Vite dev server by preventing `/static/media/*` paths from being proxied to the backend.

Modified the `/media/` proxy pattern to use a negative lookahead that excludes `/static/media/*` (Vite's built font assets) while still proxying `/media/*` (backend user uploads).

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Explanation of why no additional tests are needed

**No additional tests needed:** Development-only configuration change. Can be verified by starting the Vite dev server and confirming font files load without 404 errors.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
