### PR TITLE
Support auto-rerun when `config.toml` is created

### DIFF
--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -117,7 +117,9 @@ class EventBasedPathWatcher:
         allow_nonexistent : bool
             If True, the watcher will not raise an exception if the path does
             not exist. This can be used to watch for the creation of a file or
-            directory at a given path.
+            directory at a given path. Note: The parent directory of the path
+            must exist for watching to work. If the parent doesn't exist, the
+            watcher is silently skipped.
         """
         self._path = os.path.realpath(path)
         self._on_changed = on_changed
@@ -205,6 +207,18 @@ class _MultiPathWatcher:
                         folder_handler, folder_path, recursive=True
                     )
                     self._folder_handlers[folder_path] = folder_handler
+                except FileNotFoundError:
+                    # This happens when watching a non-existent file whose parent
+                    # directory also doesn't exist (e.g., .streamlit/config.toml
+                    # when .streamlit/ hasn't been created yet). This is expected
+                    # and not an error - we just can't watch until the directory
+                    # is created.
+                    _LOGGER.debug(
+                        "Cannot watch path %s: directory %s does not exist",
+                        path,
+                        folder_path,
+                    )
+                    return
                 except Exception as ex:
                     _LOGGER.warning(
                         "Failed to schedule watch observer for path %s",

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -69,7 +69,20 @@ def _get_abs_folder_path(path: str) -> str:
 
 
 class EventBasedPathWatcher:
-    """Watches a single path on disk using watchdog."""
+    """Watches a single path on disk using watchdog.
+
+    Behavior differs based on whether watching a file or directory:
+
+    **File watching:** Detects content changes via MD5 hash comparison. The
+    callback receives the file path and is invoked when content changes. With
+    allow_nonexistent=True, also detects file creation.
+
+    **Directory watching:** Detects any file activity within the directory
+    (creation, deletion, modification). The callback receives the actual
+    changed file path (not the directory). Note that glob_pattern only affects
+    the initial state hash, not which events trigger callbacks - all file
+    events in the directory invoke the callback.
+    """
 
     @staticmethod
     def close_all() -> None:
@@ -91,13 +104,16 @@ class EventBasedPathWatcher:
         Parameters
         ----------
         path : str
-            The path to watch.
+            The path to watch (file or directory).
         on_changed : Callable[[str], None]
-            Callback to call when the path changes.
+            Callback invoked when changes are detected. For files, receives
+            the file path. For directories, receives the path of the actual
+            changed file within the directory.
         glob_pattern : str or None
-            A glob pattern to filter the files in a directory that should be
-            watched. Only relevant when creating an EventBasedPathWatcher on a
-            directory.
+            A glob pattern for initial state detection when watching a
+            directory (e.g., "*.py"). Note: This does NOT filter which file
+            events trigger the callback - all file events in the directory
+            will invoke the callback regardless of this pattern.
         allow_nonexistent : bool
             If True, the watcher will not raise an exception if the path does
             not exist. This can be used to watch for the creation of a file or
@@ -387,12 +403,9 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         # To prevent a race condition, we hold a lock while accessing
         # _watched_paths.
-        watched_path: str | None = None
         with self._lock:
             # First check if the exact path is being watched
             changed_path_info = self._watched_paths.get(abs_changed_path, None)
-            if changed_path_info is not None:
-                watched_path = abs_changed_path
 
             # If the exact path isn't found, check if it's inside any watched
             # directories. This is necessary for the folder watching feature to
@@ -405,7 +418,6 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     try:
                         if os.path.commonpath([path, abs_changed_path]) == path:
                             changed_path_info = info
-                            watched_path = path  # Track the watched directory path
                             break
                     except ValueError as ex:
                         # On Windows, os.path.commonpath raises ValueError when paths
@@ -420,7 +432,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                         continue
 
         # If we still haven't found a matching path, ignore this event
-        if changed_path_info is None or watched_path is None:
+        if changed_path_info is None:
             _LOGGER.debug(
                 "Ignoring changed path %s.\nWatched_paths: %s",
                 abs_changed_path,
@@ -443,21 +455,18 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 return
 
             changed_path_info.modification_time = modification_time
-            # Use watched_path for MD5 calculation so that glob_pattern filtering
-            # works correctly when watching directories. For individual file watches,
-            # watched_path == abs_changed_path, so behavior is unchanged.
             new_md5 = util.calc_md5_with_blocking_retries(
-                watched_path,
+                abs_changed_path,
                 glob_pattern=changed_path_info.glob_pattern,
                 allow_nonexistent=changed_path_info.allow_nonexistent,
             )
             if new_md5 == changed_path_info.md5:
-                _LOGGER.debug("File/dir MD5 did not change: %s", watched_path)
+                _LOGGER.debug("File/dir MD5 did not change: %s", abs_changed_path)
                 return
 
-            _LOGGER.debug("File/dir MD5 changed: %s", watched_path)
+            _LOGGER.debug("File/dir MD5 changed: %s", abs_changed_path)
             changed_path_info.md5 = new_md5
-            changed_path_info.on_changed.send(watched_path)
+            changed_path_info.on_changed.send(abs_changed_path)
         except StreamlitMaxRetriesError as ex:
             _LOGGER.debug(
                 "Ignoring file change. Failed to calculate MD5 for path %s",

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -387,9 +387,12 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         # To prevent a race condition, we hold a lock while accessing
         # _watched_paths.
+        watched_path: str | None = None
         with self._lock:
             # First check if the exact path is being watched
             changed_path_info = self._watched_paths.get(abs_changed_path, None)
+            if changed_path_info is not None:
+                watched_path = abs_changed_path
 
             # If the exact path isn't found, check if it's inside any watched
             # directories. This is necessary for the folder watching feature to
@@ -402,6 +405,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     try:
                         if os.path.commonpath([path, abs_changed_path]) == path:
                             changed_path_info = info
+                            watched_path = path  # Track the watched directory path
                             break
                     except ValueError as ex:
                         # On Windows, os.path.commonpath raises ValueError when paths
@@ -416,7 +420,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                         continue
 
         # If we still haven't found a matching path, ignore this event
-        if changed_path_info is None:
+        if changed_path_info is None or watched_path is None:
             _LOGGER.debug(
                 "Ignoring changed path %s.\nWatched_paths: %s",
                 abs_changed_path,
@@ -439,18 +443,21 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 return
 
             changed_path_info.modification_time = modification_time
+            # Use watched_path for MD5 calculation so that glob_pattern filtering
+            # works correctly when watching directories. For individual file watches,
+            # watched_path == abs_changed_path, so behavior is unchanged.
             new_md5 = util.calc_md5_with_blocking_retries(
-                abs_changed_path,
+                watched_path,
                 glob_pattern=changed_path_info.glob_pattern,
                 allow_nonexistent=changed_path_info.allow_nonexistent,
             )
             if new_md5 == changed_path_info.md5:
-                _LOGGER.debug("File/dir MD5 did not change: %s", abs_changed_path)
+                _LOGGER.debug("File/dir MD5 did not change: %s", watched_path)
                 return
 
-            _LOGGER.debug("File/dir MD5 changed: %s", abs_changed_path)
+            _LOGGER.debug("File/dir MD5 changed: %s", watched_path)
             changed_path_info.md5 = new_md5
-            changed_path_info.on_changed.send(abs_changed_path)
+            changed_path_info.on_changed.send(watched_path)
         except StreamlitMaxRetriesError as ex:
             _LOGGER.debug(
                 "Ignoring file change. Failed to calculate MD5 for path %s",

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -137,8 +137,12 @@ def watch_file(
     path: str,
     on_file_changed: Callable[[str], None],
     watcher_type: str | None = None,
+    *,  # keyword-only arguments:
+    allow_nonexistent: bool = False,
 ) -> bool:
-    return _watch_path(path, on_file_changed, watcher_type)
+    return _watch_path(
+        path, on_file_changed, watcher_type, allow_nonexistent=allow_nonexistent
+    )
 
 
 def watch_dir(

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -156,6 +156,9 @@ def watch_file(
         Optional watcher type ('watchdog', 'poll', 'auto', or 'none').
     allow_nonexistent
         If True, watch for file creation even if the file doesn't exist yet.
+        Note: The file's parent directory must exist for watching to work.
+        If the parent directory doesn't exist, the watcher silently skips
+        watching (the file can't be created without its parent directory).
 
     Returns
     -------

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -140,6 +140,28 @@ def watch_file(
     *,  # keyword-only arguments:
     allow_nonexistent: bool = False,
 ) -> bool:
+    """Watch a file for changes.
+
+    The callback is invoked when the file's content changes (detected via MD5).
+    If allow_nonexistent is True, the watcher will also detect when the file
+    is created.
+
+    Parameters
+    ----------
+    path
+        Path to the file to watch.
+    on_file_changed
+        Callback invoked with the file path when changes are detected.
+    watcher_type
+        Optional watcher type ('watchdog', 'poll', 'auto', or 'none').
+    allow_nonexistent
+        If True, watch for file creation even if the file doesn't exist yet.
+
+    Returns
+    -------
+    bool
+        True if the watcher was successfully created.
+    """
     return _watch_path(
         path, on_file_changed, watcher_type, allow_nonexistent=allow_nonexistent
     )
@@ -153,6 +175,36 @@ def watch_dir(
     glob_pattern: str | None = None,
     allow_nonexistent: bool = False,
 ) -> bool:
+    """Watch a directory for file changes.
+
+    The callback is invoked for any file activity within the directory,
+    including file creation, deletion, and content modifications. The callback
+    receives the path of the actual changed file (not the directory path).
+
+    Note: The glob_pattern parameter only affects the initial state detection
+    (which files are counted when determining if the directory changed). It does
+    NOT filter which file events trigger the callback - all file events in the
+    directory will invoke the callback regardless of glob_pattern.
+
+    Parameters
+    ----------
+    path
+        Path to the directory to watch.
+    on_dir_changed
+        Callback invoked with the changed file path when changes are detected.
+    watcher_type
+        Optional watcher type ('watchdog', 'poll', 'auto', or 'none').
+    glob_pattern
+        Glob pattern for initial state detection (e.g., "*.py"). Does not
+        filter runtime events.
+    allow_nonexistent
+        If True, watch for directory creation even if it doesn't exist yet.
+
+    Returns
+    -------
+    bool
+        True if the watcher was successfully created.
+    """
     # Add a trailing slash to the path to ensure
     # that its interpreted as a directory.
     path = os.path.join(path, "")

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -63,11 +63,19 @@ def calc_md5_with_blocking_retries(
         # There's a race condition where sometimes file_path no longer exists when
         # we try to read it (since the file is in the process of being written).
         # So here we retry a few times using this loop. See issue #186.
-        content = _do_with_retries(
-            lambda: _get_file_content(path),
-            (FileNotFoundError, PermissionError),
-            path,
-        )
+        try:
+            content = _do_with_retries(
+                lambda: _get_file_content(path),
+                (FileNotFoundError, PermissionError),
+                path,
+            )
+        except StreamlitMaxRetriesError:
+            # If allow_nonexistent is True and the file was deleted between our
+            # exists check and the read, treat it as nonexistent instead of raising.
+            if allow_nonexistent:
+                content = path.encode("UTF-8")
+            else:
+                raise
 
     return calc_md5(content)
 
@@ -91,11 +99,19 @@ def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:
 
     # Use retries to avoid race condition where file may be in the process of being
     # modified.
-    return _do_with_retries(
-        lambda: os.stat(path).st_mtime,
-        (FileNotFoundError, PermissionError),
-        path,
-    )
+    try:
+        return _do_with_retries(
+            lambda: os.stat(path).st_mtime,
+            (FileNotFoundError, PermissionError),
+            path,
+        )
+    except StreamlitMaxRetriesError:
+        # If allow_nonexistent is True and the file was deleted between our
+        # exists check and the stat call, return 0.0 instead of raising.
+        # This handles the race condition where a file is deleted while being watched.
+        if allow_nonexistent:
+            return 0.0
+        raise
 
 
 def _get_file_content(file_path: str) -> bytes:

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -23,7 +23,7 @@ from typing import Any, Final
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
 from streamlit.logger import get_logger
-from streamlit.watcher import report_watchdog_availability, watch_dir, watch_file
+from streamlit.watcher import report_watchdog_availability, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket, server_util
 
 _LOGGER: Final = get_logger(__name__)
@@ -325,18 +325,9 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
         load_config_options(flag_options)
 
     for filename in config.get_config_files("config.toml"):
-        if os.path.exists(filename):
-            # Watch existing file for modifications
-            watch_file(filename, on_config_changed)
-        else:
-            # Watch parent directory for file creation
-            parent_dir = os.path.dirname(filename)
-            watch_dir(
-                parent_dir,
-                on_config_changed,
-                glob_pattern="config.toml",
-                allow_nonexistent=True,
-            )
+        # Watch the file path directly, even if it doesn't exist yet.
+        # This allows detecting both file creation and subsequent modifications.
+        watch_file(filename, on_config_changed, allow_nonexistent=True)
 
 
 def run_asgi_app(

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -325,9 +325,17 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
         load_config_options(flag_options)
 
     for filename in config.get_config_files("config.toml"):
-        # Watch the file path directly, even if it doesn't exist yet.
+        # Watch each config file path directly, even if it doesn't exist yet.
         # This allows detecting both file creation and subsequent modifications.
-        watch_file(filename, on_config_changed, allow_nonexistent=True)
+        # We use the poll watcher because:
+        # 1. It handles non-existent paths gracefully, including when parent
+        #    directories (like ~/.streamlit/) don't exist yet. The event-based
+        #    watcher requires the parent directory to exist to schedule a watch.
+        # 2. Config files change rarely, so the polling overhead is negligible.
+        # 3. The 200ms poll interval latency is imperceptible for config reloads.
+        watch_file(
+            filename, on_config_changed, watcher_type="poll", allow_nonexistent=True
+        )
 
 
 def run_asgi_app(

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -23,7 +23,7 @@ from typing import Any, Final
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
 from streamlit.logger import get_logger
-from streamlit.watcher import report_watchdog_availability, watch_file
+from streamlit.watcher import report_watchdog_availability, watch_dir, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket, server_util
 
 _LOGGER: Final = get_logger(__name__)
@@ -326,7 +326,17 @@ def _install_config_watchers(flag_options: dict[str, Any]) -> None:
 
     for filename in config.get_config_files("config.toml"):
         if os.path.exists(filename):
+            # Watch existing file for modifications
             watch_file(filename, on_config_changed)
+        else:
+            # Watch parent directory for file creation
+            parent_dir = os.path.dirname(filename)
+            watch_dir(
+                parent_dir,
+                on_config_changed,
+                glob_pattern="config.toml",
+                allow_nonexistent=True,
+            )
 
 
 def run_asgi_app(

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -518,14 +518,18 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         ro.close()
 
     @mock.patch("os.path.isdir")
-    def test_glob_pattern_filters_file_events_in_directory(self, mock_is_dir):
-        """Test that glob_pattern filtering works for file events inside directories.
+    @mock.patch("os.path.exists")
+    def test_detects_file_creation_in_watched_directory(self, mock_exists, mock_is_dir):
+        """Test that file creation inside a watched directory triggers callback.
 
-        When watching a directory with a glob_pattern, only files matching the
-        pattern should trigger the callback. This is important for use cases like
-        watching .streamlit/ for config.toml but ignoring secrets.toml changes.
+        When watching a directory, file events inside the directory should:
+        1. Trigger the callback with the actual file path (not directory path)
+        2. Calculate MD5 on the actual file (to detect content changes)
         """
         watched_dir = "/app/.streamlit"
