### PR TITLE
Fix TransientNode not capturing BlockNode as anchor when replacing

### DIFF
--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -90,3 +90,10 @@ if st.button("Run spinner with container"):
         cols = st.container().columns(2)
         cols[0].write("Column 1")
         cols[1].write("Column 2")
+
+# Regression test for transient node replacing block node
+if st.button("Run spinner with delayed container write"):
+    with st.spinner("Processing..."):
+        container = st.container()
+        time.sleep(2)  # Container exists but is empty when spinner renders
+        container.write("Hello World")

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -212,3 +212,24 @@ def test_spinner_with_container_elements(app: Page):
     expect(app.get_by_test_id("stSpinner")).to_have_count(0)
     expect(app.get_by_text("Column 1")).to_be_visible()
     expect(app.get_by_text("Column 2")).to_be_visible()
+
+
+def test_spinner_with_delayed_container_write(app: Page):
+    """Test that writing to a container after a delay inside spinner context works.
+
+    This tests the scenario where a container is created inside a spinner,
+    exists empty when the spinner first renders, and then content is added.
+    The fix ensures the TransientNode properly captures the BlockNode as its
+    anchor when replacing it.
+    """
+    get_button(app, "Run spinner with delayed container write").click()
+
+    # The spinner should appear while processing
+    expect(app.get_by_test_id("stSpinner")).to_be_visible()
+
+    # Wait for the app to finish running
+    wait_for_app_run(app)
+
+    # After the spinner completes, the container content should be visible
+    expect(app.get_by_test_id("stSpinner")).to_have_count(0)
+    expect(app.get_by_text("Hello World")).to_be_visible()

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.test.ts
@@ -229,6 +229,51 @@ describe("SetNodeByDeltaPathVisitor", () => {
       expect(result).toBe(nodeToSet)
     })
 
+    it("wraps block node as anchor when setting TransientNode without anchor", () => {
+      const originalBlock = block([text("child1"), text("child2")])
+      const transientNode = new TransientNode(
+        "run_id",
+        undefined, // No anchor provided
+        [text("spinner")],
+        123
+      )
+      const visitor = new SetNodeByDeltaPathVisitor(
+        [],
+        transientNode,
+        "run_id"
+      )
+
+      const result = visitor.visitBlockNode(originalBlock) as TransientNode
+
+      // Should wrap originalBlock as the anchor
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.anchor).toBe(originalBlock)
+      expect(result.transientNodes).toEqual(transientNode.transientNodes)
+      expect(result.deltaMsgReceivedAt).toBe(transientNode.deltaMsgReceivedAt)
+    })
+
+    it("does not modify TransientNode when it already has an anchor", () => {
+      const originalBlock = block([text("original")])
+      const existingAnchor = text("existing_anchor")
+      const transientNode = new TransientNode(
+        "run_id",
+        existingAnchor, // Already has an anchor
+        [text("spinner")],
+        123
+      )
+      const visitor = new SetNodeByDeltaPathVisitor(
+        [],
+        transientNode,
+        "run_id"
+      )
+
+      const result = visitor.visitBlockNode(originalBlock)
+
+      // Should return the TransientNode as-is since it already has an anchor
+      expect(result).toBe(transientNode)
+      expect((result as TransientNode).anchor).toBe(existingAnchor)
+    })
+
     it("inserts TransientNode before child when anchors do not match", () => {
       const childA = text("A")
       const childB = text("B")

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
@@ -84,6 +84,19 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
 
   visitBlockNode(node: BlockNode): AppNode {
     if (this.deltaPath.length === 0) {
+      // When replacing a BlockNode with a TransientNode that has no anchor,
+      // capture the current BlockNode as the anchor. This preserves the original
+      // block structure so it can be restored when transient elements are cleared.
+      // This mirrors the analogous behavior in visitElementNode.
+      if (this.nodeToSet instanceof TransientNode && !this.nodeToSet.anchor) {
+        return new TransientNode(
+          this.nodeToSet.scriptRunId,
+          node,
+          this.nodeToSet.transientNodes,
+          this.nodeToSet.deltaMsgReceivedAt
+        )
+      }
+
       return this.nodeToSet
     }
 

--- a/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/SetNodeByDeltaPathVisitor.ts
@@ -48,7 +48,7 @@ export class SetNodeByDeltaPathVisitor implements AppNodeVisitor<AppNode> {
     // we have an opportunity to set the anchor.
     if (this.nodeToSet instanceof TransientNode && !this.nodeToSet.anchor) {
       return new TransientNode(
-        this.scriptRunId,
+        this.nodeToSet.scriptRunId,
         node,
         this.nodeToSet.transientNodes,
         this.nodeToSet.deltaMsgReceivedAt


### PR DESCRIPTION
## Summary
- Fixes an issue where a `TransientNode` without an anchor would not properly capture the existing `BlockNode` when replacing it at an empty delta path
- This preserves the original block structure so it can be restored when transient elements (like spinners) are cleared
- Mirrors the existing behavior in `visitElementNode`

## Test plan
- [x] Added unit tests for the new behavior in `SetNodeByDeltaPathVisitor.test.ts`
- [x] Added e2e test `test_spinner_with_delayed_container_write` that verifies container content written after a spinner renders appears correctly
- [x] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)