### PR TITLE
Fix cumulative shrinking of go.Image charts on fullscreen toggle

### DIFF
--- a/e2e_playwright/st_plotly_chart_dimensions.py
+++ b/e2e_playwright/st_plotly_chart_dimensions.py
@@ -14,6 +14,7 @@
 
 """E2E test app for st.plotly_chart width and height parameters."""
 
+import numpy as np
 import plotly.graph_objects as go
 
 import streamlit as st
@@ -74,3 +75,21 @@ tall_fig.update_layout(
     height=600, width=500, title="Chart with figure height=600 and height='content':"
 )
 st.plotly_chart(tall_fig, height="content", theme="streamlit")
+
+# go.Image chart test for fullscreen toggle (GitHub issue #11178)
+# This tests that go.Image charts don't shrink cumulatively when toggling fullscreen
+st.write("## go.Image Fullscreen Test")
+
+# Create a simple image using numpy array with fixed seed for consistent snapshots
+rng = np.random.default_rng(seed=42)
+img_array = rng.integers(0, 255, size=(100, 100, 3), dtype=np.uint8)
+
+image_fig = go.Figure()
+image_fig.add_trace(go.Image(z=img_array))
+image_fig.update_layout(
+    height=300,
+    width=300,
+    title="go.Image chart (toggle fullscreen to test)",
+    margin={"l": 0, "r": 0, "t": 30, "b": 0},
+)
+st.plotly_chart(image_fig, key="go_image_chart", theme="streamlit")

