### PR TITLE
[Prototype] Add `streamlit cloud deploy` CLI command

### DIFF
--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -365,6 +365,80 @@ def config_show(**kwargs: Any) -> None:
     _config.show_config()
 
 
+# SUBCOMMAND cloud
+
+DEPLOY_URL: Final = "https://share.streamlit.io/deploy"
+STREAMLIT_CLOUD_URL: Final = "https://streamlit.io/cloud"
+
+
+@main.group("cloud")
+def cloud() -> None:
+    """Manage Streamlit Community Cloud deployments."""
+
+
+@cloud.command("deploy")
+@click.argument("target", default=".", required=False)
+def cloud_deploy(target: str = ".") -> None:
+    """Open the browser to deploy to Streamlit Community Cloud.
+
+    If the current directory (or TARGET) is inside a GitHub repository,
+    the deploy page will be pre-filled with the repository, branch, and
+    main module information.
+
+    TARGET can be:
+    - A path to a Python file (e.g., streamlit_app.py)
+    - A path to a directory containing streamlit_app.py
+    - Omitted to use the current directory
+    """
+    from urllib.parse import urlencode
+
+    from streamlit import cli_util
+    from streamlit.git_util import GitRepo
+
+    path = Path(target)
+
+    # Determine the script path
+    if path.is_dir():
+        script_path = path / "streamlit_app.py"
+        if not script_path.exists():
+            # If no streamlit_app.py, just use the directory for git info
+            script_path = path
+    else:
+        script_path = path
+
+    script_path = script_path.resolve()
+
+    # Try to get git repository information
+    repo = GitRepo(str(script_path))
+    repo_info = repo.get_repo_info()
+
+    if repo_info:
+        repository, branch, module = repo_info
+        # Remove .git suffix if present (matching DeployDialog behavior)
+        repository = repository.removesuffix(".git")
+
+        params = {
+            "repository": repository,
+            "branch": branch,
+            "mainModule": module,
+        }
+        deploy_url = f"{DEPLOY_URL}?{urlencode(params)}"
+
+        click.echo("Opening Streamlit Community Cloud deploy page...")
+        click.echo(f"  Repository: {repository}")
+        click.echo(f"  Branch: {branch}")
+        click.echo(f"  Main module: {module}")
+    else:
+        deploy_url = STREAMLIT_CLOUD_URL
+        click.echo("Opening Streamlit Community Cloud...")
+        click.echo(
+            "  (No GitHub repository detected. "
+            "Make sure your code is pushed to GitHub to deploy.)"
+        )
+
+    cli_util.open_browser(deploy_url)
+
+
 # SUBCOMMAND activate
 
 

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -368,7 +368,6 @@ def config_show(**kwargs: Any) -> None:
 # SUBCOMMAND cloud
 
 DEPLOY_URL: Final = "https://share.streamlit.io/deploy"
-STREAMLIT_CLOUD_URL: Final = "https://streamlit.io/cloud"
 
 
 @main.group("cloud")
@@ -441,15 +440,12 @@ def cloud_deploy(target: str = "streamlit_app.py") -> None:
             click.echo(f"  Main script: {module}")
         else:
             click.echo("  Main script: (not specified - please select on Cloud page)")
-    else:
-        deploy_url = STREAMLIT_CLOUD_URL
-        click.echo("Opening Streamlit Community Cloud...")
-        click.echo(
-            "  (No GitHub repository detected. "
-            "Make sure your code is pushed to GitHub to deploy.)"
-        )
 
-    cli_util.open_browser(deploy_url)
+        cli_util.open_browser(deploy_url)
+    else:
+        raise click.ClickException(
+            "Deploying to Community Cloud requires the code to be pushed to GitHub."
+        )
 
 
 # SUBCOMMAND activate

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -367,7 +367,7 @@ def config_show(**kwargs: Any) -> None:
 
 # SUBCOMMAND cloud
 
-DEPLOY_URL: Final = "https://share.streamlit.io/deploy"
+_DEPLOY_URL: Final = "https://share.streamlit.io/deploy"
 
 
 @main.group("cloud")
@@ -377,7 +377,7 @@ def cloud() -> None:
 
 @cloud.command("deploy")
 @click.argument("target", default="streamlit_app.py", envvar="STREAMLIT_RUN_TARGET")
