### PR TITLE
Fix a regression with snowflake connection being closed

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -349,6 +349,7 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         """Closes the underlying Snowflake connection."""
         if self._raw_instance is not None:
             self._raw_instance.close()
+            self._raw_instance = None
 
 
 class SnowflakeConnection(BaseSnowflakeConnection):

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -228,6 +228,58 @@ class SnowflakeConnectionTest(unittest.TestCase):
         assert conn._connect.call_count == 1
 
 
+class TestSnowflakeConnectionClose:
+    """Tests for SnowflakeConnection.close() method (no integration required)."""
+
+    def test_close_resets_raw_instance(self) -> None:
+        """Tests that close() closes the connection and resets _raw_instance.
+
+        After close() is called, the next access to _instance should create a new
+        connection, not return the closed one.
+        """
+        mock_connection = MagicMock()
+        second_mock_connection = MagicMock()
+
+        with patch(
+            "streamlit.connections.snowflake_connection.SnowflakeConnection._connect"
+        ) as mock_connect:
+            mock_connect.side_effect = [mock_connection, second_mock_connection]
+
+            conn = SnowflakeConnection("my_snowflake_connection")
+
+            # First access creates the connection
+            assert conn._instance is mock_connection
+            mock_connect.assert_called_once()
+
+            # Close the connection
+            conn.close()
+            mock_connection.close.assert_called_once()
+
+            # _raw_instance should be None after close
+            assert conn._raw_instance is None
+
+            # Next access to _instance should create a new connection
+            assert conn._instance is second_mock_connection
+            assert mock_connect.call_count == 2
+
+    def test_close_is_noop_when_not_connected(self) -> None:
+        """Tests that close() doesn't fail when _raw_instance is None."""
+        with patch(
+            "streamlit.connections.snowflake_connection.SnowflakeConnection._connect"
+        ) as mock_connect:
+            mock_connect.return_value = MagicMock()
+
+            conn = SnowflakeConnection("my_snowflake_connection")
+            # Reset the connection to simulate it not being connected
+            conn._raw_instance = None
+
+            # close() should not raise when _raw_instance is None
+            conn.close()
+
+            # _raw_instance should still be None
+            assert conn._raw_instance is None
+
+
 class TestSnowflakeCallersRightsConnection:
     def test_get_connection_params_errors_on_missing_env(self):
         """Tests that _get_connection_params handles missing environment variables."""


### PR DESCRIPTION
## Describe your changes

Fixes an issue with Snowflake connections not getting re-initialized after having been closed. 

<details>
<summary>Claude issue analysis</summary> 
# Issue Report: Snowflake Connection "Connection is closed" Error

## Summary

After recent PRs adding `on_release` to `st.cache_resource` and session-scoped connection support, users may encounter a `snowflake.connector.errors.DatabaseError: 250002 (08003): Connection is closed` error when using `st.connection("snowflake")` with cached data queries.

## Related PRs

- **PR #13439**: Add `on_release` to `st.cache_resource`
- **PR #13482**: Add session scoping to caches
- **PR #13538**: Add `SnowflakeCallersRightsConnection`
- **PR #13506**: Add session-scoped connection support

## Error Details

```
Traceback (most recent call last):
  File ".../streamlit/runtime/scriptrunner/exec_code.py", line 129, in exec_func_with_error_handling
    result = func()
  ...
  File ".../snowflake/snowpark/_internal/server_connection.py", line 205, in _cursor
    self._thread_store.cursor = self._conn.cursor()
  File ".../snowflake/connector/connection.py", line 1270, in cursor
    Error.errorhandler_wrapper(...)
snowflake.connector.errors.DatabaseError: 250002 (08003): Connection is closed
```

## Root Cause Analysis

### Background

The PRs mentioned added important functionality:

1. **PR #13439** added the `on_release` callback to `st.cache_resource`, which is called when cache entries are evicted
2. **PR #13506** modified `connection_factory.py` to use this `on_release` callback to call `connection.close()` when a connection is evicted from the cache

This is the relevant code in `connection_factory.py`:

```python
def on_release_wrapped(connection: ConnectionClass) -> None:
    connection.close()

__create_connection = cache_resource(
    max_entries=max_entries,
    show_spinner="Running `st.connection(...)`.",
    ttl=ttl,
    scope=scope,
    on_release=on_release_wrapped,  # Calls close() when evicted
)(__create_connection)
```

