### PR TITLE
Fix crash with container elements in spinner context

### DIFF
--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -86,7 +86,7 @@ if st.button("Run spinner with 300px width"):
 # Regression test for issue #13658: container elements in spinner context
 if st.button("Run spinner with container"):
     with st.spinner("Running..."):
-        time.sleep(0.1)  # Small delay to trigger spinner rendering
+        time.sleep(2)  # Small delay to trigger spinner rendering
         cols = st.container().columns(2)
         cols[0].write("Column 1")
         cols[1].write("Column 2")

--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -82,3 +82,11 @@ if st.button("Run spinner with 300px width"):
         width=300,
     ):
         time.sleep(2)
+
+# Regression test for issue #13658: container elements in spinner context
+if st.button("Run spinner with container"):
+    with st.spinner("Running..."):
+        time.sleep(0.1)  # Small delay to trigger spinner rendering
+        cols = st.container().columns(2)
+        cols[0].write("Column 1")
+        cols[1].write("Column 2")

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -192,3 +192,23 @@ def test_spinner_width_300px_snapshot(app: Page, assert_snapshot: ImageCompareFu
     spinner_element = app.get_by_test_id("stSpinner")
     expect(spinner_element).to_be_visible()
     assert_snapshot(spinner_element, name="st_spinner-width_300px")
+
+
+def test_spinner_with_container_elements(app: Page):
+    """Test that container elements (columns) can be created inside a spinner context.
+
+    Regression test for issue #13658: App crash when creating container elements
+    (st.columns, st.tabs) inside a container within a st.spinner context.
+    """
+    get_button(app, "Run spinner with container").click()
+
+    # The spinner should appear first
+    expect(app.get_by_test_id("stSpinner")).to_be_visible()
+
+    # Wait for the app to finish running
+    wait_for_app_run(app)
+
+    # After the spinner completes, the columns should be visible with their content
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Column 1")).to_be_visible()
+    expect(app.get_by_text("Column 2")).to_be_visible()

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
@@ -518,8 +518,12 @@ describe("SetNodeByDeltaPathVisitor", () => {
       expect(result).toBeInstanceOf(TransientNode)
       expect(result.transientNodes).toEqual(t.transientNodes)
       // The anchor should be updated
+      expect(result.anchor).toBeDefined()
       expect(
-        GetNodeByDeltaPathVisitor.getNodeAtPath(result.anchor!, [0])
+        GetNodeByDeltaPathVisitor.getNodeAtPath(
+          result.anchor as BlockNode,
+          [0]
+        )
       ).toBeTextNode("new_child")
     })
 

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
@@ -505,37 +505,76 @@ describe("SetNodeByDeltaPathVisitor", () => {
   })
 
   describe("visitTransientNode", () => {
-    it("drills through anchor when remaining path exists", () => {
+    it("drills through anchor without consuming path index and preserves transient wrapper", () => {
+      // TransientNode is transparent in delta path - it doesn't consume an index
       const inner = block([text("child")])
       const t = new TransientNode("run", inner, [text("t1")], 1)
       const nodeToSet = text("new_child")
-      const visitor = new SetNodeByDeltaPathVisitor([0, 0], nodeToSet, "run")
+      // Path [0] should pass through to anchor and set child at index 0
+      const visitor = new SetNodeByDeltaPathVisitor([0], nodeToSet, "run")
 
-      const result = visitor.visitTransientNode(t) as BlockNode
+      const result = visitor.visitTransientNode(t) as TransientNode
+      // Should preserve TransientNode wrapper
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.transientNodes).toEqual(t.transientNodes)
+      // The anchor should be updated
       expect(
-        GetNodeByDeltaPathVisitor.getNodeAtPath(result, [0])
+        GetNodeByDeltaPathVisitor.getNodeAtPath(result.anchor!, [0])
       ).toBeTextNode("new_child")
     })
 
     it("throws when drilling required but no anchor exists", () => {
       const t = new TransientNode("run", undefined, [text("t1")], 1)
       const nodeToSet = text("x")
-      // Use a path with a remaining segment after the first index to force drill
-      const visitor = new SetNodeByDeltaPathVisitor([0, 1], nodeToSet, "run")
+      // Any non-empty path should require drilling through anchor
+      const visitor = new SetNodeByDeltaPathVisitor([0], nodeToSet, "run")
       expect(() => visitor.visitTransientNode(t)).toThrow(
         "TransientNode has no anchor to set node at"
       )
     })
 
-    it("delegates to nodeToSet.replaceTransientNodeWithSelf when path consumed", () => {
+    it("delegates to nodeToSet.replaceTransientNodeWithSelf when path is empty", () => {
       const t = new TransientNode("run", text("anchor"), [text("t1")], 5)
       const nodeToSet = new BlockNode("hash", [])
       const spy = vi.spyOn(nodeToSet, "replaceTransientNodeWithSelf")
-      const visitor = new SetNodeByDeltaPathVisitor([0], nodeToSet, "run")
+      // Empty path means we're replacing the TransientNode itself
+      const visitor = new SetNodeByDeltaPathVisitor([], nodeToSet, "run")
 
-      // Path consumed after slicing in visitTransientNode; this should call replaceTransientNodeWithSelf
       visitor.visitTransientNode(t)
       expect(spy).toHaveBeenCalledWith(t)
+    })
+
+    it("preserves transient nodes when setting deep inside anchor", () => {
+      // Scenario: TransientNode wraps a container, and we're adding children inside
+      const container = block([])
+      const transientElements = [text("spinner")]
+      const t = new TransientNode("run", container, transientElements, 1)
+
+      // Add first child at path [0] (inside container)
+      const column0 = block([text("col0")])
+      const visitor1 = new SetNodeByDeltaPathVisitor([0], column0, "run")
+      const result1 = visitor1.visitTransientNode(t) as TransientNode
+
+      // TransientNode should be preserved
+      expect(result1).toBeInstanceOf(TransientNode)
+      expect(result1.transientNodes).toEqual(transientElements)
+
+      // Container (anchor) should have the new child
+      const updatedContainer = result1.anchor as BlockNode
+      expect(updatedContainer.children).toHaveLength(1)
+
+      // Add second child at path [1]
+      const column1 = block([text("col1")])
+      const visitor2 = new SetNodeByDeltaPathVisitor([1], column1, "run")
+      const result2 = visitor2.visitTransientNode(result1) as TransientNode
+
+      // TransientNode should still be preserved
+      expect(result2).toBeInstanceOf(TransientNode)
+      expect(result2.transientNodes).toEqual(transientElements)
+
+      // Container should now have two children
+      const finalContainer = result2.anchor as BlockNode
+      expect(finalContainer.children).toHaveLength(2)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
@@ -59,27 +59,27 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
   }
 
   visitTransientNode(node: TransientNode): AppNode {
-    const [, ...remainingPath] = this.deltaPath
-
-    // If we need to drill down, we will travel through the anchor.
-    if (remainingPath.length > 0) {
-      if (node.anchor) {
-        return node.anchor.accept(
-          new SetNodeByDeltaPathVisitor(
-            remainingPath,
-            this.nodeToSet,
-            this.scriptRunId
-          )
-        )
-      }
-
-      throw new Error("TransientNode has no anchor to set node at")
+    // If the path is empty, we're replacing this transient node.
+    // Let the node decide how to best replace the transient node.
+    // This is especially important for transient nodes to reconcile themselves.
+    if (this.deltaPath.length === 0) {
+      return this.nodeToSet.replaceTransientNodeWithSelf(node)
     }
 
-    // At this point, we know the nodeToSet is to replace the transient node
-    // so we let the node decide how to best replace the transient node
-    // This is especially important for transient nodes to reconcile themselves
-    return this.nodeToSet.replaceTransientNodeWithSelf(node)
+    // TransientNode is transparent in the delta path hierarchy - it doesn't
+    // consume an index from the path. We drill through to the anchor and
+    // preserve the transient wrapper around the modified anchor.
+    if (node.anchor) {
+      const newAnchor = node.anchor.accept(this)
+      return new TransientNode(
+        node.scriptRunId,
+        newAnchor,
+        node.transientNodes,
+        node.deltaMsgReceivedAt
+      )
+    }
+
+    throw new Error("TransientNode has no anchor to set node at")
   }
 
   visitBlockNode(node: BlockNode): AppNode {


### PR DESCRIPTION
## Describe your changes

Fix a regression where creating container elements (`st.columns`, `st.tabs`) inside a container within a `st.spinner` context caused the app to crash with "Bad delta path index" errors.

The root cause was that `SetNodeByDeltaPathVisitor.visitTransientNode` incorrectly consumed an index from the delta path when visiting TransientNodes, while `GetNodeByDeltaPathVisitor` correctly treats them as transparent. This caused delta paths to become misaligned with the actual tree structure.

The fix treats TransientNode as transparent in the delta path hierarchy and preserves the transient wrapper when modifying nodes inside its anchor.

## GitHub Issue Link (if applicable)

Closes #13658

## Testing Plan

- Unit Tests (JS): Updated and added tests for `SetNodeByDeltaPathVisitor.visitTransientNode` to verify the fix
- E2E Tests: Added regression test `test_spinner_with_container_elements` that reproduces the exact scenario from the issue
- All 5630 frontend tests pass
- All 201 render-tree tests pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.