### PR TITLE
Improve file uploader resilience against Android picker quirks

### DIFF
--- a/component-lib/yarn.lock
+++ b/component-lib/yarn.lock
@@ -6286,15 +6286,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.3
-  resolution: "tar@npm:7.5.3"
+  version: 7.5.6
+  resolution: "tar@npm:7.5.6"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/e5e3237bca325fbb33282d92d9807f4c8d81abaf71bf2627efdf93bd5610c146460c78fc7e9767d4ab5ae3c0b18af8197314c964f8cbd23b30b25bf4d42d7cb4
+  checksum: 10c0/08af3807035957650ad5f2a300c49ca4fe0566ac0ea5a23741a5b5103c6da42891a9eeaed39bc1fbcf21c5cac4dc846828a004727fb08b9d946322d3144d1fd2
   languageName: node
   linkType: hard
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -969,3 +969,187 @@ describe("FileUploader widget tests", () => {
     })
   })
 })
+
+describe("FileUploader Android resilience", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: { current: null },
+      values: [250],
+    })
+  })
+
+  it("shows error for zero-size files (Android picker issue)", async () => {
+    const props = getProps({ multipleFiles: true })
+    render(<FileUploader {...props} />)
+
+    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+
+    // Simulate a zero-size file (common Android picker issue)
+    const zeroSizeFile = new File([], "empty.jpg", {
+      type: "image/jpeg",
+      lastModified: 0,
+    })
+    const normalFile = new File(["content"], "normal.txt", {
+      type: "text/plain",
+      lastModified: 0,
+    })
+
+    fireEvent.drop(fileDropZone, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [zeroSizeFile, normalFile],
+        items: [zeroSizeFile, normalFile].map(file => ({
+          kind: "file",
+          type: file.type,
+          getAsFile: () => file,
+        })),
+      },
+    })
+
+    await waitFor(() => {
+      const fileElements = screen.getAllByTestId("stFileUploaderFile")
+      expect(fileElements.length).toBe(2)
+    })
+
+    // One file should be uploaded, one should have an error
+    await waitFor(() =>
+      expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(1)
+    )
+
+    const errorMessages = screen.getAllByTestId(
+      "stFileUploaderFileErrorMessage"
+    )
+    expect(errorMessages.length).toBe(1)
+    expect(errorMessages[0].textContent).toContain("empty")
+  })
+
+  it("filters out duplicate files", async () => {
+    const props = getProps({ multipleFiles: true })
+    vi.spyOn(props.widgetMgr, "setFileUploaderStateValue")
+    render(<FileUploader {...props} />)
+
+    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+
+    // Simulate duplicate files (same name and size)
+    const file1 = new File(["content"], "duplicate.txt", {
+      type: "text/plain",
+      lastModified: 0,
+    })
+    const file2 = new File(["content"], "duplicate.txt", {
+      type: "text/plain",
+      lastModified: 0,
+    })
+    const file3 = new File(["other"], "unique.txt", {
+      type: "text/plain",
+      lastModified: 0,
+    })
+
+    fireEvent.drop(fileDropZone, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [file1, file2, file3],
+        items: [file1, file2, file3].map(file => ({
+          kind: "file",
+          type: file.type,
+          getAsFile: () => file,
+        })),
+      },
+    })
+
+    await waitFor(() => {
+      // Should show 3 files: 2 unique uploads + 1 duplicate error
+      const fileElements = screen.getAllByTestId("stFileUploaderFile")
+      expect(fileElements.length).toBe(3)
+    })
+
+    // Should only upload 2 unique files
+    await waitFor(() =>
+      expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
+    )
+
+    // One should have duplicate error
+    const errorMessages = screen.getAllByTestId(
+      "stFileUploaderFileErrorMessage"
+    )
+    expect(errorMessages.length).toBe(1)
+    expect(errorMessages[0].textContent).toContain("Duplicate")
+  })
+
+  it("handles empty change event gracefully", async () => {
+    const props = getProps({ multipleFiles: true })
+    render(<FileUploader {...props} />)
+
+    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+
+    // Simulate empty drop (user cancelled)
+    fireEvent.drop(fileDropZone, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [],
+        items: [],
+      },
+    })
+
+    // No uploads should happen
+    await waitFor(() => {
+      expect(props.uploadClient.uploadFile).not.toHaveBeenCalled()
+    })
+
+    // No file elements should be shown
+    expect(screen.queryByTestId("stFileUploaderFile")).not.toBeInTheDocument()
+  })
+
+  it(
+    "handles mixed valid and invalid files correctly",
+    async () => {
+      const props = getProps({ multipleFiles: true })
+      render(<FileUploader {...props} />)
+
+      const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+
+      // Mix of valid files, zero-size, and duplicates
+      const validFile1 = new File(["content1"], "file1.txt", {
+        type: "text/plain",
+      })
+      const validFile2 = new File(["content2"], "file2.txt", {
+        type: "text/plain",
+      })
+      const zeroSizeFile = new File([], "empty.txt", { type: "text/plain" })
+      const duplicateFile = new File(["content1"], "file1.txt", {
+        type: "text/plain",
+      })
+
+      fireEvent.drop(fileDropZone, {
+        dataTransfer: {
+          types: ["Files"],
+          files: [validFile1, validFile2, zeroSizeFile, duplicateFile],
+          items: [validFile1, validFile2, zeroSizeFile, duplicateFile].map(
+            file => ({
+              kind: "file",
+              type: file.type,
+              getAsFile: () => file,
+            })
+          ),
+        },
+      })
+
+      // Wait for all files to be processed and verify in single waitFor
+      await waitFor(
+        () => {
+          // Should show all 4 files (2 valid uploads + 2 errors)
+          const fileElements = screen.getAllByTestId("stFileUploaderFile")
+          expect(fileElements.length).toBe(4)
+          // Should only upload 2 valid files
+          expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
+          // Should have 2 errors (zero-size and duplicate)
+          const errorMessages = screen.getAllByTestId(
+            "stFileUploaderFileErrorMessage"
+          )
+          expect(errorMessages.length).toBe(2)
+        },
+        { timeout: 10000 }
+      )
+    },
+    15000
+  )
+})

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -47,7 +47,9 @@ import {
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import FileDropzone from "./FileDropzone"
+import { getValidationErrorMessage, validateFiles } from "./fileValidation"
 import { StyledFileUploader } from "./styled-components"
+import { logFileSelection, logUploadResults } from "./uploadDiagnostics"
 import UploadedFiles from "./UploadedFiles"
 import { UploadedStatus, UploadFileInfo } from "./UploadFileInfo"
 
@@ -495,11 +497,48 @@ const FileUploader = ({
       let acceptedFiles = [...acceptedFilesParam]
       let rejectedFiles = [...rejectedFilesParam]
 
+      // Log file selection for diagnostics (when enabled)
+      logFileSelection(multipleFiles, acceptedFiles)
+
       if (isDirectoryUpload && acceptedFiles.length > 0) {
         const { accepted, rejected } = filterDirectoryFiles(acceptedFiles)
         acceptedFiles = accepted
         rejectedFiles = [...rejectedFiles, ...rejected]
       }
+
+      // Validate files for Android picker issues (zero-size, duplicates)
+      const validation = validateFiles(acceptedFiles)
+
+      // Add invalid files (e.g., zero-size) to rejected with appropriate error
+      validation.invalid.forEach(({ file, error }) => {
+        rejectedFiles.push({
+          file,
+          errors: [
+            {
+              code: error,
+              message: getValidationErrorMessage(
+                error as Parameters<typeof getValidationErrorMessage>[0]
+              ),
+            },
+          ],
+        })
+      })
+
+      // Add duplicate files to rejected
+      validation.duplicates.forEach(file => {
+        rejectedFiles.push({
+          file,
+          errors: [
+            {
+              code: "file-duplicate",
+              message: "Duplicate file ignored.",
+            },
+          ],
+        })
+      })
+
+      // Use only validated files
+      acceptedFiles = validation.valid
 
       if (
         !multipleFiles &&
@@ -517,6 +556,13 @@ const FileUploader = ({
           rejectedFiles.splice(firstFileIndex, 1)
         }
       }
+
+      // Track upload results for diagnostics
+      const uploadResultsTracker: Array<{
+        name: string
+        success: boolean
+        error?: string
+      }> = []
 
       uploadClient
         .fetchFileURLs(acceptedFiles)
@@ -542,6 +588,16 @@ const FileUploader = ({
           )
         })
         .catch((errorMessage: string) => {
+          // Log the batch failure
+          acceptedFiles.forEach(f => {
+            uploadResultsTracker.push({
+              name: f.name,
+              success: false,
+              error: errorMessage,
+            })
+          })
+          logUploadResults(uploadResultsTracker)
+
           addFiles(
             acceptedFiles.map(
               f =>

--- a/frontend/lib/src/components/widgets/FileUploader/fileValidation.test.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/fileValidation.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FileValidationError,
+  filterDuplicateFiles,
+  getFileKey,
+  getValidationErrorMessage,
+  validateFileNotEmpty,
+  validateFileReadable,
+  validateFiles,
+} from "./fileValidation"
+
+const createMockFile = (
+  name: string,
+  size: number,
+  type = "text/plain",
+  webkitRelativePath?: string
+): File => {
+  // Create a real File with actual content matching the size
+  const content = size > 0 ? new Array(size).fill("x").join("") : ""
+  const file = new File([content], name, { type })
+
+  // Mock size if needed (for zero-size testing)
+  if (size === 0 && content.length > 0) {
+    Object.defineProperty(file, "size", { value: 0, writable: false })
+  }
+
+  if (webkitRelativePath) {
+    Object.defineProperty(file, "webkitRelativePath", {
+      value: webkitRelativePath,
+      writable: false,
+    })
+  }
+
+  return file
+}
+
+describe("fileValidation", () => {
+  describe("validateFileNotEmpty", () => {
+    it("returns valid for non-empty file", () => {
+      const file = createMockFile("test.txt", 100)
+      const result = validateFileNotEmpty(file)
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+
+    it("returns invalid for zero-size file", () => {
+      const file = new File([], "empty.txt", { type: "text/plain" })
+      const result = validateFileNotEmpty(file)
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe(FileValidationError.ZERO_SIZE)
+    })
+  })
+
+  describe("validateFileReadable", () => {
+    it("returns valid for readable file", async () => {
+      const file = createMockFile("test.txt", 100)
+      const result = await validateFileReadable(file)
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+
+    it("returns valid for empty file (skipped)", async () => {
+      const file = new File([], "empty.txt", { type: "text/plain" })
+      const result = await validateFileReadable(file)
+      // Empty files are skipped by validateFileReadable
+      expect(result.isValid).toBe(true)
+    })
+
+    it("handles read timeout gracefully", async () => {
+      const file = createMockFile("test.txt", 100)
+
+      // Mock FileReader to simulate timeout (never fires onload or onerror)
+      const originalFileReader = window.FileReader
+      class MockFileReader {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        readAsArrayBuffer = vi.fn() // Does nothing, so timeout triggers
+      }
+      window.FileReader = MockFileReader as unknown as typeof FileReader
+
+      const result = await validateFileReadable(file, 50) // 50ms timeout
+
+      // Restore original FileReader
+      window.FileReader = originalFileReader
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe(FileValidationError.READ_ERROR)
+    })
+  })
+
+  describe("getFileKey", () => {
+    it("creates key from name and size", () => {
+      const file = createMockFile("test.txt", 100, "text/plain")
+      const key = getFileKey(file)
+      expect(key).toBe("test.txt:100:text/plain")
+    })
+
+    it("uses webkitRelativePath when available", () => {
+      const file = createMockFile(
+        "test.txt",
+        100,
+        "text/plain",
+        "folder/test.txt"
+      )
+      const key = getFileKey(file)
+      expect(key).toBe("folder/test.txt:100:text/plain")
+    })
+
+    it("handles unknown type", () => {
+      const file = createMockFile("test.bin", 100, "")
+      const key = getFileKey(file)
+      expect(key).toContain("unknown")
+    })
+  })
+
+  describe("filterDuplicateFiles", () => {
+    it("returns all files when no duplicates", () => {
+      const files = [
+        createMockFile("file1.txt", 100),
+        createMockFile("file2.txt", 200),
+        createMockFile("file3.txt", 300),
+      ]
+      const result = filterDuplicateFiles(files)
+      expect(result.unique).toHaveLength(3)
+      expect(result.duplicates).toHaveLength(0)
+    })
+
+    it("filters out duplicate files by name and size", () => {
+      const files = [
+        createMockFile("file1.txt", 100),
+        createMockFile("file1.txt", 100), // duplicate
+        createMockFile("file2.txt", 200),
+      ]
+      const result = filterDuplicateFiles(files)
+      expect(result.unique).toHaveLength(2)
+      expect(result.duplicates).toHaveLength(1)
+      expect(result.duplicates[0].name).toBe("file1.txt")
+    })
+
+    it("considers different sizes as unique", () => {
+      const files = [
+        createMockFile("file.txt", 100),
+        createMockFile("file.txt", 200), // different size
+      ]
+      const result = filterDuplicateFiles(files)
+      expect(result.unique).toHaveLength(2)
+      expect(result.duplicates).toHaveLength(0)
+    })
+
+    it("handles empty array", () => {
+      const result = filterDuplicateFiles([])
+      expect(result.unique).toHaveLength(0)
+      expect(result.duplicates).toHaveLength(0)
+    })
+  })
+
+  describe("validateFiles", () => {
+    it("returns all valid files when no issues", () => {
+      const files = [
+        createMockFile("file1.txt", 100),
+        createMockFile("file2.txt", 200),
+      ]
+      const result = validateFiles(files)
+      expect(result.valid).toHaveLength(2)
+      expect(result.invalid).toHaveLength(0)
+      expect(result.duplicates).toHaveLength(0)
+    })
+
+    it("detects zero-size files", () => {
+      const files = [
+        createMockFile("good.txt", 100),
+        new File([], "empty.txt", { type: "text/plain" }),
+      ]
+      const result = validateFiles(files)
+      expect(result.valid).toHaveLength(1)
+      expect(result.valid[0].name).toBe("good.txt")
+      expect(result.invalid).toHaveLength(1)
+      expect(result.invalid[0].file.name).toBe("empty.txt")
+      expect(result.invalid[0].error).toBe(FileValidationError.ZERO_SIZE)
+    })
+
+    it("detects duplicates and zero-size files together", () => {
+      const files = [
+        createMockFile("file1.txt", 100),
+        createMockFile("file1.txt", 100), // duplicate
+        new File([], "empty.txt", { type: "text/plain" }), // zero-size
+      ]
+      const result = validateFiles(files)
+      expect(result.valid).toHaveLength(1)
+      expect(result.duplicates).toHaveLength(1)
+      expect(result.invalid).toHaveLength(1)
+    })
+  })
+
+  describe("getValidationErrorMessage", () => {
+    it("returns correct message for zero-size error", () => {
+      const message = getValidationErrorMessage(FileValidationError.ZERO_SIZE)
+      expect(message).toContain("empty")
+      expect(message).toContain("file picker")
+    })
+
+    it("returns correct message for read error", () => {
+      const message = getValidationErrorMessage(FileValidationError.READ_ERROR)
+      expect(message).toContain("Could not read")
+    })
+
+    it("returns correct message for duplicate", () => {
+      const message = getValidationErrorMessage(FileValidationError.DUPLICATE)
+      expect(message).toContain("Duplicate")
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/FileUploader/fileValidation.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/fileValidation.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for validating files before upload, particularly for detecting
+ * Android picker issues where files may be returned but not readable.
+ */
+
+export interface FileValidationResult {
+  file: File
+  isValid: boolean
+  error?: string
+}
+
+/**
+ * Error code constants for file validation errors.
+ */
+export const FileValidationError = {
+  ZERO_SIZE: "file-zero-size",
+  READ_ERROR: "file-read-error",
+  DUPLICATE: "file-duplicate",
+} as const
+
+export type FileValidationErrorCode =
+  (typeof FileValidationError)[keyof typeof FileValidationError]
+
+/**
+ * Check if a file has zero size, which may indicate an Android picker issue
+ * where the file was selected but cannot be read.
+ */
+export function validateFileNotEmpty(file: File): FileValidationResult {
+  if (file.size === 0) {
+    return {
+      file,
+      isValid: false,
+      error: FileValidationError.ZERO_SIZE,
+    }
+  }
+  return { file, isValid: true }
+}
+
+/**
+ * Attempt to read the first few bytes of a file to verify it's actually readable.
+ * This helps detect Android picker issues where a File object exists but
+ * the underlying file cannot be read due to permissions or other issues.
+ *
+ * @param file The file to validate
+ * @param timeoutMs Timeout for the read operation (default 5000ms)
+ * @returns Promise that resolves to a validation result
+ */
+export async function validateFileReadable(
+  file: File,
+  timeoutMs = 5000
+): Promise<FileValidationResult> {
+  // Skip validation for empty files (caught by validateFileNotEmpty)
+  if (file.size === 0) {
+    return { file, isValid: true }
+  }
+
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      resolve({
+        file,
+        isValid: false,
+        error: FileValidationError.READ_ERROR,
+      })
+    }, timeoutMs)
+
+    // Try to read just the first byte to verify the file is accessible
+    const slice = file.slice(0, 1)
+    const reader = new FileReader()
+
+    reader.onload = () => {
+      clearTimeout(timeout)
+      resolve({ file, isValid: true })
+    }
+
+    reader.onerror = () => {
+      clearTimeout(timeout)
+      resolve({
+        file,
+        isValid: false,
+        error: FileValidationError.READ_ERROR,
+      })
+    }
+
+    reader.readAsArrayBuffer(slice)
+  })
+}
+
+/**
+ * Create a unique key for a file based on name and size.
+ * Used for duplicate detection.
+ */
+export function getFileKey(file: File): string {
+  // Use webkitRelativePath if available (for directory uploads)
+  const name = file.webkitRelativePath || file.name
+  return `${name}:${file.size}:${file.type || "unknown"}`
+}
+
+/**
+ * Filter out duplicate files from a list.
+ * Returns both the unique files and the duplicates.
+ */
+export function filterDuplicateFiles(files: File[]): {
+  unique: File[]
+  duplicates: File[]
+} {
+  const seen = new Set<string>()
+  const unique: File[] = []
+  const duplicates: File[] = []
+
+  for (const file of files) {
+    const key = getFileKey(file)
+    if (seen.has(key)) {
+      duplicates.push(file)
+    } else {
+      seen.add(key)
+      unique.push(file)
+    }
+  }
+
+  return { unique, duplicates }
+}
+
+/**
+ * Validate a batch of files for common issues.
+ * This performs synchronous validation only (zero-size check, duplicate check).
+ */
+export function validateFiles(files: File[]): {
+  valid: File[]
+  invalid: Array<{ file: File; error: string }>
+  duplicates: File[]
+} {
+  const valid: File[] = []
+  const invalid: Array<{ file: File; error: string }> = []
+
+  // First, filter duplicates
+  const { unique, duplicates } = filterDuplicateFiles(files)
+
+  // Then validate remaining files
+  for (const file of unique) {
+    const result = validateFileNotEmpty(file)
+    if (result.isValid) {
+      valid.push(file)
+    } else {
+      invalid.push({ file, error: result.error as string })
+    }
+  }
+
+  return { valid, invalid, duplicates }
+}
+
+/**
+ * Get a human-readable error message for a file validation error.
+ */
+export function getValidationErrorMessage(
+  errorCode: FileValidationErrorCode
+): string {
+  switch (errorCode) {
+    case FileValidationError.ZERO_SIZE:
+      return "File appears to be empty or could not be read. This may be a file picker issue on your device."
+    case FileValidationError.READ_ERROR:
+      return "Could not read file. Please try selecting the file again or use a different file picker."
+    case FileValidationError.DUPLICATE:
+      return "Duplicate file ignored."
+    default:
+      return "Unknown file validation error."
+  }
+}

--- a/frontend/lib/src/components/widgets/FileUploader/uploadDiagnostics.test.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/uploadDiagnostics.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  clearFileUploadDiagnosticLog,
+  disableDiagnosticLogging,
+  enableDiagnosticLogging,
+  getFileUploadDiagnosticLog,
+  getFormattedDiagnosticLog,
+  isAndroidDevice,
+  isDiagnosticLoggingEnabled,
+  logFileSelection,
+  logUploadResults,
+  mayHaveAndroidPickerIssues,
+} from "./uploadDiagnostics"
+
+describe("uploadDiagnostics", () => {
+  beforeEach(() => {
+    // Clear window.localStorage before each test
+    window.localStorage.clear()
+  })
+
+  describe("isDiagnosticLoggingEnabled", () => {
+    it("returns false when not enabled", () => {
+      expect(isDiagnosticLoggingEnabled()).toBe(false)
+    })
+
+    it("returns true when enabled", () => {
+      window.localStorage.setItem("streamlit.fileUploader.debug", "true")
+      expect(isDiagnosticLoggingEnabled()).toBe(true)
+    })
+
+    it("returns false when set to something other than true", () => {
+      window.localStorage.setItem("streamlit.fileUploader.debug", "false")
+      expect(isDiagnosticLoggingEnabled()).toBe(false)
+    })
+  })
+
+  describe("enableDiagnosticLogging", () => {
+    it("enables diagnostic logging", () => {
+      expect(isDiagnosticLoggingEnabled()).toBe(false)
+      enableDiagnosticLogging()
+      expect(isDiagnosticLoggingEnabled()).toBe(true)
+    })
+  })
+
+  describe("disableDiagnosticLogging", () => {
+    it("disables diagnostic logging", () => {
+      enableDiagnosticLogging()
+      expect(isDiagnosticLoggingEnabled()).toBe(true)
+      disableDiagnosticLogging()
+      expect(isDiagnosticLoggingEnabled()).toBe(false)
+    })
+  })
+
+  describe("logFileSelection", () => {
+    it("returns null when logging is disabled", () => {
+      const files = [new File(["test"], "test.txt")]
+      const result = logFileSelection(true, files)
+      expect(result).toBeNull()
+    })
+
+    it("logs file selection when enabled", () => {
+      enableDiagnosticLogging()
+      const files = [
+        new File(["test"], "test.txt", { type: "text/plain" }),
+        new File(["test2"], "test2.pdf", { type: "application/pdf" }),
+      ]
+
+      const result = logFileSelection(true, files)
+
+      expect(result).not.toBeNull()
+      expect(result?.multipleEnabled).toBe(true)
+      expect(result?.filesReceived).toBe(2)
+      expect(result?.files).toHaveLength(2)
+      expect(result?.files[0].name).toBe("test.txt")
+      expect(result?.files[0].type).toBe("text/plain")
+      expect(result?.files[1].name).toBe("test2.pdf")
+    })
+
+    it("includes user agent in log", () => {
+      enableDiagnosticLogging()
+      const files = [new File(["test"], "test.txt")]
+
+      const result = logFileSelection(false, files)
+
+      expect(result?.userAgent).toBe(navigator.userAgent)
+    })
+
+    it("stores entry in window.localStorage", () => {
+      enableDiagnosticLogging()
+      const files = [new File(["test"], "test.txt")]
+
+      logFileSelection(true, files)
+
+      const log = getFileUploadDiagnosticLog()
+      expect(log).not.toBeNull()
+      expect(log?.entries).toHaveLength(1)
+    })
+  })
+
+  describe("logUploadResults", () => {
+    it("does nothing when logging is disabled", () => {
+      logUploadResults([{ name: "test.txt", success: true }])
+      const log = getFileUploadDiagnosticLog()
+      expect(log).toBeNull()
+    })
+
+    it("updates most recent entry with results", () => {
+      enableDiagnosticLogging()
+      const files = [new File(["test"], "test.txt")]
+      logFileSelection(true, files)
+
+      logUploadResults([
+        { name: "test.txt", success: true },
+        { name: "failed.txt", success: false, error: "Network error" },
+      ])
+
+      const log = getFileUploadDiagnosticLog()
+      expect(log?.entries[0].uploadResults).toHaveLength(2)
+      expect(log?.entries[0].uploadResults?.[0].success).toBe(true)
+      expect(log?.entries[0].uploadResults?.[1].success).toBe(false)
+      expect(log?.entries[0].uploadResults?.[1].error).toBe("Network error")
+    })
+  })
+
+  describe("getFileUploadDiagnosticLog", () => {
+    it("returns null when no log exists", () => {
+      expect(getFileUploadDiagnosticLog()).toBeNull()
+    })
+
+    it("returns stored log", () => {
+      enableDiagnosticLogging()
+      logFileSelection(true, [new File(["test"], "test.txt")])
+
+      const log = getFileUploadDiagnosticLog()
+      expect(log).not.toBeNull()
+      expect(log?.sessionId).toBeDefined()
+      expect(log?.entries).toHaveLength(1)
+    })
+  })
+
+  describe("clearFileUploadDiagnosticLog", () => {
+    it("clears the diagnostic log", () => {
+      enableDiagnosticLogging()
+      logFileSelection(true, [new File(["test"], "test.txt")])
+      expect(getFileUploadDiagnosticLog()).not.toBeNull()
+
+      clearFileUploadDiagnosticLog()
+      expect(getFileUploadDiagnosticLog()).toBeNull()
+    })
+  })
+
+  describe("getFormattedDiagnosticLog", () => {
+    it("returns message when no entries", () => {
+      const formatted = getFormattedDiagnosticLog()
+      expect(formatted).toContain("No diagnostic entries")
+    })
+
+    it("returns formatted markdown when entries exist", () => {
+      enableDiagnosticLogging()
+      logFileSelection(true, [new File(["test"], "test.txt")])
+
+      const formatted = getFormattedDiagnosticLog()
+      expect(formatted).toContain("## File Uploader Diagnostic Log")
+      expect(formatted).toContain("Session ID:")
+      expect(formatted).toContain("### Entries")
+      expect(formatted).toContain("```json")
+    })
+  })
+
+  describe("isAndroidDevice", () => {
+    it("detects Android in user agent", () => {
+      // This test depends on the actual test environment's user agent
+      // In most test environments, this will be false
+      const result = isAndroidDevice()
+      expect(typeof result).toBe("boolean")
+    })
+  })
+
+  describe("mayHaveAndroidPickerIssues", () => {
+    it("returns same as isAndroidDevice", () => {
+      expect(mayHaveAndroidPickerIssues()).toBe(isAndroidDevice())
+    })
+  })
+
+  describe("log size management", () => {
+    it("keeps only most recent entries when exceeding max", () => {
+      enableDiagnosticLogging()
+
+      // Add more than MAX_LOG_ENTRIES (50)
+      for (let i = 0; i < 55; i++) {
+        logFileSelection(true, [new File([`test${i}`], `test${i}.txt`)])
+      }
+
+      const log = getFileUploadDiagnosticLog()
+      expect(log?.entries.length).toBeLessThanOrEqual(50)
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/FileUploader/uploadDiagnostics.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/uploadDiagnostics.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Diagnostic logging for file uploads, useful for debugging Android picker issues.
+ * Enable by setting window.localStorage.setItem('streamlit.fileUploader.debug', 'true')
+ */
+
+export interface FileUploadDiagnosticEntry {
+  timestamp: string
+  userAgent: string
+  multipleEnabled: boolean
+  filesReceived: number
+  files: Array<{
+    name: string
+    type: string
+    size: number
+    error?: string
+  }>
+  uploadResults?: Array<{
+    name: string
+    success: boolean
+    error?: string
+  }>
+}
+
+export interface FileUploadDiagnosticLog {
+  sessionId: string
+  entries: FileUploadDiagnosticEntry[]
+}
+
+const STORAGE_KEY = "streamlit.fileUploader.debug"
+const LOG_STORAGE_KEY = "streamlit.fileUploader.diagnosticLog"
+const MAX_LOG_ENTRIES = 50
+
+/**
+ * Check if diagnostic logging is enabled via window.localStorage.
+ */
+export function isDiagnosticLoggingEnabled(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Enable diagnostic logging for file uploads.
+ */
+export function enableDiagnosticLogging(): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "true")
+    // eslint-disable-next-line no-console
+    console.log(
+      "[FileUploader] Diagnostic logging enabled. Use getFileUploadDiagnosticLog() to retrieve logs."
+    )
+  } catch {
+    // window.localStorage not available
+  }
+}
+
+/**
+ * Disable diagnostic logging for file uploads.
+ */
+export function disableDiagnosticLogging(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+    // eslint-disable-next-line no-console
+    console.log("[FileUploader] Diagnostic logging disabled.")
+  } catch {
+    // window.localStorage not available
+  }
+}
+
+/**
+ * Get the current diagnostic log.
+ */
+export function getFileUploadDiagnosticLog(): FileUploadDiagnosticLog | null {
+  try {
+    const stored = window.localStorage.getItem(LOG_STORAGE_KEY)
+    return stored ? (JSON.parse(stored) as FileUploadDiagnosticLog) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Clear the diagnostic log.
+ */
+export function clearFileUploadDiagnosticLog(): void {
+  try {
+    window.localStorage.removeItem(LOG_STORAGE_KEY)
+    // eslint-disable-next-line no-console
+    console.log("[FileUploader] Diagnostic log cleared.")
+  } catch {
+    // window.localStorage not available
+  }
+}
+
+/**
+ * Get a formatted diagnostic log suitable for pasting into a GitHub issue.
+ */
+export function getFormattedDiagnosticLog(): string {
+  const log = getFileUploadDiagnosticLog()
+  if (!log || log.entries.length === 0) {
+    return "No diagnostic entries recorded."
+  }
+
+  const lines: string[] = [
+    "## File Uploader Diagnostic Log",
+    "",
+    `Session ID: ${log.sessionId}`,
+    `Entries: ${log.entries.length}`,
+    "",
+    "### Entries",
+    "",
+  ]
+
+  log.entries.forEach((entry, idx) => {
+    lines.push(`#### Entry ${idx + 1} - ${entry.timestamp}`)
+    lines.push("")
+    lines.push("```json")
+    lines.push(JSON.stringify(entry, null, 2))
+    lines.push("```")
+    lines.push("")
+  })
+
+  return lines.join("\n")
+}
+
+let sessionId: string | null = null
+
+function getSessionId(): string {
+  if (!sessionId) {
+    sessionId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+  }
+  return sessionId
+}
+
+/**
+ * Log a file selection event for diagnostics.
+ */
+export function logFileSelection(
+  multipleEnabled: boolean,
+  files: File[]
+): FileUploadDiagnosticEntry | null {
+  if (!isDiagnosticLoggingEnabled()) {
+    return null
+  }
+
+  const entry: FileUploadDiagnosticEntry = {
+    timestamp: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    multipleEnabled,
+    filesReceived: files.length,
+    files: files.map(f => ({
+      name: f.name,
+      type: f.type || "unknown",
+      size: f.size,
+    })),
+  }
+
+  try {
+    const log = getFileUploadDiagnosticLog() || {
+      sessionId: getSessionId(),
+      entries: [],
+    }
+
+    log.entries.push(entry)
+
+    // Keep only the most recent entries
+    if (log.entries.length > MAX_LOG_ENTRIES) {
+      log.entries = log.entries.slice(-MAX_LOG_ENTRIES)
+    }
+
+    window.localStorage.setItem(LOG_STORAGE_KEY, JSON.stringify(log))
+
+    // eslint-disable-next-line no-console
+    console.log("[FileUploader] Diagnostic entry logged:", entry)
+  } catch {
+    // window.localStorage not available
+  }
+
+  return entry
+}
+
+/**
+ * Update the most recent diagnostic entry with upload results.
+ */
+export function logUploadResults(
+  results: Array<{ name: string; success: boolean; error?: string }>
+): void {
+  if (!isDiagnosticLoggingEnabled()) {
+    return
+  }
+
+  try {
+    const log = getFileUploadDiagnosticLog()
+    if (log && log.entries.length > 0) {
+      log.entries[log.entries.length - 1].uploadResults = results
+      window.localStorage.setItem(LOG_STORAGE_KEY, JSON.stringify(log))
+      // eslint-disable-next-line no-console
+      console.log("[FileUploader] Upload results logged:", results)
+    }
+  } catch {
+    // window.localStorage not available
+  }
+}
+
+/**
+ * Detect if the user agent suggests an Android device.
+ */
+export function isAndroidDevice(): boolean {
+  return /android/i.test(navigator.userAgent)
+}
+
+/**
+ * Detect if the user agent suggests "Files by Google" or similar problematic pickers.
+ * Note: We cannot directly detect the picker app, but we can detect Android.
+ */
+export function mayHaveAndroidPickerIssues(): boolean {
+  return isAndroidDevice()
+}
+
+// Expose functions globally for developer console access
+if (typeof window !== "undefined") {
+  // @ts-expect-error - Adding to window for debug access
+  window.streamlitFileUploaderDiagnostics = {
+    enable: enableDiagnosticLogging,
+    disable: disableDiagnosticLogging,
+    getLog: getFileUploadDiagnosticLog,
+    getFormattedLog: getFormattedDiagnosticLog,
+    clear: clearFileUploadDiagnosticLog,
+  }
+}

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -119,6 +119,12 @@ const getErrorMessage = (
       return `File size is too small.`
     case "too-many-files":
       return "Only one file is allowed."
+    case "file-zero-size":
+      return "File appears to be empty or could not be read. This may be a file picker issue on your device."
+    case "file-read-error":
+      return "Could not read file. Please try selecting the file again or use a different file picker."
+    case "file-duplicate":
+      return "Duplicate file ignored."
     default:
       return "Unexpected error. Please try again."
   }


### PR DESCRIPTION
## Describe your changes

Hardened Streamlit's file uploader widget against Android file picker issues where multi-select returns incomplete results, zero-size files, or duplicates. These issues are common when using "Files by Google" picker on Android devices.

**Key improvements:**
- Detect and filter zero-size files before upload (common Android picker failure mode)
- Filter duplicate file entries (same name, size, and type)
- Add optional debug logging to localStorage for troubleshooting (enable via `localStorage.setItem('streamlit.fileUploader.debug', 'true')`)
- Per-file error messages guide users when uploads fail
- Diagnostic logs can be exported as GitHub issue-ready markdown

## Testing Plan

- **Unit Tests**: 18 tests for file validation utilities, 19 tests for diagnostic logging, 4 Android resilience tests for FileUploader component
- **Validation**: All tests pass (fileValidation.test.ts, uploadDiagnostics.test.ts)
- **Manual testing**: Per-file error handling ensures successful uploads aren't blocked by failures

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.