+
+        # Directory exists
+        mock_exists.return_value = True
         mock_is_dir.side_effect = lambda p: p == watched_dir
 
         cb = mock.Mock()
@@ -533,13 +537,13 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         # Initial setup
         self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            return_value="initial"
+            return_value="initial_hash"
         )
 
         ro = event_based_path_watcher.EventBasedPathWatcher(
             watched_dir,
             cb,
-            glob_pattern="config.toml",
+            glob_pattern="*.toml",
             allow_nonexistent=True,
         )
 
@@ -548,107 +552,25 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        # Simulate a secrets.toml file event (should NOT trigger callback)
-        # The MD5 should be calculated on the watched directory, not the file,
-        # so the glob_pattern will filter it out.
+        # Simulate config.toml being created
         self.mock_util.path_modification_time = lambda *args: 102.0
-        # MD5 doesn't change because secrets.toml isn't included in glob
         self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            return_value="initial"
+            return_value="file_content_hash"
         )
 
-        ev = events.FileSystemEvent(f"{watched_dir}/secrets.toml")
+        config_file_path = f"{watched_dir}/config.toml"
+        ev = events.FileSystemEvent(config_file_path)
         ev.event_type = events.EVENT_TYPE_CREATED
         folder_handler.on_created(ev)
 
-        # Verify calc_md5 was called with the DIRECTORY path, not the file path
+        # Verify calc_md5 was called with the FILE path (not directory)
+        # This ensures file content changes are detected
         call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
