### PR TITLE
[Prototype] Allow fragments to write widgets to outside containers

### DIFF
--- a/e2e_playwright/st_fragment_outside_container.py
+++ b/e2e_playwright/st_fragment_outside_container.py
@@ -31,7 +31,7 @@ outside_container = st.container()
 def fragment_with_outside_widget():
     """Fragment that writes a button to an outside container."""
     outside_container.button("Outside Button", key="outside_btn")
-    st.write(f"Fragment UUID: {uuid4()}")
+    st.write(f"Basic fragment UUID: {uuid4()}")
 
 
 fragment_with_outside_widget()

--- a/e2e_playwright/st_fragment_outside_container.py
+++ b/e2e_playwright/st_fragment_outside_container.py
@@ -1,0 +1,93 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test app for fragments writing widgets to outside containers.
+
+This tests the feature that allows fragments to write widgets to containers
+that were created outside the fragment's scope.
+"""
+
+from uuid import uuid4
+
+import streamlit as st
+
+# Test 1: Basic widget in outside container
+# The container is created BEFORE the fragment, and the fragment writes to it
+outside_container = st.container()
+
+
+@st.fragment
+def fragment_with_outside_widget():
+    """Fragment that writes a button to an outside container."""
+    outside_container.button("Outside Button", key="outside_btn")
+    st.write(f"Fragment UUID: {uuid4()}")
+
+
+fragment_with_outside_widget()
+st.write(f"App UUID: {uuid4()}")
+
+st.divider()
+
+# Test 2: Counter in outside container to verify state works correctly
+if "counter" not in st.session_state:
+    st.session_state.counter = 0
+
+counter_container = st.container()
+
+
+@st.fragment
+def counter_fragment():
+    """Fragment that manages a counter in an outside container."""
+    if counter_container.button("Increment Counter", key="increment_btn"):
+        st.session_state.counter += 1
+    counter_container.write(f"Counter value: {st.session_state.counter}")
+
+
+counter_fragment()
+
+st.divider()
+
+# Test 3: Multiple elements written to outside container
+multi_container = st.container()
+
+
+@st.fragment
+def multi_element_fragment():
+    """Fragment that writes multiple elements to an outside container."""
+    multi_container.text_input("Name", key="name_input")
+    multi_container.selectbox("Color", ["Red", "Green", "Blue"], key="color_select")
+    multi_container.write(f"Multi-element fragment UUID: {uuid4()}")
+
+
+multi_element_fragment()
+
+st.divider()
+
+# Test 4: Nested container scenario
+outer_container = st.container()
+with outer_container:
+    inner_container = st.container()
+
+
+@st.fragment
+def nested_container_fragment():
+    """Fragment that writes to a nested container created outside."""
+    inner_container.button("Nested Button", key="nested_btn")
+    inner_container.write(f"Nested fragment UUID: {uuid4()}")
+
+
+nested_container_fragment()
+
+# Full rerun button at the bottom
+st.button("Full Rerun", key="full_rerun_btn")

--- a/e2e_playwright/st_fragment_outside_container_test.py
+++ b/e2e_playwright/st_fragment_outside_container_test.py
@@ -31,7 +31,7 @@ def test_widget_in_outside_container_no_duplication(app: Page):
     expect(outside_btn).to_have_count(1)
 
     # Get initial UUIDs
-    fragment_uuid = app.get_by_text("Fragment UUID:").text_content()
+    fragment_uuid = app.get_by_text("Basic fragment UUID:").text_content()
     app_uuid = app.get_by_text("App UUID:").text_content()
 
     # Click the button to trigger fragment rerun
@@ -42,7 +42,7 @@ def test_widget_in_outside_container_no_duplication(app: Page):
     expect(app.get_by_role("button", name="Outside Button")).to_have_count(1)
 
     # Fragment UUID should have changed, app UUID should remain the same
-    expect(app.get_by_text("Fragment UUID:")).not_to_have_text(fragment_uuid)
+    expect(app.get_by_text("Basic fragment UUID:")).not_to_have_text(fragment_uuid)
     expect(app.get_by_text("App UUID:")).to_have_text(app_uuid)
 
     # Click again to verify no accumulation
@@ -120,14 +120,14 @@ def test_nested_container_widget(app: Page):
 def test_full_rerun_clears_fragment_elements(app: Page):
     """Verify that a full rerun properly handles fragment elements in outside containers."""
     # Get initial UUIDs
-    fragment_uuid = app.get_by_text("Fragment UUID:").text_content()
+    fragment_uuid = app.get_by_text("Basic fragment UUID:").text_content()
     app_uuid = app.get_by_text("App UUID:").text_content()
 
     # Trigger full rerun
     click_button(app, "Full Rerun")
 
     # Both UUIDs should change
-    expect(app.get_by_text("Fragment UUID:")).not_to_have_text(fragment_uuid)
+    expect(app.get_by_text("Basic fragment UUID:")).not_to_have_text(fragment_uuid)
     expect(app.get_by_text("App UUID:")).not_to_have_text(app_uuid)
 
     # No element duplication

--- a/e2e_playwright/st_fragment_outside_container_test.py
+++ b/e2e_playwright/st_fragment_outside_container_test.py
@@ -1,0 +1,136 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fragments writing widgets to outside containers.
+
+These tests verify that fragments can write widgets to containers that were
+created outside the fragment's scope, without causing widget duplication.
+"""
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import click_button
+
+
+def test_widget_in_outside_container_no_duplication(app: Page):
+    """Verify that a widget in an outside container doesn't duplicate on fragment rerun."""
+    # Initial state: should have exactly one "Outside Button"
+    outside_btn = app.get_by_role("button", name="Outside Button")
+    expect(outside_btn).to_have_count(1)
+
+    # Get initial UUIDs
+    fragment_uuid = app.get_by_text("Fragment UUID:").text_content()
+    app_uuid = app.get_by_text("App UUID:").text_content()
+
+    # Click the button to trigger fragment rerun
+    outside_btn.click()
+    wait_for_app_run(app)
+
+    # Should still have exactly one button (not duplicated)
+    expect(app.get_by_role("button", name="Outside Button")).to_have_count(1)
+
+    # Fragment UUID should have changed, app UUID should remain the same
+    expect(app.get_by_text("Fragment UUID:")).not_to_have_text(fragment_uuid)
+    expect(app.get_by_text("App UUID:")).to_have_text(app_uuid)
+
+    # Click again to verify no accumulation
+    app.get_by_role("button", name="Outside Button").click()
+    wait_for_app_run(app)
+
+    # Still exactly one button
+    expect(app.get_by_role("button", name="Outside Button")).to_have_count(1)
+
+
+def test_counter_widget_in_outside_container(app: Page):
+    """Verify that a counter widget works correctly in an outside container."""
+    # Initial count should be 0
+    expect(app.get_by_text("Counter value: 0")).to_be_visible()
+
+    # Click increment button
+    click_button(app, "Increment Counter")
+
+    # Count should be 1, and only one counter display
+    expect(app.get_by_text("Counter value: 1")).to_be_visible()
+    expect(app.get_by_text("Counter value: 0")).not_to_be_visible()
+    expect(app.get_by_role("button", name="Increment Counter")).to_have_count(1)
+
+    # Click again
+    click_button(app, "Increment Counter")
+
+    # Count should be 2
+    expect(app.get_by_text("Counter value: 2")).to_be_visible()
+    expect(app.get_by_role("button", name="Increment Counter")).to_have_count(1)
+
+
+def test_multiple_widgets_in_outside_container(app: Page):
+    """Verify that multiple widgets in an outside container don't duplicate."""
+    # Initial state: should have exactly one of each widget
+    expect(app.get_by_test_id("stTextInput").filter(has_text="Name")).to_have_count(1)
+    expect(app.get_by_test_id("stSelectbox").filter(has_text="Color")).to_have_count(1)
+
+    # Get initial UUID
+    multi_uuid = app.get_by_text("Multi-element fragment UUID:").text_content()
+
+    # Interact with text input to trigger fragment rerun
+    text_input = app.get_by_test_id("stTextInput").locator("input")
+    text_input.fill("Test Name")
+    text_input.press("Enter")
+    wait_for_app_run(app)
+
+    # Should still have exactly one of each widget
+    expect(app.get_by_test_id("stTextInput").filter(has_text="Name")).to_have_count(1)
+    expect(app.get_by_test_id("stSelectbox").filter(has_text="Color")).to_have_count(1)
+
+    # UUID should have changed
+    expect(app.get_by_text("Multi-element fragment UUID:")).not_to_have_text(multi_uuid)
+
+
+def test_nested_container_widget(app: Page):
+    """Verify that widgets in nested outside containers work correctly."""
+    # Initial state: should have exactly one nested button
+    nested_btn = app.get_by_role("button", name="Nested Button")
+    expect(nested_btn).to_have_count(1)
+
+    # Get initial UUID
+    nested_uuid = app.get_by_text("Nested fragment UUID:").text_content()
+
+    # Click to trigger fragment rerun
+    nested_btn.click()
+    wait_for_app_run(app)
+
+    # Should still have exactly one button
+    expect(app.get_by_role("button", name="Nested Button")).to_have_count(1)
+
+    # UUID should have changed
+    expect(app.get_by_text("Nested fragment UUID:")).not_to_have_text(nested_uuid)
+
+
+def test_full_rerun_clears_fragment_elements(app: Page):
+    """Verify that a full rerun properly handles fragment elements in outside containers."""
+    # Get initial UUIDs
+    fragment_uuid = app.get_by_text("Fragment UUID:").text_content()
+    app_uuid = app.get_by_text("App UUID:").text_content()
+
+    # Trigger full rerun
+    click_button(app, "Full Rerun")
+
+    # Both UUIDs should change
+    expect(app.get_by_text("Fragment UUID:")).not_to_have_text(fragment_uuid)
+    expect(app.get_by_text("App UUID:")).not_to_have_text(app_uuid)
+
+    # No element duplication
+    expect(app.get_by_role("button", name="Outside Button")).to_have_count(1)
+    expect(app.get_by_role("button", name="Increment Counter")).to_have_count(1)
+    expect(app.get_by_role("button", name="Nested Button")).to_have_count(1)

