### PR TITLE
Prepare pandas 3.0 compatibility

### DIFF
--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -50,16 +50,12 @@ st.header("Pandas Styler: Background and font styling")
 df = pd.DataFrame(np.random.randn(20, 4), columns=["A", "B", "C", "D"])
 
 
-def style_negative(v: float, props: str = "") -> str | None:
-    return props if v < 0 else None
-
-
 def highlight_max(s: Any, props: str = "") -> npt.NDArray[Any]:
     return np.where(s == np.nanmax(s.values), props, "")
 
 
 # Passing style values w/ all color formats to test css-style-string parsing robustness.
-styled_df = df.style.map(style_negative, props="color:#FF0000;").map(
+styled_df = df.style.map(lambda v: "color:#FF0000;" if v < 0 else None).map(
     lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None
 )
 

--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -23,7 +23,6 @@ import pandas as pd
 import streamlit as st
 
 if TYPE_CHECKING:
-    import numpy.typing as npt
     from pandas.io.formats.style import Styler
 
 # Explicitly seed the RNG for deterministic results
@@ -50,24 +49,31 @@ st.header("Pandas Styler: Background and font styling")
 df = pd.DataFrame(np.random.randn(20, 4), columns=["A", "B", "C", "D"])
 
 
-def highlight_max(s: Any, props: str = "") -> npt.NDArray[Any]:
-    return np.where(s == np.nanmax(s.values), props, "")
-
-
 # Passing style values w/ all color formats to test css-style-string parsing robustness.
 styled_df = df.style.map(lambda v: "color:#FF0000;" if v < 0 else None).map(
     lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None
 )
 
 styled_df.apply(
-    highlight_max,
-    props="color:white;background-color:rgb(255, 0, 0);font-weight:800;",
+    lambda s: np.where(
+        s == np.nanmax(s.values),
+        "color:white;background-color:rgb(255, 0, 0);font-weight:800;",
+        "",
+    ),
     axis=0,
 )
 
 styled_df.apply(
-    highlight_max, props="color:white;background-color:hsl(273, 98%, 60%);", axis=1
-).apply(highlight_max, props="color:white;background-color:purple", axis=None)
+    lambda s: np.where(
+        s == np.nanmax(s.values), "color:white;background-color:hsl(273, 98%, 60%);", ""
+    ),
+    axis=1,
+).apply(
+    lambda s: np.where(
+        s == np.nanmax(s.values), "color:white;background-color:purple", ""
+    ),
+    axis=None,
+)
 
 st.dataframe(styled_df)
 

--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -59,7 +59,7 @@ def highlight_max(s: Any, props: str = "") -> npt.NDArray[Any]:
 
 
 # Passing style values w/ all color formats to test css-style-string parsing robustness.
-styled_df = df.style.map(style_negative, props="color:#FF0000;").applymap(  # type: ignore[call-overload]
+styled_df = df.style.map(style_negative, props="color:#FF0000;").map(
     lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None
 )
 

--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -50,11 +50,13 @@ df = pd.DataFrame(np.random.randn(20, 4), columns=["A", "B", "C", "D"])
 
 
 # Passing style values w/ all color formats to test css-style-string parsing robustness.
-styled_df = df.style.map(lambda v: "color:#FF0000;" if v < 0 else None).map(
-    lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None
+styled_df = df.style.map(
+    lambda v: "color:#FF0000;" if v < 0 else None  # type: ignore[operator]
+).map(
+    lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None  # type: ignore[operator]
 )
 
-styled_df.apply(
+styled_df.apply(  # type: ignore[call-overload]
     lambda s: np.where(
         s == np.nanmax(s.values),
         "color:white;background-color:rgb(255, 0, 0);font-weight:800;",
@@ -63,7 +65,7 @@ styled_df.apply(
     axis=0,
 )
 
-styled_df.apply(
+styled_df.apply(  # type: ignore[call-overload]
     lambda s: np.where(
         s == np.nanmax(s.values), "color:white;background-color:hsl(273, 98%, 60%);", ""
     ),

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1072,8 +1072,10 @@ def is_colum_type_arrow_incompatible(column: Series[Any] | Index[Any]) -> bool:
         return True
 
     if column.dtype == "object":
-        # The dtype of mixed type columns is always object, the actual type of the column
-        # values can be determined via the infer_dtype function:
+        # The dtype of mixed type columns is always object. In pandas 3.0+, pure
+        # string columns use StringDtype instead of object, so they won't enter
+        # this block (and they're Arrow-compatible anyway). The actual type of
+        # object dtype column values can be determined via the infer_dtype function:
         # https://pandas.pydata.org/docs/reference/api/pandas.api.types.infer_dtype.html
         inferred_type = infer_dtype(column, skipna=True)
 

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -611,6 +611,9 @@ def _melt_data(
 
     y_series = melted_df[new_y_column_name]
     if (
+        # After melting columns of different dtypes, the result has object dtype.
+        # In pandas 3.0+, melting columns with the same StringDtype keeps StringDtype,
+        # so this check correctly identifies only truly mixed-type scenarios.
         y_series.dtype == "object"
         and "mixed" in infer_dtype(y_series)
         and len(y_series.unique()) > 100

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -255,7 +255,9 @@ def _determine_data_kind_via_pandas_dtype(
     if pd.api.types.is_object_dtype(
         column_dtype
     ) is False and pd.api.types.is_string_dtype(column_dtype):
-        # The is_string_dtype
+        # This handles pandas 3.0+ StringDtype (and PyArrow-backed string types).
+        # We exclude object dtype here because object columns with string values
+        # are handled via _determine_data_kind_via_inferred_type in the caller.
         return ColumnDataKind.STRING
 
     return ColumnDataKind.UNKNOWN


### PR DESCRIPTION
## Describe your changes

Fixed deprecated pandas Styler API and clarified dtype handling for pandas 3.0 compatibility:
- Replaced deprecated `.applymap()` with `.map()` in e2e test (breaking change in pandas 3.0)
- Added clarifying comments to dtype checks that already handle StringDtype correctly

The codebase was already well-prepared for pandas 3.0. These changes ensure compatibility when pandas version constraint is updated from `<3` to `<4` in setup.py.

## Testing Plan

- No new tests required; changes are backwards compatible with pandas 2.x
- Existing e2e and unit tests cover this functionality
- Ready for testing with pandas 3.0 release candidate

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.