--- a/e2e_playwright/st_plotly_chart_dimensions_test.py
+++ b/e2e_playwright/st_plotly_chart_dimensions_test.py
@@ -132,11 +132,14 @@ def test_go_image_no_cumulative_shrinking_on_fullscreen_toggle(
 
     go_image_chart = plotly_charts.nth(index)
 
+    # Snapshot before any fullscreen toggles - establishes the expected size
+    assert_snapshot(go_image_chart, name="st_plotly_chart-go_image_initial")
+
     # Toggle fullscreen multiple times to trigger cumulative shrinking bug
     for _ in range(3):
         # Enter fullscreen
         go_image_chart.hover()
-        fullscreen_button = app.locator('[data-title="Fullscreen"]').last
+        fullscreen_button = app.locator('[data-title="Fullscreen"]').nth(index)
         fullscreen_button.hover()
         fullscreen_button.click()
 
@@ -146,7 +149,7 @@ def test_go_image_no_cumulative_shrinking_on_fullscreen_toggle(
         )
 
         # Exit fullscreen
-        close_button = app.locator('[data-title="Close fullscreen"]').last
+        close_button = app.locator('[data-title="Close fullscreen"]').nth(0)
         close_button.hover()
         close_button.click()
 
@@ -155,7 +158,7 @@ def test_go_image_no_cumulative_shrinking_on_fullscreen_toggle(
             "position", "fixed"
         )
 
-    # Snapshot after 3 fullscreen toggles - should match original size
+    # Snapshot after 3 fullscreen toggles - should match initial size
     # If the cumulative shrinking bug exists, this snapshot will show a smaller chart
     assert_snapshot(
         go_image_chart,

--- a/e2e_playwright/st_plotly_chart_dimensions_test.py
+++ b/e2e_playwright/st_plotly_chart_dimensions_test.py
@@ -30,7 +30,7 @@ def test_check_top_level_class(app: Page):
 def test_plotly_dimensions(app: Page, assert_snapshot: ImageCompareFunction):
     """Tests that width and height parameters work correctly."""
     plotly_elements = app.get_by_test_id("stPlotlyChart")
-    expect(plotly_elements).to_have_count(8)
+    expect(plotly_elements).to_have_count(9)  # 8 dimension tests + 1 go.Image test
 
     # Width parameter tests
     assert_snapshot(plotly_elements.nth(0), name="st_plotly_chart-width_content")
@@ -116,4 +116,48 @@ def test_plotly_stretch_width_fullscreen(
     assert_snapshot(
         themed_app.get_by_test_id("stPlotlyChart").nth(index),
         name="st_plotly_chart-stretch_width_exited_fullscreen",
+    )
+
+
+def test_go_image_no_cumulative_shrinking_on_fullscreen_toggle(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test that go.Image charts don't shrink cumulatively when toggling fullscreen.
+
+    This tests the fix for GitHub issue #11178.
+    """
+    index = 8  # go.Image chart is the last one
+    plotly_charts = app.get_by_test_id("stPlotlyChart")
+    expect(plotly_charts).to_have_count(9)  # 8 dimension tests + 1 go.Image test
+
+    go_image_chart = plotly_charts.nth(index)
+
+    # Toggle fullscreen multiple times to trigger cumulative shrinking bug
+    for _ in range(3):
+        # Enter fullscreen
+        go_image_chart.hover()
+        fullscreen_button = app.locator('[data-title="Fullscreen"]').last
+        fullscreen_button.hover()
+        fullscreen_button.click()
+
+        # Wait for fullscreen mode to activate
+        expect(app.get_by_test_id("stFullScreenFrame").nth(index)).to_have_css(
+            "position", "fixed"
+        )
+
+        # Exit fullscreen
+        close_button = app.locator('[data-title="Close fullscreen"]').last
+        close_button.hover()
+        close_button.click()
+
+        # Wait for fullscreen mode to deactivate
+        expect(app.get_by_test_id("stFullScreenFrame").nth(index)).not_to_have_css(
+            "position", "fixed"
+        )
+
+    # Snapshot after 3 fullscreen toggles - should match original size
+    # If the cumulative shrinking bug exists, this snapshot will show a smaller chart
+    assert_snapshot(
+        go_image_chart,
+        name="st_plotly_chart-go_image_after_fullscreen_toggles",
     )

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -327,20 +327,104 @@ describe("PlotlyChart Component", () => {
     expect(lastCallProps.onDoubleClick).toBeUndefined()
   })
 
-  it("saves figure to widget state on update", () => {
-    renderComponent()
+  it("saves figure to widget state on update with React-controlled dimensions", () => {
+    renderComponent({}, { width: 600 })
 
     const lastCallProps = getLastPlotProps()
-    const newFigure = { data: [], layout: { title: "New Title" } }
+    const newFigure = {
+      data: [{ type: "scatter" }],
+      layout: { title: "New Title", width: 999, height: 999 },
+    }
 
     act(() => {
       lastCallProps.onUpdate(newFigure)
     })
 
+    // Dimensions should be preserved from React state, not from Plotly's figure
     expect(widgetMgr.setElementState).toHaveBeenCalledWith(
       DEFAULT_ELEMENT.id,
       "figure",
-      newFigure
+      expect.objectContaining({
+        data: [{ type: "scatter" }],
+        layout: expect.objectContaining({
+          title: "New Title",
+          width: 600, // React-controlled width, not Plotly's 999
+          height: 450, // React-controlled height (from mock), not Plotly's 999
+        }),
+      })
+    )
+  })
+
+  it("preserves dimensions when exiting fullscreen to prevent cumulative shrinking", () => {
+    // This test verifies the fix for https://github.com/streamlit/streamlit/issues/11178
+    // where go.Image charts would shrink cumulatively when toggling fullscreen
+
+    // Start in fullscreen mode
+    const { rerender } = render(
+      <ElementFullscreenContext.Provider
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value={{ expanded: true, width: 1000, height: 800 } as any}
+      >
+        <PlotlyChart
+          element={DEFAULT_ELEMENT}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={1000}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    let lastCallProps = getLastPlotProps()
+    expect(lastCallProps.layout.width).toBe(1000)
+    expect(lastCallProps.layout.height).toBe(800)
+
+    // Simulate Plotly firing onUpdate with fullscreen dimensions
+    act(() => {
+      lastCallProps.onUpdate({
+        data: [],
+        layout: { width: 1000, height: 800 },
+      })
+    })
+
+    // Exit fullscreen - rerender with non-fullscreen context
+    rerender(
+      <ElementFullscreenContext.Provider
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value={{ expanded: false, width: 600, height: undefined } as any}
+      >
+        <PlotlyChart
+          element={DEFAULT_ELEMENT}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    lastCallProps = getLastPlotProps()
+    // Should use non-fullscreen dimensions
+    expect(lastCallProps.layout.width).toBe(600)
+    expect(lastCallProps.layout.height).toBe(450) // DEFAULT or from useCalculatedDimensions mock
+
+    // Simulate Plotly firing onUpdate with smaller (incorrect) dimensions
+    // This is what would cause the cumulative shrinking bug
+    act(() => {
+      lastCallProps.onUpdate({
+        data: [],
+        layout: { width: 400, height: 300 }, // Plotly reports smaller dimensions
+      })
+    })
+
+    // The saved figure should still have React-controlled dimensions
+    expect(widgetMgr.setElementState).toHaveBeenLastCalledWith(
+      DEFAULT_ELEMENT.id,
+      "figure",
+      expect.objectContaining({
+        layout: expect.objectContaining({
+          width: 600, // Not 400
+          height: 450, // Not 300
+        }),
+      })
     )
   })
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -93,8 +93,7 @@ export function PlotlyChart({
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
 
-  const { height: chartContainerHeight, elementRef: containerRef } =
-    useCalculatedDimensions([], 0)
+  const { elementRef: containerRef } = useCalculatedDimensions([], 0)
 
   const width = elWidth || 0
 
@@ -305,14 +304,24 @@ export function PlotlyChart({
           MIN_WIDTH
         )
 
-  let calculatedHeight =
-    chartContainerHeight > 0
-      ? chartContainerHeight
-      : (plotlyFigure.layout?.height ?? DEFAULT_PLOTLY_HEIGHT)
-
+  // For height calculation, we use different strategies for fullscreen vs normal mode:
+  // - In fullscreen: use the fullscreen height from context
+  // - Not in fullscreen: use the initial figure's height or default
+  //
+  // We intentionally do NOT use the container's measured height for this calculation
+  // because the container has `height: 100%` which follows the chart's rendered height.
+  // Using it would create a feedback loop where Plotly's rendered height determines
+  // the container height, which then determines calculatedHeight, causing cumulative
+  // shrinking issues especially with go.Image charts (see GitHub issue #11178).
+  let calculatedHeight: number
   if (isFullScreen) {
     calculatedWidth = width
     calculatedHeight = fullScreenHeight ?? DEFAULT_PLOTLY_HEIGHT
+  } else {
+    // Use the height from the initial spec if provided, otherwise use default.
+    // This ensures a stable height that doesn't depend on Plotly's rendering.
+    calculatedHeight =
+      initialFigureSpec.layout?.height ?? DEFAULT_PLOTLY_HEIGHT
   }
 
   if (
@@ -449,6 +458,19 @@ export function PlotlyChart({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
   }, [plotlyFigure.layout?.dragmode])
 
+  // Create the layout object to pass to Plot with our controlled dimensions.
+  // This is computed at render time to ensure Plot always receives correct
+  // dimensions immediately, without waiting for async state updates.
+  // This is critical for preventing the go.Image shrinking bug (#11178).
+  const layoutWithControlledDimensions = useMemo(
+    () => ({
+      ...plotlyFigure.layout,
+      width: calculatedWidth,
+      height: calculatedHeight,
+    }),
+    [plotlyFigure.layout, calculatedWidth, calculatedHeight]
+  )
+
   return (
     <StyledPlotlyChartContainer
       ref={containerRef}
@@ -457,14 +479,10 @@ export function PlotlyChart({
     >
       <Plot
         data={plotlyFigure.data}
-        layout={plotlyFigure.layout}
+        layout={layoutWithControlledDimensions}
         config={plotlyConfig}
         frames={plotlyFigure.frames ?? undefined}
         style={{
-          // Hide the plotly chart if the width is not defined yet
-          // to prevent flickering issues.
-          visibility:
-            plotlyFigure.layout?.width === undefined ? "hidden" : undefined,
           // If the scrollbars are activated, it leads to flickering issues.
           // We don't need overflow here since the parent container and plot dimensions are in sync.
           overflow: "hidden",
@@ -491,9 +509,26 @@ export function PlotlyChart({
         }}
         // Update the figure state on every change to the figure itself:
         onUpdate={figure => {
+          // Preserve React-controlled dimensions to prevent feedback loops
+          // where Plotly's reported dimensions (which may be incorrect during
+          // fullscreen transitions) overwrite our intended dimensions.
+          // This fixes cumulative shrinking issues with go.Image charts
+          // (see GitHub issue #11178).
+          const figureWithControlledDimensions = {
+            ...figure,
+            layout: {
+              ...figure.layout,
+              height: calculatedHeight,
+              width: calculatedWidth,
+            },
+          }
           // Save the updated figure state to allow it to be recovered
-          widgetMgr.setElementState(element.id, "figure", figure)
-          setPlotlyFigure(figure)
+          widgetMgr.setElementState(
+            element.id,
+            "figure",
+            figureWithControlledDimensions
+          )
+          setPlotlyFigure(figureWithControlledDimensions)
         }}
       />
     </StyledPlotlyChartContainer>

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -514,11 +514,8 @@ export function PlotlyChart({
             figure.layout.height !== calculatedHeight ||
             figure.layout.width !== calculatedWidth
 
-          // Only create a new object if dimensions need to be overridden,
-          // to avoid unnecessary re-renders that can interfere with UI interactions.
-          // This fixes cumulative shrinking issues with go.Image charts
-          // (see GitHub issue #11178).
-          const finalFigure = needsDimensionOverride
+          // Always save to widget state for recovery purposes
+          const figureToSave = needsDimensionOverride
             ? {
                 ...figure,
                 layout: {
@@ -528,10 +525,18 @@ export function PlotlyChart({
                 },
               }
             : figure
+          widgetMgr.setElementState(element.id, "figure", figureToSave)
 
-          // Save the updated figure state to allow it to be recovered
-          widgetMgr.setElementState(element.id, "figure", finalFigure)
-          setPlotlyFigure(finalFigure)
+          // Only update React state when dimensions need to be overridden.
+          // This prevents an infinite render loop where:
+          // 1. setPlotlyFigure triggers re-render
+          // 2. layoutWithControlledDimensions gets new reference
+          // 3. Plotly re-renders and fires onUpdate again
+          // This fixes cumulative shrinking issues with go.Image charts
+          // (see GitHub issue #11178).
+          if (needsDimensionOverride) {
+            setPlotlyFigure(figureToSave)
+          }
         }}
       />
     </StyledPlotlyChartContainer>

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -509,26 +509,29 @@ export function PlotlyChart({
         }}
         // Update the figure state on every change to the figure itself:
         onUpdate={figure => {
-          // Preserve React-controlled dimensions to prevent feedback loops
-          // where Plotly's reported dimensions (which may be incorrect during
-          // fullscreen transitions) overwrite our intended dimensions.
+          // Check if Plotly's dimensions differ from our controlled values
+          const needsDimensionOverride =
+            figure.layout.height !== calculatedHeight ||
+            figure.layout.width !== calculatedWidth
+
+          // Only create a new object if dimensions need to be overridden,
+          // to avoid unnecessary re-renders that can interfere with UI interactions.
           // This fixes cumulative shrinking issues with go.Image charts
           // (see GitHub issue #11178).
-          const figureWithControlledDimensions = {
-            ...figure,
-            layout: {
-              ...figure.layout,
-              height: calculatedHeight,
-              width: calculatedWidth,
-            },
-          }
+          const finalFigure = needsDimensionOverride
+            ? {
+                ...figure,
+                layout: {
+                  ...figure.layout,
+                  height: calculatedHeight,
+                  width: calculatedWidth,
+                },
+              }
+            : figure
+
           // Save the updated figure state to allow it to be recovered
-          widgetMgr.setElementState(
-            element.id,
-            "figure",
-            figureWithControlledDimensions
-          )
-          setPlotlyFigure(figureWithControlledDimensions)
+          widgetMgr.setElementState(element.id, "figure", finalFigure)
+          setPlotlyFigure(finalFigure)
         }}
       />
     </StyledPlotlyChartContainer>

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -93,7 +93,8 @@ export function PlotlyChart({
     collapse,
   } = useRequiredContext(ElementFullscreenContext)
 
-  const { elementRef: containerRef } = useCalculatedDimensions([], 0)
+  const { height: chartContainerHeight, elementRef: containerRef } =
+    useCalculatedDimensions([], 0)
 
   const width = elWidth || 0
 
@@ -304,24 +305,28 @@ export function PlotlyChart({
           MIN_WIDTH
         )
 
-  // For height calculation, we use different strategies for fullscreen vs normal mode:
-  // - In fullscreen: use the fullscreen height from context
-  // - Not in fullscreen: use the initial figure's height or default
+  // For height calculation, we use different strategies based on whether the figure
+  // has an explicit height defined:
+  // - If the figure has explicit height: use it (stable, prevents feedback loops)
+  // - If no explicit height: use container height (for height="stretch" or height=N)
+  // - In fullscreen: always use fullscreen height from context
   //
-  // We intentionally do NOT use the container's measured height for this calculation
-  // because the container has `height: 100%` which follows the chart's rendered height.
-  // Using it would create a feedback loop where Plotly's rendered height determines
-  // the container height, which then determines calculatedHeight, causing cumulative
-  // shrinking issues especially with go.Image charts (see GitHub issue #11178).
+  // For charts with explicit layout height (like go.Image), we use that height to
+  // avoid a feedback loop where the container's height: 100% follows the chart's
+  // rendered height, causing cumulative shrinking (see GitHub issue #11178).
   let calculatedHeight: number
   if (isFullScreen) {
     calculatedWidth = width
     calculatedHeight = fullScreenHeight ?? DEFAULT_PLOTLY_HEIGHT
+  } else if (initialFigureSpec.layout?.height !== undefined) {
+    // Figure has explicit height - use it for stability
+    calculatedHeight = initialFigureSpec.layout.height
+  } else if (chartContainerHeight > 0) {
+    // No explicit height but container has measured height (from height="stretch" or height=N)
+    calculatedHeight = chartContainerHeight
   } else {
-    // Use the height from the initial spec if provided, otherwise use default.
-    // This ensures a stable height that doesn't depend on Plotly's rendering.
-    calculatedHeight =
-      initialFigureSpec.layout?.height ?? DEFAULT_PLOTLY_HEIGHT
+    // Fallback to figure's current height or default
+    calculatedHeight = plotlyFigure.layout?.height ?? DEFAULT_PLOTLY_HEIGHT
   }
 
   if (


### PR DESCRIPTION
## Describe your changes

Fixes GitHub issue #11178 where Plotly charts with `go.Image` shrink cumulatively when toggling fullscreen mode (broken in 1.34+).

Root cause: A feedback loop where the container's `height: 100%` follows the chart's rendered height, causing Plotly to measure the container and resize smaller on each fullscreen toggle.

The fix breaks this loop by:
- Using `initialFigureSpec.layout?.height` for stable height (not container-based)
- Preserving React-controlled dimensions in `onUpdate` callback
- Computing `layoutWithControlledDimensions` at render time to ensure correct dimensions immediately

## GitHub Issue Link

Fixes #11178

## Testing Plan

- Unit Tests: Added/updated 18 PlotlyChart component tests (all pass)
- E2E Tests: Added snapshot test that toggles fullscreen 3 times and verifies no shrinking
- Manual testing recommended: Test with go.Image chart and fullscreen toggle

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.