### PR TITLE
[feat] Utilize standardized app_base_url throughout e2e tests

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -51,6 +51,17 @@ Import from `conftest.py`:
   - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
   - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
+## URL Handling (No Localhost Hardcoding)
+
+- In test modules (outside `conftest.py`), never hardcode or construct `http://localhost:{app_port}`.
+- Use `app_base_url` (and `build_app_url`) for navigation, routing, and URL assertions.
+- Build URLs with `build_app_url(app_base_url, path=..., query=..., fragment=...)` to preserve any base path/query and support external app runs.
+- For direct navigation, prefer `page.goto(build_app_url(...))` over string concatenation.
+- For network interception and direct HTTP calls, also build from `app_base_url`:
+  - `page.route(build_app_url(app_base_url, path="/media/**"), handler)`
+  - `page.request.get(build_app_url(app_base_url, path="/_stcore/health"))`
+- Avoid parsing the current URL to “recover” a localhost port (e.g. `urlparse(app.url).port`). If you need a stable base, use `app_base_url` (or `app_target.base_url`).
+
 ## Best Practices
 
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -49,6 +49,17 @@ Import from `conftest.py`:
   - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
   - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
+## URL Handling (No Localhost Hardcoding)
+
+- In test modules (outside `conftest.py`), never hardcode or construct `http://localhost:{app_port}`.
+- Use `app_base_url` (and `build_app_url`) for navigation, routing, and URL assertions.
+- Build URLs with `build_app_url(app_base_url, path=..., query=..., fragment=...)` to preserve any base path/query and support external app runs.
+- For direct navigation, prefer `page.goto(build_app_url(...))` over string concatenation.
+- For network interception and direct HTTP calls, also build from `app_base_url`:
+  - `page.route(build_app_url(app_base_url, path="/media/**"), handler)`
+  - `page.request.get(build_app_url(app_base_url, path="/_stcore/health"))`
+- Avoid parsing the current URL to “recover” a localhost port (e.g. `urlparse(app.url).port`). If you need a stable base, use `app_base_url` (or `app_target.base_url`).
+
 ## Best Practices
 
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -45,6 +45,17 @@ Import from `conftest.py`:
   - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
   - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
+## URL Handling (No Localhost Hardcoding)
+
+- In test modules (outside `conftest.py`), never hardcode or construct `http://localhost:{app_port}`.
+- Use `app_base_url` (and `build_app_url`) for navigation, routing, and URL assertions.
+- Build URLs with `build_app_url(app_base_url, path=..., query=..., fragment=...)` to preserve any base path/query and support external app runs.
+- For direct navigation, prefer `page.goto(build_app_url(...))` over string concatenation.
+- For network interception and direct HTTP calls, also build from `app_base_url`:
+  - `page.route(build_app_url(app_base_url, path="/media/**"), handler)`
+  - `page.request.get(build_app_url(app_base_url, path="/_stcore/health"))`
+- Avoid parsing the current URL to “recover” a localhost port (e.g. `urlparse(app.url).port`). If you need a stable base, use `app_base_url` (or `app_target.base_url`).
+
 ## Best Practices
 
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.

--- a/e2e_playwright/auth_test.py
+++ b/e2e_playwright/auth_test.py
@@ -24,6 +24,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     AsyncSubprocess,
+    build_app_url,
     find_available_port,
     wait_for_app_run,
 )
@@ -34,14 +35,14 @@ if TYPE_CHECKING:
 
 AUTH_SECRETS_TEMPLATE = """
 [auth]
-redirect_uri = "http://localhost:{app_port}/oauth2callback"
+redirect_uri = "{redirect_uri}"
 cookie_secret = "your_cookie_secret_here"
 expose_tokens = ["id", "access"]
 
 [auth.testprovider]
 client_id = "test-client-id"
 client_secret = "test-client-secret"
-server_metadata_url = "http://localhost:{oidc_server_port}/.well-known/openid-configuration"
+server_metadata_url = "{server_metadata_url}"
 """
 
 
@@ -112,11 +113,14 @@ def fake_oidc_server(
 
 
 @pytest.fixture(scope="module")
-def prepare_secrets_file(app_port: int, oidc_server_port: int):
-    """Fixture that inject the correct port to auth_secrets.toml file redirect_uri."""
-    # Read in the file
+def prepare_secrets_file(app_base_url: str, oidc_server_port: int):
+    """Create a temporary auth secrets TOML with correct redirect/provider URLs."""
+    redirect_uri = build_app_url(app_base_url, path="/oauth2callback")
+    server_metadata_url = build_app_url(
+        f"http://localhost:{oidc_server_port}", path="/.well-known/openid-configuration"
+    )
     rendered_secrets = AUTH_SECRETS_TEMPLATE.format(
-        app_port=app_port, oidc_server_port=oidc_server_port
+        redirect_uri=redirect_uri, server_metadata_url=server_metadata_url
     )
     with NamedTemporaryFile(suffix=".toml", delete=False) as tmp_secrets_file:
         tmp_secrets_file.write(rendered_secrets.encode())
@@ -139,7 +143,7 @@ def app_server_extra_args(
 
 
 def _click_and_wait_for_oauth_redirect(
-    app: Page, button_label: str, app_port: int
+    app: Page, button_label: str, app_base_url: str
 ) -> None:
     """Click a button that triggers OAuth redirect and wait for navigation back to app.
 
@@ -148,15 +152,15 @@ def _click_and_wait_for_oauth_redirect(
     """
     get_button(app, button_label).click()
     # Wait for OAuth redirect chain to complete and return to app root
-    app.wait_for_url(f"http://localhost:{app_port}/")
+    app.wait_for_url(build_app_url(app_base_url, path="/"))
     wait_for_app_run(app)
 
 
 @pytest.mark.parametrize("fake_oidc_server", ["success"], indirect=True)
 @pytest.mark.usefixtures("fake_oidc_server", "prepare_secrets_file")
-def test_login_successful(app: Page, app_port: int):
+def test_login_successful(app: Page, app_base_url: str):
     """Test authentication flow with test provider."""
-    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_port)
+    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_base_url)
 
     expect_markdown(app, "authtest@example.com")
 
@@ -168,9 +172,9 @@ def test_login_successful(app: Page, app_port: int):
 
 @pytest.mark.parametrize("fake_oidc_server", ["failure"], indirect=True)
 @pytest.mark.usefixtures("fake_oidc_server", "prepare_secrets_file")
-def test_login_failure(app: Page, app_port: int):
+def test_login_failure(app: Page, app_base_url: str):
     """Test authentication flow with error response from oidc server."""
-    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_port)
+    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_base_url)
 
     text = app.get_by_test_id("stMarkdownContainer").filter(has_text="John Doe")
     expect(text).not_to_be_attached()
@@ -178,20 +182,20 @@ def test_login_failure(app: Page, app_port: int):
 
 @pytest.mark.parametrize("fake_oidc_server", ["success"], indirect=True)
 @pytest.mark.usefixtures("fake_oidc_server", "prepare_secrets_file")
-def test_logout_with_end_session_endpoint(app: Page, app_port: int):
+def test_logout_with_end_session_endpoint(app: Page, app_base_url: str):
     """Test logout flow using OIDC end_session_endpoint.
 
     This tests PR #12693: logout should redirect to provider's end_session_endpoint.
     """
     # First login
-    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_port)
+    _click_and_wait_for_oauth_redirect(app, "TEST LOGIN", app_base_url)
 
     # Verify we're logged in
     expect_markdown(app, "YOU ARE LOGGED IN")
     expect_markdown(app, "John Doe")
 
     # Now logout (also goes through OIDC end_session_endpoint redirect)
-    _click_and_wait_for_oauth_redirect(app, "TEST LOGOUT", app_port)
+    _click_and_wait_for_oauth_redirect(app, "TEST LOGOUT", app_base_url)
 
     # Verify we're logged out
     expect_markdown(app, "NOT LOGGED IN")

--- a/e2e_playwright/basic_app_test.py
+++ b/e2e_playwright/basic_app_test.py
@@ -18,6 +18,7 @@ from typing import Final
 import pytest
 from playwright.sync_api import Page, Response, WebSocket, expect
 
+from e2e_playwright.conftest import build_app_url
 from e2e_playwright.shared.app_utils import goto_app
 
 
@@ -33,7 +34,7 @@ def test_is_webdriver_set(app: Page):
     assert content, "window.navigator.webdriver is set to False"
 
 
-def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
+def test_total_loaded_assets_size_under_threshold(page: Page, app_base_url: str):
     """Test that verifies the total size of loaded web assets is under a
     configured threshold.
     """
@@ -63,7 +64,7 @@ def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
     # Register the response handler
     page.on("response", handle_response)
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, build_app_url(app_base_url, path="/"))
     # Wait until all dependent resources are loaded:
     page.wait_for_load_state()
     # Wait until Hello world is visible:
@@ -85,7 +86,7 @@ def test_total_loaded_assets_size_under_threshold(page: Page, app_port: int):
     reruns=3  # TODO(lukasmasuch): Webkit is a bit flaky here and sometimes transfers
     # more messages than expected (> bytes threshold). Something to investigate at some point.
 )
-def test_check_total_websocket_message_number_and_size(page: Page, app_port: int):
+def test_check_total_websocket_message_number_and_size(page: Page, app_base_url: str):
     """Test that verifies the number and total size of websocket messages
     of the basic app is under a configured threshold.
     """
@@ -136,7 +137,7 @@ def test_check_total_websocket_message_number_and_size(page: Page, app_port: int
     # Register websocket handler
     page.on("websocket", on_web_socket)
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, build_app_url(app_base_url, path="/"))
     # Wait until all dependent resources are loaded:
     page.wait_for_load_state()
     # Wait until Hello world is visible:

--- a/e2e_playwright/compilation_error_dialog_test.py
+++ b/e2e_playwright/compilation_error_dialog_test.py
@@ -14,15 +14,15 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, build_app_url
 
 
 def test_compilation_error_dialog(
-    page: Page, app_port: int, assert_snapshot: ImageCompareFunction
+    page: Page, app_base_url: str, assert_snapshot: ImageCompareFunction
 ):
     # Do the navigation manually because our app fixture waits for the app to run, but
     # with the compilation error the app never runs
-    page.goto(f"http://localhost:{app_port}/")
+    page.goto(build_app_url(app_base_url, path="/"))
     dialog = page.get_by_role("dialog")
     expect(dialog).to_be_visible(timeout=10000)
     # make sure that the close-x button is not focused

--- a/e2e_playwright/config_static_serving_test.py
+++ b/e2e_playwright/config_static_serving_test.py
@@ -14,26 +14,27 @@
 
 from playwright.sync_api import Page, expect
 
+from e2e_playwright.conftest import build_app_url
 from e2e_playwright.shared.app_utils import (
     get_markdown,
     wait_for_all_images_to_be_loaded,
 )
 
 
-def test_should_serve_existing_asset(app: Page, app_port: int):
+def test_should_serve_existing_asset(app: Page, app_base_url: str):
     """Test that the static serving feature serves an existing asset."""
     response = app.request.get(
-        f"http://localhost:{app_port}/app/static/streamlit-logo.png"
+        build_app_url(app_base_url, path="/app/static/streamlit-logo.png")
     )
     expect(response).to_be_ok()
     # Assert is safe here since we don't need to wait for something here:
     assert response.status == 200
 
 
-def test_static_endpoint_has_nosniff_header(app: Page, app_port: int):
+def test_static_endpoint_has_nosniff_header(app: Page, app_base_url: str):
     """Test that static endpoint sets X-Content-Type-Options: nosniff header."""
     response = app.request.get(
-        f"http://localhost:{app_port}/app/static/streamlit-logo.png"
+        build_app_url(app_base_url, path="/app/static/streamlit-logo.png")
     )
     expect(response).to_be_ok()
     nosniff_header = response.headers.get("x-content-type-options")
@@ -42,10 +43,10 @@ def test_static_endpoint_has_nosniff_header(app: Page, app_port: int):
     )
 
 
-def test_should_return_error_on_non_existing_asset(app: Page, app_port: int):
+def test_should_return_error_on_non_existing_asset(app: Page, app_base_url: str):
     """Test that the static serving feature returns error code for non-existing asset."""
     response = app.request.get(
-        f"http://localhost:{app_port}/app/static/notexisting.jpeg"
+        build_app_url(app_base_url, path="/app/static/notexisting.jpeg")
     )
     expect(response).not_to_be_ok()
     # Assert is safe here since we don't need to wait for something here:

--- a/e2e_playwright/custom_components/component_errors_test.py
+++ b/e2e_playwright/custom_components/component_errors_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, Route, expect
 
-from e2e_playwright.conftest import wait_until
+from e2e_playwright.conftest import build_app_url, wait_until
 
 # The timeout value from ComponentInstance.tsx
 COMPONENT_READY_WARNING_TIME_MS = 60000  # 60 seconds
