### PR TITLE
[WIP] Allow dynamic changes to `st.data_editor` with `num_rows="fixed"` when `key` is provided (phase 1)

### DIFF
--- a/e2e_playwright/st_data_editor_state_persistence.py
+++ b/e2e_playwright/st_data_editor_state_persistence.py
@@ -32,9 +32,11 @@ if "df_feedback" not in st.session_state:
     st.session_state.df_feedback = pd.DataFrame({"In": [0, 1, 2], "Out": [0, 0, 0]})
 
 # The key is crucial here - it ensures stable widget identity
+# Explicitly set num_rows="fixed" to test the fixed mode behavior
 st.session_state.df_feedback = st.data_editor(
     st.session_state.df_feedback,
     key="feedback_editor",
+    num_rows="fixed",
     width="content",
     hide_index=True,
 )
@@ -59,6 +61,7 @@ if "df_simple" not in st.session_state:
 st.session_state.df_simple = st.data_editor(
     st.session_state.df_simple,
     key="simple_editor",
+    num_rows="fixed",
     width="content",
     hide_index=True,
 )

--- a/e2e_playwright/st_data_editor_state_persistence.py
+++ b/e2e_playwright/st_data_editor_state_persistence.py
@@ -1,0 +1,67 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test app for data_editor state persistence with session state feedback loop.
+
+This app tests the fix for issue #7749:
+https://github.com/streamlit/streamlit/issues/7749
+
+The issue was that when using st.data_editor with session state and a computed
+column, edits would "disappear" and require double-input to register changes.
+"""
+
+import pandas as pd
+
+import streamlit as st
+
+# Test 1: Session state feedback loop with computed column (issue #7749)
+st.subheader("Session State Feedback Loop")
+
+if "df_feedback" not in st.session_state:
+    st.session_state.df_feedback = pd.DataFrame({"In": [0, 1, 2], "Out": [0, 0, 0]})
+
+# The key is crucial here - it ensures stable widget identity
+st.session_state.df_feedback = st.data_editor(
+    st.session_state.df_feedback,
+    key="feedback_editor",
+    width="content",
+    hide_index=True,
+)
+
+# Compute the "Out" column based on "In" - this is what triggers the issue
+st.session_state.df_feedback["Out"] = st.session_state.df_feedback["In"] ** 2
+
+st.write("Current state:")
+st.dataframe(st.session_state.df_feedback, key="feedback_display")
+
+# Show the "In" column sum for verification
+in_sum = st.session_state.df_feedback["In"].sum()
+st.markdown(f"Sum of In column: `{in_sum}`")
+
+
+# Test 2: Simple edit without computed column (baseline)
+st.subheader("Simple Edit (No Computed Column)")
+
+if "df_simple" not in st.session_state:
+    st.session_state.df_simple = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+
+st.session_state.df_simple = st.data_editor(
+    st.session_state.df_simple,
+    key="simple_editor",
+    width="content",
+    hide_index=True,
+)
+
+simple_sum = st.session_state.df_simple["A"].sum()
+st.markdown(f"Sum of A column: `{simple_sum}`")

--- a/e2e_playwright/st_data_editor_state_persistence.py
+++ b/e2e_playwright/st_data_editor_state_persistence.py
@@ -51,6 +51,10 @@ st.dataframe(st.session_state.df_feedback, key="feedback_display")
 in_sum = st.session_state.df_feedback["In"].sum()
 st.markdown(f"Sum of In column: `{in_sum}`")
 
+# Show the first "Out" value to verify computed column is updated correctly
+out_first = st.session_state.df_feedback["Out"].iloc[0]
+st.markdown(f"Out[0] value: `{out_first}`")
+
 
 # Test 2: Simple edit without computed column (baseline)
 st.subheader("Simple Edit (No Computed Column)")

--- a/e2e_playwright/st_data_editor_state_persistence_test.py
+++ b/e2e_playwright/st_data_editor_state_persistence_test.py
@@ -68,6 +68,11 @@ def test_data_editor_preserves_edit_in_session_state_feedback_loop(app: Page) ->
     # This is the key test - previously this would show 3 (edit lost) on first try
     expect_prefixed_markdown(app, "Sum of In column:", "8")
 
+    # Verify the computed "Out" column was updated correctly (5^2 = 25)
+    # This is a "must NOT happen" check: Out[0] must NOT be 0 (old computed value)
+    # It must be 25 (the square of the edited In[0] value of 5)
+    expect_prefixed_markdown(app, "Out[0] value:", "25")
+
 
 def test_data_editor_simple_edit_persists(app: Page) -> None:
     """Test that simple edits persist without a computed column (baseline test)."""

--- a/e2e_playwright/st_data_editor_state_persistence_test.py
+++ b/e2e_playwright/st_data_editor_state_persistence_test.py
@@ -1,0 +1,95 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for data_editor state persistence with session state feedback loop.
+
+Tests the fix for issue #7749:
+https://github.com/streamlit/streamlit/issues/7749
+"""
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    expect_prefixed_markdown,
+    get_element_by_key,
+)
+from e2e_playwright.shared.dataframe_utils import (
+    click_on_cell,
+    expect_canvas_to_be_visible,
+    get_open_cell_overlay,
+)
+
+
+def test_data_editor_preserves_edit_in_session_state_feedback_loop(app: Page) -> None:
+    """Test that edits persist when data_editor is used in a session state feedback loop.
+
+    This tests the fix for issue #7749 where edits would "disappear" when the
+    underlying data was modified programmatically (e.g., computing a column).
+
+    The test workflow:
+    1. Edit a cell in the "In" column
+    2. Verify the edit persists after the app reruns (with computed "Out" column)
+    3. Verify the computed column reflects the edit
+    """
+    # Get the feedback loop data editor
+    editor = get_element_by_key(app, "feedback_editor").get_by_test_id("stDataFrame")
+    expect_canvas_to_be_visible(editor)
+
+    # Initial state should have sum = 0 + 1 + 2 = 3
+    expect_prefixed_markdown(app, "Sum of In column:", "3")
+
+    # Click on the first cell of the "In" column (row 1, column 0 since index is hidden)
+    # Row 0 is header, so we click on row 1 which is the first data row
+    # Column layout with hide_index=True: 0=In, 1=Out
+    click_on_cell(editor, row_pos=1, col_pos=0, double_click=True, column_width="small")
+
+    # Get the cell overlay and type a new value
+    cell_overlay = get_open_cell_overlay(app)
+    expect(cell_overlay).to_be_visible()
+
+    # Clear the cell and type a new value (5)
+    cell_overlay.locator("input").fill("5")
+    app.keyboard.press("Enter")
+    wait_for_app_run(app)
+
+    # After the edit, sum should be 5 + 1 + 2 = 8
+    # This is the key test - previously this would show 3 (edit lost) on first try
+    expect_prefixed_markdown(app, "Sum of In column:", "8")
+
+
+def test_data_editor_simple_edit_persists(app: Page) -> None:
+    """Test that simple edits persist without a computed column (baseline test)."""
+    # Get the simple data editor
+    editor = get_element_by_key(app, "simple_editor").get_by_test_id("stDataFrame")
+    expect_canvas_to_be_visible(editor)
+
+    # Initial state should have sum = 1 + 2 + 3 = 6
+    expect_prefixed_markdown(app, "Sum of A column:", "6")
+
+    # Click on the first cell of column "A" (row 1, column 0 since index is hidden)
+    # Column layout with hide_index=True: 0=A, 1=B
+    click_on_cell(editor, row_pos=1, col_pos=0, double_click=True, column_width="small")
+
+    # Get the cell overlay and type a new value
+    cell_overlay = get_open_cell_overlay(app)
+    expect(cell_overlay).to_be_visible()
+
+    # Clear the cell and type a new value (10)
+    cell_overlay.locator("input").fill("10")
+    app.keyboard.press("Enter")
+    wait_for_app_run(app)
+
+    # After the edit, sum should be 10 + 2 + 3 = 15
+    expect_prefixed_markdown(app, "Sum of A column:", "15")

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -271,6 +271,7 @@ function DataFrame({
     fragmentId,
     originalNumRows,
     originalColumns,
+    dataHash: data.hash,
   })
 
   const { getCellContent: getOriginalCellContent } = useDataLoader(

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -271,7 +271,7 @@ function DataFrame({
     fragmentId,
     originalNumRows,
     originalColumns,
-    dataHash: data.hash,
+    dataHash: element.dataHash,
   })
 
   const { getCellContent: getOriginalCellContent } = useDataLoader(

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.test.ts
@@ -82,6 +82,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: [],
+          dataHash: "test-hash",
         })
       )
 