-def cloud_deploy(target: str = "streamlit_app.py") -> None:
+def cloud_deploy(target: str) -> None:
     """Open the browser to deploy to Streamlit Community Cloud.
 
     If the current directory (or TARGET) is inside a GitHub repository,
@@ -434,7 +434,7 @@ def cloud_deploy(target: str = "streamlit_app.py") -> None:
         if has_specific_script:
             params["mainModule"] = module
 
-        deploy_url = f"{DEPLOY_URL}?{urlencode(params)}"
+        deploy_url = f"{_DEPLOY_URL}?{urlencode(params)}"
 
         click.echo("Opening Streamlit Community Cloud deploy page...")
         click.echo(f"  Repository: {repository}")

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -377,18 +377,17 @@ def cloud() -> None:
 
 
 @cloud.command("deploy")
-@click.argument("target", default=".", required=False)
-def cloud_deploy(target: str = ".") -> None:
+@click.argument("target", default="streamlit_app.py", envvar="STREAMLIT_RUN_TARGET")
+def cloud_deploy(target: str = "streamlit_app.py") -> None:
     """Open the browser to deploy to Streamlit Community Cloud.
 
     If the current directory (or TARGET) is inside a GitHub repository,
     the deploy page will be pre-filled with the repository, branch, and
-    main module information.
+    main script information.
 
     TARGET can be:
-    - A path to a Python file (e.g., streamlit_app.py)
+    - A path to a Python file (default: streamlit_app.py)
     - A path to a directory containing streamlit_app.py
-    - Omitted to use the current directory
     """
     from urllib.parse import urlencode
 
@@ -397,12 +396,12 @@ def cloud_deploy(target: str = ".") -> None:
 
     path = Path(target)
 
-    # Determine the script path and whether we have a specific module to prefill
-    has_specific_module = False
+    # Determine the script path and whether we have a specific script to prefill
+    has_specific_script = False
     if path.is_dir():
         script_path = path / "streamlit_app.py"
         if script_path.exists():
-            has_specific_module = True
+            has_specific_script = True
         else:
             # No streamlit_app.py found, use directory for git info
             # but don't prefill mainModule so user can specify it on Cloud page
@@ -411,7 +410,7 @@ def cloud_deploy(target: str = ".") -> None:
         # User specified a file path
         if not path.exists():
             click.echo(f"Warning: File does not exist: {path}")
-        has_specific_module = True
+        has_specific_script = True
         script_path = path
 
     script_path = script_path.resolve()
@@ -430,7 +429,7 @@ def cloud_deploy(target: str = ".") -> None:
             "branch": branch,
         }
         # Only include mainModule if we have a specific script file
-        if has_specific_module:
+        if has_specific_script:
             params["mainModule"] = module
 
         deploy_url = f"{DEPLOY_URL}?{urlencode(params)}"
@@ -438,10 +437,10 @@ def cloud_deploy(target: str = ".") -> None:
         click.echo("Opening Streamlit Community Cloud deploy page...")
         click.echo(f"  Repository: {repository}")
         click.echo(f"  Branch: {branch}")
-        if has_specific_module:
-            click.echo(f"  Main module: {module}")
+        if has_specific_script:
+            click.echo(f"  Main script: {module}")
         else:
-            click.echo("  Main module: (not specified - please select on Cloud page)")
+            click.echo("  Main script: (not specified - please select on Cloud page)")
     else:
         deploy_url = STREAMLIT_CLOUD_URL
         click.echo("Opening Streamlit Community Cloud...")

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -408,7 +408,10 @@ def cloud_deploy(target: str = "streamlit_app.py") -> None:
     else:
         # User specified a file path
         if not path.exists():
-            click.echo(f"Warning: File does not exist: {path}")
+            raise click.ClickException(
+                f"File does not exist: {path}\n"
+                "Specify your main script with: streamlit cloud deploy <your_script.py>"
+            )
         has_specific_script = True
         script_path = path
 

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -397,13 +397,21 @@ def cloud_deploy(target: str = ".") -> None:
 
     path = Path(target)
 
-    # Determine the script path
+    # Determine the script path and whether we have a specific module to prefill
+    has_specific_module = False
     if path.is_dir():
         script_path = path / "streamlit_app.py"
-        if not script_path.exists():
-            # If no streamlit_app.py, just use the directory for git info
+        if script_path.exists():
+            has_specific_module = True
+        else:
+            # No streamlit_app.py found, use directory for git info
+            # but don't prefill mainModule so user can specify it on Cloud page
             script_path = path
     else:
+        # User specified a file path
+        if not path.exists():
+            click.echo(f"Warning: File does not exist: {path}")
+        has_specific_module = True
         script_path = path
 
     script_path = script_path.resolve()
@@ -417,17 +425,23 @@ def cloud_deploy(target: str = ".") -> None:
         # Remove .git suffix if present (matching DeployDialog behavior)
         repository = repository.removesuffix(".git")
 
-        params = {
+        params: dict[str, str] = {
             "repository": repository,
             "branch": branch,
-            "mainModule": module,
         }
+        # Only include mainModule if we have a specific script file
+        if has_specific_module:
+            params["mainModule"] = module
+
         deploy_url = f"{DEPLOY_URL}?{urlencode(params)}"
 
         click.echo("Opening Streamlit Community Cloud deploy page...")
         click.echo(f"  Repository: {repository}")
         click.echo(f"  Branch: {branch}")
-        click.echo(f"  Main module: {module}")
+        if has_specific_module:
+            click.echo(f"  Main module: {module}")
+        else:
+            click.echo("  Main module: (not specified - please select on Cloud page)")
     else:
         deploy_url = STREAMLIT_CLOUD_URL
         click.echo("Opening Streamlit Community Cloud...")

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -867,25 +867,19 @@ class CloudDeployTest(unittest.TestCase):
         assert "https://share.streamlit.io/deploy" in url
         assert "mainModule=app%2Fmain.py" in url
 
-    def test_cloud_deploy_nonexistent_file_shows_warning(self):
-        """Test cloud deploy shows warning when specified file doesn't exist."""
+    def test_cloud_deploy_nonexistent_file_shows_error(self):
+        """Test cloud deploy shows error when specified file doesn't exist."""
         with patch("streamlit.cli_util.open_browser") as mock_open_browser:
