### PR TITLE
Fix selectbox and multiselect clearing selections for custom objects

### DIFF
--- a/e2e_playwright/st_multiselect.py
+++ b/e2e_playwright/st_multiselect.py
@@ -217,3 +217,35 @@ else:
         format_func=lambda x: x.capitalize(),
     )
     st.write("Initial multiselect value:", str(sms_value))
+
+
+# Test for issue #13646: Custom class objects without __eq__ should work with format_func
+# This tests that selections are preserved for custom class objects after script reruns
+# when the widget uses a format_func to display the options.
+class CustomOption:  # noqa: B903
+    """Custom class without __eq__ implementation.
+
+    This simulates the common pattern where users have custom objects with a
+    format_func that extracts a display string, but the class itself doesn't
+    implement __eq__ for value comparison.
+    """
+
+    def __init__(self, value: str, label: str):
+        self.value = value
+        self.label = label
+
+
+# Create new options on each script run (simulating the behavior that triggers the bug)
+custom_options_20 = [
+    CustomOption("opt_a", "Option A"),
+    CustomOption("opt_b", "Option B"),
+    CustomOption("opt_c", "Option C"),
+]
+
+i20 = st.multiselect(
+    "multiselect 20 - custom objects",
+    options=custom_options_20,
+    format_func=lambda x: x.label,
+    key="multiselect_custom_objects",
+)
+st.text(f"value 20: {[opt.value for opt in i20]}")

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -30,7 +30,7 @@ from e2e_playwright.shared.app_utils import (
     get_multiselect,
 )
 
-MULTISELECT_COUNT = 20
+MULTISELECT_COUNT = 21
 
 
 def _get_multiselect_input(locator: Locator | Page, label: str) -> Locator:
@@ -517,3 +517,40 @@ def test_multiselect_preserves_scroll_position_on_remove(app: Page):
     # Verify scroll position is preserved
     final_scroll = value_container.evaluate("el => el.scrollTop")
     assert final_scroll == initial_scroll
