### PR TITLE
feat: Add hidden parameter to st.Page for navigation control

### DIFF
--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -387,9 +387,17 @@ def _navigation(
             msg.navigation.position = NavigationProto.Position.SIDEBAR
 
     msg.navigation.expanded = expanded
-    msg.navigation.sections[:] = nav_sections.keys()
+    # Filter out hidden pages from sections list, but only include sections that have visible pages
+    visible_sections = [
+        section for section in nav_sections.keys()
+        if any(not page._hidden for page in nav_sections[section])
+    ]
+    msg.navigation.sections[:] = visible_sections
     for section_header in nav_sections:
         for page in nav_sections[section_header]:
+            # Skip hidden pages from the navigation menu
+            if page._hidden:
+                continue
             p = msg.navigation.app_pages.add()
             p.page_script_hash = page._script_hash
             p.page_name = page.title

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -37,6 +37,7 @@ def Page(  # noqa: N802
     icon: str | None = None,
     url_path: str | None = None,
     default: bool = False,
+    hidden: bool = False,
 ) -> StreamlitPage:
     """Configure a page for ``st.navigation`` in a multipage app.
 
@@ -112,6 +113,13 @@ def Page(  # noqa: N802
         default page. If ``default`` is ``True``, then the page will have
         an empty pathname and ``url_path`` will be ignored.
 
+    hidden : bool
+        Whether this page should be hidden from the navigation menu. If
+        ``hidden`` is ``False`` (default), the page will be shown in the
+        navigation menu. If ``hidden`` is ``True``, the page will not be
+        shown in the navigation menu, but it will still be accessible via
+        its URL path or through ``st.page_link``.
+
     Returns
     -------
     StreamlitPage
@@ -127,11 +135,12 @@ def Page(  # noqa: N802
     >>> pg = st.navigation([
     >>>     st.Page("page1.py", title="First page", icon="🔥"),
     >>>     st.Page(page2, title="Second page", icon=":material/favorite:"),
+    >>>     st.Page("secret.py", title="Secret page", hidden=True),
     >>> ])
     >>> pg.run()
     """
     return StreamlitPage(
-        page, title=title, icon=icon, url_path=url_path, default=default
+        page, title=title, icon=icon, url_path=url_path, default=default, hidden=hidden
     )
 
 
@@ -167,6 +176,12 @@ class StreamlitPage:
         The default page will always have a ``url_path`` of ``""`` to indicate
         the root URL (e.g. homepage).
 
+    hidden : bool
+        Whether the page is hidden from the navigation menu.
+
+        If ``hidden`` is ``True``, the page will not be shown in the navigation
+        menu but will still be accessible via its URL path or ``st.page_link``.
+
     """
 
     def __init__(
@@ -177,10 +192,12 @@ class StreamlitPage:
         icon: str | None = None,
         url_path: str | None = None,
         default: bool = False,
+        hidden: bool = False,
     ) -> None:
         # Must appear before the return so all pages, even if running in bare Python,
         # have a _default property. This way we can always tell which script needs to run.
         self._default: bool = default
+        self._hidden: bool = hidden
 
         ctx = get_script_run_ctx()
         if not ctx:
@@ -278,6 +295,15 @@ class StreamlitPage:
         the root URL (e.g. homepage).
         """
         return "" if self._default else self._url_path
+
+    @property
+    def hidden(self) -> bool:
+        """Whether the page is hidden from the navigation menu.
+
+        If ``hidden`` is ``True``, the page will not be shown in the navigation
+        menu but will still be accessible via its URL path or ``st.page_link``.
+        """
+        return self._hidden
 
     def run(self) -> None:
         """Execute the page.

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -458,3 +458,86 @@ class NavigationTest(DeltaGeneratorTestCase):
         # Test with invalid type
         with pytest.raises(StreamlitAPIException):
             st.navigation([st.Page("page1.py")], position=123)  # type: ignore
+
+    def test_hidden_pages_not_shown_in_navigation(self):
+        """Test that hidden pages are not included in the navigation menu."""
+        st.navigation(
+            [
+                st.Page("page1.py"),
+                st.Page("page2.py", hidden=True),
+                st.Page("page3.py"),
+            ]
+        )
+        c = self.get_message_from_queue().navigation
+        # Only page1 and page3 should be in the navigation
+        assert len(c.app_pages) == 2
+        assert c.app_pages[0].page_name == "page1"
+        assert c.app_pages[1].page_name == "page3"
+
+    def test_hidden_page_can_be_found_by_url_path(self):
+        """Test that hidden pages can still be accessed via URL path."""
+        hidden_page = st.Page("page2.py", hidden=True)
+        self.script_run_ctx.pages_manager.set_script_intent(
+            hidden_page._script_hash, ""
+        )
+        page = st.navigation(
+            [st.Page("page1.py"), hidden_page, st.Page("page3.py")]
+        )
+        # Should return the hidden page when navigating directly to it
+        assert page == hidden_page
+        # But it should not appear in the navigation menu
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 2
+        assert all(p.page_name != "page2" for p in c.app_pages)
+
+    def test_hidden_pages_with_sections(self):
+        """Test that hidden pages work correctly with sections."""
+        st.navigation(
+            {
+                "Section 1": [
+                    st.Page("page1.py"),
+                    st.Page("page2.py", hidden=True),
+                ],
+                "Section 2": [
+                    st.Page("page3.py"),
+                    st.Page("page4.py", hidden=True),
+                ],
+            }
+        )
+        c = self.get_message_from_queue().navigation
+        # Only visible pages should appear
+        assert len(c.app_pages) == 2
+        assert c.app_pages[0].page_name == "page1"
+        assert c.app_pages[0].section_header == "Section 1"
+        assert c.app_pages[1].page_name == "page3"
+        assert c.app_pages[1].section_header == "Section 2"
+
+    def test_all_hidden_pages_in_section_hides_section(self):
+        """Test that a section with all hidden pages is not shown."""
+        st.navigation(
+            {
+                "Section 1": [st.Page("page1.py")],
+                "Section 2": [
+                    st.Page("page2.py", hidden=True),
+                    st.Page("page3.py", hidden=True),
+                ],
+            }
+        )
+        c = self.get_message_from_queue().navigation
+        # Only Section 1 should be in the sections list
+        assert len(c.sections) == 1
+        assert c.sections[0] == "Section 1"
+        # Only page1 should be in the navigation
+        assert len(c.app_pages) == 1
+        assert c.app_pages[0].page_name == "page1"
+
+    def test_hidden_default_page(self):
+        """Test that a hidden page can be the default page."""
+        default_page = st.Page("page1.py", default=True, hidden=True)
+        page = st.navigation([default_page, st.Page("page2.py")])
+        # Should return the hidden default page
+        assert page == default_page
+        # But it should not appear in the navigation menu
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 1
+        assert c.app_pages[0].page_name == "page2"

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -176,6 +176,27 @@ class StPagesTest(DeltaGeneratorTestCase):
         # Provide an assertion to ensure no error
         assert True
 
+    def test_hidden_defaults_to_false(self):
+        """Test that hidden property defaults to False."""
+        page = st.Page("page.py")
+        assert page.hidden is False
+
+    def test_hidden_can_be_set_to_true(self):
+        """Test that hidden property can be set to True."""
+        page = st.Page("page.py", hidden=True)
+        assert page.hidden is True
+
+    def test_hidden_page_still_has_url_path(self):
+        """Test that a hidden page still has a valid url_path."""
+        page = st.Page("page.py", hidden=True)
+        assert page.url_path == "page"
+
+    def test_hidden_page_can_be_default(self):
+        """Test that a hidden page can also be the default page."""
+        page = st.Page("page.py", hidden=True, default=True)
+        assert page.hidden is True
+        assert page.url_path == ""
+
 
 # NOTE: This test needs to live outside of the StPagesTest class because the class-level
 # @patch mocking the return value of `is_file` takes precedence over the method level


### PR DESCRIPTION
## Summary

This PR adds a `hidden` parameter to `st.Page` that allows pages to be accessible via URL but not shown in the navigation menu.

Fixes #10738

## Changes

### `lib/streamlit/navigation/page.py`
- Added `hidden: bool = False` parameter to `st.Page()` function
- Added `_hidden` attribute to `StreamlitPage` class
- Added `hidden` property to expose the hidden state

### `lib/streamlit/commands/navigation.py`
- Modified `_generate_navigation_message()` to filter out hidden pages from the navigation menu
- Sections containing only hidden pages are also not displayed

### Tests
- Added test cases in `page_test.py` to verify hidden defaults to False and can be set to True
- Added test case in `navigation_test.py` to verify hidden pages are not shown in navigation

## Usage

```python
import streamlit as st

pages = [
    st.Page("home.py", title="Home"),
    st.Page("secret.py", title="Secret", hidden=True),  # Accessible via URL but not in nav
    st.Page("about.py", title="About"),
]

st.navigation(pages)
```

---
This is a Gittensor contribution
gittensor::146701565