### PR TITLE
[chore] Ensure node types reflect the same version as nvmrc

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -77,7 +77,7 @@
     "@types/iframe-resizer": "~4.0.0",
     "@types/jsdom": "~21.1.7",
     "@types/lodash-es": "~4.17.12",
-    "@types/node": "^25.0.5",
+    "@types/node": ">=24 <25",
     "@types/prop-types": "~15.7.15",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "testCoverage": "vitest run --coverage"
   },
   "resolutions": {
+    "@types/node": ">=24 <25",
     "d3-color": "^3.1.0",
     "dompurify": "^3.2.4",
     "prismjs": "^1.30.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3227,7 +3227,7 @@ __metadata:
     "@types/iframe-resizer": "npm:~4.0.0"
     "@types/jsdom": "npm:~21.1.7"
     "@types/lodash-es": "npm:~4.17.12"
-    "@types/node": "npm:^25.0.5"
+    "@types/node": "npm:>=24 <25"
     "@types/prop-types": "npm:~15.7.15"
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
@@ -4717,21 +4717,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^25.0.5":
-  version: 25.0.8
-  resolution: "@types/node@npm:25.0.8"
+"@types/node@npm:>=24 <25":
+  version: 24.10.9
+  resolution: "@types/node@npm:24.10.9"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/2282464cd928ab184b2310b79899c76bfaa88c8d14640dfab2f9218fdee7e2d916056492de683aa3a26050c8f3bbcade0305616a55277a7c344926c0393149e0
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^24.0.3":
-  version: 24.10.4
-  resolution: "@types/node@npm:24.10.4"
-  dependencies:
-    undici-types: "npm:~7.16.0"
-  checksum: 10c0/069639cb7233ee747df1897b5e784f6b6c5da765c96c94773c580aac888fa1a585048d2a6e95eb8302d89c7a9df75801c8b5a0b7d0221d4249059cf09a5f4228
+  checksum: 10c0/e9e436fcd2136bddb1bbe3271a89f4653910bcf6ee8047c4117f544c7905a106c039e2720ee48f28505ef2560e22fb9ead719f28bf5e075fdde0c1120e38e3b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

The version of node we run (defined in `.nvmrc`) should always have matching major version of its types. We needlessly upgraded to types for v25 of node, despite Streamlit using LTS of v24. This change intentionally pins the range.

Changes include:
- Pinned `@types/node` to version range `>=24 <25` in package.json files

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.