### PR TITLE
Allow dynamic changes to `pills` and `segmented_control` options if `key` is provided

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -203,15 +203,20 @@ if st.toggle("Update pills props"):
         key="dynamic_pills_with_key",
         help="updated help",
         width=300,
-        default="banana",
+        default="papaya",
         on_change=lambda a, param: print(
             f"Updated pills - callback triggered: {a} {param}"
         ),
         args=("Updated pills arg",),
         kwargs={"param": "updated kwarg param"},
-        # Whitelisted args:
-        options=["apple", "banana", "orange"],
+        options=["mango", "papaya", "grape", "apple"],
+        # Whitelisted args (can change without resetting widget):
         selection_mode="single",
+        # Changing format_func is allowed, but selection is based on the
+        # formatted string labels. If the formatted label changes (e.g.,
+        # "Apple" vs "APPLE"), previously selected options may become
+        # unselected. This is something we might be able to improve with
+        # additional refactorings.
         format_func=lambda x: x.capitalize(),
     )
     st.write("Updated pills value:", dyn_val)
@@ -227,8 +232,8 @@ else:
         ),
         args=("Initial pills arg",),
         kwargs={"param": "initial kwarg param"},
-        # Whitelisted args:
-        options=["apple", "banana", "orange"],
+        options=["apple", "banana", "mango", "orange"],
+        # Whitelisted args (can change without resetting widget):
         selection_mode="single",
         format_func=lambda x: x.capitalize(),
     )

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -254,11 +254,17 @@ def test_pills_width_examples(app: Page, assert_snapshot: ImageCompareFunction):
 
 
 def test_dynamic_pills_props(app: Page, assert_snapshot: ImageCompareFunction):
-    """Test that the pills can be updated dynamically while keeping the state."""
+    """Test that pills can be updated dynamically.
+
+    Options can be changed dynamically when a key is provided.
+    When using dynamic options with a key:
+    - The selection is preserved only if the formatted value exists in the new options.
+    - When the selected value is removed from options, it resets to the new default.
+    """
     dynamic_pills = get_element_by_key(app, "dynamic_pills_with_key")
     expect(dynamic_pills).to_be_visible()
 
-    # Initial state
+    # Initial state: options are [apple, banana, mango, orange], default is apple
     expect(dynamic_pills).to_contain_text("Initial dynamic pills")
     assert_snapshot(dynamic_pills, name="st_pills-dynamic_initial")
     expect_prefixed_markdown(app, "Initial pills value:", "apple")
@@ -266,20 +272,18 @@ def test_dynamic_pills_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Check that the help tooltip is correct:
     expect_help_tooltip(app, dynamic_pills, "initial help")
 
-    # Click a selection and submit
-    get_pill_button(dynamic_pills, "banana").click()
+    # Select "banana" which only exists in initial options
+    get_pill_button(dynamic_pills, "Banana").click()
     wait_for_app_run(app)
-
     expect_prefixed_markdown(app, "Initial pills value:", "banana")
 
-    # Click the toggle to update the pills props
+    # Toggle to update options to [mango, papaya, grape, apple], default is papaya
+    # Since "banana" doesn't exist in new options, it should reset to default "papaya"
     click_toggle(app, "Update pills props")
 
-    # new pills is visible:
     expect(dynamic_pills).to_contain_text("Updated dynamic pills")
-
-    # Ensure the previously entered value remains visible
-    expect_prefixed_markdown(app, "Updated pills value:", "banana")
+    # "banana" was removed, so selection resets to new default "papaya"
+    expect_prefixed_markdown(app, "Updated pills value:", "papaya")
 
     dynamic_pills.scroll_into_view_if_needed()
     assert_snapshot(dynamic_pills, name="st_pills-dynamic_updated")
@@ -287,7 +291,13 @@ def test_dynamic_pills_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Check that the help tooltip is correct:
     expect_help_tooltip(app, dynamic_pills, "updated help")
 
-    # Click a different value
-    get_pill_button(dynamic_pills, "orange").click()
+    # Now select "mango" which exists in both option sets
+    get_pill_button(dynamic_pills, "Mango").click()
     wait_for_app_run(app)
-    expect_prefixed_markdown(app, "Updated pills value:", "orange")
+    expect_prefixed_markdown(app, "Updated pills value:", "mango")
+
+    # Toggle back to initial options - "mango" should be preserved
+    click_toggle(app, "Update pills props")
+    expect(dynamic_pills).to_contain_text("Initial dynamic pills")
+    # "mango" exists in both sets, so selection is preserved
+    expect_prefixed_markdown(app, "Initial pills value:", "mango")

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -227,15 +227,20 @@ if st.toggle("Update segmented control props"):
         key="dynamic_segmented_control_with_key",
         help="updated help",
         width=300,
-        default="banana",
+        default="papaya",
         on_change=lambda a, param: print(
             f"Updated segmented control - callback triggered: {a} {param}"
         ),
         args=("Updated segmented control arg",),
         kwargs={"param": "updated kwarg param"},
-        # Whitelisted args:
-        options=["apple", "banana", "orange"],
+        options=["mango", "papaya", "grape", "apple"],
+        # Whitelisted args (can change without resetting widget):
         selection_mode="single",
+        # Changing format_func is allowed, but selection is based on the
+        # formatted string labels. If the formatted label changes (e.g.,
+        # "Apple" vs "APPLE"), previously selected options may become
+        # unselected. This is something we might be able to improve with
+        # additional refactorings.
         format_func=lambda text: text.capitalize(),
     )
     st.write("Updated segmented control value:", dyn_val)
@@ -251,8 +256,8 @@ else:
         ),
         args=("Initial segmented control arg",),
         kwargs={"param": "initial kwarg param"},
-        # Whitelisted args:
-        options=["apple", "banana", "orange"],
+        options=["apple", "banana", "mango", "orange"],
+        # Whitelisted args (can change without resetting widget):
         selection_mode="single",
         format_func=lambda text: text.capitalize(),
     )