-        assert call_args[0][0] == watched_dir  # First positional arg is the path
-        assert call_args[1]["glob_pattern"] == "config.toml"
+        assert call_args[0][0] == config_file_path
 
-        # Callback should NOT be triggered (MD5 unchanged)
-        cb.assert_not_called()
-
-        # Now simulate a config.toml file event (should trigger callback)
-        self.mock_util.path_modification_time = lambda *args: 103.0
-        # MD5 changes because config.toml IS included in glob
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            return_value="changed"
-        )
-
-        ev = events.FileSystemEvent(f"{watched_dir}/config.toml")
-        ev.event_type = events.EVENT_TYPE_CREATED
-        folder_handler.on_created(ev)
-
-        # Verify calc_md5 was called with the DIRECTORY path
-        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
-        assert call_args[0][0] == watched_dir
-
-        # Callback SHOULD be triggered (MD5 changed)
-        cb.assert_called_once()
-
-        ro.close()
-
-    @mock.patch("os.path.isdir")
-    @mock.patch("os.path.exists")
-    def test_detects_file_creation_in_nonexistent_directory(
-        self, mock_exists, mock_is_dir
-    ):
-        """Test that file creation is detected when directory initially doesn't exist.
-
-        This tests the scenario where:
-        1. .streamlit/ directory doesn't exist at startup
-        2. User creates .streamlit/config.toml
-        3. The watcher should detect the creation and trigger callback
-        """
-        watched_dir = "/app/.streamlit"
-
-        # Initially directory doesn't exist
-        mock_exists.return_value = False
-        mock_is_dir.return_value = False
-
-        cb = mock.Mock()
-
-        # Initial MD5 when path doesn't exist (uses path string as content)
-        self.mock_util.path_modification_time = lambda *args: 0.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            return_value="nonexistent_hash"
-        )
-
-        ro = event_based_path_watcher.EventBasedPathWatcher(
-            watched_dir,
-            cb,
-            glob_pattern="config.toml",
-            allow_nonexistent=True,
-        )
-
-        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
-        folder_handler = fo._observer.schedule.call_args[0][0]
-
-        cb.assert_not_called()
-
-        # Now simulate config.toml being created (directory now exists)
-        mock_exists.return_value = True
-        mock_is_dir.side_effect = lambda p: p == watched_dir
-
-        self.mock_util.path_modification_time = lambda *args: 101.0
-        # MD5 changes because directory now exists with config.toml
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            return_value="dir_with_config_hash"
-        )
-
-        ev = events.FileSystemEvent(f"{watched_dir}/config.toml")
-        ev.event_type = events.EVENT_TYPE_CREATED
-        folder_handler.on_created(ev)
-
-        # Verify calc_md5 was called with the DIRECTORY path
-        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
-        assert call_args[0][0] == watched_dir
-        assert call_args[1]["glob_pattern"] == "config.toml"
-        assert call_args[1]["allow_nonexistent"] is True
-
-        # Callback SHOULD be triggered (MD5 changed from nonexistent to existing)
-        cb.assert_called_once()
+        # Callback should receive the actual file path (not directory)
+        # This is important for path-specific filtering like _is_in_ignored_directory
+        cb.assert_called_once_with(config_file_path)
 
         ro.close()
 

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -651,3 +651,76 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_called_once()
 
         ro.close()