@@ -30,11 +30,12 @@ def handle_component_timeout_failure(route: Route):
     route.abort("failed")
 
 
-def test_component_source_failure(page: Page, app_port: int):
+def test_component_source_failure(page: Page, app_base_url: str):
     """Test that a component source failure is handled correctly."""
     # Ensure custom component source requests return a 404 status
     page.route(
-        f"http://localhost:{app_port}/component/**", handle_component_source_failure
+        build_app_url(app_base_url, path="/component/**"),
+        handle_component_source_failure,
     )
 
     # Capture console messages
@@ -42,7 +43,7 @@ def test_component_source_failure(page: Page, app_port: int):
     page.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    page.goto(f"http://localhost:{app_port}")
+    page.goto(app_base_url)
 
     # Expect the iframe to be attached
     # Use a higher timeout since the goto triggers a rerun which sometimes can take
@@ -60,11 +61,12 @@ def test_component_source_failure(page: Page, app_port: int):
     )
 
 
-def test_component_timeout_failure(page: Page, app_port: int):
+def test_component_timeout_failure(page: Page, app_base_url: str):
     """Test that a component timeout failure is handled correctly."""
     # Ensure custom component requests times out
     page.route(
-        f"http://localhost:{app_port}/component/**", handle_component_timeout_failure
+        build_app_url(app_base_url, path="/component/**"),
+        handle_component_timeout_failure,
     )
 
     # Capture console messages
@@ -72,7 +74,7 @@ def test_component_timeout_failure(page: Page, app_port: int):
     page.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    page.goto(f"http://localhost:{app_port}")
+    page.goto(app_base_url)
 
     # Expect the iframe to be attached
     # Use a higher timeout since the goto triggers a rerun which sometimes can take

--- a/e2e_playwright/forward_msg_cache_test.py
+++ b/e2e_playwright/forward_msg_cache_test.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
+from e2e_playwright.conftest import build_app_url
 from e2e_playwright.shared.app_utils import (
     click_button,
     click_toggle,
@@ -69,9 +70,9 @@ def test_simulate_many_small_messages_performance(app: Page):
     _rerun_app(app, 10)
 
 
-def test_check_total_websocket_message_number_and_size(page: Page, app_port: int):
+def test_check_total_websocket_message_number_and_size(page: Page, app_base_url: str):
     """Test that verifies the number and total size of websocket messages
-    during the simluated forward message cache run is under a configured threshold.
+    during the simulated forward message cache run is under a configured threshold.
     """
 
     # Define an acceptable threshold for total websocket message size (in MB)
@@ -127,7 +128,7 @@ def test_check_total_websocket_message_number_and_size(page: Page, app_port: int
     # Register websocket handler
     page.on("websocket", on_web_socket)
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, build_app_url(app_base_url, path="/"))
     # Wait until all dependent resources are loaded:
     page.wait_for_load_state()
 

--- a/e2e_playwright/host_config_bypass_test.py
+++ b/e2e_playwright/host_config_bypass_test.py
@@ -22,12 +22,18 @@ without waiting for the host-config endpoint response (bypass mode).
 from __future__ import annotations
 
 import json
+from urllib import parse
 
 import pytest
 from playwright.sync_api import Page, Route, WebSocket, expect
 
-from e2e_playwright.conftest import wait_until
+from e2e_playwright.conftest import build_app_url, wait_until
 from e2e_playwright.shared.app_utils import goto_app
+
+
+def _origin_from_url(url: str) -> str:
+    split_url = parse.urlsplit(url)
+    return f"{split_url.scheme}://{split_url.netloc}"
 
 
 def _verify_fullscreen_button(page: Page, *, should_be_visible: bool) -> None:
@@ -59,16 +65,17 @@ def _inject_bypass_config(page: Page, backend_url: str) -> None:
     """Inject minimal host config to enable bypass mode.
 
     Uses default values from routes.py:
-    - allowedOrigins: ["http://localhost"] (default in dev mode)
+    - allowedOrigins: [backend origin]
     - useExternalAuthToken: False (default)
     - metricsUrl: "" (default)
     """
+    backend_origin = _origin_from_url(backend_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
             BACKEND_BASE_URL: "{backend_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"],
+                allowedOrigins: ["{backend_origin}"],
                 useExternalAuthToken: false,
                 metricsUrl: ""
             }}
