### PR TITLE
Remove deprecated `st.experimental_user` command

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -111,7 +111,6 @@ from streamlit.runtime.state import (
 )
 from streamlit.user_info import (
     UserInfoProxy as _UserInfoProxy,
-    DeprecatedUserInfoProxy as _DeprecatedUserInfoProxy,
     login as _login,
     logout as _logout,
 )
@@ -274,9 +273,6 @@ logout = _logout
 
 # User
 user = _UserInfoProxy()
-
-# Experimental APIs
-experimental_user = _DeprecatedUserInfoProxy()
 
 # make it possible to call streamlit.components.v1.html etc. by importing it here
 # import in the very end to avoid partially-initialized module import errors, because

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -30,10 +30,6 @@ from streamlit.auth_util import (
     is_authlib_installed,
     validate_auth_credentials,
 )
-from streamlit.deprecation_util import (
-    make_deprecated_name_warning,
-    show_deprecation_warning,
-)
 from streamlit.errors import StreamlitAPIException, StreamlitAuthError
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
@@ -701,38 +697,3 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         """Access exposed tokens via a dict-like object."""
         user_info = _get_user_info()
         return TokensProxy(cast("dict[str, str]", user_info.get("tokens", {})))
-
-
-has_shown_experimental_user_warning = False
-
-
-def maybe_show_deprecated_user_warning() -> None:
-    """Show a deprecation warning for the experimental_user alias."""
-    global has_shown_experimental_user_warning  # noqa: PLW0603
-
-    if not has_shown_experimental_user_warning:
-        has_shown_experimental_user_warning = True
-        show_deprecation_warning(
-            make_deprecated_name_warning(
-                "experimental_user",
-                "user",
-                "2025-11-06",
-            )
-        )
-
-
-class DeprecatedUserInfoProxy(UserInfoProxy):
-    """
-    A deprecated alias for UserInfoProxy.
-
-    This class is deprecated and will be removed in a future version of
-    Streamlit.
-    """
-
-    def __getattribute__(self, name: str) -> Any:
-        maybe_show_deprecated_user_warning()
-        return super().__getattribute__(name)
-
-    def __getitem__(self, key: str) -> Any:
-        maybe_show_deprecated_user_warning()
-        return super().__getitem__(key)

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -57,7 +57,6 @@ NON_ELEMENT_COMMANDS: set[str] = {
     "cache_resource",
     "connection",
     "context",
-    "experimental_user",
     "fragment",
     "get_option",
     "login",

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -147,24 +147,6 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         finally:
             add_script_run_ctx(threading.current_thread(), orig_report_ctx)
 
-    @patch("streamlit.user_info.show_deprecation_warning")
-    @patch("streamlit.user_info.has_shown_experimental_user_warning", False)
-    def test_deprecate_st_experimental_user(self, mock_show_warning: MagicMock):
-        """Test that we show deprecation warning only once."""
-        st.write(st.experimental_user)
-
-        expected_warning = (
-            "Please replace `st.experimental_user` with `st.user`.\n\n"
-            "`st.experimental_user` will be removed after 2025-11-06."
-        )
-
-        # We only show the warning a single time for a given object.
-        mock_show_warning.assert_called_once_with(expected_warning)
-        mock_show_warning.reset_mock()
-
-        st.write(st.experimental_user)
-        mock_show_warning.assert_not_called()
-
 
 @patch(
     "streamlit.auth_util.secrets_singleton",


### PR DESCRIPTION
## Describe your changes

Removes the deprecated `st.experimental_user` command alias along with its deprecation warning infrastructure. The `st.user` command remains as the primary user info API.

## Testing Plan

- Existing test for st.user functionality remains in place
- Removed deprecation warning test that is no longer applicable
- All Python syntax validated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.