### PR TITLE
Fix SnowflakeConnection.query() cache key to include params

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -135,6 +135,8 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ),
             wait=wait_fixed(1),
         )
+        # `params` must be an explicit parameter (not captured from closure) so that
+        # `@st.cache_data` includes it in the cache key.
         def _query(sql: str, params: Any = None) -> DataFrame:
             cur = self._instance.cursor()
             cur.execute(sql, params=params, **kwargs)

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -135,7 +135,7 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ),
             wait=wait_fixed(1),
         )
-        def _query(sql: str) -> DataFrame:
+        def _query(sql: str, params: Any = None) -> DataFrame:
             cur = self._instance.cursor()
             cur.execute(sql, params=params, **kwargs)
             return cur.fetch_pandas_all()  # type: ignore
@@ -153,7 +153,7 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ttl=ttl,
         )(_query)
 
-        return _query(sql)
+        return _query(sql, params)
 
     def write_pandas(
         self,

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -122,6 +122,13 @@ class SnowflakeConnectionTest(unittest.TestCase):
         # Should have been called twice (once for each unique params value)
         assert conn._instance.cursor.call_count == 2
         assert mock_cursor.execute.call_count == 2
+        # Verify execute was called with the correct params
+        mock_cursor.execute.assert_any_call(
+            "SELECT * FROM t WHERE status = ?", params=["active"]
+        )
+        mock_cursor.execute.assert_any_call(
+            "SELECT * FROM t WHERE status = ?", params=["inactive"]
+        )
 
     @patch(
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -102,6 +102,31 @@ class SnowflakeConnectionTest(unittest.TestCase):
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
         MagicMock(),
     )
+    def test_query_caches_separately_for_different_params(self):
+        """Test that different params values create separate cache entries."""
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(return_value="i am a dataframe")
+        conn = SnowflakeConnection("my_snowflake_connection_params")
+        conn._instance.cursor.return_value = mock_cursor
+
+        # Call with different params - should result in separate cache entries
+        conn.query("SELECT * FROM t WHERE status = ?", params=["active"])
+        conn.query("SELECT * FROM t WHERE status = ?", params=["inactive"])
+        # Call again with same params - should hit cache
+        conn.query("SELECT * FROM t WHERE status = ?", params=["active"])
+        conn.query("SELECT * FROM t WHERE status = ?", params=["inactive"])
+
+        # Should have been called twice (once for each unique params value)
+        assert conn._instance.cursor.call_count == 2
+        assert mock_cursor.execute.call_count == 2
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
     def test_does_not_reset_cache_when_ttl_changes(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())


### PR DESCRIPTION
## Describe your changes

Fixed a bug in `SnowflakeConnection.query()` where the `params` argument was captured as a closure variable instead of being passed as an explicit parameter to the cached `_query` function. This caused different parameter values to incorrectly share the same cache entry, returning stale results when queries were executed with different parameters.

The fix makes `params` an explicit parameter of the `_query` function, ensuring `st.cache_data` includes it in the cache key, consistent with how `SQLConnection.query()` handles this pattern.

Closes: #13644

## Testing Plan

Added a new test `test_query_caches_separately_for_different_params` that verifies different parameter values create separate cache entries while identical parameters correctly hit the cache.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.