-            with patch(
-                "streamlit.git_util.GitRepo.get_repo_info",
-                return_value=("owner/repo", "main", "nonexistent.py"),
-            ):
-                with patch("pathlib.Path.is_dir", return_value=False):
-                    with patch("pathlib.Path.exists", return_value=False):
-                        result = self.runner.invoke(
-                            cli, ["cloud", "deploy", "nonexistent.py"]
-                        )
+            with patch("pathlib.Path.is_dir", return_value=False):
+                with patch("pathlib.Path.exists", return_value=False):
+                    result = self.runner.invoke(
+                        cli, ["cloud", "deploy", "nonexistent.py"]
+                    )
 
-        assert result.exit_code == 0
-        assert "Warning: File does not exist" in result.output
-        # Should still open browser with the specified module
-        mock_open_browser.assert_called_once()
-        url = mock_open_browser.call_args[0][0]
-        assert "mainModule=nonexistent.py" in url
+        assert result.exit_code != 0
+        assert "File does not exist: nonexistent.py" in result.output
+        assert "streamlit cloud deploy <your_script.py>" in result.output
+        mock_open_browser.assert_not_called()
 
     def test_cloud_deploy_output_messages(self):
         """Test cloud deploy outputs the correct information."""

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -787,3 +787,87 @@ class HTTPServerIntegrationTest(unittest.TestCase):
                     response.raise_for_status()
             finally:
                 proc.kill()