+
+    @mock.patch("os.path.isdir")
+    @mock.patch("os.path.exists")
+    def test_detects_file_creation_and_modification_with_allow_nonexistent(
+        self, mock_exists, mock_is_dir
+    ):
+        """Test watching a nonexistent file detects both creation and modification.
+
+        This tests the scenario where:
+        1. config.toml doesn't exist at startup
+        2. User creates config.toml → callback triggered
+        3. User modifies config.toml → callback triggered again
+
+        This is the fix for the bug where watching a directory with glob_pattern
+        would not detect file content changes (only file list changes).
+        """
+        watched_file = "/app/.streamlit/config.toml"
+
+        # Initially file doesn't exist
+        mock_exists.return_value = False
+        mock_is_dir.return_value = False
+
+        cb = mock.Mock()
+
+        # Initial MD5 when file doesn't exist (uses path string as content)
+        self.mock_util.path_modification_time = lambda *args: 0.0
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="nonexistent_hash"
+        )
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            watched_file,
+            cb,
+            allow_nonexistent=True,
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        cb.assert_not_called()
+
+        # Step 1: Simulate file being created
+        mock_exists.return_value = True
+        mock_is_dir.return_value = False
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        # MD5 changes because file now exists with content
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="initial_content_hash"
+        )
+
+        ev = events.FileSystemEvent(watched_file)
+        ev.event_type = events.EVENT_TYPE_CREATED
+        folder_handler.on_created(ev)
+
+        # Callback SHOULD be triggered (file was created)
+        assert cb.call_count == 1
+
+        # Step 2: Simulate file being modified
+        self.mock_util.path_modification_time = lambda *args: 102.0
+        # MD5 changes because file content changed
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="modified_content_hash"
+        )
+
+        ev = events.FileSystemEvent(watched_file)
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        # Callback SHOULD be triggered again (file was modified)
+        assert cb.call_count == 2
+
+        ro.close()

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -519,7 +519,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
     @mock.patch("os.path.isdir")
     @mock.patch("os.path.exists")