+
+
+def test_multiselect_custom_objects_without_eq(app: Page):
+    """Test that custom class objects without __eq__ work correctly with format_func.
+
+    This tests the fix for https://github.com/streamlit/streamlit/issues/13646
+    where custom objects without __eq__ would have their selections cleared
+    after script reruns because the validation used identity comparison after
+    deepcopy created new instances.
+    """
+    # Get the multiselect with custom objects
+    multiselect_elem = get_multiselect(app, "multiselect 20 - custom objects")
+
+    # Initial state - no selections
+    expect_text(app, "value 20: []")
+
+    # Select first option "Option A"
+    select_for_multiselect(app, "multiselect 20 - custom objects", "Option A", True)
+
+    # Verify selection is preserved after the script rerun
+    # This is the key test - without the fix, the selection would be cleared
+    # because deepcopy creates new object instances and the validation used
+    # identity comparison (==) which fails for objects without __eq__
+    expect_text(app, "value 20: ['opt_a']")
+
+    # Verify the selection is visible in the UI
+    expect(multiselect_elem.locator('[data-baseweb="tag"]')).to_have_count(1)
+    expect(
+        multiselect_elem.get_by_role("button").get_by_text("Option A", exact=True)
+    ).to_be_visible()
+
+    # Select another option to verify multiple selections work
+    select_for_multiselect(app, "multiselect 20 - custom objects", "Option B", True)
+    expect_text(app, "value 20: ['opt_a', 'opt_b']")
+
+    # Verify both selections are visible
+    expect(multiselect_elem.locator('[data-baseweb="tag"]')).to_have_count(2)

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -339,6 +339,7 @@ def validate_and_sync_multiselect_value_with_options(
     current_values: list[T] | list[T | str],
     opt: Sequence[T],
     key: str | int | None,
+    format_func: Callable[[Any], str] = str,
 ) -> tuple[list[T] | list[T | str], bool]:
     """Validate multiselect values against options, syncing session state if needed.
 
@@ -356,6 +357,11 @@ def validate_and_sync_multiselect_value_with_options(
         The sequence of valid options.
     key
         The widget key for session state updates.
+    format_func
+        Function to format options for comparison. Used to compare values by their
+        string representation instead of using == directly. This is necessary because
+        widget values are deepcopied, and for custom classes without __eq__, the
+        deepcopied instances would fail identity comparison.
 
     Returns
     -------
@@ -365,13 +371,26 @@ def validate_and_sync_multiselect_value_with_options(
     if not current_values:
         return current_values, False
 
+    # Create a set of formatted options for O(1) lookup.
+    # We use format_func to compare values by their string representation
+    # instead of using == directly. This is necessary because widget values
+    # are deepcopied, and for custom classes without __eq__, the deepcopied
+    # instances would fail identity comparison.
+    formatted_options_set = {format_func(o) for o in opt}
+
     valid_values: list[T | str] = []
     for value in current_values:
         try:
-            index_(opt, value)
+            formatted_value = format_func(value)
+        except Exception:  # noqa: S112
+            # format_func failed on this value (e.g., a string value from a previous
+            # session when format_func expects an object with specific attributes).
+            # In this case, the value is definitely not valid since the current options
+            # can be formatted successfully.
+            continue
+
+        if formatted_value in formatted_options_set:
             valid_values.append(value)
-        except ValueError:  # noqa: PERF203
-            pass
 
     if len(valid_values) == len(current_values):
         return current_values, False

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -321,19 +321,29 @@ def validate_and_sync_value_with_options(
     if current_value is None:
         return current_value, False
 
-    # Check if current value is still in the new options using format_func comparison.
-    # We use format_func instead of index_() with == because widget values are
-    # deepcopied, and for custom classes without __eq__, the deepcopied instances
-    # would fail identity comparison.
-    try:
-        formatted_value = format_func(current_value)
-    except Exception:
-        # format_func failed - value is invalid
-        formatted_value = None
+    # For Enum values, use the original index_() approach which uses == comparison.
+    # This correctly handles enum class identity - enums from different classes
+    # (e.g., after script rerun) should NOT be considered equal, which is important
+    # for enum coercion to work correctly when coercion is disabled.
+    if isinstance(current_value, Enum):
+        try:
+            index_(opt, current_value)
+            return current_value, False
+        except ValueError:
+            pass  # Fall through to reset logic below
+    else:
+        # For non-Enum values, use format_func comparison. This handles custom objects
+        # without __eq__ where widget values are deepcopied and the deepcopied instances
+        # would fail identity comparison with ==.
+        try:
+            formatted_value = format_func(current_value)
+        except Exception:
+            # format_func failed - value is invalid
+            formatted_value = None
 
-    formatted_options_set = {format_func(o) for o in opt}
-    if formatted_value is not None and formatted_value in formatted_options_set:
-        return current_value, False
+        formatted_options_set = {format_func(o) for o in opt}
+        if formatted_value is not None and formatted_value in formatted_options_set:
+            return current_value, False
 
     # Value not in options - reset to default
     if default_index is not None and len(opt) > 0:

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -290,6 +290,7 @@ def validate_and_sync_value_with_options(
     opt: Sequence[T],
     default_index: int | None,
     key: str | int | None,
+    format_func: Callable[[Any], str] = str,
 ) -> tuple[T | None, bool]:
     """Validate current value against options, resetting session state if invalid.
 