+
+
+class CloudDeployTest(unittest.TestCase):
+    """Tests for the cloud deploy command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_cloud_deploy_with_git_repo(self):
+        """Test cloud deploy opens browser with prefilled git info when in a repo."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("owner/repo", "main", "streamlit_app.py"),
+            ):
+                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
+                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+
+        assert result.exit_code == 0
+        mock_open_browser.assert_called_once()
+        url = mock_open_browser.call_args[0][0]
+        assert "https://share.streamlit.io/deploy" in url
+        assert "repository=owner%2Frepo" in url
+        assert "branch=main" in url
+        assert "mainModule=streamlit_app.py" in url
+
+    def test_cloud_deploy_without_git_repo(self):
+        """Test cloud deploy opens generic cloud URL when not in a repo."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch("streamlit.git_util.GitRepo.get_repo_info", return_value=None):
+                result = self.runner.invoke(cli, ["cloud", "deploy"])
+
+        assert result.exit_code == 0
+        mock_open_browser.assert_called_once_with("https://streamlit.io/cloud")
+        assert "No GitHub repository detected" in result.output
+
+    def test_cloud_deploy_with_target_path(self):
+        """Test cloud deploy with an explicit target path."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("owner/repo", "develop", "app/main.py"),
+            ):
+                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
+                    with patch("pathlib.Path.is_dir", return_value=False):
+                        result = self.runner.invoke(
+                            cli, ["cloud", "deploy", "app/main.py"]
+                        )
+
+        assert result.exit_code == 0
+        mock_open_browser.assert_called_once()
+        url = mock_open_browser.call_args[0][0]
+        assert "https://share.streamlit.io/deploy" in url
+
+    def test_cloud_deploy_output_messages(self):
+        """Test cloud deploy outputs the correct information."""
+        with patch("streamlit.cli_util.open_browser"):
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("myorg/myrepo", "feature-branch", "src/app.py"),
+            ):
+                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
+                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+
+        assert "Opening Streamlit Community Cloud deploy page" in result.output
+        assert "Repository: myorg/myrepo" in result.output
+        assert "Branch: feature-branch" in result.output
+        assert "Main module: src/app.py" in result.output
+
+    def test_cloud_deploy_removes_git_suffix(self):
+        """Test cloud deploy removes .git suffix from repository name."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("owner/repo.git", "main", "app.py"),
+            ):
+                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
+                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+
+        assert result.exit_code == 0
+        url = mock_open_browser.call_args[0][0]
+        # Should have owner/repo without .git suffix
+        assert "repository=owner%2Frepo" in url
+        assert ".git" not in url

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -815,14 +815,17 @@ class CloudDeployTest(unittest.TestCase):
         assert "mainModule=streamlit_app.py" in url
 
     def test_cloud_deploy_without_git_repo(self):
-        """Test cloud deploy opens generic cloud URL when not in a repo."""
+        """Test cloud deploy shows error when not in a GitHub repo."""
         with patch("streamlit.cli_util.open_browser") as mock_open_browser:
             with patch("streamlit.git_util.GitRepo.get_repo_info", return_value=None):
                 result = self.runner.invoke(cli, ["cloud", "deploy"])
 
-        assert result.exit_code == 0
-        mock_open_browser.assert_called_once_with("https://streamlit.io/cloud")
-        assert "No GitHub repository detected" in result.output
+        assert result.exit_code != 0
+        mock_open_browser.assert_not_called()
+        assert (
+            "Deploying to Community Cloud requires the code to be pushed to GitHub"
+            in result.output
+        )
 
     def test_cloud_deploy_directory_without_streamlit_app(self):
         """Test cloud deploy omits mainModule when no streamlit_app.py exists in directory."""

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -900,7 +900,7 @@ class CloudDeployTest(unittest.TestCase):
         assert "Opening Streamlit Community Cloud deploy page" in result.output
         assert "Repository: myorg/myrepo" in result.output
         assert "Branch: feature-branch" in result.output
-        assert "Main module: src/app.py" in result.output
+        assert "Main script: src/app.py" in result.output
 
     def test_cloud_deploy_removes_git_suffix(self):
         """Test cloud deploy removes .git suffix from repository name."""

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -818,7 +818,9 @@ class CloudDeployTest(unittest.TestCase):
         """Test cloud deploy shows error when not in a GitHub repo."""
         with patch("streamlit.cli_util.open_browser") as mock_open_browser:
             with patch("streamlit.git_util.GitRepo.get_repo_info", return_value=None):
-                result = self.runner.invoke(cli, ["cloud", "deploy"])
+                with patch("pathlib.Path.is_dir", return_value=False):
+                    with patch("pathlib.Path.exists", return_value=True):
+                        result = self.runner.invoke(cli, ["cloud", "deploy"])
 
         assert result.exit_code != 0
         mock_open_browser.assert_not_called()

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -795,15 +795,16 @@ class CloudDeployTest(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
 
-    def test_cloud_deploy_with_git_repo(self):
-        """Test cloud deploy opens browser with prefilled git info when in a repo."""
+    def test_cloud_deploy_with_git_repo_and_streamlit_app(self):
+        """Test cloud deploy opens browser with prefilled git info when streamlit_app.py exists."""
         with patch("streamlit.cli_util.open_browser") as mock_open_browser:
             with patch(
                 "streamlit.git_util.GitRepo.get_repo_info",
                 return_value=("owner/repo", "main", "streamlit_app.py"),
             ):
-                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
-                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+                with patch("pathlib.Path.is_dir", return_value=True):
+                    with patch("pathlib.Path.exists", return_value=True):
+                        result = self.runner.invoke(cli, ["cloud", "deploy"])
 
         assert result.exit_code == 0
         mock_open_browser.assert_called_once()
@@ -823,15 +824,36 @@ class CloudDeployTest(unittest.TestCase):
         mock_open_browser.assert_called_once_with("https://streamlit.io/cloud")
         assert "No GitHub repository detected" in result.output
 
+    def test_cloud_deploy_directory_without_streamlit_app(self):
+        """Test cloud deploy omits mainModule when no streamlit_app.py exists in directory."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("owner/repo", "main", "."),
+            ):
+                with patch("pathlib.Path.is_dir", return_value=True):
+                    with patch("pathlib.Path.exists", return_value=False):
+                        result = self.runner.invoke(cli, ["cloud", "deploy"])
+
+        assert result.exit_code == 0
+        mock_open_browser.assert_called_once()
+        url = mock_open_browser.call_args[0][0]
+        assert "https://share.streamlit.io/deploy" in url
+        assert "repository=owner%2Frepo" in url
+        assert "branch=main" in url
+        # mainModule should NOT be in the URL
+        assert "mainModule" not in url
+        assert "not specified - please select on Cloud page" in result.output
+
     def test_cloud_deploy_with_target_path(self):