@@ -101,6 +102,7 @@ describe("useWidgetState hook", () => {
             fragmentId: undefined,
             originalNumRows,
             originalColumns: [],
+            dataHash: "test-hash",
           }),
         { initialProps: { originalNumRows: 10 } }
       )
@@ -113,6 +115,42 @@ describe("useWidgetState hook", () => {
       expect(result.current.editingState.current.getNumRows()).toBe(20)
     })
 
+    it("resets editingState when dataHash changes", () => {
+      const columns = [createMockColumn("col1", 0)]
+
+      const { result, rerender } = renderHook(
+        ({ dataHash }) =>
+          useWidgetState({
+            element: ArrowProto.create({
+              editingMode: ArrowProto.EditingMode.FIXED,
+            }),
+            widgetMgr: undefined,
+            fragmentId: undefined,
+            originalNumRows: 10,
+            originalColumns: columns,
+            dataHash,
+          }),
+        { initialProps: { dataHash: "hash-1" } }
+      )
+
+      expect(result.current.numRows).toBe(10)
+
+      // Add a row to simulate user edits
+      act(() => {
+        result.current.editingState.current.addRow(new Map())
+        result.current.updateNumRows()
+      })
+
+      expect(result.current.numRows).toBe(11)
+
+      // Change dataHash to simulate data content change
+      rerender({ dataHash: "hash-2" })
+
+      // Editing state should be reset, numRows back to original
+      expect(result.current.numRows).toBe(10)
+      expect(result.current.editingState.current.getNumRows()).toBe(10)
+    })
+
     it("updateNumRows syncs component state with editing state", () => {
       const { result } = renderHook(() =>
         useWidgetState({
@@ -123,6 +161,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: [createMockColumn("col1", 0)],
+          dataHash: "test-hash",
         })
       )
 
@@ -163,6 +202,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 5,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -203,6 +243,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 5,
           originalColumns: [],
+          dataHash: "test-hash",
         })
       )
 