-    def test_detects_file_creation_in_watched_directory(self, mock_exists, mock_is_dir):
+    def test_detects_file_creation_in_watched_directory(
+        self, mock_exists: mock.Mock, mock_is_dir: mock.Mock
+    ) -> None:
         """Test that file creation inside a watched directory triggers callback.
 
         When watching a directory, file events inside the directory should:
@@ -577,8 +579,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
     @mock.patch("os.path.isdir")
     @mock.patch("os.path.exists")
     def test_detects_file_creation_and_modification_with_allow_nonexistent(
-        self, mock_exists, mock_is_dir
-    ):
+        self, mock_exists: mock.Mock, mock_is_dir: mock.Mock
+    ) -> None:
         """Test watching a nonexistent file detects both creation and modification.
 
         This tests the scenario where:

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -516,3 +516,138 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         ro.close()
+
+    @mock.patch("os.path.isdir")
+    def test_glob_pattern_filters_file_events_in_directory(self, mock_is_dir):
+        """Test that glob_pattern filtering works for file events inside directories.
+
+        When watching a directory with a glob_pattern, only files matching the
+        pattern should trigger the callback. This is important for use cases like
+        watching .streamlit/ for config.toml but ignoring secrets.toml changes.
+        """
+        watched_dir = "/app/.streamlit"
+        mock_is_dir.side_effect = lambda p: p == watched_dir
+
+        cb = mock.Mock()
+
+        # Initial setup
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="initial"
+        )
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            watched_dir,
+            cb,
+            glob_pattern="config.toml",
+            allow_nonexistent=True,
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        cb.assert_not_called()
+
+        # Simulate a secrets.toml file event (should NOT trigger callback)
+        # The MD5 should be calculated on the watched directory, not the file,
+        # so the glob_pattern will filter it out.
+        self.mock_util.path_modification_time = lambda *args: 102.0
+        # MD5 doesn't change because secrets.toml isn't included in glob
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="initial"
+        )
+
+        ev = events.FileSystemEvent(f"{watched_dir}/secrets.toml")
+        ev.event_type = events.EVENT_TYPE_CREATED
+        folder_handler.on_created(ev)
+
+        # Verify calc_md5 was called with the DIRECTORY path, not the file path
+        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
+        assert call_args[0][0] == watched_dir  # First positional arg is the path
+        assert call_args[1]["glob_pattern"] == "config.toml"
+
+        # Callback should NOT be triggered (MD5 unchanged)
+        cb.assert_not_called()
+
+        # Now simulate a config.toml file event (should trigger callback)
+        self.mock_util.path_modification_time = lambda *args: 103.0
+        # MD5 changes because config.toml IS included in glob
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="changed"
+        )
+
+        ev = events.FileSystemEvent(f"{watched_dir}/config.toml")
+        ev.event_type = events.EVENT_TYPE_CREATED
+        folder_handler.on_created(ev)
+
+        # Verify calc_md5 was called with the DIRECTORY path
+        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
+        assert call_args[0][0] == watched_dir
+
+        # Callback SHOULD be triggered (MD5 changed)
+        cb.assert_called_once()
+
+        ro.close()
+
+    @mock.patch("os.path.isdir")
+    @mock.patch("os.path.exists")
+    def test_detects_file_creation_in_nonexistent_directory(
+        self, mock_exists, mock_is_dir
+    ):
+        """Test that file creation is detected when directory initially doesn't exist.
+
+        This tests the scenario where:
+        1. .streamlit/ directory doesn't exist at startup
+        2. User creates .streamlit/config.toml
+        3. The watcher should detect the creation and trigger callback
+        """
+        watched_dir = "/app/.streamlit"
+
+        # Initially directory doesn't exist
+        mock_exists.return_value = False
+        mock_is_dir.return_value = False
+
+        cb = mock.Mock()
+
+        # Initial MD5 when path doesn't exist (uses path string as content)
+        self.mock_util.path_modification_time = lambda *args: 0.0
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="nonexistent_hash"
+        )
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            watched_dir,
+            cb,
+            glob_pattern="config.toml",
+            allow_nonexistent=True,
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        cb.assert_not_called()
+
+        # Now simulate config.toml being created (directory now exists)
+        mock_exists.return_value = True
+        mock_is_dir.side_effect = lambda p: p == watched_dir
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        # MD5 changes because directory now exists with config.toml
+        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="dir_with_config_hash"
+        )
+
+        ev = events.FileSystemEvent(f"{watched_dir}/config.toml")
+        ev.event_type = events.EVENT_TYPE_CREATED
+        folder_handler.on_created(ev)
+
+        # Verify calc_md5 was called with the DIRECTORY path
+        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
+        assert call_args[0][0] == watched_dir
+        assert call_args[1]["glob_pattern"] == "config.toml"
+        assert call_args[1]["allow_nonexistent"] is True
+
+        # Callback SHOULD be triggered (MD5 changed from nonexistent to existing)
+        cb.assert_called_once()
+
+        ro.close()

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -160,7 +160,7 @@ class FileWatcherTest(unittest.TestCase):
         "streamlit.watcher.path_watcher._is_watchdog_available", Mock(return_value=True)
     )
     @patch("streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher")