@@ -78,7 +85,7 @@ def _inject_bypass_config(page: Page, backend_url: str) -> None:
 
 
 def test_bypass_mode_executes_websocket_and_host_config_in_parallel(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that bypass mode executes both WebSocket and host-config requests.
 
@@ -109,10 +116,10 @@ def test_bypass_mode_executes_websocket_and_host_config_in_parallel(
     page.route("**/_stcore/host-config", track_host_config)
 
     # Inject bypass config BEFORE navigation
-    _inject_bypass_config(page, f"http://localhost:{app_port}")
+    _inject_bypass_config(page, app_base_url)
 
     # Navigate to app
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify both WebSocket and host-config were used
     ws_events = [e for e in events if e["type"] == "websocket"]
@@ -124,11 +131,11 @@ def test_bypass_mode_executes_websocket_and_host_config_in_parallel(
     )
 
 
-def test_bypass_mode_app_becomes_interactive(page: Page, app_port: int) -> None:
+def test_bypass_mode_app_becomes_interactive(page: Page, app_base_url: str) -> None:
     """Test that app becomes interactive in bypass mode."""
-    _inject_bypass_config(page, f"http://localhost:{app_port}")
+    _inject_bypass_config(page, app_base_url)
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify app content loaded
     expect(page.get_by_text("Connection status test")).to_be_visible()
@@ -144,7 +151,7 @@ def test_bypass_mode_app_becomes_interactive(page: Page, app_port: int) -> None:
 
 
 def test_bypass_mode_host_config_values_take_precedence(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that window.__streamlit.HOST_CONFIG values override endpoint values.
 
@@ -162,7 +169,7 @@ def test_bypass_mode_host_config_values_take_precedence(
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
                 allowedOrigins: {json.dumps(custom_allowed_origins)},
                 useExternalAuthToken: false,  // False so we don't block on auth token
@@ -172,7 +179,7 @@ def test_bypass_mode_host_config_values_take_precedence(
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # The main verification is that the app loads successfully with custom config
     # If precedence was not working correctly, the app would fail or behave incorrectly
@@ -184,7 +191,7 @@ def test_bypass_mode_host_config_values_take_precedence(
     expect(button).to_be_enabled()
 
 
-def test_default_path_without_bypass_config(page: Page, app_port: int) -> None:
+def test_default_path_without_bypass_config(page: Page, app_base_url: str) -> None:
     """Test default behavior when no bypass config is provided.
 
     Without window.__streamlit config, the app should use the normal path
@@ -211,7 +218,7 @@ def test_default_path_without_bypass_config(page: Page, app_port: int) -> None:
     page.on("websocket", track_websocket)
 
     # Don't inject any window.__streamlit config - use default path
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify both host-config and WebSocket were used
     hc_events = [e for e in events if e["type"] == "host-config-start"]
@@ -239,7 +246,7 @@ def test_default_path_without_bypass_config(page: Page, app_port: int) -> None:
 
 
 def test_bypass_mode_handles_connection_errors_gracefully(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test bypass mode functions by blocking host-config endpoint
     The app should still load because we bypass the endpoints to establish
@@ -263,10 +270,10 @@ def test_bypass_mode_handles_connection_errors_gracefully(
     page.route("**/_stcore/host-config", block_host_config)
 
     # Inject bypass config BEFORE navigation
-    _inject_bypass_config(page, f"http://localhost:{app_port}")
+    _inject_bypass_config(page, app_base_url)
 
     # Navigate to app
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify WebSocket connected despite host-config being blocked
     assert ws_connected["connected"], (
@@ -291,7 +298,7 @@ def test_bypass_mode_handles_connection_errors_gracefully(
     )
 
 
-def test_bypass_requires_all_minimal_fields(page: Page, app_port: int) -> None:
+def test_bypass_requires_all_minimal_fields(page: Page, app_base_url: str) -> None:
     """Test that bypass mode requires all minimal fields to be present.
 
     Missing any of: BACKEND_BASE_URL, allowedOrigins, or useExternalAuthToken
@@ -313,19 +320,20 @@ def test_bypass_requires_all_minimal_fields(page: Page, app_port: int) -> None:
     page.on("websocket", track_websocket)
 
     # Test with missing useExternalAuthToken (incomplete config)
+    app_origin = _origin_from_url(app_base_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"]
+                allowedOrigins: ["{app_origin}"]
                 // Missing useExternalAuthToken - should NOT enable bypass
             }}
         }}
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify default path was used (host-config before WebSocket)
     hc_events = [e for e in events if e["type"] == "host-config-start"]
@@ -346,7 +354,9 @@ def test_bypass_requires_all_minimal_fields(page: Page, app_port: int) -> None:
     expect(page.get_by_text("Connection status test")).to_be_visible()
 
 
-def test_bypass_requires_non_empty_allowed_origins(page: Page, app_port: int) -> None:
+def test_bypass_requires_non_empty_allowed_origins(
+    page: Page, app_base_url: str
+) -> None:
     """Test that bypass mode requires allowedOrigins to be non-empty."""
     # Track order of events to verify default path is used
     events = []
@@ -365,7 +375,7 @@ def test_bypass_requires_non_empty_allowed_origins(page: Page, app_port: int) ->
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
                 allowedOrigins: [],  // Empty array should NOT enable bypass
                 useExternalAuthToken: false
@@ -374,7 +384,7 @@ def test_bypass_requires_non_empty_allowed_origins(page: Page, app_port: int) ->
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Verify default path was used (host-config before WebSocket)
     hc_events = [e for e in events if e["type"] == "host-config-start"]
@@ -396,19 +406,20 @@ def test_bypass_requires_non_empty_allowed_origins(page: Page, app_port: int) ->
 
 
 def test_disable_fullscreen_mode_via_window_in_bypass(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that disableFullscreenMode can be set via window config in bypass mode.
 
     When disableFullscreenMode is true, the fullscreen button should NOT be visible
     in the dataframe toolbar.
     """
+    app_origin = _origin_from_url(app_base_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"],
+                allowedOrigins: ["{app_origin}"],
                 useExternalAuthToken: false,
                 disableFullscreenMode: true
             }}
@@ -416,13 +427,13 @@ def test_disable_fullscreen_mode_via_window_in_bypass(
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     _verify_fullscreen_button(page, should_be_visible=False)
 
 
 def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_in_bypass(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that window config takes precedence over endpoint for disableFullscreenMode in bypass.
 
@@ -441,12 +452,13 @@ def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_in_bypass
     page.route("**/_stcore/host-config", modify_host_config)
 
     # Window config sets disableFullscreenMode: false (should take precedence)
+    app_origin = _origin_from_url(app_base_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"],
+                allowedOrigins: ["{app_origin}"],
                 useExternalAuthToken: false,
                 disableFullscreenMode: false
             }}
@@ -454,13 +466,13 @@ def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_in_bypass
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     _verify_fullscreen_button(page, should_be_visible=True)
 
 
 def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_without_bypass(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that window config takes precedence over endpoint for disableFullscreenMode without bypass.
 
@@ -486,7 +498,7 @@ def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_without_b
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
                 disableFullscreenMode: false
             }}
@@ -494,25 +506,26 @@ def test_disable_fullscreen_mode_window_takes_precedence_over_endpoint_without_b
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     _verify_fullscreen_button(page, should_be_visible=True)
 
 
 def test_block_error_dialogs_via_window_config_bypass(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ) -> None:
     """Test that blockErrorDialogs can be set via window config in bypass mode.
 
     When blockErrorDialogs is true, error dialogs should not be shown.
     Instead, errors are sent to the host via postMessage.
     """
+    app_origin = _origin_from_url(app_base_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"],
+                allowedOrigins: ["{app_origin}"],
                 useExternalAuthToken: false,
                 blockErrorDialogs: true
             }}
@@ -521,7 +534,7 @@ def test_block_error_dialogs_via_window_config_bypass(
     )
 
     # Initial load of page
-    goto_app(page, f"http://localhost:{app_port}")
+    goto_app(page, app_base_url)
 
     # Verify app loaded
     expect(page.get_by_text("Connection status test")).to_be_visible()
@@ -531,7 +544,7 @@ def test_block_error_dialogs_via_window_config_bypass(
     page.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to a non-existent page to trigger page not found error
-    page.goto(f"http://localhost:{app_port}/nonexistent_page")
+    page.goto(build_app_url(app_base_url, path="/nonexistent_page"))
 
     # Wait until the expected error is logged
     wait_until(
@@ -548,7 +561,7 @@ def test_block_error_dialogs_via_window_config_bypass(
 
 # Firefox doesn't render pydeck charts properly in CI, so no Mapbox API requests are made
 @pytest.mark.skip_browser("firefox")
-def test_mapbox_token_via_window_config_bypass(page: Page, app_port: int) -> None:
+def test_mapbox_token_via_window_config_bypass(page: Page, app_base_url: str) -> None:
     """Test that mapboxToken from window config is used in Mapbox API requests.
 
     The app contains a pydeck chart with explicit Mapbox style (mapbox://styles/mapbox/light-v9).
@@ -566,12 +579,13 @@ def test_mapbox_token_via_window_config_bypass(page: Page, app_port: int) -> Non
 
     page.route("**/api.mapbox.com/**", track_mapbox_request)
 
+    app_origin = _origin_from_url(app_base_url)
     page.add_init_script(
         f"""
         window.__streamlit = {{
-            BACKEND_BASE_URL: "http://localhost:{app_port}",
+            BACKEND_BASE_URL: "{app_base_url}",
             HOST_CONFIG: {{
-                allowedOrigins: ["http://localhost"],
+                allowedOrigins: ["{app_origin}"],
                 useExternalAuthToken: false,
                 mapboxToken: "{test_token}"
             }}
@@ -579,7 +593,7 @@ def test_mapbox_token_via_window_config_bypass(page: Page, app_port: int) -> Non
     """
     )
 
-    goto_app(page, f"http://localhost:{app_port}/")
+    goto_app(page, app_base_url)
 
     # Wait for the pydeck chart to be visible (it uses Mapbox style)
     expect(page.get_by_text("Mapbox token test")).to_be_visible()

--- a/e2e_playwright/host_config_test.py
+++ b/e2e_playwright/host_config_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, Route, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_until,
 )
 from e2e_playwright.shared.app_utils import goto_app
@@ -35,14 +36,14 @@ def handle_route_hostconfig_disable_fullscreen_and_error_dialogs(route: Route) -
 
 
 def test_disable_fullscreen(
-    page: Page, app_port: int, assert_snapshot: ImageCompareFunction
+    page: Page, app_base_url: str, assert_snapshot: ImageCompareFunction
 ):
     """Test that fullscreen mode is disabled for elements when set via host-config."""
     page.route(
         "**/_stcore/host-config",
         handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
     )
-    goto_app(page, f"http://localhost:{app_port}")
+    goto_app(page, app_base_url)
 
     # Test that the toolbar is not shown when hovering over a dataframe
     dataframe_element = page.get_by_test_id("stDataFrame").nth(0)
@@ -61,23 +62,23 @@ def test_disable_fullscreen(
     )
 
 
-def test_block_error_dialogs(page: Page, app_port: int):
+def test_block_error_dialogs(page: Page, app_base_url: str):
     """Test that error dialogs are blocked and sent to host when set via host-config."""
     # Need to be more specific about the route to allow for successful redirect
     page.route(
-        f"http://localhost:{app_port}/_stcore/host-config",
+        build_app_url(app_base_url, path="/_stcore/host-config"),
         handle_route_hostconfig_disable_fullscreen_and_error_dialogs,
     )
 
     # Initial load of page
-    goto_app(page, f"http://localhost:{app_port}")
+    goto_app(page, app_base_url)
 
     # Capture console messages
     messages = []
     page.on("console", lambda msg: messages.append(msg))
 
     # Navigate to a non-existent page to trigger page not found error
-    page.goto(f"http://localhost:{app_port}/nonexistent_page")
+    page.goto(build_app_url(app_base_url, path="/nonexistent_page"))
 
     # Wait until the expected error is logged - console should include 2 404 errors
     # (health & host-config) then the page not found error

--- a/e2e_playwright/hostframe_app_test.py
+++ b/e2e_playwright/hostframe_app_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Final
+from urllib import parse
 
 import pytest
 from playwright.sync_api import FilePayload, FrameLocator, Locator, Route, expect
@@ -24,6 +25,7 @@ from e2e_playwright.conftest import (
     IframedPage,
     IframedPageAttrs,
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_run,
     wait_until,
 )
@@ -49,7 +51,8 @@ def _load_html_and_get_locators(
     def fulfill_host_config_request(route: Route):
         response = route.fetch()
         result = response.json()
-        result["allowedOrigins"] = ["http://localhost"]
+        split_url = parse.urlsplit(page.url)
+        result["allowedOrigins"] = [f"{split_url.scheme}://{split_url.netloc}"]
         route.fulfill(json=result)
 
     page.route("**/_stcore/host-config", fulfill_host_config_request)
@@ -76,6 +79,14 @@ def _open_embed(iframed_app: IframedPage) -> FrameLocator:
     )
     wait_for_app_run(frame_locator)
     return frame_locator
+
+
+def test_iframed_app_loads_with_hostframe_html(iframed_app: IframedPage):
+    frame_locator: FrameLocator = iframed_app.open_app(
+        IframedPageAttrs(html_content=HOSTFRAME_TEST_HTML)
+    )
+    wait_for_app_run(frame_locator)
+    expect(frame_locator.get_by_test_id("stAppViewContainer")).to_be_attached()
 
 
 def _check_widgets_and_sidebar_nav_links_disabled(frame_locator: FrameLocator):
@@ -148,7 +159,9 @@ def test_handles_host_theme_message(
     )
 
 
-def test_handles_set_file_upload_client_config_message(iframed_app: IframedPage):
+def test_handles_set_file_upload_client_config_message(
+    iframed_app: IframedPage, app_base_url: str
+):
     frame_locator, toolbar_buttons = _load_html_and_get_locators(iframed_app)
 
     file_name1 = "file1.txt"
@@ -180,8 +193,14 @@ def test_handles_set_file_upload_client_config_message(iframed_app: IframedPage)
     response = r.value.response()
     assert response is not None
     assert response.status == 204  # Upload successful
-    assert url.startswith("http://localhost")
-    assert "_stcore/upload_file" in url
+    expected_upload_base = build_app_url(app_base_url, path="/_stcore/upload_file/")
+    expected_split = parse.urlsplit(expected_upload_base)
+    actual_split = parse.urlsplit(url)
+    assert (actual_split.scheme, actual_split.netloc) == (
+        expected_split.scheme,
+        expected_split.netloc,
+    )
+    assert actual_split.path.startswith(expected_split.path)
     assert "header1" not in headers
 
     wait_for_app_run(frame_locator, wait_delay=500)
@@ -234,14 +253,14 @@ def test_handles_host_rerun_script_message(iframed_app: IframedPage):
 
 
 def test_context_url_is_correct_when_hosted_in_iframe(
-    iframed_app: IframedPage, app_port: int
+    iframed_app: IframedPage, app_base_url: str
 ):
     frame_locator, _ = _load_html_and_get_locators(iframed_app)
 
     frame_locator.get_by_test_id("stExpander").locator(
         EXPANDER_HEADER_IDENTIFIER
     ).click()
-    expect_prefixed_markdown(frame_locator, "Full url:", f"http://localhost:{app_port}")
+    expect_prefixed_markdown(frame_locator, "Full url:", app_base_url)
 
 
 @pytest.mark.skip(

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -58,7 +58,7 @@ def is_expected_error(
     # TODO(lukasmasuch): Investigate why webkit is running into this blob: issue:
     return bool(
         msg.text == "Failed to load resource"
-        and "blob:http://localhost:" in msg.location["url"]
+        and re.match(r"blob:https?://", msg.location["url"]) is not None
         and browser_name == "webkit"
         and uses_csp
     )

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -48,9 +49,9 @@ def test_can_switch_between_pages_by_clicking_on_sidebar_links(app: Page):
     expect(app.get_by_test_id("stHeading")).to_contain_text("Page 2")
 
 
-def test_supports_navigating_to_page_directly_via_url(page: Page, app_port: int):
+def test_supports_navigating_to_page_directly_via_url(page: Page, app_base_url: str):
     """Test that we can navigate to a page directly via URL."""
-    goto_app(page, f"http://localhost:{app_port}/page2")
+    goto_app(page, build_app_url(app_base_url, path="/page2"))
 
     expect(page.get_by_test_id("stHeading")).to_contain_text("Page 2")
 
@@ -89,27 +90,27 @@ def test_can_switch_to_the_first_page_with_a_duplicate_name(app: Page):
 
 
 def test_runs_the_first_page_with_a_duplicate_name_if_navigating_via_url(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ):
     """Test that we run the first page with a duplicate name if navigating via URL."""
-    goto_app(page, f"http://localhost:{app_port}/page_with_duplicate_name")
+    goto_app(page, build_app_url(app_base_url, path="/page_with_duplicate_name"))
 
     expect(page.get_by_test_id("stHeading")).to_contain_text("Page 4")
 
 
-def test_show_not_found_dialog(page: Page, app_port: int):
+def test_show_not_found_dialog(page: Page, app_base_url: str):
     """Test that we show a not found dialog if the page doesn't exist."""
-    goto_app(page, f"http://localhost:{app_port}/not_a_page")
+    goto_app(page, build_app_url(app_base_url, path="/not_a_page"))
 
     expect(page.locator('[role="dialog"]')).to_contain_text("Page not found")
 
 
 def test_handles_expand_collapse_of_mpa_nav_correctly(
-    page: Page, app_port: int, assert_snapshot: ImageCompareFunction
+    page: Page, app_base_url: str, assert_snapshot: ImageCompareFunction
 ):
     """Test that we handle expand/collapse of MPA nav correctly."""
 
-    goto_app(page, f"http://localhost:{app_port}/page_7")
+    goto_app(page, build_app_url(app_base_url, path="/page_7"))
 
     view_button = page.get_by_test_id("stSidebarNavViewButton")
 
@@ -164,13 +165,15 @@ def test_switch_page(app: Page):
     expect(app.get_by_test_id("stHeading")).to_contain_text("Main Page")
 
 
-def test_switch_page_preserves_embed_params(page: Page, app_port: int):
+def test_switch_page_preserves_embed_params(page: Page, app_base_url: str):
     """Test that st.switch_page only preserves embed params."""
 
     # Start at main page with embed & other query params
     goto_app(
         page,
-        f"http://localhost:{app_port}/?embed=true&embed_options=light_theme&bar=foo",
+        build_app_url(
+            app_base_url, query="embed=true&embed_options=light_theme&bar=foo"
+        ),
     )
     expect(page.get_by_test_id("stJson")).to_contain_text('{"bar":"foo"}')
 
@@ -180,22 +183,24 @@ def test_switch_page_preserves_embed_params(page: Page, app_port: int):
 
     # Check that only embed query params persist
     expect(page).to_have_url(
-        f"http://localhost:{app_port}/page2?embed=true&embed_options=light_theme"
+        build_app_url(
+            app_base_url, path="/page2", query="embed=true&embed_options=light_theme"
+        )
     )
     expect(page.get_by_test_id("stJson")).not_to_contain_text('{"bar":"foo"}')
 
 
-def test_switch_page_removes_query_params(page: Page, app_port: int):
+def test_switch_page_removes_query_params(page: Page, app_base_url: str):
     """Test that query params are removed when navigating via st.switch_page."""
 
     # Start at main page with query params
-    goto_app(page, f"http://localhost:{app_port}/?foo=bar")
+    goto_app(page, build_app_url(app_base_url, query="foo=bar"))
 
     # Trigger st.switch_page
     page.get_by_test_id("stButton").nth(0).locator("button").first.click()
     wait_for_app_loaded(page)
     # Check that query params don't persist
-    expect(page).to_have_url(f"http://localhost:{app_port}/page2")
+    expect(page).to_have_url(build_app_url(app_base_url, path="/page2"))
 
 
 def test_switch_page_switches_immediately_if_second_page_is_slow(app: Page):
@@ -249,29 +254,39 @@ def test_widget_state_reset_on_page_switch(app: Page):
     expect(app.get_by_test_id("stMarkdown")).to_contain_text("x is 0")
 
 
-def test_removes_query_params_when_swapping_pages(page: Page, app_port: int):
+def test_removes_query_params_when_swapping_pages(page: Page, app_base_url: str):
     """Test that query params are removed when swapping pages."""
 
-    goto_app(page, f"http://localhost:{app_port}/page_7?foo=bar")
+    goto_app(page, build_app_url(app_base_url, path="/page_7", query="foo=bar"))
 
     page.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
     wait_for_app_loaded(page)
-    expect(page).to_have_url(f"http://localhost:{app_port}/page3")
+    expect(page).to_have_url(build_app_url(app_base_url, path="/page3"))
 
 
-def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port: int):
+def test_removes_non_embed_query_params_when_swapping_pages(
+    page: Page, app_base_url: str
+):
     """Test that query params are removed when swapping pages."""
 
     goto_app(
         page,
-        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line",
+        build_app_url(
+            app_base_url,
+            path="/page_7",
+            query="foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line",
+        ),
     )
 
     page.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
     wait_for_app_loaded(page)
 
     expect(page).to_have_url(
-        f"http://localhost:{app_port}/page3?embed=true&embed_options=show_toolbar&embed_options=show_colored_line"
+        build_app_url(
+            app_base_url,
+            path="/page3",
+            query="embed=true&embed_options=show_toolbar&embed_options=show_colored_line",
+        )
     )
 
 

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_basics_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
     wait_until,
@@ -134,29 +135,31 @@ def test_main_script_widgets_persist_across_page_changes(app: Page):
     expect(app.get_by_test_id("stMarkdown").nth(0)).to_contain_text("x is 1")
 
 
-def test_context_url(app: Page, app_port: int):
+def test_context_url(app: Page, app_base_url: str):
     """Test that the page url_path is correct."""
 
-    expected_url = f"http://localhost:{app_port}"
+    expected_url = build_app_url(app_base_url)
     expect_prefixed_markdown(app, "Context URL:", expected_url)
 
     get_page_link(app, "Different Title").click()
     wait_for_app_run(app)
-    new_expected_url = f"http://localhost:{app_port}/page_3"
+    new_expected_url = build_app_url(app_base_url, path="/page_3")
     expect_prefixed_markdown(app, "Context URL:", new_expected_url)
 
 
-def test_supports_navigating_to_page_directly_via_url(app: Page, app_port: int):
+def test_supports_navigating_to_page_directly_via_url(app: Page, app_base_url: str):
     """Test that we can navigate to a page directly via URL."""
-    goto_app(app, f"http://localhost:{app_port}/page_5")
+    goto_app(app, build_app_url(app_base_url, path="/page_5"))
 
     expect(page_heading(app)).to_contain_text("Page 5")
 
 
-def test_supports_navigating_to_page_directly_via_url_path(app: Page, app_port: int):
+def test_supports_navigating_to_page_directly_via_url_path(
+    app: Page, app_base_url: str
+):
     """Test that we can navigate to a page directly via URL. using the url_path."""
-    goto_app(app, f"http://localhost:{app_port}/my_url_path")
-    expect(app).to_have_url(f"http://localhost:{app_port}/my_url_path")
+    goto_app(app, build_app_url(app_base_url, path="/my_url_path"))
+    expect(app).to_have_url(build_app_url(app_base_url, path="/my_url_path"))
     expect(page_heading(app)).to_contain_text("Page 8")
 
 
@@ -196,9 +199,9 @@ def test_dynamic_pages(themed_app: Page, assert_snapshot: ImageCompareFunction):
     assert_snapshot(nav, name="dynamic-pages")
 
 
-def test_show_not_found_dialog(app: Page, app_port: int):
+def test_show_not_found_dialog(app: Page, app_base_url: str):
     """Test that we show a not found dialog if the page doesn't exist."""
-    goto_app(app, f"http://localhost:{app_port}/not_a_page")
+    goto_app(app, build_app_url(app_base_url, path="/not_a_page"))
 
     expect(app.locator('[role="dialog"]')).to_contain_text("Page not found")
 
@@ -318,7 +321,7 @@ def test_handles_expanded_navigation_parameter_correctly(app: Page):
     expect(links).to_have_count(13)
 
 
-def test_preserves_navigation_expansion_user_preference(app: Page, app_port: int):
+def test_preserves_navigation_expansion_user_preference(app: Page, app_base_url: str):
     """Test that the navigation expansion state is preserved across page changes."""
     click_checkbox(app, "Show sidebar elements")
     wait_for_app_run(app)
@@ -339,7 +342,7 @@ def test_preserves_navigation_expansion_user_preference(app: Page, app_port: int
     expect(links).to_have_count(13)
 
     # Reload the page and ensure elements are in the sidebar
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     click_checkbox(app, "Show sidebar elements")
     wait_for_app_run(app)
@@ -360,7 +363,7 @@ def test_preserves_navigation_expansion_user_preference(app: Page, app_port: int
     expect(links).to_have_count(10)
 
     # Reload the page and ensure elements are in the sidebar
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     click_checkbox(app, "Show sidebar elements")
     wait_for_app_run(app)
@@ -386,67 +389,87 @@ def test_switch_page_by_st_page(app: Page):
     expect(page_heading(app)).to_contain_text("Page 9")
 
 
-def test_removes_query_params_with_st_switch_page(app: Page, app_port: int):
+def test_removes_query_params_with_st_switch_page(app: Page, app_base_url: str):
     """Test that query params are removed when navigating via st.switch_page."""
 
     # Start at main page with query params
-    goto_app(app, f"http://localhost:{app_port}/?foo=bar")
-    expect(app).to_have_url(f"http://localhost:{app_port}/?foo=bar")
+    goto_app(app, build_app_url(app_base_url, query="foo=bar"))
+    expect(app).to_have_url(build_app_url(app_base_url, query="foo=bar"))
 
     # Trigger st.switch_page
     click_button(app, "page 5")
 
     # Check that query params don't persist
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_5")
+    expect(app).to_have_url(build_app_url(app_base_url, path="/page_5"))
 
 
-def test_switch_page_with_query_params(app: Page, app_port: int):
+def test_switch_page_with_query_params(app: Page, app_base_url: str):
     """Test that st.switch_page applies provided query params."""
 
     click_button(app, "Navigate with query params")
 
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_5?team=streamlit")
+    expect(app).to_have_url(
+        build_app_url(app_base_url, path="/page_5", query="team=streamlit")
+    )
     expect_prefixed_markdown(app, "Query Params:", "{'team': 'streamlit'}")
 
 
-def test_removes_query_params_when_clicking_link(app: Page, app_port: int):
+def test_removes_query_params_when_clicking_link(app: Page, app_base_url: str):
     """Test that query params are removed when swapping pages by clicking on a link."""
 
-    goto_app(app, f"http://localhost:{app_port}/page_7?foo=bar")
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_7?foo=bar")
+    goto_app(app, build_app_url(app_base_url, path="/page_7", query="foo=bar"))
+    expect(app).to_have_url(
+        build_app_url(app_base_url, path="/page_7", query="foo=bar")
+    )
 
     get_page_link(app, "page 4").click()
     wait_for_app_loaded(app)
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_4")
+    expect(app).to_have_url(build_app_url(app_base_url, path="/page_4"))
 
 
-def test_removes_non_embed_query_params_when_swapping_pages(app: Page, app_port: int):
+def test_removes_non_embed_query_params_when_swapping_pages(
+    app: Page, app_base_url: str
+):
     """Test that non-embed query params are removed when swapping pages."""
 
     goto_app(
         app,
-        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line",
+        build_app_url(
+            app_base_url,
+            path="/page_7",
+            query="foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line",
+        ),
     )
     expect(app).to_have_url(
-        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line"
+        build_app_url(
+            app_base_url,
+            path="/page_7",
+            query="foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line",
+        )
     )
 
     get_page_link(app, "page 4").click()
     wait_for_app_loaded(app)
 
     expect(app).to_have_url(
-        f"http://localhost:{app_port}/page_4?embed=true&embed_options=show_toolbar&embed_options=show_colored_line"
+        build_app_url(
+            app_base_url,
+            path="/page_4",
+            query="embed=true&embed_options=show_toolbar&embed_options=show_colored_line",
+        )
     )
 
 
-def test_preserves_query_params_on_browser_back_navigation(app: Page, app_port: int):
+def test_preserves_query_params_on_browser_back_navigation(
+    app: Page, app_base_url: str
+):
     """Test that query params are preserved on first script run after browser back button.
 
     Regression test for https://github.com/streamlit/streamlit/issues/9279
     """
     # Navigate to main page with query params
-    goto_app(app, f"http://localhost:{app_port}/?mykey=myvalue")
-    expect(app).to_have_url(f"http://localhost:{app_port}/?mykey=myvalue")
+    goto_app(app, build_app_url(app_base_url, query="mykey=myvalue"))
+    expect(app).to_have_url(build_app_url(app_base_url, query="mykey=myvalue"))
 
     # Verify query params are displayed
     expect_prefixed_markdown(app, "Query Params:", "{'mykey': 'myvalue'}")
@@ -454,14 +477,14 @@ def test_preserves_query_params_on_browser_back_navigation(app: Page, app_port: 
     # Navigate to another page via sidebar (this clears query params)
     get_page_link(app, "page 4").click()
     wait_for_app_loaded(app)
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_4")
+    expect(app).to_have_url(build_app_url(app_base_url, path="/page_4"))
 
     # Use browser back button to return to main page with query params
     app.go_back()
     wait_for_app_loaded(app)
 
     # Verify query params are preserved on the first script run after back navigation
-    expect(app).to_have_url(f"http://localhost:{app_port}/?mykey=myvalue")
+    expect(app).to_have_url(build_app_url(app_base_url, query="mykey=myvalue"))
     expect_prefixed_markdown(app, "Query Params:", "{'mykey': 'myvalue'}")
 
 
@@ -515,7 +538,7 @@ def test_page_link_with_st_file(app: Page):
     expect(page_heading(app)).to_contain_text("Page 9")
 
 
-def test_page_link_with_query_params(app: Page, app_port: int):
+def test_page_link_with_query_params(app: Page, app_base_url: str):
     """Test st.page_link with query params works."""
 
     page_link = app.get_by_test_id("stPageLink-NavLink").filter(
@@ -528,7 +551,9 @@ def test_page_link_with_query_params(app: Page, app_port: int):
     wait_for_app_loaded(app)
 
     expect(page_heading(app)).to_contain_text("Page 9")
-    expect(app).to_have_url(f"http://localhost:{app_port}/page_9?foo=bar&baz=1&baz=2")
+    expect(app).to_have_url(
+        build_app_url(app_base_url, path="/page_9", query="foo=bar&baz=1&baz=2")
+    )
     expect_prefixed_markdown(app, "Query Params:", "{'foo': 'bar', 'baz': ['1', '2']}")
 
 
@@ -546,25 +571,27 @@ def test_hidden_navigation(app: Page):
     expect(nav_exists).not_to_be_attached()
 
 
-def test_set_default_navigation(app: Page, app_port: int):
+def test_set_default_navigation(app: Page, app_base_url: str):
     """Test the default page set will be shown on initial load."""
 
     expect(page_heading(app)).to_contain_text("Page 2")
     wait_for_app_run(app)
 
-    goto_app(app, f"http://localhost:{app_port}/?default=True")
+    goto_app(app, build_app_url(app_base_url, query="default=True"))
 
     expect(page_heading(app)).to_contain_text("Page 7")
 
 
-def test_page_url_path_appears_in_url(app: Page, app_port: int):
+def test_page_url_path_appears_in_url(app: Page, app_base_url: str):
     """Test that st.Page's url_path is included in the URL."""
     link = get_page_link(app, "page 8")
 
-    expect(link).to_have_attribute("href", f"http://localhost:{app_port}/my_url_path")
+    expect(link).to_have_attribute(
+        "href", build_app_url(app_base_url, path="/my_url_path")
+    )
     link.click()
     wait_for_app_loaded(app)
-    expect(app).to_have_url(f"http://localhost:{app_port}/my_url_path")
+    expect(app).to_have_url(build_app_url(app_base_url, path="/my_url_path"))
 
 
 def test_sidebar_mixed_empty_and_named_sections(app: Page):
@@ -777,10 +804,10 @@ def test_sidebar_interaction_performance(app: Page):
         option.hover()
 
 
-def test_logo_source_errors(app: Page, app_port: int):
+def test_logo_source_errors(app: Page, app_base_url: str):
     """Test that logo source errors are logged."""
     app.route(
-        f"http://localhost:{app_port}/media/**",
+        build_app_url(app_base_url, path="/media/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -791,7 +818,7 @@ def test_logo_source_errors(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     wait_until(

--- a/e2e_playwright/st_audio_test.py
+++ b/e2e_playwright/st_audio_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_until,
 )
 from e2e_playwright.shared.app_utils import (
@@ -179,7 +180,7 @@ def test_audio_uses_unified_height(
 
 # TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
 @pytest.mark.only_browser("chromium")
-def test_audio_source_error_with_url(app: Page, app_port: int):
+def test_audio_source_error_with_url(app: Page, app_base_url: str):
     """Test `st.audio` source error when data is a url."""
     # Ensure audio source request return a 404 status
     app.route(
@@ -194,7 +195,7 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with url
@@ -205,11 +206,11 @@ def test_audio_source_error_with_url(app: Page, app_port: int):
 
 # TODO(mgbarnes): Figure out why this test is flaky on firefox & webkit.
 @pytest.mark.only_browser("chromium")
-def test_audio_source_error_with_path(app: Page, app_port: int):
+def test_audio_source_error_with_path(app: Page, app_base_url: str):
     """Test `st.audio` source error when data is path (media endpoint)."""
     # Ensure audio source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/media/**",
+        build_app_url(app_base_url, path="/media/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -220,7 +221,7 @@ def test_audio_source_error_with_path(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     # Wait until the expected errors are logged, indicating CLIENT_ERROR was sent
     # Should be 3 instances of the error, one for each audio element with path

--- a/e2e_playwright/st_chat_input_test.py
+++ b/e2e_playwright/st_chat_input_test.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from functools import wraps
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunsplit
 
 import pytest
 from playwright.sync_api import Error, FilePayload, Locator, Page, expect
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     rerun_app,
     wait_for_app_loaded,
     wait_for_app_run,
@@ -95,11 +96,8 @@ def use_chat_input(key: str) -> Callable[[Callable[..., Any]], Callable[..., Any
 
 def goto_chat_input(app: Page, key: str) -> None:
     """Navigate to a specific chat input using query params."""
-    # Extract port and existing query params from current URL
+    # Parse the current URL so we can preserve existing query params and rebuild it
     parsed = urlparse(app.url)
-
-    if parsed.port is None:
-        raise ValueError(f"Could not parse port from URL: {app.url}")
 
     # Preserve existing query parameters (especially theme-related ones like embed_options)
     existing_params = parse_qs(parsed.query)
@@ -108,8 +106,9 @@ def goto_chat_input(app: Page, key: str) -> None:
     # Set/override the key parameter
     params["key"] = key
 
+    base_url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
     query_string = urlencode(params)
-    app.goto(f"http://localhost:{parsed.port}/?{query_string}")
+    app.goto(build_app_url(base_url, query=query_string))
     wait_for_app_loaded(app)
 
 
@@ -368,7 +367,7 @@ def test_max_characters_enforced(
 
 def test_embedded_app_with_bottom_chat_input(
     themed_app: Page,
-    app_port: int,
+    app_base_url: str,
     app_theme: str,
     assert_snapshot: ImageCompareFunction,
 ):
@@ -377,7 +376,14 @@ def test_embedded_app_with_bottom_chat_input(
 
     goto_app(
         themed_app,
-        f"http://localhost:{app_port}/?key=bottom_max_chars&embed=true&embed_options={app_theme}",
+        build_app_url(
+            app_base_url,
+            query={
+                "key": "bottom_max_chars",
+                "embed": "true",
+                "embed_options": app_theme,
+            },
+        ),
     )
 
     app_view_block = themed_app.get_by_test_id("stMainBlockContainer")

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -212,9 +213,9 @@ def test_dynamic_checkbox_props(app: Page, assert_snapshot: ImageCompareFunction
     expect_prefixed_markdown(app, "Updated checkbox state:", "False")
 
 
-def test_checkbox_query_param_seeding(page: Page, app_port: int):
+def test_checkbox_query_param_seeding(page: Page, app_base_url: str):
     """Test that checkbox value can be seeded from URL query params."""
-    page.goto(f"http://localhost:{app_port}/?bound_checkbox=true")
+    page.goto(build_app_url(app_base_url, query={"bound_checkbox": "true"}))
     wait_for_app_loaded(page)
 
     expect_prefixed_markdown(page, "bound checkbox value:", "True")
@@ -241,10 +242,10 @@ def test_checkbox_query_param_updates_url(app: Page):
     expect(app).not_to_have_url(re.compile(r"bound_checkbox"))
 
 
-def test_checkbox_query_param_default_true(page: Page, app_port: int):
+def test_checkbox_query_param_default_true(page: Page, app_base_url: str):
     """Test checkbox with default True: seeding and param removal."""
     # Load app with query param overriding the True default
-    page.goto(f"http://localhost:{app_port}/?bound_true=false")
+    page.goto(build_app_url(app_base_url, query={"bound_true": "false"}))
     wait_for_app_loaded(page)
 
     # Checkbox should be unchecked (overriding True default)
@@ -258,9 +259,9 @@ def test_checkbox_query_param_default_true(page: Page, app_port: int):
     expect(page).not_to_have_url(re.compile(r"bound_true"))
 
 
-def test_checkbox_query_param_invalid_value(page: Page, app_port: int):
+def test_checkbox_query_param_invalid_value(page: Page, app_base_url: str):
     """Test that invalid URL values are cleared and widget uses default."""
-    page.goto(f"http://localhost:{app_port}/?bound_checkbox=invalid")
+    page.goto(build_app_url(app_base_url, query={"bound_checkbox": "invalid"}))
     wait_for_app_loaded(page)
 
     # Checkbox should use default (False), and invalid param should be cleared

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -19,6 +19,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -199,10 +200,10 @@ def test_typing_new_hsl_color_on_color_picker_works(
     assert_snapshot(default_picker, name="st_color_picker-typed_new_hsl_color")
 
 
-def test_color_picker_query_param_seeding(page: Page, app_port: int):
+def test_color_picker_query_param_seeding(page: Page, app_base_url: str):
     """Test that color picker value can be seeded from URL query params."""
     # Load app with query param set (URL-encoded # is %23)
-    page.goto(f"http://localhost:{app_port}/?bound_color=%23FF5733")
+    page.goto(build_app_url(app_base_url, query={"bound_color": "#FF5733"}))
     wait_for_app_loaded(page)
 
     # Color picker should show the seeded color (displayed uppercase)
@@ -240,10 +241,10 @@ def test_color_picker_query_param_updates_url(app: Page):
     expect_prefixed_markdown(app, "bound color value:", "#000000")
 
 
-def test_color_picker_query_param_default_custom(page: Page, app_port: int):
+def test_color_picker_query_param_default_custom(page: Page, app_base_url: str):
     """Test color picker with custom default: seeding and param removal."""
     # Load app with query param overriding the red default
-    page.goto(f"http://localhost:{app_port}/?bound_red=%2300FF00")
+    page.goto(build_app_url(app_base_url, query={"bound_red": "#00FF00"}))
     wait_for_app_loaded(page)
 
     # Color picker should show green (overriding red default, case preserved from URL)
@@ -262,10 +263,10 @@ def test_color_picker_query_param_default_custom(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound color red value:", "#ff0000")
 
 
-def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
+def test_color_picker_query_param_invalid_value(page: Page, app_base_url: str):
     """Test that invalid URL values are cleared and widget uses default."""
     # Load app with invalid query param value (not a valid hex color)
-    page.goto(f"http://localhost:{app_port}/?bound_color=notacolor")
+    page.goto(build_app_url(app_base_url, query={"bound_color": "notacolor"}))
     wait_for_app_loaded(page)
 
     # Color picker should use default (black), and invalid param should be cleared
@@ -274,11 +275,11 @@ def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
     expect(page).not_to_have_url(re.compile(r"bound_color"))
 
 
-def test_color_picker_query_param_3char_hex(page: Page, app_port: int):
+def test_color_picker_query_param_3char_hex(page: Page, app_base_url: str):
     """Test that 3-char hex shorthand colors (e.g., #F00) work in URL params."""
     # Load app with 3-char hex color (URL-encoded # is %23)
     # #F00 is shorthand for #FF0000 (red)
-    page.goto(f"http://localhost:{app_port}/?bound_color=%23F00")
+    page.goto(build_app_url(app_base_url, query={"bound_color": "#F00"}))
     wait_for_app_loaded(page)
 
     # Color picker should accept the 3-char hex and display it

--- a/e2e_playwright/st_components_v1_test.py
+++ b/e2e_playwright/st_components_v1_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import math
-import re
+from urllib import parse
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, build_app_url
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     get_checkbox,
@@ -120,7 +120,7 @@ def test_iframe_tab_index_attributes(app: Page):
     expect(zero_iframe).to_have_attribute("tabindex", "0")
 
 
-def test_declare_component_correctly_sets_attr(app: Page):
+def test_declare_component_correctly_sets_attr(app: Page, app_base_url: str):
     """Test that components.declare_component correctly sets attributes and rendered size."""
 
     checkbox_element = get_checkbox(app, "Show custom component")
@@ -133,11 +133,10 @@ def test_declare_component_correctly_sets_attr(app: Page):
     expect(declare_component).to_have_attribute(
         "title", "st_components_v1.test_component"
     )
+    expected_streamlit_url = build_app_url(app_base_url, path="/")
+    expected_streamlit_url_encoded = parse.quote(expected_streamlit_url, safe="")
     expect(declare_component).to_have_attribute(
-        "src",
-        re.compile(
-            r"http://not.a.real.url\?streamlitUrl=http%3A%2F%2Flocalhost%3A\d*%2F$"
-        ),
+        "src", f"http://not.a.real.url?streamlitUrl={expected_streamlit_url_encoded}"
     )
 
 

--- a/e2e_playwright/st_context_test.py
+++ b/e2e_playwright/st_context_test.py
@@ -39,10 +39,9 @@ def test_locale(app: Page):
     expect_prefixed_markdown(app, "Locale primary language:", "it-IT")
 
 
-def test_url(app: Page, app_port: int):
+def test_url(app: Page, app_base_url: str):
     """Test that the URL is correctly set."""
-    expected_url = f"http://localhost:{app_port}"
-    expect_prefixed_markdown(app, "Full url:", expected_url)
+    expect_prefixed_markdown(app, "Full url:", app_base_url)
 
 
 @pytest.mark.browser_context_args(timezone_id="Europe/Paris")

--- a/e2e_playwright/st_download_button_test.py
+++ b/e2e_playwright/st_download_button_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_run,
     wait_until,
 )
@@ -246,11 +247,11 @@ def test_custom_css_class_via_key(app: Page):
     expect(get_element_by_key(app, "download_button")).to_be_visible()
 
 
-def test_download_button_source_error(app: Page, app_port: int):
+def test_download_button_source_error(app: Page, app_base_url: str):
     """Test that the download button source error is correctly logged."""
     # Ensure download source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/media/**",
+        build_app_url(app_base_url, path="/media/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -261,7 +262,7 @@ def test_download_button_source_error(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     wait_until(

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -23,6 +23,7 @@ from playwright.sync_api import FilePayload, Page, Route, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     rerun_app,
     wait_for_app_run,
     wait_until,
@@ -725,11 +726,11 @@ def test_file_uploader_works_with_fragments(app: Page):
     expect(app.get_by_text("Runs: 1")).to_be_visible()
 
 
-def test_file_uploader_upload_error(app: Page, app_port: int):
+def test_file_uploader_upload_error(app: Page, app_base_url: str):
     """Test that the file uploader upload error is correctly logged."""
     # Ensure file upload source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        build_app_url(app_base_url, path="/_stcore/upload_file/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -740,7 +741,7 @@ def test_file_uploader_upload_error(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     file_name1 = "file1.txt"
     file_content1 = b"file1content"
@@ -768,7 +769,7 @@ def test_file_uploader_upload_error(app: Page, app_port: int):
     )
 
 
-def test_file_uploader_delete_error(app: Page, app_port: int):
+def test_file_uploader_delete_error(app: Page, app_base_url: str):
     """Test that the file uploader delete error is correctly logged."""
 
     # Allow GET requests to pass through, but block DELETE requests
@@ -782,7 +783,7 @@ def test_file_uploader_delete_error(app: Page, app_port: int):
 
     # Ensure file upload source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/_stcore/upload_file/**",
+        build_app_url(app_base_url, path="/_stcore/upload_file/**"),
         allow_file_upload_block_delete,
     )
 
@@ -791,7 +792,7 @@ def test_file_uploader_delete_error(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     file_name1 = "file1.txt"
     file_content1 = b"file1content"

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -19,6 +19,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_until,
 )
 from e2e_playwright.shared.app_utils import (
@@ -308,11 +309,11 @@ def test_check_top_level_class(app: Page):
     check_top_level_class(app, "stImage")
 
 
-def test_image_source_error(app: Page, app_port: int):
+def test_image_source_error(app: Page, app_base_url: str):
     """Test `st.image` source error."""
     # Ensure image source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/media/**",
+        build_app_url(app_base_url, path="/media/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -323,7 +324,7 @@ def test_image_source_error(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
 
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent
     wait_until(

--- a/e2e_playwright/st_main_layout_test.py
+++ b/e2e_playwright/st_main_layout_test.py
@@ -21,6 +21,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     start_app_server,
     wait_for_app_loaded,
     wait_for_app_run,
@@ -47,6 +48,7 @@ def app_server():
 @pytest.fixture
 def app(
     page: Page,
+    app_base_url: str,
     app_port: int,
     request: pytest.FixtureRequest,
     sidebar_mode: str,
@@ -63,7 +65,7 @@ def app(
 
     try:
         # Open the app page
-        response = page.goto(f"http://localhost:{app_port}/")
+        response = page.goto(build_app_url(app_base_url, path="/"))
         if response is None or response.status != 200:
             raise RuntimeError("Unable to load page")
 

--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -313,7 +313,7 @@ def test_check_top_level_class(app: Page):
 @pytest.mark.app_hash("bold-header1")
 def test_anchor_scrolling(app: Page):
     """Test that anchor scrolling works correctly."""
-    # The app fixture navigates to http://localhost:{app_port}/#bold-header1
+    # The app fixture navigates with the requested hash fragment (#bold-header1),
     # which should scroll to the header.
     expect(app.get_by_text("Bold header1")).to_be_in_viewport()
 

--- a/e2e_playwright/st_pyplot_test.py
+++ b/e2e_playwright/st_pyplot_test.py
@@ -34,7 +34,7 @@ def test_displays_a_pyplot_figures(
 
     # pyplot graph assertion
     expect(themed_app.get_by_test_id("stImage").last.locator("img")).to_have_attribute(
-        "src", re.compile(r"localhost*")
+        "src", re.compile(r".*/media/.*")
     )
 
     pyplot_elements = themed_app.get_by_test_id("stImage").locator("img")

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -15,7 +15,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded, wait_until
+from e2e_playwright.conftest import build_app_url, wait_for_app_loaded, wait_until
 
 
 def setup_viewport(page: Page, viewport_type: str) -> None:
@@ -164,7 +164,7 @@ def wait_for_sidebar_stable(
 @pytest.mark.parametrize("viewport", ["desktop", "mobile"])
 @pytest.mark.parametrize("initial_sidebar_state", ["collapsed", "expanded", "auto"])
 def test_sidebar_no_flicker_on_initial_load(
-    page: Page, app_port: int, viewport: str, initial_sidebar_state: str
+    page: Page, app_base_url: str, viewport: str, initial_sidebar_state: str
 ):
     """Test that sidebar doesn't flicker during initial page load.
 
@@ -182,7 +182,7 @@ def test_sidebar_no_flicker_on_initial_load(
     page.add_init_script(create_sidebar_monitor_script())
 
     # Navigate to the page
-    page.goto(f"http://localhost:{app_port}/?test_mode={initial_sidebar_state}")
+    page.goto(build_app_url(app_base_url, query={"test_mode": initial_sidebar_state}))
 
     # Wait for app to load
     wait_for_app_loaded(page)
@@ -191,7 +191,7 @@ def test_sidebar_no_flicker_on_initial_load(
     verify_no_sidebar_flicker(page, initial_sidebar_state, expected_final_state)
 
 
-def test_sidebar_collapsed_state_no_flicker(page: Page, app_port: int):
+def test_sidebar_collapsed_state_no_flicker(page: Page, app_base_url: str):
     """Test that sidebar stays collapsed when configured as collapsed.
 
     This focused test ensures that a sidebar configured as collapsed
@@ -202,13 +202,13 @@ def test_sidebar_collapsed_state_no_flicker(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=collapsed")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "collapsed"}))
     wait_for_app_loaded(page)
 
     verify_no_sidebar_flicker(page, "collapsed", "collapsed")
 
 
-def test_sidebar_expanded_state_no_flicker(page: Page, app_port: int):
+def test_sidebar_expanded_state_no_flicker(page: Page, app_base_url: str):
     """Test that sidebar stays expanded when configured as expanded.
 
     This focused test ensures that a sidebar configured as expanded
@@ -219,13 +219,13 @@ def test_sidebar_expanded_state_no_flicker(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=expanded")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "expanded"}))
     wait_for_app_loaded(page)
 
     verify_no_sidebar_flicker(page, "expanded", "expanded")
 
 
-def test_sidebar_auto_state_desktop(page: Page, app_port: int):
+def test_sidebar_auto_state_desktop(page: Page, app_base_url: str):
     """Test that sidebar auto state works correctly on desktop.
 
     On desktop, auto state should result in an expanded sidebar.
@@ -235,13 +235,13 @@ def test_sidebar_auto_state_desktop(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=auto")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "auto"}))
     wait_for_app_loaded(page)
 
     verify_no_sidebar_flicker(page, "auto", "expanded")
 
 
-def test_sidebar_auto_state_mobile(page: Page, app_port: int):
+def test_sidebar_auto_state_mobile(page: Page, app_base_url: str):
     """Test that sidebar auto state works correctly on mobile.
 
     On mobile, auto state should result in a collapsed sidebar.
@@ -251,13 +251,13 @@ def test_sidebar_auto_state_mobile(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=auto")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "auto"}))
     wait_for_app_loaded(page)
 
     verify_no_sidebar_flicker(page, "auto", "collapsed")
 
 
-def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
+def test_sidebar_no_flicker_without_page_config(page: Page, app_base_url: str):
     """Test sidebar behavior when set_page_config is not called.
 
     Should default to auto behavior (expanded on desktop).
@@ -267,7 +267,7 @@ def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=no_config")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "no_config"}))
     wait_for_app_loaded(page)
 
     # Without page config, should behave like auto (expanded on desktop)
@@ -290,7 +290,7 @@ def test_sidebar_no_flicker_without_page_config(page: Page, app_port: int):
                 )
 
 
-def test_sidebar_stability_after_initial_load(page: Page, app_port: int):
+def test_sidebar_stability_after_initial_load(page: Page, app_base_url: str):
     """Test that sidebar state remains stable after initial load.
 
     Verifies that the sidebar doesn't change state unexpectedly
@@ -301,7 +301,7 @@ def test_sidebar_stability_after_initial_load(page: Page, app_port: int):
     # Inject monitoring script before page loads
     page.add_init_script(create_sidebar_monitor_script())
 
-    page.goto(f"http://localhost:{app_port}/?test_mode=collapsed")
+    page.goto(build_app_url(app_base_url, query={"test_mode": "collapsed"}))
     wait_for_app_loaded(page)
 
     # Verify initial state

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -186,9 +187,9 @@ def test_dynamic_toggle_props(app: Page, assert_snapshot: ImageCompareFunction):
     expect_prefixed_markdown(app, "Updated toggle state:", "False")
 
 
-def test_toggle_query_param_seeding(page: Page, app_port: int):
+def test_toggle_query_param_seeding(page: Page, app_base_url: str):
     """Test that toggle value can be seeded from URL query params."""
-    page.goto(f"http://localhost:{app_port}/?bound_toggle=true")
+    page.goto(build_app_url(app_base_url, query={"bound_toggle": "true"}))
     wait_for_app_loaded(page)
 
     expect_prefixed_markdown(page, "bound toggle value:", "True")
@@ -215,10 +216,10 @@ def test_toggle_query_param_updates_url(app: Page):
     expect(app).not_to_have_url(re.compile(r"bound_toggle="))
 
 
-def test_toggle_query_param_default_true(page: Page, app_port: int):
+def test_toggle_query_param_default_true(page: Page, app_base_url: str):
     """Test toggle with default True: seeding and param removal."""
     # Load app with query param overriding the True default
-    page.goto(f"http://localhost:{app_port}/?bound_toggle_true=false")
+    page.goto(build_app_url(app_base_url, query={"bound_toggle_true": "false"}))
     wait_for_app_loaded(page)
 
     # Toggle should be off (overriding True default)
@@ -232,9 +233,9 @@ def test_toggle_query_param_default_true(page: Page, app_port: int):
     expect(page).not_to_have_url(re.compile(r"bound_toggle_true"))
 
 
-def test_toggle_query_param_invalid_value(page: Page, app_port: int):
+def test_toggle_query_param_invalid_value(page: Page, app_base_url: str):
     """Test that invalid URL values are cleared and widget uses default."""
-    page.goto(f"http://localhost:{app_port}/?bound_toggle=invalid")
+    page.goto(build_app_url(app_base_url, query={"bound_toggle": "invalid"}))
     wait_for_app_loaded(page)
 
     # Toggle should use default (False), and invalid param should be cleared

--- a/e2e_playwright/st_video_test.py
+++ b/e2e_playwright/st_video_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_until,
 )
 from e2e_playwright.shared.app_utils import (
@@ -233,11 +234,11 @@ def test_check_top_level_class(app: Page):
     check_top_level_class(app, "stVideo")
 
 
-def test_video_source_error(app: Page, app_port: int):
+def test_video_source_error(app: Page, app_base_url: str):
     """Test `st.video` source error."""
     # Ensure video source request return a 404 status
     app.route(
-        f"http://localhost:{app_port}/media/**",
+        build_app_url(app_base_url, path="/media/**"),
         lambda route: route.fulfill(
             status=404, headers={"Content-Type": "text/plain"}, body="Not Found"
         ),
@@ -248,7 +249,7 @@ def test_video_source_error(app: Page, app_port: int):
     app.on("console", lambda msg: messages.append(msg.text))
 
     # Navigate to the app
-    goto_app(app, f"http://localhost:{app_port}")
+    goto_app(app, app_base_url)
     _select_video_to_show(app, "mp4 video")
 
     # Wait until the expected error is logged, indicating CLIENT_ERROR was sent

--- a/e2e_playwright/theming/custom_dark_sidebar_theme_test.py
+++ b/e2e_playwright/theming/custom_dark_sidebar_theme_test.py
@@ -17,12 +17,16 @@ import os
 import pytest
 from playwright.sync_api import Page
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_loaded
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+)
 from e2e_playwright.shared.app_utils import expect_no_skeletons
 
 
 @pytest.fixture
-def app(page: Page, app_port: int) -> Page:
+def app(page: Page, app_base_url: str) -> Page:
     """Custom app fixture that sets dark mode color scheme before navigation.
 
     This uses page.emulate_media() instead of browser_context_args to avoid
@@ -31,7 +35,7 @@ def app(page: Page, app_port: int) -> Page:
     # Set dark mode color scheme before navigating to the app
     page.emulate_media(color_scheme="dark")
 
-    response = page.goto(f"http://localhost:{app_port}/")
+    response = page.goto(build_app_url(app_base_url, path="/"))
     if response is None or response.status != 200:
         raise RuntimeError("Unable to load page")
 

--- a/e2e_playwright/theming/custom_dark_theme_test.py
+++ b/e2e_playwright/theming/custom_dark_theme_test.py
@@ -18,12 +18,16 @@ import os
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_loaded
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+)
 from e2e_playwright.shared.app_utils import expect_no_skeletons
 
 
 @pytest.fixture
-def app(page: Page, app_port: int) -> Page:
+def app(page: Page, app_base_url: str) -> Page:
     """Custom app fixture that sets dark mode color scheme before navigation.
 
     This uses page.emulate_media() instead of browser_context_args to avoid
@@ -32,7 +36,7 @@ def app(page: Page, app_port: int) -> Page:
     # Set dark mode color scheme before navigating to the app
     page.emulate_media(color_scheme="dark")
 
-    response = page.goto(f"http://localhost:{app_port}/")
+    response = page.goto(build_app_url(app_base_url, path="/"))
     if response is None or response.status != 200:
         raise RuntimeError("Unable to load page")
 

--- a/e2e_playwright/web_server_test.py
+++ b/e2e_playwright/web_server_test.py
@@ -29,45 +29,57 @@ These tests verify expected server behavior covering:
 
 from __future__ import annotations
 
+from urllib import parse
+
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
+from e2e_playwright.conftest import build_app_url, wait_for_app_loaded, wait_for_app_run
 from e2e_playwright.shared.app_utils import click_button
+
+
+def _app_ws_url(app_base_url: str, path: str) -> str:
+    http_url = build_app_url(app_base_url, path=path)
+    split_url = parse.urlsplit(http_url)
+    scheme = "wss" if split_url.scheme == "https" else "ws"
+    return parse.urlunsplit(
+        (scheme, split_url.netloc, split_url.path, split_url.query, "")
+    )
+
 
 # =============================================================================
 # Health Endpoint Tests
 # =============================================================================
 
 
-def test_health_endpoint_returns_ok(app: Page, app_port: int):
+def test_health_endpoint_returns_ok(app: Page, app_base_url: str):
     """Test that /_stcore/health returns 'ok' when app is healthy."""
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/health")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/health"))
 
     expect(response).to_be_ok()
     assert response.status == 200
     assert response.text() == "ok"
 
 
-def test_health_endpoint_has_no_cache_header(app: Page, app_port: int):
+def test_health_endpoint_has_no_cache_header(app: Page, app_base_url: str):
     """Test that health endpoint sets Cache-Control: no-cache."""
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/health")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/health"))
 
     expect(response).to_be_ok()
     assert response.headers.get("cache-control") == "no-cache"
 
 
-def test_health_endpoint_supports_head_method(app: Page, app_port: int):
+def test_health_endpoint_supports_head_method(app: Page, app_base_url: str):
     """Test that health endpoint supports HEAD method for monitoring services."""
-    response = app.request.head(f"http://localhost:{app_port}/_stcore/health")
+    response = app.request.head(build_app_url(app_base_url, path="/_stcore/health"))
 
     expect(response).to_be_ok()
     assert response.status == 200
 
 
-def test_health_endpoint_supports_options_for_cors(app: Page, app_port: int):
+def test_health_endpoint_supports_options_for_cors(app: Page, app_base_url: str):
     """Test that health endpoint handles OPTIONS requests for CORS preflight."""
     response = app.request.fetch(
-        f"http://localhost:{app_port}/_stcore/health",
+        build_app_url(app_base_url, path="/_stcore/health"),
         method="OPTIONS",
     )
 
@@ -75,10 +87,10 @@ def test_health_endpoint_supports_options_for_cors(app: Page, app_port: int):
     assert response.status == 204
 
 
-def test_script_health_endpoint_returns_ok(app: Page, app_port: int):
+def test_script_health_endpoint_returns_ok(app: Page, app_base_url: str):
     """Test that /_stcore/script-health-check returns 'ok' for valid script."""
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/script-health-check"
+        build_app_url(app_base_url, path="/_stcore/script-health-check")
     )
 
     expect(response).to_be_ok()
@@ -92,9 +104,9 @@ def test_script_health_endpoint_returns_ok(app: Page, app_port: int):
 # =============================================================================
 
 
-def test_metrics_endpoint_returns_valid_response(app: Page, app_port: int):
+def test_metrics_endpoint_returns_valid_response(app: Page, app_base_url: str):
     """Test that /_stcore/metrics returns metrics in openmetrics format."""
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/metrics")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/metrics"))
 
     expect(response).to_be_ok()
     assert response.status == 200
@@ -107,10 +119,10 @@ def test_metrics_endpoint_returns_valid_response(app: Page, app_port: int):
     assert len(response.text()) > 0
 
 
-def test_metrics_endpoint_accepts_protobuf(app: Page, app_port: int):
+def test_metrics_endpoint_accepts_protobuf(app: Page, app_base_url: str):
     """Test that metrics endpoint can return protobuf when requested."""
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics",
+        build_app_url(app_base_url, path="/_stcore/metrics"),
         headers={"Accept": "application/x-protobuf"},
     )
 
@@ -122,7 +134,7 @@ def test_metrics_endpoint_accepts_protobuf(app: Page, app_port: int):
     assert "protobuf" in content_type
 
 
-def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_port: int):
+def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_base_url: str):
     """Test that metrics endpoint filters results by families query parameter.
 
     When requesting families=cache_memory_bytes, only cache memory metrics
@@ -132,7 +144,9 @@ def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_port: in
     wait_for_app_loaded(app)
 
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics?families=cache_memory_bytes"
+        build_app_url(
+            app_base_url, path="/_stcore/metrics", query="families=cache_memory_bytes"
+        )
     )
 
     expect(response).to_be_ok()
@@ -146,13 +160,17 @@ def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_port: in
     assert "active_sessions" not in text
 
 
-def test_metrics_endpoint_filters_by_family_session_events(app: Page, app_port: int):
+def test_metrics_endpoint_filters_by_family_session_events(
+    app: Page, app_base_url: str
+):
     """Test that metrics endpoint returns session_events_total when requested.
 
     Session events metrics track connections, reconnections, and disconnections.
     """
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics?families=session_events_total"
+        build_app_url(
+            app_base_url, path="/_stcore/metrics", query="families=session_events_total"
+        )
     )
 
     expect(response).to_be_ok()
@@ -166,13 +184,17 @@ def test_metrics_endpoint_filters_by_family_session_events(app: Page, app_port: 
     assert "active_sessions" not in text
 
 
-def test_metrics_endpoint_filters_by_family_active_sessions(app: Page, app_port: int):
+def test_metrics_endpoint_filters_by_family_active_sessions(
+    app: Page, app_base_url: str
+):
     """Test that metrics endpoint returns active_sessions when requested.
 
     Active sessions metrics track the current number of connected sessions.
     """
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics?families=active_sessions"
+        build_app_url(
+            app_base_url, path="/_stcore/metrics", query="families=active_sessions"
+        )
     )
 
     expect(response).to_be_ok()
@@ -186,14 +208,17 @@ def test_metrics_endpoint_filters_by_family_active_sessions(app: Page, app_port:
     assert "session_events_total" not in text
 
 
-def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_port: int):
+def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_base_url: str):
     """Test that metrics endpoint supports filtering by multiple families.
 
     Multiple families query params should return metrics for all requested families.
     """
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics"
-        "?families=session_events_total&families=active_sessions"
+        build_app_url(
+            app_base_url,
+            path="/_stcore/metrics",
+            query="families=session_events_total&families=active_sessions",
+        )
     )
 
     expect(response).to_be_ok()
@@ -207,14 +232,16 @@ def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_port: int)
     assert "cache_memory_bytes" not in text
 
 
-def test_metrics_endpoint_unknown_family_returns_empty(app: Page, app_port: int):
+def test_metrics_endpoint_unknown_family_returns_empty(app: Page, app_base_url: str):
     """Test that metrics endpoint returns empty response for unknown families.
 
     When requesting a family that doesn't exist, the response should contain
     only the EOF marker.
     """
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics?families=unknown_family"
+        build_app_url(
+            app_base_url, path="/_stcore/metrics", query="families=unknown_family"
+        )
     )
 
     expect(response).to_be_ok()
@@ -225,7 +252,7 @@ def test_metrics_endpoint_unknown_family_returns_empty(app: Page, app_port: int)
     assert text.strip() == "# EOF"
 
 
-def test_metrics_endpoint_no_filter_returns_all_families(app: Page, app_port: int):
+def test_metrics_endpoint_no_filter_returns_all_families(app: Page, app_base_url: str):
     """Test that metrics endpoint without filter returns all metric families.
 
     When no families query param is provided, all available metrics should be returned.
@@ -234,7 +261,7 @@ def test_metrics_endpoint_no_filter_returns_all_families(app: Page, app_port: in
     """
     wait_for_app_loaded(app)
 
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/metrics")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/metrics"))
 
     expect(response).to_be_ok()
     assert response.status == 200
@@ -252,9 +279,9 @@ def test_metrics_endpoint_no_filter_returns_all_families(app: Page, app_port: in
 # =============================================================================
 
 
-def test_host_config_endpoint_returns_json(app: Page, app_port: int):
+def test_host_config_endpoint_returns_json(app: Page, app_base_url: str):
     """Test that /_stcore/host-config returns valid JSON configuration."""
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/host-config")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/host-config"))
 
     expect(response).to_be_ok()
     assert response.status == 200
@@ -268,9 +295,9 @@ def test_host_config_endpoint_returns_json(app: Page, app_port: int):
     assert "enableCustomParentMessages" in config
 
 
-def test_host_config_has_no_cache_header(app: Page, app_port: int):
+def test_host_config_has_no_cache_header(app: Page, app_base_url: str):
     """Test that host-config endpoint sets Cache-Control: no-cache."""
-    response = app.request.get(f"http://localhost:{app_port}/_stcore/host-config")
+    response = app.request.get(build_app_url(app_base_url, path="/_stcore/host-config"))
 
     expect(response).to_be_ok()
     assert response.headers.get("cache-control") == "no-cache"
@@ -281,12 +308,14 @@ def test_host_config_has_no_cache_header(app: Page, app_port: int):
 # =============================================================================
 
 
-def test_cors_options_preflight_returns_204(app: Page, app_port: int):
+def test_cors_options_preflight_returns_204(app: Page, app_base_url: str):
     """Test that OPTIONS preflight requests return 204 No Content."""
+    split_base_url = parse.urlsplit(app_base_url)
+    request_origin = f"{split_base_url.scheme}://{split_base_url.netloc}"
     response = app.request.fetch(
-        f"http://localhost:{app_port}/_stcore/health",
+        build_app_url(app_base_url, path="/_stcore/health"),
         method="OPTIONS",
-        headers={"Origin": "http://localhost:3000"},
+        headers={"Origin": request_origin},
     )
 
     # OPTIONS should return 204 No Content
@@ -298,15 +327,15 @@ def test_cors_options_preflight_returns_204(app: Page, app_port: int):
 # =============================================================================
 
 
-def _get_media_url_from_image(app: Page, app_port: int) -> str | None:
+def _get_media_url_from_image(app: Page, app_base_url: str) -> str | None:
     """Helper to get the media URL from an image element.
 
     Parameters
     ----------
     app : Page
         The Playwright page object.
-    app_port : int
-        The port number where the app is running.
+    app_base_url : str
+        The base URL where the app is running.
 
     Returns
     -------
@@ -324,15 +353,15 @@ def _get_media_url_from_image(app: Page, app_port: int) -> str | None:
     if src and "/media/" in src:
         # Make it a full URL if it's relative
         if src.startswith("/"):
-            return f"http://localhost:{app_port}{src}"
+            return build_app_url(app_base_url, path=src)
         return src
 
     return None
 
 
-def test_media_endpoint_serves_image_content(app: Page, app_port: int):
+def test_media_endpoint_serves_image_content(app: Page, app_base_url: str):
     """Test that media endpoint correctly serves image content."""
-    media_url = _get_media_url_from_image(app, app_port)
+    media_url = _get_media_url_from_image(app, app_base_url)
 
     assert media_url is not None
 
@@ -348,9 +377,9 @@ def test_media_endpoint_serves_image_content(app: Page, app_port: int):
     assert "image" in content_type
 
 
-def test_media_endpoint_supports_range_requests(app: Page, app_port: int):
+def test_media_endpoint_supports_range_requests(app: Page, app_base_url: str):
     """Test that media endpoint supports Accept-Ranges header for streaming."""
-    media_url = _get_media_url_from_image(app, app_port)
+    media_url = _get_media_url_from_image(app, app_base_url)
 
     assert media_url is not None
 
@@ -363,9 +392,9 @@ def test_media_endpoint_supports_range_requests(app: Page, app_port: int):
     assert accept_ranges == "bytes"
 
 
-def test_media_endpoint_handles_range_request(app: Page, app_port: int):
+def test_media_endpoint_handles_range_request(app: Page, app_base_url: str):
     """Test that media endpoint correctly handles Range header requests."""
-    media_url = _get_media_url_from_image(app, app_port)
+    media_url = _get_media_url_from_image(app, app_base_url)
 
     assert media_url is not None
 
@@ -384,10 +413,10 @@ def test_media_endpoint_handles_range_request(app: Page, app_port: int):
     assert len(response.body()) == 10
 
 
-def test_media_endpoint_returns_404_for_invalid_file(app: Page, app_port: int):
+def test_media_endpoint_returns_404_for_invalid_file(app: Page, app_base_url: str):
     """Test that media endpoint returns 404 for non-existent files."""
     response = app.request.get(
-        f"http://localhost:{app_port}/media/nonexistent-file-id.txt"
+        build_app_url(app_base_url, path="/media/nonexistent-file-id.txt")
     )
 
     assert response.status == 404
@@ -398,10 +427,10 @@ def test_media_endpoint_returns_404_for_invalid_file(app: Page, app_port: int):
 # =============================================================================
 
 
-def test_upload_endpoint_options_returns_cors_headers(app: Page, app_port: int):
+def test_upload_endpoint_options_returns_cors_headers(app: Page, app_base_url: str):
     """Test that upload endpoint OPTIONS request returns CORS headers."""
     response = app.request.fetch(
-        f"http://localhost:{app_port}/_stcore/upload_file/test-session/test-file",
+        build_app_url(app_base_url, path="/_stcore/upload_file/test-session/test-file"),
         method="OPTIONS",
     )
 
@@ -414,7 +443,7 @@ def test_upload_endpoint_options_returns_cors_headers(app: Page, app_port: int):
     assert "DELETE" in response.headers.get("access-control-allow-methods", "")
 
 
-def test_upload_endpoint_rejects_invalid_session(app: Page, app_port: int):
+def test_upload_endpoint_rejects_invalid_session(app: Page, app_base_url: str):
     """Test that upload endpoint rejects uploads with invalid session_id.
 
     When XSRF protection is enabled (default), the server will return 403 Forbidden
@@ -425,7 +454,9 @@ def test_upload_endpoint_rejects_invalid_session(app: Page, app_port: int):
 
     # Try to upload with an invalid session ID
     response = app.request.put(
-        f"http://localhost:{app_port}/_stcore/upload_file/invalid-session-id/test-file",
+        build_app_url(
+            app_base_url, path="/_stcore/upload_file/invalid-session-id/test-file"
+        ),
         multipart={
             "file": {
                 "name": "test.txt",
@@ -439,7 +470,7 @@ def test_upload_endpoint_rejects_invalid_session(app: Page, app_port: int):
     assert response.status in {400, 403}, f"Expected 400 or 403, got {response.status}"
 
 
-def test_upload_delete_endpoint(app: Page, app_port: int):
+def test_upload_delete_endpoint(app: Page, app_base_url: str):
     """Test that upload DELETE endpoint responds correctly.
 
     When XSRF protection is enabled (default), the server will return 403 Forbidden
@@ -450,7 +481,7 @@ def test_upload_delete_endpoint(app: Page, app_port: int):
 
     # DELETE on a non-existent file
     response = app.request.delete(
-        f"http://localhost:{app_port}/_stcore/upload_file/any-session/any-file"
+        build_app_url(app_base_url, path="/_stcore/upload_file/any-session/any-file")
     )
 
     # Should return 204 (success) or 403 (XSRF protection)
@@ -494,10 +525,10 @@ def test_xsrf_cookie_format(app: Page):
 # =============================================================================
 
 
-def test_frontend_static_files_served(app: Page, app_port: int):
+def test_frontend_static_files_served(app: Page, app_base_url: str):
     """Test that frontend static files (JS, CSS) are served correctly."""
     # Request the main page
-    response = app.request.get(f"http://localhost:{app_port}/")
+    response = app.request.get(build_app_url(app_base_url, path="/"))
 
     expect(response).to_be_ok()
     assert response.status == 200
@@ -507,19 +538,19 @@ def test_frontend_static_files_served(app: Page, app_port: int):
     assert "text/html" in content_type
 
 
-def test_frontend_static_files_have_cache_headers(app: Page, app_port: int):
+def test_frontend_static_files_have_cache_headers(app: Page, app_base_url: str):
     """Test that index.html has no-cache but assets have long cache."""
     # Index should have no-cache
-    response = app.request.get(f"http://localhost:{app_port}/")
+    response = app.request.get(build_app_url(app_base_url, path="/"))
 
     expect(response).to_be_ok()
     cache_control = response.headers.get("cache-control", "")
     assert "no-cache" in cache_control
 
 
-def test_nonexistent_route_returns_index(app: Page, app_port: int):
+def test_nonexistent_route_returns_index(app: Page, app_base_url: str):
     """Test that non-existent routes return index.html (SPA behavior)."""
-    response = app.request.get(f"http://localhost:{app_port}/nonexistent-page")
+    response = app.request.get(build_app_url(app_base_url, path="/nonexistent-page"))
 
     # Should still return 200 and serve the SPA
     expect(response).to_be_ok()
@@ -534,7 +565,7 @@ def test_nonexistent_route_returns_index(app: Page, app_port: int):
 # =============================================================================
 
 
-def test_trailing_slash_redirect_on_static_paths(app: Page, app_port: int):
+def test_trailing_slash_redirect_on_static_paths(app: Page, app_base_url: str):
     """Test that trailing slashes on static paths are handled correctly.
 
     The server should either:
@@ -545,7 +576,7 @@ def test_trailing_slash_redirect_on_static_paths(app: Page, app_port: int):
     """
     # Request a path with trailing slash
     response = app.request.get(
-        f"http://localhost:{app_port}/some-path/",
+        build_app_url(app_base_url, path="/some-path/"),
         max_redirects=0,  # Don't follow redirects to see the redirect response
     )
 
@@ -560,7 +591,7 @@ def test_trailing_slash_redirect_on_static_paths(app: Page, app_port: int):
     )
 
 
-def test_base_url_without_trailing_slash(app: Page, app_port: int):
+def test_base_url_without_trailing_slash(app: Page, app_base_url: str):
     """Test that base URL without trailing slash is handled correctly.
 
     The server should either:
@@ -568,14 +599,14 @@ def test_base_url_without_trailing_slash(app: Page, app_port: int):
     - Or serve content directly
     """
     # The root path should work (may redirect to add trailing slash or serve directly)
-    response = app.request.get(f"http://localhost:{app_port}")
+    response = app.request.get(app_base_url.rstrip("/"))
 
     # Should succeed (possibly after redirect)
     expect(response).to_be_ok()
     assert response.status == 200
 
 
-def test_double_slash_not_redirected_to_external(app: Page, app_port: int):
+def test_double_slash_not_redirected_to_external(app: Page, app_base_url: str):
     """Test that double slashes don't cause redirect to external host.
 
     A path like //example.com could be misinterpreted as a protocol-relative URL.
@@ -583,7 +614,7 @@ def test_double_slash_not_redirected_to_external(app: Page, app_port: int):
     """
     # Request with double slash at start
     response = app.request.get(
-        f"http://localhost:{app_port}//some-path",
+        build_app_url(app_base_url, path="//some-path"),
         max_redirects=0,
     )
 
@@ -626,7 +657,7 @@ def test_websocket_connection_to_stream_endpoint(app: Page):
     )
 
 
-def test_direct_websocket_connection_with_subprotocol(app: Page, app_port: int):
+def test_direct_websocket_connection_with_subprotocol(app: Page, app_base_url: str):
     """Test direct WebSocket connection with Sec-WebSocket-Protocol header.
 
     This verifies the server correctly handles the subprotocol negotiation.
@@ -634,25 +665,26 @@ def test_direct_websocket_connection_with_subprotocol(app: Page, app_port: int):
     of Python async WebSocket libraries conflicting with Playwright's event loop.
     """
     # The app fixture automatically navigates and waits for the app to load.
-    result = app.evaluate(f"""
-        () => new Promise((resolve, reject) => {{
-            const ws = new WebSocket(
-                'ws://localhost:{app_port}/_stcore/stream',
-                ['streamlit']
-            );
-            ws.onopen = () => {{
+    ws_url = _app_ws_url(app_base_url, path="/_stcore/stream")
+    result = app.evaluate(
+        """
+        (url) => new Promise((resolve, reject) => {
+            const ws = new WebSocket(url, ['streamlit']);
+            ws.onopen = () => {
                 resolve(ws.protocol);
                 ws.close();
-            }};
+            };
             ws.onerror = () => reject('connection failed');
             setTimeout(() => reject('timeout'), 5000);
-        }})
-    """)
+        })
+    """,
+        ws_url,
+    )
 
     assert result == "streamlit", f"Expected 'streamlit' subprotocol, got: {result}"
 
 
-def test_direct_websocket_with_session_id_in_subprotocol(app: Page, app_port: int):
+def test_direct_websocket_with_session_id_in_subprotocol(app: Page, app_base_url: str):
     """Test that server accepts session ID in Sec-WebSocket-Protocol for reconnection.
 
     This verifies the server correctly parses the third entry (session ID)
@@ -670,20 +702,24 @@ def test_direct_websocket_with_session_id_in_subprotocol(app: Page, app_port: in
         session_id = "test-session-id-12345"
 
     # Subprotocol entries: protocol name, XSRF token placeholder, session ID
-    result = app.evaluate(f"""
-        () => new Promise((resolve, reject) => {{
+    ws_url = _app_ws_url(app_base_url, path="/_stcore/stream")
+    result = app.evaluate(
+        """
+        ([url, sessionId]) => new Promise((resolve, reject) => {
             const ws = new WebSocket(
-                'ws://localhost:{app_port}/_stcore/stream',
-                ['streamlit', 'placeholder', '{session_id}']
+                url,
+                ['streamlit', 'placeholder', sessionId]
             );
-            ws.onopen = () => {{
-                resolve({{ connected: true, protocol: ws.protocol }});
+            ws.onopen = () => {
+                resolve({ connected: true, protocol: ws.protocol });
                 ws.close();
-            }};
-            ws.onerror = () => resolve({{ connected: false, error: 'connection failed' }});
-            setTimeout(() => resolve({{ connected: false, error: 'timeout' }}), 5000);
-        }})
-    """)
+            };
+            ws.onerror = () => resolve({ connected: false, error: 'connection failed' });
+            setTimeout(() => resolve({ connected: false, error: 'timeout' }), 5000);
+        })
+    """,
+        [ws_url, session_id],
+    )
 
     assert result["connected"], f"WebSocket connection failed: {result.get('error')}"
     assert result["protocol"] == "streamlit", (

--- a/e2e_playwright/websocket_reconnects_test.py
+++ b/e2e_playwright/websocket_reconnects_test.py
@@ -20,7 +20,7 @@ from typing import Final
 import pytest
 from playwright.sync_api import FilePayload, Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.conftest import build_app_url, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     click_button,
     expect_connection_status,
@@ -35,13 +35,15 @@ NUM_DISCONNECTS: Final[int] = 15
 DISCONNECT_WEBSOCKET_ACTION: Final = "window.streamlitDebug.disconnectWebsocket();"
 
 
-def _get_session_event_counts(app: Page, app_port: int) -> dict[str, int]:
+def _get_session_event_counts(app: Page, app_base_url: str) -> dict[str, int]:
     """Fetch session event metrics from the metrics endpoint.
 
     Returns a dict with keys 'connect', 'reconnect', 'disconnect' and their counts.
     """
     response = app.request.get(
-        f"http://localhost:{app_port}/_stcore/metrics?families=session_events_total"
+        build_app_url(
+            app_base_url, path="/_stcore/metrics", query="families=session_events_total"
+        )
     )
     text = response.text()
 
@@ -132,13 +134,13 @@ def test_retain_uploaded_files_when_websocket_connection_drops_and_reconnects(
 # skip webkit because the camera permission cannot be set programmatically
 @pytest.mark.skip_browser("webkit")
 def test_retain_captured_pictures_when_websocket_connection_drops_and_reconnects(
-    app: Page, app_port: int
+    app: Page, app_base_url: str
 ):
     # wait for the media call that is made when the image is returned
     with app.expect_event(
         "response",
         predicate=lambda response: response.url.startswith(
-            f"http://localhost:{app_port}/media/"
+            build_app_url(app_base_url, path="/media/")
         ),
     ):
         expect(app.get_by_test_id("stToolbar")).to_be_attached()
@@ -164,7 +166,7 @@ def test_retain_captured_pictures_when_websocket_connection_drops_and_reconnects
 
 
 def test_session_event_metrics_increase_on_disconnect_and_reconnect(
-    app: Page, app_port: int
+    app: Page, app_base_url: str
 ):
     """Test that session_events_total metrics increase on disconnect/reconnect.
 
@@ -173,7 +175,7 @@ def test_session_event_metrics_increase_on_disconnect_and_reconnect(
     """
     wait_for_app_run(app)
 
-    initial_counts = _get_session_event_counts(app, app_port)
+    initial_counts = _get_session_event_counts(app, app_base_url)
 
     assert initial_counts["connect"] > 0, (
         f"Expected connect count to be nonzero, got {initial_counts['connect']}"
@@ -183,7 +185,7 @@ def test_session_event_metrics_increase_on_disconnect_and_reconnect(
     expect_connection_status(app, "CONNECTING", DISCONNECT_WEBSOCKET_ACTION)
     expect(app.get_by_test_id("stStatusWidget")).not_to_be_attached()
 
-    updated_counts = _get_session_event_counts(app, app_port)
+    updated_counts = _get_session_event_counts(app, app_base_url)
 
     assert updated_counts["disconnect"] > initial_counts["disconnect"], (
         f"Expected disconnect count to increase from {initial_counts['disconnect']}, "
@@ -197,7 +199,7 @@ def test_session_event_metrics_increase_on_disconnect_and_reconnect(
 
 
 def test_session_event_metrics_increase_after_multiple_disconnects(
-    app: Page, app_port: int
+    app: Page, app_base_url: str
 ):
     """Test that session_events_total metrics accumulate over multiple disconnects.
 
@@ -206,7 +208,7 @@ def test_session_event_metrics_increase_after_multiple_disconnects(
     """
     wait_for_app_run(app)
 
-    initial_counts = _get_session_event_counts(app, app_port)
+    initial_counts = _get_session_event_counts(app, app_base_url)
 
     num_disconnects = 3
     for _ in range(num_disconnects):
@@ -214,7 +216,7 @@ def test_session_event_metrics_increase_after_multiple_disconnects(
         expect_connection_status(app, "CONNECTING", DISCONNECT_WEBSOCKET_ACTION)
         expect(app.get_by_test_id("stStatusWidget")).not_to_be_attached()
 
-    final_counts = _get_session_event_counts(app, app_port)
+    final_counts = _get_session_event_counts(app, app_base_url)
 
     disconnect_increase = final_counts["disconnect"] - initial_counts["disconnect"]
     assert disconnect_increase >= num_disconnects, (


### PR DESCRIPTION
## Describe your changes

- Standardize e2e URL construction by switching tests from `app_port`/`http://localhost:{app_port}` to `app_base_url` + `build_app_url(...)` for navigation, request calls, route interception, and URL assertions.
- Ensure direct WebSocket connections derive `ws://` vs `wss://` from `app_base_url` (so the same tests work for https/external runs, not just local http).
- Document the “no localhost hardcoding” rule in e2e guidance (`e2e_playwright/AGENTS.md`, `.github` instructions, and Cursor rules).

## Testing Plan

- Existing tests have been updated and are passing
- Tests can now run against external deployments by configuring the appropriate CLI flags or environment variables (tested in SiS vNext)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.