--- a/e2e_playwright/st_segmented_control_test.py
+++ b/e2e_playwright/st_segmented_control_test.py
@@ -244,11 +244,17 @@ def test_segmented_control_width_examples(
 def test_dynamic_segmented_control_props(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
-    """Test that the segmented control can be updated dynamically while keeping the state."""
+    """Test that segmented control can be updated dynamically.
+
+    Options can be changed dynamically when a key is provided.
+    When using dynamic options with a key:
+    - The selection is preserved only if the formatted value exists in the new options.
+    - When the selected value is removed from options, it resets to the new default.
+    """
     dynamic_segmented = get_element_by_key(app, "dynamic_segmented_control_with_key")
     expect(dynamic_segmented).to_be_visible()
 
-    # Initial state
+    # Initial state: options are [apple, banana, mango, orange], default is apple
     expect(dynamic_segmented).to_contain_text("Initial dynamic segmented control")
     assert_snapshot(dynamic_segmented, name="st_segmented_control-dynamic_initial")
     expect_prefixed_markdown(app, "Initial segmented control value:", "apple")
@@ -256,25 +262,30 @@ def test_dynamic_segmented_control_props(
     # Check that the help tooltip is correct:
     expect_help_tooltip(app, dynamic_segmented, "initial help")
 
-    # Click a value
-    get_segment_button(dynamic_segmented, "banana").click()
+    # Select "banana" which only exists in initial options
+    get_segment_button(dynamic_segmented, "Banana").click()
     wait_for_app_run(app)
     expect_prefixed_markdown(app, "Initial segmented control value:", "banana")
 
-    # Click the toggle to update the segmented control props
+    # Toggle to update options to [mango, papaya, grape, apple], default is papaya
+    # Since "banana" doesn't exist in new options, it should reset to default "papaya"
     click_toggle(app, "Update segmented control props")
 
-    # new segmented control is visible:
     expect(dynamic_segmented).to_contain_text("Updated dynamic segmented control")
-
-    # Ensure the previously entered value remains visible
-    expect_prefixed_markdown(app, "Updated segmented control value:", "banana")
+    # "banana" was removed, so selection resets to new default "papaya"
+    expect_prefixed_markdown(app, "Updated segmented control value:", "papaya")
 
     dynamic_segmented.scroll_into_view_if_needed()
     assert_snapshot(dynamic_segmented, name="st_segmented_control-dynamic_updated")
     expect_help_tooltip(app, dynamic_segmented, "updated help")
 
-    # Click a different value
-    get_segment_button(dynamic_segmented, "orange").click()
+    # Now select "mango" which exists in both option sets
+    get_segment_button(dynamic_segmented, "Mango").click()
     wait_for_app_run(app)
-    expect_prefixed_markdown(app, "Updated segmented control value:", "orange")
+    expect_prefixed_markdown(app, "Updated segmented control value:", "mango")
+
+    # Toggle back to initial options - "mango" should be preserved
+    click_toggle(app, "Update segmented control props")
+    expect(dynamic_segmented).to_contain_text("Initial dynamic segmented control")
+    # "mango" exists in both sets, so selection is preserved
+    expect_prefixed_markdown(app, "Initial segmented control value:", "mango")

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -160,12 +160,13 @@ describe("ButtonGroup widget", () => {
 
   it("sets widget value on mount", () => {
     const props = getProps()
-    vi.spyOn(props.widgetMgr, "setIntArrayValue")
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
     render(<ButtonGroup {...props} />)
-    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+    // For borderless (feedback) style, values are indices as strings
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element,
-      props.element.default,
+      [String(defaultSelectedIndex)],
       {
         fromUi: false,
       },
@@ -187,49 +188,50 @@ describe("ButtonGroup widget", () => {
     it("onClick prop for single select", async () => {
       const user = userEvent.setup()
       const props = getProps()
-      vi.spyOn(props.widgetMgr, "setIntArrayValue")
+      vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
       render(<ButtonGroup {...props} />)
 
       const buttons = getButtonGroupButtons()
       expect(buttons).toHaveLength(EXPECTED_BUTTONS_LENGTH)
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      // For borderless (feedback) style, values are indices as strings
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        props.element.default,
+        [String(defaultSelectedIndex)],
         { fromUi: false },
         undefined
       )
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(1)
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(1)
 
       // click element at index 1 to select it
       await user.click(buttons[1])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        [1],
+        ["1"],
         { fromUi: true },
         undefined
       )
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(2)
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(2)
 
       // click element at index 0 to select it
       await user.click(getButtonGroupButtons()[0])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        [0],
+        ["0"],
         { fromUi: true },
         undefined
       )
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(3)
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(3)
 
       // click on same button does deselect it
       await user.click(getButtonGroupButtons()[0])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
         [],
         { fromUi: true },
         undefined
       )
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(4)
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(4)
     })
 
     it("onClick prop for multi select", async () => {
@@ -237,39 +239,40 @@ describe("ButtonGroup widget", () => {
       const props = getProps({
         clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
       })
-      vi.spyOn(props.widgetMgr, "setIntArrayValue")
+      vi.spyOn(props.widgetMgr, "setStringArrayValue")
       render(<ButtonGroup {...props} />)
 
       const buttons = getButtonGroupButtons()
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      // For borderless (feedback) style, values are indices as strings
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        props.element.default,
+        [String(defaultSelectedIndex)],
         { fromUi: false },
         undefined
       )
 
       await user.click(buttons[1])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
         // the 2 is default value
-        [2, 1],
+        ["2", "1"],
         { fromUi: true },
         undefined
       )
 
       await user.click(getButtonGroupButtons()[0])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        [2, 1, 0],
+        ["2", "1", "0"],
         { fromUi: true },
         undefined
       )
 
       // unselect the second button
       await user.click(getButtonGroupButtons()[1])
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        [2, 0],
+        ["2", "0"],
         { fromUi: true },
         undefined
       )
@@ -283,21 +286,22 @@ describe("ButtonGroup widget", () => {
           fragmentId: "myFragmentId",
         }
       )
-      vi.spyOn(props.widgetMgr, "setIntArrayValue")
+      vi.spyOn(props.widgetMgr, "setStringArrayValue")
       render(<ButtonGroup {...props} />)
 
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      // For borderless (feedback) style, values are indices as strings
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        props.element.default,
+        [String(defaultSelectedIndex)],
         { fromUi: false },
         "myFragmentId"
       )
 
       const button = getButtonGroupButtons()[0]
       await user.click(button)
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        [0],
+        ["0"],
         { fromUi: true },
         "myFragmentId"
       )
@@ -316,17 +320,18 @@ describe("ButtonGroup widget", () => {
     })
 
     it("sets widget value on update", () => {
-      const props = getProps({ value: [3], setValue: true })
-      vi.spyOn(props.widgetMgr, "setIntArrayValue")
+      const props = getProps({ rawValues: ["3"], setValue: true })
+      vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
       render(<ButtonGroup {...props} />)
       const buttons = getButtonGroupButtons()
       expectHighlightStyle(buttons[3])
       expectHighlightStyle(buttons[defaultSelectedIndex], false)
 
-      expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      // For borderless (feedback) style, values are indices as strings
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
-        props.element.default,
+        [String(defaultSelectedIndex)],
         {
           fromUi: false,
         },
@@ -531,7 +536,7 @@ describe("ButtonGroup widget", () => {
     })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
 
-    vi.spyOn(props.widgetMgr, "setIntArrayValue")
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
     render(<ButtonGroup {...props} />)
 
@@ -554,9 +559,10 @@ describe("ButtonGroup widget", () => {
     expectHighlightStyle(buttons[0], false)
     expectHighlightStyle(buttons[1], false)
     expectHighlightStyle(buttons[2])
-    expect(props.widgetMgr.setIntArrayValue).toHaveBeenLastCalledWith(
+    // For borderless (feedback) style, values are indices as strings
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
       props.element,
-      props.element.default,
+      [String(defaultSelectedIndex)],
       { fromUi: true },
       undefined
     )

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -393,7 +393,6 @@ function getDefaultStateFromProto(
 }
 
 function getCurrStateFromProto(element: ButtonGroupProto): ButtonGroupValue {
-  // Use rawValues (string-based) instead of deprecated value field
   const rawValues = element.rawValues ?? []
   return stringsToIndices(rawValues, element.options, element.style)
 }

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -61,6 +61,88 @@ export interface Props {
   widthConfig: streamlit.IWidthConfig | undefined | null
 }
 
+/**
+ * Convert a string value to an option index.
+ * For borderless (feedback), the string is the index itself.
+ * For pills/segmented_control, the string is the reconstructed formatted option.
+ */
+function stringToIndex(
+  value: string,
+  options: ButtonGroupProto.IOption[],
+  style: ButtonGroupProto.Style
+): number {
+  if (style === ButtonGroupProto.Style.BORDERLESS) {
+    // For feedback, the string is the index as a string
+    const index = parseInt(value, 10)
+    return isNaN(index) ? -1 : index
+  }
+  // For pills/segmented_control, match by reconstructed formatted option
+  return options.findIndex(opt => optionToFormattedString(opt) === value)
+}
+
+/**
+ * Reconstruct the full formatted option string from the proto option.
+ * The backend extracts icons from the formatted string, so we need to
+ * reconstruct it: "icon content" or just "icon" or just "content".
+ */
+function optionToFormattedString(option: ButtonGroupProto.IOption): string {
+  const icon = option.contentIcon ?? ""
+  const content = option.content ?? ""
+
+  if (icon && content) {
+    return `${icon} ${content}`
+  }
+  if (icon) {
+    return icon
+  }
+  return content
+}
+
+/**
+ * Convert an option index to a string value.
+ * For borderless (feedback), the string is the index itself.
+ * For pills/segmented_control, the string is the reconstructed formatted option.
+ */
+function indexToString(
+  index: number,
+  options: ButtonGroupProto.IOption[],
+  style: ButtonGroupProto.Style
+): string {
+  if (style === ButtonGroupProto.Style.BORDERLESS) {
+    // For feedback, use the index as a string
+    return index.toString()
+  }
+  // For pills/segmented_control, reconstruct the full formatted option string
+  const option = options[index]
+  return option ? optionToFormattedString(option) : index.toString()
+}
+
+/**
+ * Convert string values to indices for UI display.
+ */
+function stringsToIndices(
+  values: string[],
+  options: ButtonGroupProto.IOption[],
+  style: ButtonGroupProto.Style
+): number[] {
+  return values
+    .map(v => stringToIndex(v, options, style))
+    .filter(i => i >= 0 && i < options.length)
+}
+
+/**
+ * Convert indices to string values for storage.
+ */
+function indicesToStrings(
+  indices: number[],
+  options: ButtonGroupProto.IOption[],
+  style: ButtonGroupProto.Style
+): string[] {
+  return indices
+    .filter(i => i >= 0 && i < options.length)
+    .map(i => indexToString(i, options, style))
+}
+
 function handleMultiSelection(
   index: number,
   currentSelection: number[]
@@ -97,9 +179,15 @@ function syncWithWidgetManager(
   valueWithSource: ValueWithSource<ButtonGroupValue>,
   fragmentId?: string
 ): void {
-  widgetMgr.setIntArrayValue(
-    element,
+  // Convert indices to string values before syncing
+  const stringValues = indicesToStrings(
     valueWithSource.value,
+    element.options,
+    element.style
+  )
+  widgetMgr.setStringArrayValue(
+    element,
+    stringValues,
     { fromUi: valueWithSource.fromUi },
     fragmentId
   )
@@ -290,7 +378,12 @@ function getInitialValue(
   widgetMgr: WidgetStateManager,
   element: ButtonGroupProto
 ): ButtonGroupValue | undefined {
-  return widgetMgr.getIntArrayValue(element)
+  const stringValues = widgetMgr.getStringArrayValue(element)
+  if (stringValues === undefined) {
+    return undefined
+  }
+  // Convert string values to indices
+  return stringsToIndices(stringValues, element.options, element.style)
 }
 
 function getDefaultStateFromProto(
@@ -300,7 +393,9 @@ function getDefaultStateFromProto(
 }
 
 function getCurrStateFromProto(element: ButtonGroupProto): ButtonGroupValue {
-  return element.value ?? []
+  // Use rawValues (string-based) instead of deprecated value field
+  const rawValues = element.rawValues ?? []
+  return stringsToIndices(rawValues, element.options, element.style)
 }
 
 function ButtonGroup(props: Readonly<Props>): ReactElement {

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -326,6 +326,7 @@ class _FeedbackSerdeString:
             if 0 <= index < len(self.options_indices):
                 return self.options_indices[index]
         except ValueError:
+            # Invalid index string (not an integer) - fall through to default handling
             pass
 
         # Invalid value - return default
@@ -1185,9 +1186,6 @@ class ButtonGroupMixin:
             selection_mode,
         )
 
-        if selection_mode == "multi":
-            return validated_value
-
         return validated_value
 
     def _button_group(
@@ -1310,9 +1308,15 @@ class ButtonGroupMixin:
             value_type="string_array_value",
         )
 
-        if widget_state.value_changed:
-            serialized = serializer(widget_state.value)
-            proto.raw_values[:] = serialized
+        # Always serialize the current value to raw_values
+        serialized = serializer(widget_state.value)
+        proto.raw_values[:] = serialized
+
+        # Set setValue when value changed OR when we have a value.
+        # The latter ensures frontend maps to correct indices after dynamic option
+        # changes, where the string→index mapping changes but the widget ID stays
+        # the same (because options are in key_as_main_identity for whitelisting).
+        if widget_state.value_changed or serialized:
             proto.set_value = True
 
         if ctx:

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -231,40 +231,39 @@ def _validate_button_group_value(
     options: Sequence[T],
     default_indices: list[int],
     selection_mode: Literal["single", "multi"],
-) -> tuple[T | list[T] | None, bool]:
+) -> T | list[T] | None:
     """Validate value against current options.
 
-    Returns (validated_value, needs_reset).
     For multi-select, filters out invalid values.
     For single-select, resets to default if value is invalid.
     """
     if selection_mode == "multi":
         # Multi-select: filter to only valid values
         if value is None or not isinstance(value, list) or len(value) == 0:
-            return [], False
+            return []
 
         if len(options) == 0:
-            return [], len(value) > 0
+            return []
 
         valid_values = [v for v in value if _index_safe(options, v) is not None]
-        needs_reset = len(valid_values) != len(value)
 
         # If all values were invalid, reset to default
-        if len(valid_values) == 0 and needs_reset:
+        if len(valid_values) == 0:
             if default_indices:
-                return [options[i] for i in default_indices if i < len(options)], True
-            return [], True
+                return [options[i] for i in default_indices if i < len(options)]
+            return []
 
-        return valid_values, needs_reset
+        return valid_values
+
     # Single-select: reset to default if invalid
     if value is None:
-        return None, False
+        return None
 
     if len(options) == 0:
-        return None, value is not None
+        return None
 
     if _index_safe(options, value) is not None:
-        return value, False
+        return value
 
     # Value not in options - reset to default
     if (
@@ -272,8 +271,8 @@ def _validate_button_group_value(
         and len(default_indices) > 0
         and default_indices[0] < len(options)
     ):
-        return options[default_indices[0]], True
-    return None, True
+        return options[default_indices[0]]
+    return None
 
 
 class _FeedbackSerdeString:
@@ -1179,14 +1178,12 @@ class ButtonGroupMixin:
         )
 
         # Validate the value against current options (handles dynamic option changes)
-        validated_value, _ = _validate_button_group_value(
+        return _validate_button_group_value(
             res.value,
             indexable_options,
             default_values,
             selection_mode,
         )
-
-        return validated_value
 
     def _button_group(
         self,

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -36,7 +36,6 @@ from streamlit.elements.lib.layout_utils import (
     validate_width,
 )
 from streamlit.elements.lib.options_selector_utils import (
-    check_and_convert_to_indices,
     convert_to_sequence_and_check_comparable,
     get_default_indices,
 )
@@ -93,96 +92,248 @@ _SELECTED_STAR_ICON: Final = ":material/star_filled:"
 SelectionMode: TypeAlias = Literal["single", "multi"]
 
 
-@dataclass
-class _MultiSelectSerde(Generic[T]):
-    """Only meant to be used internally for the button_group element.
+def _index_safe(options: Sequence[T], value: T) -> int | None:
+    """Find index of value in options, returning None if not found."""
+    for i, opt in enumerate(options):
+        if opt == value:
+            return i
+    return None
 
-    This serde is inspired by the MultiSelectSerde from multiselect.py. That serde has
-    been updated since then to support the accept_new_options parameter, which is not
-    required by the button_group element. If this changes again at some point,
-    the two elements can share the same serde again.
+
+@dataclass
+class _MultiSelectSerdeString(Generic[T]):
+    """String-based serde for multi-select button group.
+
+    Uses formatted option strings for robust handling of dynamic option changes.
     """
 
     options: Sequence[T]
-    default_value: list[int] = field(default_factory=list)
+    formatted_options: list[str]
+    formatted_option_to_option_index: dict[str, int]
+    default_values: list[int]
 
-    def serialize(self, value: list[T]) -> list[int]:
-        indices = check_and_convert_to_indices(self.options, value)
-        return indices if indices is not None else []
+    def serialize(self, values: list[T]) -> list[str]:
+        """Convert list of option values to list of formatted strings."""
+        if not values:
+            return []
+        result: list[str] = []
+        for v in values:
+            option_index = _index_safe(self.options, v)
+            if option_index is not None:
+                result.append(self.formatted_options[option_index])
+            elif isinstance(v, str):
+                # Value is a string not in options - include as-is
+                result.append(v)
+        return result
 
-    def deserialize(self, ui_value: list[int] | None) -> list[T]:
-        current_value: list[int] = (
-            ui_value if ui_value is not None else self.default_value
-        )
-        return [self.options[i] for i in current_value]
+    def deserialize(self, ui_value: list[str] | None) -> list[T]:
+        """Convert list of formatted strings to list of option values.
 
+        If the ui_value contains strings not in the current options, they are
+        filtered out. If all values are filtered out, returns default values.
+        """
+        if ui_value is None:
+            # Return default values
+            return [
+                self.options[i] for i in self.default_values if i < len(self.options)
+            ]
 
-class _SingleSelectSerde(Generic[T]):
-    """Only meant to be used internally for the button_group element.
+        result: list[T] = []
+        for formatted_str in ui_value:
+            option_index = self.formatted_option_to_option_index.get(formatted_str)
+            if option_index is not None and option_index < len(self.options):
+                result.append(self.options[option_index])
+            # Strings not in options are skipped
 
-    Uses the ButtonGroup's _MultiSelectSerde under-the-hood, but accepts a single
-    index value and deserializes to a single index value.
-    This is because button_group can be single and multi select, but we use the same
-    proto for both and, thus, map single values to a list of values and a receiving
-    value wrapped in a list to a single value.
+        # If all values were filtered out (none valid), return default values
+        if len(result) == 0 and len(ui_value) > 0:
+            return [
+                self.options[i] for i in self.default_values if i < len(self.options)
+            ]
 
-    When a default_value is provided is provided, the option corresponding to the
-    index is serialized/deserialized.
-    """
-
-    def __init__(
-        self,
-        option_indices: Sequence[T],
-        default_value: list[int] | None = None,
-    ) -> None:
-        # see docstring about why we use MultiSelectSerde here
-        self.multiselect_serde: _MultiSelectSerde[T] = _MultiSelectSerde(
-            option_indices, default_value if default_value is not None else []
-        )
-
-    def serialize(self, value: T | None) -> list[int]:
-        _value = [value] if value is not None else []
-        return self.multiselect_serde.serialize(_value)
-
-    def deserialize(self, ui_value: list[int] | None) -> T | None:
-        deserialized = self.multiselect_serde.deserialize(ui_value)
-
-        if len(deserialized) == 0:
-            return None
-
-        return deserialized[0]
+        return result
 
 
-class ButtonGroupSerde(Generic[T]):
-    """A serde that can handle both single and multi select options.
+class _SingleSelectSerdeString(Generic[T]):
+    """String-based serde for single-select button group.
 
-    It uses the same proto to wire the data, so that we can send and receive
-    single values via a list. We have different serdes for both cases though so
-    that when setting / getting the value via session_state, it is mapped correctly.
-    So for single select, the value will be a single value and for multi select, it will
-    be a list of values.
+    Wraps _MultiSelectSerdeString for consistent handling.
     """
 
     def __init__(
         self,
         options: Sequence[T],
+        formatted_options: list[str],
+        formatted_option_to_option_index: dict[str, int],
         default_values: list[int],
-        type: Literal["single", "multi"],
     ) -> None:
-        self.options = options
-        self.default_values = default_values
-        self.type = type
-        self.serde: _SingleSelectSerde[T] | _MultiSelectSerde[T] = (
-            _SingleSelectSerde(options, default_value=default_values)
-            if type == "single"
-            else _MultiSelectSerde(options, default_values)
+        self.multiselect_serde: _MultiSelectSerdeString[T] = _MultiSelectSerdeString(
+            options=options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_values=default_values,
         )
 
-    def serialize(self, value: T | list[T] | None) -> list[int]:
+    def serialize(self, value: T | None) -> list[str]:
+        _value = [value] if value is not None else []
+        return self.multiselect_serde.serialize(_value)
+
+    def deserialize(self, ui_value: list[str] | None) -> T | None:
+        deserialized = self.multiselect_serde.deserialize(ui_value)
+        return deserialized[0] if deserialized else None
+
+
+class ButtonGroupSerdeString(Generic[T]):
+    """String-based serde that handles both single and multi select.
+
+    Uses formatted option strings for robust handling of dynamic option changes.
+    """
+
+    def __init__(
+        self,
+        options: Sequence[T],
+        formatted_options: list[str],
+        formatted_option_to_option_index: dict[str, int],
+        default_values: list[int],
+        selection_mode: Literal["single", "multi"],
+    ) -> None:
+        self.options = options
+        self.formatted_options = formatted_options
+        self.formatted_option_to_option_index = formatted_option_to_option_index
+        self.default_values = default_values
+        self.selection_mode = selection_mode
+
+        self.serde: _SingleSelectSerdeString[T] | _MultiSelectSerdeString[T] = (
+            _SingleSelectSerdeString(
+                options,
+                formatted_options,
+                formatted_option_to_option_index,
+                default_values,
+            )
+            if selection_mode == "single"
+            else _MultiSelectSerdeString(
+                options=options,
+                formatted_options=formatted_options,
+                formatted_option_to_option_index=formatted_option_to_option_index,
+                default_values=default_values,
+            )
+        )
+
+    def serialize(self, value: T | list[T] | None) -> list[str]:
         return self.serde.serialize(cast("Any", value))
 
-    def deserialize(self, ui_value: list[int] | None) -> list[T] | T | None:
+    def deserialize(self, ui_value: list[str] | None) -> list[T] | T | None:
         return self.serde.deserialize(ui_value)
+
+
+def _validate_button_group_value(
+    value: T | list[T] | None,
+    options: Sequence[T],
+    default_indices: list[int],
+    selection_mode: Literal["single", "multi"],
+) -> tuple[T | list[T] | None, bool]:
+    """Validate value against current options.
+
+    Returns (validated_value, needs_reset).
+    For multi-select, filters out invalid values.
+    For single-select, resets to default if value is invalid.
+    """
+    if selection_mode == "multi":
+        # Multi-select: filter to only valid values
+        if value is None or not isinstance(value, list) or len(value) == 0:
+            return [], False
+
+        if len(options) == 0:
+            return [], len(value) > 0
+
+        valid_values = [v for v in value if _index_safe(options, v) is not None]
+        needs_reset = len(valid_values) != len(value)
+
+        # If all values were invalid, reset to default
+        if len(valid_values) == 0 and needs_reset:
+            if default_indices:
+                return [options[i] for i in default_indices if i < len(options)], True
+            return [], True
+
+        return valid_values, needs_reset
+    # Single-select: reset to default if invalid
+    if value is None:
+        return None, False
+
+    if len(options) == 0:
+        return None, value is not None
+
+    if _index_safe(options, value) is not None:
+        return value, False
+
+    # Value not in options - reset to default
+    if (
+        default_indices
+        and len(default_indices) > 0
+        and default_indices[0] < len(options)
+    ):
+        return options[default_indices[0]], True
+    return None, True
+
+
+class _FeedbackSerdeString:
+    """String-based serde for feedback widget.
+
+    Converts between sentiment values (returned to user) and index strings
+    (used for widget state). The index corresponds to the position in the
+    displayed options.
+    """
+
+    def __init__(
+        self,
+        options_indices: Sequence[int],
+        default_value: list[int] | None = None,
+    ) -> None:
+        self.options_indices = options_indices
+        self.default_value = default_value
+        # Build mapping from sentiment to index
+        self._sentiment_to_index: dict[int, int] = {
+            sentiment: i for i, sentiment in enumerate(options_indices)
+        }
+
+    def serialize(self, value: int | None) -> list[str]:
+        """Convert sentiment value to list of index strings."""
+        if value is None:
+            return []
+        # Find the index for this sentiment value
+        index = self._sentiment_to_index.get(value)
+        if index is not None:
+            return [str(index)]
+        return []
+
+    def deserialize(self, ui_value: list[str] | None) -> int | None:
+        """Convert list of index strings to sentiment value."""
+        if ui_value is None:
+            # Return default sentiment value
+            # Note: default_value contains indices into options_indices, not sentiment values
+            if self.default_value and len(self.default_value) > 0:
+                default_index = self.default_value[0]
+                if 0 <= default_index < len(self.options_indices):
+                    return self.options_indices[default_index]
+            return None
+
+        if len(ui_value) == 0:
+            return None
+
+        # Convert index string to sentiment value
+        try:
+            index = int(ui_value[0])
+            if 0 <= index < len(self.options_indices):
+                return self.options_indices[index]
+        except ValueError:
+            pass
+
+        # Invalid value - return default
+        if self.default_value and len(self.default_value) > 0:
+            default_index = self.default_value[0]
+            if 0 <= default_index < len(self.options_indices):
+                return self.options_indices[default_index]
+        return None
 
 
 def get_mapped_options(
@@ -451,7 +602,7 @@ class ButtonGroupMixin:
         _default: list[int] | None = (
             [options_indices[default]] if default is not None else None
         )
-        serde = _SingleSelectSerde[int](options_indices, default_value=_default)
+        serde = _FeedbackSerdeString(options_indices, default_value=_default)
 
         selection_visualization = ButtonGroupProto.SelectionVisualization.ONLY_SELECTED
         if options == "stars":
@@ -957,11 +1108,15 @@ class ButtonGroupMixin:
     ) -> list[V] | V | None:
         maybe_raise_label_warnings(label, label_visibility)
 
+        def _format_option_string(option: V) -> str:
+            """Format an option to a string for use as widget state value."""
+            return format_func(option) if format_func else str(option)
+
         def _transformed_format_func(option: V) -> ButtonGroupProto.Option:
             """If option starts with a material icon or an emoji, we extract it to send
             it parsed to the frontend.
             """
-            transformed = format_func(option) if format_func else str(option)
+            transformed = _format_option_string(option)
             transformed_parts = transformed.split(" ")
             icon: str | None = None
             if len(transformed_parts) > 0:
@@ -987,8 +1142,20 @@ class ButtonGroupMixin:
         indexable_options = convert_to_sequence_and_check_comparable(options)
         default_values = get_default_indices(indexable_options, default)
 
-        serde: ButtonGroupSerde[V] = ButtonGroupSerde[V](
-            indexable_options, default_values, selection_mode
+        # Build formatted options list and mapping for string-based serde
+        formatted_options = [_format_option_string(opt) for opt in indexable_options]
+        formatted_option_to_option_index: dict[str, int] = {}
+        for i, formatted_opt in enumerate(formatted_options):
+            # Only use the first occurrence if duplicates exist
+            if formatted_opt not in formatted_option_to_option_index:
+                formatted_option_to_option_index[formatted_opt] = i
+
+        serde: ButtonGroupSerdeString[V] = ButtonGroupSerdeString[V](
+            options=indexable_options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_values=default_values,
+            selection_mode=selection_mode,
         )
 
         res = self._button_group(
@@ -1010,10 +1177,18 @@ class ButtonGroupMixin:
             width=width,
         )
 
-        if selection_mode == "multi":
-            return res.value
+        # Validate the value against current options (handles dynamic option changes)
+        validated_value, _ = _validate_button_group_value(
+            res.value,
+            indexable_options,
+            default_values,
+            selection_mode,
+        )
 
-        return res.value
+        if selection_mode == "multi":
+            return validated_value
+
+        return validated_value
 
     def _button_group(
         self,
@@ -1081,7 +1256,7 @@ class ButtonGroupMixin:
 
         ctx = get_script_run_ctx()
         form_id = current_form_id(self.dg)
-        formatted_options = (
+        proto_options = (
             indexable_options
             if format_func is None
             else [
@@ -1095,12 +1270,13 @@ class ButtonGroupMixin:
             # "feedback" in errors
             "feedback" if style == "borderless" else style,
             user_key=key,
-            # Treat the provided key as the main identity for segmented_control, pills and feedback,
-            # and only include kwargs that can invalidate the current selection.
-            # We whitelist the formatted options and the click mode (single vs multi).
-            key_as_main_identity={"options", "click_mode"},
+            key_as_main_identity={"click_mode"}
+            if style != "borderless"
+            # Feedback always has fixed options and should change identity
+            # if a different option set is used.
+            else {"options", "click_mode"},
             dg=self.dg,
-            options=formatted_options,
+            options=proto_options,
             default=default,
             click_mode=parsed_selection_mode,
             style=style,
@@ -1111,7 +1287,7 @@ class ButtonGroupMixin:
 
         proto = _build_proto(
             element_id,
-            formatted_options,
+            proto_options,
             default or [],
             disabled,
             form_id,
@@ -1131,11 +1307,12 @@ class ButtonGroupMixin:
             deserializer=deserializer,
             serializer=serializer,
             ctx=ctx,
-            value_type="int_array_value",
+            value_type="string_array_value",
         )
 
         if widget_state.value_changed:
-            proto.value[:] = serializer(widget_state.value)
+            serialized = serializer(widget_state.value)
+            proto.raw_values[:] = serialized
             proto.set_value = True
 
         if ctx:

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -31,10 +31,10 @@ from streamlit.elements.widgets.button_group import (
     _STAR_ICON,
     _THUMB_ICONS,
     ButtonGroupMixin,
-    ButtonGroupSerde,
+    ButtonGroupSerdeString,
     SelectionMode,
-    _MultiSelectSerde,
-    _SingleSelectSerde,
+    _MultiSelectSerdeString,
+    _SingleSelectSerdeString,
     get_mapped_options,
 )
 from streamlit.errors import StreamlitAPIException
@@ -92,127 +92,186 @@ class TestGetMappedOptions:
             assert options_indices[index] == index
 
 
-class TestSingleSelectSerde:
+class TestSingleSelectSerdeString:
+    """Tests for the string-based single-select serde."""
+
+    def _make_serde(
+        self,
+        options: list[int],
+        default_values: list[int] | None = None,
+    ) -> _SingleSelectSerdeString[int]:
+        """Helper to create a serde with formatted options."""
+        formatted_options = [str(opt) for opt in options]
+        formatted_option_to_option_index = {
+            fmt: i for i, fmt in enumerate(formatted_options)
+        }
+        return _SingleSelectSerdeString(
+            options=options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_values=default_values or [],
+        )
+
     def test_serialize(self):
-        option_indices = [5, 6, 7]
-        serde = _SingleSelectSerde[int](option_indices)
+        """Test serializing a single value to a string list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
         res = serde.serialize(6)
-        assert res == [1]
+        assert res == ["6"]
 
-    def test_serialize_raise_option_does_not_exist(self):
-        option_indices = [5, 6, 7]
-        serde = _SingleSelectSerde[int](option_indices)
-
-        with pytest.raises(StreamlitAPIException):
-            serde.serialize(8)
+    def test_serialize_none(self):
+        """Test serializing None returns empty list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
+        res = serde.serialize(None)
+        assert res == []
 
     def test_deserialize(self):
-        option_indices = [5, 6, 7]
-        serde = _SingleSelectSerde[int](option_indices)
-        res = serde.deserialize([1])
+        """Test deserializing a string list to a single value."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
+        res = serde.deserialize(["6"])
         assert res == 6
 
     def test_deserialize_with_default_value(self):
-        option_indices = [5, 6, 7]
-        serde = _SingleSelectSerde[int](option_indices, default_value=[2])
+        """Test deserializing None returns the default value."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, default_values=[2])
         res = serde.deserialize(None)
         assert res == 7
 
-    def test_deserialize_raise_indexerror(self):
-        option_indices = [5, 6, 7]
-        serde = _SingleSelectSerde[int](option_indices)
+    def test_deserialize_invalid_value_returns_none(self):
+        """Test deserializing an invalid value returns None."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
+        res = serde.deserialize(["999"])
+        assert res is None
 
-        with pytest.raises(IndexError):
-            serde.deserialize([3])
 
+class TestMultiSelectSerdeString:
+    """Tests for the string-based multi-select serde."""
 
-class TestMultiSelectSerde:
+    def _make_serde(
+        self,
+        options: list[int],
+        default_values: list[int] | None = None,
+    ) -> _MultiSelectSerdeString[int]:
+        """Helper to create a serde with formatted options."""
+        formatted_options = [str(opt) for opt in options]
+        formatted_option_to_option_index = {
+            fmt: i for i, fmt in enumerate(formatted_options)
+        }
+        return _MultiSelectSerdeString(
+            options=options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_values=default_values or [],
+        )
+
     def test_serialize(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
+        """Test serializing multiple values to string list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
         res = serde.serialize([5, 7])
-        assert res == [0, 2]
+        assert res == ["5", "7"]
 
     def test_serialize_empty_list(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
+        """Test serializing empty list returns empty list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
         res = serde.serialize([])
         assert res == []
 
-    def test_serialize_raise_option_does_not_exist(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
-
-        with pytest.raises(StreamlitAPIException):
-            serde.serialize([5, 8])
-
     def test_deserialize(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
-        res = serde.deserialize([0, 2])
+        """Test deserializing string list to values."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
+        res = serde.deserialize(["5", "7"])
         assert res == [5, 7]
 
     def test_deserialize_empty_list(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
+        """Test deserializing empty list returns empty list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
         res = serde.deserialize([])
         assert res == []
 
     def test_deserialize_with_default_value(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices, default_value=[0, 2])
+        """Test deserializing None returns default values."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, default_values=[0, 2])
         res = serde.deserialize(None)
         assert res == [5, 7]
 
-    def test_deserialize_raise_indexerror(self):
-        option_indices = [5, 6, 7]
-        serde = _MultiSelectSerde[int](option_indices)
+    def test_deserialize_invalid_value_skipped(self):
+        """Test deserializing filters out invalid values."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options)
+        res = serde.deserialize(["5", "999", "7"])
+        assert res == [5, 7]
 
-        with pytest.raises(IndexError):
-            serde.deserialize([3])
 
+class TestButtonGroupSerdeString:
+    """Tests for the unified string-based serde."""
 
-class TestSingleOrMultiSelectSerde:
-    @parameterized.expand([("single",), ("multi",)])
-    def test_serialize(self, selection_mode: SelectionMode):
-        option_indices = [5, 6, 7]
-        serde = ButtonGroupSerde[int](option_indices, [], selection_mode)
-        res = serde.serialize(6)
-        assert res == [1]
+    def _make_serde(
+        self,
+        options: list[int],
+        default_values: list[int],
+        selection_mode: SelectionMode,
+    ) -> ButtonGroupSerdeString[int]:
+        """Helper to create a serde with formatted options."""
+        formatted_options = [str(opt) for opt in options]
+        formatted_option_to_option_index = {
+            fmt: i for i, fmt in enumerate(formatted_options)
+        }
+        return ButtonGroupSerdeString(
+            options=options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_values=default_values,
+            selection_mode=selection_mode,
+        )
 
-    @parameterized.expand([("single",), ("multi",)])
-    def test_serialize_raise_option_does_not_exist(self, selection_mode: SelectionMode):
-        option_indices = [5, 6, 7]
-        serde = ButtonGroupSerde[int](option_indices, [], selection_mode)
-
-        with pytest.raises(StreamlitAPIException):
-            serde.serialize(8)
+    @parameterized.expand([("single", 6, ["6"]), ("multi", [6], ["6"])])
+    def test_serialize(
+        self, selection_mode: SelectionMode, value: int | list[int], expected: list[str]
+    ):
+        """Test serializing a value to string list."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, [], selection_mode)
+        res = serde.serialize(value)
+        assert res == expected
 
     @parameterized.expand([("single", 6), ("multi", [6])])
     def test_deserialize(
         self, selection_mode: SelectionMode, expected: int | list[int]
     ):
-        option_indices = [5, 6, 7]
-        serde = ButtonGroupSerde[int](option_indices, [], selection_mode)
-        res = serde.deserialize([1])
+        """Test deserializing string list to value(s)."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, [], selection_mode)
+        res = serde.deserialize(["6"])
         assert res == expected
 
     @parameterized.expand([("single", 7), ("multi", [7])])
     def test_deserialize_with_default_value(
         self, selection_mode: SelectionMode, expected: list[int] | int
     ):
-        option_indices = [5, 6, 7]
-        serde = ButtonGroupSerde[int](option_indices, [2], selection_mode)
+        """Test deserializing None returns default value(s)."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, [2], selection_mode)
         res = serde.deserialize(None)
         assert res == expected
 
-    @parameterized.expand([("single",), ("multi",)])
-    def test_deserialize_raise_indexerror(self, selection_mode: SelectionMode):
-        option_indices = [5, 6, 7]
-        serde = ButtonGroupSerde[int](option_indices, [], selection_mode)
-
-        with pytest.raises(IndexError):
-            serde.deserialize([3])
+    @parameterized.expand([("single", None), ("multi", [])])
+    def test_deserialize_invalid_value(
+        self, selection_mode: SelectionMode, expected: list[int] | int | None
+    ):
+        """Test deserializing invalid values handles gracefully."""
+        options = [5, 6, 7]
+        serde = self._make_serde(options, [], selection_mode)
+        res = serde.deserialize(["999"])
+        assert res == expected
 
 
 class TestFeedbackCommand(DeltaGeneratorTestCase):
@@ -1046,15 +1105,14 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             ("options", ["a", "b"], ["x", "y"]),
-            ("selection_mode", "single", "multi"),
             ("format_func", lambda x: x.capitalize(), lambda x: x.lower()),
         ]
     )
     def test_whitelisted_stable_key_kwargs_segmented_control(
         self, kwarg_name: str, value1: object, value2: object
     ):
-        """Test that the widget ID changes for segmented_control when a whitelisted kwarg changes even when the key
-        is provided.
+        """Test that the widget ID is STABLE for segmented_control when options
+        or format_func change (to support dynamic options).
         """
         with patch(
             "streamlit.elements.lib.utils._register_element_id",
@@ -1067,18 +1125,18 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                 "selection_mode": "single",
             }
 
-            # Apply first value for the whitelisted kwarg
+            # Apply first value for the kwarg
             base_kwargs[kwarg_name] = value1
             st.segmented_control(**base_kwargs)  # type: ignore[arg-type]
             proto1 = self.get_delta_from_queue().new_element.button_group
             id1 = proto1.id
 
-            # Apply second value for the whitelisted kwarg
+            # Apply second value for the kwarg - ID should remain stable
             base_kwargs[kwarg_name] = value2
             st.segmented_control(**base_kwargs)  # type: ignore[arg-type]
             proto2 = self.get_delta_from_queue().new_element.button_group
             id2 = proto2.id
-            assert id1 != id2
+            assert id1 == id2
 
     def test_stable_id_with_key_feedback(self):
         """Test that the widget ID is stable for feedback when a stable key is provided."""
@@ -1196,15 +1254,14 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             ("options", ["a", "b"], ["x", "y"]),
-            ("selection_mode", "single", "multi"),
             ("format_func", lambda x: x.capitalize(), lambda x: x.lower()),
         ]
     )
     def test_whitelisted_stable_key_kwargs_pills(
         self, kwarg_name: str, value1: object, value2: object
     ):
-        """Test that the widget ID changes for pills when a whitelisted kwarg changes even when the key
-        is provided.
+        """Test that the widget ID is STABLE for pills when options
+        or format_func change (to support dynamic options).
         """
         with patch(
             "streamlit.elements.lib.utils._register_element_id",
@@ -1217,15 +1274,15 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
                 "selection_mode": "single",
             }
 
-            # Apply first value for the whitelisted kwarg
+            # Apply first value for the kwarg
             base_kwargs[kwarg_name] = value1
             st.pills(**base_kwargs)  # type: ignore[arg-type]
             proto1 = self.get_delta_from_queue().new_element.button_group
             id1 = proto1.id
 
-            # Apply second value for the whitelisted kwarg
+            # Apply second value for the kwarg - ID should remain stable
             base_kwargs[kwarg_name] = value2
             st.pills(**base_kwargs)  # type: ignore[arg-type]
             proto2 = self.get_delta_from_queue().new_element.button_group
             id2 = proto2.id
-            assert id1 != id2
+            assert id1 == id2

--- a/proto/streamlit/proto/ButtonGroup.proto
+++ b/proto/streamlit/proto/ButtonGroup.proto
@@ -45,8 +45,11 @@ message ButtonGroup {
   ClickMode click_mode = 5;
   string form_id = 6;
 
-  // value passed by the backend
-  repeated uint32 value = 7;
+  // value passed by the backend (DEPRECATED: use raw_values instead)
+  repeated uint32 value = 7 [deprecated = true];
+  // String-based values for dynamic options support (replaces index-based value field)
+  repeated string raw_values = 14;
+
   bool set_value = 8;
 
   enum SelectionVisualization {
@@ -66,5 +69,6 @@ message ButtonGroup {
   LabelVisibilityMessage label_visibility = 12;
   optional string help = 13;
 
-  // next id: 14
+
+  // next id: 15
 }


### PR DESCRIPTION
## Describe your changes

Allow dynamically changing the options for `st.pills` and `st.segmented_control` without triggering an identity change / state reset. If the current selected options isn't in the list of available option, it will be reset to the default value. 

This also applies a needed change from index-based widget value to string-based (formatted options). The same change was already implemented for `st.selectbox` and `st.multiselect` some time ago.

## GitHub Issue Link (if applicable)

- Related: https://github.com/streamlit/streamlit/issues/11277
- Closes: https://github.com/streamlit/streamlit/issues/12392

## Testing Plan

- Added unit and e2e tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