@@ -306,6 +307,11 @@ def validate_and_sync_value_with_options(
         The default index to reset to if value is invalid.
     key
         The widget key for session state updates.
+    format_func
+        Function to format options for comparison. Used to compare values by their
+        string representation instead of using == directly. This is necessary because
+        widget values are deepcopied, and for custom classes without __eq__, the
+        deepcopied instances would fail identity comparison.
 
     Returns
     -------
@@ -315,24 +321,33 @@ def validate_and_sync_value_with_options(
     if current_value is None:
         return current_value, False
 
-    # Check if current value is still in the new options
+    # Check if current value is still in the new options using format_func comparison.
+    # We use format_func instead of index_() with == because widget values are
+    # deepcopied, and for custom classes without __eq__, the deepcopied instances
+    # would fail identity comparison.
     try:
-        index_(opt, current_value)
+        formatted_value = format_func(current_value)
+    except Exception:
+        # format_func failed - value is invalid
+        formatted_value = None
+
+    formatted_options_set = {format_func(o) for o in opt}
+    if formatted_value is not None and formatted_value in formatted_options_set:
         return current_value, False
-    except ValueError:
-        # Value not in options - reset to default
-        if default_index is not None and len(opt) > 0:
-            new_value: T | None = opt[default_index]
-        else:
-            new_value = None
 
-        if key is not None:
-            # Update session_state so subsequent accesses in this run
-            # return the corrected value. Use reset_state_value to avoid
-            # the "cannot be modified after widget instantiated" error.
-            get_session_state().reset_state_value(str(key), new_value)
+    # Value not in options - reset to default
+    if default_index is not None and len(opt) > 0:
+        new_value: T | None = opt[default_index]
+    else:
+        new_value = None
 
-        return new_value, True
+    if key is not None:
+        # Update session_state so subsequent accesses in this run
+        # return the corrected value. Use reset_state_value to avoid
+        # the "cannot be modified after widget instantiated" error.
+        get_session_state().reset_state_value(str(key), new_value)
+
+    return new_value, True
 
 
 def validate_and_sync_multiselect_value_with_options(

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -138,16 +138,20 @@ class MultiSelectSerde(Generic[T]):
                 formatted_value = self.format_func(v)
             except Exception:
                 # format_func failed (e.g., v is a string but format_func expects
-                # an object with specific attributes). Treat v as a raw string.
-                values.append(cast("str", v))
+                # an object with specific attributes). Use str(v) to ensure we append
+                # a proper string, not the original object. This handles both cases:
+                # - v is already a string -> str(v) returns it unchanged
+                # - v is a custom object -> str(v) gives its string representation
+                values.append(str(v))
                 continue
 
             if formatted_value in self.formatted_option_to_option_index:
                 values.append(formatted_value)
             else:
                 # Value not found in options - it's likely a user-entered string
-                # (when accept_new_options=True) or an invalid value
-                values.append(cast("str", v))
+                # (when accept_new_options=True) or an invalid value. Use the
+                # formatted string (not the original object) for type consistency.
+                values.append(formatted_value)
         return values
 
     def deserialize(self, ui_value: list[str] | None) -> list[T | str] | list[T]:

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -82,6 +82,7 @@ class MultiSelectSerde(Generic[T]):
     formatted_options: list[str]
     formatted_option_to_option_index: dict[str, int]
     default_options_indices: list[int]
+    format_func: Callable[[Any], str]
 
     def __init__(
         self,
@@ -90,6 +91,7 @@ class MultiSelectSerde(Generic[T]):
         formatted_options: list[str],
         formatted_option_to_option_index: dict[str, int],
         default_options_indices: list[int] | None = None,
+        format_func: Callable[[Any], str] = str,
     ) -> None:
         """Initialize the MultiSelectSerde.
 
@@ -111,23 +113,40 @@ class MultiSelectSerde(Generic[T]):
         default_option_index : int or None, optional
             The index of the default option to use when no selection is made.
             If None, no default option is selected.
+        format_func : Callable[[Any], str], optional
+            Function to format options for comparison. Used to compare values by their
+            string representation instead of using == directly. This is necessary because
+            widget values are deepcopied, and for custom classes without __eq__, the
+            deepcopied instances would fail identity comparison.
         """
 
         self.options = options
         self.formatted_options = formatted_options
         self.formatted_option_to_option_index = formatted_option_to_option_index
         self.default_options_indices = default_options_indices or []
+        self.format_func = format_func
 
     def serialize(self, value: list[T | str] | list[T]) -> list[str]:
         converted_value = convert_anything_to_list(value)
         values: list[str] = []
         for v in converted_value:
+            # Use format_func to find the formatted option instead of using
+            # self.options.index(v) which relies on == comparison. This is necessary
+            # because widget values are deepcopied, and for custom classes without
+            # __eq__, the deepcopied instances would fail identity comparison.
             try:
-                option_index = self.options.index(v)
-                values.append(self.formatted_options[option_index])
-            except ValueError:  # noqa: PERF203
-                # at this point we know that v is a string, otherwise
-                # it would have been found in the options
+                formatted_value = self.format_func(v)
+            except Exception:
+                # format_func failed (e.g., v is a string but format_func expects
+                # an object with specific attributes). Treat v as a raw string.
+                values.append(cast("str", v))
+                continue
+
+            if formatted_value in self.formatted_option_to_option_index:
+                values.append(formatted_value)
+            else:
+                # Value not found in options - it's likely a user-entered string
+                # (when accept_new_options=True) or an invalid value
                 values.append(cast("str", v))
         return values
 
@@ -530,6 +549,7 @@ class MultiSelectMixin:
             formatted_options=formatted_options,
             formatted_option_to_option_index=formatted_option_to_option_index,
             default_options_indices=default_values,
+            format_func=format_func,
         )
 
         widget_state = register_widget(

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -560,7 +560,7 @@ class MultiSelectMixin:
             # previously selected values are no longer available.
             current_values, value_needs_reset = (
                 validate_and_sync_multiselect_value_with_options(
-                    widget_state.value, indexable_options, key
+                    widget_state.value, indexable_options, key, format_func
                 )
             )
 

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -35,7 +35,6 @@ from streamlit.elements.lib.layout_utils import (
 )
 from streamlit.elements.lib.options_selector_utils import (
     create_mappings,
-    index_,
     maybe_coerce_enum,
     validate_and_sync_value_with_options,
 )
@@ -79,6 +78,7 @@ class SelectboxSerde(Generic[T]):
     formatted_options: list[str]
     formatted_option_to_option_index: dict[str, int]
     default_option_index: int | None
+    format_func: Callable[[Any], str]
 
     def __init__(
         self,
@@ -87,6 +87,7 @@ class SelectboxSerde(Generic[T]):
         formatted_options: list[str],
         formatted_option_to_option_index: dict[str, int],
         default_option_index: int | None = None,
+        format_func: Callable[[Any], str] = str,
     ) -> None:
         """Initialize the SelectboxSerde.
 
@@ -108,12 +109,18 @@ class SelectboxSerde(Generic[T]):
         default_option_index : int or None, optional
             The index of the default option to use when no selection is made.
             If None, no default option is selected.
+        format_func : Callable[[Any], str], optional
+            Function to format options for comparison. Used to compare values by their
+            string representation instead of using == directly. This is necessary because
+            widget values are deepcopied, and for custom classes without __eq__, the
+            deepcopied instances would fail identity comparison.
         """
 
         self.options = options
         self.formatted_options = formatted_options
         self.formatted_option_to_option_index = formatted_option_to_option_index
         self.default_option_index = default_option_index
+        self.format_func = format_func
 
     def serialize(self, v: T | str | None) -> str | None:
         if v is None:
@@ -121,16 +128,21 @@ class SelectboxSerde(Generic[T]):
         if len(self.options) == 0:
             return ""
 
-        # we don't check for isinstance(v, str) because this could lead to wrong
-        # results if v is a string that is part of the options itself as it would
-        # skip formatting in that case
+        # Use format_func to find the formatted option instead of using
+        # index_(self.options, v) which relies on == comparison. This is necessary
+        # because widget values are deepcopied, and for custom classes without
+        # __eq__, the deepcopied instances would fail identity comparison.
         try:
-            option_index = index_(self.options, v)
-            return self.formatted_options[option_index]
-        except ValueError:
-            # we know that v is a string, otherwise it would have been found in the
-            # options
+            formatted_value = self.format_func(v)
+        except Exception:
+            # format_func failed (e.g., v is a string but format_func expects
+            # an object with specific attributes). Treat v as a raw string.
             return cast("str", v)
+
+        if formatted_value in self.formatted_option_to_option_index:
+            return formatted_value
+        # Value not found in options - return as raw string
+        return cast("str", v)
 
     def deserialize(self, ui_value: str | None) -> T | str | None:
         # check if the option is pointing to a generic option type T,
@@ -583,6 +595,7 @@ class SelectboxMixin:
             formatted_options=formatted_options,
             formatted_option_to_option_index=formatted_option_to_option_index,
             default_option_index=index,
+            format_func=format_func,
         )
         widget_state = register_widget(
             selectbox_proto.id,
@@ -605,7 +618,7 @@ class SelectboxMixin:
             # This handles the case where options change dynamically and the
             # previously selected value is no longer available.
             current_value, value_needs_reset = validate_and_sync_value_with_options(
-                widget_state.value, opt, index, key
+                widget_state.value, opt, index, key, format_func
             )
 
         if value_needs_reset or widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -125,8 +125,9 @@ class SelectboxSerde(Generic[T]):
     def serialize(self, v: T | str | None) -> str | None:
         if v is None:
             return None
-        if len(self.options) == 0:
-            return None
+        # Note: We don't short-circuit for empty options here because
+        # accept_new_options=True allows user-entered values even with no options.
+        # The normal flow below handles this correctly.
 
         # Use format_func to find the formatted option instead of using
         # index_(self.options, v) which relies on == comparison. This is necessary
@@ -149,16 +150,16 @@ class SelectboxSerde(Generic[T]):
         return formatted_value
 
     def deserialize(self, ui_value: str | None) -> T | str | None:
-        # If no options, there's no valid value - return None
-        if len(self.options) == 0:
-            return None
+        # Note: We don't short-circuit for empty options here because
+        # accept_new_options=True allows user-entered values even with no options.
+        # The normal flow below handles this: ui_value not in options -> return ui_value.
 
         # Check if the option is pointing to a generic option type T,
         # otherwise return the option itself.
         if ui_value is None:
             return (
                 self.options[self.default_option_index]
-                if self.default_option_index is not None
+                if self.default_option_index is not None and len(self.options) > 0
                 else None
             )
 

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -126,7 +126,7 @@ class SelectboxSerde(Generic[T]):
         if v is None:
             return None
         if len(self.options) == 0:
-            return ""
+            return None
 
         # Use format_func to find the formatted option instead of using
         # index_(self.options, v) which relies on == comparison. This is necessary
@@ -136,21 +136,29 @@ class SelectboxSerde(Generic[T]):
             formatted_value = self.format_func(v)
         except Exception:
             # format_func failed (e.g., v is a string but format_func expects
-            # an object with specific attributes). Treat v as a raw string.
-            return cast("str", v)
+            # an object with specific attributes). Use str(v) to ensure we return
+            # a proper string, not the original object. This handles both cases:
+            # - v is already a string -> str(v) returns it unchanged
+            # - v is a custom object -> str(v) gives its string representation
+            return str(v)
 
         if formatted_value in self.formatted_option_to_option_index:
             return formatted_value
-        # Value not found in options - return as raw string
-        return cast("str", v)
+        # Value not found in options - return the formatted string (not the original
+        # object) to maintain type consistency since serialize() must return str|None
+        return formatted_value
 
     def deserialize(self, ui_value: str | None) -> T | str | None:
-        # check if the option is pointing to a generic option type T,
-        # otherwise return the option itself
+        # If no options, there's no valid value - return None
+        if len(self.options) == 0:
+            return None
+
+        # Check if the option is pointing to a generic option type T,
+        # otherwise return the option itself.
         if ui_value is None:
             return (
                 self.options[self.default_option_index]
-                if self.default_option_index is not None and len(self.options) > 0
+                if self.default_option_index is not None
                 else None
             )
 

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -577,3 +577,132 @@ class TestValidateAndSyncMultiselectValueWithOptions(unittest.TestCase):
         )
         assert values == expected_values
         assert needs_reset is expected_needs_reset
+
+
+class TestValidateMultiselectWithCustomObjects(unittest.TestCase):
+    """Test class for validating multiselect with custom class objects.
+
+    This tests the fix for https://github.com/streamlit/streamlit/issues/13646
+    where custom objects without __eq__ would fail validation after deepcopy.
+    """
+
+    def test_custom_objects_without_eq_using_format_func(self):
+        """Test that custom objects without __eq__ work with format_func validation."""
+
+        # Custom class without __eq__ implementation
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        # Create options and their deepcopied equivalents (simulating what happens
+        # after register_widget deepcopies the values)
+        from copy import deepcopy
+
+        original_options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        deepcopied_values = [
+            deepcopy(original_options[0]),
+            deepcopy(original_options[1]),
+        ]
+
+        # Without the fix, this would fail because deepcopy creates new instances
+        # and == falls back to identity comparison for objects without __eq__
+        values, needs_reset = validate_and_sync_multiselect_value_with_options(
+            deepcopied_values,
+            original_options,
+            None,
+            format_func=lambda x: x.value,  # Compare by .value attribute
+        )
+
+        # All values should be valid since they have matching format_func output
+        assert len(values) == 2
+        assert needs_reset is False
+
+    def test_custom_objects_partial_match_with_format_func(self):
+        """Test that only matching custom objects are kept."""
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        from copy import deepcopy
+
+        original_options = [MyOption("a"), MyOption("b")]  # "c" is removed
+        # Simulate values that include one that's no longer in options
+        deepcopied_values = [
+            deepcopy(MyOption("a")),
+            deepcopy(MyOption("c")),  # This one should be filtered out
+        ]
+
+        values, needs_reset = validate_and_sync_multiselect_value_with_options(
+            deepcopied_values,
+            original_options,
+            None,
+            format_func=lambda x: x.value,
+        )
+
+        # Only "a" should remain, "c" should be filtered out
+        assert len(values) == 1
+        assert values[0].value == "a"
+        assert needs_reset is True
+
+    def test_default_format_func_with_custom_str(self):
+        """Test that custom objects with __str__ work with default format_func."""
+
+        class MyOption:
+            def __init__(self, value: str):
+                self.value = value
+
+            def __str__(self):
+                return self.value
+
+        from copy import deepcopy
+
+        original_options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        deepcopied_values = [deepcopy(original_options[0])]
+
+        # Using default str format_func
+        values, needs_reset = validate_and_sync_multiselect_value_with_options(
+            deepcopied_values,
+            original_options,
+            None,
+            # format_func defaults to str
+        )
+
+        assert len(values) == 1
+        assert needs_reset is False
+
+    def test_format_func_failure_filters_out_value(self):
+        """Test that values are filtered out when format_func fails on them.
+
+        This handles the edge case where options changed and the deserializer
+        returned a raw string (because the formatted option no longer exists),
+        but the format_func can't handle strings (e.g., lambda x: x.attribute).
+        """
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        # format_func that only works on MyOption objects, not strings
+        def format_func(x):
+            return x.value
+
+        original_options = [MyOption("b"), MyOption("c")]
+
+        # Simulate a string value that came from an old session where
+        # the option no longer exists (deserializer returns raw string)
+        current_values = ["old_value", MyOption("b")]
+
+        # The string should be filtered out (format_func fails on it)
+        # but MyOption("b") should remain valid
+        values, needs_reset = validate_and_sync_multiselect_value_with_options(
+            current_values,
+            original_options,
+            None,
+            format_func=format_func,
+        )
+
+        # Only MyOption("b") should remain
+        assert len(values) == 1
+        assert values[0].value == "b"
+        assert needs_reset is True

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -513,6 +513,35 @@ class TestValidateAndSyncValueWithOptions(unittest.TestCase):
         assert value == expected_value
         assert needs_reset is expected_needs_reset
 
+    def test_custom_objects_without_eq_using_format_func(self):
+        """Test that custom objects without __eq__ work with format_func validation."""
+        from copy import deepcopy
+
+        # Custom class without __eq__ implementation
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        def format_func(x):
+            return x.value
+
+        original_options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        deepcopied_value = deepcopy(original_options[1])
+
+        # Without the fix, this would reset because deepcopy creates new instances
+        # and == falls back to identity comparison for objects without __eq__
+        value, needs_reset = validate_and_sync_value_with_options(
+            deepcopied_value,
+            original_options,
+            0,
+            None,
+            format_func=format_func,
+        )
+
+        # Value should be valid since format_func output matches
+        assert value is deepcopied_value
+        assert needs_reset is False
+
 
 class TestValidateAndSyncMultiselectValueWithOptions(unittest.TestCase):
     """Test class for validate_and_sync_multiselect_value_with_options utility function."""

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -631,6 +631,7 @@ class TestMultiSelectSerde:
             options,
             formatted_options=formatted_options,
             formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=format_func,
         )
 
         res = serde.serialize(["A", "Option C"])
@@ -696,6 +697,41 @@ class TestMultiSelectSerde:
 
         res = serde.deserialize(["First", "Third"])
         assert res == [complex_options[0], complex_options[2]]
+
+    def test_serialize_deepcopied_custom_objects(self):
+        """Test that serialize works with deepcopied custom objects without __eq__.
+
+        This tests the fix for https://github.com/streamlit/streamlit/issues/13646
+        where custom objects without __eq__ would fail serialization after deepcopy
+        because the old implementation used options.index() which relies on ==.
+        """
+        from copy import deepcopy
+
+        # Custom class without __eq__ implementation
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        def format_func(x):
+            return x.value
+
+        options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        formatted_options, formatted_option_to_option_index = create_mappings(
+            options, format_func
+        )
+        serde = MultiSelectSerde(
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=format_func,
+        )
+
+        # Simulate deepcopied values (what happens after register_widget)
+        deepcopied_values = [deepcopy(options[0]), deepcopy(options[1])]
+
+        # This should work correctly using format_func comparison
+        res = serde.serialize(deepcopied_values)
+        assert res == ["a", "b"]
 
 
 def test_multiselect_preserves_selection_when_options_expand():

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -634,8 +634,10 @@ class TestMultiSelectSerde:
             format_func=format_func,
         )
 