--- a/fragments-writing-to-outside-containers.md
+++ b/fragments-writing-to-outside-containers.md
@@ -1,0 +1,464 @@
+# Fragments Writing to Outside Containers - Investigation Report
+
+## Executive Summary
+
+This document investigates the feasibility of allowing Streamlit fragments to write widgets to containers outside their own delta path. Currently, this is explicitly disallowed (since PR #8756) due to widget duplication bugs. This investigation analyzes the root causes and explores potential solutions.
+
+## Background
+
+### What is a Fragment?
+
+A Streamlit fragment (`@st.fragment`) is a decorated function that can independently re-run without triggering a full app rerun. Fragments are useful for:
+- Reducing latency for interactive widgets
+- Isolating expensive computations
+- Creating real-time updating sections
+
+### The Problem
+
+When a fragment writes widgets to containers outside its own scope, those widgets get duplicated on each fragment rerun instead of being replaced:
+
+```python
+import streamlit as st
+
+B = st.container()  # Container created OUTSIDE fragment
+
+@st.fragment
+def my_fragment():
+    B.button("Test")  # Widget written to OUTSIDE container
+
+my_fragment()
+st.button("Full Rerun")
+```
+
+**Expected behavior:** Clicking "Test" should trigger a fragment rerun and the button should remain as a single button.
+
+**Actual behavior:** Each click on "Test" adds another identical button to container B.
+
+### Current Solution (PR #8756)
+
+The current solution is to simply disallow this pattern. The `check_fragment_path_policy()` function in `lib/streamlit/elements/lib/policies.py:129-161` raises a `StreamlitFragmentWidgetsNotAllowedOutsideError` when a widget attempts to write to a delta path that doesn't start with the fragment's delta path.
+
+---
+
+## Technical Analysis
+
+### How Fragments Work
+
+#### 1. Fragment Registration (Decoration Time)
+
+When `@st.fragment` is applied to a function (`lib/streamlit/runtime/fragment.py:136-276`):
+
+1. **Snapshot Capture** (lines 168-169):
+   ```python
+   cursors_snapshot = deepcopy(ctx.cursors)
+   dg_stack_snapshot = deepcopy(context_dg_stack.get())
+   ```
+   - `ctx.cursors`: Dictionary mapping root containers to `RunningCursor` objects
+   - `context_dg_stack`: Stack of active DeltaGenerators (containers you're "inside" via `with`)
+
+2. **Fragment ID Generation** (lines 170-172):
+   ```python
+   fragment_id = calc_md5(
+       f"{func.__module__}.{get_object_name(func)}{dg_stack[-1]._get_delta_path_str()}{additional_hash_info}"
+   )
+   ```
+
+3. **Wrapped Function Creation**: A closure that captures the snapshots and fragment ID
+
+#### 2. Fragment Execution (Rerun Time)
+
+When a fragment reruns (`lib/streamlit/runtime/fragment.py:178-258`):
+
+1. **State Restoration** (lines 189-194):
+   ```python
+   if ctx.fragment_ids_this_run:
+       ctx.cursors = deepcopy(cursors_snapshot)
+       context_dg_stack.set(deepcopy(dg_stack_snapshot))
+   ```
+
+2. **Fragment Context Setup** (lines 206-207, 221-235):
+   - Sets `ctx.current_fragment_id`
+   - Creates a container wrapper (`with st.container()`)
+   - Sets `ctx.current_fragment_delta_path`
+
+3. **Function Execution**: The user's fragment function runs
+
+4. **Cleanup** (lines 255-257): Restores previous context
+
+### How Delta Paths Work
+
+Delta paths are arrays of integers that locate elements in the app tree:
+- `[0]` = Main container root
+- `[0, 2]` = Third child of main container
+- `[0, 2, 1]` = Second child of a nested container that's the third child of main
+
+The `RunningCursor` class (`lib/streamlit/cursor.py:191-250`) tracks the current index and auto-increments when `get_locked_cursor()` is called:
+```python
+def get_locked_cursor(self, **props: Any) -> LockedCursor:
+    locked_cursor = LockedCursor(...)
+    self._index += 1  # <-- Auto-increment
+    return locked_cursor
+```
+
+### How Frontend Handles Fragment Reruns
+
+The frontend (`frontend/lib/src/render-tree/`) manages the app tree using:
+
+1. **AppRoot** (`AppRoot.ts`): Root of the element tree
+2. **BlockNode** (`BlockNode.ts`): Container nodes with children
+3. **ElementNode** (`ElementNode.ts`): Leaf nodes (widgets, text, etc.)
+
+Each node tracks:
+- `scriptRunId`: Identifies which run created the node
+- `fragmentId`: Identifies which fragment created the node (if any)
+
+#### Stale Node Clearing (`ClearStaleNodeVisitor.ts:40-168`)
+
+After a script run finishes, stale nodes are cleared:
+
+1. **Full App Run**: All nodes with `scriptRunId !== currentScriptRunId` are removed
+2. **Fragment Run**: Only nodes whose **parent block's** `fragmentId` is in `fragmentIdsThisRun` AND have stale `scriptRunId` are removed
+
+The key insight is in `visitBlockNode()` (lines 84-94):
+```typescript
+// This block is modified by the current run, so we indicate this to our children
+if (
+  node.fragmentId &&
+  this.fragmentIdsThisRun.includes(node.fragmentId) &&
+  node.scriptRunId === this.currentScriptRunId
+) {
+  clearStaleNodeVisitor = new ClearStaleNodeVisitor(
+    this.currentScriptRunId,
+    this.fragmentIdsThisRun,
+    node.fragmentId  // Pass fragmentId to children
+  )
+}
+```
+
+---
+
+## Root Cause Analysis
+
+### The Core Issue: Cursor State Not Restored for Outside Containers
+
+When a fragment writes to an outside container (e.g., `B.button("Test")`):
+
+1. **Container B is a separate DeltaGenerator** captured by closure, NOT part of `ctx.cursors` or `dg_stack`
+2. **B's cursor is NOT restored** on fragment rerun
+3. **Each fragment rerun increments B's cursor**, placing the widget at a NEW delta path
+4. **Frontend doesn't clear old widgets** because B's block doesn't have the fragment's `fragmentId`
+
+#### Visual Timeline
+
+```
+Initial Full Run:
+1. B = st.container()           → B created at [0, 0], B._cursor.index = 0
+2. @st.fragment decorator       → Snapshot: cursors={main: idx=1}, dg_stack=[main]
+3. fragment() runs              → Fragment container at [0, 1]
+4. B.button("Test") inside      → Button at [0, 0, 0], B._cursor.index = 1
+
+Fragment Rerun #1:
+1. Restore cursors snapshot     → main cursor reset, BUT B still has index=1
+2. Fragment container re-sent   → [0, 1] replaced
+3. B.button("Test")            → Button at [0, 0, 1] (NEW position!)
+4. Old button at [0, 0, 0]     → NOT cleared (B not a fragment block)
+   Result: 2 buttons visible
+
+Fragment Rerun #2:
+1. B._cursor.index = 2
+2. Button at [0, 0, 2]
+3. Old buttons NOT cleared
+   Result: 3 buttons visible
+```
+
+### Why Widget IDs Don't Cause DuplicateWidgetID Error
+
+Widget ID tracking (`ctx.widget_ids_this_run`) is reset at the start of each script run. Since the widget ID is computed deterministically (based on type, key, parameters, etc.), each fragment rerun registers the same widget ID - but into a freshly cleared set.
+
+The backend sees one widget; the frontend sees multiple elements.
+
+---
+
+## Potential Solutions
+
+### Solution 1: Element-Level Fragment Clearing (Recommended)
+
+**Concept**: Clear stale elements based on the element's own `fragmentId`, not the parent block's.
+
+**Changes Required**:
+
+1. **Frontend (`ClearStaleNodeVisitor.ts`)**:
+   Modify `visitElementNode()` to check the element's `fragmentId`:
+   ```typescript
+   visitElementNode(node: ElementNode): AppNode | undefined {
+     if (this.isFragmentRun) {
+       // Clear if element's fragmentId matches current fragment and is stale
+       if (
+         node.fragmentId &&
+         this.fragmentIdsThisRun.includes(node.fragmentId) &&
+         node.scriptRunId !== this.currentScriptRunId
+       ) {
+         return undefined  // Clear this element
+       }
+       // Preserve if not related to current fragment
+       return node
+     }
+     return node.scriptRunId === this.currentScriptRunId ? node : undefined
+   }
+   ```
+
+2. **Backend**: Remove the restriction in `check_fragment_path_policy()`
+
+**Pros**:
+- Clean conceptual model: "elements belong to their creating fragment"
+- Minimal backend changes
+- Works with existing fragment ID tagging
+
+**Cons**:
+- Elements from multiple fragments could be interleaved in a container
+- May cause visual "jumping" if elements are cleared/added in different positions
+- Needs thorough testing for edge cases
+
+**Risk Level**: Medium - Changes core clearing algorithm
+
+---
+
+### Solution 2: Reset Outside Container Cursors
+
+**Concept**: Track which outside containers are written to during fragment execution, and reset their cursors on fragment rerun.
+
+**Changes Required**:
+
+1. **Backend (`fragment.py`)**:
+   - Track outside container writes during fragment execution
+   - Before fragment rerun, reset those containers' cursors to their snapshot positions
+
+2. **Backend (DeltaGenerator)**:
+   - Add mechanism to track when a DG is written to from a fragment
+   - Store cursor state per fragment
+
+**Pros**:
+- Elements are placed at consistent positions
+- Frontend replacement logic works naturally
+- No frontend changes needed
+
+**Cons**:
+- Complex tracking of which containers are "touched"
+- Requires storing per-fragment cursor states
+- May interfere with normal container usage outside fragments
+
+**Risk Level**: High - Complex state management
+
+---
+
+### Solution 3: Stable Delta Paths via Hash
+
+**Concept**: When writing to outside containers from fragments, use a stable delta path computed from a hash instead of the auto-incrementing cursor.
+
+**Changes Required**:
+
+1. **Backend (DeltaGenerator/_enqueue)**:
+   - Detect when writing to outside container from fragment
+   - Use hash-based index instead of cursor index
+   - e.g., `index = hash(widget_id) % RESERVED_RANGE`
+
+**Pros**:
+- Same widget always goes to same position
+- Natural replacement on frontend
+- No stale clearing changes needed
+
+**Cons**:
+- Hash collisions could cause issues
+- Reserved index ranges are fragile
+- Mixes two paradigms (sequential vs hash-based)
+
+**Risk Level**: High - Fundamental change to delta path semantics
+
+---
+
+### Solution 4: Explicit Clear Before Fragment Rerun
+
+**Concept**: Before executing a fragment rerun, send explicit "clear" messages for all elements the fragment previously wrote to outside containers.
+
+**Changes Required**:
+
+1. **Backend (fragment.py)**:
+   - Track elements written to outside containers (delta paths + fragment ID)
+   - On fragment rerun, emit clear/remove messages for those elements
+
+2. **Frontend**:
+   - Handle new "clear element at path" message type
+   - Or: use a special "fragment clear" message
+
+**Pros**:
+- Explicit behavior, easy to understand
+- Works with existing frontend tree structure
+- Can be implemented incrementally
+
+**Cons**:
+- Extra network traffic
+- Requires tracking what was written where
+- Adds complexity to fragment rerun protocol
+
+**Risk Level**: Medium - New message type, but isolated changes
+
+---
+
+### Solution 5: Frontend-Side Fragment Element Tracking
+
+**Concept**: The frontend tracks which elements were created by which fragment, and proactively clears them at the start of a fragment rerun.
+
+**Changes Required**:
+
+1. **Frontend (App.tsx / AppRoot.ts)**:
+   - Maintain a map: `fragmentId → Set<deltaPath>`
+   - When NewSession arrives for fragment run, clear all elements in that map
+   - Update map as elements are added
+
+**Pros**:
+- Frontend has full control
+- No backend protocol changes
+- Can be optimized for performance
+
+**Cons**:
+- Duplicates some backend knowledge on frontend
+- Map needs to stay in sync
+- Memory overhead for tracking
+
+**Risk Level**: Medium - New frontend state management
+
+---
+
+### Solution 6: Controlled Opt-In API (Conservative)
+
+**Concept**: Allow the feature with explicit opt-in, making users aware of the implications.
+
+**Changes Required**:
+
+1. **Backend**: Add parameter to allow outside writes
+   ```python
+   @st.fragment(allow_outside_writes=True)
+   def my_fragment():
+       B.button("Test")
+   ```
+
+2. **Backend**: Implement one of the above solutions, gated by this flag
+
+3. **Documentation**: Clearly explain behavior and limitations
+
+**Pros**:
+- Backward compatible
+- Users explicitly opt-in
+- Can iterate on behavior over time
+
+**Cons**:
+- Adds API surface
+- May confuse users about when to use it
+- Still requires implementing a solution
+
+**Risk Level**: Low (for opt-in) + Medium/High (for underlying solution)
+
+---
+
+## Recommendation
+
+### Short-Term: Solution 1 (Element-Level Fragment Clearing)
+
+This is the cleanest conceptual model and requires the fewest changes. The key insight is that elements already carry their `fragmentId` - we just need to use it for clearing decisions.
+
+**Implementation Steps**:
+
+1. Modify `ClearStaleNodeVisitor.visitElementNode()` to check element's `fragmentId`
+2. Add comprehensive tests for:
+   - Fragment writing to outside container
+   - Multiple fragments writing to same container
+   - Nested fragments
+   - Mixed widget/non-widget elements
+3. Remove restriction in `check_fragment_path_policy()` (or make it a warning)
+4. Update documentation
+
+### Long-Term Considerations
+
+1. **Visual Stability**: Consider adding a mechanism to maintain element order in outside containers
+2. **Performance**: Profile impact of element-level clearing on large apps
+3. **Edge Cases**: Document behavior when:
+   - Fragment is removed from app
+   - Multiple fragments write to same container
+   - Fragment writes to sidebar vs main
+
+---
+
+## Implementation Checklist
+
+- [ ] Update `ClearStaleNodeVisitor.visitElementNode()` in frontend
+- [ ] Add/update tests in `ClearStaleNodeVisitor.test.ts`
+- [ ] Update `check_fragment_path_policy()` in backend
+- [ ] Add E2E tests for outside container writes
+- [ ] Update fragment documentation
+- [ ] Consider adding opt-in flag for gradual rollout
+
+---
+
+## Appendix A: Key File Locations
+
+| Component | File Path |
+|-----------|-----------|
+| Fragment decorator | `lib/streamlit/runtime/fragment.py:136-276` |
+| Fragment path policy | `lib/streamlit/elements/lib/policies.py:129-161` |
+| Cursor system | `lib/streamlit/cursor.py` |
+| DeltaGenerator | `lib/streamlit/delta_generator.py` |
+| Script run context | `lib/streamlit/runtime/scriptrunner_utils/script_run_context.py` |
+| Frontend stale clearing | `frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts` |
+| Frontend element node | `frontend/lib/src/render-tree/ElementNode.ts` |
+| Frontend block node | `frontend/lib/src/render-tree/BlockNode.ts` |
+| Frontend app root | `frontend/lib/src/render-tree/AppRoot.ts` |
+
+## Appendix B: Related Issues/PRs
+
+- PR #8756: "Don't allow writing widgets outside the fragment" (original restriction)
+- Original spec document describing the restriction rationale
+
+## Appendix C: Test Scenarios
+
+1. **Basic Outside Write**
+   ```python
+   B = st.container()
+   @st.fragment
+   def frag():
+       B.button("Click me")
+   frag()
+   ```
+
+2. **Multiple Outside Containers**
+   ```python
+   A = st.container()
+   B = st.container()
+   @st.fragment
+   def frag():
+       A.write("In A")
+       B.button("In B")
+   frag()
+   ```
+
+3. **Nested Fragments**
+   ```python
+   outer = st.container()
+   @st.fragment
+   def outer_frag():
+       inner = st.container()
+       @st.fragment
+       def inner_frag():
+           outer.button("To outer")
+       inner_frag()
+   outer_frag()
+   ```
+
+4. **Fragment Removed on Full Rerun**
+   ```python
+   B = st.container()
+   if st.checkbox("Show fragment"):
+       @st.fragment
+       def frag():
+           B.button("Click")
+       frag()
+   ```

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -57,7 +57,9 @@ describe("ClearStaleNodeVisitor", () => {
         expect(result).toBe(element)
       })
 
-      it("returns element if fragmentIdOfBlock is not set", () => {
+      it("clears stale element with fragment ID even when fragmentIdOfBlock is not set (outside container)", () => {
+        // This is the core new behavior: elements with fragmentId get cleared
+        // even when not inside a fragment block context (i.e., element is in an outside container)
         const currentRunId = "current_run"
         const element = new ElementNode(
           makeProto(Element, { text: { body: "with_fragment" } }),
@@ -70,7 +72,9 @@ describe("ClearStaleNodeVisitor", () => {
 
         const result = visitor.visitElementNode(element)
 
-        expect(result).toBe(element)
+        // Element should be cleared because its fragmentId is in fragmentIdsThisRun
+        // and its scriptRunId doesn't match current run
+        expect(result).toBeUndefined()
       })
 
       it("returns element if it matches current script run ID", () => {
@@ -111,6 +115,80 @@ describe("ClearStaleNodeVisitor", () => {
         const result = visitor.visitElementNode(staleElement)
 
         expect(result).toBeUndefined()
+      })
+
+      it("preserves current element with fragment ID when not in fragment block context", () => {
+        // Current elements are always preserved
+        const currentRunId = "current_run"
+        const currentElement = new ElementNode(
+          makeProto(Element, { text: { body: "current_outside" } }),
+          ForwardMsgMetadata.create(),
+          currentRunId,
+          "script_hash",
+          "fragment1"
+        )
+        const visitor = new ClearStaleNodeVisitor(currentRunId, ["fragment1"])
+
+        const result = visitor.visitElementNode(currentElement)
+
+        expect(result).toBe(currentElement)
+      })
+
+      it("preserves element belonging to different fragment", () => {
+        // Elements from fragments not running should not be cleared
+        const currentRunId = "current_run"
+        const element = new ElementNode(
+          makeProto(Element, { text: { body: "other_fragment" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "other_fragment_id"
+        )
+        const visitor = new ClearStaleNodeVisitor(currentRunId, ["fragment1"])
+
+        const result = visitor.visitElementNode(element)
+
+        expect(result).toBe(element)
+      })
+
+      it("handles multiple fragments running simultaneously", () => {
+        const currentRunId = "current_run"
+
+        // Fragment 1's stale element should be cleared
+        const fragment1Stale = new ElementNode(
+          makeProto(Element, { text: { body: "frag1_stale" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "fragment1"
+        )
+
+        // Fragment 2's stale element should also be cleared
+        const fragment2Stale = new ElementNode(
+          makeProto(Element, { text: { body: "frag2_stale" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "fragment2"
+        )
+
+        // Fragment 3's element (not running) should be preserved
+        const fragment3Element = new ElementNode(
+          makeProto(Element, { text: { body: "frag3" } }),
+          ForwardMsgMetadata.create(),
+          "old_run",
+          "script_hash",
+          "fragment3"
+        )
+
+        const visitor = new ClearStaleNodeVisitor(currentRunId, [
+          "fragment1",
+          "fragment2",
+        ])
+
+        expect(visitor.visitElementNode(fragment1Stale)).toBeUndefined()
+        expect(visitor.visitElementNode(fragment2Stale)).toBeUndefined()
+        expect(visitor.visitElementNode(fragment3Element)).toBe(fragment3Element)
       })
     })
   })

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -124,18 +124,22 @@ export class ClearStaleNodeVisitor implements AppNodeVisitor<
 
   visitElementNode(node: ElementNode): AppNode | undefined {
     if (this.isFragmentRun) {
-      // If we're currently running a fragment, nodes unrelated to the fragment
-      // shouldn't be cleared. This can happen when,
-      //   1. This element doesn't correspond to a fragment at all.
-      //   2. This element is a fragment but is in no path that was modified.
-      //   3. This element belongs to a path that was modified, but it was modified in the same run.
+      // Clear stale elements that belong to the current fragment(s),
+      // regardless of whether we're inside a fragment block or not.
+      // This enables fragments to write widgets to outside containers
+      // without causing duplication on fragment reruns.
       if (
-        !node.fragmentId ||
-        !this.fragmentIdOfBlock ||
-        node.scriptRunId === this.currentScriptRunId
+        node.fragmentId &&
+        this.fragmentIdsThisRun.includes(node.fragmentId) &&
+        node.scriptRunId !== this.currentScriptRunId
       ) {
-        return node
+        return undefined
       }
+      // Preserve element if:
+      // 1. Element has no fragmentId (not created by a fragment), OR
+      // 2. Element belongs to a different fragment (not running this time), OR
+      // 3. Element is current (matches this script run ID)
+      return node
     }
     return node.scriptRunId === this.currentScriptRunId ? node : undefined
   }

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -170,7 +170,9 @@ def check_widget_policies(
     enable_check_callback_rules: bool = True,
 ) -> None:
     """Check all widget policies for the given DeltaGenerator."""
-    check_fragment_path_policy(dg)
+    # NOTE: check_fragment_path_policy was removed to allow fragments to write
+    # widgets to outside containers. The frontend now handles clearing these
+    # elements via element-level fragment clearing in ClearStaleNodeVisitor.
     check_cache_replay_rules()
     if enable_check_callback_rules:
         check_callback_rules(dg, on_change)

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -232,11 +232,16 @@ class FragmentCannotWriteToOutsidePathTest(unittest.TestCase):
 @patch("streamlit.elements.lib.policies.check_session_state_rules")
 @patch("streamlit.elements.lib.policies.check_callback_rules")
 @patch("streamlit.elements.lib.policies.check_cache_replay_rules")
-@patch("streamlit.elements.lib.policies.check_fragment_path_policy")
 class CheckWidget(ElementPoliciesTest):
+    """Tests for check_widget_policies function.
+
+    Note: check_fragment_path_policy is no longer called by check_widget_policies.
+    Fragments can now write widgets to outside containers, with the frontend
+    handling cleanup via element-level fragment clearing.
+    """
+
     def test_all_relevant_policies_are_called(
         self,
-        patched_check_fragment_path_policy,
         patched_check_cache_replay_rules,
         patched_check_callback_rules,
         patched_check_session_state_rules,
@@ -248,7 +253,6 @@ class CheckWidget(ElementPoliciesTest):
         key = "my_key"
         default_value = 5
         check_widget_policies(dg, key, on_change, default_value=default_value)
-        patched_check_fragment_path_policy.assert_called_once()
         patched_check_cache_replay_rules.assert_called_once()
         patched_check_callback_rules.assert_called_once_with(dg, on_change)
         patched_check_session_state_rules.assert_called_once_with(
@@ -257,7 +261,6 @@ class CheckWidget(ElementPoliciesTest):
 
     def test_check_callback_rules_is_not_called(
         self,
-        patched_check_fragment_path_policy,
         patched_check_cache_replay_rules,
         patched_check_callback_rules,
         patched_check_session_state_rules,
@@ -265,14 +268,12 @@ class CheckWidget(ElementPoliciesTest):
         check_widget_policies(
             MagicMock(), None, None, enable_check_callback_rules=False
         )
-        patched_check_fragment_path_policy.assert_called_once()
         patched_check_cache_replay_rules.assert_called_once()
         patched_check_callback_rules.assert_not_called()
         patched_check_session_state_rules.assert_called_once()
 
     def test_writes_allowed_can_be_disabled(
         self,
-        patched_check_fragment_path_policy,
         patched_check_cache_replay_rules,
         patched_check_callback_rules,
         patched_check_session_state_rules,
@@ -280,7 +281,6 @@ class CheckWidget(ElementPoliciesTest):
         dg = MagicMock()
         key = "my_key"
         check_widget_policies(dg, key, None, writes_allowed=False)
-        patched_check_fragment_path_policy.assert_called_once()
         patched_check_cache_replay_rules.assert_called_once()
         patched_check_callback_rules.assert_called_once()
         patched_check_session_state_rules.assert_called_once_with(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -27,7 +27,6 @@ from streamlit.delta_generator_singletons import context_dg_stack
 from streamlit.errors import (
     FragmentHandledException,
     FragmentStorageKeyError,
-    StreamlitFragmentWidgetsNotAllowedOutsideError,
 )
 from streamlit.runtime.fragment import (
     MemoryFragmentStorage,
@@ -560,24 +559,25 @@ def get_test_tuples(
     ]
 
 
-class FragmentCannotWriteToOutsidePathTest(DeltaGeneratorTestCase):
+class FragmentWriteToOutsideContainerTest(DeltaGeneratorTestCase):
+    """Tests that fragments can now write widgets to outside containers.
+
+    This behavior was previously disallowed but is now supported via
+    element-level fragment clearing on the frontend.
+    """
+
     @parameterized.expand(
         get_test_tuples(outside_container_writing_apps, WIDGET_ELEMENTS)
     )
-    def test_write_element_outside_container_raises_exception_for_widgets(
+    def test_write_widget_outside_container_succeeds(
         self,
         _: str,  # the test name argument used by pytest
         _app: Callable[[Callable[[], DeltaGenerator]], None],
         _element_producer: ELEMENT_PRODUCER,
     ):
-        with pytest.raises(FragmentHandledException) as ex:
-            _app(_element_producer)
-
-        inner_exception = ex.value.__cause__ or ex.value.__context__
-
-        assert isinstance(
-            inner_exception, StreamlitFragmentWidgetsNotAllowedOutsideError
-        )
+        """Verify widgets can now be written to outside containers without exception."""
+        # This should not raise - fragments can now write widgets to outside containers
+        _app(_element_producer)
 
     @parameterized.expand(
         get_test_tuples(outside_container_writing_apps, NON_WIDGET_ELEMENTS)


### PR DESCRIPTION
## Describe your changes

Allow Streamlit fragments to write widgets to containers outside their delta path without causing widget duplication. Previously, this was explicitly blocked due to a bug where widgets would duplicate on fragment reruns.

The solution implements element-level fragment clearing in the frontend `ClearStaleNodeVisitor`. Instead of only clearing elements within fragment blocks, stale elements from all running fragments are now cleared regardless of block hierarchy, preventing duplication.

### Key Changes:
- **Frontend**: Modified `ClearStaleNodeVisitor.visitElementNode()` to clear stale elements based on their own `fragmentId` rather than requiring the parent block to match
- **Backend**: Removed `check_fragment_path_policy()` restriction that prevented widgets in outside containers
- **Tests**: Added comprehensive unit tests (frontend and backend) and E2E tests with multiple scenarios

## Testing Plan

- **Unit Tests (Frontend)**: 4 new tests in `ClearStaleNodeVisitor.test.ts` covering element-level clearing with multiple fragments
- **Unit Tests (Backend)**: Updated `element_policies_test.py` to verify widgets can now be written to outside containers
- **Integration Tests**: Updated `fragment_test.py` with `FragmentWriteToOutsideContainerTest` class
- **E2E Tests**: Added `st_fragment_outside_container.py` app and `st_fragment_outside_container_test.py` with 5 comprehensive test cases covering basic widgets, stateful counters, multiple widgets, nested containers, and full reruns

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.