-    def test_watch_file_allow_nonexistent(self, mock_event_watcher):
+    def test_watch_file_allow_nonexistent(self, mock_event_watcher: Mock) -> None:
         """Test that watch_file passes allow_nonexistent to the watcher class."""
         on_file_changed = Mock()
 
@@ -183,7 +183,7 @@ class FileWatcherTest(unittest.TestCase):
         "streamlit.watcher.path_watcher._is_watchdog_available", Mock(return_value=True)
     )
     @patch("streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher")
-    def test_watch_dir_kwarg_plumbing(self, mock_event_watcher):
+    def test_watch_dir_kwarg_plumbing(self, mock_event_watcher: Mock) -> None:
         """Test that watch_dir passes kwargs to the watcher class."""
         on_file_changed = Mock()
 

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -160,10 +160,31 @@ class FileWatcherTest(unittest.TestCase):
         "streamlit.watcher.path_watcher._is_watchdog_available", Mock(return_value=True)
     )
     @patch("streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher")
+    def test_watch_file_allow_nonexistent(self, mock_event_watcher):
+        """Test that watch_file passes allow_nonexistent to the watcher class."""
+        on_file_changed = Mock()
+
+        watching_file = watch_file(
+            "some/file/path",
+            on_file_changed,
+            watcher_type="watchdog",
+            allow_nonexistent=True,
+        )
+
+        assert watching_file
+        mock_event_watcher.assert_called_with(
+            "some/file/path",
+            on_file_changed,
+            glob_pattern=None,
+            allow_nonexistent=True,
+        )
+
+    @patch(
+        "streamlit.watcher.path_watcher._is_watchdog_available", Mock(return_value=True)
+    )
+    @patch("streamlit.watcher.event_based_path_watcher.EventBasedPathWatcher")
     def test_watch_dir_kwarg_plumbing(self, mock_event_watcher):
-        # NOTE: We only test kwarg plumbing for watch_dir since watcher_class
-        # selection is tested extensively in test_watch_file, and the two
-        # functions are otherwise identical.
+        """Test that watch_dir passes kwargs to the watcher class."""
         on_file_changed = Mock()
 
         watching_dir = watch_dir(

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -243,3 +243,64 @@ class PollingPathWatcherTest(unittest.TestCase):
         # should not have increased.
         assert callback1.call_count == 1
         assert callback2.call_count == 2
+
+    def test_detects_file_creation_and_modification_with_allow_nonexistent(self):
+        """Test watching a nonexistent file detects both creation and modification.
+
+        This tests the scenario where:
+        1. config.toml doesn't exist at startup
+        2. User creates config.toml → callback triggered
+        3. User modifies config.toml → callback triggered again
+
+        This ensures the polling watcher properly handles allow_nonexistent=True
+        for file paths (not just directories).
+        """
+        callback = mock.Mock()
+
+        # Initially file doesn't exist: modification_time=0.0, MD5 based on path
+        self.util_mock.path_modification_time = mock.Mock(return_value=0.0)
+        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="nonexistent_hash"
+        )
+
+        watcher = polling_path_watcher.PollingPathWatcher(
+            "/app/.streamlit/config.toml",
+            callback,
+            allow_nonexistent=True,
+        )
+
+        # Verify allow_nonexistent was passed to initial calculations
+        _, kwargs = self.util_mock.path_modification_time.call_args
+        assert kwargs == {}  # path_modification_time uses positional arg
+        args = self.util_mock.path_modification_time.call_args[0]
+        assert args[1] is True  # allow_nonexistent
+
+        _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
+        assert kwargs["allow_nonexistent"] is True
+
+        self._run_executor_tasks()
+        callback.assert_not_called()
+
+        # Step 1: Simulate file being created
+        self.util_mock.path_modification_time = mock.Mock(return_value=101.0)
+        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="initial_content_hash"
+        )
+
+        self._run_executor_tasks()
+
+        # Callback SHOULD be triggered (file was created)
+        assert callback.call_count == 1
+
+        # Step 2: Simulate file being modified
+        self.util_mock.path_modification_time = mock.Mock(return_value=102.0)
+        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+            return_value="modified_content_hash"
+        )
+
+        self._run_executor_tasks()
+
+        # Callback SHOULD be triggered again (file was modified)
+        assert callback.call_count == 2
+
+        watcher.close()

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -244,7 +244,9 @@ class PollingPathWatcherTest(unittest.TestCase):
         assert callback1.call_count == 1
         assert callback2.call_count == 2
 