+        # "A" is not in options but format_func succeeds, so it returns formatted value
+        # "Option C" is in options, so it also returns formatted value
         res = serde.serialize(["A", "Option C"])
-        assert res == ["A", "Format: Option C"]
+        assert res == ["Format: A", "Format: Option C"]
 
     def test_deserialize(self):
         options = ["Option A", "Option B", "Option C"]

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -623,7 +623,12 @@ class TestSelectboxSerde:
         assert res is None
 
     def test_serialize_empty_options(self):
-        """Test that serializing with empty options returns None, not empty string."""
+        """Test serializing with empty options.
+
+        Even with empty options, serialize should return the formatted value
+        (not None or empty string) because accept_new_options=True allows
+        user-entered values even when the options list is empty.
+        """
         options = []
         formatted_options, formatted_option_to_option_index = create_mappings(options)
         serde = SelectboxSerde(
@@ -632,10 +637,12 @@ class TestSelectboxSerde:
             formatted_option_to_option_index=formatted_option_to_option_index,
         )
 
+        # With default format_func (str), "something" should serialize to "something"
         res = serde.serialize("something")
-        assert res is None
-        # Should not return empty string which would cause issues in session state
+        assert res == "something"
+        # Should not return empty string or None
         assert res != ""
+        assert res is not None
 
     def test_serialize_with_format_func(self):
         options = ["Option A", "Option B", "Option C"]
