### PR TITLE
Hide developer options when toolbarMode="viewer"

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2083,7 +2083,9 @@ export class App extends PureComponent<Props, State> {
       sessionInfo: this.sessionInfo,
       isServerConnected: this.isServerConnected(),
       settings: this.state.userSettings,
-      allowRunOnSave: this.state.allowRunOnSave,
+      allowRunOnSave:
+        this.state.allowRunOnSave &&
+        showDevelopmentOptions(this.state.isOwner, this.state.toolbarMode),
       onSave: this.saveSettings,
       onClose: () => {},
       animateModal,


### PR DESCRIPTION
## Describe your changes
When `client.toolbarMode="viewer"`, the developer options are hidden from the top level of the app menu, but not in the settings dialog. This PR hides the developer options (Run on save) in the settings dialog, consistent with the `toolbarMode` configuration option.

This was mentioned in a forum post: https://discuss.streamlit.io/t/hide-development-options-in-settings-panel/120571

## Screenshot or video (only for visual changes)
<img width="522" height="372" alt="image" src="https://github.com/user-attachments/assets/cec366e8-c4ca-48f1-b6ff-bfa86e6973af" />

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