-    def test_detects_file_creation_and_modification_with_allow_nonexistent(self):
+    def test_detects_file_creation_and_modification_with_allow_nonexistent(
+        self,
+    ) -> None:
         """Test watching a nonexistent file detects both creation and modification.
 
         This tests the scenario where:

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -18,6 +18,9 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
+import pytest
+
+from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.watcher import util
 
 
@@ -118,3 +121,66 @@ class DirHelperTests(unittest.TestCase):
     )
     def test_stable_dir_files_change(self):
         assert util._stable_dir_identifier("my_dir", "*") == "my_dir+bar"
+
+
+class RaceConditionTests(unittest.TestCase):
+    """Tests for race conditions where files are deleted during watcher operations."""
+
+    @patch("streamlit.watcher.util._do_with_retries")
+    @patch("streamlit.watcher.util.os.path.exists")
+    def test_path_modification_time_handles_deletion_race_condition(
+        self, mock_exists: MagicMock, mock_do_with_retries: MagicMock
+    ) -> None:
+        """Test that path_modification_time handles file deletion gracefully.
+
+        Scenario: File exists when checked, but is deleted before os.stat() completes.
+        With allow_nonexistent=True, should return 0.0 instead of raising.
+        """
+        # File exists initially
+        mock_exists.return_value = True
+        # But stat fails because file was deleted (race condition)
+        mock_do_with_retries.side_effect = StreamlitMaxRetriesError("File gone")
+
+        # With allow_nonexistent=True, should return 0.0 (not raise)
+        result = util.path_modification_time(
+            "deleted_file.toml", allow_nonexistent=True
+        )
+        assert result == 0.0
+
+        # Without allow_nonexistent, should raise
+        with pytest.raises(StreamlitMaxRetriesError):
+            util.path_modification_time("deleted_file.toml", allow_nonexistent=False)
+
+    @patch("streamlit.watcher.util._do_with_retries")
+    @patch("streamlit.watcher.util.os.path.isdir")
+    @patch("streamlit.watcher.util.os.path.exists")
+    def test_calc_md5_handles_deletion_race_condition(
+        self,
+        mock_exists: MagicMock,
+        mock_isdir: MagicMock,
+        mock_do_with_retries: MagicMock,
+    ) -> None:
+        """Test that calc_md5_with_blocking_retries handles file deletion gracefully.
+
+        Scenario: File exists when checked, but is deleted before read() completes.
+        With allow_nonexistent=True, should return MD5 of path string instead of raising.
+        """
+        # File exists initially, is not a directory
+        mock_exists.return_value = True
+        mock_isdir.return_value = False
+        # But read fails because file was deleted (race condition)
+        mock_do_with_retries.side_effect = StreamlitMaxRetriesError("File gone")
+
+        # With allow_nonexistent=True, should return MD5 of path (not raise)
+        result = util.calc_md5_with_blocking_retries(
+            "deleted_file.toml", allow_nonexistent=True
+        )
+        # MD5 of "deleted_file.toml" encoded as UTF-8
+        expected_md5 = util.calc_md5(b"deleted_file.toml")
+        assert result == expected_md5
+
+        # Without allow_nonexistent, should raise
+        with pytest.raises(StreamlitMaxRetriesError):
+            util.calc_md5_with_blocking_retries(
+                "deleted_file.toml", allow_nonexistent=False
+            )

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -410,6 +410,64 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             },
         )
 
+    @patch("streamlit.config.get_config_options")
+    @patch("streamlit.web.bootstrap.watch_dir")
+    @patch("streamlit.web.bootstrap.watch_file")
+    def test_install_config_watcher_for_nonexistent_files(
+        self, patched_watch_file, patched_watch_dir, patched_get_config_options
+    ):
+        """Test that we watch directories for config files that don't exist."""
+        with patch("os.path.exists", return_value=False):
+            bootstrap._install_config_watchers(flag_options={"server_port": 8502})
+
+        # watch_file should not be called since no files exist
+        assert patched_watch_file.call_count == 0
+        # watch_dir should be called for each config file location
+        assert patched_watch_dir.call_count == 2
+
+        # Verify watch_dir was called with correct parameters
+        args, kwargs = patched_watch_dir.call_args_list[0]
+        assert kwargs["glob_pattern"] == "config.toml"
+        assert kwargs["allow_nonexistent"] is True
+
+        # Test that the callback triggers config reload
+        on_config_changed = args[1]
+        on_config_changed("/some/.streamlit/config.toml")
+
+        patched_get_config_options.assert_called_once_with(
+            force_reparse=True,
+            options_from_flags={
+                "server.port": 8502,
+            },
+        )
+
+    @patch("streamlit.config.get_config_options")
+    @patch("streamlit.web.bootstrap.watch_dir")
+    @patch("streamlit.web.bootstrap.watch_file")
+    def test_install_config_watcher_mixed_existing_and_nonexistent(
+        self, patched_watch_file, patched_watch_dir, patched_get_config_options
+    ):
+        """Test watching when some config files exist and some don't."""
+
+        def exists_side_effect(path):
+            # Simulate: first config file exists, second doesn't
+            return "home" in path or path.endswith("0")
+
+        call_count = [0]
+
+        def custom_exists(path):
+            result = call_count[0] == 0
+            call_count[0] += 1
+            return result
+
+        with patch("os.path.exists", side_effect=custom_exists):
+            bootstrap._install_config_watchers(flag_options={})
+
+        # First file exists -> watch_file called
+        assert patched_watch_file.call_count == 1
+        # Second file doesn't exist -> watch_dir called
+        assert patched_watch_dir.call_count == 1
+
 
 class BootstrapRunTest(IsolatedAsyncioTestCase):
     def tearDown(self):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -448,14 +448,10 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         self, patched_watch_file, patched_watch_dir, patched_get_config_options
     ):
         """Test watching when some config files exist and some don't."""