@@ -728,10 +735,11 @@ class TestSelectboxSerde:
         assert res is None
 
     def test_deserialize_empty_options_with_string_value(self):
-        """Test that deserializing empty string with empty options returns None.
+        """Test deserializing a string value with empty options.
 
-        This tests the fix for session state getting "" instead of None
-        when options are empty.
+        When accept_new_options=True, users can enter custom values even
+        when options is empty. The serde should return these user-entered
+        values as-is.
         """
         options = []
         formatted_options, formatted_option_to_option_index = create_mappings(options)
@@ -741,11 +749,13 @@ class TestSelectboxSerde:
             formatted_option_to_option_index=formatted_option_to_option_index,
         )
 
-        # If serialize returned "" (the old behavior), deserialize should still return None
+        # User-entered values should be returned as-is (supports accept_new_options=True)
+        res = serde.deserialize("user_entered_value")
+        assert res == "user_entered_value"
+
+        # Even empty string is a valid user input when accept_new_options=True
         res = serde.deserialize("")
-        assert res is None
-        # Should not return empty string which would cause issues in session state
-        assert res != ""
+        assert res == ""
 
     def test_deserialize_complex_options(self):
         # Test with more complex option types

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -648,6 +648,7 @@ class TestSelectboxSerde:
             options,
             formatted_options=formatted_options,
             formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=format_func,
         )
 
         res = serde.serialize("Option A")
@@ -777,3 +778,38 @@ class TestSelectboxSerde:
 
         res = serde.deserialize("TestEnum.B")
         assert res == TestEnum.B
+
+    def test_serialize_deepcopied_custom_objects(self):
+        """Test that serialize works with deepcopied custom objects without __eq__.
+
+        This tests the fix for https://github.com/streamlit/streamlit/issues/13646
+        where custom objects without __eq__ would fail serialization after deepcopy
+        because the old implementation used index_() which relies on ==.
+        """
+        from copy import deepcopy
+
+        # Custom class without __eq__ implementation
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        def format_func(x):
+            return x.value
+
+        options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        formatted_options, formatted_option_to_option_index = create_mappings(
+            options, format_func
+        )
+        serde = SelectboxSerde(
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=format_func,
+        )
+
+        # Simulate deepcopied value (what happens after register_widget)
+        deepcopied_value = deepcopy(options[0])
+
+        # This should work correctly using format_func comparison
+        res = serde.serialize(deepcopied_value)
+        assert res == "a"

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -623,6 +623,7 @@ class TestSelectboxSerde:
         assert res is None
 
     def test_serialize_empty_options(self):
+        """Test that serializing with empty options returns None, not empty string."""
         options = []
         formatted_options, formatted_option_to_option_index = create_mappings(options)
         serde = SelectboxSerde(
@@ -632,7 +633,9 @@ class TestSelectboxSerde:
         )
 
         res = serde.serialize("something")
-        assert res == ""
+        assert res is None
+        # Should not return empty string which would cause issues in session state
+        assert res != ""
 
     def test_serialize_with_format_func(self):
         options = ["Option A", "Option B", "Option C"]
@@ -654,8 +657,10 @@ class TestSelectboxSerde:
         res = serde.serialize("Option A")
         assert res == "Format: Option A"
 
+        # When a value is not found in options but format_func succeeds,
+        # return the formatted value (not the original) for type consistency
         res = serde.serialize("Option D")
-        assert res == "Option D"
+        assert res == "Format: Option D"
 
     def test_deserialize(self):
         options = ["Option A", "Option B", "Option C"]
@@ -708,6 +713,7 @@ class TestSelectboxSerde:
         assert res == "Option C"
 
     def test_deserialize_empty_options_with_default_index(self):
+        """Test that deserializing with empty options returns None even with default index."""
         options = []
         formatted_options, formatted_option_to_option_index = create_mappings(options)
         default_index = 0
@@ -720,6 +726,26 @@ class TestSelectboxSerde:
 
         res = serde.deserialize(None)
         assert res is None
+
+    def test_deserialize_empty_options_with_string_value(self):
+        """Test that deserializing empty string with empty options returns None.
+
+        This tests the fix for session state getting "" instead of None
+        when options are empty.
+        """
+        options = []
+        formatted_options, formatted_option_to_option_index = create_mappings(options)
+        serde = SelectboxSerde(
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+        )
+
+        # If serialize returned "" (the old behavior), deserialize should still return None
+        res = serde.deserialize("")
+        assert res is None
+        # Should not return empty string which would cause issues in session state
+        assert res != ""
 
     def test_deserialize_complex_options(self):
         # Test with more complex option types


### PR DESCRIPTION
## Describe your changes

Fixes issue #13646 where `st.multiselect()` and `st.selectbox` clears user selections after each script rerun when using custom class objects without `__eq__` implementation and a `format_func` parameter. This was a regression introduced in PR #13448.

**Root Cause**: The validation logic compared multiselect values using `==`, which falls back to identity comparison for objects without `__eq__`. Since `register_widget()` deepcopies widget values, the new instances fail identity comparison with original options, causing valid selections to be filtered out.

**Solution**: Changed validation to compare values using `format_func()` by their formatted string representation instead of using `==`. This is more robust and works correctly regardless of whether custom classes implement `__eq__`.

## Testing Plan

- Unit Tests: Added 4 comprehensive test cases covering custom objects without `__eq__`, partial matches, objects with `__str__`, and edge cases where `format_func` fails on incompatible types
- E2E Tests: Added `test_multiselect_custom_objects_without_eq` to verify selections persist across script reruns with custom class objects
- Backward Compatibility: The `format_func` parameter has a default value of `str`, so existing code continues to work without changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.