@@ -237,6 +278,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 0,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -271,6 +313,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -319,6 +362,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -366,6 +410,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -414,6 +459,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -461,6 +507,7 @@ describe("useWidgetState hook", () => {
           fragmentId: "test-fragment",
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -503,6 +550,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: [],
+          dataHash: "test-hash",
         })
       )
 
@@ -529,6 +577,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: [],
+          dataHash: "test-hash",
         })
       )
 
@@ -560,6 +609,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: [],
+          dataHash: "test-hash",
         })
       )
 
@@ -601,6 +651,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -648,6 +699,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 
@@ -691,6 +743,7 @@ describe("useWidgetState hook", () => {
           fragmentId: undefined,
           originalNumRows: 10,
           originalColumns: columns,
+          dataHash: "test-hash",
         })
       )
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
@@ -59,6 +59,8 @@ export interface UseWidgetStateParams {
   fragmentId?: string
   originalNumRows: number
   originalColumns: BaseColumn[]
+  /** Hash identifying the underlying data content. Used to reset editing state when data changes. */
+  dataHash: string
 }
 
 export interface UseWidgetStateReturn {
@@ -109,6 +111,7 @@ function useWidgetState({
   fragmentId,
   originalNumRows,
   originalColumns,
+  dataHash,
 }: UseWidgetStateParams): UseWidgetStateReturn {
   const { READ_ONLY } = ArrowProto.EditingMode
 
@@ -118,14 +121,14 @@ function useWidgetState({
   )
   const [numRows, setNumRows] = useState(editingStateRef.current.getNumRows())
 
-  // Reset editing state when originalNumRows changes.
+  // Reset editing state when originalNumRows or dataHash changes.
   // Using useExecuteWhenChanged instead of useEffect to follow React best practices
   // for adjusting state when props change (avoids extra render cycle).
   // See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   useExecuteWhenChanged(() => {
     editingStateRef.current = new EditingState(originalNumRows)
     setNumRows(editingStateRef.current.getNumRows())
-  }, [originalNumRows])
+  }, [originalNumRows, dataHash])
 
   /**
    * Resets the editing state to a fresh state

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -492,9 +492,11 @@ def _compute_schema_hash(
     str
         MD5 hash of the schema components.
     """
-    # Build schema components list
-    components: list[str] = [f"col:{col}" for col in df.columns]
-    components.extend(f"type:{field.name}:{field.type}" for field in arrow_schema)
+    # Build schema components list from the Arrow schema so that
+    # each column's name and type are captured in a single pass.
+    components: list[str] = [
+        f"col:{field.name}:type:{field.type}" for field in arrow_schema
+    ]
     components.append(f"index:{type(df.index).__name__}")
 
     # Include row count - editing state uses positional indices,

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -1123,14 +1123,17 @@ class DataEditorMixin:
         # as close as possible to how it used to be.
         ctx = get_script_run_ctx()
 
-        # When a user provides a key, they're signaling intent for a persistent
-        # widget identity. We use schema_hash as the main identity component.
-        # This keeps the widget ID stable when only data values change,
-        # allowing editing state to persist across reruns.
+        # When a user provides a key and num_rows="fixed", we use schema_hash
+        # as the main identity component. This keeps the widget ID stable when
+        # only data values change, allowing editing state to persist across reruns.
+        # For other num_rows modes (dynamic/add/delete), row count can change
+        # legitimately, so we keep the default behavior until those modes are
+        # explicitly supported with proper reconciliation logic.
+        use_schema_hash_identity = key is not None and num_rows == "fixed"
         element_id = compute_and_register_element_id(
             "data_editor",
             user_key=key,
-            key_as_main_identity={"schema_hash"} if key else False,
+            key_as_main_identity={"schema_hash"} if use_schema_hash_identity else False,
             dg=self.dg,
             schema_hash=schema_hash,
             # Keep data in kwargs for backward compatibility when no key is provided

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -1132,6 +1132,9 @@ class DataEditorMixin:
         # legitimately, so we keep the default behavior until those modes are
         # explicitly supported with proper reconciliation logic.
         use_schema_hash_identity = key is not None and num_rows == "fixed"
+
+        data_hash = calc_md5(arrow_bytes)
+
         element_id = compute_and_register_element_id(
             "data_editor",
             user_key=key,
@@ -1139,7 +1142,7 @@ class DataEditorMixin:
             dg=self.dg,
             schema_hash=schema_hash,
             # Keep data in kwargs for backward compatibility when no key is provided
-            data=arrow_bytes,
+            data=data_hash,
             width=width,
             height=height,
             use_container_width=use_container_width,
@@ -1192,6 +1195,9 @@ class DataEditorMixin:
             marshall_styler(proto, data, styler_uuid)
 
         proto.data = arrow_bytes
+        # Use the datahash of the data content to detect changes in the frontend.
+        # This is used to reset the editing state when the underlying data changes.
+        proto.data_hash = data_hash
 
         marshall_column_config(proto, column_config_mapping)
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -464,6 +464,46 @@ def _apply_dataframe_edits(
         _apply_row_additions(df, data_editor_state["added_rows"], dataframe_schema)
 
 
+def _compute_schema_hash(
+    df: pd.DataFrame,
+    arrow_schema: pa.Schema,
+) -> str:
+    """Compute a hash of the dataframe schema (structure, not values).
+
+    This hash captures the structural identity of a dataframe:
+    - Column names and order
+    - Column types (from Arrow schema)
+    - Index type
+    - Row count (editing state uses positional indices)
+
+    The hash does NOT include actual data values, allowing the widget ID
+    to remain stable when only cell values change (not structure).
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe to compute the schema hash for.
+
+    arrow_schema : pa.Schema
+        The Arrow schema of the dataframe.
+
+    Returns
+    -------
+    str
+        MD5 hash of the schema components.
+    """
+    # Build schema components list
+    components: list[str] = [f"col:{col}" for col in df.columns]
+    components.extend(f"type:{field.name}:{field.type}" for field in arrow_schema)
+    components.append(f"index:{type(df.index).__name__}")
+
+    # Include row count - editing state uses positional indices,
+    # so row count changes would invalidate edit positions
+    components.append(f"rows:{len(df)}")
+
+    return calc_md5("|".join(components))
+
+
 def _is_supported_index(df_index: pd.Index[Any]) -> bool:
     """Check if the index is supported by the data editor component.
 
@@ -1072,16 +1112,28 @@ class DataEditorMixin:
 
         arrow_bytes = dataframe_util.convert_arrow_table_to_arrow_bytes(arrow_table)
 
+        # Compute schema hash for stable widget identity when key is provided.
+        # The schema hash captures structure (columns, types, row count) but not
+        # data values, allowing edits to persist when only values change.
+        schema_hash = _compute_schema_hash(data_df, arrow_table.schema)
+
         # We want to do this as early as possible to avoid introducing nondeterminism,
         # but it isn't clear how much processing is needed to have the data in a
         # format that will hash consistently, so we do it late here to have it
         # as close as possible to how it used to be.
         ctx = get_script_run_ctx()
+
+        # When a user provides a key, they're signaling intent for a persistent
+        # widget identity. We use schema_hash as the main identity component.
+        # This keeps the widget ID stable when only data values change,
+        # allowing editing state to persist across reruns.
         element_id = compute_and_register_element_id(
             "data_editor",
             user_key=key,
-            key_as_main_identity=False,
+            key_as_main_identity={"schema_hash"} if key else False,
             dg=self.dg,
+            schema_hash=schema_hash,
+            # Keep data in kwargs for backward compatibility when no key is provided
             data=arrow_bytes,
             width=width,
             height=height,

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -47,6 +47,7 @@ from streamlit.elements.widgets.data_editor import (
     _apply_row_deletions,
     _check_column_names,
     _check_type_compatibilities,
+    _compute_schema_hash,
     _parse_value,
 )
 from streamlit.errors import StreamlitAPIException
@@ -599,6 +600,89 @@ class DataEditorUtilTest(unittest.TestCase):
         expected_col2_values = [f"value_{i}" for i in range(8)]
         assert df["col1"].tolist() == expected_col1_values
         assert df["col2"].tolist() == expected_col2_values
+
+
+class ComputeSchemaHashTest(unittest.TestCase):
+    """Tests for the _compute_schema_hash function."""
+
+    def test_hash_stable_when_only_values_change(self):
+        """Hash should be stable when only cell values change."""
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        df2 = pd.DataFrame({"A": [10, 20, 30], "B": [40, 50, 60]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 == hash2, "Hash should be stable when only values change"
+
+    def test_hash_changes_when_column_added(self):
+        """Hash should change when a column is added."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})
+        df2 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when column is added"
+
+    def test_hash_changes_when_column_removed(self):
+        """Hash should change when a column is removed."""
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        df2 = pd.DataFrame({"A": [1, 2, 3]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when column is removed"
+
+    def test_hash_changes_when_column_reordered(self):
+        """Hash should change when column order changes."""
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        df2 = pd.DataFrame({"B": [4, 5, 6], "A": [1, 2, 3]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when columns are reordered"
+
+    def test_hash_changes_when_column_type_changes(self):
+        """Hash should change when column type changes."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})
+        df2 = pd.DataFrame({"A": ["1", "2", "3"]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when column type changes"
+
+    def test_hash_changes_when_row_count_changes(self):
+        """Hash should change when row count changes."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})
+        df2 = pd.DataFrame({"A": [1, 2, 3, 4]})
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when row count changes"
+
+    def test_hash_changes_when_index_type_changes(self):
+        """Hash should change when index type changes."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})  # Default RangeIndex
+        df2 = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([10, 20, 30]))  # Int64Index
+
+        hash1 = _compute_schema_hash(df1, _get_arrow_schema(df1))
+        hash2 = _compute_schema_hash(df2, _get_arrow_schema(df2))
+
+        assert hash1 != hash2, "Hash should change when index type changes"
+
+    def test_hash_deterministic(self):
+        """Hash should be deterministic for the same input."""
+        df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
+
+        hash1 = _compute_schema_hash(df, _get_arrow_schema(df))
+        hash2 = _compute_schema_hash(df, _get_arrow_schema(df))
+
+        assert hash1 == hash2, "Hash should be deterministic"
 
 
 class DataEditorTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -582,6 +582,7 @@ class ComputeElementIdTests(DeltaGeneratorTestCase):
 
         # Make some changes to expected_sig unique to st.data_editor.
         expected_sig["column_config_mapping"] = ANY
+        expected_sig["schema_hash"] = ANY  # Internal param for stable widget identity
         del expected_sig["hide_index"]
         del expected_sig["column_config"]
 

--- a/proto/streamlit/proto/Arrow.proto
+++ b/proto/streamlit/proto/Arrow.proto
@@ -51,6 +51,9 @@ message Arrow {
   BorderMode border_mode = 14;
   // Placeholder string used when rendering missing values (e.g. nulls, NaNs).
   optional string placeholder = 15;
+  // Hash of the data content, used to detect when underlying data changes.
+  // This is computed from the serialized Arrow bytes on the backend.
+  string data_hash = 16;
 
   // Available editing modes:
   enum EditingMode {


### PR DESCRIPTION
## Describe your changes

Implements Phase 1 of the dynamic data editor feature to fix issue #7749 where cell edits would "disappear" when underlying data was modified programmatically (e.g., computing columns).

**Core approach**: When a user provides a `key`, we now use a schema hash as the main widget identity component instead of the full data. This keeps the widget ID stable when only cell values change (not structure), allowing the editing state to persist across reruns.

**Changes**:
- Added `_compute_schema_hash()` to capture dataframe structure (columns, types, index type, row count) without data values
- Updated widget ID computation to use `key_as_main_identity={"schema_hash"}` when key is provided
- Added E2E tests covering session state feedback loop scenarios

## Testing Plan

**E2E Tests**:
- `test_data_editor_preserves_edit_in_session_state_feedback_loop`: Edit cell with computed column update, verify edit persists
- `test_data_editor_simple_edit_persists`: Baseline test without computed column

**Manual Testing**: The fix enables the pattern in issue #7749 where a data_editor with key used in session state feedback loop now preserves edits when computed columns are updated.