-
-        def exists_side_effect(path):
-            # Simulate: first config file exists, second doesn't
-            return "home" in path or path.endswith("0")
-
         call_count = [0]
 
         def custom_exists(path):
+            # First call returns True (file exists), second returns False
             result = call_count[0] == 0
             call_count[0] += 1
             return result

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -391,16 +391,17 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
     @patch("streamlit.config.get_config_options")
     @patch("streamlit.web.bootstrap.watch_file")
     def test_install_config_watcher(
-        self, patched_watch_file, patched_get_config_options
-    ):
+        self, patched_watch_file: Mock, patched_get_config_options: Mock
+    ) -> None:
         """Test that config watchers are installed for all config file locations."""
         bootstrap._install_config_watchers(flag_options={"server_port": 8502})
 
         # watch_file should be called for each config file location (2 locations)
         assert patched_watch_file.call_count == 2
 
-        # Verify watch_file was called with allow_nonexistent=True
+        # Verify watch_file was called with poll watcher and allow_nonexistent=True
         _args, kwargs = patched_watch_file.call_args_list[0]
+        assert kwargs["watcher_type"] == "poll"
         assert kwargs["allow_nonexistent"] is True
 
         args, _kwargs = patched_watch_file.call_args_list[0]

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -393,9 +393,15 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
     def test_install_config_watcher(
         self, patched_watch_file, patched_get_config_options
     ):
-        with patch("os.path.exists", return_value=True):
-            bootstrap._install_config_watchers(flag_options={"server_port": 8502})
+        """Test that config watchers are installed for all config file locations."""
+        bootstrap._install_config_watchers(flag_options={"server_port": 8502})
+
+        # watch_file should be called for each config file location (2 locations)
         assert patched_watch_file.call_count == 2
+
+        # Verify watch_file was called with allow_nonexistent=True
+        _args, kwargs = patched_watch_file.call_args_list[0]
+        assert kwargs["allow_nonexistent"] is True
 
         args, _kwargs = patched_watch_file.call_args_list[0]
         on_config_changed = args[1]
@@ -409,60 +415,6 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
                 "server.port": 8502,
             },
         )
-
-    @patch("streamlit.config.get_config_options")
-    @patch("streamlit.web.bootstrap.watch_dir")
-    @patch("streamlit.web.bootstrap.watch_file")
-    def test_install_config_watcher_for_nonexistent_files(
-        self, patched_watch_file, patched_watch_dir, patched_get_config_options
-    ):
-        """Test that we watch directories for config files that don't exist."""
-        with patch("os.path.exists", return_value=False):
-            bootstrap._install_config_watchers(flag_options={"server_port": 8502})
-
-        # watch_file should not be called since no files exist
-        assert patched_watch_file.call_count == 0
-        # watch_dir should be called for each config file location
-        assert patched_watch_dir.call_count == 2
-
-        # Verify watch_dir was called with correct parameters
-        args, kwargs = patched_watch_dir.call_args_list[0]
-        assert kwargs["glob_pattern"] == "config.toml"
-        assert kwargs["allow_nonexistent"] is True
-
-        # Test that the callback triggers config reload
-        on_config_changed = args[1]
-        on_config_changed("/some/.streamlit/config.toml")
-
-        patched_get_config_options.assert_called_once_with(
-            force_reparse=True,
-            options_from_flags={
-                "server.port": 8502,
-            },
-        )
-
-    @patch("streamlit.config.get_config_options")
-    @patch("streamlit.web.bootstrap.watch_dir")
-    @patch("streamlit.web.bootstrap.watch_file")
-    def test_install_config_watcher_mixed_existing_and_nonexistent(
-        self, patched_watch_file, patched_watch_dir, patched_get_config_options
-    ):
-        """Test watching when some config files exist and some don't."""
-        call_count = [0]
-
-        def custom_exists(path):
-            # First call returns True (file exists), second returns False
-            result = call_count[0] == 0
-            call_count[0] += 1
-            return result
-
-        with patch("os.path.exists", side_effect=custom_exists):
-            bootstrap._install_config_watchers(flag_options={})
-
-        # First file exists -> watch_file called
-        assert patched_watch_file.call_count == 1
-        # Second file doesn't exist -> watch_dir called
-        assert patched_watch_dir.call_count == 1
 
 
 class BootstrapRunTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Describe your changes

When Streamlit starts without a `config.toml` file, creating one now triggers an automatic app rerun to apply the configuration. This addresses the issue where newly created config files were not recognized without a manual server restart.

The implementation watches parent `.streamlit` directories for file creation using `watch_dir()` with a glob pattern when the config file doesn't exist at startup. The existing callback mechanism reloads configuration upon file creation.

## GitHub Issue Link

Fixes #11296

## Testing Plan

- **Unit Tests**: Added two comprehensive test cases:
  - `test_install_config_watcher_for_nonexistent_files`: Verifies directory watching when config files don't exist
  - `test_install_config_watcher_mixed_existing_and_nonexistent`: Tests mixed scenarios with existing and non-existing files
- **Manual Testing**: Create a config file while app is running to verify automatic rerun
- **No regression**: Existing behavior for watching existing config files remains unchanged

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.