-        """Test cloud deploy with an explicit target path."""
+        """Test cloud deploy with an explicit target file path."""
         with patch("streamlit.cli_util.open_browser") as mock_open_browser:
             with patch(
                 "streamlit.git_util.GitRepo.get_repo_info",
                 return_value=("owner/repo", "develop", "app/main.py"),
             ):
-                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
-                    with patch("pathlib.Path.is_dir", return_value=False):
+                with patch("pathlib.Path.is_dir", return_value=False):
+                    with patch("pathlib.Path.exists", return_value=True):
                         result = self.runner.invoke(
                             cli, ["cloud", "deploy", "app/main.py"]
                         )
@@ -840,6 +862,27 @@ class CloudDeployTest(unittest.TestCase):
         mock_open_browser.assert_called_once()
         url = mock_open_browser.call_args[0][0]
         assert "https://share.streamlit.io/deploy" in url
+        assert "mainModule=app%2Fmain.py" in url
+
+    def test_cloud_deploy_nonexistent_file_shows_warning(self):
+        """Test cloud deploy shows warning when specified file doesn't exist."""
+        with patch("streamlit.cli_util.open_browser") as mock_open_browser:
+            with patch(
+                "streamlit.git_util.GitRepo.get_repo_info",
+                return_value=("owner/repo", "main", "nonexistent.py"),
+            ):
+                with patch("pathlib.Path.is_dir", return_value=False):
+                    with patch("pathlib.Path.exists", return_value=False):
+                        result = self.runner.invoke(
+                            cli, ["cloud", "deploy", "nonexistent.py"]
+                        )
+
+        assert result.exit_code == 0
+        assert "Warning: File does not exist" in result.output
+        # Should still open browser with the specified module
+        mock_open_browser.assert_called_once()
+        url = mock_open_browser.call_args[0][0]
+        assert "mainModule=nonexistent.py" in url
 
     def test_cloud_deploy_output_messages(self):
         """Test cloud deploy outputs the correct information."""
@@ -848,8 +891,11 @@ class CloudDeployTest(unittest.TestCase):
                 "streamlit.git_util.GitRepo.get_repo_info",
                 return_value=("myorg/myrepo", "feature-branch", "src/app.py"),
             ):
-                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
-                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+                with patch("pathlib.Path.is_dir", return_value=False):
+                    with patch("pathlib.Path.exists", return_value=True):
+                        result = self.runner.invoke(
+                            cli, ["cloud", "deploy", "src/app.py"]
+                        )
 
         assert "Opening Streamlit Community Cloud deploy page" in result.output
         assert "Repository: myorg/myrepo" in result.output
@@ -863,8 +909,9 @@ class CloudDeployTest(unittest.TestCase):
                 "streamlit.git_util.GitRepo.get_repo_info",
                 return_value=("owner/repo.git", "main", "app.py"),
             ):
-                with patch("streamlit.git_util.GitRepo.is_valid", return_value=True):
-                    result = self.runner.invoke(cli, ["cloud", "deploy"])
+                with patch("pathlib.Path.is_dir", return_value=False):
+                    with patch("pathlib.Path.exists", return_value=True):
+                        result = self.runner.invoke(cli, ["cloud", "deploy", "app.py"])
 
         assert result.exit_code == 0
         url = mock_open_browser.call_args[0][0]


### PR DESCRIPTION
## Describe your changes

Adds a new `streamlit cloud deploy` CLI command that opens the browser to the Community Cloud deploy page. When run inside a GitHub repository, the URL is prefilled with the repository owner/name, current branch, and main module path (matching the existing DeployDialog behavior). Falls back to the generic Cloud homepage when not in a git repo.

The command accepts an optional TARGET argument to specify a file or directory path, defaulting to the current directory.

# GitHub Issues

- Closes https://github.com/streamlit/streamlit/issues/13635

## Testing Plan

- Unit tests covering: git repo detection, fallback behavior, target path handling, output messages, and .git suffix removal
- Manual testing can be done by running `streamlit cloud deploy` in a git repository to verify the browser opens with correct prefilled parameters

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.