### PR TITLE
Allow dynamically changing `min_value` and `max_value` in `st.datetime_input` when `key` is provided

### DIFF
--- a/e2e_playwright/st_datetime_input.py
+++ b/e2e_playwright/st_datetime_input.py
@@ -124,6 +124,8 @@ if st.toggle("Update datetime input props"):
         key="dynamic_datetime_input_with_key",
         on_change=lambda: None,
         step=900,
+        min_value=datetime(2020, 1, 1, 0, 0),
+        max_value=datetime(2025, 12, 31, 23, 59),
     )
     st.write("Updated datetime input value:", dval)
 else:
@@ -135,5 +137,7 @@ else:
         key="dynamic_datetime_input_with_key",
         on_change=lambda: None,
         step=900,
+        min_value=datetime(2010, 1, 1, 0, 0),
+        max_value=datetime(2030, 12, 31, 23, 59),
     )
     st.write("Initial datetime input value:", dval)

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -269,3 +269,29 @@ def test_dynamic_props_update(app: Page):
     expect_prefixed_markdown(
         app, "Updated datetime input value:", "2025-12-01 14:30:00"
     )
+
+    # Test dynamic min/max behavior when bounds change:
+    # Toggle back to initial bounds (2010-2030)
+    click_toggle(app, "Update datetime input props")
+    expect_prefixed_markdown(
+        app, "Initial datetime input value:", "2025-12-01 14:30:00"
+    )
+
+    # Set value to 2028/01/01 which is valid in initial bounds (2010-2030)
+    input_field.fill("2028/01/01, 10:00")
+    input_field.press("Enter")
+    # Click on a markdown element to close the popover
+    app.get_by_text("Dynamic datetime input:").click()
+    wait_for_app_run(app)
+    expect_prefixed_markdown(
+        app, "Initial datetime input value:", "2028-01-01 10:00:00"
+    )
+
+    # Toggle to updated bounds (2020-2025) - value 2028 is outside, should reset to default
+    click_toggle(app, "Update datetime input props")
+    # The default value for updated state is BASE_DATETIME + 3h15m = 2025-11-19 20:00:00
+    expect_prefixed_markdown(
+        app, "Updated datetime input value:", "2025-11-19 20:00:00"
+    )
+    # Anti-regression: ensure the old out-of-bounds value is not retained
+    expect(app.get_by_text("2028-01-01")).not_to_be_visible()

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -544,10 +544,10 @@ def _validate_datetime_value(
     parsed_values: _DateTimeInputValues,
     has_explicit_bounds: bool,
 ) -> tuple[datetime | None, bool]:
-    """Validate current datetime value against min/max bounds and reset if needed.
+    """Validate current datetime value against min/max bounds and determine if reset is needed.
 
     Only validates when has_explicit_bounds is True (user provided min_value or max_value).
-    This avoids incorrectly resetting values against computed default bounds.
+    This avoids incorrectly determining if reset is needed against computed default bounds.
 
     Parameters
     ----------
