### PR TITLE
Split Playwright E2E tests into 4 parallel shards

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,9 +20,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  playwright-e2e-tests:
+  playwright-e2e-tests-shard:
     runs-on: ubuntu-latest-64-cores
     timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     defaults:
       run:
@@ -56,14 +61,40 @@ jobs:
           else
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
           fi
-      - name: Run playwright tests
+      - name: Run playwright tests (shard ${{ matrix.shard }}/4)
         run: |
           cd e2e_playwright
           rm -rf ./test-results
-          pytest --ignore ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1 -m "not performance"
-      - name: Upload failed test results
+          pytest --ignore ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1 -m "not performance" --splits 4 --group ${{ matrix.shard }}
+      - name: Upload test results
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
+          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}_shard${{ matrix.shard }}
           path: e2e_playwright/test-results
+
+  playwright-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: playwright-e2e-tests-shard
+    if: always()
+
+    steps:
+      - name: Get short SHA
+        id: short_sha
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
+          else
+            echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
+          fi
+      - name: Download all test results
+        uses: actions/download-artifact@v6
+        with:
+          pattern: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}_shard*
+          path: all-test-results
+          merge-multiple: true
+      - name: Upload combined test results
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
+          path: all-test-results

--- a/component-lib/yarn.lock
+++ b/component-lib/yarn.lock
@@ -6286,15 +6286,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.3
-  resolution: "tar@npm:7.5.3"
+  version: 7.5.6
+  resolution: "tar@npm:7.5.6"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/e5e3237bca325fbb33282d92d9807f4c8d81abaf71bf2627efdf93bd5610c146460c78fc7e9767d4ab5ae3c0b18af8197314c964f8cbd23b30b25bf4d42d7cb4
+  checksum: 10c0/08af3807035957650ad5f2a300c49ca4fe0566ac0ea5a23741a5b5103c6da42891a9eeaed39bc1fbcf21c5cac4dc846828a004727fb08b9d946322d3144d1fd2
   languageName: node
   linkType: hard
 

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -40,6 +40,7 @@ playwright==1.57.*
 pytest-playwright>=0.3.3
 pixelmatch>=0.3.0
 pytest-xdist>=3.6.1
+pytest-split>=0.9.0
 # pytest-rerunfailures 16.0 is breaking our CI:
 # https://github.com/pytest-dev/pytest-rerunfailures/issues/302
 pytest-rerunfailures>=15.0,!=16.0


### PR DESCRIPTION
## Describe your changes

Split the Playwright E2E tests across 4 parallel shards using pytest-split for deterministic test distribution. Each shard runs approximately 25% of tests with full browser coverage (webkit, chromium, firefox) and maintains xdist internal parallelization. A new combine job merges results from all shards into a single artifact, preserving the existing output format.

## Testing Plan

- The new sharding strategy is transparent to individual tests
- Each shard runs with --reruns 1 and all existing pytest markers (-m "not performance")
- Artifact naming allows tracking results per shard before combining
- Total test coverage remains identical, just distributed across parallel runners

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.