### The Bug

In `BaseSnowflakeConnection.close()`, after calling `self._raw_instance.close()`, the `_raw_instance` attribute was **NOT** reset to `None`:

```python
def close(self) -> None:
    """Closes the underlying Snowflake connection."""
    if self._raw_instance is not None:
        self._raw_instance.close()
        # BUG: _raw_instance was NOT set to None!
```

This caused the following issue:

1. When `close()` was called (e.g., via `on_release` when a cache entry is evicted), the underlying connection was closed
2. However, `_raw_instance` still referenced the **closed** connection object
3. The `_instance` property checks `if self._raw_instance is None` to decide whether to create a new connection:

   ```python
   @property
   def _instance(self) -> RawConnectionT:
       if self._raw_instance is None:
           self._raw_instance = self._connect(**self._kwargs)
       return self._raw_instance
   ```

4. Since `_raw_instance` wasn't `None`, subsequent access to `_instance` returned the **CLOSED** connection
5. Any operations on the closed connection failed with "Connection is closed"

### When This Bug Manifests

The `on_release` callback (which calls `close()`) is triggered when:

- Cache entries expire due to TTL
- Cache is full and oldest entries are evicted (`max_entries`)
- `st.cache_resource.clear()` is called
- For session-scoped caches: when a session disconnects

For global-scoped connections like `st.connection("snowflake")`, this typically only happens if:
- `st.cache_resource.clear()` is called explicitly
- TTL is set and expires
- `max_entries` is set and exceeded

### Additional Consideration: Snowpark Sessions

When users call `conn.session()`, they get a Snowpark Session that internally references `self._instance`. If the underlying connection is closed:

```python
def session(self) -> Session:
    if running_in_sis():
        return get_active_session()
    return Session.builder.configs({"connection": self._instance}).create()
```

Any Snowpark Sessions created from the connection will also fail because they hold a reference to the now-closed underlying connection object.

## Fix

The fix is simple: reset `_raw_instance` to `None` after closing the connection:

```python
def close(self) -> None:
    """Closes the underlying Snowflake connection."""
    if self._raw_instance is not None:
        self._raw_instance.close()
        self._raw_instance = None  # Added this line
```

This ensures that after `close()` is called, the next access to `_instance` will create a new connection instead of returning the closed one.

## Files Changed

1. **`lib/streamlit/connections/snowflake_connection.py`**
   - Fixed `close()` method to reset `_raw_instance = None` after closing

2. **`lib/tests/streamlit/connections/snowflake_connection_test.py`**
   - Added `TestSnowflakeConnectionClose` test class with:
     - `test_close_resets_raw_instance`: Verifies that `close()` closes the connection AND resets `_raw_instance`
     - `test_close_is_noop_when_not_connected`: Verifies that `close()` doesn't fail when `_raw_instance` is already `None`

## Testing

```bash
PYTHONPATH=lib pytest lib/tests/streamlit/connections/snowflake_connection_test.py::TestSnowflakeConnectionClose -v
```

Output:
```
lib/tests/streamlit/connections/snowflake_connection_test.py::TestSnowflakeConnectionClose::test_close_resets_raw_instance PASSED
lib/tests/streamlit/connections/snowflake_connection_test.py::TestSnowflakeConnectionClose::test_close_is_noop_when_not_connected PASSED
```

## Recommendations for Users

Until this fix is released, users experiencing this issue can:

1. **Avoid storing Snowpark Sessions long-term**: Instead of caching Snowpark Sessions, create them fresh when needed
2. **Check if using `st.cache_resource.clear()`**: If calling this anywhere in the app, it will close all cached connections
3. **Consider connection TTL settings**: If TTL is set on the connection, it may expire and close

## Impact

- **Affected**: Users of `st.connection("snowflake")` and `st.connection("snowflake-callers-rights")` who experience cache eviction scenarios
- **Severity**: Medium - The bug causes operations to fail with a confusing error message, but the workaround (restarting the app or avoiding cache clears) is available
- **Scope**: Only affects `SnowflakeConnection` and its subclasses; other connection types (`SQLConnection`, `SnowparkConnection`) inherit the no-op `close()` from `BaseConnection` and are not affected
</details>

## GitHub Issue Link (if applicable)

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