@@ -578,7 +578,7 @@ def _validate_datetime_value(
     if not value_needs_reset:
         return current_value, value_needs_reset
 
-    # Reset to the default value from parsed_values
+    # Needs reset to the default value from parsed_values
     return parsed_values.value, True
 
 
@@ -1175,9 +1175,9 @@ class TimeWidgetsMixin:
         element_id = compute_and_register_element_id(
             "date_time_input",
             user_key=key,
-            # Ensure stable ID when key is provided. Only format and step are whitelisted
-            # because they affect the selectable options and display format.
-            # min_value and max_value support dynamic changes.
+            # Format is whitelisted because of a bug in the BaseWeb date input component.
+            # Step is whitelisted because it invalidates the current selection.
+            # We might be able to unlock this as a follow-up.
             key_as_main_identity={"format", "step"},
             dg=self.dg,
             label=label,
@@ -1260,7 +1260,6 @@ class TimeWidgetsMixin:
             widget_state.value, datetime_values, has_explicit_bounds
         )
 
-        # Reset if needed.
         if value_needs_reset and key is not None:
             # Update session_state so subsequent accesses in this run
             # return the corrected value. Use reset_state_value to avoid

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -566,20 +566,13 @@ def _validate_datetime_value(
         original value (if valid) or the default value (if reset was needed), and
         was_reset indicates whether a reset occurred.
     """
-    value_needs_reset = False
-
     if current_value is None or not has_explicit_bounds:
-        return current_value, value_needs_reset
+        return current_value, False
 
-    # Check if current value is outside bounds
     if current_value < parsed_values.min or current_value > parsed_values.max:
-        value_needs_reset = True
+        return parsed_values.value, True
 
-    if not value_needs_reset:
-        return current_value, value_needs_reset
-
-    # Needs reset to the default value from parsed_values
-    return parsed_values.value, True
+    return current_value, False
 
 
 @dataclass

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -539,6 +539,49 @@ def _validate_date_value(
     return cast("DateWidgetReturn", tuple(parsed_values.value)), True
 
 
+def _validate_datetime_value(
+    current_value: datetime | None,
+    parsed_values: _DateTimeInputValues,
+    has_explicit_bounds: bool,
+) -> tuple[datetime | None, bool]:
+    """Validate current datetime value against min/max bounds and reset if needed.
+
+    Only validates when has_explicit_bounds is True (user provided min_value or max_value).
+    This avoids incorrectly resetting values against computed default bounds.
+
+    Parameters
+    ----------
+    current_value : datetime | None
+        The current value of the datetime input widget.
+    parsed_values : _DateTimeInputValues
+        Parsed configuration containing min, max, and default value.
+    has_explicit_bounds : bool
+        Whether the user explicitly provided min_value or max_value. If False, validation
+        is skipped to avoid resetting against computed default bounds.
+
+    Returns
+    -------
+    tuple[datetime | None, bool]
+        A tuple of (validated_value, was_reset) where validated_value is either the
+        original value (if valid) or the default value (if reset was needed), and
+        was_reset indicates whether a reset occurred.
+    """
+    value_needs_reset = False
+
+    if current_value is None or not has_explicit_bounds:
+        return current_value, value_needs_reset
+
+    # Check if current value is outside bounds
+    if current_value < parsed_values.min or current_value > parsed_values.max:
+        value_needs_reset = True
+
+    if not value_needs_reset:
+        return current_value, value_needs_reset
+
+    # Reset to the default value from parsed_values
+    return parsed_values.value, True
+
+
 @dataclass
 class DateInputSerde:
     value: _DateInputValues
@@ -1132,9 +1175,10 @@ class TimeWidgetsMixin:
         element_id = compute_and_register_element_id(
             "date_time_input",
             user_key=key,
-            # Ensure stable IDs when the key is provided; whitelist parameters that
-            # affect the selectable range or formatting.
-            key_as_main_identity={"min_value", "max_value", "format", "step"},
+            # Ensure stable ID when key is provided. Only format and step are whitelisted
+            # because they affect the selectable options and display format.
+            # min_value and max_value support dynamic changes.
+            key_as_main_identity={"format", "step"},
             dg=self.dg,
             label=label,
             value=value_for_id,
@@ -1145,7 +1189,9 @@ class TimeWidgetsMixin:
             step=step,
             width=width,
         )
-        del value
+        # Track if user explicitly set bounds (before del)
+        has_explicit_bounds = min_value is not None or max_value is not None
+        del value, min_value, max_value
 
         if not bool(ALLOWED_DATE_FORMATS.match(format)):
             raise StreamlitAPIException(
@@ -1208,8 +1254,21 @@ class TimeWidgetsMixin:
             value_type="string_array_value",
         )
 
-        if widget_state.value_changed:
-            date_time_input_proto.value[:] = serde.serialize(widget_state.value)
+        # Validate the current value against the new min/max bounds.
+        # Only validate when user explicitly provided min_value or max_value.
+        current_value, value_needs_reset = _validate_datetime_value(
+            widget_state.value, datetime_values, has_explicit_bounds
+        )
+
+        # Reset if needed.
+        if value_needs_reset and key is not None:
+            # Update session_state so subsequent accesses in this run
+            # return the corrected value. Use reset_state_value to avoid
+            # the "cannot be modified after widget instantiated" error.
+            get_session_state().reset_state_value(key, current_value)
+
+        if value_needs_reset or widget_state.value_changed:
+            date_time_input_proto.value[:] = serde.serialize(current_value)
             date_time_input_proto.set_value = True
 
         validate_width(width)
@@ -1218,7 +1277,7 @@ class TimeWidgetsMixin:
         self.dg._enqueue(
             "date_time_input", date_time_input_proto, layout_config=layout_config
         )
-        return widget_state.value
+        return current_value
 
     @overload
     def date_input(

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -436,3 +436,143 @@ def test_session_state_takes_precedence():
     at = AppTest.from_function(script).run()
     widget = at.datetime_input[0]
     assert widget.value == datetime(2024, 12, 25, 10, 0)
+
+
+def test_dynamic_min_value_resets_value_when_below_new_min():
+    """Test that value resets to default when dynamically changing min_value makes current value invalid."""
+
+    def script():
+        from datetime import datetime
+
+        import streamlit as st
+
+        if "update_bounds" not in st.session_state:
+            st.session_state["update_bounds"] = False
+
+        if st.session_state["update_bounds"]:
+            # New min_value makes the previous value invalid
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 6, 1, 0, 0),
+                max_value=datetime(2024, 12, 31, 23, 59),
+                key="datetime",
+                value=datetime(2024, 7, 15, 12, 0),
+            )
+        else:
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 1, 1, 0, 0),
+                max_value=datetime(2024, 12, 31, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        st.write(f"value: {value}")
+
+        if st.button("Toggle bounds"):
+            st.session_state["update_bounds"] = not st.session_state["update_bounds"]
+
+    at = AppTest.from_function(script).run()
+    assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)
+
+    # Set value to March 1 (valid with min_value=Jan 1)
+    at = at.datetime_input[0].set_value(datetime(2024, 3, 1, 10, 0)).run()
+    assert at.datetime_input[0].value == datetime(2024, 3, 1, 10, 0)
+
+    # Toggle bounds - the click updates session_state["update_bounds"] to True
+    at = at.button[0].click().run()
+    # AppTest requires an additional run to process the widget with the new bounds
+    at = at.run()
+    # Now min_value=June 1, so March 1 is invalid and should reset to default (July 15)
+    assert at.datetime_input[0].value == datetime(2024, 7, 15, 12, 0)
+
+
+def test_dynamic_max_value_resets_value_when_above_new_max():
+    """Test that value resets to default when dynamically changing max_value makes current value invalid."""
+
+    def script():
+        from datetime import datetime
+
+        import streamlit as st
+
+        if "update_bounds" not in st.session_state:
+            st.session_state["update_bounds"] = False
+
+        if st.session_state["update_bounds"]:
+            # New max_value makes the previous value invalid
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 1, 1, 0, 0),
+                max_value=datetime(2024, 6, 30, 23, 59),
+                key="datetime",
+                value=datetime(2024, 3, 15, 12, 0),
+            )
+        else:
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 1, 1, 0, 0),
+                max_value=datetime(2024, 12, 31, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        st.write(f"value: {value}")
+
+        if st.button("Toggle bounds"):
+            st.session_state["update_bounds"] = not st.session_state["update_bounds"]
+
+    at = AppTest.from_function(script).run()
+    assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)
+
+    # Set value to October 1 (valid with max_value=Dec 31)
+    at = at.datetime_input[0].set_value(datetime(2024, 10, 1, 14, 0)).run()
+    assert at.datetime_input[0].value == datetime(2024, 10, 1, 14, 0)
+
+    # Toggle bounds - the click updates session_state["update_bounds"] to True
+    at = at.button[0].click().run()
+    # AppTest requires an additional run to process the widget with the new bounds
+    at = at.run()
+    # Now max_value=June 30, so October 1 is invalid and should reset to default (March 15)
+    assert at.datetime_input[0].value == datetime(2024, 3, 15, 12, 0)
+
+
+def test_dynamic_bounds_preserves_valid_value():
+    """Test that value is preserved when it remains valid after bound changes."""
+
+    def script():
+        from datetime import datetime
+
+        import streamlit as st
+
+        if "update_bounds" not in st.session_state:
+            st.session_state["update_bounds"] = False
+
+        if st.session_state["update_bounds"]:
+            # Changing bounds but May 15 is still valid (between Apr 1 and Sep 30)
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 4, 1, 0, 0),
+                max_value=datetime(2024, 9, 30, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        else:
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 1, 1, 0, 0),
+                max_value=datetime(2024, 12, 31, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        st.write(f"value: {value}")
+
+        if st.button("Toggle bounds"):
+            st.session_state["update_bounds"] = not st.session_state["update_bounds"]
+
+    at = AppTest.from_function(script).run()
+    assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)
+
+    # Toggle bounds - the click updates session_state["update_bounds"] to True
+    at = at.button[0].click().run()
+    # AppTest requires an additional run to process the widget with the new bounds
+    at = at.run()
+    # Value should be preserved because it's still within the new bounds
+    assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -576,3 +576,53 @@ def test_dynamic_bounds_preserves_valid_value():
     at = at.run()
     # Value should be preserved because it's still within the new bounds
     assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)
+
+
+def test_dynamic_bounds_preserves_user_set_valid_value():
+    """Test that a user-set value (different from default) is preserved when still valid after bound changes."""
+
+    def script():
+        from datetime import datetime
+
+        import streamlit as st
+
+        if "update_bounds" not in st.session_state:
+            st.session_state["update_bounds"] = False
+
+        if st.session_state["update_bounds"]:
+            # New bounds: Apr 1 to Sep 30 - July 1 is still valid
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 4, 1, 0, 0),
+                max_value=datetime(2024, 9, 30, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        else:
+            value = st.datetime_input(
+                "datetime",
+                min_value=datetime(2024, 1, 1, 0, 0),
+                max_value=datetime(2024, 12, 31, 23, 59),
+                key="datetime",
+                value=datetime(2024, 5, 15, 12, 0),
+            )
+        st.write(f"value: {value}")
+
+        if st.button("Toggle bounds"):
+            st.session_state["update_bounds"] = not st.session_state["update_bounds"]
+
+    at = AppTest.from_function(script).run()
+    assert at.datetime_input[0].value == datetime(2024, 5, 15, 12, 0)
+
+    # Set value to July 1 (different from default May 15, valid in both bound ranges)
+    at = at.datetime_input[0].set_value(datetime(2024, 7, 1, 10, 0)).run()
+    assert at.datetime_input[0].value == datetime(2024, 7, 1, 10, 0)
+
+    # Toggle bounds - the click updates session_state["update_bounds"] to True
+    at = at.button[0].click().run()
+    # AppTest requires an additional run to process the widget with the new bounds
+    at = at.run()
+    # User-set value (July 1) should be preserved, not reset to default (May 15)
+    assert at.datetime_input[0].value == datetime(2024, 7, 1, 10, 0)
+    # Ensure it's not reset to the default value
+    assert at.datetime_input[0].value != datetime(2024, 5, 15, 12, 0)


### PR DESCRIPTION
## Describe your changes

Allow dynamically changing the `min_value`, `max_value` of `st.datetime_input` without triggering an identity change / state reset. If the current selected value isn't in the range, it will be reset to the default value. 

## GitHub Issue Link (if applicable)

- Related issue https://github.com/streamlit/streamlit/issues/11277

## Testing Plan

- Added e2e and unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
